### PR TITLE
test(app): cover Android tablet new-tab provider

### DIFF
--- a/packages/app/src/screens/workspace/workspace-screen-provider.test.ts
+++ b/packages/app/src/screens/workspace/workspace-screen-provider.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const workspaceScreenPath = new URL("./workspace-screen.tsx", import.meta.url);
+
+function getJsxTagName(node: ts.Node): string | null {
+  if (ts.isJsxElement(node)) {
+    return node.openingElement.tagName.getText();
+  }
+  if (ts.isJsxSelfClosingElement(node)) {
+    return node.tagName.getText();
+  }
+  return null;
+}
+
+function findJsxElements(sourceFile: ts.SourceFile, tagName: string): ts.Node[] {
+  const matches: ts.Node[] = [];
+  const visit = (node: ts.Node): void => {
+    if (getJsxTagName(node) === tagName) {
+      matches.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return matches;
+}
+
+function hasJsxAncestor(node: ts.Node, tagName: string): boolean {
+  let parent = node.parent;
+  while (parent) {
+    if (getJsxTagName(parent) === tagName) {
+      return true;
+    }
+    parent = parent.parent;
+  }
+  return false;
+}
+
+describe("workspace screen provider wiring", () => {
+  it("provides a new-tab launcher to the native non-compact fallback tab row", () => {
+    const source = readFileSync(workspaceScreenPath, "utf8");
+    const sourceFile = ts.createSourceFile(
+      workspaceScreenPath.pathname,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    );
+    const fallbackTabRows = findJsxElements(sourceFile, "WorkspaceDesktopTabsRow");
+
+    expect(fallbackTabRows).toHaveLength(1);
+    expect(hasJsxAncestor(fallbackTabRows[0]!, "NewTabLauncherProvider")).toBe(true);
+  });
+});

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -3854,11 +3854,7 @@ function WorkspaceScreenContent({
       ) : null}
 
       {shouldRenderDesktopPaneFallback ? (
-        // The splits path renders tab rows inside WorkspacePanelContent, which is what
-        // provides NewTabLauncherProvider. This fallback row sits outside it, and its
-        // new-tab menu content mounts eagerly, so without its own provider every
-        // non-compact native layout (tablets, foldables in landscape) crashed on mount
-        // with "NewTabLauncherProvider is required" (#3750).
+        // This row sits outside WorkspacePanelContent, but its new-tab menu mounts eagerly.
         <NewTabLauncherProvider value={newTabLauncher}>
           <WorkspaceDesktopTabsRow
             paneId={focusedPaneIdOrUndefined}


### PR DESCRIPTION
Companion regression coverage for #3760.

The branch preserves the contributor commit and adds a focused structural test for the native non-compact fallback provider boundary. The contributor PR remains the product fix and closes #3750.