### PR TITLE
fix(server): let plugin sessions see agents on every provider

### DIFF
--- a/packages/server/src/server/plugins/plugin-paseo-api.e2e.test.ts
+++ b/packages/server/src/server/plugins/plugin-paseo-api.e2e.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, expect, test } from "vitest";
 import { DaemonClient } from "../test-utils/daemon-client.js";
 import { createTestPaseoDaemon } from "../test-utils/paseo-daemon.js";
+import { createTestAgentClient, createTestAgentClients } from "../test-utils/fake-agent-client.js";
 
 const roots: string[] = [];
 
@@ -80,6 +81,86 @@ export default function contribute(plugin: PluginContext) {
     expect(agents.entries.map((entry) => entry.agent.id)).toContain(
       Reflect.get(created, "agentId"),
     );
+  } finally {
+    await client.close().catch(() => undefined);
+    await daemon.close();
+  }
+}, 60_000);
+
+test("plugin sessions see agents on providers outside the legacy allow-list", async () => {
+  const pluginDirectory = await mkdtemp(path.join(tmpdir(), "paseo-visibility-plugin-"));
+  const workspaceDirectory = await mkdtemp(path.join(tmpdir(), "paseo-visibility-workspace-"));
+  roots.push(pluginDirectory, workspaceDirectory);
+  await writeFile(
+    path.join(pluginDirectory, "paseo-plugin.json"),
+    JSON.stringify({ id: "provider-visibility" }),
+  );
+  await writeFile(
+    path.join(pluginDirectory, "index.tsx"),
+    `import { defineRpc, type PluginContext } from "@getpaseo/plugin";
+import { z } from "zod";
+
+const create = defineRpc({
+  name: "create",
+  input: z.object({ path: z.string() }),
+  output: z.object({ agentId: z.string() }),
+});
+
+const list = defineRpc({
+  name: "list",
+  input: z.object({}),
+  output: z.object({ agentIds: z.array(z.string()) }),
+});
+
+export default function contribute(plugin: PluginContext) {
+  plugin.handle(create, async ({ path }, { paseo }) => {
+    const workspace = await paseo.workspaces.create({
+      source: { kind: "directory", path },
+      title: "Provider visibility workspace",
+    });
+    const agent = await workspace.agents.create({
+      config: { provider: "pi/test" },
+      prompt: "Created by a plugin handler",
+    });
+    return { agentId: agent.id };
+  });
+  plugin.handle(list, async (_input, { paseo }) => {
+    const result = await paseo.agents.list({ page: { limit: 100 } });
+    return { agentIds: result.entries.map((entry) => entry.agent.id) };
+  });
+  return () => undefined;
+}`,
+  );
+
+  const daemon = await createTestPaseoDaemon({
+    agentClients: { ...createTestAgentClients(), pi: createTestAgentClient("pi") },
+  });
+  const client = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    appVersion: "0.4.0",
+  });
+
+  try {
+    await client.connect();
+    await client.patchDaemonConfig({ pluginsEnabled: true });
+    await expect(client.installDirectoryPlugin(pluginDirectory)).resolves.toMatchObject({
+      id: "provider-visibility",
+      status: "running",
+    });
+
+    const created = await client.invokePluginRpc("provider-visibility", "create", {
+      path: workspaceDirectory,
+    });
+    if (typeof created !== "object" || created === null) {
+      throw new Error("Plugin returned an invalid creation result");
+    }
+    const agentId = Reflect.get(created, "agentId");
+
+    // The plugin's own session must not be treated as a legacy client: `pi` is
+    // outside the claude/codex/opencode allow-list, so a session that declares
+    // no version has the agent filtered out of its directory entirely.
+    const listed = await client.invokePluginRpc("provider-visibility", "list", {});
+    expect(listed).toEqual({ agentIds: expect.arrayContaining([agentId]) });
   } finally {
     await client.close().catch(() => undefined);
     await daemon.close();

--- a/packages/server/src/server/plugins/plugin-process.ts
+++ b/packages/server/src/server/plugins/plugin-process.ts
@@ -8,6 +8,7 @@ import {
 } from "@getpaseo/plugin/server";
 import { createPaseoApi, type PaseoApi } from "@getpaseo/client";
 import { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { resolveDaemonVersion } from "../daemon-version.js";
 import { createPluginDaemonTransportFactory } from "./daemon-transport.js";
 import { isPluginSdkSpecifier } from "./plugin-sdk-specifiers.js";
 
@@ -99,6 +100,10 @@ async function initialize(message: Extract<PluginProcessRequest, { type: "initia
     url: `ipc://plugin/${encodeURIComponent(message.pluginId)}`,
     clientId: `plugin:${message.pluginId}`,
     clientType: "cli",
+    // A plugin subprocess ships with the daemon, so it must not fall into the
+    // legacy-client provider allow-list that hides non-legacy agents from
+    // sessions that declare no version.
+    appVersion: resolveDaemonVersion(import.meta.url),
     reconnect: { enabled: false },
     transportFactory,
   });

--- a/packages/server/src/server/test-utils/fake-agent-client.ts
+++ b/packages/server/src/server/test-utils/fake-agent-client.ts
@@ -1281,3 +1281,14 @@ export function createTestAgentClients(
     opencode: new FakeAgentClient("opencode", options),
   };
 }
+
+/**
+ * A fake client for one provider id, so tests can cover providers outside the
+ * legacy claude/codex/opencode set.
+ */
+export function createTestAgentClient(
+  provider: string,
+  options: TestAgentClientOptions = {},
+): AgentClient {
+  return new FakeAgentClient(provider, options);
+}


### PR DESCRIPTION
### Linked issue

Closes #3763

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A plugin panel that reads agents shows nothing next to a running Pi or OMP agent, and everything next to a Claude one. Nothing errors, nothing logs — the agent is simply missing from `agents.list()`, so the plugin renders its empty state and the user concludes the plugin is broken.

The cause is that `plugin-process.ts` builds the plugin's `DaemonClient` without an `appVersion`, so the session hits the legacy-client compat path:

```ts
const LEGACY_PROVIDER_IDS = new Set(["claude", "codex", "opencode"]);
const MIN_VERSION_ALL_PROVIDERS = "0.1.45";

isProviderVisibleToClient(provider) {
  if (clientSupportsAllProviders(this.appVersion)) return true;  // appVersion is undefined
  return LEGACY_PROVIDER_IDS.has(provider);
}
```

That shim exists so old mobile builds are not handed provider ids they cannot parse. A plugin subprocess spawned by the daemon is not an old foreign client — it is pinned to the daemon's own version — so it should never have been on that path. It now declares `resolveDaemonVersion(import.meta.url)`, the same helper `bootstrap` and `logger` already use.

The value to users is that plugins stop being silently provider-dependent: a side-chat, QA-plan, or context panel behaves the same whichever provider the agent they are looking at runs on.

### Goals

- A plugin's daemon session sees every agent the daemon knows about, whatever the provider.
- `isProviderVisibleToClient` keeps protecting genuinely old clients: only the plugin client's own declaration changes.
- Regression coverage for a provider outside the legacy allow-list, since the current fakes cannot express one.

### Non-goals

- No change to the legacy allow-list, `MIN_VERSION_ALL_PROVIDERS`, or the compat rule for app, web, mobile, and CLI sessions.
- No new plugin-process protocol field. The version is resolved in the subprocess rather than passed down from the parent, to keep the change to one line and one import.
- No attempt to widen anything else the plugin session is gated on.

### QA

Reproduced against my own daemon at 0.5.1 before touching the source, with a plugin whose server handler calls `paseo.agents.list(...)`.

**Before — one running agent on `omp`, invisible to the plugin.**

```
$ paseo ls
AGENT ID  NAME                             PROVIDER                     STATUS
7210034   paseo için codex'teki sidechat…  omp/anthropic/claude-opus-5  running
```

Temporary log inside the plugin handler:

```
[side-chat][debug] list result {"entries":0,"pageInfo":{"nextCursor":null,"prevCursor":null,"hasMore":false},...,"directory":"/Users/alnzy/Documents/Projects/ilterugur/claude-devbox"}
```

Note `directory` resolved in the same handler, on the same session — `workspaces.ref(id).refresh()` works, so this is not a broken connection. Invoking the plugin RPC through `plugin.rpc.invoke.request` returned `{"targets":[]}` for both workspaces that contain that agent.

The same request from a normal session that declares `appVersion: "0.5.1"`, against the same daemon, at the same moment:

```
wks_773629199ca2f0a8 -> 1 target ["7210034d"]
```

Starting a `claude` agent and asking the same plugin RPC returned it immediately, which isolates the deciding factor to the provider id:

```
targets: [{"agentId":"fcc98822-…","provider":"claude","model":"claude-opus-5","status":"idle","scope":"workspace"}]
```

**After — patched the built daemon in place with exactly this change and `paseo plugin reload`, no daemon restart:**

```
wks_773629199ca2f0a8 -> [{"id":"7210034d","provider":"omp","scope":"workspace"}]
wks_33fe73f611f12430 -> [{"id":"7210034d","provider":"omp","scope":"directory"}]
```

Then the full plugin flow end to end on that daemon — the handler read the target's transcript, created a parented side agent, and answered:

```
after ask: running | messages: 1 | side: null
final status: idle | side agent: a91e9a45
  QUESTION: What port does config.js define? One line.
  ANSWER: config.js defines `PORT = 3000`.
```

**Automated:**

- `npx vitest run packages/server/src/server/plugins/plugin-paseo-api.e2e.test.ts` → 3 passed.
- Same file with the `appVersion` line deleted → the new test fails on the `agentIds` assertion, 1 failed / 2 skipped. So the test genuinely covers the regression rather than passing incidentally.
- `npx vitest run packages/server/src/server/plugins` → 7 files, 46 passed.
- `npm run typecheck`, `npm run lint`, `npm run format` all clean (also enforced by the pre-commit hook on this commit).

No UI surface changed, so there are no screenshots to attach.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

### Note on the test gap

`createTestAgentClients()` fakes exactly `claude`, `codex`, and `opencode` — the three ids the legacy allow-list permits — so no existing plugin test could observe this. I added `createTestAgentClient(provider)` so a test can register one fake for any provider id, and used it to register `pi`. Happy to fold it into `createTestAgentClients` as an options argument instead if you prefer that shape.

Exempting the reserved `plugin:<id>` identity inside `isProviderVisibleToClient` would also fix it, and states the intent more directly. I went with the client-side declaration because it keeps the session logic untouched; say the word and I will switch.
