### PR TITLE
Clear Claude permission cards when callbacks are canceled

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -24,6 +24,12 @@ interface TestClaudeSession {
   close(): Promise<void>;
 }
 
+function isPermissionResolvedEvent(
+  event: AgentStreamEvent,
+): event is Extract<AgentStreamEvent, { type: "permission_resolved" }> {
+  return event.type === "permission_resolved";
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -628,6 +634,80 @@ describe("ClaudeAgentSession features", () => {
     });
     return { queryFactory, queryMock, launches };
   }
+
+  test("publishes a resolution when the SDK aborts a permission callback", async () => {
+    const { queryFactory } = createQueryMock();
+    const session = await new ClaudeAgentClient({
+      logger,
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    }).createSession({ provider: "claude", cwd: process.cwd(), modeId: "default" });
+    const events: AgentStreamEvent[] = [];
+    const unsubscribe = session.subscribe((event) => events.push(event));
+
+    try {
+      await session.startTurn("run the tool");
+      const canUseTool = queryFactory.mock.calls[0]?.[0].options.canUseTool;
+      if (!canUseTool) throw new Error("Expected canUseTool callback");
+      const abort = new AbortController();
+      const permission = canUseTool(
+        "Bash",
+        { command: "printf test" },
+        { signal: abort.signal, toolUseID: "tool-aborted" },
+      );
+      abort.abort();
+
+      await expect(permission).rejects.toThrow("Permission request aborted");
+      expect(events.find(isPermissionResolvedEvent)).toMatchObject({
+        type: "permission_resolved",
+        provider: "claude",
+        requestId: expect.any(String),
+        resolution: { behavior: "deny", message: "Permission request canceled" },
+      });
+      expect(session.getPendingPermissions()).toEqual([]);
+    } finally {
+      unsubscribe();
+      await session.close();
+    }
+  });
+
+  test("does not duplicate a resolution when interruption later aborts the SDK callback", async () => {
+    const { queryFactory } = createQueryMock();
+    const session = await new ClaudeAgentClient({
+      logger,
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    }).createSession({ provider: "claude", cwd: process.cwd(), modeId: "default" });
+    const events: AgentStreamEvent[] = [];
+    const unsubscribe = session.subscribe((event) => events.push(event));
+
+    try {
+      await session.startTurn("run the tool");
+      const canUseTool = queryFactory.mock.calls[0]?.[0].options.canUseTool;
+      if (!canUseTool) throw new Error("Expected canUseTool callback");
+      const abort = new AbortController();
+      const permission = canUseTool(
+        "Bash",
+        { command: "printf test" },
+        { signal: abort.signal, toolUseID: "tool-interrupted" },
+      );
+
+      await session.interrupt();
+      abort.abort();
+
+      await expect(permission).rejects.toThrow("Permission request canceled");
+      expect(events.filter(isPermissionResolvedEvent)).toEqual([
+        expect.objectContaining({
+          provider: "claude",
+          resolution: { behavior: "deny", message: "Permission request canceled" },
+        }),
+      ]);
+      expect(session.getPendingPermissions()).toEqual([]);
+    } finally {
+      unsubscribe();
+      await session.close();
+    }
+  });
 
   test("passes exact configured Fable 5 IDs through to Claude Code", async () => {
     const { queryFactory, queryMock } = createQueryMock();

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -2232,7 +2232,7 @@ class ClaudeAgentSession implements AgentSession {
       if (this.cancelCurrentTurn === requestCancel) {
         this.cancelCurrentTurn = null;
       }
-      this.rejectAllPendingPermissions(new Error("Permission request aborted"));
+      this.rejectAllPendingPermissions(new Error("Permission request canceled"));
       this.finishForegroundTurn({
         type: "turn_canceled",
         provider: "claude",
@@ -4635,6 +4635,12 @@ class ClaudeAgentSession implements AgentSession {
       const abortHandler = () => {
         this.pendingPermissions.delete(requestId);
         cleanup();
+        this.pushEvent({
+          type: "permission_resolved",
+          provider: "claude",
+          requestId,
+          resolution: { behavior: "deny", message: "Permission request canceled" },
+        });
         reject(new Error("Permission request aborted"));
       };
 
@@ -4775,6 +4781,12 @@ class ClaudeAgentSession implements AgentSession {
       pending.cleanup?.();
       pending.reject(error);
       this.pendingPermissions.delete(id);
+      this.pushEvent({
+        type: "permission_resolved",
+        provider: "claude",
+        requestId: id,
+        resolution: { behavior: "deny", message: error.message },
+      });
     }
   }
 


### PR DESCRIPTION
### Linked issue

Refs #3732

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Claude can cancel an in-flight `canUseTool` control request through the callback AbortSignal. Paseo removed the provider-side pending request and rejected its promise, but did not publish the matching terminal permission event. A client that had already rendered the request could therefore retain a card after Claude no longer accepted a response.

This publishes `permission_resolved` at the provider boundary whenever a pending callback is canceled. Paseo interruption keeps its existing cleanup behavior; the callback listener is removed before the SDK interruption arrives, so the same request resolves only once.

### Goals

- Every surfaced Claude permission request receives a terminal event when its callback is canceled.
- Clear the provider, manager, and client representations of the same request.
- Preserve exactly-once resolution during Paseo-initiated interruption.
- Preserve Claude permission rules and the selected permission mode.

### Non-goals

- Do not auto-approve tools in Bypass mode.
- Do not reinterpret Claude allow, ask, or deny rules.
- Do not claim to reproduce or resolve every accumulation reported in #3732.
- Do not add replay caches or client recovery state.

### QA

Real locally authenticated Claude, full isolated daemon/client path, run twice:

1. Created a Claude session in Default mode with Bash configured to ask.
2. Prompted Claude to run a harmless `printf` command and waited for the real permission request.
3. Canceled the active run through the daemon client.
4. Observed zero pending permissions and exactly one matching `permission_resolved` event.

Real locally authenticated Claude, direct installed SDK/CLI path, run twice:

1. Started a real Claude query with a pending Bash `canUseTool` callback.
2. Issued the SDK control cancellation.
3. Observed the callback AbortSignal fire exactly once.

Automated verification:

- `npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts --bail=1` — 74 passed.
- `npm run typecheck` — passed.
- `npm run lint -- packages/server/src/server/agent/providers/claude/agent.ts packages/server/src/server/agent/providers/claude/agent.test.ts` — passed with zero warnings and errors.
- `npm run format:check` — passed.

Platform coverage: daemon on macOS. No app code or platform-specific code changed.

### Risk surface

The change is limited to terminal events for canceled Claude permission callbacks. The main regression risk is duplicate resolution during interruption; both deterministic coverage and two real daemon runs assert exactly one event.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
