### PR TITLE
fix(desktop): calibrate browser element capture against guest viewport

### DIFF
--- a/packages/app/src/desktop/browser/pane/element-selector.electron.ts
+++ b/packages/app/src/desktop/browser/pane/element-selector.electron.ts
@@ -2,6 +2,8 @@ import type { BrowserElementAttachment } from "@/attachments/types";
 
 export type BrowserElementSelection = Omit<BrowserElementAttachment, "formatted" | "comment"> & {
   attributes?: Record<string, string>;
+  /** Marker stamped on the clicked node so capture re-measures the same element. */
+  captureId?: string;
 };
 
 export type ElementSelectorMode = "annotate" | "screenshot";
@@ -330,8 +332,12 @@ function buildElementSelectorScript(sessionToken: string): string {
           boundingRect: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) },
           reactSource: getReactSource(el),
           parentChain: getParentChain(el, 5),
-          children: getChildSummary(el, 8)
+          children: getChildSummary(el, 8),
+          captureId: sessionToken
         };
+        // Stamped so the capture flow re-measures this exact node at
+        // screenshot time; it removes the mark itself when it finishes.
+        el.setAttribute('data-paseo-capture-id', sessionToken);
         destroy();
         window.__paseoSelectorResult = result;
       }

--- a/packages/app/src/desktop/browser/pane/index.electron.tsx
+++ b/packages/app/src/desktop/browser/pane/index.electron.tsx
@@ -1088,7 +1088,12 @@ export function BrowserPane({
         return undefined;
       }
       try {
-        const dataUrl = await captureElement(browserIdRef.current, { x, y, width, height });
+        const dataUrl = await captureElement(
+          browserIdRef.current,
+          { x, y, width, height },
+          selection.selector,
+          selection.captureId,
+        );
         if (!dataUrl) {
           return undefined;
         }
@@ -1115,7 +1120,12 @@ export function BrowserPane({
       let imageDataUrl: string | undefined;
       if (typeof captureElement === "function" && width > 0 && height > 0) {
         try {
-          const dataUrl = await captureElement(browserIdRef.current, { x, y, width, height });
+          const dataUrl = await captureElement(
+            browserIdRef.current,
+            { x, y, width, height },
+            selection.selector,
+            selection.captureId,
+          );
           imageDataUrl = dataUrl ?? undefined;
         } catch (error) {
           console.warn("[browser-pane] capture element for screenshot failed", error);

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -159,10 +159,17 @@ export interface DesktopBrowserBridge {
   executeAutomationCommand?: (
     request: BrowserAutomationExecuteRequest,
   ) => Promise<BrowserAutomationExecuteResponse["payload"]>;
-  /** Capture a PNG screenshot of the guest viewport cropped to `rect`. */
+  /**
+   * Capture a PNG screenshot of the guest viewport cropped to `rect` (CSS
+   * pixels). `captureId` lets main re-measure the exact stamped element at
+   * capture time so a scroll between selection and capture cannot skew the
+   * crop; `selector` is the fallback lookup when the stamp is gone.
+   */
   captureElement?: (
     browserId: string,
     rect: { x: number; y: number; width: number; height: number },
+    selector?: string | null,
+    captureId?: string | null,
   ) => Promise<string | null>;
   /** Copy element text and/or an image to the system clipboard from main. */
   copyElement?: (payload: { text?: string; imageDataUrl?: string }) => Promise<boolean>;

--- a/packages/desktop/src/features/browser-capture.test.ts
+++ b/packages/desktop/src/features/browser-capture.test.ts
@@ -6,7 +6,12 @@ import {
 } from "./browser-capture.js";
 
 function image(dataUrl = "data:image/png;base64,capture"): BrowserCaptureImage {
-  return { isEmpty: () => false, toDataURL: () => dataUrl };
+  return {
+    isEmpty: () => false,
+    toDataURL: () => dataUrl,
+    getSize: () => ({ width: 100, height: 100 }),
+    crop: () => image(dataUrl),
+  };
 }
 
 function harness(guest: BrowserCaptureGuest | null = null) {
@@ -28,8 +33,18 @@ function harness(guest: BrowserCaptureGuest | null = null) {
 
 describe("browser capture service", () => {
   it("validates and rounds guest-relative bounds before capture", async () => {
-    const capturePage = vi.fn(async () => image());
-    const { service } = harness({ isDestroyed: () => false, capturePage });
+    const cropped = image("data:image/png;base64,cropped");
+    const frame = {
+      ...image(),
+      getSize: () => ({ width: 100, height: 100 }),
+      crop: vi.fn(() => cropped),
+    };
+    const capturePage = vi.fn(async () => frame);
+    // Viewport matches the frame, so the normalized rect crops 1:1.
+    const executeJavaScript = vi.fn(async () =>
+      JSON.stringify({ viewportWidth: 100, viewportHeight: 100, rect: null }),
+    );
+    const { service } = harness({ isDestroyed: () => false, capturePage, executeJavaScript });
 
     await expect(
       service.capture({
@@ -37,13 +52,72 @@ describe("browser capture service", () => {
         hostWebContentsId: 42,
         rect: { x: -2.4, y: 8.6, width: 20.2, height: 10.8 },
       }),
-    ).resolves.toBe("data:image/png;base64,capture");
-    expect(capturePage).toHaveBeenCalledWith({ x: 0, y: 9, width: 20, height: 11 });
+    ).resolves.toBe("data:image/png;base64,cropped");
+    expect(frame.crop).toHaveBeenCalledWith({ x: 0, y: 9, width: 20, height: 11 });
+  });
+
+  it("crops the full guest frame when the guest reports viewport metrics", async () => {
+    const cropped = image("data:image/png;base64,cropped");
+    const frame = {
+      ...image(),
+      getSize: () => ({ width: 200, height: 100 }),
+      crop: vi.fn(() => cropped),
+    };
+    const capturePage = vi.fn(async () => frame);
+    const executeJavaScript = vi.fn(async () =>
+      JSON.stringify({ viewportWidth: 100, viewportHeight: 100, rect: null }),
+    );
+    const { service } = harness({ isDestroyed: () => false, capturePage, executeJavaScript });
+
+    await expect(
+      service.capture({
+        browserId: "browser-1",
+        hostWebContentsId: 42,
+        rect: { x: 10, y: 10, width: 20, height: 20 },
+        selector: ".annotated",
+        captureId: "cap-1",
+      }),
+    ).resolves.toBe("data:image/png;base64,cropped");
+    expect(capturePage).toHaveBeenCalledWith();
+    expect(frame.crop).toHaveBeenCalledWith({ x: 20, y: 10, width: 40, height: 20 });
+    expect(executeJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining("data-paseo-capture-id"),
+    );
+  });
+
+  it("reports guest measurement failures through warn", async () => {
+    const capturePage = vi.fn(async () => image());
+    const executeJavaScript = vi.fn(async () => {
+      throw new Error("navigation in progress");
+    });
+    const { service, warn } = harness({
+      isDestroyed: () => false,
+      capturePage,
+      executeJavaScript,
+    });
+
+    await expect(
+      service.capture({
+        browserId: "browser-1",
+        hostWebContentsId: 42,
+        rect: { x: 10, y: 10, width: 20, height: 20 },
+      }),
+    ).resolves.toBeNull();
+    // No uncalibrated capture is attempted when the guest cannot be measured.
+    expect(capturePage).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith("measure-failed", {
+      browserId: "browser-1",
+      error: "navigation in progress",
+    });
   });
 
   it("rejects invalid or unavailable captures without touching the guest", async () => {
     const capturePage = vi.fn(async () => image());
-    const { service } = harness({ isDestroyed: () => false, capturePage });
+    const { service } = harness({
+      isDestroyed: () => false,
+      capturePage,
+      executeJavaScript: vi.fn(async () => undefined),
+    });
 
     await expect(
       service.capture({ browserId: "browser-1", hostWebContentsId: 42, rect: { width: 0 } }),

--- a/packages/desktop/src/features/browser-capture.ts
+++ b/packages/desktop/src/features/browser-capture.ts
@@ -1,18 +1,22 @@
+import {
+  captureElementScreenshot,
+  normalizeBrowserCaptureRect,
+  type BrowserCaptureRect,
+} from "./browser-webviews/capture-element.js";
+
+export type { BrowserCaptureRect };
+
 export interface BrowserCaptureImage {
   isEmpty(): boolean;
   toDataURL(): string;
+  getSize(): { width: number; height: number };
+  crop(rect: BrowserCaptureRect): BrowserCaptureImage;
 }
 
 export interface BrowserCaptureGuest<TImage extends BrowserCaptureImage = BrowserCaptureImage> {
   isDestroyed(): boolean;
-  capturePage(rect: BrowserCaptureRect): Promise<TImage>;
-}
-
-export interface BrowserCaptureRect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
+  capturePage(rect?: BrowserCaptureRect): Promise<TImage>;
+  executeJavaScript(code: string): Promise<unknown>;
 }
 
 interface BrowserCaptureClipboardPayload<TImage extends BrowserCaptureImage> {
@@ -28,7 +32,10 @@ interface BrowserCaptureDependencies<TImage extends BrowserCaptureImage> {
   findGuest(browserId: string, hostWebContentsId: number): BrowserCaptureGuest<TImage> | null;
   decodeImage(dataUrl: string): TImage;
   clipboard: BrowserCaptureClipboard<TImage>;
-  warn(event: "capture-failed" | "image-decode-failed", details: Record<string, unknown>): void;
+  warn(
+    event: "capture-failed" | "image-decode-failed" | "measure-failed",
+    details: Record<string, unknown>,
+  ): void;
 }
 
 export interface BrowserCaptureService {
@@ -36,29 +43,10 @@ export interface BrowserCaptureService {
     browserId: unknown;
     hostWebContentsId: number;
     rect: unknown;
+    selector?: unknown;
+    captureId?: unknown;
   }): Promise<string | null>;
   copy(payload: unknown): Promise<boolean>;
-}
-
-function captureRect(value: unknown): BrowserCaptureRect | null {
-  if (!value || typeof value !== "object") return null;
-  const record = value as Record<string, unknown>;
-  const coordinates = [record.x, record.y, record.width, record.height];
-  if (
-    !coordinates.every(
-      (coordinate) => typeof coordinate === "number" && Number.isFinite(coordinate),
-    )
-  ) {
-    return null;
-  }
-  const [x, y, width, height] = coordinates as number[];
-  if (width <= 0 || height <= 0) return null;
-  return {
-    x: Math.max(0, Math.round(x)),
-    y: Math.max(0, Math.round(y)),
-    width: Math.round(width),
-    height: Math.round(height),
-  };
 }
 
 function copyPayload(value: unknown): { text: string | null; imageDataUrl: string | null } {
@@ -77,14 +65,24 @@ export function createBrowserCaptureService<TImage extends BrowserCaptureImage>(
   dependencies: BrowserCaptureDependencies<TImage>,
 ): BrowserCaptureService {
   return {
-    async capture({ browserId, hostWebContentsId, rect }) {
+    async capture({ browserId, hostWebContentsId, rect, selector, captureId }) {
       if (typeof browserId !== "string" || browserId.trim().length === 0) return null;
       const guest = dependencies.findGuest(browserId, hostWebContentsId);
-      const bounds = captureRect(rect);
+      const bounds = normalizeBrowserCaptureRect(rect);
       if (!guest || guest.isDestroyed() || !bounds) return null;
+      const elementSelector = typeof selector === "string" && selector.trim() ? selector : null;
+      const elementCaptureId = typeof captureId === "string" && captureId.trim() ? captureId : null;
       try {
-        const image = await guest.capturePage(bounds);
-        return image.isEmpty() ? null : image.toDataURL();
+        // capturePage(rect) crops in a different coordinate space than
+        // getBoundingClientRect() whenever the display scale factor or page
+        // zoom is not 1; captureElementScreenshot calibrates against the
+        // guest viewport and never hands the CSS rect to capturePage.
+        return await captureElementScreenshot(guest, {
+          rect: bounds,
+          selector: elementSelector,
+          captureId: elementCaptureId,
+          warn: (error) => dependencies.warn("measure-failed", { browserId, error }),
+        });
       } catch (error) {
         dependencies.warn("capture-failed", { browserId, error });
         return null;

--- a/packages/desktop/src/features/browser-webviews/capture-element.test.ts
+++ b/packages/desktop/src/features/browser-webviews/capture-element.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  captureElementScreenshot,
+  normalizeBrowserCaptureRect,
+  type BrowserCaptureRect,
+} from "./capture-element.js";
+
+describe("normalizeBrowserCaptureRect", () => {
+  it("rounds and clamps a valid rect", () => {
+    expect(normalizeBrowserCaptureRect({ x: 10.4, y: -3.6, width: 100.5, height: 50.2 })).toEqual({
+      x: 10,
+      y: 0,
+      width: 101,
+      height: 50,
+    });
+  });
+
+  it("rejects non-finite or non-positive rects", () => {
+    expect(normalizeBrowserCaptureRect(null)).toBeNull();
+    expect(normalizeBrowserCaptureRect({ x: NaN, y: 0, width: 10, height: 10 })).toBeNull();
+    expect(normalizeBrowserCaptureRect({ x: 0, y: 0, width: 0, height: 10 })).toBeNull();
+    expect(normalizeBrowserCaptureRect({ x: 0, y: 0, width: "10", height: 10 })).toBeNull();
+  });
+});
+
+function metricsJson(input: {
+  viewportWidth: number;
+  viewportHeight: number;
+  rect?: { x: number; y: number; width: number; height: number } | null;
+  error?: string | null;
+}): string {
+  return JSON.stringify({ rect: null, error: null, ...input });
+}
+
+function makeGuest(options: {
+  measures?: Array<string | Error>;
+  frameSize?: { width: number; height: number };
+}) {
+  const measures = [...(options.measures ?? [])];
+  const frameSize = options.frameSize ?? { width: 2000, height: 1000 };
+  const scripts: string[] = [];
+  const captureArgs: Array<BrowserCaptureRect | undefined> = [];
+  const crops: BrowserCaptureRect[] = [];
+  const contents = {
+    executeJavaScript: vi.fn(async (code: string) => {
+      scripts.push(code);
+      const next = measures.length > 1 ? measures.shift() : measures[0];
+      if (next instanceof Error) {
+        throw next;
+      }
+      return next ?? null;
+    }),
+    capturePage: vi.fn(async (rect?: BrowserCaptureRect) => {
+      captureArgs.push(rect);
+      if (rect === undefined) {
+        return {
+          isEmpty: () => false,
+          getSize: () => frameSize,
+          crop: (crop: BrowserCaptureRect) => {
+            crops.push(crop);
+            return {
+              isEmpty: () => false,
+              getSize: () => ({ width: crop.width, height: crop.height }),
+              crop: () => null,
+              toDataURL: () => "data:image/png;base64,cropped",
+            };
+          },
+          toDataURL: () => "data:image/png;base64,full",
+        };
+      }
+      return {
+        isEmpty: () => false,
+        getSize: () => ({ width: rect.width, height: rect.height }),
+        crop: () => null,
+        toDataURL: () => "data:image/png;base64,legacy",
+      };
+    }),
+  };
+  return { contents, scripts, captureArgs, crops };
+}
+
+const INPUT_RECT = { x: 10, y: 20, width: 30, height: 40 };
+
+describe("captureElementScreenshot", () => {
+  it("crops the full frame with calibrated coordinates and prefers the fresh rect", async () => {
+    const guest = makeGuest({
+      measures: [
+        metricsJson({
+          viewportWidth: 1000,
+          viewportHeight: 500,
+          rect: { x: 10, y: 20, width: 30, height: 40 },
+        }),
+      ],
+    });
+    const dataUrl = await captureElementScreenshot(guest.contents as never, {
+      rect: { x: 0, y: 0, width: 999, height: 999 },
+      selector: "#target",
+    });
+    // Fresh rect wins over the stale requested rect, scaled by the 2x frame.
+    expect(dataUrl).toBe("data:image/png;base64,cropped");
+    expect(guest.crops).toEqual([{ x: 20, y: 40, width: 60, height: 80 }]);
+    expect(guest.captureArgs[0]).toBeUndefined();
+    expect(guest.scripts[0]).toContain("#target");
+  });
+
+  it("calibrates for page zoom on top of the device scale factor", async () => {
+    const guest = makeGuest({
+      measures: [metricsJson({ viewportWidth: 800, viewportHeight: 500 })],
+      frameSize: { width: 1250, height: 781.25 },
+    });
+    const dataUrl = await captureElementScreenshot(guest.contents as never, {
+      rect: { x: 80, y: 64, width: 160, height: 96 },
+      selector: null,
+    });
+    // Effective scale 1.5625 on both axes.
+    expect(dataUrl).toBe("data:image/png;base64,cropped");
+    expect(guest.crops).toEqual([{ x: 125, y: 100, width: 250, height: 150 }]);
+  });
+
+  it("clamps the crop to the frame for partially offscreen elements", async () => {
+    const guest = makeGuest({
+      measures: [
+        metricsJson({
+          viewportWidth: 1000,
+          viewportHeight: 500,
+          rect: { x: 900, y: 450, width: 300, height: 200 },
+        }),
+      ],
+    });
+    await captureElementScreenshot(guest.contents as never, {
+      rect: INPUT_RECT,
+      selector: "#edge",
+    });
+    expect(guest.crops).toEqual([{ x: 1800, y: 900, width: 200, height: 100 }]);
+  });
+
+  it("queries the element by its capture marker before the selector", async () => {
+    const guest = makeGuest({
+      measures: [metricsJson({ viewportWidth: 1000, viewportHeight: 500 })],
+    });
+    await captureElementScreenshot(guest.contents as never, {
+      rect: INPUT_RECT,
+      selector: "div:nth-of-type(2)",
+      captureId: "cap-9",
+    });
+    expect(guest.scripts[0]).toContain("data-paseo-capture-id");
+    expect(guest.scripts[0]).toContain('"cap-9"');
+    expect(guest.scripts[0]).toContain("div:nth-of-type(2)");
+    // The capture removes its own mark when it finishes.
+    expect(guest.scripts.at(-1)).toContain("removeAttribute");
+  });
+
+  it("re-measures and recaptures when the page moves during capture", async () => {
+    const moved = metricsJson({
+      viewportWidth: 1000,
+      viewportHeight: 500,
+      rect: { x: 50, y: 60, width: 30, height: 40 },
+    });
+    const guest = makeGuest({
+      measures: [
+        metricsJson({
+          viewportWidth: 1000,
+          viewportHeight: 500,
+          rect: { x: 10, y: 20, width: 30, height: 40 },
+        }),
+        moved,
+      ],
+    });
+    const dataUrl = await captureElementScreenshot(guest.contents as never, {
+      rect: INPUT_RECT,
+      selector: "#target",
+    });
+    expect(dataUrl).toBe("data:image/png;base64,cropped");
+    // First attempt diverged, second attempt agreed: two full-frame captures.
+    expect(guest.captureArgs).toEqual([undefined, undefined]);
+    expect(guest.crops).toEqual([{ x: 100, y: 120, width: 60, height: 80 }]);
+  });
+
+  it("returns null when the page never sits still", async () => {
+    const a = metricsJson({
+      viewportWidth: 1000,
+      viewportHeight: 500,
+      rect: { x: 10, y: 20, width: 30, height: 40 },
+    });
+    const b = metricsJson({
+      viewportWidth: 1000,
+      viewportHeight: 500,
+      rect: { x: 90, y: 90, width: 30, height: 40 },
+    });
+    const guest = makeGuest({ measures: [a, b, a, b] });
+    const dataUrl = await captureElementScreenshot(guest.contents as never, {
+      rect: INPUT_RECT,
+      selector: "#target",
+    });
+    // Both attempts diverged: any rect could land on unrelated content.
+    expect(dataUrl).toBeNull();
+    expect(guest.captureArgs).toEqual([undefined, undefined]);
+    expect(guest.crops).toEqual([]);
+  });
+
+  it("warns and returns null when guest measurement fails", async () => {
+    const warn = vi.fn();
+    const guest = makeGuest({ measures: [new Error("navigation in progress")] });
+    const dataUrl = await captureElementScreenshot(guest.contents as never, {
+      rect: INPUT_RECT,
+      selector: "#target",
+      warn,
+    });
+    // Without viewport metrics no crop can be trusted, and a misleading
+    // screenshot is worse than none.
+    expect(dataUrl).toBeNull();
+    expect(guest.captureArgs).toEqual([]);
+    expect(warn).toHaveBeenCalledWith("navigation in progress");
+  });
+
+  it("warns and returns null when the guest returns unusable metrics", async () => {
+    const warn = vi.fn();
+    const guest = makeGuest({ measures: ["not json"] });
+    const dataUrl = await captureElementScreenshot(guest.contents as never, {
+      rect: INPUT_RECT,
+      selector: null,
+      warn,
+    });
+    expect(dataUrl).toBeNull();
+    expect(warn).toHaveBeenCalledWith("guest returned no usable capture metrics");
+  });
+
+  it("reports in-page selector errors but still captures", async () => {
+    const warn = vi.fn();
+    const guest = makeGuest({
+      measures: [
+        metricsJson({
+          viewportWidth: 1000,
+          viewportHeight: 500,
+          error: "SyntaxError: '#[' is not a valid selector",
+        }),
+      ],
+    });
+    const dataUrl = await captureElementScreenshot(guest.contents as never, {
+      rect: INPUT_RECT,
+      selector: "#[",
+      warn,
+    });
+    // No fresh rect, so the requested rect is calibrated and cropped.
+    expect(dataUrl).toBe("data:image/png;base64,cropped");
+    expect(guest.crops).toEqual([{ x: 20, y: 40, width: 60, height: 80 }]);
+    expect(warn).toHaveBeenCalledWith("SyntaxError: '#[' is not a valid selector");
+  });
+
+  it("returns null when the captured frame size cannot be trusted", async () => {
+    const guest = makeGuest({
+      measures: [metricsJson({ viewportWidth: 1000, viewportHeight: 500 })],
+      frameSize: { width: Number.NaN, height: 100 },
+    });
+    const dataUrl = await captureElementScreenshot(guest.contents as never, {
+      rect: INPUT_RECT,
+      selector: null,
+    });
+    expect(dataUrl).toBeNull();
+    expect(guest.captureArgs).toEqual([undefined, undefined]);
+  });
+});

--- a/packages/desktop/src/features/browser-webviews/capture-element.ts
+++ b/packages/desktop/src/features/browser-webviews/capture-element.ts
@@ -1,0 +1,304 @@
+export interface BrowserCaptureRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface GuestCaptureMetrics {
+  viewportWidth: number;
+  viewportHeight: number;
+  freshRect: BrowserCaptureRect | null;
+  measureError: string | null;
+}
+
+interface CaptureContents {
+  capturePage: (rect?: BrowserCaptureRect) => Promise<NativeImageLike>;
+  executeJavaScript: (code: string) => Promise<unknown>;
+}
+
+// Deliberately shaped like Electron's NativeImage so tests can stub it without
+// loading electron.
+interface NativeImageLike {
+  isEmpty(): boolean;
+  getSize(): { width: number; height: number };
+  crop(rect: BrowserCaptureRect): NativeImageLike;
+  toDataURL(): string;
+}
+
+export function normalizeBrowserCaptureRect(rect: unknown): BrowserCaptureRect | null {
+  if (!rect || typeof rect !== "object") {
+    return null;
+  }
+  const candidate = rect as Record<string, unknown>;
+  const x = candidate.x;
+  const y = candidate.y;
+  const width = candidate.width;
+  const height = candidate.height;
+  if (
+    typeof x !== "number" ||
+    typeof y !== "number" ||
+    typeof width !== "number" ||
+    typeof height !== "number" ||
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return null;
+  }
+  return {
+    x: Math.max(0, Math.round(x)),
+    y: Math.max(0, Math.round(y)),
+    width: Math.round(width),
+    height: Math.round(height),
+  };
+}
+
+// The selector flow stamps data-paseo-capture-id on the clicked node so the
+// re-measure below finds that exact element even if the DOM shifted; a bare
+// positional or duplicate-id selector could resolve to a different node.
+function buildGuestCaptureMetricsScript(selector: string | null, captureId: string | null): string {
+  return `
+    (function() {
+      var out = { viewportWidth: window.innerWidth, viewportHeight: window.innerHeight, rect: null, error: null };
+      var captureId = ${captureId === null ? "null" : JSON.stringify(captureId)};
+      var selector = ${selector === null ? "null" : JSON.stringify(selector)};
+      var el = null;
+      try {
+        if (captureId) {
+          el = document.querySelector('[data-paseo-capture-id=' + JSON.stringify(captureId) + ']');
+        }
+        if (!el && selector) {
+          el = document.querySelector(selector);
+        }
+      } catch (err) {
+        out.error = String(err);
+      }
+      if (el && el.isConnected) {
+        var r = el.getBoundingClientRect();
+        if (r.width > 0 && r.height > 0) {
+          out.rect = { x: r.x, y: r.y, width: r.width, height: r.height };
+        }
+      }
+      return JSON.stringify(out);
+    })()
+  `;
+}
+
+function parseGuestCaptureMetrics(value: unknown): GuestCaptureMetrics | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+  const record = parsed as Record<string, unknown>;
+  const viewportWidth = record.viewportWidth;
+  const viewportHeight = record.viewportHeight;
+  if (
+    typeof viewportWidth !== "number" ||
+    typeof viewportHeight !== "number" ||
+    !Number.isFinite(viewportWidth) ||
+    !Number.isFinite(viewportHeight) ||
+    viewportWidth < 1 ||
+    viewportHeight < 1
+  ) {
+    return null;
+  }
+  return {
+    viewportWidth,
+    viewportHeight,
+    freshRect: normalizeBrowserCaptureRect(record.rect),
+    measureError: typeof record.error === "string" && record.error ? record.error : null,
+  };
+}
+
+function clampCropRect(
+  rect: BrowserCaptureRect,
+  bounds: { width: number; height: number },
+): BrowserCaptureRect | null {
+  const x = Math.min(Math.max(0, Math.round(rect.x)), bounds.width - 1);
+  const y = Math.min(Math.max(0, Math.round(rect.y)), bounds.height - 1);
+  const width = Math.min(Math.max(1, Math.round(rect.width)), bounds.width - x);
+  const height = Math.min(Math.max(1, Math.round(rect.height)), bounds.height - y);
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+  return { x, y, width, height };
+}
+
+// Maps a CSS-pixel element rect onto the captured frame. capturePage returns
+// device-scaled pixels while getBoundingClientRect() is CSS pixels, and page
+// zoom multiplies the two by another factor. Deriving the scale from the
+// actual frame size versus the guest viewport keeps the crop correct on every
+// display scale factor and zoom level.
+function computeCalibratedCropRect(
+  rect: BrowserCaptureRect,
+  metrics: GuestCaptureMetrics,
+  frameSize: { width: number; height: number },
+): BrowserCaptureRect | null {
+  const scaleX = frameSize.width / metrics.viewportWidth;
+  const scaleY = frameSize.height / metrics.viewportHeight;
+  if (
+    !Number.isFinite(scaleX) ||
+    !Number.isFinite(scaleY) ||
+    scaleX <= 0 ||
+    scaleY <= 0 ||
+    scaleX > 16 ||
+    scaleY > 16
+  ) {
+    return null;
+  }
+  return clampCropRect(
+    {
+      x: rect.x * scaleX,
+      y: rect.y * scaleY,
+      width: rect.width * scaleX,
+      height: rect.height * scaleY,
+    },
+    frameSize,
+  );
+}
+
+const CAPTURE_ATTEMPTS = 2;
+const STABILITY_TOLERANCE_PX = 1;
+
+function rectsStable(a: BrowserCaptureRect | null, b: BrowserCaptureRect | null): boolean {
+  if (a === null || b === null) {
+    return a === b;
+  }
+  return (
+    Math.abs(a.x - b.x) <= STABILITY_TOLERANCE_PX &&
+    Math.abs(a.y - b.y) <= STABILITY_TOLERANCE_PX &&
+    Math.abs(a.width - b.width) <= STABILITY_TOLERANCE_PX &&
+    Math.abs(a.height - b.height) <= STABILITY_TOLERANCE_PX
+  );
+}
+
+function metricsStable(a: GuestCaptureMetrics, b: GuestCaptureMetrics): boolean {
+  return (
+    a.viewportWidth === b.viewportWidth &&
+    a.viewportHeight === b.viewportHeight &&
+    rectsStable(a.freshRect, b.freshRect)
+  );
+}
+
+async function measureGuest(
+  contents: CaptureContents,
+  script: string,
+  warn?: (error: string) => void,
+): Promise<GuestCaptureMetrics | null> {
+  let raw: unknown;
+  try {
+    raw = await contents.executeJavaScript(script);
+  } catch (error) {
+    warn?.(error instanceof Error ? error.message : String(error));
+    return null;
+  }
+  const metrics = parseGuestCaptureMetrics(raw);
+  if (!metrics) {
+    warn?.("guest returned no usable capture metrics");
+    return null;
+  }
+  if (metrics.measureError) {
+    warn?.(metrics.measureError);
+  }
+  return metrics;
+}
+
+async function captureFullFrame(contents: CaptureContents): Promise<NativeImageLike | null> {
+  try {
+    return await contents.capturePage();
+  } catch {
+    return null;
+  }
+}
+
+function cropFrame(
+  frame: NativeImageLike,
+  rect: BrowserCaptureRect,
+  metrics: GuestCaptureMetrics,
+): string | null {
+  const crop = computeCalibratedCropRect(rect, metrics, frame.getSize());
+  if (!crop) return null;
+  const cropped = frame.crop(crop);
+  return cropped && !cropped.isEmpty() ? cropped.toDataURL() : null;
+}
+
+// The mark belongs to the capture: removing it here, scoped to this capture's
+// id, keeps a later selector session's sweep-free install from racing a
+// still-pending re-measure for this selection.
+function buildClearCaptureMarkScript(captureId: string): string {
+  return `
+    (function() {
+      var el = document.querySelector('[data-paseo-capture-id=' + JSON.stringify(${JSON.stringify(
+        captureId,
+      )}) + ']');
+      if (el) el.removeAttribute('data-paseo-capture-id');
+    })()
+  `;
+}
+
+export async function captureElementScreenshot(
+  contents: CaptureContents,
+  input: {
+    rect: BrowserCaptureRect;
+    selector: string | null;
+    captureId?: string | null;
+    warn?: (error: string) => void;
+  },
+): Promise<string | null> {
+  const script = buildGuestCaptureMetricsScript(input.selector, input.captureId ?? null);
+  try {
+    let metrics: GuestCaptureMetrics | null = null;
+    let pageMoving = false;
+
+    for (let attempt = 0; attempt < CAPTURE_ATTEMPTS; attempt++) {
+      const before = await measureGuest(contents, script, input.warn);
+      if (!before) break;
+      metrics = before;
+      const frame = await captureFullFrame(contents);
+      if (!frame || frame.isEmpty()) break;
+      // The guest can scroll, resize, or navigate between measurement and
+      // frame capture; only crop when the metrics taken around the frame
+      // agree.
+      const after = await measureGuest(contents, script, input.warn);
+      if (!after) break;
+      metrics = after;
+      if (!metricsStable(before, after)) {
+        pageMoving = true;
+        continue;
+      }
+      pageMoving = false;
+      const dataUrl = cropFrame(frame, after.freshRect ?? input.rect, after);
+      if (dataUrl) return dataUrl;
+      break;
+    }
+
+    // Never hand the CSS-pixel rect to capturePage: on a scaled or zoomed
+    // display it crops the wrong region, which is the bug being fixed. A
+    // calibrated crop of the freshest known rect is still safe, but only when
+    // the page was not actively moving.
+    if (!metrics || pageMoving) return null;
+    const frame = await captureFullFrame(contents);
+    if (!frame || frame.isEmpty()) return null;
+    return cropFrame(frame, metrics.freshRect ?? input.rect, metrics);
+  } finally {
+    if (input.captureId) {
+      try {
+        await contents.executeJavaScript(buildClearCaptureMarkScript(input.captureId));
+      } catch {
+        // Best-effort cleanup; a stale mark is inert.
+      }
+    }
+  }
+}

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -545,8 +545,16 @@ const browserCapture = createBrowserCaptureService<Electron.NativeImage>({
   warn: (event, details) => log.warn(`[browser-capture] ${event}`, details),
 });
 
-ipcMain.handle("paseo:browser:capture-element", (event, browserId: unknown, rect: unknown) =>
-  browserCapture.capture({ browserId, hostWebContentsId: event.sender.id, rect }),
+ipcMain.handle(
+  "paseo:browser:capture-element",
+  (event, browserId: unknown, rect: unknown, selector: unknown, captureId: unknown) =>
+    browserCapture.capture({
+      browserId,
+      hostWebContentsId: event.sender.id,
+      rect,
+      selector,
+      captureId,
+    }),
 );
 
 ipcMain.handle("paseo:browser:copy-element", (_event, payload: unknown) =>

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -133,7 +133,16 @@ contextBridge.exposeInMainWorld("paseoDesktop", {
     captureElement: (
       browserId: string,
       rect: { x: number; y: number; width: number; height: number },
-    ) => ipcRenderer.invoke("paseo:browser:capture-element", browserId, rect),
+      selector?: string | null,
+      captureId?: string | null,
+    ) =>
+      ipcRenderer.invoke(
+        "paseo:browser:capture-element",
+        browserId,
+        rect,
+        selector ?? null,
+        captureId ?? null,
+      ),
     copyElement: (payload: { text?: string; imageDataUrl?: string }) =>
       ipcRenderer.invoke("paseo:browser:copy-element", payload),
   },


### PR DESCRIPTION
### Linked issue

No issue filed yet, happy to open one with the raw evidence if preferred. Repro details are in QA below.

### Type of change: Bug fix

### Reasoning

Element screenshots for browser annotations were inaccurate: agents received an image that did not match the annotated div. Pixel analysis of a real case showed the captured image contained entirely different content than the expected element.

The `paseo:browser:capture-element` handler passed the CSS-pixel rect from `getBoundingClientRect()` straight into `contents.capturePage(rect)`. The returned frame is device-scaled, and page zoom shifts the mapping further, so whenever display scale or zoom was not exactly 1 the crop landed offset and undersized. A second failure mode: any scroll between clicking an element and the screenshot landing used the stale click-time rect.

This matters to users because annotated element screenshots are what agents see when driving the browser pane, a wrong crop means the agent reasons about pixels the user never pointed at. Also, I presume many people use Paseo 

Reproduced with real Electron under Xvfb + MacOS (27.0 Beta 26A5416b) against a fixture page (fraction = share of captured pixels matching the annotated element):

| Scenario | legacy `capturePage(rect)` | calibrated crop (this PR) |
| --- | --- | --- |
| Display scale 1.25 | 100% | 99.5% |
| Page zoom 1.25 (dpr 1.5625) | **67.6%** | 99.1% |
| Scroll between measure and capture (+ zoom) | **54.9%** | 99.1% |

The fix captures the full guest frame and crops itself, deriving the CSS→pixel scale from the actual frame size versus the measured guest viewport (`innerWidth`/`innerHeight`). That makes the result independent of how Electron maps rects internally across platforms, display configurations, and versions. The selector flow stamps a unique `data-paseo-capture-id` on the clicked node, and the element is re-measured by that marker at capture time so scroll drift cannot skew the region and a stale/ambiguous selector cannot retarget the crop. The guest is measured again after the frame lands and the crop is only applied when both measurements agree (one retry). The crop is clamped to frame bounds. The CSS rect is never passed to `capturePage`; when no trustworthy crop can be produced the call returns null rather than an unrelated screenshot.

New module `packages/desktop/src/features/browser-webviews/capture-element.ts`, wired through the existing `browserCapture` service; preload and both call sites pass `selection.selector` + `selection.captureId`.

### Goals

- Element annotation screenshots match the annotated element on any display scale factor and page zoom
- Scroll between selection and capture cannot corrupt the region
- Partially-offscreen elements clamp instead of producing out-of-bounds crops
- Never produce a wrong-region crop: crop the freshest known rect when metrics are trustworthy; return null rather than a misleading image otherwise

### Non-goals

- No changes to the automation screenshot path
- Not addressing capture latency/polling behavior

### QA

- Reproduced the bug first: real Electron + forced `--force-device-scale-factor=1.25` + page zoom 1.25 under Xvfb; legacy `capturePage(rect)` captured only 67.6% of the target element (54.9% after a scroll), confirming both failure modes above.
- Confirmed fixed: same harness, calibrated crop → 99.1–99.5% across all scenarios (table above).
- New unit tests: `npx vitest run src/features/browser-webviews/capture-element.test.ts src/features/browser-capture.test.ts` → 18 passed.
- `npm run typecheck -w @getpaseo/desktop -w @getpaseo/app`: clean. `npm run lint` on changed files: 0 warnings/errors.

Platforms: tested on Linux (Xvfb,Electron). and MacOS (27.0 Beta 26A5416b). Not tested Windows, I don't have a windows machine. However, the calibration does not depend on platform capture internals, but confirmation on a HiDPI Windows display would be welcome.

### Before and After Screenshots
Reproduced at 1.5x zoom on the Paseo desktop app on MacOS.

#### Before screenshots from website:
Screenshot 1:
<img width="385" height="101" alt="file-163a54c985dbe3101c0ab2f23fa1ac9b" src="https://github.com/user-attachments/assets/0737cbf6-fe53-4d36-a054-ff528279d9a9" />
Image sent to agent:
<img width="276" height="25" alt="image" src="https://github.com/user-attachments/assets/6887f14c-4e98-45cd-9364-36599366b8ce" />

Screenshot 2:
<img width="385" height="333" alt="image" src="https://github.com/user-attachments/assets/1166998c-2787-4c6a-a7f3-82f04e5d9ca0" />
Image sent to agent:
<img width="39" height="20" alt="image" src="https://github.com/user-attachments/assets/ba18ca2a-bc18-4318-9c3c-e9d1bec82ecd" />

In each “before” pair, the image sent to the agent showed different content than the annotated element: e.g., highlighting the stats card delivered a crop of an unrelated region.

#### After screenshots from website:
Screenshot 1:
<img width="341" height="90" alt="image" src="https://github.com/user-attachments/assets/5c3614dc-a4b0-4662-a2b5-06bf12da3b8a" />
Image sent to agent:
<img width="302" height="27" alt="image" src="https://github.com/user-attachments/assets/7d809001-b8ef-4a58-bdf0-3280921bf99d" />

Screenshot 2:
<img width="352" height="255" alt="file-e0577a5c4c0635bea34fcaac48d9203e" src="https://github.com/user-attachments/assets/ccf4b605-d2dc-427d-8ac9-7ddb867eb81a" />
Image sent to agent:
<img width="43" height="22" alt="image" src="https://github.com/user-attachments/assets/c07fb478-9274-43db-8162-d7378df5f944" />

As seen in the after screenshots, the images sent to the agents matched identically to the annotation area selected with the annotation tool.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense