### PR TITLE
Fix settings resets across app revisions

### DIFF
--- a/packages/app/src/hooks/use-settings/keys.ts
+++ b/packages/app/src/hooks/use-settings/keys.ts
@@ -5,9 +5,9 @@ export const LEGACY_SETTINGS_KEY = "@paseo:settings";
 
 /**
  * The applied-migration marker deliberately sits outside the settings blob:
- * `StoredAppSettingsSchema` is a strict object and `readValidatedJson` clears the value when
- * parsing fails, so a new field there would wipe every setting for anyone who downgrades to a
- * client that predates it. Keeping the marker as a list of ids also means the next migration is
- * a new entry rather than a schema change.
+ * App settings preserve fields newer builds understand, but this marker remains separate so
+ * applying a migration never becomes an app-settings field that older builds must interpret.
+ * Keeping the marker as a list of ids also means the next migration is a new entry rather than
+ * a schema change.
  */
 export const SETTINGS_MIGRATIONS_KEY = "@paseo:settings-migrations";

--- a/packages/app/src/hooks/use-settings/migrations.ts
+++ b/packages/app/src/hooks/use-settings/migrations.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { readValidatedJson } from "@/storage/validated-storage";
 import { APP_SETTINGS_KEY, SETTINGS_MIGRATIONS_KEY } from "./keys";
-import type { AppSettings, KeyValueStorage } from "./storage";
+import type { AppSettings, KeyValueStorage, PersistedAppSettings } from "./storage";
 
 const AppliedMigrationsSchema = z.strictObject({ applied: z.array(z.string()) });
 
