### PR TITLE
feat(pi): project pi-subagents into provider panels

### DIFF
--- a/packages/app/src/panels/provider-subagent-panel.tsx
+++ b/packages/app/src/panels/provider-subagent-panel.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Text, View } from "react-native";
+import { Button } from "@/components/ui/button";
+import { EditingTextInput } from "@/components/ui/text-input";
 import { StyleSheet } from "react-native-unistyles";
 import invariant from "tiny-invariant";
 import { useShallow } from "zustand/react/shallow";
@@ -17,6 +19,7 @@ import {
 } from "@/subagents/provider-store";
 import { useTranslation } from "react-i18next";
 import type { PendingPermission } from "@/types/shared";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { StreamItem } from "@/types/stream";
 import { deriveSidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { TIMELINE_FETCH_PAGE_SIZE } from "@/timeline/timeline-fetch-policy";
@@ -66,6 +69,141 @@ function useProviderSubagentDescriptor(
   };
 }
 
+interface ProviderSubagentControlsProps {
+  client: DaemonClient;
+  parentAgentId: string;
+  subagentId: string;
+  status: "running" | "completed" | "failed" | "canceled";
+}
+
+function ProviderSubagentControls(props: ProviderSubagentControlsProps) {
+  const [message, setMessage] = useState("");
+  const [inputKey, setInputKey] = useState(0);
+  const [pending, setPending] = useState<"stop" | "steer" | "resume" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const runControl = useCallback(
+    async (action: "stop" | "steer" | "resume") => {
+      if (pending) return;
+      const trimmed = message.trim();
+      if ((action === "steer" || action === "resume") && !trimmed) {
+        setError("Enter a message first");
+        return;
+      }
+      setPending(action);
+      setError(null);
+      try {
+        await props.client.controlProviderSubagent({
+          parentAgentId: props.parentAgentId,
+          subagentId: props.subagentId,
+          action,
+          ...(trimmed ? { message: trimmed } : {}),
+        });
+        if (action !== "stop") {
+          setMessage("");
+          setInputKey((value) => value + 1);
+        }
+      } catch (controlError) {
+        setError(controlError instanceof Error ? controlError.message : String(controlError));
+      } finally {
+        setPending(null);
+      }
+    },
+    [message, pending, props.client, props.parentAgentId, props.subagentId],
+  );
+  const handleSteer = useCallback(() => void runControl("steer"), [runControl]);
+  const handleStop = useCallback(() => void runControl("stop"), [runControl]);
+  const handleResume = useCallback(() => void runControl("resume"), [runControl]);
+
+  return (
+    <>
+      <View style={styles.controls} testID="provider-subagent-controls">
+        <EditingTextInput
+          key={inputKey}
+          style={styles.controlInput}
+          initialValue={message}
+          onChangeText={setMessage}
+          placeholder={
+            props.status === "running" ? "Steer this subagent" : "Message to resume this subagent"
+          }
+          placeholderTextColor={styles.placeholderColor.color}
+          editable={pending === null}
+          accessibilityLabel="Pi Subagent control message"
+        />
+        {props.status === "running" ? (
+          <>
+            <Button
+              size="xs"
+              variant="default"
+              loading={pending === "steer"}
+              disabled={pending !== null}
+              onPress={handleSteer}
+            >
+              Steer
+            </Button>
+            <Button
+              size="xs"
+              variant="outline"
+              loading={pending === "stop"}
+              disabled={pending !== null}
+              onPress={handleStop}
+            >
+              Stop
+            </Button>
+          </>
+        ) : (
+          <Button
+            size="xs"
+            variant="default"
+            loading={pending === "resume"}
+            disabled={pending !== null}
+            onPress={handleResume}
+          >
+            Resume
+          </Button>
+        )}
+      </View>
+      {error ? <Text style={styles.controlError}>{error}</Text> : null}
+    </>
+  );
+}
+
+interface ProviderSubagentHeaderProps {
+  subtitle: string | undefined;
+  controlsSupported: boolean;
+  client: DaemonClient | null;
+  descriptor: {
+    status: "running" | "completed" | "failed" | "canceled";
+  } | null;
+  parentAgentId: string;
+  subagentId: string;
+}
+
+function ProviderSubagentHeader(props: ProviderSubagentHeaderProps) {
+  if (!props.subtitle && !props.controlsSupported) return null;
+  return (
+    <View style={styles.controlHeader}>
+      {props.subtitle ? (
+        <Text
+          style={styles.subtitleText}
+          numberOfLines={1}
+          testID="provider-subagent-pane-subtitle"
+        >
+          {props.subtitle}
+        </Text>
+      ) : null}
+      {props.controlsSupported && props.client && props.descriptor ? (
+        <ProviderSubagentControls
+          client={props.client}
+          parentAgentId={props.parentAgentId}
+          subagentId={props.subagentId}
+          status={props.descriptor.status}
+        />
+      ) : null}
+    </View>
+  );
+}
+
 function ProviderSubagentPanel() {
   const { t } = useTranslation();
   const { serverId, target, openFileInWorkspace } = usePaneContext();
@@ -89,6 +227,8 @@ function ProviderSubagentPanel() {
   // COMPAT(providerSubagents): added in v0.2.11, remove after 2027-01-12.
   const supported = serverInfo?.features?.providerSubagents === true;
   const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  // COMPAT(providerSubagentControl): added in v0.5.1-pie.1, remove after 2027-02-24.
+  const controlsSupported = serverInfo?.features?.providerSubagentControl === true;
 
   useEffect(() => {
     if (!client || !supported) return;
@@ -184,17 +324,14 @@ function ProviderSubagentPanel() {
 
   return (
     <View style={styles.container} testID="provider-subagent-panel">
-      {subtitle ? (
-        <View style={styles.subtitleHeader}>
-          <Text
-            style={styles.subtitleText}
-            numberOfLines={1}
-            testID="provider-subagent-pane-subtitle"
-          >
-            {subtitle}
-          </Text>
-        </View>
-      ) : null}
+      <ProviderSubagentHeader
+        subtitle={subtitle}
+        controlsSupported={controlsSupported}
+        client={client}
+        descriptor={descriptor}
+        parentAgentId={target.parentAgentId}
+        subagentId={target.subagentId}
+      />
       <AgentStreamView
         agentId={streamId}
         serverId={serverId}
@@ -214,14 +351,39 @@ function ProviderSubagentPanel() {
 
 const styles = StyleSheet.create((theme) => ({
   container: { flex: 1, minHeight: 0 },
-  subtitleHeader: {
+  controlHeader: {
+    gap: theme.spacing[1],
     paddingHorizontal: theme.spacing[3],
-    paddingVertical: theme.spacing[1],
+    paddingVertical: theme.spacing[2],
     borderBottomWidth: theme.borderWidth[1],
     borderBottomColor: theme.colors.border,
   },
   subtitleText: {
     color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  controls: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  controlInput: {
+    flex: 1,
+    minWidth: 0,
+    color: theme.colors.foreground,
+    backgroundColor: theme.colors.surface2,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: theme.spacing[1],
+    fontSize: theme.fontSize.sm,
+  },
+  placeholderColor: {
+    color: theme.colors.foregroundMuted,
+  },
+  controlError: {
+    color: theme.colors.statusDanger,
     fontSize: theme.fontSize.sm,
   },
   unsupported: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -575,6 +575,10 @@ export type ProviderSubagentTimelinePayload = Extract<
   SessionOutboundMessage,
   { type: "agent.provider_subagents.timeline.get.response" }
 >["payload"];
+export type ProviderSubagentControlPayload = Extract<
+  SessionOutboundMessage,
+  { type: "agent.provider_subagents.control.response" }
+>["payload"];
 export interface FetchProviderSubagentTimelineOptions {
   direction?: ProviderSubagentTimelinePayload["direction"];
   cursor?: FetchAgentTimelineCursor;
@@ -2956,6 +2960,40 @@ export class DaemonClient {
       options: { skipQueue: true },
       select: (response) =>
         response.type === "agent.provider_subagents.timeline.get.response" &&
+        response.payload.requestId === requestId
+          ? response.payload
+          : null,
+    });
+    if (payload.error) {
+      throw new Error(payload.error);
+    }
+    return payload;
+  }
+
+  async controlProviderSubagent(input: {
+    parentAgentId: string;
+    subagentId: string;
+    action: "stop" | "steer" | "resume";
+    message?: string;
+    requestId?: string;
+    timeout?: number;
+  }): Promise<ProviderSubagentControlPayload> {
+    const requestId = this.createRequestId(input.requestId);
+    const message = SessionInboundMessageSchema.parse({
+      type: "agent.provider_subagents.control.request",
+      parentAgentId: input.parentAgentId,
+      subagentId: input.subagentId,
+      action: input.action,
+      ...(input.message ? { message: input.message } : {}),
+      requestId,
+    });
+    const payload = await this.sendRequest({
+      requestId,
+      message,
+      timeout: input.timeout,
+      options: { skipQueue: true },
+      select: (response) =>
+        response.type === "agent.provider_subagents.control.response" &&
         response.payload.requestId === requestId
           ? response.payload
           : null,

--- a/packages/protocol/src/messages.provider-subagents.test.ts
+++ b/packages/protocol/src/messages.provider-subagents.test.ts
@@ -36,6 +36,34 @@ describe("provider subagent protocol", () => {
     });
   });
 
+  test("accepts correlated provider-subagent control requests and responses", () => {
+    expect(
+      SessionInboundMessageSchema.parse({
+        type: "agent.provider_subagents.control.request",
+        parentAgentId: "parent-1",
+        subagentId: "child-1",
+        action: "steer",
+        message: "focus on tests",
+        requestId: "control-1",
+      }),
+    ).toMatchObject({ action: "steer", message: "focus on tests" });
+
+    expect(
+      SessionOutboundMessageSchema.parse({
+        type: "agent.provider_subagents.control.response",
+        payload: {
+          requestId: "control-1",
+          parentAgentId: "parent-1",
+          subagentId: "child-1",
+          action: "steer",
+          accepted: true,
+          message: "steer accepted",
+          error: null,
+        },
+      }),
+    ).toMatchObject({ payload: { accepted: true, message: "steer accepted" } });
+  });
+
   test("accepts a provider child working directory while remaining compatible when absent", () => {
     const descriptor = {
       id: "child-1",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1744,6 +1744,15 @@ export const ProviderSubagentTimelineRequestMessageSchema = z.object({
   limit: z.number().int().nonnegative().optional(),
 });
 
+export const ProviderSubagentControlRequestMessageSchema = z.object({
+  type: z.literal("agent.provider_subagents.control.request"),
+  parentAgentId: z.string(),
+  subagentId: z.string(),
+  action: z.enum(["stop", "steer", "resume"]),
+  message: z.string().optional(),
+  requestId: z.string(),
+});
+
 export const SetAgentTimelineSubscriptionRequestMessageSchema = z.object({
   type: z.literal("agent.timeline.set_subscription.request"),
   agentIds: z.array(z.string()),
@@ -3021,6 +3030,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   AgentTimelineListPromptsRequestMessageSchema,
   ProviderSubagentListRequestMessageSchema,
   ProviderSubagentTimelineRequestMessageSchema,
+  ProviderSubagentControlRequestMessageSchema,
   SetAgentTimelineSubscriptionRequestMessageSchema,
   AgentForkContextRequestMessageSchema,
   SetAgentModeRequestMessageSchema,
@@ -3373,6 +3383,8 @@ export const ServerInfoStatusPayloadSchema = z
         agentForkContextCursor: z.boolean().optional(),
         // COMPAT(providerSubagents): added in v0.1.107, remove gate after 2027-01-12.
         providerSubagents: z.boolean().optional(),
+        // COMPAT(providerSubagentControl): added in v0.5.1-pie.1, remove after 2027-02-24.
+        providerSubagentControl: z.boolean().optional(),
         // COMPAT(workspacePinning): added in v0.1.107, remove gate after 2027-01-12.
         workspacePinning: z.boolean().optional(),
         // COMPAT(hubRelationship): added in v0.1.X, drop the gate when floor >= v0.1.X.
@@ -4340,6 +4352,19 @@ export const ProviderSubagentTimelineResponseMessageSchema = z.object({
         seq: z.number().int().nonnegative(),
       }),
     ),
+    error: z.string().nullable(),
+  }),
+});
+
+export const ProviderSubagentControlResponseMessageSchema = z.object({
+  type: z.literal("agent.provider_subagents.control.response"),
+  payload: z.object({
+    requestId: z.string(),
+    parentAgentId: z.string(),
+    subagentId: z.string(),
+    action: z.enum(["stop", "steer", "resume"]),
+    accepted: z.boolean(),
+    message: z.string().optional(),
     error: z.string().nullable(),
   }),
 });
@@ -6226,6 +6251,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   AgentTimelineListPromptsResponseMessageSchema,
   ProviderSubagentListResponseMessageSchema,
   ProviderSubagentTimelineResponseMessageSchema,
+  ProviderSubagentControlResponseMessageSchema,
   ProviderSubagentUpdateMessageSchema,
   SetAgentTimelineSubscriptionResponseMessageSchema,
   AgentAttentionRequiredMessageSchema,

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -47,6 +47,8 @@ import {
   type ImportedTimelineEntry,
   type ImportableProviderSession,
   type ListImportableSessionsOptions,
+  type ProviderSubagentControlAction,
+  type ProviderSubagentControlResult,
 } from "./agent-sdk-types.js";
 import { buildArchivedAgentRecord, type ArchivedStoredAgentRecord } from "./agent-archive.js";
 import type { StoredAgentRecord, AgentStorage } from "./agent-storage.js";
@@ -1126,6 +1128,27 @@ export class AgentManager {
   ): AgentTimelineFetchResult {
     this.requirePublicAgent(parentAgentId);
     return this.providerSubagents.fetchTimeline(parentAgentId, subagentId, options);
+  }
+
+  async controlProviderSubagent(input: {
+    parentAgentId: string;
+    subagentId: string;
+    action: ProviderSubagentControlAction;
+    message?: string;
+  }): Promise<ProviderSubagentControlResult> {
+    const agent = this.requireSessionAgent(input.parentAgentId);
+    const descriptor = this.providerSubagents.get(input.parentAgentId, input.subagentId);
+    if (!descriptor || descriptor.provider !== agent.provider) {
+      return { status: "unavailable", message: "Provider subagent was not found" };
+    }
+    if (!agent.session.controlProviderSubagent) {
+      return { status: "unavailable", message: "Provider subagent controls are unavailable" };
+    }
+    return await agent.session.controlProviderSubagent({
+      subagentId: input.subagentId,
+      action: input.action,
+      ...(input.message ? { message: input.message } : {}),
+    });
   }
 
   createAgent(

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -221,6 +221,18 @@ export interface AgentSteerOptions extends AgentRunOptions {
 
 export type SteerResult = { status: "accepted" } | { status: "unavailable" };
 
+export type ProviderSubagentControlAction = "stop" | "steer" | "resume";
+
+export interface ProviderSubagentControlInput {
+  subagentId: string;
+  action: ProviderSubagentControlAction;
+  message?: string;
+}
+
+export type ProviderSubagentControlResult =
+  | { status: "accepted"; message?: string }
+  | { status: "unavailable"; message?: string };
+
 export interface SteerActiveTurnOptions extends AgentSteerOptions {
   expectedTurnId: string;
 }
@@ -641,6 +653,9 @@ export interface AgentSession {
   run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult>;
   startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<{ turnId: string }>;
   steerActiveTurn?(prompt: AgentPromptInput, options: SteerActiveTurnOptions): Promise<SteerResult>;
+  controlProviderSubagent?(
+    input: ProviderSubagentControlInput,
+  ): Promise<ProviderSubagentControlResult>;
   subscribe(callback: (event: AgentStreamEvent) => void): () => void;
   streamHistory(): AsyncGenerator<AgentStreamEvent>;
   getRuntimeInfo(): Promise<AgentRuntimeInfo>;

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -229,6 +229,13 @@ class SessionEvents {
     });
   }
 
+  providerSubagentEvents() {
+    return this.events.filter(
+      (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
+        event.type === "provider_subagent",
+    );
+  }
+
   turnCompletedEvents() {
     return this.events.filter(
       (event): event is Extract<AgentStreamEvent, { type: "turn_completed" }> =>
@@ -302,6 +309,47 @@ class SessionEvents {
 }
 
 describe("PiRpcAgentSession", () => {
+  test("projects Pi Subagents async status widgets into provider-subagent events", async () => {
+    const { pi, events } = await createSession();
+    pi.latestSession().emit({
+      type: "extension_ui_request",
+      id: "subagents-widget",
+      method: "setWidget",
+      widgetKey: "subagent-async",
+      widgetLines: [
+        `PI_SUBAGENT_ASYNC_JSON:${JSON.stringify({
+          kind: "pi-subagents.async-status-snapshot",
+          version: 1,
+          generatedAt: 70_000,
+          caps: {},
+          omitted: {},
+          runs: [
+            {
+              id: "async-1",
+              kind: "subagent",
+              label: "worker",
+              state: "running",
+              startedAt: 10_000,
+              activity: { currentTool: "read", toolCount: 2 },
+            },
+          ],
+        })}`,
+      ],
+    });
+
+    expect(events.providerSubagentEvents()).toEqual([
+      expect.objectContaining({
+        provider: "pi",
+        event: expect.objectContaining({
+          type: "upsert",
+          title: "worker",
+          status: "running",
+          subtitle: "running · read · 2 tools · 1m",
+        }),
+      }),
+    ]);
+  });
+
   test("bridges Pi RPC select extension UI requests through question permissions", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -322,7 +322,7 @@ describe("PiRpcAgentSession", () => {
           version: 1,
           generatedAt: 70_000,
           caps: {},
-          omitted: {},
+          omitted: { runs: 0, children: 0, byteLimitExceeded: false },
           runs: [
             {
               id: "async-1",

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -350,6 +350,76 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("routes provider-subagent controls through the Pi extension RPC bridge", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagents-widget-control",
+      method: "setWidget",
+      widgetKey: "subagent-async",
+      widgetLines: [
+        `PI_SUBAGENT_ASYNC_JSON:${JSON.stringify({
+          kind: "pi-subagents.async-status-snapshot",
+          version: 1,
+          generatedAt: 70_000,
+          caps: {},
+          omitted: { runs: 0, children: 0, byteLimitExceeded: false },
+          runs: [
+            {
+              id: "async-control",
+              kind: "subagent",
+              label: "worker",
+              state: "running",
+              startedAt: 10_000,
+            },
+          ],
+        })}`,
+      ],
+    });
+    const projected = events.providerSubagentEvents()[0];
+    if (!projected || projected.event.type !== "upsert") {
+      throw new Error("Expected projected Pi subagent");
+    }
+
+    fakeSession.subagentControlErrors.push(new Error("Status file not found for async run"));
+    await expect(
+      session.controlProviderSubagent?.({
+        subagentId: projected.event.id,
+        action: "stop",
+      }),
+    ).resolves.toEqual({ status: "accepted", message: "stop accepted" });
+    await expect(
+      session.controlProviderSubagent?.({
+        subagentId: projected.event.id,
+        action: "steer",
+        message: "focus on tests",
+      }),
+    ).resolves.toEqual({ status: "accepted", message: "steer accepted" });
+    await expect(
+      session.controlProviderSubagent?.({
+        subagentId: projected.event.id,
+        action: "resume",
+        message: "continue",
+      }),
+    ).resolves.toEqual({ status: "accepted", message: "resume accepted" });
+
+    expect(fakeSession.subagentControlRequests).toEqual([
+      { requestId: expect.any(String), method: "stop", params: { id: "async-control" } },
+      { requestId: expect.any(String), method: "stop", params: { id: "async-control" } },
+      {
+        requestId: expect.any(String),
+        method: "steer",
+        params: { id: "async-control", message: "focus on tests", mode: "steer" },
+      },
+      {
+        requestId: expect.any(String),
+        method: "resume",
+        params: { id: "async-control", message: "continue" },
+      },
+    ]);
+  });
+
   test("bridges Pi RPC select extension UI requests through question permissions", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1202,6 +1202,7 @@ export class PiRpcAgentSession implements AgentSession {
   private readonly activeToolCalls = new Map<string, PiTrackedToolCall>();
   private readonly pendingExtensionUiRequests = new Map<string, AgentPermissionRequest>();
   private readonly subagentsBridge = new PiSubagentsBridge();
+  private readonly requestedSubagentInspections = new Set<string>();
   private activeAskUserDialog: ActiveAskUserDialog | null = null;
   private pendingCombinedAskUserResponse: PendingCombinedAskUserResponse | null = null;
   private activeTurnId: string | null = null;
@@ -1932,6 +1933,9 @@ export class PiRpcAgentSession implements AgentSession {
       for (const bridgeEvent of subagents.events) {
         this.emit(bridgeEvent);
       }
+      for (const inspection of subagents.inspectionTargets) {
+        this.requestSubagentInspection(inspection.descriptorId, inspection.terminal);
+      }
       return;
     }
 
@@ -1972,6 +1976,27 @@ export class PiRpcAgentSession implements AgentSession {
       request,
       turnId: this.currentTurnIdForEvent(),
     });
+  }
+
+  private requestSubagentInspection(descriptorId: string, terminal: boolean): void {
+    const inspectionKey = `${descriptorId}:${terminal ? "terminal" : "live"}`;
+    if (this.requestedSubagentInspections.has(inspectionKey)) {
+      return;
+    }
+    const requestId = randomUUID();
+    const target = this.subagentsBridge.beginInspection(requestId, descriptorId);
+    if (!target) {
+      return;
+    }
+    this.requestedSubagentInspections.add(inspectionKey);
+    const child = target.childId ? ` ${target.childId}` : "";
+    void this.runtimeSession
+      .prompt(`/subagents-inspect-rpc ${requestId} ${target.asyncId}${child} --lines 100`)
+      .catch((error) => {
+        this.subagentsBridge.failInspection(requestId);
+        this.requestedSubagentInspections.delete(inspectionKey);
+        this.logger.debug({ err: error, descriptorId }, "Pi Subagents inspection command failed");
+      });
   }
 
   private respondToCombinedAskUserFollowUp(

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -65,6 +65,7 @@ import { materializeProviderImage } from "../provider-image-output.js";
 import { PiCliRuntime } from "./cli-runtime.js";
 import { revertPiConversation } from "./rewind.js";
 import { listPiImportableSessions, readPiImportSessionConfig } from "./session-descriptor.js";
+import { PiSubagentsBridge } from "./subagents-bridge.js";
 import type { PiRuntime, PiRuntimeSession, PiStartSessionInput } from "./runtime.js";
 import type {
   PiAgentSessionEvent,
@@ -1200,6 +1201,7 @@ export class PiRpcAgentSession implements AgentSession {
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly activeToolCalls = new Map<string, PiTrackedToolCall>();
   private readonly pendingExtensionUiRequests = new Map<string, AgentPermissionRequest>();
+  private readonly subagentsBridge = new PiSubagentsBridge();
   private activeAskUserDialog: ActiveAskUserDialog | null = null;
   private pendingCombinedAskUserResponse: PendingCombinedAskUserResponse | null = null;
   private activeTurnId: string | null = null;
@@ -1925,6 +1927,14 @@ export class PiRpcAgentSession implements AgentSession {
   private handleExtensionUiRequest(
     event: Extract<PiRuntimeEvent, { type: "extension_ui_request" }>,
   ): void {
+    const subagents = this.subagentsBridge.handleExtensionUiRequest(event);
+    if (subagents.handled) {
+      for (const bridgeEvent of subagents.events) {
+        this.emit(bridgeEvent);
+      }
+      return;
+    }
+
     const message = optionalString(event.message);
     if (event.method === "notify" && message) {
       if (

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -36,6 +36,8 @@ import {
   type ListImportableSessionsOptions,
   type ProviderCatalog,
   type ProviderRefreshContext,
+  type ProviderSubagentControlInput,
+  type ProviderSubagentControlResult,
   type ToolCallDetail,
 } from "../../agent-sdk-types.js";
 import { importSessionFromPersistence } from "../../provider-session-import.js";
@@ -92,6 +94,7 @@ const DEFAULT_PI_THINKING_LEVEL: PiThinkingLevel = "medium";
 const PI_BINARY_COMMAND = process.env.PI_COMMAND ?? process.env.PI_ACP_PI_COMMAND ?? "pi";
 const PASEO_PI_TREE_EXTENSION_COMMAND = "paseo_tree";
 const PASEO_PI_CAPTURE_EXTENSION_COMMAND = "paseo_capture_entries";
+const PASEO_PI_SUBAGENT_CONTROL_EXTENSION_COMMAND = "paseo_subagent_control";
 const PASEO_PI_ENTRY_CAPTURE_MARKER = "PASEO_ENTRY_CAPTURE";
 const PASEO_PI_SUBMITTED_USER_ENTRY_MARKER = "PASEO_SUBMITTED_USER_ENTRY";
 const PASEO_PI_COMMAND_RESULT_MARKER = "PASEO_COMMAND_RESULT";
@@ -649,6 +652,23 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 	  );
 	}
 
+	function requestSubagentRpc(pi, request) {
+	  return new Promise((resolve, reject) => {
+	    const replyEvent = "subagents:rpc:v1:reply:" + request.requestId;
+	    let unsubscribe;
+	    const timer = setTimeout(() => {
+	      if (typeof unsubscribe === "function") unsubscribe();
+	      reject(new Error("Pi Subagents control request timed out"));
+	    }, 15000);
+	    unsubscribe = pi.events.on(replyEvent, (reply) => {
+	      clearTimeout(timer);
+	      if (typeof unsubscribe === "function") unsubscribe();
+	      resolve(reply);
+	    });
+	    pi.events.emit("subagents:rpc:v1:request", request);
+	  });
+	}
+
 	export default function paseoIntegration(pi) {
 	  const submittedUserMessages = [];
 
@@ -711,6 +731,31 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 	    },
 	  });
 
+	  pi.registerCommand("${PASEO_PI_SUBAGENT_CONTROL_EXTENSION_COMMAND}", {
+	    description: "Internal Paseo Pi Subagents control bridge",
+	    handler: async (args, ctx) => {
+	      const payload = decodePayload(args.trim());
+	      try {
+	        const reply = await requestSubagentRpc(pi, {
+	          version: 1,
+	          requestId: payload.requestId,
+	          method: payload.method,
+	          params: payload.params,
+	          source: { extension: "paseo" },
+	        });
+	        if (reply && reply.success === true) {
+	          emitCommandResult(ctx, payload.requestId, { ok: true, result: reply.data });
+	          return;
+	        }
+	        const error = reply?.error?.message || "Pi Subagents rejected the control request";
+	        emitCommandResult(ctx, payload.requestId, { ok: false, error });
+	      } catch (error) {
+	        const message = error instanceof Error ? error.message : String(error);
+	        emitCommandResult(ctx, payload.requestId, { ok: false, error: message });
+	      }
+	    },
+	  });
+
 	  pi.registerCommand("${PASEO_PI_TREE_EXTENSION_COMMAND}", {
 	    description: "Internal Paseo tree navigation bridge",
 	    handler: async (args, ctx) => {
@@ -763,6 +808,13 @@ function withPiCapabilities(supportsMcpServers: boolean): AgentCapabilityFlags {
     ...PI_CAPABILITIES,
     supportsMcpServers,
   };
+}
+
+function parsePiSubagentStepIndex(childId: string): number | undefined {
+  const match = /^step:(\d+)$/.exec(childId);
+  if (!match) return undefined;
+  const index = Number.parseInt(match[1] ?? "", 10);
+  return Number.isSafeInteger(index) ? index : undefined;
 }
 
 function isPiRequestAbortError(error: unknown): boolean {
@@ -1289,6 +1341,74 @@ export class PiRpcAgentSession implements AgentSession {
       reduceFinalText: ({ current, item }) =>
         item.type === "assistant_message" ? `${current}${item.text}` : current,
     });
+  }
+
+  async controlProviderSubagent(
+    input: ProviderSubagentControlInput,
+  ): Promise<ProviderSubagentControlResult> {
+    const target = this.subagentsBridge.resolveTarget(input.subagentId);
+    if (!target) {
+      return { status: "unavailable", message: "Pi Subagents target is no longer available" };
+    }
+    const message = input.message?.trim();
+    if ((input.action === "steer" || input.action === "resume") && !message) {
+      return { status: "unavailable", message: `${input.action} requires a message` };
+    }
+
+    const params: Record<string, unknown> = { id: target.asyncId };
+    if (input.action === "stop" && target.childId) {
+      params.childId = target.childId;
+    }
+    if (input.action === "steer") {
+      const index = target.childId ? parsePiSubagentStepIndex(target.childId) : undefined;
+      if (target.childId && index === undefined) {
+        return {
+          status: "unavailable",
+          message: "This Pi Subagents child does not expose a steerable step index",
+        };
+      }
+      params.message = message;
+      params.mode = "steer";
+      if (index !== undefined) params.index = index;
+    }
+    if (input.action === "resume") {
+      params.message = message;
+    }
+
+    const attempts = input.action === "stop" ? 3 : 1;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        return await this.executePiSubagentControl(input.action, params);
+      } catch (error) {
+        if (
+          attempt === attempts ||
+          !/status file not found/i.test(toDiagnosticErrorMessage(error))
+        ) {
+          throw error;
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 250));
+      }
+    }
+    return { status: "unavailable" };
+  }
+
+  private async executePiSubagentControl(
+    action: ProviderSubagentControlInput["action"],
+    params: Record<string, unknown>,
+  ): Promise<ProviderSubagentControlResult> {
+    const requestId = randomUUID();
+    const resultPromise = this.waitForExtensionResult(requestId);
+    const payload = Buffer.from(
+      JSON.stringify({ requestId, method: action, params }),
+      "utf8",
+    ).toString("base64url");
+    await this.runtimeSession.prompt(`/${PASEO_PI_SUBAGENT_CONTROL_EXTENSION_COMMAND} ${payload}`);
+    const result = await resultPromise;
+    const resultRecord = isRecord(result) ? result : null;
+    return {
+      status: "accepted",
+      ...(typeof resultRecord?.message === "string" ? { message: resultRecord.message } : {}),
+    };
   }
 
   async startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<StartTurnResult> {

--- a/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
+++ b/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
@@ -18,7 +18,7 @@ function makeSnapshot(overrides: Record<string, unknown> = {}) {
     version: 1,
     generatedAt: 70_000,
     caps: {},
-    omitted: {},
+    omitted: { runs: 0, children: 0, byteLimitExceeded: false },
     runs: [
       {
         id: "async-1",
@@ -116,7 +116,100 @@ describe("PiSubagentsBridge", () => {
         widgetKey: "other",
         widgetLines: ["text"],
       }),
-    ).toEqual({ handled: false, events: [] });
+    ).toEqual({ handled: false, events: [], inspectionTargets: [] });
+  });
+
+  test("maps a correlated inspection reply into descriptor and timeline events", () => {
+    const bridge = new PiSubagentsBridge();
+    const status = bridge.handleExtensionUiRequest(widget(makeSnapshot()));
+    const child = status.inspectionTargets[1];
+    if (!child) throw new Error("Expected child inspection target");
+    expect(bridge.beginInspection("inspect-1", child.descriptorId)).toEqual({
+      asyncId: "async-1",
+      childId: "child-1",
+    });
+
+    const result = bridge.handleExtensionUiRequest({
+      type: "extension_ui_request",
+      id: "inspect-widget",
+      method: "setWidget",
+      widgetKey: "subagent-inspect",
+      widgetLines: [
+        `PI_SUBAGENT_INSPECT_JSON:${JSON.stringify({
+          kind: "pi-subagents.inspect-reply",
+          version: 1,
+          requestId: "inspect-1",
+          asyncId: "async-1",
+          childId: "child-1",
+          status: "complete",
+          label: "worker",
+          task: "Review the diff",
+          messages: [
+            { role: "user", kind: "text", text: "Review the diff" },
+            { role: "assistant", kind: "text", text: "Done" },
+            { role: "assistant", kind: "toolCall", name: "read", text: "src/a.ts" },
+          ],
+          finalOutput: "No issues",
+          truncated: { task: false, messages: 2, finalOutput: false },
+        })}`,
+      ],
+    });
+
+    expect(result.events).toEqual([
+      expect.objectContaining({
+        type: "provider_subagent",
+        event: expect.objectContaining({
+          type: "upsert",
+          id: child.descriptorId,
+          title: "worker",
+          description: "Review the diff",
+          status: "completed",
+        }),
+      }),
+      expect.objectContaining({
+        type: "provider_subagent",
+        event: expect.objectContaining({
+          type: "timeline",
+          id: child.descriptorId,
+          item: { type: "user_message", text: "Review the diff" },
+        }),
+      }),
+      expect.objectContaining({
+        type: "provider_subagent",
+        event: expect.objectContaining({
+          type: "timeline",
+          id: child.descriptorId,
+          item: { type: "assistant_message", text: "Done" },
+        }),
+      }),
+      expect.objectContaining({
+        type: "provider_subagent",
+        event: expect.objectContaining({
+          type: "timeline",
+          id: child.descriptorId,
+          item: expect.objectContaining({ type: "tool_call", name: "read" }),
+        }),
+      }),
+      expect.objectContaining({
+        type: "provider_subagent",
+        event: expect.objectContaining({
+          type: "timeline",
+          id: child.descriptorId,
+          item: { type: "assistant_message", text: "No issues" },
+        }),
+      }),
+      expect.objectContaining({
+        type: "provider_subagent",
+        event: expect.objectContaining({
+          type: "timeline",
+          id: child.descriptorId,
+          item: expect.objectContaining({
+            type: "assistant_message",
+            text: expect.stringContaining("2 messages omitted"),
+          }),
+        }),
+      }),
+    ]);
   });
 
   test("reports an unsupported protocol version once", () => {

--- a/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
+++ b/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
@@ -106,6 +106,117 @@ describe("PiSubagentsBridge", () => {
     });
   });
 
+  test("keeps parallel and nested children distinct and reconciles absent nodes", () => {
+    const bridge = new PiSubagentsBridge();
+    const first = bridge.handleExtensionUiRequest(
+      widget(
+        makeSnapshot({
+          runs: [
+            {
+              id: "workflow-1",
+              kind: "workflow",
+              label: "parallel review",
+              state: "running",
+              children: [
+                { id: "step:0", kind: "step", label: "worker", state: "running" },
+                {
+                  id: "step:1",
+                  kind: "step",
+                  label: "reviewer",
+                  state: "running",
+                  children: [
+                    {
+                      id: "nested-1",
+                      kind: "subagent",
+                      label: "nested tester",
+                      state: "running",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+    const upserts = first.events.filter(
+      (event) => event.type === "provider_subagent" && event.event.type === "upsert",
+    );
+    expect(upserts).toHaveLength(4);
+    expect(new Set(upserts.map((event) => event.event.id)).size).toBe(4);
+
+    const second = bridge.handleExtensionUiRequest(
+      widget(
+        makeSnapshot({
+          runs: [
+            {
+              id: "workflow-1",
+              kind: "workflow",
+              label: "parallel review",
+              state: "running",
+              children: [{ id: "step:0", kind: "step", label: "worker", state: "complete" }],
+            },
+          ],
+        }),
+      ),
+    );
+    expect(
+      second.events.filter(
+        (event) => event.type === "provider_subagent" && event.event.type === "remove",
+      ),
+    ).toHaveLength(2);
+  });
+
+  test("does not duplicate timeline rows across live and terminal inspections", () => {
+    const bridge = new PiSubagentsBridge();
+    const status = bridge.handleExtensionUiRequest(
+      widget(
+        makeSnapshot({
+          runs: [{ id: "run", kind: "subagent", label: "worker", state: "running" }],
+        }),
+      ),
+    );
+    const target = status.inspectionTargets[0];
+    if (!target) throw new Error("Expected inspection target");
+    const reply = {
+      kind: "pi-subagents.inspect-reply",
+      version: 1,
+      asyncId: "run",
+      status: "running",
+      messages: [{ role: "assistant", kind: "text", text: "same output" }],
+    };
+
+    bridge.beginInspection("live", target.descriptorId);
+    const live = bridge.handleExtensionUiRequest({
+      type: "extension_ui_request",
+      id: "live",
+      method: "setWidget",
+      widgetKey: "subagent-inspect",
+      widgetLines: [`PI_SUBAGENT_INSPECT_JSON:${JSON.stringify({ ...reply, requestId: "live" })}`],
+    });
+    bridge.beginInspection("terminal", target.descriptorId);
+    const terminal = bridge.handleExtensionUiRequest({
+      type: "extension_ui_request",
+      id: "terminal",
+      method: "setWidget",
+      widgetKey: "subagent-inspect",
+      widgetLines: [
+        `PI_SUBAGENT_INSPECT_JSON:${JSON.stringify({ ...reply, requestId: "terminal", status: "complete", finalOutput: "same output" })}`,
+      ],
+    });
+
+    expect(
+      live.events.filter(
+        (event) => event.type === "provider_subagent" && event.event.type === "timeline",
+      ),
+    ).toHaveLength(1);
+    expect(
+      terminal.events.filter(
+        (event) => event.type === "provider_subagent" && event.event.type === "timeline",
+      ),
+    ).toHaveLength(0);
+  });
+
   test("ignores unrelated extension widgets", () => {
     const bridge = new PiSubagentsBridge();
     expect(

--- a/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
+++ b/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
@@ -165,6 +165,13 @@ describe("PiSubagentsBridge", () => {
         (event) => event.type === "provider_subagent" && event.event.type === "remove",
       ),
     ).toHaveLength(2);
+
+    const empty = bridge.handleExtensionUiRequest(widget(makeSnapshot({ runs: [] })));
+    expect(
+      empty.events.filter(
+        (event) => event.type === "provider_subagent" && event.event.type === "remove",
+      ),
+    ).toHaveLength(1);
   });
 
   test("does not duplicate timeline rows across live and terminal inspections", () => {

--- a/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
+++ b/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
@@ -163,7 +163,6 @@ describe("PiSubagentsBridge", () => {
           id: child.descriptorId,
           title: "worker",
           description: "Review the diff",
-          status: "completed",
         }),
       }),
       expect.objectContaining({

--- a/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
+++ b/packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "vitest";
+
+import { PiSubagentsBridge } from "./subagents-bridge.js";
+
+function widget(payload: unknown) {
+  return {
+    type: "extension_ui_request" as const,
+    id: "widget-1",
+    method: "setWidget",
+    widgetKey: "subagent-async",
+    widgetLines: [`PI_SUBAGENT_ASYNC_JSON:${JSON.stringify(payload)}`],
+  };
+}
+
+function makeSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "pi-subagents.async-status-snapshot",
+    version: 1,
+    generatedAt: 70_000,
+    caps: {},
+    omitted: {},
+    runs: [
+      {
+        id: "async-1",
+        kind: "workflow",
+        label: "Implementation workflow",
+        state: "running",
+        startedAt: 10_000,
+        activity: { currentTool: "read", turnCount: 2, toolCount: 3 },
+        children: [
+          {
+            id: "child-1",
+            kind: "step",
+            label: "worker",
+            state: "running",
+            startedAt: 20_000,
+            activity: { currentTool: "edit", toolCount: 1 },
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("PiSubagentsBridge", () => {
+  test("projects a live run and child into provider-subagent events", () => {
+    const bridge = new PiSubagentsBridge();
+
+    const result = bridge.handleExtensionUiRequest(widget(makeSnapshot()));
+
+    expect(result.handled).toBe(true);
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0]).toMatchObject({
+      type: "provider_subagent",
+      provider: "pi",
+      event: {
+        type: "upsert",
+        title: "Implementation workflow",
+        description: "Implementation workflow",
+        status: "running",
+        subtitle: "running · read · 2 turns · 3 tools · 1m",
+        timestamp: new Date(10_000).toISOString(),
+      },
+    });
+    expect(result.events[1]).toMatchObject({
+      type: "provider_subagent",
+      provider: "pi",
+      event: {
+        type: "upsert",
+        title: "worker",
+        description: "Implementation workflow / worker",
+        status: "running",
+        subtitle: "running · edit · 1 tools · 50s",
+      },
+    });
+
+    const childEvent = result.events[1];
+    if (childEvent?.type !== "provider_subagent" || childEvent.event.type !== "upsert") {
+      throw new Error("Expected child provider-subagent upsert");
+    }
+    expect(bridge.resolveTarget(childEvent.event.id)).toEqual({
+      asyncId: "async-1",
+      childId: "child-1",
+    });
+  });
+
+  test.each([
+    ["complete", "completed"],
+    ["failed", "failed"],
+    ["paused", "failed"],
+    ["rejected", "failed"],
+    ["stopped", "canceled"],
+    ["queued", "running"],
+  ] as const)("maps %s to %s", (source, expected) => {
+    const bridge = new PiSubagentsBridge();
+    const result = bridge.handleExtensionUiRequest(
+      widget(
+        makeSnapshot({ runs: [{ id: "run", kind: "subagent", label: "worker", state: source }] }),
+      ),
+    );
+
+    expect(result.events[0]).toMatchObject({
+      type: "provider_subagent",
+      event: { type: "upsert", status: expected },
+    });
+  });
+
+  test("ignores unrelated extension widgets", () => {
+    const bridge = new PiSubagentsBridge();
+    expect(
+      bridge.handleExtensionUiRequest({
+        type: "extension_ui_request",
+        id: "other",
+        method: "setWidget",
+        widgetKey: "other",
+        widgetLines: ["text"],
+      }),
+    ).toEqual({ handled: false, events: [] });
+  });
+
+  test("reports an unsupported protocol version once", () => {
+    const bridge = new PiSubagentsBridge();
+    const unsupported = widget(makeSnapshot({ version: 2 }));
+
+    expect(bridge.handleExtensionUiRequest(unsupported).events).toEqual([
+      expect.objectContaining({
+        type: "timeline",
+        item: expect.objectContaining({
+          type: "error",
+          message: expect.stringContaining("version 2"),
+        }),
+      }),
+    ]);
+    expect(bridge.handleExtensionUiRequest(unsupported).events).toEqual([]);
+  });
+
+  test("reports malformed payloads without throwing", () => {
+    const bridge = new PiSubagentsBridge();
+    const result = bridge.handleExtensionUiRequest({
+      type: "extension_ui_request",
+      id: "bad",
+      method: "setWidget",
+      widgetKey: "subagent-async",
+      widgetLines: ["PI_SUBAGENT_ASYNC_JSON:{bad"],
+    });
+
+    expect(result.events).toEqual([
+      expect.objectContaining({
+        type: "timeline",
+        item: expect.objectContaining({ type: "error" }),
+      }),
+    ]);
+  });
+});

--- a/packages/server/src/server/agent/providers/pi/subagents-bridge.ts
+++ b/packages/server/src/server/agent/providers/pi/subagents-bridge.ts
@@ -155,6 +155,7 @@ export class PiSubagentsBridge {
   private readonly targets = new Map<string, PiSubagentTarget>();
   private readonly pendingInspections = new Map<string, PendingInspection>();
   private readonly projectedDescriptorIds = new Set<string>();
+  private readonly inspectionFingerprints = new Map<string, Set<string>>();
   private lastCompatibilityError: string | null = null;
 
   handleExtensionUiRequest(
@@ -269,7 +270,12 @@ export class PiSubagentsBridge {
     this.pendingInspections.delete(parsed.data.requestId);
     return {
       handled: true,
-      events: inspectionEvents(pending.descriptorId, parsed.data),
+      events: inspectionEvents(
+        pending.descriptorId,
+        parsed.data,
+        this.inspectionFingerprints.get(pending.descriptorId) ?? new Set<string>(),
+        (seen) => this.inspectionFingerprints.set(pending.descriptorId, seen),
+      ),
       inspectionTargets: [],
     };
   }
@@ -361,9 +367,14 @@ function toProviderSubagentEvent(entry: FlattenedNode, snapshot: AsyncSnapshot):
   };
 }
 
-function inspectionEvents(descriptorId: string, reply: InspectReply): AgentStreamEvent[] {
+function inspectionEvents(
+  descriptorId: string,
+  reply: InspectReply,
+  seen: Set<string>,
+  saveSeen: (seen: Set<string>) => void,
+): AgentStreamEvent[] {
   const events: AgentStreamEvent[] = [];
-  if (reply.task || reply.label || reply.status) {
+  if (reply.task || reply.label) {
     events.push({
       type: "provider_subagent",
       provider: "pi",
@@ -372,42 +383,64 @@ function inspectionEvents(descriptorId: string, reply: InspectReply): AgentStrea
         id: descriptorId,
         ...(reply.label ? { title: reply.label } : {}),
         ...(reply.task ? { description: reply.task } : {}),
-        ...(reply.status ? { status: mapInspectStatus(reply.status) } : {}),
       },
     });
   }
   if (reply.error) {
-    events.push(
-      toSubagentTimeline(descriptorId, {
+    appendUniqueTimeline(
+      events,
+      descriptorId,
+      {
         type: "error",
         message: `${reply.error.code}: ${reply.error.message}`,
-      }),
+      },
+      seen,
     );
+    saveSeen(seen);
     return events;
   }
   for (const [index, message] of (reply.messages ?? []).entries()) {
-    events.push(toSubagentTimeline(descriptorId, inspectMessageToTimeline(message, index)));
+    appendUniqueTimeline(events, descriptorId, inspectMessageToTimeline(message, index), seen);
   }
   if (reply.finalOutput) {
-    events.push(
-      toSubagentTimeline(descriptorId, {
+    appendUniqueTimeline(
+      events,
+      descriptorId,
+      {
         type: "assistant_message",
         text: reply.finalOutput,
-      }),
+      },
+      seen,
     );
   }
   if (
     reply.truncated &&
     (reply.truncated.task || reply.truncated.messages > 0 || reply.truncated.finalOutput)
   ) {
-    events.push(
-      toSubagentTimeline(descriptorId, {
+    appendUniqueTimeline(
+      events,
+      descriptorId,
+      {
         type: "assistant_message",
         text: `[Inspection truncated: ${reply.truncated.messages} messages omitted]`,
-      }),
+      },
+      seen,
     );
   }
+  saveSeen(seen);
   return events;
+}
+
+function appendUniqueTimeline(
+  events: AgentStreamEvent[],
+  descriptorId: string,
+  item: AgentTimelineItem,
+  seen: Set<string>,
+): void {
+  const fingerprint = JSON.stringify(item);
+  if (seen.has(fingerprint)) return;
+  seen.add(fingerprint);
+  events.push(toSubagentTimeline(descriptorId, item));
 }
 
 function inspectMessageToTimeline(
@@ -446,13 +479,6 @@ function mapStatus(state: SnapshotNode["state"]): "running" | "completed" | "fai
   if (state === "complete") return "completed";
   if (state === "stopped") return "canceled";
   if (state === "failed" || state === "paused" || state === "rejected") return "failed";
-  return "running";
-}
-
-function mapInspectStatus(status: string): "running" | "completed" | "failed" | "canceled" {
-  if (status === "complete" || status === "completed") return "completed";
-  if (status === "stopped" || status === "canceled" || status === "cancelled") return "canceled";
-  if (status === "failed" || status === "paused" || status === "rejected") return "failed";
   return "running";
 }
 

--- a/packages/server/src/server/agent/providers/pi/subagents-bridge.ts
+++ b/packages/server/src/server/agent/providers/pi/subagents-bridge.ts
@@ -155,6 +155,7 @@ export class PiSubagentsBridge {
   private readonly targets = new Map<string, PiSubagentTarget>();
   private readonly pendingInspections = new Map<string, PendingInspection>();
   private readonly projectedDescriptorIds = new Set<string>();
+  private readonly descriptorStates = new Map<string, SnapshotNode["state"]>();
   private readonly inspectionFingerprints = new Map<string, Set<string>>();
   private lastCompatibilityError: string | null = null;
 
@@ -202,17 +203,21 @@ export class PiSubagentsBridge {
     const events = flattened.map((entry) => {
       this.targets.set(entry.descriptorId, entry.target);
       this.projectedDescriptorIds.add(entry.descriptorId);
+      this.descriptorStates.set(entry.descriptorId, entry.node.state);
       return toProviderSubagentEvent(entry, parsed.data);
     });
     if (canReconcileAbsence(parsed.data)) {
       for (const descriptorId of this.projectedDescriptorIds) {
         if (currentIds.has(descriptorId)) continue;
+        const previousState = this.descriptorStates.get(descriptorId);
+        if (previousState && isTerminal(previousState)) continue;
         events.push({
           type: "provider_subagent",
           provider: "pi",
           event: { type: "remove", id: descriptorId },
         });
         this.projectedDescriptorIds.delete(descriptorId);
+        this.descriptorStates.delete(descriptorId);
         this.targets.delete(descriptorId);
       }
     }

--- a/packages/server/src/server/agent/providers/pi/subagents-bridge.ts
+++ b/packages/server/src/server/agent/providers/pi/subagents-bridge.ts
@@ -1,12 +1,16 @@
 import { z } from "zod";
 
-import type { AgentStreamEvent } from "../../agent-sdk-types.js";
+import type { AgentStreamEvent, AgentTimelineItem } from "../../agent-sdk-types.js";
 import type { PiRuntimeEvent } from "./rpc-types.js";
 
 const ASYNC_WIDGET_KEY = "subagent-async";
 const ASYNC_WIDGET_PREFIX = "PI_SUBAGENT_ASYNC_JSON:";
 const ASYNC_SNAPSHOT_KIND = "pi-subagents.async-status-snapshot";
 const ASYNC_SNAPSHOT_VERSION = 1;
+const INSPECT_WIDGET_KEY = "subagent-inspect";
+const INSPECT_WIDGET_PREFIX = "PI_SUBAGENT_INSPECT_JSON:";
+const INSPECT_REPLY_KIND = "pi-subagents.inspect-reply";
+const INSPECT_REPLY_VERSION = 1;
 const MAX_WIDGET_BYTES = 64 * 1024;
 
 const SnapshotStateSchema = z.enum([
@@ -63,20 +67,76 @@ const AsyncSnapshotSchema = z
     kind: z.literal(ASYNC_SNAPSHOT_KIND),
     version: z.literal(ASYNC_SNAPSHOT_VERSION),
     generatedAt: z.number().int().nonnegative(),
+    omitted: z
+      .object({
+        runs: z.number().int().nonnegative(),
+        children: z.number().int().nonnegative(),
+        byteLimitExceeded: z.boolean(),
+      })
+      .passthrough()
+      .optional(),
     runs: z.array(SnapshotNodeSchema).max(64),
   })
   .passthrough();
 
+const InspectMessageSchema = z
+  .object({
+    role: z.string().max(32),
+    kind: z.enum(["text", "toolCall", "toolResult"]),
+    text: z.string().max(4_096),
+    name: z.string().max(128).optional(),
+    isError: z.boolean().optional(),
+  })
+  .passthrough();
+
+const InspectReplySchema = z
+  .object({
+    kind: z.literal(INSPECT_REPLY_KIND),
+    version: z.literal(INSPECT_REPLY_VERSION),
+    requestId: z.string().min(1).max(64),
+    asyncId: z.string().max(256).optional(),
+    childId: z.string().max(256).optional(),
+    status: z.string().max(32).optional(),
+    label: z.string().max(256).optional(),
+    task: z.string().max(4_096).optional(),
+    messages: z.array(InspectMessageSchema).max(200).optional(),
+    finalOutput: z.string().max(16_384).optional(),
+    truncated: z
+      .object({
+        task: z.boolean(),
+        messages: z.number().int().nonnegative(),
+        finalOutput: z.boolean(),
+      })
+      .passthrough()
+      .optional(),
+    error: z
+      .object({
+        code: z.string().max(64),
+        message: z.string().max(1_024),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
 type AsyncSnapshot = z.infer<typeof AsyncSnapshotSchema>;
+type InspectReply = z.infer<typeof InspectReplySchema>;
 
 export interface PiSubagentTarget {
   asyncId: string;
   childId?: string;
 }
 
+export interface PiSubagentInspectionTarget {
+  descriptorId: string;
+  target: PiSubagentTarget;
+  terminal: boolean;
+}
+
 export interface PiSubagentsBridgeResult {
   handled: boolean;
   events: AgentStreamEvent[];
+  inspectionTargets: PiSubagentInspectionTarget[];
 }
 
 interface FlattenedNode {
@@ -86,20 +146,33 @@ interface FlattenedNode {
   parentLabel?: string;
 }
 
+interface PendingInspection {
+  descriptorId: string;
+  target: PiSubagentTarget;
+}
+
 export class PiSubagentsBridge {
   private readonly targets = new Map<string, PiSubagentTarget>();
+  private readonly pendingInspections = new Map<string, PendingInspection>();
+  private readonly projectedDescriptorIds = new Set<string>();
   private lastCompatibilityError: string | null = null;
 
   handleExtensionUiRequest(
     event: Extract<PiRuntimeEvent, { type: "extension_ui_request" }>,
   ): PiSubagentsBridgeResult {
-    if (event.method !== "setWidget" || event.widgetKey !== ASYNC_WIDGET_KEY) {
-      return { handled: false, events: [] };
+    if (event.method !== "setWidget") {
+      return emptyResult(false);
+    }
+    if (event.widgetKey === INSPECT_WIDGET_KEY) {
+      return this.handleInspectWidget(event.widgetLines);
+    }
+    if (event.widgetKey !== ASYNC_WIDGET_KEY) {
+      return emptyResult(false);
     }
 
     const line = firstWidgetLine(event.widgetLines);
     if (!line?.startsWith(ASYNC_WIDGET_PREFIX)) {
-      return { handled: true, events: [] };
+      return emptyResult(true);
     }
     if (Buffer.byteLength(line, "utf8") > MAX_WIDGET_BYTES) {
       return this.compatibilityFailure(
@@ -123,13 +196,45 @@ export class PiSubagentsBridge {
     }
 
     this.lastCompatibilityError = null;
+    const flattened = flattenSnapshot(parsed.data);
+    const currentIds = new Set(flattened.map((entry) => entry.descriptorId));
+    const events = flattened.map((entry) => {
+      this.targets.set(entry.descriptorId, entry.target);
+      this.projectedDescriptorIds.add(entry.descriptorId);
+      return toProviderSubagentEvent(entry, parsed.data);
+    });
+    if (canReconcileAbsence(parsed.data)) {
+      for (const descriptorId of this.projectedDescriptorIds) {
+        if (currentIds.has(descriptorId)) continue;
+        events.push({
+          type: "provider_subagent",
+          provider: "pi",
+          event: { type: "remove", id: descriptorId },
+        });
+        this.projectedDescriptorIds.delete(descriptorId);
+        this.targets.delete(descriptorId);
+      }
+    }
     return {
       handled: true,
-      events: flattenSnapshot(parsed.data).map((entry) => {
-        this.targets.set(entry.descriptorId, entry.target);
-        return toProviderSubagentEvent(entry, parsed.data);
-      }),
+      events,
+      inspectionTargets: flattened.map((entry) => ({
+        descriptorId: entry.descriptorId,
+        target: entry.target,
+        terminal: isTerminal(entry.node.state),
+      })),
     };
+  }
+
+  beginInspection(requestId: string, descriptorId: string): PiSubagentTarget | null {
+    const target = this.targets.get(descriptorId);
+    if (!target) return null;
+    this.pendingInspections.set(requestId, { descriptorId, target });
+    return { ...target };
+  }
+
+  failInspection(requestId: string): void {
+    this.pendingInspections.delete(requestId);
   }
 
   resolveTarget(descriptorId: string): PiSubagentTarget | null {
@@ -137,9 +242,41 @@ export class PiSubagentsBridge {
     return target ? { ...target } : null;
   }
 
+  private handleInspectWidget(widgetLines: unknown): PiSubagentsBridgeResult {
+    const line = firstWidgetLine(widgetLines);
+    if (!line?.startsWith(INSPECT_WIDGET_PREFIX)) {
+      return emptyResult(true);
+    }
+    if (Buffer.byteLength(line, "utf8") > MAX_WIDGET_BYTES) {
+      return this.compatibilityFailure(
+        "Pi Subagents inspection exceeded the supported host payload size.",
+      );
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line.slice(INSPECT_WIDGET_PREFIX.length)) as unknown;
+    } catch {
+      return emptyResult(true);
+    }
+    const parsed = InspectReplySchema.safeParse(raw);
+    if (!parsed.success) {
+      return emptyResult(true);
+    }
+    const pending = this.pendingInspections.get(parsed.data.requestId);
+    if (!pending) {
+      return emptyResult(true);
+    }
+    this.pendingInspections.delete(parsed.data.requestId);
+    return {
+      handled: true,
+      events: inspectionEvents(pending.descriptorId, parsed.data),
+      inspectionTargets: [],
+    };
+  }
+
   private compatibilityFailure(message: string): PiSubagentsBridgeResult {
     if (this.lastCompatibilityError === message) {
-      return { handled: true, events: [] };
+      return emptyResult(true);
     }
     this.lastCompatibilityError = message;
     return {
@@ -151,8 +288,13 @@ export class PiSubagentsBridge {
           item: { type: "error", message },
         },
       ],
+      inspectionTargets: [],
     };
   }
+}
+
+function emptyResult(handled: boolean): PiSubagentsBridgeResult {
+  return { handled, events: [], inspectionTargets: [] };
 }
 
 function firstWidgetLine(value: unknown): string | null {
@@ -164,6 +306,11 @@ function firstWidgetLine(value: unknown): string | null {
 function flattenSnapshot(snapshot: AsyncSnapshot): FlattenedNode[] {
   const entries: FlattenedNode[] = [];
   for (const run of snapshot.runs) {
+    if (run.kind === "subagent" && run.children?.length === 1) {
+      const child = run.children[0];
+      flattenNode(entries, child, { asyncId: run.id, childId: child.id }, [run.id], undefined);
+      continue;
+    }
     flattenNode(entries, run, { asyncId: run.id }, [], undefined);
   }
   return entries;
@@ -214,11 +361,117 @@ function toProviderSubagentEvent(entry: FlattenedNode, snapshot: AsyncSnapshot):
   };
 }
 
+function inspectionEvents(descriptorId: string, reply: InspectReply): AgentStreamEvent[] {
+  const events: AgentStreamEvent[] = [];
+  if (reply.task || reply.label || reply.status) {
+    events.push({
+      type: "provider_subagent",
+      provider: "pi",
+      event: {
+        type: "upsert",
+        id: descriptorId,
+        ...(reply.label ? { title: reply.label } : {}),
+        ...(reply.task ? { description: reply.task } : {}),
+        ...(reply.status ? { status: mapInspectStatus(reply.status) } : {}),
+      },
+    });
+  }
+  if (reply.error) {
+    events.push(
+      toSubagentTimeline(descriptorId, {
+        type: "error",
+        message: `${reply.error.code}: ${reply.error.message}`,
+      }),
+    );
+    return events;
+  }
+  for (const [index, message] of (reply.messages ?? []).entries()) {
+    events.push(toSubagentTimeline(descriptorId, inspectMessageToTimeline(message, index)));
+  }
+  if (reply.finalOutput) {
+    events.push(
+      toSubagentTimeline(descriptorId, {
+        type: "assistant_message",
+        text: reply.finalOutput,
+      }),
+    );
+  }
+  if (
+    reply.truncated &&
+    (reply.truncated.task || reply.truncated.messages > 0 || reply.truncated.finalOutput)
+  ) {
+    events.push(
+      toSubagentTimeline(descriptorId, {
+        type: "assistant_message",
+        text: `[Inspection truncated: ${reply.truncated.messages} messages omitted]`,
+      }),
+    );
+  }
+  return events;
+}
+
+function inspectMessageToTimeline(
+  message: z.infer<typeof InspectMessageSchema>,
+  index: number,
+): AgentTimelineItem {
+  if (message.kind === "toolCall") {
+    const item = {
+      type: "tool_call" as const,
+      callId: `pi-subagents-inspect-${index}`,
+      name: message.name ?? "tool",
+      detail: { type: "plain_text" as const, text: message.text },
+    };
+    return message.isError
+      ? { ...item, status: "failed", error: message.text }
+      : { ...item, status: "completed", error: null };
+  }
+  if (message.kind === "toolResult" && message.isError) {
+    return { type: "error", message: message.text };
+  }
+  if (message.role === "user") {
+    return { type: "user_message", text: message.text };
+  }
+  return { type: "assistant_message", text: message.text };
+}
+
+function toSubagentTimeline(descriptorId: string, item: AgentTimelineItem): AgentStreamEvent {
+  return {
+    type: "provider_subagent",
+    provider: "pi",
+    event: { type: "timeline", id: descriptorId, item },
+  };
+}
+
 function mapStatus(state: SnapshotNode["state"]): "running" | "completed" | "failed" | "canceled" {
   if (state === "complete") return "completed";
   if (state === "stopped") return "canceled";
   if (state === "failed" || state === "paused" || state === "rejected") return "failed";
   return "running";
+}
+
+function mapInspectStatus(status: string): "running" | "completed" | "failed" | "canceled" {
+  if (status === "complete" || status === "completed") return "completed";
+  if (status === "stopped" || status === "canceled" || status === "cancelled") return "canceled";
+  if (status === "failed" || status === "paused" || status === "rejected") return "failed";
+  return "running";
+}
+
+function isTerminal(state: SnapshotNode["state"]): boolean {
+  return (
+    state === "complete" ||
+    state === "failed" ||
+    state === "paused" ||
+    state === "stopped" ||
+    state === "rejected"
+  );
+}
+
+function canReconcileAbsence(snapshot: AsyncSnapshot): boolean {
+  return (
+    snapshot.omitted?.runs === 0 &&
+    snapshot.omitted.children === 0 &&
+    snapshot.omitted.byteLimitExceeded === false
+  );
 }
 
 function formatSubtitle(node: SnapshotNode, generatedAt: number): string {

--- a/packages/server/src/server/agent/providers/pi/subagents-bridge.ts
+++ b/packages/server/src/server/agent/providers/pi/subagents-bridge.ts
@@ -1,0 +1,241 @@
+import { z } from "zod";
+
+import type { AgentStreamEvent } from "../../agent-sdk-types.js";
+import type { PiRuntimeEvent } from "./rpc-types.js";
+
+const ASYNC_WIDGET_KEY = "subagent-async";
+const ASYNC_WIDGET_PREFIX = "PI_SUBAGENT_ASYNC_JSON:";
+const ASYNC_SNAPSHOT_KIND = "pi-subagents.async-status-snapshot";
+const ASYNC_SNAPSHOT_VERSION = 1;
+const MAX_WIDGET_BYTES = 64 * 1024;
+
+const SnapshotStateSchema = z.enum([
+  "queued",
+  "running",
+  "complete",
+  "failed",
+  "paused",
+  "stopped",
+  "rejected",
+]);
+
+const SnapshotActivitySchema = z
+  .object({
+    state: z.string().optional(),
+    currentTool: z.string().optional(),
+    lastActivityAt: z.number().int().nonnegative().optional(),
+    currentToolStartedAt: z.number().int().nonnegative().optional(),
+    turnCount: z.number().int().nonnegative().optional(),
+    toolCount: z.number().int().nonnegative().optional(),
+  })
+  .passthrough();
+
+interface SnapshotNode {
+  id: string;
+  kind: "subagent" | "workflow" | "step";
+  label: string;
+  state: z.infer<typeof SnapshotStateSchema>;
+  startedAt?: number;
+  updatedAt?: number;
+  endedAt?: number;
+  activity?: z.infer<typeof SnapshotActivitySchema>;
+  children?: SnapshotNode[];
+}
+
+const SnapshotNodeSchema: z.ZodType<SnapshotNode> = z.lazy(() =>
+  z
+    .object({
+      id: z.string().min(1).max(256),
+      kind: z.enum(["subagent", "workflow", "step"]),
+      label: z.string().min(1).max(256),
+      state: SnapshotStateSchema,
+      startedAt: z.number().int().nonnegative().optional(),
+      updatedAt: z.number().int().nonnegative().optional(),
+      endedAt: z.number().int().nonnegative().optional(),
+      activity: SnapshotActivitySchema.optional(),
+      children: z.array(SnapshotNodeSchema).max(64).optional(),
+    })
+    .passthrough(),
+);
+
+const AsyncSnapshotSchema = z
+  .object({
+    kind: z.literal(ASYNC_SNAPSHOT_KIND),
+    version: z.literal(ASYNC_SNAPSHOT_VERSION),
+    generatedAt: z.number().int().nonnegative(),
+    runs: z.array(SnapshotNodeSchema).max(64),
+  })
+  .passthrough();
+
+type AsyncSnapshot = z.infer<typeof AsyncSnapshotSchema>;
+
+export interface PiSubagentTarget {
+  asyncId: string;
+  childId?: string;
+}
+
+export interface PiSubagentsBridgeResult {
+  handled: boolean;
+  events: AgentStreamEvent[];
+}
+
+interface FlattenedNode {
+  node: SnapshotNode;
+  target: PiSubagentTarget;
+  descriptorId: string;
+  parentLabel?: string;
+}
+
+export class PiSubagentsBridge {
+  private readonly targets = new Map<string, PiSubagentTarget>();
+  private lastCompatibilityError: string | null = null;
+
+  handleExtensionUiRequest(
+    event: Extract<PiRuntimeEvent, { type: "extension_ui_request" }>,
+  ): PiSubagentsBridgeResult {
+    if (event.method !== "setWidget" || event.widgetKey !== ASYNC_WIDGET_KEY) {
+      return { handled: false, events: [] };
+    }
+
+    const line = firstWidgetLine(event.widgetLines);
+    if (!line?.startsWith(ASYNC_WIDGET_PREFIX)) {
+      return { handled: true, events: [] };
+    }
+    if (Buffer.byteLength(line, "utf8") > MAX_WIDGET_BYTES) {
+      return this.compatibilityFailure(
+        "Pi Subagents status exceeded the supported host payload size.",
+      );
+    }
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line.slice(ASYNC_WIDGET_PREFIX.length)) as unknown;
+    } catch {
+      return this.compatibilityFailure("Pi Subagents returned an invalid status payload.");
+    }
+    const parsed = AsyncSnapshotSchema.safeParse(raw);
+    if (!parsed.success) {
+      const record = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : null;
+      const version = record && "version" in record ? String(record.version) : "unknown";
+      return this.compatibilityFailure(
+        `Pi Subagents status protocol version ${version} is not supported by this Paseo build.`,
+      );
+    }
+
+    this.lastCompatibilityError = null;
+    return {
+      handled: true,
+      events: flattenSnapshot(parsed.data).map((entry) => {
+        this.targets.set(entry.descriptorId, entry.target);
+        return toProviderSubagentEvent(entry, parsed.data);
+      }),
+    };
+  }
+
+  resolveTarget(descriptorId: string): PiSubagentTarget | null {
+    const target = this.targets.get(descriptorId);
+    return target ? { ...target } : null;
+  }
+
+  private compatibilityFailure(message: string): PiSubagentsBridgeResult {
+    if (this.lastCompatibilityError === message) {
+      return { handled: true, events: [] };
+    }
+    this.lastCompatibilityError = message;
+    return {
+      handled: true,
+      events: [
+        {
+          type: "timeline",
+          provider: "pi",
+          item: { type: "error", message },
+        },
+      ],
+    };
+  }
+}
+
+function firstWidgetLine(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  const first = value[0];
+  return typeof first === "string" ? first : null;
+}
+
+function flattenSnapshot(snapshot: AsyncSnapshot): FlattenedNode[] {
+  const entries: FlattenedNode[] = [];
+  for (const run of snapshot.runs) {
+    flattenNode(entries, run, { asyncId: run.id }, [], undefined);
+  }
+  return entries;
+}
+
+function flattenNode(
+  entries: FlattenedNode[],
+  node: SnapshotNode,
+  target: PiSubagentTarget,
+  path: string[],
+  parentLabel: string | undefined,
+): void {
+  const currentPath = [...path, node.id];
+  const descriptorId = encodeDescriptorId(target.asyncId, currentPath);
+  entries.push({ node, target, descriptorId, parentLabel });
+  for (const child of node.children ?? []) {
+    flattenNode(
+      entries,
+      child,
+      { asyncId: target.asyncId, childId: child.id },
+      currentPath,
+      node.label,
+    );
+  }
+}
+
+function encodeDescriptorId(asyncId: string, path: string[]): string {
+  return `pi-subagents:${Buffer.from(JSON.stringify({ asyncId, path }), "utf8").toString("base64url")}`;
+}
+
+function toProviderSubagentEvent(entry: FlattenedNode, snapshot: AsyncSnapshot): AgentStreamEvent {
+  return {
+    type: "provider_subagent",
+    provider: "pi",
+    event: {
+      type: "upsert",
+      id: entry.descriptorId,
+      title: entry.node.label,
+      description: entry.parentLabel
+        ? `${entry.parentLabel} / ${entry.node.label}`
+        : entry.node.label,
+      status: mapStatus(entry.node.state),
+      subtitle: formatSubtitle(entry.node, snapshot.generatedAt),
+      ...(entry.node.startedAt !== undefined
+        ? { timestamp: new Date(entry.node.startedAt).toISOString() }
+        : {}),
+    },
+  };
+}
+
+function mapStatus(state: SnapshotNode["state"]): "running" | "completed" | "failed" | "canceled" {
+  if (state === "complete") return "completed";
+  if (state === "stopped") return "canceled";
+  if (state === "failed" || state === "paused" || state === "rejected") return "failed";
+  return "running";
+}
+
+function formatSubtitle(node: SnapshotNode, generatedAt: number): string {
+  const parts: string[] = [node.state];
+  if (node.activity?.currentTool) parts.push(node.activity.currentTool);
+  if (node.activity?.turnCount !== undefined) parts.push(`${node.activity.turnCount} turns`);
+  if (node.activity?.toolCount !== undefined) parts.push(`${node.activity.toolCount} tools`);
+  if (node.startedAt !== undefined && generatedAt >= node.startedAt) {
+    parts.push(formatDuration(generatedAt - node.startedAt));
+  }
+  return parts.join(" · ");
+}
+
+function formatDuration(durationMs: number): string {
+  const seconds = Math.max(0, Math.floor(durationMs / 1_000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -102,6 +102,12 @@ export class FakePiSession implements PiRuntimeSession {
   readonly setThinkingLevelRequests: string[] = [];
   readonly treeNavigationRequests: string[] = [];
   readonly handoffRequests: Array<{ customInstructions?: string }> = [];
+  readonly subagentControlRequests: Array<{
+    requestId: string;
+    method: string;
+    params: Record<string, unknown>;
+  }> = [];
+  readonly subagentControlErrors: Error[] = [];
   readonly sessionNameRequests: string[] = [];
   readonly rawFrames: Array<object & { type: string }> = [];
   capturedUserEntries: Array<{ id: string; parentId: string | null; text: string }> = [];
@@ -177,6 +183,7 @@ export class FakePiSession implements PiRuntimeSession {
     }
     this.handleTreeNavigationCommand(message);
     this.handleEntryCaptureCommand(message);
+    this.handleSubagentControlCommand(message);
     return this.promptAck;
   }
 
@@ -387,6 +394,39 @@ export class FakePiSession implements PiRuntimeSession {
       id: `submitted-user-${entry.id}`,
       method: "notify",
       message: `PASEO_SUBMITTED_USER_ENTRY ${JSON.stringify({ entry })}`,
+    });
+  }
+
+  private handleSubagentControlCommand(message: string): void {
+    const prefix = "/paseo_subagent_control ";
+    if (!message.startsWith(prefix)) {
+      return;
+    }
+    const payload = JSON.parse(
+      Buffer.from(message.slice(prefix.length), "base64url").toString("utf8"),
+    ) as { requestId?: unknown; method?: unknown; params?: unknown };
+    if (
+      typeof payload.requestId !== "string" ||
+      typeof payload.method !== "string" ||
+      !payload.params ||
+      typeof payload.params !== "object" ||
+      Array.isArray(payload.params)
+    ) {
+      return;
+    }
+    this.subagentControlRequests.push({
+      requestId: payload.requestId,
+      method: payload.method,
+      params: payload.params as Record<string, unknown>,
+    });
+    const error = this.subagentControlErrors.shift();
+    if (error) {
+      this.emitExtensionCommandResult(payload.requestId, { ok: false, error: error.message });
+      return;
+    }
+    this.emitExtensionCommandResult(payload.requestId, {
+      ok: true,
+      result: { message: `${payload.method} accepted` },
     });
   }
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2184,6 +2184,8 @@ export class Session {
         return this.handleProviderSubagentListRequest(msg);
       case "agent.provider_subagents.timeline.get.request":
         return this.handleProviderSubagentTimelineRequest(msg);
+      case "agent.provider_subagents.control.request":
+        return this.handleProviderSubagentControlRequest(msg);
       case "agent.timeline.set_subscription.request": {
         const agentIds = [...new Set(msg.agentIds)].sort();
         if (
@@ -7094,6 +7096,48 @@ export class Session {
           hasOlder: false,
           hasNewer: false,
           rows: [],
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+
+  private async handleProviderSubagentControlRequest(
+    msg: Extract<SessionInboundMessage, { type: "agent.provider_subagents.control.request" }>,
+  ): Promise<void> {
+    try {
+      await ensureUnarchivedAgentLoaded(msg.parentAgentId, {
+        agentManager: this.agentManager,
+        agentStorage: this.agentStorage,
+        logger: this.sessionLogger,
+      });
+      const result = await this.agentManager.controlProviderSubagent({
+        parentAgentId: msg.parentAgentId,
+        subagentId: msg.subagentId,
+        action: msg.action,
+        ...(msg.message ? { message: msg.message } : {}),
+      });
+      this.emit({
+        type: "agent.provider_subagents.control.response",
+        payload: {
+          requestId: msg.requestId,
+          parentAgentId: msg.parentAgentId,
+          subagentId: msg.subagentId,
+          action: msg.action,
+          accepted: result.status === "accepted",
+          ...(result.message ? { message: result.message } : {}),
+          error: result.status === "accepted" ? null : (result.message ?? "Control unavailable"),
+        },
+      });
+    } catch (error) {
+      this.emit({
+        type: "agent.provider_subagents.control.response",
+        payload: {
+          requestId: msg.requestId,
+          parentAgentId: msg.parentAgentId,
+          subagentId: msg.subagentId,
+          action: msg.action,
+          accepted: false,
           error: error instanceof Error ? error.message : String(error),
         },
       });

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1724,6 +1724,8 @@ export class VoiceAssistantWebSocketServer {
         agentForkContextCursor: true,
         // COMPAT(providerSubagents): added in v0.1.107, remove gate after 2027-01-12.
         providerSubagents: true,
+        // COMPAT(providerSubagentControl): added in v0.5.1-pie.1, remove after 2027-02-24.
+        providerSubagentControl: true,
         // COMPAT(workspacePinning): added in v0.1.107, remove gate after 2027-01-12.
         workspacePinning: true,
         // COMPAT(hubRelationship): added in v0.1.X, drop the gate when floor >= v0.1.X.

--- a/scripts/build-daemon-web-ui.mjs
+++ b/scripts/build-daemon-web-ui.mjs
@@ -37,8 +37,16 @@ function run(command, args, options) {
 
 async function exportBrowserWebApp() {
   console.log("Exporting browser web app...");
+  const npmExecPath = process.env.npm_execpath;
+  if (npmExecPath) {
+    await run(process.execPath, [npmExecPath, "run", "build:web", "--workspace=@getpaseo/app"], {
+      cwd: REPO_ROOT,
+    });
+    return;
+  }
   await run("npm", ["run", "build:web", "--workspace=@getpaseo/app"], {
     cwd: REPO_ROOT,
+    shell: process.platform === "win32",
   });
 }
 


### PR DESCRIPTION
## Product discussion

https://github.com/getpaseo/paseo/discussions/3789

## Problem

Paseo already has a provider-neutral subagent store, list/timeline protocol, and responsive provider-subagent panel. Pi sessions using the installed `pi-subagents` extension currently expose delegated work only inside the parent tool output because the Pi provider ignores the extension's versioned RPC Host widgets.

## Change

- parse the public `pi-subagents.async-status-snapshot` v1 widget;
- project run/step/nested state into existing `provider_subagent` descriptors;
- fetch bounded detail through `/subagents-inspect-rpc` and map task/messages/tools/final output into the existing timeline;
- add a capability-gated provider-subagent control RPC for Stop, Steer, and Resume;
- route controls through the public in-process `subagents:rpc:v1` event-bus protocol from Paseo's already-injected Pi extension;
- reconcile nested/parallel identities, deduplicate repeated inspection rows, preserve terminal descriptors, and retry the short status-file creation race for Stop;
- fix the daemon Web UI build command on Windows by invoking npm through the active npm CLI path.

No `pi-subagents` dependency is added. The provider consumes the installed extension's documented Host protocol and fails closed on unsupported payload versions.

## Protocol compatibility

- Existing provider-subagent messages remain unchanged.
- The new control request/response pair uses dotted names and is gated by optional `server_info.features.providerSubagentControl`.
- Old clients do not receive or send the new control flow.
- Ordinary Pi sessions without `pi-subagents` behave as before.
- Other providers continue using the existing shared store and panel.

## Automated QA

```text
npx vitest run packages/protocol/src/messages.provider-subagents.test.ts packages/server/src/server/agent/providers/pi/agent.test.ts packages/server/src/server/agent/providers/pi/subagents-bridge.test.ts --bail=1
3 files passed, 80 tests passed

npm run build:client
passed
npm run typecheck --workspace=@getpaseo/server
passed
npm run typecheck --workspace=@getpaseo/app
passed
npm run build:server
passed
npm run build:daemon-web-ui
passed; raw 19.51 MiB, gzip 4.43 MiB, brotli 3.26 MiB
npm run lint -- <changed files>
0 warnings, 0 errors
```

## Real provider QA

Windows 11, Pi 0.84.2, pi-subagents 0.56.0:

- launched a detached worker through a real Pi parent;
- observed one provider-subagent descriptor with live activity and completed status through `agent.provider_subagents.list`;
- inspection returned the delegated task, tool activity, transcript window, and final output;
- a real Steer control returned accepted and appeared in the child transcript;
- a real Stop control returned accepted and converged to a stopped terminal state;
- the parent daemon remained alive after the CLI client disconnected and delivered the completion;
- a mobile-sized Chromium Web session opened the existing Subagent track and provider panel.

Playwright accessibility snapshot from the running mobile panel:

```text
textbox "Pi Subagent control message" (placeholder: Steer this subagent)
button "Steer"
button "Stop"
```

After completion the same panel showed:

```text
textbox "Pi Subagent control message" (placeholder: Message to resume this subagent)
button "Resume"
```

The fork canary is published at https://github.com/TaroPie1214/paseo/releases/tag/v0.5.1-pie.3.

## Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| Windows daemon | Yes | Real Pi and pi-subagents |
| Browser Web | Yes | Mobile-sized Chromium and responsive panel |
| Android native | No | Existing protocol remains compatible; no custom binary published |
| iOS native | No | Existing protocol remains compatible; no custom binary published |
| macOS/Linux daemon | No | Host payload parser and provider store are platform-neutral |

## Known limits

- The daemon owns the Pi process; restarting the daemon does not preserve a live child process.
- This draft uses existing provider-subagent presentation rather than reproducing the Pi Fleet TUI.
- Control labels are currently English literals and should be moved into the translation resources before marking the PR ready.

Development used an agent; raw command results and real-provider observations are included above.

