### PR TITLE
fix(app): provide NewTabLauncher to the non-compact native fallback tab row

### DIFF
--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -3854,29 +3854,36 @@ function WorkspaceScreenContent({
       ) : null}
 
       {shouldRenderDesktopPaneFallback ? (
-        <WorkspaceDesktopTabsRow
-          paneId={focusedPaneIdOrUndefined}
-          isFocused={isRouteFocused}
-          tabs={desktopTabRowItems}
-          normalizedServerId={normalizedServerId}
-          normalizedWorkspaceId={normalizedWorkspaceId}
-          setHoveredCloseTabKey={setHoveredCloseTabKey}
-          onNavigateTab={navigateToTabId}
-          onCloseTab={handleCloseTabById}
-          onCopyResumeCommand={handleCopyResumeCommand}
-          onCopyAgentId={handleCopyAgentId}
-          onCopyTerminalId={handleCopyTerminalId}
-          onCopyFilePath={handleCopyFilePath}
-          onReloadAgent={handleReloadAgent}
-          onRenameTab={handleRenameTab}
-          onCloseTabsToLeft={handleCloseTabsToLeft}
-          onCloseTabsToRight={handleCloseTabsToRight}
-          onCloseOtherTabs={handleCloseOtherTabs}
-          onCreateNewTab={handleCreateNewTab}
-          onReorderTabs={handleReorderTabsInFocusedPane}
-          focusModeEnabled={desktopFocusModeEnabled}
-          onExitFocusMode={toggleFocusMode}
-        />
+        // The splits path renders tab rows inside WorkspacePanelContent, which is what
+        // provides NewTabLauncherProvider. This fallback row sits outside it, and its
+        // new-tab menu content mounts eagerly, so without its own provider every
+        // non-compact native layout (tablets, foldables in landscape) crashed on mount
+        // with "NewTabLauncherProvider is required" (#3750).
+        <NewTabLauncherProvider value={newTabLauncher}>
+          <WorkspaceDesktopTabsRow
+            paneId={focusedPaneIdOrUndefined}
+            isFocused={isRouteFocused}
+            tabs={desktopTabRowItems}
+            normalizedServerId={normalizedServerId}
+            normalizedWorkspaceId={normalizedWorkspaceId}
+            setHoveredCloseTabKey={setHoveredCloseTabKey}
+            onNavigateTab={navigateToTabId}
+            onCloseTab={handleCloseTabById}
+            onCopyResumeCommand={handleCopyResumeCommand}
+            onCopyAgentId={handleCopyAgentId}
+            onCopyTerminalId={handleCopyTerminalId}
+            onCopyFilePath={handleCopyFilePath}
+            onReloadAgent={handleReloadAgent}
+            onRenameTab={handleRenameTab}
+            onCloseTabsToLeft={handleCloseTabsToLeft}
+            onCloseTabsToRight={handleCloseTabsToRight}
+            onCloseOtherTabs={handleCloseOtherTabs}
+            onCreateNewTab={handleCreateNewTab}
+            onReorderTabs={handleReorderTabsInFocusedPane}
+            focusModeEnabled={desktopFocusModeEnabled}
+            onExitFocusMode={toggleFocusMode}
+          />
+        </NewTabLauncherProvider>
       ) : null}
 
       <View style={styles.centerContent}>{workspacePanelContent}</View>


### PR DESCRIPTION
Fixes #3750.

## Problem

On the 0.5.0/0.5.1 Android app, every non-compact layout (tablets, foldables in landscape) crashes on workspace mount with `Invariant failed` — the stripped message is `NewTabLauncherProvider is required` from `useWorkspaceTabLaunchCatalog`. Retry cannot recover because the crash is in the mounted layout itself. Phones in portrait and the web UI at the same width are unaffected, matching the report matrix in #3750.

## Mechanism (raw evidence)

- `supportsDesktopPaneSplits()` is `isWeb` (`packages/app/src/constants/layout.ts:51-53`), so `shouldRenderDesktopPaneFallback = !isMobile && !canRenderDesktopPaneSplits` (`workspace-screen.tsx:3358-3361`) is true on **every non-compact native** device.
- On that path, `WorkspaceScreenContent` renders `WorkspaceDesktopTabsRow` directly in the center column, **above** `<View style={styles.centerContent}>{workspacePanelContent}</View>` (`workspace-screen.tsx:~3857`). `WorkspacePanelContent` is the component that provides `NewTabLauncherProvider` (`workspace-screen.tsx:1286-1298`), so the fallback row sits outside it.
- The row mounts `WorkspaceNewTabMenuContent` eagerly inside its `DropdownMenu` (`workspace-desktop-tabs-row.tsx:259`), and the first hook call is `useWorkspaceTabLaunchCatalog`, whose first statement is `invariant(launcher, "NewTabLauncherProvider is required")` (`workspace-tabs/launcher/index.tsx:86`). Missing context → crash at mount, before any user interaction.
- The splits path (web) renders tab rows inside `WorkspacePanelContent` via the split container, and compact renders `MobileWorkspaceTabSwitcher` instead of the row — which is why only non-compact native crashes.

## Fix

Wrap the fallback `WorkspaceDesktopTabsRow` in `NewTabLauncherProvider` with the same `newTabLauncher` value the panel content already receives. One focused change; no behavior change on web or compact.

## Verification

- `npm run typecheck -w @getpaseo/app` (tsgo): clean
- `npx vitest run --project unit` in `packages/app`: 553 files, 4609 tests, all pass
- `oxfmt --check` / `oxlint` on the changed file: clean

## Platforms tested

- Code-path verification + full unit suite on Linux (details above).
- **Not run on Android tablet hardware** — I don't have the failing device class; the fallback branch is gated on `!isWeb` so it is unreachable from the browser e2e project. The fix makes the fallback row's context identical to what the splits path already provides, and the reporter's matrix (#3750: Tab S9 and Z Fold landscape fail, phone portrait and web work) matches the traced gating exactly. Happy to iterate if a maintainer can exercise a debug APK on a wide device.

_Investigated with an agent; the file:line trace above is the raw evidence. Maintainer edits enabled._