@@ -22,7 +22,7 @@ const STEER_DEFAULT_MIGRATION = "steer-default";
 export async function migrateAppSettings(
   settings: AppSettings,
   storage: KeyValueStorage,
-  stored: Record<string, unknown> = {},
+  stored?: PersistedAppSettings,
 ): Promise<AppSettings> {
   const migrationMarker = await readValidatedJson(
     storage,
@@ -37,9 +37,7 @@ export async function migrateAppSettings(
   const migrated: AppSettings =
     settings.sendBehavior === "interrupt" ? { ...settings, sendBehavior: "steer" } : settings;
   if (migrated !== settings) {
-    const storedSidebarRowItems = isPlainJsonObject(stored.sidebarRowItems)
-      ? stored.sidebarRowItems
-      : {};
+    const storedSidebarRowItems = stored?.sidebarRowItems ?? {};
     await storage.setItem(
       APP_SETTINGS_KEY,
       JSON.stringify({
@@ -53,8 +51,4 @@ export async function migrateAppSettings(
   applied.add(STEER_DEFAULT_MIGRATION);
   await storage.setItem(SETTINGS_MIGRATIONS_KEY, JSON.stringify({ applied: [...applied] }));
   return migrated;
-}
-
-function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/app/src/hooks/use-settings/migrations.ts
+++ b/packages/app/src/hooks/use-settings/migrations.ts
@@ -22,9 +22,14 @@ const STEER_DEFAULT_MIGRATION = "steer-default";
 export async function migrateAppSettings(
   settings: AppSettings,
   storage: KeyValueStorage,
+  stored: Record<string, unknown> = {},
 ): Promise<AppSettings> {
-  const stored = await readValidatedJson(storage, SETTINGS_MIGRATIONS_KEY, AppliedMigrationsSchema);
-  const applied = new Set(stored?.applied ?? []);
+  const migrationMarker = await readValidatedJson(
+    storage,
+    SETTINGS_MIGRATIONS_KEY,
+    AppliedMigrationsSchema,
+  );
+  const applied = new Set(migrationMarker?.applied ?? []);
   if (applied.has(STEER_DEFAULT_MIGRATION)) {
     return settings;
   }
@@ -32,10 +37,24 @@ export async function migrateAppSettings(
   const migrated: AppSettings =
     settings.sendBehavior === "interrupt" ? { ...settings, sendBehavior: "steer" } : settings;
   if (migrated !== settings) {
-    await storage.setItem(APP_SETTINGS_KEY, JSON.stringify(migrated));
+    const storedSidebarRowItems = isPlainJsonObject(stored.sidebarRowItems)
+      ? stored.sidebarRowItems
+      : {};
+    await storage.setItem(
+      APP_SETTINGS_KEY,
+      JSON.stringify({
+        ...stored,
+        ...migrated,
+        sidebarRowItems: { ...storedSidebarRowItems, ...migrated.sidebarRowItems },
+      }),
+    );
   }
 
   applied.add(STEER_DEFAULT_MIGRATION);
   await storage.setItem(SETTINGS_MIGRATIONS_KEY, JSON.stringify({ applied: [...applied] }));
   return migrated;
+}
+
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -130,8 +130,8 @@ describe("loadAppSettingsFromStorage", () => {
 
     expect(result).toEqual(DEFAULT_CLIENT_SETTINGS);
     expect(DEFAULT_CLIENT_SETTINGS.language).toBe("system");
-    expect(deps.storage.entries.get(APP_SETTINGS_KEY)).toBe(
-      JSON.stringify(DEFAULT_CLIENT_SETTINGS),
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual(
+      DEFAULT_CLIENT_SETTINGS,
     );
   });
 

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -50,6 +50,28 @@ describe("loadAppSettingsFromStorage", () => {
     });
     expect((await loadAppSettingsFromStorage(deps)).sendBehavior).toBe("steer");
   });
+
+  it("keeps valid settings when another build wrote unknown fields or enum values", async () => {
+    const stored = {
+      theme: "dark",
+      contentFontSize: 16,
+      sendBehavior: "future-mode",
+      futureSetting: { enabled: true },
+      sidebarRowItems: { host: false, futureRowItem: true },
+    };
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify(stored),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.theme).toBe("dark");
+    expect(result.sendBehavior).toBe(DEFAULT_CLIENT_SETTINGS.sendBehavior);
+    expect(result.sidebarRowItems.host).toBe(false);
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual(stored);
+  });
   it("migrates a stored interrupt to steer and persists it", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({
@@ -235,7 +257,11 @@ describe("loadAppSettingsFromStorage", () => {
       theme: "dark",
       contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
     });
-    expect(deps.storage.entries.get(APP_SETTINGS_KEY)).toBe(JSON.stringify(result));
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual({
+      manageBuiltInDaemon: false,
+      releaseChannel: "beta",
+      ...result,
+    });
   });
 
   it("preserves the legacy key's explicit interface size as content size", async () => {
@@ -400,6 +426,36 @@ describe("loadSettingsFromStorage", () => {
 });
 
 describe("saveAppSettings", () => {
+  it("round-trips fields written by a newer build", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          theme: "dark",
+          contentFontSize: 16,
+          sendBehavior: "future-mode",
+          futureSetting: { enabled: true },
+          sidebarRowItems: { host: false, futureRowItem: true },
+        }),
+      }),
+    });
+
+    await loadAppSettingsFromStorage(deps);
+    await saveAppSettings({
+      queryClient: new QueryClient(),
+      updates: { theme: "light" },
+      deps,
+    });
+
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
+      theme: "light",
+      futureSetting: { enabled: true },
+      sidebarRowItems: {
+        host: false,
+        futureRowItem: true,
+      },
+    });
+  });
+
   it("saves terminal scrollback through app settings persistence", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({
@@ -609,7 +665,7 @@ describe("appearance settings", () => {
 
       expect(result.uiBaseFontSize).toBe(baseSize);
       expect(persisted).toMatchObject({ uiBaseFontSize: baseSize });
-      expect(persisted).not.toHaveProperty("uiFontSize");
+      expect(persisted.uiFontSize).toBe(legacySize);
     },
   );
 

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -85,6 +85,32 @@ describe("loadAppSettingsFromStorage", () => {
     expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "{}").sendBehavior).toBe(
       "steer",
     );
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "{}")).not.toHaveProperty(
+      "needsWrite",
+    );
+  });
+
+  it("keeps an explicit services choice over the legacy scripts fallback", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          contentFontSize: 16,
+          sidebarRowItems: { scripts: false, services: true },
+        }),
+      }),
+    });
+
+    expect((await loadAppSettingsFromStorage(deps)).sidebarRowItems.services).toBe(true);
+
+    await saveAppSettings({
+      queryClient: new QueryClient(),
+      updates: {
+        sidebarRowItems: { ...DEFAULT_SIDEBAR_ROW_ITEMS, services: true },
+      },
+      deps,
+    });
+
+    expect((await loadAppSettingsFromStorage(deps)).sidebarRowItems.services).toBe(true);
   });
 
   it("keeps an interrupt the user picked after the migration ran", async () => {

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -12,7 +12,6 @@ import {
   DEFAULT_SIDEBAR_ROW_ITEMS,
   isChecksHiddenByLegacyRowItem,
   parseSidebarRowItems,
-  SIDEBAR_ROW_ITEMS,
   type SidebarRowItems,
 } from "@/components/sidebar/display-preferences/row-items";
 import { isNative } from "@/constants/platform";
@@ -257,111 +256,26 @@ export async function loadSettingsFromStorage(deps: SettingsDeps): Promise<Setti
 
 export function normalizeAppSettings(value: unknown): AppSettings {
   const stored = isPlainJsonObject(value) ? value : {};
-  const picked = pickAppSettings(stored);
-  warnDiscardedAppSettings(stored);
   return {
     ...DEFAULT_CLIENT_SETTINGS,
-    ...picked,
+    ...pickAppSettings(stored),
   };
 }
 
-function warnDiscardedAppSettings(stored: StoredAppSettings): void {
-  const discarded = (key: string, valid: boolean): void => {
-    if (stored[key] !== undefined && !valid) {
-      console.warn(`[AppSettings] Ignoring invalid ${key}.`);
-    }
-  };
+function pickStoredSetting<Value>(
+  stored: StoredAppSettings,
+  key: string,
+  parse: (value: unknown) => Value | null,
+): Value | null {
+  const value = parse(stored[key]);
+  if (stored[key] !== undefined && value === null) {
+    console.warn(`[AppSettings] Ignoring invalid ${key}.`);
+  }
+  return value;
+}
 
-  discarded("theme", isEnumValue(VALID_THEMES, stored.theme));
-  discarded(
-    "sendBehavior",
-    stored.sendBehavior === "interrupt" ||
-      stored.sendBehavior === "steer" ||
-      stored.sendBehavior === "queue",
-  );
-  discarded(
-    "serviceUrlBehavior",
-    isEnumValue(VALID_SERVICE_URL_BEHAVIORS, stored.serviceUrlBehavior),
-  );
-  discarded("language", parseAppLanguage(stored.language) !== null);
-  discarded(
-    "syntaxTheme",
-    typeof stored.syntaxTheme === "string" && isSyntaxThemeId(stored.syntaxTheme),
-  );
-  discarded(
-    "workspaceTitleSource",
-    isEnumValue(VALID_WORKSPACE_TITLE_SOURCES, stored.workspaceTitleSource),
-  );
-  discarded(
-    "sidebarWorkspaceTrailing",
-    isEnumValue(VALID_SIDEBAR_WORKSPACE_TRAILINGS, stored.sidebarWorkspaceTrailing),
-  );
-  discarded(
-    "sidebarChecksDisplay",
-    parseSidebarChecksDisplay(stored.sidebarChecksDisplay) !== null,
-  );
-  discarded(
-    "terminalScrollbackLines",
-    parseTerminalScrollbackLines(stored.terminalScrollbackLines) !== null,
-  );
-  discarded("uiFontFamily", sanitizeFontFamily(stored.uiFontFamily) !== null);
-  discarded("monoFontFamily", sanitizeFontFamily(stored.monoFontFamily) !== null);
-  discarded(
-    "uiBaseFontSize",
-    parseClampedFontSize(stored.uiBaseFontSize, {
-      min: MIN_UI_BASE_FONT_SIZE,
-      max: MAX_UI_BASE_FONT_SIZE,
-    }) !== null,
-  );
-  discarded(
-    "contentFontSize",
-    parseClampedFontSize(stored.contentFontSize, {
-      min: MIN_CONTENT_FONT_SIZE,
-      max: MAX_CONTENT_FONT_SIZE,
-    }) !== null,
-  );
-  discarded(
-    "codeFontSize",
-    parseClampedFontSize(stored.codeFontSize, {
-      min: MIN_CODE_FONT_SIZE,
-      max: MAX_CODE_FONT_SIZE,
-    }) !== null,
-  );
-  discarded("uiFontSize", parseClampedFontSize(stored.uiFontSize, { min: 11, max: 24 }) !== null);
-  for (const key of [
-    "useLegacyTerminalRenderer",
-    "vimKeybindings",
-    "chatOutlineEnabled",
-    "openSupportingTabsInSidePanel",
-    "autoExpandReasoning",
-  ]) {
-    discarded(key, typeof stored[key] === "boolean");
-  }
-  discarded(
-    "toolCallDetailLevel",
-    isEnumValue(VALID_TOOL_CALL_DETAIL_LEVELS, stored.toolCallDetailLevel) ||
-      stored.toolCallDetailLevel === "concise",
-  );
-  discarded("compactToolCalls", typeof stored.compactToolCalls === "boolean");
-  if (
-    stored.pluginThemeId !== undefined &&
-    stored.pluginThemeId !== null &&
-    typeof stored.pluginThemeId !== "string"
-  ) {
-    console.warn("[AppSettings] Ignoring invalid pluginThemeId.");
-  }
-  if (stored.sidebarRowItems !== undefined && !isPlainJsonObject(stored.sidebarRowItems)) {
-    console.warn("[AppSettings] Ignoring invalid sidebarRowItems.");
-  } else if (isPlainJsonObject(stored.sidebarRowItems)) {
-    for (const key of SIDEBAR_ROW_ITEMS) {
-      if (
-        stored.sidebarRowItems[key] !== undefined &&
-        typeof stored.sidebarRowItems[key] !== "boolean"
-      ) {
-        console.warn(`[AppSettings] Ignoring invalid sidebarRowItems.${key}.`);
-      }
-    }
-  }
+function parseBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
 }
 
 function parseToolCallDetailLevel(stored: StoredAppSettings): ToolCallDetailLevel | null {
@@ -371,17 +285,22 @@ function parseToolCallDetailLevel(stored: StoredAppSettings): ToolCallDetailLeve
     }
     // COMPAT(toolCallDetailLevelConcise): removed in v0.1.107; legacy "concise" values
     // keep their former meaning. Remove after 2027-01-14.
-    return stored.toolCallDetailLevel === "concise" ? "overview" : null;
+    if (stored.toolCallDetailLevel === "concise") {
+      return "overview";
+    }
+    console.warn("[AppSettings] Ignoring invalid toolCallDetailLevel.");
+    return null;
   }
-  if (typeof stored.compactToolCalls === "boolean") {
+  const compactToolCalls = pickStoredSetting(stored, "compactToolCalls", parseBoolean);
+  if (compactToolCalls !== null) {
     // COMPAT(compactToolCalls): migrated in v0.1.105, remove after 2027-01-12.
-    return stored.compactToolCalls ? "overview" : "detailed";
+    return compactToolCalls ? "overview" : "detailed";
   }
   return null;
 }
 
 function parseStoredSidebarChecksDisplay(stored: StoredAppSettings): SidebarChecksDisplay | null {
-  const display = parseSidebarChecksDisplay(stored.sidebarChecksDisplay);
+  const display = pickStoredSetting(stored, "sidebarChecksDisplay", parseSidebarChecksDisplay);
   if (display !== null) {
     return display;
   }
@@ -391,17 +310,29 @@ function parseStoredSidebarChecksDisplay(stored: StoredAppSettings): SidebarChec
 
 function pickBooleanAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   const result: Partial<AppSettings> = {};
-  if (typeof stored.useLegacyTerminalRenderer === "boolean") {
-    result.useLegacyTerminalRenderer = stored.useLegacyTerminalRenderer;
+  const useLegacyTerminalRenderer = pickStoredSetting(
+    stored,
+    "useLegacyTerminalRenderer",
+    parseBoolean,
+  );
+  if (useLegacyTerminalRenderer !== null) {
+    result.useLegacyTerminalRenderer = useLegacyTerminalRenderer;
   }
-  if (typeof stored.vimKeybindings === "boolean") {
-    result.vimKeybindings = stored.vimKeybindings;
+  const vimKeybindings = pickStoredSetting(stored, "vimKeybindings", parseBoolean);
+  if (vimKeybindings !== null) {
+    result.vimKeybindings = vimKeybindings;
   }
-  if (typeof stored.chatOutlineEnabled === "boolean") {
-    result.chatOutlineEnabled = stored.chatOutlineEnabled;
+  const chatOutlineEnabled = pickStoredSetting(stored, "chatOutlineEnabled", parseBoolean);
+  if (chatOutlineEnabled !== null) {
+    result.chatOutlineEnabled = chatOutlineEnabled;
   }
-  if (typeof stored.openSupportingTabsInSidePanel === "boolean") {
-    result.openSupportingTabsInSidePanel = stored.openSupportingTabsInSidePanel;
+  const openSupportingTabsInSidePanel = pickStoredSetting(
+    stored,
+    "openSupportingTabsInSidePanel",
+    parseBoolean,
+  );
+  if (openSupportingTabsInSidePanel !== null) {
+    result.openSupportingTabsInSidePanel = openSupportingTabsInSidePanel;
   }
   return result;
 }
@@ -413,27 +344,41 @@ function pickBooleanAppSettings(stored: StoredAppSettings): Partial<AppSettings>
  */
 function pickEnumAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   const result: Partial<AppSettings> = {};
-  if (isEnumValue(VALID_THEMES, stored.theme)) {
-    result.theme = stored.theme;
+  const theme = pickStoredSetting(stored, "theme", (value) =>
+    isEnumValue(VALID_THEMES, value) ? value : null,
+  );
+  if (theme !== null) {
+    result.theme = theme;
   }
-  if (
-    stored.sendBehavior === "interrupt" ||
-    stored.sendBehavior === "steer" ||
-    stored.sendBehavior === "queue"
-  ) {
-    result.sendBehavior = stored.sendBehavior;
+  const sendBehavior = pickStoredSetting(stored, "sendBehavior", (value): SendBehavior | null =>
+    value === "interrupt" || value === "steer" || value === "queue" ? value : null,
+  );
+  if (sendBehavior !== null) {
+    result.sendBehavior = sendBehavior;
   }
-  if (isEnumValue(VALID_SERVICE_URL_BEHAVIORS, stored.serviceUrlBehavior)) {
-    result.serviceUrlBehavior = stored.serviceUrlBehavior;
+  const serviceUrlBehavior = pickStoredSetting(stored, "serviceUrlBehavior", (value) =>
+    isEnumValue(VALID_SERVICE_URL_BEHAVIORS, value) ? value : null,
+  );
+  if (serviceUrlBehavior !== null) {
+    result.serviceUrlBehavior = serviceUrlBehavior;
   }
-  if (typeof stored.syntaxTheme === "string" && isSyntaxThemeId(stored.syntaxTheme)) {
-    result.syntaxTheme = stored.syntaxTheme;
+  const syntaxTheme = pickStoredSetting(stored, "syntaxTheme", (value) =>
+    typeof value === "string" && isSyntaxThemeId(value) ? value : null,
+  );
+  if (syntaxTheme !== null) {
+    result.syntaxTheme = syntaxTheme;
   }
-  if (isEnumValue(VALID_WORKSPACE_TITLE_SOURCES, stored.workspaceTitleSource)) {
-    result.workspaceTitleSource = stored.workspaceTitleSource;
+  const workspaceTitleSource = pickStoredSetting(stored, "workspaceTitleSource", (value) =>
+    isEnumValue(VALID_WORKSPACE_TITLE_SOURCES, value) ? value : null,
+  );
+  if (workspaceTitleSource !== null) {
+    result.workspaceTitleSource = workspaceTitleSource;
   }
-  if (isEnumValue(VALID_SIDEBAR_WORKSPACE_TRAILINGS, stored.sidebarWorkspaceTrailing)) {
-    result.sidebarWorkspaceTrailing = stored.sidebarWorkspaceTrailing;
+  const sidebarWorkspaceTrailing = pickStoredSetting(stored, "sidebarWorkspaceTrailing", (value) =>
+    isEnumValue(VALID_SIDEBAR_WORKSPACE_TRAILINGS, value) ? value : null,
+  );
+  if (sidebarWorkspaceTrailing !== null) {
+    result.sidebarWorkspaceTrailing = sidebarWorkspaceTrailing;
   }
   return result;
 }
@@ -443,49 +388,61 @@ function pickAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   Object.assign(result, pickEnumAppSettings(stored));
   if (typeof stored.pluginThemeId === "string") {
     result.pluginThemeId = stored.pluginThemeId;
+  } else if (stored.pluginThemeId !== undefined && stored.pluginThemeId !== null) {
+    console.warn("[AppSettings] Ignoring invalid pluginThemeId.");
   }
   if (stored.sidebarRowItems !== undefined) {
+    if (!isPlainJsonObject(stored.sidebarRowItems)) {
+      console.warn("[AppSettings] Ignoring invalid sidebarRowItems.");
+    }
     result.sidebarRowItems = parseSidebarRowItems(stored.sidebarRowItems);
   }
   const sidebarChecksDisplay = parseStoredSidebarChecksDisplay(stored);
   if (sidebarChecksDisplay !== null) {
     result.sidebarChecksDisplay = sidebarChecksDisplay;
   }
-  const language = parseAppLanguage(stored.language);
+  const language = pickStoredSetting(stored, "language", parseAppLanguage);
   if (language !== null) {
     result.language = language;
   }
-  const terminalScrollbackLines = parseTerminalScrollbackLines(stored.terminalScrollbackLines);
+  const terminalScrollbackLines = pickStoredSetting(
+    stored,
+    "terminalScrollbackLines",
+    parseTerminalScrollbackLines,
+  );
   if (terminalScrollbackLines !== null) {
     result.terminalScrollbackLines = terminalScrollbackLines;
   }
-  const uiFontFamily = sanitizeFontFamily(stored.uiFontFamily);
+  const uiFontFamily = pickStoredSetting(stored, "uiFontFamily", sanitizeFontFamily);
   if (uiFontFamily !== null) {
     result.uiFontFamily = uiFontFamily;
   }
-  const monoFontFamily = sanitizeFontFamily(stored.monoFontFamily);
+  const monoFontFamily = pickStoredSetting(stored, "monoFontFamily", sanitizeFontFamily);
   if (monoFontFamily !== null) {
     result.monoFontFamily = monoFontFamily;
   }
-  const uiBaseFontSize = parseClampedFontSize(stored.uiBaseFontSize, {
-    min: MIN_UI_BASE_FONT_SIZE,
-    max: MAX_UI_BASE_FONT_SIZE,
-  });
+  const uiBaseFontSize = pickStoredSetting(stored, "uiBaseFontSize", (value) =>
+    parseClampedFontSize(value, {
+      min: MIN_UI_BASE_FONT_SIZE,
+      max: MAX_UI_BASE_FONT_SIZE,
+    }),
+  );
   if (uiBaseFontSize !== null) {
     result.uiBaseFontSize = uiBaseFontSize;
   } else {
-    const legacyUiFontSize = parseClampedFontSize(stored.uiFontSize, {
-      min: 11,
-      max: 24,
-    });
+    const legacyUiFontSize = pickStoredSetting(stored, "uiFontSize", (value) =>
+      parseClampedFontSize(value, { min: 11, max: 24 }),
+    );
     if (legacyUiFontSize !== null) {
       result.uiBaseFontSize = Math.round((FONT_SIZE.base * legacyUiFontSize) / 16);
     }
   }
-  const contentFontSize = parseClampedFontSize(stored.contentFontSize, {
-    min: MIN_CONTENT_FONT_SIZE,
-    max: MAX_CONTENT_FONT_SIZE,
-  });
+  const contentFontSize = pickStoredSetting(stored, "contentFontSize", (value) =>
+    parseClampedFontSize(value, {
+      min: MIN_CONTENT_FONT_SIZE,
+      max: MAX_CONTENT_FONT_SIZE,
+    }),
+  );
   if (contentFontSize !== null) {
     result.contentFontSize = contentFontSize;
   } else if (stored.contentFontSize === undefined) {
@@ -493,16 +450,19 @@ function pickAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
     // once, then persist the independent setting during the read migration.
     result.contentFontSize = result.uiBaseFontSize ?? DEFAULT_UI_BASE_FONT_SIZE;
   }
-  const codeFontSize = parseClampedFontSize(stored.codeFontSize, {
-    min: MIN_CODE_FONT_SIZE,
-    max: MAX_CODE_FONT_SIZE,
-  });
+  const codeFontSize = pickStoredSetting(stored, "codeFontSize", (value) =>
+    parseClampedFontSize(value, {
+      min: MIN_CODE_FONT_SIZE,
+      max: MAX_CODE_FONT_SIZE,
+    }),
+  );
   if (codeFontSize !== null) {
     result.codeFontSize = codeFontSize;
   }
   Object.assign(result, pickBooleanAppSettings(stored));
-  if (typeof stored.autoExpandReasoning === "boolean") {
-    result.autoExpandReasoning = stored.autoExpandReasoning;
+  const autoExpandReasoning = pickStoredSetting(stored, "autoExpandReasoning", parseBoolean);
+  if (autoExpandReasoning !== null) {
+    result.autoExpandReasoning = autoExpandReasoning;
   }
   const toolCallDetailLevel = parseToolCallDetailLevel(stored);
   if (toolCallDetailLevel !== null) {

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -2,16 +2,14 @@ import { isSyntaxThemeId, type SyntaxThemeId } from "@getpaseo/highlight";
 import type { ActiveTurnBehavior } from "@getpaseo/protocol/messages";
 import type { QueryClient } from "@tanstack/react-query";
 import type { DesktopSettings } from "@/desktop/settings/desktop-settings";
-import { parseAppLanguage, type AppLanguage } from "@/i18n/locales";
+import type { AppLanguage } from "@/i18n/locales";
 import {
   DEFAULT_SIDEBAR_CHECKS_DISPLAY,
-  parseSidebarChecksDisplay,
   type SidebarChecksDisplay,
 } from "@/components/sidebar/display-preferences/checks-display";
 import {
   DEFAULT_SIDEBAR_ROW_ITEMS,
   isChecksHiddenByLegacyRowItem,
-  parseSidebarRowItems,
   type SidebarRowItems,
 } from "@/components/sidebar/display-preferences/row-items";
 import { isNative } from "@/constants/platform";
@@ -21,6 +19,7 @@ import {
   THEME_OPTIONS,
   type ThemePreference,
 } from "@/styles/theme";
+import { z } from "zod";
 import { APP_SETTINGS_KEY, LEGACY_SETTINGS_KEY } from "./keys";
 import { migrateAppSettings } from "./migrations";
 
@@ -35,20 +34,12 @@ export type WorkspaceTitleSource = "title" | "branch";
 export type SidebarWorkspaceTrailing = "diff" | "timestamp" | "none";
 export type ToolCallDetailLevel = "overview" | "detailed";
 
-const VALID_THEMES = new Set<ThemePreference>([
+const ThemePreferenceSchema = z.enum([
   ...THEME_OPTIONS.map((option) => option.name),
   PLUGIN_THEME_PREFERENCE,
 ] as ThemePreference[]);
 /** Where the theme picker lands when the persisted preference cannot be honoured. */
 export const DEFAULT_THEME_PREFERENCE = "auto" satisfies ThemePreference;
-const VALID_SERVICE_URL_BEHAVIORS = new Set<ServiceUrlBehavior>(["ask", "in-app", "external"]);
-const VALID_WORKSPACE_TITLE_SOURCES = new Set<WorkspaceTitleSource>(["title", "branch"]);
-const VALID_SIDEBAR_WORKSPACE_TRAILINGS = new Set<SidebarWorkspaceTrailing>([
-  "diff",
-  "timestamp",
-  "none",
-]);
-const VALID_TOOL_CALL_DETAIL_LEVELS = new Set<ToolCallDetailLevel>(["overview", "detailed"]);
 export const DEFAULT_TERMINAL_SCROLLBACK_LINES = 10_000;
 export const MIN_TERMINAL_SCROLLBACK_LINES = 0;
 export const MAX_TERMINAL_SCROLLBACK_LINES = 1_000_000;
@@ -70,13 +61,6 @@ export const DEFAULT_CODE_FONT_SIZE = 12; // == FONT_SIZE.code
 export const MIN_CODE_FONT_SIZE = 9;
 export const MAX_CODE_FONT_SIZE = 22; // line-height 1.5×22=33 stays safe
 export const MAX_FONT_FAMILY_LENGTH = 200;
-
-function isEnumValue<Value extends string>(
-  values: ReadonlySet<Value>,
-  value: unknown,
-): value is Value {
-  return typeof value === "string" && values.has(value as Value);
-}
 
 export interface AppSettings {
   theme: ThemePreference;
@@ -110,8 +94,6 @@ export interface Settings extends AppSettings {
   releaseChannel: ReleaseChannel;
 }
 
-type StoredAppSettings = Record<string, unknown>;
-
 export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   theme: DEFAULT_THEME_PREFERENCE,
   pluginThemeId: null,
@@ -142,6 +124,118 @@ export const DEFAULT_APP_SETTINGS: Settings = {
   manageBuiltInDaemon: true,
   releaseChannel: "stable",
 };
+
+function clampedNumber(min: number, max: number) {
+  return z
+    .union([z.number(), z.string().trim().min(1).transform(Number)])
+    .refine(Number.isFinite)
+    .transform((value) => Math.min(max, Math.max(min, Math.floor(value))));
+}
+
+function sanitizedFontFamily() {
+  return z
+    .string()
+    .transform((value) => value.trim())
+    .refine((value) => value.length <= MAX_FONT_FAMILY_LENGTH)
+    .refine((value) => !/[;{}<>]/.test(value))
+    .refine((value) => ![...value].some((char) => char.charCodeAt(0) <= 0x1f));
+}
+
+const SidebarRowItemsSchema = z
+  .looseObject({
+    branch: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.branch),
+    project: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.project),
+    host: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.host),
+    changeRequest: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.changeRequest),
+    services: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.services),
+    labels: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.labels),
+    // COMPAT(sidebarRowItemsChecks): migrated in v0.3.0, remove after 2027-08-05.
+    checks: z.boolean().optional().catch(undefined),
+    // COMPAT(sidebarRowItemsScripts): migrated in v0.3.0, remove after 2027-08-05.
+    scripts: z.boolean().optional().catch(undefined),
+  })
+  .catch(DEFAULT_SIDEBAR_ROW_ITEMS);
+
+const StoredAppSettingsSchema = z
+  .looseObject({
+    theme: ThemePreferenceSchema.catch(DEFAULT_THEME_PREFERENCE),
+    pluginThemeId: z.string().nullable().catch(null),
+    language: z
+      .enum(["system", "ar", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN"])
+      .catch("system"),
+    sendBehavior: z.enum(["interrupt", "steer", "queue"]).catch("steer"),
+    serviceUrlBehavior: z.enum(["ask", "in-app", "external"]).catch("ask"),
+    terminalScrollbackLines: clampedNumber(
+      MIN_TERMINAL_SCROLLBACK_LINES,
+      MAX_TERMINAL_SCROLLBACK_LINES,
+    ).catch(DEFAULT_TERMINAL_SCROLLBACK_LINES),
+    useLegacyTerminalRenderer: z.boolean().catch(false),
+    uiFontFamily: sanitizedFontFamily().catch(""),
+    monoFontFamily: sanitizedFontFamily().catch(""),
+    uiBaseFontSize: clampedNumber(MIN_UI_BASE_FONT_SIZE, MAX_UI_BASE_FONT_SIZE)
+      .optional()
+      .catch(DEFAULT_UI_BASE_FONT_SIZE),
+    contentFontSize: clampedNumber(MIN_CONTENT_FONT_SIZE, MAX_CONTENT_FONT_SIZE)
+      .optional()
+      .catch(DEFAULT_CONTENT_FONT_SIZE),
+    // COMPAT(uiFontSizeScale): replaced by the literal base size in v0.4, remove after 2027-08-17.
+    uiFontSize: clampedNumber(11, 24).optional().catch(undefined),
+    codeFontSize: clampedNumber(MIN_CODE_FONT_SIZE, MAX_CODE_FONT_SIZE).catch(
+      DEFAULT_CODE_FONT_SIZE,
+    ),
+    syntaxTheme: z.string().refine(isSyntaxThemeId).catch("one"),
+    workspaceTitleSource: z.enum(["title", "branch"]).catch("title"),
+    sidebarWorkspaceTrailing: z.enum(["diff", "timestamp", "none"]).catch("diff"),
+    sidebarRowItems: SidebarRowItemsSchema,
+    sidebarChecksDisplay: z.enum(["iconAndText", "icon", "none"]).optional().catch("iconAndText"),
+    autoExpandReasoning: z.boolean().catch(false),
+    toolCallDetailLevel: z
+      .enum(["overview", "detailed"])
+      .or(z.literal("concise").transform(() => "overview" as const))
+      .optional()
+      .catch("detailed"),
+    // COMPAT(compactToolCalls): migrated in v0.1.105, remove after 2027-01-12.
+    compactToolCalls: z.boolean().optional().catch(undefined),
+    chatOutlineEnabled: z.boolean().catch(true),
+    vimKeybindings: z.boolean().catch(false),
+    openSupportingTabsInSidePanel: z.boolean().catch(true),
+    // COMPAT(rendererDesktopSettings): these fields used to share this renderer-owned key.
+    manageBuiltInDaemon: z.boolean().optional().catch(undefined),
+    releaseChannel: z.enum(["stable", "beta"]).optional().catch(undefined),
+  })
+  .transform((stored) => {
+    const needsWrite =
+      (stored.uiBaseFontSize === undefined && stored.uiFontSize !== undefined) ||
+      stored.contentFontSize === undefined;
+    const uiBaseFontSize =
+      stored.uiBaseFontSize ??
+      (stored.uiFontSize === undefined
+        ? DEFAULT_UI_BASE_FONT_SIZE
+        : Math.round((FONT_SIZE.base * stored.uiFontSize) / 16));
+    const sidebarChecksDisplay =
+      stored.sidebarChecksDisplay ??
+      (isChecksHiddenByLegacyRowItem(stored.sidebarRowItems)
+        ? "none"
+        : DEFAULT_SIDEBAR_CHECKS_DISPLAY);
+    const toolCallDetailLevel =
+      stored.toolCallDetailLevel ?? (stored.compactToolCalls ? "overview" : "detailed");
+    return {
+      ...stored,
+      uiBaseFontSize,
+      contentFontSize: stored.contentFontSize ?? uiBaseFontSize,
+      sidebarChecksDisplay,
+      sidebarRowItems: {
+        ...stored.sidebarRowItems,
+        services:
+          stored.sidebarRowItems.scripts === false ? false : stored.sidebarRowItems.services,
+      },
+      toolCallDetailLevel,
+      needsWrite,
+    };
+  })
+  .catch({ ...DEFAULT_CLIENT_SETTINGS, needsWrite: false } as never);
+
+type StoredAppSettings = z.output<typeof StoredAppSettingsSchema>;
 
 export interface KeyValueStorage {
   getItem(key: string): Promise<string | null>;
@@ -176,7 +270,8 @@ export async function saveAppSettings(input: {
   input.queryClient.setQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY, next);
   await writeAppSettings(
     input.deps.storage,
-    (await readSettingsObject(input.deps.storage, APP_SETTINGS_KEY)) ?? {},
+    (await readSettingsObject(input.deps.storage, APP_SETTINGS_KEY)) ??
+      StoredAppSettingsSchema.parse({}),
     next,
   );
 }
@@ -206,9 +301,7 @@ async function readAppSettings(
     return {
       settings: normalizeAppSettings(stored),
       // COMPAT(uiFontSizeScale): persist the converted base size, remove after 2027-08-17.
-      needsWrite:
-        (stored.uiBaseFontSize === undefined && stored.uiFontSize !== undefined) ||
-        stored.contentFontSize === undefined,
+      needsWrite: stored.needsWrite,
       stored,
     };
   }
@@ -225,7 +318,8 @@ async function readAppSettings(
     };
   }
 
-  return { settings: DEFAULT_CLIENT_SETTINGS, needsWrite: true, stored: {} };
+  const defaultStored = StoredAppSettingsSchema.parse({});
+  return { settings: DEFAULT_CLIENT_SETTINGS, needsWrite: true, stored: defaultStored };
 }
 
 export async function loadSettingsFromStorage(deps: SettingsDeps): Promise<Settings> {
@@ -255,235 +349,25 @@ export async function loadSettingsFromStorage(deps: SettingsDeps): Promise<Setti
 }
 
 export function normalizeAppSettings(value: unknown): AppSettings {
-  const stored = isPlainJsonObject(value) ? value : {};
+  const {
+    needsWrite: _needsWrite,
+    manageBuiltInDaemon: _manageBuiltInDaemon,
+    releaseChannel: _releaseChannel,
+    compactToolCalls: _compactToolCalls,
+    uiFontSize: _uiFontSize,
+    ...settings
+  } = StoredAppSettingsSchema.parse(value);
+  return settings as AppSettings;
+}
+
+function pickAppSettingsFromLegacy(legacy: StoredAppSettings): AppSettings {
+  const settings = normalizeAppSettings(legacy);
   return {
-    ...DEFAULT_CLIENT_SETTINGS,
-    ...pickAppSettings(stored),
+    ...settings,
+    // The legacy key rendered content on the interface ramp. Freeze that
+    // rendered value into the new independent preference during migration.
+    contentFontSize: legacy.uiBaseFontSize,
   };
-}
-
-function pickStoredSetting<Value>(
-  stored: StoredAppSettings,
-  key: string,
-  parse: (value: unknown) => Value | null,
-): Value | null {
-  const value = parse(stored[key]);
-  if (stored[key] !== undefined && value === null) {
-    console.warn(`[AppSettings] Ignoring invalid ${key}.`);
-  }
-  return value;
-}
-
-function parseBoolean(value: unknown): boolean | null {
-  return typeof value === "boolean" ? value : null;
-}
-
-function parseToolCallDetailLevel(stored: StoredAppSettings): ToolCallDetailLevel | null {
-  if (stored.toolCallDetailLevel !== undefined) {
-    if (isEnumValue(VALID_TOOL_CALL_DETAIL_LEVELS, stored.toolCallDetailLevel)) {
-      return stored.toolCallDetailLevel;
-    }
-    // COMPAT(toolCallDetailLevelConcise): removed in v0.1.107; legacy "concise" values
-    // keep their former meaning. Remove after 2027-01-14.
-    if (stored.toolCallDetailLevel === "concise") {
-      return "overview";
-    }
-    console.warn("[AppSettings] Ignoring invalid toolCallDetailLevel.");
-    return null;
-  }
-  const compactToolCalls = pickStoredSetting(stored, "compactToolCalls", parseBoolean);
-  if (compactToolCalls !== null) {
-    // COMPAT(compactToolCalls): migrated in v0.1.105, remove after 2027-01-12.
-    return compactToolCalls ? "overview" : "detailed";
-  }
-  return null;
-}
-
-function parseStoredSidebarChecksDisplay(stored: StoredAppSettings): SidebarChecksDisplay | null {
-  const display = pickStoredSetting(stored, "sidebarChecksDisplay", parseSidebarChecksDisplay);
-  if (display !== null) {
-    return display;
-  }
-  // COMPAT(sidebarRowItemsChecks): migrated in v0.3.0, remove after 2027-08-05.
-  return isChecksHiddenByLegacyRowItem(stored.sidebarRowItems) ? "none" : null;
-}
-
-function pickBooleanAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
-  const result: Partial<AppSettings> = {};
-  const useLegacyTerminalRenderer = pickStoredSetting(
-    stored,
-    "useLegacyTerminalRenderer",
-    parseBoolean,
-  );
-  if (useLegacyTerminalRenderer !== null) {
-    result.useLegacyTerminalRenderer = useLegacyTerminalRenderer;
-  }
-  const vimKeybindings = pickStoredSetting(stored, "vimKeybindings", parseBoolean);
-  if (vimKeybindings !== null) {
-    result.vimKeybindings = vimKeybindings;
-  }
-  const chatOutlineEnabled = pickStoredSetting(stored, "chatOutlineEnabled", parseBoolean);
-  if (chatOutlineEnabled !== null) {
-    result.chatOutlineEnabled = chatOutlineEnabled;
-  }
-  const openSupportingTabsInSidePanel = pickStoredSetting(
-    stored,
-    "openSupportingTabsInSidePanel",
-    parseBoolean,
-  );
-  if (openSupportingTabsInSidePanel !== null) {
-    result.openSupportingTabsInSidePanel = openSupportingTabsInSidePanel;
-  }
-  return result;
-}
-
-/**
- * The settings whose stored value only has to be a member of a fixed set. Grouped like the
- * boolean settings are: the numeric and font settings need real parsing and clamping, these
- * need a membership check and nothing else.
- */
-function pickEnumAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
-  const result: Partial<AppSettings> = {};
-  const theme = pickStoredSetting(stored, "theme", (value) =>
-    isEnumValue(VALID_THEMES, value) ? value : null,
-  );
-  if (theme !== null) {
-    result.theme = theme;
-  }
-  const sendBehavior = pickStoredSetting(stored, "sendBehavior", (value): SendBehavior | null =>
-    value === "interrupt" || value === "steer" || value === "queue" ? value : null,
-  );
-  if (sendBehavior !== null) {
-    result.sendBehavior = sendBehavior;
-  }
-  const serviceUrlBehavior = pickStoredSetting(stored, "serviceUrlBehavior", (value) =>
-    isEnumValue(VALID_SERVICE_URL_BEHAVIORS, value) ? value : null,
-  );
-  if (serviceUrlBehavior !== null) {
-    result.serviceUrlBehavior = serviceUrlBehavior;
-  }
-  const syntaxTheme = pickStoredSetting(stored, "syntaxTheme", (value) =>
-    typeof value === "string" && isSyntaxThemeId(value) ? value : null,
-  );
-  if (syntaxTheme !== null) {
-    result.syntaxTheme = syntaxTheme;
-  }
-  const workspaceTitleSource = pickStoredSetting(stored, "workspaceTitleSource", (value) =>
-    isEnumValue(VALID_WORKSPACE_TITLE_SOURCES, value) ? value : null,
-  );
-  if (workspaceTitleSource !== null) {
-    result.workspaceTitleSource = workspaceTitleSource;
-  }
-  const sidebarWorkspaceTrailing = pickStoredSetting(stored, "sidebarWorkspaceTrailing", (value) =>
-    isEnumValue(VALID_SIDEBAR_WORKSPACE_TRAILINGS, value) ? value : null,
-  );
-  if (sidebarWorkspaceTrailing !== null) {
-    result.sidebarWorkspaceTrailing = sidebarWorkspaceTrailing;
-  }
-  return result;
-}
-
-function pickAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
-  const result: Partial<AppSettings> = {};
-  Object.assign(result, pickEnumAppSettings(stored));
-  if (typeof stored.pluginThemeId === "string") {
-    result.pluginThemeId = stored.pluginThemeId;
-  } else if (stored.pluginThemeId !== undefined && stored.pluginThemeId !== null) {
-    console.warn("[AppSettings] Ignoring invalid pluginThemeId.");
-  }
-  if (stored.sidebarRowItems !== undefined) {
-    if (!isPlainJsonObject(stored.sidebarRowItems)) {
-      console.warn("[AppSettings] Ignoring invalid sidebarRowItems.");
-    }
-    result.sidebarRowItems = parseSidebarRowItems(stored.sidebarRowItems);
-  }
-  const sidebarChecksDisplay = parseStoredSidebarChecksDisplay(stored);
-  if (sidebarChecksDisplay !== null) {
-    result.sidebarChecksDisplay = sidebarChecksDisplay;
-  }
-  const language = pickStoredSetting(stored, "language", parseAppLanguage);
-  if (language !== null) {
-    result.language = language;
-  }
-  const terminalScrollbackLines = pickStoredSetting(
-    stored,
-    "terminalScrollbackLines",
-    parseTerminalScrollbackLines,
-  );
-  if (terminalScrollbackLines !== null) {
-    result.terminalScrollbackLines = terminalScrollbackLines;
-  }
-  const uiFontFamily = pickStoredSetting(stored, "uiFontFamily", sanitizeFontFamily);
-  if (uiFontFamily !== null) {
-    result.uiFontFamily = uiFontFamily;
-  }
-  const monoFontFamily = pickStoredSetting(stored, "monoFontFamily", sanitizeFontFamily);
-  if (monoFontFamily !== null) {
-    result.monoFontFamily = monoFontFamily;
-  }
-  const uiBaseFontSize = pickStoredSetting(stored, "uiBaseFontSize", (value) =>
-    parseClampedFontSize(value, {
-      min: MIN_UI_BASE_FONT_SIZE,
-      max: MAX_UI_BASE_FONT_SIZE,
-    }),
-  );
-  if (uiBaseFontSize !== null) {
-    result.uiBaseFontSize = uiBaseFontSize;
-  } else {
-    const legacyUiFontSize = pickStoredSetting(stored, "uiFontSize", (value) =>
-      parseClampedFontSize(value, { min: 11, max: 24 }),
-    );
-    if (legacyUiFontSize !== null) {
-      result.uiBaseFontSize = Math.round((FONT_SIZE.base * legacyUiFontSize) / 16);
-    }
-  }
-  const contentFontSize = pickStoredSetting(stored, "contentFontSize", (value) =>
-    parseClampedFontSize(value, {
-      min: MIN_CONTENT_FONT_SIZE,
-      max: MAX_CONTENT_FONT_SIZE,
-    }),
-  );
-  if (contentFontSize !== null) {
-    result.contentFontSize = contentFontSize;
-  } else if (stored.contentFontSize === undefined) {
-    // Existing content followed the interface ramp. Preserve that rendered size
-    // once, then persist the independent setting during the read migration.
-    result.contentFontSize = result.uiBaseFontSize ?? DEFAULT_UI_BASE_FONT_SIZE;
-  }
-  const codeFontSize = pickStoredSetting(stored, "codeFontSize", (value) =>
-    parseClampedFontSize(value, {
-      min: MIN_CODE_FONT_SIZE,
-      max: MAX_CODE_FONT_SIZE,
-    }),
-  );
-  if (codeFontSize !== null) {
-    result.codeFontSize = codeFontSize;
-  }
-  Object.assign(result, pickBooleanAppSettings(stored));
-  const autoExpandReasoning = pickStoredSetting(stored, "autoExpandReasoning", parseBoolean);
-  if (autoExpandReasoning !== null) {
-    result.autoExpandReasoning = autoExpandReasoning;
-  }
-  const toolCallDetailLevel = parseToolCallDetailLevel(stored);
-  if (toolCallDetailLevel !== null) {
-    result.toolCallDetailLevel = toolCallDetailLevel;
-  }
-  return result;
-}
-
-function pickAppSettingsFromLegacy(legacy: StoredAppSettings): Partial<AppSettings> {
-  const result: Partial<AppSettings> = {};
-  if (legacy.theme === "dark" || legacy.theme === "light" || legacy.theme === "auto") {
-    result.theme = legacy.theme;
-  }
-  const legacyInterfaceSize = pickAppSettings(legacy).uiBaseFontSize;
-  if (legacyInterfaceSize !== undefined) {
-    result.uiBaseFontSize = legacyInterfaceSize;
-  }
-  // The legacy key rendered content on the interface ramp. Freeze that
-  // rendered value into the new independent preference during migration.
-  result.contentFontSize = legacyInterfaceSize ?? DEFAULT_UI_BASE_FONT_SIZE;
-  return result;
 }
 
 export function parseTerminalScrollbackLines(value: unknown): number | null {
@@ -550,14 +434,10 @@ async function loadLegacyDesktopSettingsFromStorage(storage: KeyValueStorage): P
   const result: {
     manageBuiltInDaemon?: boolean;
     releaseChannel?: ReleaseChannel;
-  } = {};
-
-  if (typeof stored.manageBuiltInDaemon === "boolean") {
-    result.manageBuiltInDaemon = stored.manageBuiltInDaemon;
-  }
-  if (stored.releaseChannel === "stable" || stored.releaseChannel === "beta") {
-    result.releaseChannel = stored.releaseChannel;
-  }
+  } = {
+    manageBuiltInDaemon: stored.manageBuiltInDaemon,
+    releaseChannel: stored.releaseChannel,
+  };
 
   return Object.keys(result).length > 0 ? result : null;
 }
@@ -573,10 +453,6 @@ async function loadRendererSettingsPayload(
   return readSettingsObject(storage, LEGACY_SETTINGS_KEY);
 }
 
-function isPlainJsonObject(value: unknown): value is StoredAppSettings {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 async function readSettingsObject(
   storage: KeyValueStorage,
   key: string,
@@ -587,12 +463,7 @@ async function readSettingsObject(
   }
 
   try {
-    const decoded: unknown = JSON.parse(raw);
-    if (isPlainJsonObject(decoded)) {
-      return decoded;
-    }
-    console.warn(`[AppSettings] Ignoring ${key}: expected a JSON object.`);
-    return null;
+    return StoredAppSettingsSchema.parse(JSON.parse(raw));
   } catch {
     console.warn(`[AppSettings] Removing corrupt ${key}: invalid JSON.`);
     await storage.removeItem(key);
@@ -605,13 +476,12 @@ async function writeAppSettings(
   stored: StoredAppSettings,
   settings: AppSettings,
 ): Promise<void> {
-  const storedSidebarRowItems = isPlainJsonObject(stored.sidebarRowItems)
-    ? stored.sidebarRowItems
-    : {};
+  const { needsWrite: _needsWrite, ...persistedStored } = stored;
+  const storedSidebarRowItems = persistedStored.sidebarRowItems;
   await storage.setItem(
     APP_SETTINGS_KEY,
     JSON.stringify({
-      ...stored,
+      ...persistedStored,
       ...settings,
       sidebarRowItems: { ...storedSidebarRowItems, ...settings.sidebarRowItems },
     }),

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SIDEBAR_ROW_ITEMS,
   isChecksHiddenByLegacyRowItem,
   parseSidebarRowItems,
+  SIDEBAR_ROW_ITEMS,
   type SidebarRowItems,
 } from "@/components/sidebar/display-preferences/row-items";
 import { isNative } from "@/constants/platform";
@@ -21,8 +22,6 @@ import {
   THEME_OPTIONS,
   type ThemePreference,
 } from "@/styles/theme";
-import { z } from "zod";
-import { readValidatedJson } from "@/storage/validated-storage";
 import { APP_SETTINGS_KEY, LEGACY_SETTINGS_KEY } from "./keys";
 import { migrateAppSettings } from "./migrations";
 
@@ -37,11 +36,10 @@ export type WorkspaceTitleSource = "title" | "branch";
 export type SidebarWorkspaceTrailing = "diff" | "timestamp" | "none";
 export type ToolCallDetailLevel = "overview" | "detailed";
 
-const ThemePreferenceSchema = z.enum([
+const VALID_THEMES = new Set<ThemePreference>([
   ...THEME_OPTIONS.map((option) => option.name),
   PLUGIN_THEME_PREFERENCE,
-]);
-const VALID_THEMES = new Set<string>(ThemePreferenceSchema.options);
+] as ThemePreference[]);
 /** Where the theme picker lands when the persisted preference cannot be honoured. */
 export const DEFAULT_THEME_PREFERENCE = "auto" satisfies ThemePreference;
 const VALID_SERVICE_URL_BEHAVIORS = new Set<ServiceUrlBehavior>(["ask", "in-app", "external"]);
@@ -73,6 +71,13 @@ export const DEFAULT_CODE_FONT_SIZE = 12; // == FONT_SIZE.code
 export const MIN_CODE_FONT_SIZE = 9;
 export const MAX_CODE_FONT_SIZE = 22; // line-height 1.5×22=33 stays safe
 export const MAX_FONT_FAMILY_LENGTH = 200;
+
+function isEnumValue<Value extends string>(
+  values: ReadonlySet<Value>,
+  value: unknown,
+): value is Value {
+  return typeof value === "string" && values.has(value as Value);
+}
 
 export interface AppSettings {
   theme: ThemePreference;
@@ -106,57 +111,7 @@ export interface Settings extends AppSettings {
   releaseChannel: ReleaseChannel;
 }
 
-// Strict, so every item in SIDEBAR_ROW_ITEMS needs a key here the day it is added: the whole
-// settings write is one validation, and one unknown key silently loses every other toggle in it.
-// `checks` and `scripts` are gone from the item list and stay here for the COMPAT reads in
-// row-items.ts.
-const SidebarRowItemsSchema = z.strictObject({
-  branch: z.boolean().optional(),
-  project: z.boolean().optional(),
-  host: z.boolean().optional(),
-  changeRequest: z.boolean().optional(),
-  services: z.boolean().optional(),
-  labels: z.boolean().optional(),
-  checks: z.boolean().optional(),
-  scripts: z.boolean().optional(),
-});
-
-const StoredAppSettingsSchema = z.strictObject({
-  theme: ThemePreferenceSchema.optional(),
-  pluginThemeId: z.string().nullish(),
-  language: z
-    .enum(["system", "ar", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN"])
-    .optional(),
-  sendBehavior: z.enum(["interrupt", "steer", "queue"]).optional(),
-  serviceUrlBehavior: z.enum(["ask", "in-app", "external"]).optional(),
-  terminalScrollbackLines: z.union([z.number(), z.string()]).optional(),
-  useLegacyTerminalRenderer: z.boolean().optional(),
-  uiFontFamily: z.string().optional(),
-  monoFontFamily: z.string().optional(),
-  uiBaseFontSize: z.union([z.number(), z.string()]).optional(),
-  contentFontSize: z.union([z.number(), z.string()]).optional(),
-  // COMPAT(uiFontSizeScale): replaced by the literal base size in v0.4, remove after 2027-08-17.
-  uiFontSize: z.union([z.number(), z.string()]).optional(),
-  codeFontSize: z.union([z.number(), z.string()]).optional(),
-  syntaxTheme: z.string().refine(isSyntaxThemeId).optional(),
-  workspaceTitleSource: z.enum(["title", "branch"]).optional(),
-  sidebarWorkspaceTrailing: z.enum(["diff", "timestamp", "none"]).optional(),
-  sidebarRowItems: SidebarRowItemsSchema.optional(),
-  sidebarChecksDisplay: z.enum(["iconAndText", "icon", "none"]).optional(),
-  autoExpandReasoning: z.boolean().optional(),
-  toolCallDetailLevel: z.enum(["overview", "detailed"]).optional(),
-  compactToolCalls: z.boolean().optional(),
-  chatOutlineEnabled: z.boolean().optional(),
-  vimKeybindings: z.boolean().optional(),
-  openSupportingTabsInSidePanel: z.boolean().optional(),
-  // COMPAT(rendererDesktopSettings): these fields used to share this renderer-owned key.
-  manageBuiltInDaemon: z.boolean().optional(),
-  releaseChannel: z.enum(["stable", "beta"]).optional(),
-});
-
-const LegacyRendererSettingsSchema = StoredAppSettingsSchema;
-
-type StoredAppSettings = z.infer<typeof StoredAppSettingsSchema>;
+type StoredAppSettings = Record<string, unknown>;
 
 export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   theme: DEFAULT_THEME_PREFERENCE,
@@ -220,16 +175,20 @@ export async function saveAppSettings(input: {
   const current = normalizeAppSettings(storedCurrent);
   const next = { ...current, ...input.updates };
   input.queryClient.setQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY, next);
-  await input.deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(next));
+  await writeAppSettings(
+    input.deps.storage,
+    (await readSettingsObject(input.deps.storage, APP_SETTINGS_KEY)) ?? {},
+    next,
+  );
 }
 
 export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<AppSettings> {
   try {
     const read = await readAppSettings(deps);
     if (read.needsWrite) {
-      await deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(read.settings));
+      await writeAppSettings(deps.storage, read.stored, read.settings);
     }
-    return await migrateAppSettings(read.settings, deps.storage);
+    return await migrateAppSettings(read.settings, deps.storage, read.stored);
   } catch (error) {
     console.error("[AppSettings] Failed to load settings:", error);
     throw error;
@@ -242,8 +201,8 @@ export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<Ap
  */
 async function readAppSettings(
   deps: SettingsDeps,
-): Promise<{ settings: AppSettings; needsWrite: boolean }> {
-  const stored = await readValidatedJson(deps.storage, APP_SETTINGS_KEY, StoredAppSettingsSchema);
+): Promise<{ settings: AppSettings; needsWrite: boolean; stored: StoredAppSettings }> {
+  const stored = await readSettingsObject(deps.storage, APP_SETTINGS_KEY);
   if (stored) {
     return {
       settings: normalizeAppSettings(stored),
@@ -251,14 +210,11 @@ async function readAppSettings(
       needsWrite:
         (stored.uiBaseFontSize === undefined && stored.uiFontSize !== undefined) ||
         stored.contentFontSize === undefined,
+      stored,
     };
   }
 
-  const legacyStored = await readValidatedJson(
-    deps.storage,
-    LEGACY_SETTINGS_KEY,
-    LegacyRendererSettingsSchema,
-  );
+  const legacyStored = await readSettingsObject(deps.storage, LEGACY_SETTINGS_KEY);
   if (legacyStored) {
     return {
       settings: {
@@ -266,10 +222,11 @@ async function readAppSettings(
         ...pickAppSettingsFromLegacy(legacyStored),
       } satisfies AppSettings,
       needsWrite: true,
+      stored: legacyStored,
     };
   }
 
-  return { settings: DEFAULT_CLIENT_SETTINGS, needsWrite: true };
+  return { settings: DEFAULT_CLIENT_SETTINGS, needsWrite: true, stored: {} };
 }
 
 export async function loadSettingsFromStorage(deps: SettingsDeps): Promise<Settings> {
@@ -299,24 +256,122 @@ export async function loadSettingsFromStorage(deps: SettingsDeps): Promise<Setti
 }
 
 export function normalizeAppSettings(value: unknown): AppSettings {
-  const result = StoredAppSettingsSchema.safeParse(value);
+  const stored = isPlainJsonObject(value) ? value : {};
+  const picked = pickAppSettings(stored);
+  warnDiscardedAppSettings(stored);
   return {
     ...DEFAULT_CLIENT_SETTINGS,
-    ...pickAppSettings(result.success ? result.data : {}),
+    ...picked,
   };
+}
+
+function warnDiscardedAppSettings(stored: StoredAppSettings): void {
+  const discarded = (key: string, valid: boolean): void => {
+    if (stored[key] !== undefined && !valid) {
+      console.warn(`[AppSettings] Ignoring invalid ${key}.`);
+    }
+  };
+
+  discarded("theme", isEnumValue(VALID_THEMES, stored.theme));
+  discarded(
+    "sendBehavior",
+    stored.sendBehavior === "interrupt" ||
+      stored.sendBehavior === "steer" ||
+      stored.sendBehavior === "queue",
+  );
+  discarded(
+    "serviceUrlBehavior",
+    isEnumValue(VALID_SERVICE_URL_BEHAVIORS, stored.serviceUrlBehavior),
+  );
+  discarded("language", parseAppLanguage(stored.language) !== null);
+  discarded(
+    "syntaxTheme",
+    typeof stored.syntaxTheme === "string" && isSyntaxThemeId(stored.syntaxTheme),
+  );
+  discarded(
+    "workspaceTitleSource",
+    isEnumValue(VALID_WORKSPACE_TITLE_SOURCES, stored.workspaceTitleSource),
+  );
+  discarded(
+    "sidebarWorkspaceTrailing",
+    isEnumValue(VALID_SIDEBAR_WORKSPACE_TRAILINGS, stored.sidebarWorkspaceTrailing),
+  );
+  discarded(
+    "sidebarChecksDisplay",
+    parseSidebarChecksDisplay(stored.sidebarChecksDisplay) !== null,
+  );
+  discarded(
+    "terminalScrollbackLines",
+    parseTerminalScrollbackLines(stored.terminalScrollbackLines) !== null,
+  );
+  discarded("uiFontFamily", sanitizeFontFamily(stored.uiFontFamily) !== null);
+  discarded("monoFontFamily", sanitizeFontFamily(stored.monoFontFamily) !== null);
+  discarded(
+    "uiBaseFontSize",
+    parseClampedFontSize(stored.uiBaseFontSize, {
+      min: MIN_UI_BASE_FONT_SIZE,
+      max: MAX_UI_BASE_FONT_SIZE,
+    }) !== null,
+  );
+  discarded(
+    "contentFontSize",
+    parseClampedFontSize(stored.contentFontSize, {
+      min: MIN_CONTENT_FONT_SIZE,
+      max: MAX_CONTENT_FONT_SIZE,
+    }) !== null,
+  );
+  discarded(
+    "codeFontSize",
+    parseClampedFontSize(stored.codeFontSize, {
+      min: MIN_CODE_FONT_SIZE,
+      max: MAX_CODE_FONT_SIZE,
+    }) !== null,
+  );
+  discarded("uiFontSize", parseClampedFontSize(stored.uiFontSize, { min: 11, max: 24 }) !== null);
+  for (const key of [
+    "useLegacyTerminalRenderer",
+    "vimKeybindings",
+    "chatOutlineEnabled",
+    "openSupportingTabsInSidePanel",
+    "autoExpandReasoning",
+  ]) {
+    discarded(key, typeof stored[key] === "boolean");
+  }
+  discarded(
+    "toolCallDetailLevel",
+    isEnumValue(VALID_TOOL_CALL_DETAIL_LEVELS, stored.toolCallDetailLevel) ||
+      stored.toolCallDetailLevel === "concise",
+  );
+  discarded("compactToolCalls", typeof stored.compactToolCalls === "boolean");
+  if (
+    stored.pluginThemeId !== undefined &&
+    stored.pluginThemeId !== null &&
+    typeof stored.pluginThemeId !== "string"
+  ) {
+    console.warn("[AppSettings] Ignoring invalid pluginThemeId.");
+  }
+  if (stored.sidebarRowItems !== undefined && !isPlainJsonObject(stored.sidebarRowItems)) {
+    console.warn("[AppSettings] Ignoring invalid sidebarRowItems.");
+  } else if (isPlainJsonObject(stored.sidebarRowItems)) {
+    for (const key of SIDEBAR_ROW_ITEMS) {
+      if (
+        stored.sidebarRowItems[key] !== undefined &&
+        typeof stored.sidebarRowItems[key] !== "boolean"
+      ) {
+        console.warn(`[AppSettings] Ignoring invalid sidebarRowItems.${key}.`);
+      }
+    }
+  }
 }
 
 function parseToolCallDetailLevel(stored: StoredAppSettings): ToolCallDetailLevel | null {
   if (stored.toolCallDetailLevel !== undefined) {
-    if (
-      typeof stored.toolCallDetailLevel === "string" &&
-      VALID_TOOL_CALL_DETAIL_LEVELS.has(stored.toolCallDetailLevel)
-    ) {
+    if (isEnumValue(VALID_TOOL_CALL_DETAIL_LEVELS, stored.toolCallDetailLevel)) {
       return stored.toolCallDetailLevel;
     }
     // COMPAT(toolCallDetailLevelConcise): removed in v0.1.107; legacy "concise" values
-    // deliberately follow the unknown-value fallback. Remove after 2027-01-14.
-    return "overview";
+    // keep their former meaning. Remove after 2027-01-14.
+    return stored.toolCallDetailLevel === "concise" ? "overview" : null;
   }
   if (typeof stored.compactToolCalls === "boolean") {
     // COMPAT(compactToolCalls): migrated in v0.1.105, remove after 2027-01-12.
@@ -358,7 +413,7 @@ function pickBooleanAppSettings(stored: StoredAppSettings): Partial<AppSettings>
  */
 function pickEnumAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   const result: Partial<AppSettings> = {};
-  if (typeof stored.theme === "string" && VALID_THEMES.has(stored.theme)) {
+  if (isEnumValue(VALID_THEMES, stored.theme)) {
     result.theme = stored.theme;
   }
   if (
@@ -368,25 +423,16 @@ function pickEnumAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   ) {
     result.sendBehavior = stored.sendBehavior;
   }
-  if (
-    typeof stored.serviceUrlBehavior === "string" &&
-    VALID_SERVICE_URL_BEHAVIORS.has(stored.serviceUrlBehavior)
-  ) {
+  if (isEnumValue(VALID_SERVICE_URL_BEHAVIORS, stored.serviceUrlBehavior)) {
     result.serviceUrlBehavior = stored.serviceUrlBehavior;
   }
   if (typeof stored.syntaxTheme === "string" && isSyntaxThemeId(stored.syntaxTheme)) {
     result.syntaxTheme = stored.syntaxTheme;
   }
-  if (
-    typeof stored.workspaceTitleSource === "string" &&
-    VALID_WORKSPACE_TITLE_SOURCES.has(stored.workspaceTitleSource)
-  ) {
+  if (isEnumValue(VALID_WORKSPACE_TITLE_SOURCES, stored.workspaceTitleSource)) {
     result.workspaceTitleSource = stored.workspaceTitleSource;
   }
-  if (
-    typeof stored.sidebarWorkspaceTrailing === "string" &&
-    VALID_SIDEBAR_WORKSPACE_TRAILINGS.has(stored.sidebarWorkspaceTrailing)
-  ) {
+  if (isEnumValue(VALID_SIDEBAR_WORKSPACE_TRAILINGS, stored.sidebarWorkspaceTrailing)) {
     result.sidebarWorkspaceTrailing = stored.sidebarWorkspaceTrailing;
   }
   return result;
@@ -465,9 +511,7 @@ function pickAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   return result;
 }
 
-function pickAppSettingsFromLegacy(
-  legacy: z.infer<typeof LegacyRendererSettingsSchema>,
-): Partial<AppSettings> {
+function pickAppSettingsFromLegacy(legacy: StoredAppSettings): Partial<AppSettings> {
   const result: Partial<AppSettings> = {};
   if (legacy.theme === "dark" || legacy.theme === "light" || legacy.theme === "auto") {
     result.theme = legacy.theme;
@@ -560,11 +604,56 @@ async function loadLegacyDesktopSettingsFromStorage(storage: KeyValueStorage): P
 
 async function loadRendererSettingsPayload(
   storage: KeyValueStorage,
-): Promise<z.infer<typeof LegacyRendererSettingsSchema> | null> {
-  const current = await readValidatedJson(storage, APP_SETTINGS_KEY, LegacyRendererSettingsSchema);
+): Promise<StoredAppSettings | null> {
+  const current = await readSettingsObject(storage, APP_SETTINGS_KEY);
   if (current) {
     return current;
   }
 
-  return readValidatedJson(storage, LEGACY_SETTINGS_KEY, LegacyRendererSettingsSchema);
+  return readSettingsObject(storage, LEGACY_SETTINGS_KEY);
+}
+
+function isPlainJsonObject(value: unknown): value is StoredAppSettings {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readSettingsObject(
+  storage: KeyValueStorage,
+  key: string,
+): Promise<StoredAppSettings | null> {
+  const raw = await storage.getItem(key);
+  if (raw === null) {
+    return null;
+  }
+
+  try {
+    const decoded: unknown = JSON.parse(raw);
+    if (isPlainJsonObject(decoded)) {
+      return decoded;
+    }
+    console.warn(`[AppSettings] Ignoring ${key}: expected a JSON object.`);
+    return null;
+  } catch {
+    console.warn(`[AppSettings] Removing corrupt ${key}: invalid JSON.`);
+    await storage.removeItem(key);
+    return null;
+  }
+}
+
+async function writeAppSettings(
+  storage: KeyValueStorage,
+  stored: StoredAppSettings,
+  settings: AppSettings,
+): Promise<void> {
+  const storedSidebarRowItems = isPlainJsonObject(stored.sidebarRowItems)
+    ? stored.sidebarRowItems
+    : {};
+  await storage.setItem(
+    APP_SETTINGS_KEY,
+    JSON.stringify({
+      ...stored,
+      ...settings,
+      sidebarRowItems: { ...storedSidebarRowItems, ...settings.sidebarRowItems },
+    }),
+  );
 }

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -37,7 +37,7 @@ export type ToolCallDetailLevel = "overview" | "detailed";
 const ThemePreferenceSchema = z.enum([
   ...THEME_OPTIONS.map((option) => option.name),
   PLUGIN_THEME_PREFERENCE,
-] as ThemePreference[]);
+]);
 /** Where the theme picker lands when the persisted preference cannot be honoured. */
 export const DEFAULT_THEME_PREFERENCE = "auto" satisfies ThemePreference;
 export const DEFAULT_TERMINAL_SCROLLBACK_LINES = 10_000;
@@ -248,6 +248,7 @@ const StoredAppSettingsSchema = z
   .catch(DEFAULT_STORED_APP_SETTINGS);
 
 type StoredAppSettings = z.output<typeof StoredAppSettingsSchema>;
+export type PersistedAppSettings = Omit<StoredAppSettings, "needsWrite">;
 
 export interface KeyValueStorage {
   getItem(key: string): Promise<string | null>;
@@ -370,7 +371,7 @@ export function normalizeAppSettings(value: unknown): AppSettings {
     uiFontSize: _uiFontSize,
     ...settings
   } = StoredAppSettingsSchema.parse(value);
-  return settings as AppSettings;
+  return settings;
 }
 
 function pickAppSettingsFromLegacy(legacy: StoredAppSettings): AppSettings {

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -127,18 +127,13 @@ export const DEFAULT_APP_SETTINGS: Settings = {
 
 function clampedNumber(min: number, max: number) {
   return z
-    .union([z.number(), z.string().trim().min(1).transform(Number)])
-    .refine(Number.isFinite)
-    .transform((value) => Math.min(max, Math.max(min, Math.floor(value))));
+    .unknown()
+    .transform((value) => parseClampedFontSize(value, { min, max }))
+    .pipe(z.number());
 }
 
 function sanitizedFontFamily() {
-  return z
-    .string()
-    .transform((value) => value.trim())
-    .refine((value) => value.length <= MAX_FONT_FAMILY_LENGTH)
-    .refine((value) => !/[;{}<>]/.test(value))
-    .refine((value) => ![...value].some((char) => char.charCodeAt(0) <= 0x1f));
+  return z.unknown().transform(sanitizeFontFamily).pipe(z.string());
 }
 
 const SidebarRowItemsSchema = z
@@ -147,7 +142,7 @@ const SidebarRowItemsSchema = z
     project: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.project),
     host: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.host),
     changeRequest: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.changeRequest),
-    services: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.services),
+    services: z.boolean().optional().catch(undefined),
     labels: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.labels),
     // COMPAT(sidebarRowItemsChecks): migrated in v0.3.0, remove after 2027-08-05.
     checks: z.boolean().optional().catch(undefined),
@@ -155,6 +150,19 @@ const SidebarRowItemsSchema = z
     scripts: z.boolean().optional().catch(undefined),
   })
   .catch(DEFAULT_SIDEBAR_ROW_ITEMS);
+
+type StoredAppSettingsFallback = AppSettings & {
+  uiFontSize?: number;
+  compactToolCalls?: boolean;
+  manageBuiltInDaemon?: boolean;
+  releaseChannel?: ReleaseChannel;
+  needsWrite: boolean;
+};
+
+const DEFAULT_STORED_APP_SETTINGS = {
+  ...DEFAULT_CLIENT_SETTINGS,
+  needsWrite: false,
+} satisfies StoredAppSettingsFallback;
 
 const StoredAppSettingsSchema = z
   .looseObject({
@@ -187,7 +195,10 @@ const StoredAppSettingsSchema = z
     workspaceTitleSource: z.enum(["title", "branch"]).catch("title"),
     sidebarWorkspaceTrailing: z.enum(["diff", "timestamp", "none"]).catch("diff"),
     sidebarRowItems: SidebarRowItemsSchema,
-    sidebarChecksDisplay: z.enum(["iconAndText", "icon", "none"]).optional().catch("iconAndText"),
+    sidebarChecksDisplay: z
+      .enum(["iconAndText", "icon", "none"])
+      .optional()
+      .catch(DEFAULT_SIDEBAR_CHECKS_DISPLAY),
     autoExpandReasoning: z.boolean().catch(false),
     toolCallDetailLevel: z
       .enum(["overview", "detailed"])
@@ -227,13 +238,14 @@ const StoredAppSettingsSchema = z
       sidebarRowItems: {
         ...stored.sidebarRowItems,
         services:
-          stored.sidebarRowItems.scripts === false ? false : stored.sidebarRowItems.services,
+          stored.sidebarRowItems.services ??
+          (stored.sidebarRowItems.scripts === false ? false : DEFAULT_SIDEBAR_ROW_ITEMS.services),
       },
       toolCallDetailLevel,
       needsWrite,
     };
   })
-  .catch({ ...DEFAULT_CLIENT_SETTINGS, needsWrite: false } as never);
+  .catch(DEFAULT_STORED_APP_SETTINGS);
 
 type StoredAppSettings = z.output<typeof StoredAppSettingsSchema>;
 
@@ -282,7 +294,8 @@ export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<Ap
     if (read.needsWrite) {
       await writeAppSettings(deps.storage, read.stored, read.settings);
     }
-    return await migrateAppSettings(read.settings, deps.storage, read.stored);
+    const { needsWrite: _needsWrite, ...stored } = read.stored;
+    return await migrateAppSettings(read.settings, deps.storage, stored);
   } catch (error) {
     console.error("[AppSettings] Failed to load settings:", error);
     throw error;
@@ -434,10 +447,14 @@ async function loadLegacyDesktopSettingsFromStorage(storage: KeyValueStorage): P
   const result: {
     manageBuiltInDaemon?: boolean;
     releaseChannel?: ReleaseChannel;
-  } = {
-    manageBuiltInDaemon: stored.manageBuiltInDaemon,
-    releaseChannel: stored.releaseChannel,
-  };
+  } = {};
+
+  if (stored.manageBuiltInDaemon !== undefined) {
+    result.manageBuiltInDaemon = stored.manageBuiltInDaemon;
+  }
+  if (stored.releaseChannel !== undefined) {
+    result.releaseChannel = stored.releaseChannel;
+  }
 
   return Object.keys(result).length > 0 ? result : null;
 }
@@ -462,13 +479,15 @@ async function readSettingsObject(
     return null;
   }
 
+  let decoded: unknown;
   try {
-    return StoredAppSettingsSchema.parse(JSON.parse(raw));
+    decoded = JSON.parse(raw);
   } catch {
     console.warn(`[AppSettings] Removing corrupt ${key}: invalid JSON.`);
     await storage.removeItem(key);
     return null;
   }
+  return StoredAppSettingsSchema.parse(decoded);
 }
 
 async function writeAppSettings(


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A build that does not recognize one setting written by another revision could delete the entire app-settings blob during startup, then rewrite defaults. This affected a from-source workflow reported by Christoph in the contributing Discord channel (messages 1537698203833475114 and 1541361659543814144). PR #3289 introduced the strict validation that made the whole blob fail.

App settings now use one declarative loose Zod schema. Each field falls back independently, while loose top-level and sidebar-row objects retain fields the running build does not understand. The schema carries numeric coercion/clamping and font sanitization; its small transform holds only cross-field compatibility rules. Saves and migration writes merge the parsed loose object beneath known settings, so revisions sharing a profile do not erase one another’s settings. Invalid JSON remains the only content that is removed.

### Goals

- Keep recognized valid preferences when the blob contains a newer field or enum value.
- Preserve unrecognized top-level and sidebar-row keys across settings writes and migrations.
- Keep all app-settings validation and fallback policy in one schema.
- Keep the strict delete-on-invalid behavior for other validated-storage consumers.

### Non-goals

- Change validation or invalid-cache cleanup outside app-settings storage.
- Interpret settings unknown to the running build.

### QA

- `npx vitest run packages/app/src/hooks/use-settings/storage.test.ts --bail=1`
  - 69 tests passed, including mixed-revision load and round-trip coverage.
- `npm run typecheck`
  - Passed.
- `npm run lint`
  - Passed.
- `npm run format`
  - Passed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense