### PR TITLE
feat(app): render consecutive assistant images as a proportional gallery

### DIFF
--- a/packages/app/src/assistant-image/gallery.browser.test.tsx
+++ b/packages/app/src/assistant-image/gallery.browser.test.tsx
@@ -1,0 +1,93 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { View } from "react-native";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssistantImageGallery } from "./gallery";
+import {
+  ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT,
+  ASSISTANT_IMAGE_GALLERY_MAX_WIDTH,
+  constrainAssistantImageSize,
+} from "./layout";
+
+interface MountedGallery {
+  root: Root;
+  container: HTMLDivElement;
+}
+
+const mountedGalleries: MountedGallery[] = [];
+const paragraphStyle = { width: "100%", flexDirection: "row" } as const;
+const previewSizes = [
+  constrainAssistantImageSize({
+    intrinsic: { width: 1200, height: 600 },
+    maxWidth: ASSISTANT_IMAGE_GALLERY_MAX_WIDTH,
+    maxHeight: ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT,
+  }),
+  constrainAssistantImageSize({
+    intrinsic: { width: 390, height: 844 },
+    maxWidth: ASSISTANT_IMAGE_GALLERY_MAX_WIDTH,
+    maxHeight: ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT,
+  }),
+  constrainAssistantImageSize({
+    intrinsic: { width: 100, height: 50 },
+    maxWidth: ASSISTANT_IMAGE_GALLERY_MAX_WIDTH,
+    maxHeight: ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT,
+  }),
+] as const;
+
+function mountGallery(): HTMLDivElement {
+  const container = document.createElement("div");
+  container.style.width = "360px";
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <AssistantImageGallery paragraphStyle={paragraphStyle}>
+        <View testID="gallery-image-1" style={previewSizes[0]} />
+        <View testID="gallery-image-2" style={previewSizes[1]} />
+        <View testID="gallery-image-3" style={previewSizes[2]} />
+      </AssistantImageGallery>,
+    );
+  });
+  mountedGalleries.push({ root, container });
+  return container;
+}
+
+beforeEach(() => vi.stubGlobal("React", React));
+
+afterEach(() => {
+  for (const mounted of mountedGalleries.splice(0)) {
+    act(() => mounted.root.unmount());
+    mounted.container.remove();
+  }
+  vi.unstubAllGlobals();
+});
+
+describe("assistant image gallery", () => {
+  it("top-aligns mixed aspect ratios at intrinsic constrained sizes in one scrollable row", () => {
+    const container = mountGallery();
+    const gallery = container.querySelector('[data-testid="assistant-image-gallery"]');
+
+    expect(gallery).toBeInstanceOf(HTMLElement);
+    if (!(gallery instanceof HTMLElement)) {
+      throw new Error("Assistant image gallery did not render");
+    }
+    const images = container.querySelectorAll<HTMLElement>('[data-testid^="gallery-image-"]');
+    const imageRects = Array.from(images, (image) => image.getBoundingClientRect());
+    expect(images).toHaveLength(3);
+    expect(imageRects[0]?.width).toBe(320);
+    expect(imageRects[0]?.height).toBe(160);
+    expect(imageRects[1]?.width).toBeCloseTo(148, 0);
+    expect(imageRects[1]?.height).toBe(320);
+    expect(imageRects[2]?.width).toBe(100);
+    expect(imageRects[2]?.height).toBe(50);
+    expect(imageRects.map((rect) => rect.top)).toEqual([
+      imageRects[0]?.top,
+      imageRects[0]?.top,
+      imageRects[0]?.top,
+    ]);
+    expect(gallery.scrollWidth).toBeGreaterThan(gallery.clientWidth);
+
+    gallery.scrollLeft = 120;
+    expect(gallery.scrollLeft).toBe(120);
+  });
+});

--- a/packages/app/src/assistant-image/gallery.tsx
+++ b/packages/app/src/assistant-image/gallery.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { ScrollView, type ViewStyle } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import { MarkdownParagraphView } from "@/components/markdown-text";
+
+export function AssistantImageGallery({
+  children,
+  paragraphStyle,
+}: {
+  children: ReactNode[];
+  paragraphStyle: ViewStyle;
+}) {
+  return (
+    <MarkdownParagraphView paragraphStyle={paragraphStyle} containsImage>
+      <ScrollView
+        horizontal
+        nestedScrollEnabled
+        showsHorizontalScrollIndicator={false}
+        style={styles.viewport}
+        contentContainerStyle={styles.content}
+        testID="assistant-image-gallery"
+      >
+        {children}
+      </ScrollView>
+    </MarkdownParagraphView>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  viewport: {
+    flex: 1,
+    minWidth: 0,
+  },
+  content: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: theme.spacing[3],
+    paddingRight: theme.spacing[1],
+  },
+}));

--- a/packages/app/src/assistant-image/layout.test.ts
+++ b/packages/app/src/assistant-image/layout.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT,
+  ASSISTANT_IMAGE_GALLERY_MAX_WIDTH,
+  constrainAssistantImageSize,
+  isAssistantImageGalleryParagraph,
+} from "./layout";
+
+describe("assistant image layout", () => {
+  it("groups image-only paragraphs containing multiple images", () => {
+    expect(
+      isAssistantImageGalleryParagraph({
+        children: [{ type: "image" }, { type: "softbreak" }, { type: "image" }, { type: "image" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps single images and mixed prose on the normal markdown path", () => {
+    expect(isAssistantImageGalleryParagraph({ children: [{ type: "image" }] })).toBe(false);
+    expect(
+      isAssistantImageGalleryParagraph({
+        children: [{ type: "text", content: "Screenshots:" }, { type: "image" }, { type: "image" }],
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    {
+      label: "wide",
+      intrinsic: { width: 1200, height: 600 },
+      expected: { width: 320, height: 160 },
+    },
+    {
+      label: "tall",
+      intrinsic: { width: 390, height: 844 },
+      expected: { width: 148, height: 320 },
+    },
+    {
+      label: "small",
+      intrinsic: { width: 100, height: 50 },
+      expected: { width: 100, height: 50 },
+    },
+  ])("fits $label images without cropping or upscaling", ({ intrinsic, expected }) => {
+    const size = constrainAssistantImageSize({
+      intrinsic,
+      maxWidth: ASSISTANT_IMAGE_GALLERY_MAX_WIDTH,
+      maxHeight: ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT,
+    });
+    expect(size.width).toBeCloseTo(expected.width, 0);
+    expect(size.height).toBeCloseTo(expected.height, 0);
+  });
+});

--- a/packages/app/src/assistant-image/layout.test.ts
+++ b/packages/app/src/assistant-image/layout.test.ts
@@ -10,7 +10,13 @@ describe("assistant image layout", () => {
   it("groups image-only paragraphs containing multiple images", () => {
     expect(
       isAssistantImageGalleryParagraph({
-        children: [{ type: "image" }, { type: "softbreak" }, { type: "image" }, { type: "image" }],
+        children: [
+          { type: "image" },
+          { type: "textgroup", children: [{ type: "text", content: " " }] },
+          { type: "image" },
+          { type: "softbreak" },
+          { type: "image" },
+        ],
       }),
     ).toBe(true);
   });
@@ -19,7 +25,16 @@ describe("assistant image layout", () => {
     expect(isAssistantImageGalleryParagraph({ children: [{ type: "image" }] })).toBe(false);
     expect(
       isAssistantImageGalleryParagraph({
-        children: [{ type: "text", content: "Screenshots:" }, { type: "image" }, { type: "image" }],
+        children: [
+          {
+            type: "inline",
+            children: [
+              { type: "text", content: "Screenshots:" },
+              { type: "image" },
+              { type: "image" },
+            ],
+          },
+        ],
       }),
     ).toBe(false);
   });

--- a/packages/app/src/assistant-image/layout.ts
+++ b/packages/app/src/assistant-image/layout.ts
@@ -37,11 +37,12 @@ export function constrainAssistantImageSize(input: {
 export function isAssistantImageGalleryParagraph(
   node: AssistantImageAstNode | null | undefined,
 ): boolean {
-  const children = node?.children;
-  if (!Array.isArray(children)) {
-    return false;
-  }
+  const imageCount = countImageOnlyChildren(node?.children);
+  return imageCount !== null && imageCount > 1;
+}
 
+function countImageOnlyChildren(children: AssistantImageAstNode[] | undefined): number | null {
+  if (!Array.isArray(children)) return null;
   let imageCount = 0;
   for (const child of children) {
     if (child.type === "image") {
@@ -50,9 +51,11 @@ export function isAssistantImageGalleryParagraph(
     }
     const isWhitespaceText = child.type === "text" && !child.content?.trim();
     const isLineBreak = child.type === "softbreak" || child.type === "hardbreak";
-    if (!isWhitespaceText && !isLineBreak) {
-      return false;
-    }
+    if (isWhitespaceText || isLineBreak) continue;
+    if (child.type !== "inline" && child.type !== "textgroup") return null;
+    const nestedImageCount = countImageOnlyChildren(child.children);
+    if (nestedImageCount === null) return null;
+    imageCount += nestedImageCount;
   }
-  return imageCount > 1;
+  return imageCount;
 }

--- a/packages/app/src/assistant-image/layout.ts
+++ b/packages/app/src/assistant-image/layout.ts
@@ -1,0 +1,58 @@
+import { MAX_CONTENT_WIDTH } from "@/constants/layout";
+
+export const ASSISTANT_IMAGE_GALLERY_MAX_WIDTH = 320;
+export const ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT = 320;
+export const ASSISTANT_IMAGE_STANDALONE_MAX_WIDTH = MAX_CONTENT_WIDTH - 8;
+export const ASSISTANT_IMAGE_STANDALONE_MAX_HEIGHT = 560;
+export const ASSISTANT_IMAGE_LOADING_WIDTH = 240;
+export const ASSISTANT_IMAGE_LOADING_HEIGHT = 160;
+
+export interface AssistantImageDimensions {
+  width: number;
+  height: number;
+}
+
+interface AssistantImageAstNode {
+  children?: AssistantImageAstNode[];
+  content?: string;
+  type?: string;
+}
+
+export function constrainAssistantImageSize(input: {
+  intrinsic: AssistantImageDimensions;
+  maxWidth: number;
+  maxHeight: number;
+}): AssistantImageDimensions {
+  const scale = Math.min(
+    1,
+    input.maxWidth / input.intrinsic.width,
+    input.maxHeight / input.intrinsic.height,
+  );
+  return {
+    width: input.intrinsic.width * scale,
+    height: input.intrinsic.height * scale,
+  };
+}
+
+export function isAssistantImageGalleryParagraph(
+  node: AssistantImageAstNode | null | undefined,
+): boolean {
+  const children = node?.children;
+  if (!Array.isArray(children)) {
+    return false;
+  }
+
+  let imageCount = 0;
+  for (const child of children) {
+    if (child.type === "image") {
+      imageCount += 1;
+      continue;
+    }
+    const isWhitespaceText = child.type === "text" && !child.content?.trim();
+    const isLineBreak = child.type === "softbreak" || child.type === "hardbreak";
+    if (!isWhitespaceText && !isLineBreak) {
+      return false;
+    }
+  }
+  return imageCount > 1;
+}

--- a/packages/app/src/components/attachment-lightbox.tsx
+++ b/packages/app/src/components/attachment-lightbox.tsx
@@ -16,18 +16,28 @@ interface AttachmentLightboxProps {
 }
 
 export function AttachmentLightbox({ metadata, onClose }: AttachmentLightboxProps) {
+  const url = useAttachmentPreviewUrl(metadata);
+  return <ImageLightbox visible={metadata !== null} uri={url} onClose={onClose} />;
+}
+
+interface ImageLightboxProps {
+  visible: boolean;
+  uri: string | null;
+  onClose: () => void;
+}
+
+export function ImageLightbox({ visible, uri, onClose }: ImageLightboxProps) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
-  const url = useAttachmentPreviewUrl(metadata);
   const [errored, setErrored] = useState(false);
 
   useEffect(() => {
     setErrored(false);
-  }, [metadata?.id]);
+  }, [uri]);
 
   useEffect(() => {
-    if (!isWeb || !metadata) return;
+    if (!isWeb || !visible) return;
     function handleKeydown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         onClose();
@@ -37,7 +47,7 @@ export function AttachmentLightbox({ metadata, onClose }: AttachmentLightboxProp
     return () => {
       window.removeEventListener("keydown", handleKeydown);
     };
-  }, [metadata, onClose]);
+  }, [onClose, visible]);
 
   const closeButtonRowStyle = useMemo(
     () => [
@@ -55,13 +65,13 @@ export function AttachmentLightbox({ metadata, onClose }: AttachmentLightboxProp
 
   const handleImageError = useCallback(() => setErrored(true), []);
   const noopPress = useCallback(() => {}, []);
-  const imageSource = useMemo(() => ({ uri: url ?? "" }), [url]);
+  const imageSource = useMemo(() => ({ uri: uri ?? "" }), [uri]);
 
-  if (!metadata) {
+  if (!visible) {
     return null;
   }
 
-  const hasError = errored || !url;
+  const hasError = errored || !uri;
 
   return (
     <Modal transparent animationType="fade" statusBarTranslucent visible onRequestClose={onClose}>

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -83,6 +83,7 @@ import { writeMarkdownToRichClipboard } from "@/utils/rich-clipboard";
 import { getDefaultMarkdownClipboardEnvironment } from "@/utils/rich-clipboard-default-environment";
 import { setAssistantMarkdownBlockHeight } from "@/utils/assistant-message-height-estimate";
 import { isRenderProfileEnabled } from "@/utils/render-profiler";
+import { peekAssistantImageMetadata } from "@/utils/assistant-image-metadata";
 import { getAgentAttachmentPillContent } from "@/attachments/attachment-pill-content";
 import { PlanCard } from "./plan-card";
 import { useToolCallSheet } from "./tool-call-sheet";
@@ -98,12 +99,23 @@ import {
 } from "@/assistant-file-links";
 import { getCompactionMarkerLabel } from "./message-compaction-label";
 import { useAssistantImage } from "@/assistant-image/use-assistant-image";
+import { AssistantImageGallery } from "@/assistant-image/gallery";
+import {
+  ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT,
+  ASSISTANT_IMAGE_GALLERY_MAX_WIDTH,
+  ASSISTANT_IMAGE_LOADING_HEIGHT,
+  ASSISTANT_IMAGE_LOADING_WIDTH,
+  ASSISTANT_IMAGE_STANDALONE_MAX_HEIGHT,
+  ASSISTANT_IMAGE_STANDALONE_MAX_WIDTH,
+  constrainAssistantImageSize,
+  isAssistantImageGalleryParagraph,
+} from "@/assistant-image/layout";
 import {
   AttachmentFrame,
   AttachmentLabel,
   AttachmentThumbnail,
 } from "@/components/attachment-pill";
-import { AttachmentLightbox } from "@/components/attachment-lightbox";
+import { AttachmentLightbox, ImageLightbox } from "@/components/attachment-lightbox";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { isWeb, isNative } from "@/constants/platform";
 import type { AgentCapabilityFlags } from "@getpaseo/protocol/agent-types";
@@ -762,8 +774,18 @@ export const assistantMessageStylesheet = StyleSheet.create((theme) => ({
   },
   imageFrame: {
     width: "100%",
-    minHeight: 160,
     marginHorizontal: -theme.spacing[1],
+  },
+  imageGalleryFrame: {
+    flexShrink: 0,
+  },
+  imageGallerySurface: {
+    overflow: "hidden",
+    position: "relative",
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface1,
   },
   imageSurface: {
     width: "100%",
@@ -797,13 +819,15 @@ export const assistantMessageStylesheet = StyleSheet.create((theme) => ({
   },
 }));
 
-const ASSISTANT_IMAGE_MIN_HEIGHT = 160;
+type AssistantImagePresentation = "full" | "gallery";
 
 function AssistantMarkdownImage({
   source,
   occurrenceKey,
   alt,
   hasLeadingContent,
+  presentation,
+  onOpenPreview,
   client,
   workspaceRoot,
   serverId,
@@ -812,16 +836,19 @@ function AssistantMarkdownImage({
   occurrenceKey: string;
   alt?: string;
   hasLeadingContent: boolean;
+  presentation: AssistantImagePresentation;
+  onOpenPreview: (uri: string) => void;
   client?: DaemonClient | null;
   workspaceRoot?: string;
   serverId?: string;
 }) {
+  const { t } = useTranslation();
   const containerStyle = useMemo<StyleProp<ViewStyle>>(
     () => ({
-      marginTop: hasLeadingContent ? 16 : 0,
+      marginTop: presentation === "full" && hasLeadingContent ? 16 : 0,
       marginBottom: 0,
     }),
-    [hasLeadingContent],
+    [hasLeadingContent, presentation],
   );
   const image = useAssistantImage({
     source,
@@ -832,32 +859,87 @@ function AssistantMarkdownImage({
   });
   const binding = image.status === "failed" ? null : image.binding;
   const aspectRatio = image.status === "failed" ? null : image.aspectRatio;
+  const metadata = peekAssistantImageMetadata({ source, workspaceRoot, serverId });
+  const metadataWidth = metadata?.width ?? null;
+  const metadataHeight = metadata?.height ?? null;
+  const constrainedSize = useMemo(() => {
+    if (metadataWidth === null || metadataHeight === null) {
+      return null;
+    }
+    return constrainAssistantImageSize({
+      intrinsic: { width: metadataWidth, height: metadataHeight },
+      maxWidth:
+        presentation === "gallery"
+          ? ASSISTANT_IMAGE_GALLERY_MAX_WIDTH
+          : ASSISTANT_IMAGE_STANDALONE_MAX_WIDTH,
+      maxHeight:
+        presentation === "gallery"
+          ? ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT
+          : ASSISTANT_IMAGE_STANDALONE_MAX_HEIGHT,
+    });
+  }, [metadataHeight, metadataWidth, presentation]);
   const imageUri = binding?.uri ?? "";
   const imageSource = useMemo(() => ({ uri: imageUri }), [imageUri]);
   const frameStyle = useMemo<StyleProp<ViewStyle>>(
-    () => [assistantMessageStylesheet.imageFrame, containerStyle],
-    [containerStyle],
+    () =>
+      presentation === "gallery"
+        ? [
+            assistantMessageStylesheet.imageGalleryFrame,
+            constrainedSize ?? {
+              width: ASSISTANT_IMAGE_LOADING_WIDTH,
+              height: ASSISTANT_IMAGE_LOADING_HEIGHT,
+            },
+            containerStyle,
+          ]
+        : [assistantMessageStylesheet.imageFrame, containerStyle],
+    [constrainedSize, containerStyle, presentation],
   );
   const imageSizeStyle = useMemo<ViewStyle>(() => {
+    if (constrainedSize && aspectRatio) {
+      return presentation === "gallery"
+        ? constrainedSize
+        : { width: constrainedSize.width, maxWidth: "100%", aspectRatio };
+    }
     if (aspectRatio) {
       return { aspectRatio };
     }
-    return { height: ASSISTANT_IMAGE_MIN_HEIGHT };
-  }, [aspectRatio]);
+    return { height: ASSISTANT_IMAGE_LOADING_HEIGHT };
+  }, [aspectRatio, constrainedSize, presentation]);
   const surfaceStyle = useMemo<StyleProp<ViewStyle>>(
-    () => [assistantMessageStylesheet.imageSurface, imageSizeStyle],
-    [imageSizeStyle],
+    () => [
+      presentation === "gallery"
+        ? assistantMessageStylesheet.imageGallerySurface
+        : assistantMessageStylesheet.imageSurface,
+      imageSizeStyle,
+    ],
+    [imageSizeStyle, presentation],
   );
 
   const stateFrameStyle = useMemo<StyleProp<ViewStyle>>(
     () => [
-      assistantMessageStylesheet.imageFrame,
+      presentation === "gallery"
+        ? assistantMessageStylesheet.imageGalleryFrame
+        : assistantMessageStylesheet.imageFrame,
       containerStyle,
-      { height: ASSISTANT_IMAGE_MIN_HEIGHT },
+      presentation === "gallery"
+        ? {
+            width: constrainedSize?.width ?? ASSISTANT_IMAGE_LOADING_WIDTH,
+            height: constrainedSize?.height ?? ASSISTANT_IMAGE_LOADING_HEIGHT,
+          }
+        : { height: ASSISTANT_IMAGE_LOADING_HEIGHT },
       assistantMessageStylesheet.imageState,
     ],
-    [containerStyle],
+    [constrainedSize, containerStyle, presentation],
   );
+
+  const handleOpenPreview = useCallback(() => {
+    if (binding?.uri) {
+      onOpenPreview(binding.uri);
+    }
+  }, [binding?.uri, onOpenPreview]);
+  const previewAccessibilityLabel = alt
+    ? `${t("composer.attachments.openImage")}: ${alt}`
+    : t("composer.attachments.openImage");
 
   if (image.status === "failed") {
     return (
@@ -877,7 +959,13 @@ function AssistantMarkdownImage({
 
   return (
     <View style={frameStyle}>
-      <View style={surfaceStyle} accessibilityRole="image" accessibilityLabel={alt}>
+      <Pressable
+        testID="assistant-image-preview"
+        onPress={handleOpenPreview}
+        accessibilityRole="button"
+        accessibilityLabel={previewAccessibilityLabel}
+        style={surfaceStyle}
+      >
         <Image
           ref={binding.onRef}
           source={imageSource}
@@ -891,7 +979,7 @@ function AssistantMarkdownImage({
             <ThemedLoadingSpinner size="small" uniProps={foregroundMutedColorMapping} />
           </View>
         ) : null}
-      </View>
+      </Pressable>
     </View>
   );
 }
@@ -1464,6 +1552,9 @@ export const AssistantMessage = memo(function AssistantMessage({
   // Paint a paced prefix while the turn is streaming so text arrives at a steady
   // rate instead of in whatever lumps the daemon's coalescing window produced.
   const revealedMessage = useRevealedText(message, phase);
+  const [lightboxUri, setLightboxUri] = useState<string | null>(null);
+  const openImagePreview = useStableEvent((uri: string) => setLightboxUri(uri));
+  const closeImagePreview = useCallback(() => setLightboxUri(null), []);
 
   const fileLinkActions = useAssistantFileLinkActions();
   const handleMarkdownLinkPress = useStableEvent((url: string) => {
@@ -1853,15 +1944,24 @@ export const AssistantMessage = memo(function AssistantMessage({
         children: ReactNode[],
         _parent: ASTNode[],
         styles: MarkdownStyles,
-      ) => (
-        <MarkdownParagraphView
-          key={node.key}
-          paragraphStyle={styles.paragraph}
-          containsImage={markdownNodeContainsType(node, "image")}
-        >
-          {children}
-        </MarkdownParagraphView>
-      ),
+      ) => {
+        if (isAssistantImageGalleryParagraph(node)) {
+          return (
+            <AssistantImageGallery key={node.key} paragraphStyle={styles.paragraph}>
+              {children}
+            </AssistantImageGallery>
+          );
+        }
+        return (
+          <MarkdownParagraphView
+            key={node.key}
+            paragraphStyle={styles.paragraph}
+            containsImage={markdownNodeContainsType(node, "image")}
+          >
+            {children}
+          </MarkdownParagraphView>
+        );
+      },
       link: (node: ASTNode, children: ReactNode[], _parent: ASTNode[], styles: MarkdownStyles) => (
         <AssistantMarkdownLink
           key={node.key}
@@ -1885,6 +1985,7 @@ export const AssistantMessage = memo(function AssistantMessage({
           : [];
         const imageIndex = paragraphChildren.findIndex((child: ASTNode) => child?.key === node.key);
         const hasLeadingContent = imageIndex > 0;
+        const presentation = isAssistantImageGalleryParagraph(paragraphNode) ? "gallery" : "full";
 
         return (
           <AssistantMarkdownImage
@@ -1893,6 +1994,8 @@ export const AssistantMessage = memo(function AssistantMessage({
             occurrenceKey={`${occurrenceKey}:${node.key}`}
             alt={typeof node.attributes?.alt === "string" ? node.attributes.alt : undefined}
             hasLeadingContent={hasLeadingContent}
+            presentation={presentation}
+            onOpenPreview={openImagePreview}
             client={client}
             workspaceRoot={workspaceRoot}
             serverId={serverId}
@@ -1900,7 +2003,16 @@ export const AssistantMessage = memo(function AssistantMessage({
         );
       },
     };
-  }, [client, fileLinkActions, markdownParser, occurrenceKey, phase, serverId, workspaceRoot]);
+  }, [
+    client,
+    fileLinkActions,
+    markdownParser,
+    occurrenceKey,
+    openImagePreview,
+    phase,
+    serverId,
+    workspaceRoot,
+  ]);
 
   const blocks = useMemo(() => splitMarkdownBlocks(revealedMessage), [revealedMessage]);
   const keyedBlocks = useMemo(
@@ -1927,22 +2039,25 @@ export const AssistantMessage = memo(function AssistantMessage({
   );
 
   return (
-    <View testID="assistant-message" dataSet={revealDataSet} style={assistantContainerStyle}>
-      {keyedBlocks.map(({ key, block }, index) => (
-        <AssistantMessageBlockContainer
-          key={key}
-          block={block}
-          marginBottom={index < keyedBlocks.length - 1 ? 12 : 0}
-        >
-          <MemoizedMarkdownBlock
-            text={block}
-            rules={markdownRules}
-            parser={markdownParser}
-            onLinkPress={handleMarkdownLinkPress}
-          />
-        </AssistantMessageBlockContainer>
-      ))}
-    </View>
+    <>
+      <View testID="assistant-message" dataSet={revealDataSet} style={assistantContainerStyle}>
+        {keyedBlocks.map(({ key, block }, index) => (
+          <AssistantMessageBlockContainer
+            key={key}
+            block={block}
+            marginBottom={index < keyedBlocks.length - 1 ? 12 : 0}
+          >
+            <MemoizedMarkdownBlock
+              text={block}
+              rules={markdownRules}
+              parser={markdownParser}
+              onLinkPress={handleMarkdownLinkPress}
+            />
+          </AssistantMessageBlockContainer>
+        ))}
+      </View>
+      <ImageLightbox visible={lightboxUri !== null} uri={lightboxUri} onClose={closeImagePreview} />
+    </>
   );
 });
 

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -780,12 +780,7 @@ export const assistantMessageStylesheet = StyleSheet.create((theme) => ({
     flexShrink: 0,
   },
   imageGallerySurface: {
-    overflow: "hidden",
     position: "relative",
-    borderRadius: theme.borderRadius.lg,
-    borderWidth: theme.borderWidth[1],
-    borderColor: theme.colors.border,
-    backgroundColor: theme.colors.surface1,
   },
   imageSurface: {
     width: "100%",

--- a/packages/app/src/utils/assistant-image-metadata.test.ts
+++ b/packages/app/src/utils/assistant-image-metadata.test.ts
@@ -66,4 +66,31 @@ describe("assistant image metadata", () => {
     expect(imageOnlyHeight).toBeGreaterThan(220);
     expect(mixedHeight).toBeGreaterThan(imageOnlyHeight ?? 0);
   });
+
+  it("estimates multiple image-only outputs as one horizontal gallery", () => {
+    const markdown = [
+      "![First](https://example.com/first.png)",
+      "![Second](https://example.com/second.png)",
+      "![Third](https://example.com/third.png)",
+    ].join("");
+
+    expect(estimateAssistantMessageHeightFromCache(markdown)).toBe(224);
+  });
+
+  it("uses the tallest constrained image for a mixed gallery estimate", () => {
+    const images = [
+      { source: "https://example.com/wide.png", width: 1200, height: 600 },
+      { source: "https://example.com/tall.png", width: 390, height: 844 },
+      { source: "https://example.com/small.png", width: 100, height: 50 },
+    ];
+    for (const image of images) {
+      setAssistantImageMetadata(
+        { source: image.source },
+        { width: image.width, height: image.height },
+      );
+    }
+
+    const markdown = images.map((image, index) => `![Mixed ${index}](${image.source})`).join("");
+    expect(estimateAssistantMessageHeightFromCache(markdown)).toBe(384);
+  });
 });

--- a/packages/app/src/utils/assistant-image-metadata.ts
+++ b/packages/app/src/utils/assistant-image-metadata.ts
@@ -1,4 +1,11 @@
-import { MAX_CONTENT_WIDTH } from "@/constants/layout";
+import {
+  ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT,
+  ASSISTANT_IMAGE_GALLERY_MAX_WIDTH,
+  ASSISTANT_IMAGE_LOADING_HEIGHT,
+  ASSISTANT_IMAGE_STANDALONE_MAX_HEIGHT,
+  ASSISTANT_IMAGE_STANDALONE_MAX_WIDTH,
+  constrainAssistantImageSize,
+} from "@/assistant-image/layout";
 import { resolveAssistantImageSource } from "@/utils/assistant-image-source";
 import { createImageSourceCacheKey } from "@/attachments/utils";
 
@@ -14,8 +21,6 @@ const ASSISTANT_IMAGE_METADATA_CACHE_LIMIT = 500;
 const ASSISTANT_IMAGE_PARSE_CACHE_LIMIT = 500;
 
 const MARKDOWN_IMAGE_PATTERN = /!\[[^\]]*]\((<[^>]+>|[^)\n]+)\)/g;
-const ASSISTANT_IMAGE_ESTIMATE_WIDTH = MAX_CONTENT_WIDTH - 8;
-const ASSISTANT_IMAGE_MIN_HEIGHT = 160;
 const ASSISTANT_IMAGE_BLOCK_GAP = 24;
 const ASSISTANT_MESSAGE_BASE_HEIGHT = 96;
 const ASSISTANT_MESSAGE_MIN_HEIGHT = 220;
@@ -126,6 +131,20 @@ export function getAssistantImageMetadata(input: {
   return null;
 }
 
+export function peekAssistantImageMetadata(input: {
+  source: string;
+  workspaceRoot?: string;
+  serverId?: string;
+}): AssistantImageMetadata | null {
+  for (const key of getAssistantImageMetadataKeys(input)) {
+    const metadata = assistantImageMetadataCache.get(key);
+    if (metadata) {
+      return metadata;
+    }
+  }
+  return null;
+}
+
 export function setAssistantImageMetadata(
   input: {
     source: string;
@@ -183,13 +202,35 @@ export function estimateAssistantMessageHeightFromCache(markdown: string): numbe
     return null;
   }
 
+  if (!parsed.hasNonImageText && parsed.sources.length > 1) {
+    const galleryHeights = parsed.sources.map((source) => {
+      const metadata = getAssistantImageMetadata({ source });
+      if (!metadata) {
+        return ASSISTANT_IMAGE_LOADING_HEIGHT;
+      }
+      return constrainAssistantImageSize({
+        intrinsic: metadata,
+        maxWidth: ASSISTANT_IMAGE_GALLERY_MAX_WIDTH,
+        maxHeight: ASSISTANT_IMAGE_GALLERY_MAX_HEIGHT,
+      }).height;
+    });
+    return (
+      ASSISTANT_MESSAGE_IMAGE_ONLY_BASE_HEIGHT +
+      Math.round(Math.max(...galleryHeights)) +
+      ASSISTANT_IMAGE_BLOCK_GAP
+    );
+  }
+
   const knownHeights = parsed.sources
     .map((source) => getAssistantImageMetadata({ source }))
     .filter((metadata): metadata is AssistantImageMetadata => metadata !== null)
     .map((metadata) =>
-      Math.max(
-        ASSISTANT_IMAGE_MIN_HEIGHT,
-        Math.round(ASSISTANT_IMAGE_ESTIMATE_WIDTH / metadata.aspectRatio),
+      Math.round(
+        constrainAssistantImageSize({
+          intrinsic: metadata,
+          maxWidth: ASSISTANT_IMAGE_STANDALONE_MAX_WIDTH,
+          maxHeight: ASSISTANT_IMAGE_STANDALONE_MAX_HEIGHT,
+        }).height,
       ),
     );
 


### PR DESCRIPTION
### Linked issue

N/A — draft for product-direction review. Link the relevant product discussion before marking ready.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Agents regularly return several screenshots while working on iOS apps. Today, every screenshot is rendered as a full-width block. When one response contains multiple images, the conversation becomes very long, and it is difficult to inspect or compare those screenshots within the available conversation canvas.

This enhancement makes a subtle presentation adjustment: consecutive image-only assistant output renders as one horizontal gallery. Each image keeps its intrinsic aspect ratio, scales down to fit a 320×320 bound, and is never cropped or enlarged. Single images and images mixed with prose keep the existing block layout. Selecting an image opens the existing lightbox.

### Goals

- Group consecutive image-only assistant output into one horizontal, non-wrapping gallery.
- Preserve source order and top-align mixed aspect ratios.
- Scale large images down proportionally without enlarging small images.
- Keep image previews clickable without adding a second lightbox implementation.
- Keep virtualized timeline estimates aligned with rendered gallery height.

### Non-goals

- No provider, protocol, or attachment-storage changes.
- No changes to composer or user-message attachments.
- No grouping when prose appears in the same paragraph.
- No cropping, masonry layout, pagination, or image reordering.

### QA

Automated:

- `npx vitest run packages/app/src/assistant-image/layout.test.ts packages/app/src/utils/assistant-image-metadata.test.ts packages/app/src/components/attachment-lightbox.test.tsx --bail=1` — 3 files, 18 tests passed.
- `npm run test:browser --workspace=@getpaseo/app -- src/assistant-image/gallery.browser.test.tsx --bail=1` — Chromium browser test passed.
- `npm run typecheck` — passed for every workspace.
- `npm run lint` — 0 warnings and 0 errors.
- `npm run format:check` — passed.
- `npm run build:web --workspace=@getpaseo/app` — production web export passed.
- `APP_VARIANT=development CI=1 npx expo export --platform ios` — iOS bundle export passed (5,790 modules).
- `APP_VARIANT=development CI=1 npx expo export --platform android` — Android bundle export passed (5,785 modules).

Manual web smoke against an isolated daemon and mock agent:

- Mixed `1200×600`, `390×844`, and `100×50` images rendered at `320×160`, `147.87×320`, and `100×50`.
- All three images shared the same top coordinate.
- A 560px viewport produced horizontal overflow without wrapping or cropping.
- Selecting the tall image opened exactly one lightbox; closing it restored the gallery.
- Browser console errors: none.

Screenshots:

Portrait-only images:

<img width="1200" height="900" alt="image" src="https://github.com/user-attachments/assets/2bd9097f-a9fc-4b68-92a9-b2541c24ee4c" />

Landscape-only images:

<img width="1200" height="900" alt="image" src="https://github.com/user-attachments/assets/b482f16c-970a-47f8-a803-3a9656707bef" />

Mixed portrait, landscape, and small images:

<img width="1200" height="900" alt="image" src="https://github.com/user-attachments/assets/7dfdf17b-2613-42b5-9661-f286f9846566" />

Platform coverage:

- Browser web: tested with production export at desktop and 560×900 viewports.
- Electron: not tested.
- iOS: native bundle export passed; simulator UI not tested.
- Android: native bundle export passed; emulator UI not tested.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence — native and Electron visual coverage remains
- [x] Tests added or updated where it made sense
