### PR TITLE
fix(grok): show context-window usage on the composer meter

### DIFF
--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -38,6 +38,11 @@ const mockState = vi.hoisted(() => {
         env?: Record<string, string>;
         providerParams?: unknown;
       }>,
+      grok: [] as Array<{
+        command: string[];
+        env?: Record<string, string>;
+        providerParams?: unknown;
+      }>,
       trae: [] as Array<{
         command: string[];
         env?: Record<string, string>;
@@ -65,6 +70,7 @@ const mockState = vi.hoisted(() => {
       this.constructorArgs.codex = [];
       this.constructorArgs.copilot = [];
       this.constructorArgs.cursor = [];
+      this.constructorArgs.grok = [];
       this.constructorArgs.trae = [];
       this.constructorArgs.kimi = [];
       this.constructorArgs.pi = [];
@@ -448,6 +454,59 @@ vi.mock("./providers/trae-acp-agent.js", () => ({
         env: options.env,
       };
       mockState.constructorArgs.trae.push({
+        command: options.command,
+        env: options.env,
+        providerParams: options.providerParams,
+      });
+    }
+
+    async createSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async resumeSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async fetchCatalog(): Promise<ProviderCatalog> {
+      return {
+        models: mockState.runtimeModels.get(this.provider) ?? [],
+        modes: [],
+      };
+    }
+
+    async isAvailable(): Promise<boolean> {
+      return true;
+    }
+  },
+}));
+
+vi.mock("./providers/grok-acp-agent.js", () => ({
+  GrokACPAgentClient: class GrokACPAgentClient {
+    readonly capabilities = {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    };
+    readonly provider = "acp";
+    readonly runtimeSettings?: unknown;
+
+    constructor(options: {
+      command: string[];
+      env?: Record<string, string>;
+      providerParams?: unknown;
+    }) {
+      this.runtimeSettings = {
+        command: {
+          mode: "replace",
+          argv: options.command,
+        },
+        env: options.env,
+      };
+      mockState.constructorArgs.grok.push({
         command: options.command,
         env: options.env,
         providerParams: options.providerParams,
@@ -914,6 +973,33 @@ test("traecli provider extending acp uses TraeACPAgentClient", () => {
     },
     {
       command: ["traecli", "acp", "serve"],
+      env: undefined,
+      providerParams: undefined,
+    },
+  ]);
+  expect(mockState.constructorArgs.genericAcp).toEqual([]);
+});
+
+test("grok provider extending acp uses GrokACPAgentClient", () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      grok: {
+        extends: "acp",
+        label: "Grok",
+        command: ["grok", "agent", "stdio"],
+      },
+    },
+  });
+
+  expect(registry.grok.createClient(logger).provider).toBe("grok");
+  expect(mockState.constructorArgs.grok).toEqual([
+    {
+      command: ["grok", "agent", "stdio"],
+      env: undefined,
+      providerParams: undefined,
+    },
+    {
+      command: ["grok", "agent", "stdio"],
       env: undefined,
       providerParams: undefined,
     },

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -39,6 +39,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { GrokACPAgentClient } from "./providers/grok-acp-agent.js";
 import { KimiACPAgentClient } from "./providers/kimi-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
@@ -792,6 +793,9 @@ function addDerivedProviders(
           };
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "grok") {
+            return new GrokACPAgentClient(acpOptions);
           }
           if (providerId === "kimi") {
             return new KimiACPAgentClient(acpOptions);

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -379,6 +379,21 @@ export type ACPExtensionCommandsParser = (
   params: Record<string, unknown>,
 ) => AgentSlashCommand[] | null;
 
+export interface ACPSessionNotificationUsageContext {
+  sessionId: string | null;
+  cwd: string;
+}
+
+/**
+ * Provider-owned extractor for usage attached to a standard `session/update`
+ * notification. Return undefined when this notification does not carry usage.
+ * Grok publishes live context-window tokens on `_meta.totalTokens` this way.
+ */
+export type ACPSessionNotificationUsage = (
+  params: SessionNotification,
+  context: ACPSessionNotificationUsageContext,
+) => AgentUsage | undefined;
+
 /**
  * Context handed to an {@link ACPCatalogModelResolver} during `fetchCatalog`. It exposes
  * the already-derived models plus the live probe session so a resolver can refine them
@@ -432,6 +447,7 @@ interface ACPAgentClientOptions {
   ) => Promise<void>;
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  sessionNotificationUsage?: ACPSessionNotificationUsage;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
@@ -462,6 +478,7 @@ interface ACPAgentSessionOptions {
   ) => Promise<void>;
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  sessionNotificationUsage?: ACPSessionNotificationUsage;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -604,6 +621,18 @@ export function mapACPUsage(usage: Usage | null | undefined): AgentUsage | undef
     outputTokens: usage.outputTokens ?? undefined,
     cachedInputTokens: usage.cachedReadTokens ?? undefined,
   };
+}
+
+function sameAgentUsage(current: AgentUsage | undefined, next: AgentUsage): boolean {
+  if (!current) return false;
+  return (
+    current.inputTokens === next.inputTokens &&
+    current.outputTokens === next.outputTokens &&
+    current.cachedInputTokens === next.cachedInputTokens &&
+    current.totalCostUsd === next.totalCostUsd &&
+    current.contextWindowMaxTokens === next.contextWindowMaxTokens &&
+    current.contextWindowUsedTokens === next.contextWindowUsedTokens
+  );
 }
 
 export function resolveACPModeSelection({
@@ -822,6 +851,7 @@ export class ACPAgentClient implements AgentClient {
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly sessionNotificationUsage?: ACPSessionNotificationUsage;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -850,6 +880,7 @@ export class ACPAgentClient implements AgentClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.sessionNotificationUsage = options.sessionNotificationUsage;
   }
 
   async createSession(
@@ -880,6 +911,7 @@ export class ACPAgentClient implements AgentClient {
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
         extensionCommandsParser: this.extensionCommandsParser,
+        sessionNotificationUsage: this.sessionNotificationUsage,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
       },
@@ -931,6 +963,7 @@ export class ACPAgentClient implements AgentClient {
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       extensionCommandsParser: this.extensionCommandsParser,
+      sessionNotificationUsage: this.sessionNotificationUsage,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -1454,6 +1487,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly sessionNotificationUsage?: ACPSessionNotificationUsage;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
@@ -1494,6 +1528,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.sessionNotificationUsage = options.sessionNotificationUsage;
   }
 
   get id(): string | null {
@@ -2290,6 +2325,16 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
 
     const events = this.translateSessionUpdate(params.update);
+    const notificationUsage = this.sessionNotificationUsage?.(params, {
+      sessionId: this.sessionId,
+      cwd: this.config.cwd,
+    });
+    if (
+      notificationUsage &&
+      !sameAgentUsage(this.currentTurnUsage, { ...this.currentTurnUsage, ...notificationUsage })
+    ) {
+      events.push(this.applyUsageUpdate(notificationUsage));
+    }
     this.logger.trace(
       {
         agentId: this.agentId,
@@ -2844,6 +2889,24 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private handleUsageUpdate(update: UsageUpdate): void {
     void update;
+  }
+
+  private applyUsageUpdate(usage: AgentUsage, turnId?: string): AgentStreamEvent {
+    this.currentTurnUsage = { ...this.currentTurnUsage, ...usage };
+    const resolvedTurnId = turnId ?? this.activeForegroundTurnId ?? undefined;
+    if (resolvedTurnId) {
+      return {
+        type: "usage_updated",
+        provider: this.provider,
+        usage: this.currentTurnUsage,
+        turnId: resolvedTurnId,
+      };
+    }
+    return {
+      type: "usage_updated",
+      provider: this.provider,
+      usage: this.currentTurnUsage,
+    };
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -379,21 +379,6 @@ export type ACPExtensionCommandsParser = (
   params: Record<string, unknown>,
 ) => AgentSlashCommand[] | null;
 
-export interface ACPSessionNotificationUsageContext {
-  sessionId: string | null;
-  cwd: string;
-}
-
-/**
- * Provider-owned extractor for usage attached to a standard `session/update`
- * notification. Return undefined when this notification does not carry usage.
- * Grok publishes live context-window tokens on `_meta.totalTokens` this way.
- */
-export type ACPSessionNotificationUsage = (
-  params: SessionNotification,
-  context: ACPSessionNotificationUsageContext,
-) => AgentUsage | undefined;
-
 /**
  * Context handed to an {@link ACPCatalogModelResolver} during `fetchCatalog`. It exposes
  * the already-derived models plus the live probe session so a resolver can refine them
@@ -447,13 +432,12 @@ interface ACPAgentClientOptions {
   ) => Promise<void>;
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
-  sessionNotificationUsage?: ACPSessionNotificationUsage;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
 }
 
-interface ACPAgentSessionOptions {
+export interface ACPAgentSessionOptions {
   provider: string;
   logger: Logger;
   runtimeSettings?: ProviderRuntimeSettings;
@@ -478,7 +462,6 @@ interface ACPAgentSessionOptions {
   ) => Promise<void>;
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
-  sessionNotificationUsage?: ACPSessionNotificationUsage;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -621,18 +604,6 @@ export function mapACPUsage(usage: Usage | null | undefined): AgentUsage | undef
     outputTokens: usage.outputTokens ?? undefined,
     cachedInputTokens: usage.cachedReadTokens ?? undefined,
   };
-}
-
-function sameAgentUsage(current: AgentUsage | undefined, next: AgentUsage): boolean {
-  if (!current) return false;
-  return (
-    current.inputTokens === next.inputTokens &&
-    current.outputTokens === next.outputTokens &&
-    current.cachedInputTokens === next.cachedInputTokens &&
-    current.totalCostUsd === next.totalCostUsd &&
-    current.contextWindowMaxTokens === next.contextWindowMaxTokens &&
-    current.contextWindowUsedTokens === next.contextWindowUsedTokens
-  );
 }
 
 export function resolveACPModeSelection({
@@ -851,7 +822,6 @@ export class ACPAgentClient implements AgentClient {
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
-  private readonly sessionNotificationUsage?: ACPSessionNotificationUsage;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -880,7 +850,13 @@ export class ACPAgentClient implements AgentClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
-    this.sessionNotificationUsage = options.sessionNotificationUsage;
+  }
+
+  protected createAgentSession(
+    config: AgentSessionConfig,
+    options: ACPAgentSessionOptions,
+  ): ACPAgentSession {
+    return new ACPAgentSession(config, options);
   }
 
   async createSession(
@@ -888,7 +864,7 @@ export class ACPAgentClient implements AgentClient {
     launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
     this.assertProvider(config);
-    const session = new ACPAgentSession(
+    const session = this.createAgentSession(
       { ...config, provider: this.provider },
       {
         provider: this.provider,
@@ -911,7 +887,6 @@ export class ACPAgentClient implements AgentClient {
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
         extensionCommandsParser: this.extensionCommandsParser,
-        sessionNotificationUsage: this.sessionNotificationUsage,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
       },
@@ -941,7 +916,7 @@ export class ACPAgentClient implements AgentClient {
       provider: this.provider,
       cwd,
     };
-    const session = new ACPAgentSession(mergedConfig, {
+    const session = this.createAgentSession(mergedConfig, {
       provider: this.provider,
       logger: this.logger,
       runtimeSettings: this.runtimeSettings,
@@ -963,7 +938,6 @@ export class ACPAgentClient implements AgentClient {
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       extensionCommandsParser: this.extensionCommandsParser,
-      sessionNotificationUsage: this.sessionNotificationUsage,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -1487,7 +1461,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
-  private readonly sessionNotificationUsage?: ACPSessionNotificationUsage;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
@@ -1528,7 +1501,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
-    this.sessionNotificationUsage = options.sessionNotificationUsage;
   }
 
   get id(): string | null {
@@ -2325,16 +2297,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
 
     const events = this.translateSessionUpdate(params.update);
-    const notificationUsage = this.sessionNotificationUsage?.(params, {
-      sessionId: this.sessionId,
-      cwd: this.config.cwd,
-    });
-    if (
-      notificationUsage &&
-      !sameAgentUsage(this.currentTurnUsage, { ...this.currentTurnUsage, ...notificationUsage })
-    ) {
-      events.push(this.applyUsageUpdate(notificationUsage));
-    }
     this.logger.trace(
       {
         agentId: this.agentId,
@@ -2891,24 +2853,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     void update;
   }
 
-  private applyUsageUpdate(usage: AgentUsage, turnId?: string): AgentStreamEvent {
-    this.currentTurnUsage = { ...this.currentTurnUsage, ...usage };
-    const resolvedTurnId = turnId ?? this.activeForegroundTurnId ?? undefined;
-    if (resolvedTurnId) {
-      return {
-        type: "usage_updated",
-        provider: this.provider,
-        usage: this.currentTurnUsage,
-        turnId: resolvedTurnId,
-      };
-    }
-    return {
-      type: "usage_updated",
-      provider: this.provider,
-      usage: this.currentTurnUsage,
-    };
-  }
-
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
     this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
 
@@ -2946,7 +2890,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     };
   }
 
-  private pushEvent(event: AgentStreamEvent): void {
+  protected pushEvent(event: AgentStreamEvent): void {
     this.logger.trace(
       {
         agentId: this.agentId,

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -10,6 +10,7 @@ import {
   type ACPConfigFeatureOption,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type ACPSessionNotificationUsage,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -50,6 +51,7 @@ interface GenericACPAgentClientOptions {
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  sessionNotificationUsage?: ACPSessionNotificationUsage;
   catalogModelResolver?: ACPCatalogModelResolver;
 }
 
@@ -75,6 +77,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
       clientCapabilityMeta: options.clientCapabilityMeta,
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
+      sessionNotificationUsage: options.sessionNotificationUsage,
       catalogModelResolver: options.catalogModelResolver,
     });
 

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -10,7 +10,6 @@ import {
   type ACPConfigFeatureOption,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
-  type ACPSessionNotificationUsage,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -51,7 +50,6 @@ interface GenericACPAgentClientOptions {
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
-  sessionNotificationUsage?: ACPSessionNotificationUsage;
   catalogModelResolver?: ACPCatalogModelResolver;
 }
 
@@ -77,7 +75,6 @@ export class GenericACPAgentClient extends ACPAgentClient {
       clientCapabilityMeta: options.clientCapabilityMeta,
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
-      sessionNotificationUsage: options.sessionNotificationUsage,
       catalogModelResolver: options.catalogModelResolver,
     });
 

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,0 +1,260 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { asInternals } from "../../test-utils/class-mocks.js";
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import type { AgentStreamEvent } from "../agent-sdk-types.js";
+import { ACPAgentSession } from "./acp-agent.js";
+import {
+  grokSessionSignalsPath,
+  grokUsageFromSessionNotification,
+  readGrokContextUsage,
+  readGrokDefaultContextWindow,
+} from "./grok-acp-agent.js";
+
+function createGrokSession(): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "grok",
+      cwd: "/tmp/paseo-grok-test",
+    },
+    {
+      provider: "grok",
+      logger: createTestLogger(),
+      defaultCommand: ["grok", "agent", "stdio"],
+      defaultModes: [],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      sessionNotificationUsage: (params, context) =>
+        grokUsageFromSessionNotification(params, {
+          ...context,
+          defaultContextWindow: 500_000,
+        }),
+    },
+  );
+}
+
+describe("readGrokDefaultContextWindow", () => {
+  const homes: string[] = [];
+
+  afterEach(() => {
+    for (const home of homes.splice(0)) {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("prefers grok-4.6 context window from the models cache", () => {
+    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
+    homes.push(home);
+    writeFileSync(
+      join(home, "models_cache.json"),
+      JSON.stringify({
+        models: {
+          "grok-code": { info: { context_window: 256_000 } },
+          "grok-4.6": { info: { context_window: 500_000 } },
+        },
+      }),
+    );
+
+    expect(readGrokDefaultContextWindow(home)).toBe(500_000);
+  });
+
+  test("falls back to the first cached model with a context window", () => {
+    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
+    homes.push(home);
+    writeFileSync(
+      join(home, "models_cache.json"),
+      JSON.stringify({
+        models: {
+          "grok-code": { info: { context_window: 256_000 } },
+        },
+      }),
+    );
+
+    expect(readGrokDefaultContextWindow(home)).toBe(256_000);
+  });
+
+  test("returns null when the models cache is missing", () => {
+    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
+    homes.push(home);
+
+    expect(readGrokDefaultContextWindow(home)).toBeNull();
+  });
+});
+
+describe("readGrokContextUsage", () => {
+  const homes: string[] = [];
+
+  afterEach(() => {
+    for (const home of homes.splice(0)) {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("reads context window usage from Grok session signals", () => {
+    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
+    homes.push(home);
+    const cwd = "/Users/nexmoe/project";
+    const sessionId = "session-signals";
+    const path = grokSessionSignalsPath(cwd, sessionId, home);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        contextTokensUsed: 331488,
+        contextWindowTokens: 500000,
+        contextWindowUsage: 66,
+      }),
+    );
+
+    expect(readGrokContextUsage(cwd, sessionId, home)).toEqual({
+      contextWindowUsedTokens: 331488,
+      contextWindowMaxTokens: 500000,
+    });
+  });
+
+  test("returns null for missing or corrupt Grok session signals", () => {
+    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
+    homes.push(home);
+    const cwd = "/Users/nexmoe/project";
+    const sessionId = "session-corrupt";
+    const path = grokSessionSignalsPath(cwd, sessionId, home);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, "{not-json");
+
+    expect(readGrokContextUsage(cwd, "missing", home)).toBeNull();
+    expect(readGrokContextUsage(cwd, sessionId, home)).toBeNull();
+  });
+});
+
+describe("grokUsageFromSessionNotification", () => {
+  test("maps Grok session/update _meta.totalTokens onto the context window", () => {
+    expect(
+      grokUsageFromSessionNotification(
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "pong" },
+          },
+          _meta: { totalTokens: 11493 },
+        },
+        {
+          sessionId: "session-1",
+          cwd: "/tmp/project",
+          defaultContextWindow: 500000,
+        },
+      ),
+    ).toEqual({
+      contextWindowUsedTokens: 11493,
+      contextWindowMaxTokens: 500000,
+    });
+  });
+
+  test("prefers session signals over the default context window", () => {
+    expect(
+      grokUsageFromSessionNotification(
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "pong" },
+          },
+          _meta: { totalTokens: 87000 },
+        },
+        {
+          sessionId: "session-1",
+          cwd: "/tmp/project",
+          defaultContextWindow: 500000,
+          readSignals: () => ({
+            contextWindowUsedTokens: 87000,
+            contextWindowMaxTokens: 200000,
+          }),
+        },
+      ),
+    ).toEqual({
+      contextWindowUsedTokens: 87000,
+      contextWindowMaxTokens: 200000,
+    });
+  });
+
+  test("ignores session updates without _meta.totalTokens", () => {
+    expect(
+      grokUsageFromSessionNotification(
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "pong" },
+          },
+        },
+        {
+          sessionId: "session-1",
+          cwd: "/tmp/project",
+          defaultContextWindow: 500000,
+        },
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("Grok ACP session usage", () => {
+  test("emits usage_updated from Grok session/update _meta.totalTokens", async () => {
+    const session = createGrokSession();
+    asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "pong" },
+      },
+      _meta: { totalTokens: 11493 },
+    });
+
+    expect(events.filter((event) => event.type === "usage_updated")).toEqual([
+      {
+        type: "usage_updated",
+        provider: "grok",
+        usage: {
+          contextWindowUsedTokens: 11493,
+          contextWindowMaxTokens: 500000,
+        },
+      },
+    ]);
+  });
+
+  test("does not re-emit identical Grok context-window usage", async () => {
+    const session = createGrokSession();
+    asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    const notification = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk" as const,
+        content: { type: "text" as const, text: "pong" },
+      },
+      _meta: { totalTokens: 11493 },
+    };
+    await session.sessionUpdate(notification);
+    await session.sessionUpdate(notification);
+
+    expect(events.filter((event) => event.type === "usage_updated")).toHaveLength(1);
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -6,16 +6,14 @@ import { afterEach, describe, expect, test } from "vitest";
 import { asInternals } from "../../test-utils/class-mocks.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
-import { ACPAgentSession } from "./acp-agent.js";
 import {
-  grokSessionSignalsPath,
+  GrokACPAgentSession,
   grokUsageFromSessionNotification,
-  readGrokContextUsage,
   readGrokDefaultContextWindow,
 } from "./grok-acp-agent.js";
 
-function createGrokSession(): ACPAgentSession {
-  return new ACPAgentSession(
+function createGrokSession(defaultContextWindow: number | null = 500_000): GrokACPAgentSession {
+  return new GrokACPAgentSession(
     {
       provider: "grok",
       cwd: "/tmp/paseo-grok-test",
@@ -33,12 +31,8 @@ function createGrokSession(): ACPAgentSession {
         supportsReasoningStream: true,
         supportsToolInvocations: true,
       },
-      sessionNotificationUsage: (params, context) =>
-        grokUsageFromSessionNotification(params, {
-          ...context,
-          defaultContextWindow: 500_000,
-        }),
     },
+    defaultContextWindow,
   );
 }
 
@@ -51,14 +45,13 @@ describe("readGrokDefaultContextWindow", () => {
     }
   });
 
-  test("prefers grok-4.6 context window from the models cache", () => {
+  test("reads a context window from the Grok models cache", () => {
     const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
     homes.push(home);
     writeFileSync(
       join(home, "models_cache.json"),
       JSON.stringify({
         models: {
-          "grok-code": { info: { context_window: 256_000 } },
           "grok-4.6": { info: { context_window: 500_000 } },
         },
       }),
@@ -67,71 +60,11 @@ describe("readGrokDefaultContextWindow", () => {
     expect(readGrokDefaultContextWindow(home)).toBe(500_000);
   });
 
-  test("falls back to the first cached model with a context window", () => {
-    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
-    homes.push(home);
-    writeFileSync(
-      join(home, "models_cache.json"),
-      JSON.stringify({
-        models: {
-          "grok-code": { info: { context_window: 256_000 } },
-        },
-      }),
-    );
-
-    expect(readGrokDefaultContextWindow(home)).toBe(256_000);
-  });
-
   test("returns null when the models cache is missing", () => {
     const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
     homes.push(home);
 
     expect(readGrokDefaultContextWindow(home)).toBeNull();
-  });
-});
-
-describe("readGrokContextUsage", () => {
-  const homes: string[] = [];
-
-  afterEach(() => {
-    for (const home of homes.splice(0)) {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  test("reads context window usage from Grok session signals", () => {
-    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
-    homes.push(home);
-    const cwd = "/Users/nexmoe/project";
-    const sessionId = "session-signals";
-    const path = grokSessionSignalsPath(cwd, sessionId, home);
-    mkdirSync(join(path, ".."), { recursive: true });
-    writeFileSync(
-      path,
-      JSON.stringify({
-        contextTokensUsed: 331488,
-        contextWindowTokens: 500000,
-        contextWindowUsage: 66,
-      }),
-    );
-
-    expect(readGrokContextUsage(cwd, sessionId, home)).toEqual({
-      contextWindowUsedTokens: 331488,
-      contextWindowMaxTokens: 500000,
-    });
-  });
-
-  test("returns null for missing or corrupt Grok session signals", () => {
-    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
-    homes.push(home);
-    const cwd = "/Users/nexmoe/project";
-    const sessionId = "session-corrupt";
-    const path = grokSessionSignalsPath(cwd, sessionId, home);
-    mkdirSync(join(path, ".."), { recursive: true });
-    writeFileSync(path, "{not-json");
-
-    expect(readGrokContextUsage(cwd, "missing", home)).toBeNull();
-    expect(readGrokContextUsage(cwd, sessionId, home)).toBeNull();
   });
 });
 
@@ -147,42 +80,11 @@ describe("grokUsageFromSessionNotification", () => {
           },
           _meta: { totalTokens: 11493 },
         },
-        {
-          sessionId: "session-1",
-          cwd: "/tmp/project",
-          defaultContextWindow: 500000,
-        },
+        500000,
       ),
     ).toEqual({
       contextWindowUsedTokens: 11493,
       contextWindowMaxTokens: 500000,
-    });
-  });
-
-  test("prefers session signals over the default context window", () => {
-    expect(
-      grokUsageFromSessionNotification(
-        {
-          sessionId: "session-1",
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: "pong" },
-          },
-          _meta: { totalTokens: 87000 },
-        },
-        {
-          sessionId: "session-1",
-          cwd: "/tmp/project",
-          defaultContextWindow: 500000,
-          readSignals: () => ({
-            contextWindowUsedTokens: 87000,
-            contextWindowMaxTokens: 200000,
-          }),
-        },
-      ),
-    ).toEqual({
-      contextWindowUsedTokens: 87000,
-      contextWindowMaxTokens: 200000,
     });
   });
 
@@ -196,11 +98,7 @@ describe("grokUsageFromSessionNotification", () => {
             content: { type: "text", text: "pong" },
           },
         },
-        {
-          sessionId: "session-1",
-          cwd: "/tmp/project",
-          defaultContextWindow: 500000,
-        },
+        500000,
       ),
     ).toBeUndefined();
   });

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,0 +1,163 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import type { Logger } from "pino";
+
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import type { AgentUsage } from "../agent-sdk-types.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+const GrokSignalsSchema = z.object({
+  contextTokensUsed: z.number().finite().optional(),
+  contextWindowTokens: z.number().finite().optional(),
+});
+
+const GrokModelsCacheSchema = z
+  .object({
+    models: z.record(
+      z.string(),
+      z
+        .object({
+          info: z
+            .object({
+              context_window: z.number().finite().optional(),
+            })
+            .passthrough()
+            .optional(),
+        })
+        .passthrough(),
+    ),
+  })
+  .passthrough();
+
+interface GrokACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+export interface GrokContextUsage {
+  contextWindowUsedTokens: number;
+  contextWindowMaxTokens: number;
+}
+
+interface GrokSessionUsageContext {
+  sessionId: string | null;
+  cwd: string;
+  readSignals?: (cwd: string, sessionId: string) => GrokContextUsage | null;
+  defaultContextWindow?: number | null;
+}
+
+function readJsonFileOrNull(path: string): unknown | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    if (error instanceof SyntaxError) return null;
+    throw error;
+  }
+}
+
+function grokHomeDir(grokHome?: string): string {
+  return grokHome || process.env["GROK_HOME"] || join(homedir(), ".grok");
+}
+
+export function grokSessionSignalsPath(cwd: string, sessionId: string, grokHome?: string): string {
+  return join(
+    grokHomeDir(grokHome),
+    "sessions",
+    encodeURIComponent(cwd),
+    sessionId,
+    "signals.json",
+  );
+}
+
+function positiveContextWindow(value: number | undefined): number | null {
+  return typeof value === "number" && value > 0 ? value : null;
+}
+
+export function readGrokDefaultContextWindow(grokHome?: string): number | null {
+  const parsed = GrokModelsCacheSchema.safeParse(
+    readJsonFileOrNull(join(grokHomeDir(grokHome), "models_cache.json")),
+  );
+  if (!parsed.success) return null;
+
+  // Prefer the current default model so a leftover older cache entry does not
+  // set a stale window size.
+  const preferredWindow = positiveContextWindow(
+    parsed.data.models["grok-4.6"]?.info?.context_window,
+  );
+  if (preferredWindow !== null) return preferredWindow;
+
+  for (const model of Object.values(parsed.data.models)) {
+    const window = positiveContextWindow(model.info?.context_window);
+    if (window !== null) return window;
+  }
+  return null;
+}
+
+export function grokUsageFromSessionNotification(
+  params: SessionNotification,
+  context: GrokSessionUsageContext,
+): AgentUsage | undefined {
+  const totalTokens = params._meta?.["totalTokens"];
+  if (typeof totalTokens !== "number" || !Number.isFinite(totalTokens) || totalTokens < 0) {
+    return undefined;
+  }
+
+  const sessionId = params.sessionId || context.sessionId;
+  const signals =
+    sessionId === null || sessionId.length === 0
+      ? null
+      : (context.readSignals ?? readGrokContextUsage)(context.cwd, sessionId);
+  const maxTokens = signals?.contextWindowMaxTokens ?? context.defaultContextWindow ?? null;
+  const usage: AgentUsage = {
+    contextWindowUsedTokens: totalTokens,
+  };
+  if (maxTokens !== null) {
+    usage.contextWindowMaxTokens = maxTokens;
+  }
+  return usage;
+}
+
+export function readGrokContextUsage(
+  cwd: string,
+  sessionId: string,
+  grokHome?: string,
+): GrokContextUsage | null {
+  const parsed = GrokSignalsSchema.safeParse(
+    readJsonFileOrNull(grokSessionSignalsPath(cwd, sessionId, grokHome)),
+  );
+  if (!parsed.success) return null;
+  const used = parsed.data.contextTokensUsed;
+  const max = parsed.data.contextWindowTokens;
+  if (typeof used !== "number" || used < 0 || typeof max !== "number" || max <= 0) {
+    return null;
+  }
+  return { contextWindowUsedTokens: used, contextWindowMaxTokens: max };
+}
+
+// Grok is a catalog ACP provider, but it publishes live context-window tokens
+// on session/update `_meta.totalTokens` rather than ACP `usage_update`.
+export class GrokACPAgentClient extends GenericACPAgentClient {
+  constructor(options: GrokACPAgentClientOptions) {
+    const defaultContextWindow = readGrokDefaultContextWindow();
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId ?? "grok",
+      label: options.label ?? "Grok",
+      providerParams: options.providerParams,
+      sessionNotificationUsage: (params, context) =>
+        grokUsageFromSessionNotification(params, {
+          ...context,
+          defaultContextWindow,
+        }),
+    });
+  }
+}

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -5,13 +5,9 @@ import { z } from "zod";
 import type { Logger } from "pino";
 
 import type { SessionNotification } from "@agentclientprotocol/sdk";
-import type { AgentUsage } from "../agent-sdk-types.js";
+import type { AgentSessionConfig, AgentUsage } from "../agent-sdk-types.js";
+import { ACPAgentSession, type ACPAgentSessionOptions } from "./acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
-
-const GrokSignalsSchema = z.object({
-  contextTokensUsed: z.number().finite().optional(),
-  contextWindowTokens: z.number().finite().optional(),
-});
 
 const GrokModelsCacheSchema = z
   .object({
@@ -40,18 +36,6 @@ interface GrokACPAgentClientOptions {
   providerParams?: unknown;
 }
 
-export interface GrokContextUsage {
-  contextWindowUsedTokens: number;
-  contextWindowMaxTokens: number;
-}
-
-interface GrokSessionUsageContext {
-  sessionId: string | null;
-  cwd: string;
-  readSignals?: (cwd: string, sessionId: string) => GrokContextUsage | null;
-  defaultContextWindow?: number | null;
-}
-
 function readJsonFileOrNull(path: string): unknown | null {
   if (!existsSync(path)) return null;
   try {
@@ -62,36 +46,19 @@ function readJsonFileOrNull(path: string): unknown | null {
   }
 }
 
-function grokHomeDir(grokHome?: string): string {
-  return grokHome || process.env["GROK_HOME"] || join(homedir(), ".grok");
-}
-
-export function grokSessionSignalsPath(cwd: string, sessionId: string, grokHome?: string): string {
-  return join(
-    grokHomeDir(grokHome),
-    "sessions",
-    encodeURIComponent(cwd),
-    sessionId,
-    "signals.json",
-  );
+function grokHomeDir(): string {
+  return process.env["GROK_HOME"] || join(homedir(), ".grok");
 }
 
 function positiveContextWindow(value: number | undefined): number | null {
   return typeof value === "number" && value > 0 ? value : null;
 }
 
-export function readGrokDefaultContextWindow(grokHome?: string): number | null {
+export function readGrokDefaultContextWindow(grokHome = grokHomeDir()): number | null {
   const parsed = GrokModelsCacheSchema.safeParse(
-    readJsonFileOrNull(join(grokHomeDir(grokHome), "models_cache.json")),
+    readJsonFileOrNull(join(grokHome, "models_cache.json")),
   );
   if (!parsed.success) return null;
-
-  // Prefer the current default model so a leftover older cache entry does not
-  // set a stale window size.
-  const preferredWindow = positiveContextWindow(
-    parsed.data.models["grok-4.6"]?.info?.context_window,
-  );
-  if (preferredWindow !== null) return preferredWindow;
 
   for (const model of Object.values(parsed.data.models)) {
     const window = positiveContextWindow(model.info?.context_window);
@@ -102,50 +69,65 @@ export function readGrokDefaultContextWindow(grokHome?: string): number | null {
 
 export function grokUsageFromSessionNotification(
   params: SessionNotification,
-  context: GrokSessionUsageContext,
+  defaultContextWindow: number | null,
 ): AgentUsage | undefined {
   const totalTokens = params._meta?.["totalTokens"];
   if (typeof totalTokens !== "number" || !Number.isFinite(totalTokens) || totalTokens < 0) {
     return undefined;
   }
 
-  const sessionId = params.sessionId || context.sessionId;
-  const signals =
-    sessionId === null || sessionId.length === 0
-      ? null
-      : (context.readSignals ?? readGrokContextUsage)(context.cwd, sessionId);
-  const maxTokens = signals?.contextWindowMaxTokens ?? context.defaultContextWindow ?? null;
   const usage: AgentUsage = {
     contextWindowUsedTokens: totalTokens,
   };
-  if (maxTokens !== null) {
-    usage.contextWindowMaxTokens = maxTokens;
+  if (defaultContextWindow !== null) {
+    usage.contextWindowMaxTokens = defaultContextWindow;
   }
   return usage;
 }
 
-export function readGrokContextUsage(
-  cwd: string,
-  sessionId: string,
-  grokHome?: string,
-): GrokContextUsage | null {
-  const parsed = GrokSignalsSchema.safeParse(
-    readJsonFileOrNull(grokSessionSignalsPath(cwd, sessionId, grokHome)),
-  );
-  if (!parsed.success) return null;
-  const used = parsed.data.contextTokensUsed;
-  const max = parsed.data.contextWindowTokens;
-  if (typeof used !== "number" || used < 0 || typeof max !== "number" || max <= 0) {
-    return null;
+export class GrokACPAgentSession extends ACPAgentSession {
+  private lastUsedTokens: number | null = null;
+  private lastMaxTokens: number | null = null;
+
+  constructor(
+    config: AgentSessionConfig,
+    options: ACPAgentSessionOptions,
+    private readonly defaultContextWindow: number | null,
+  ) {
+    super(config, options);
   }
-  return { contextWindowUsedTokens: used, contextWindowMaxTokens: max };
+
+  override async sessionUpdate(params: SessionNotification): Promise<void> {
+    await super.sessionUpdate(params);
+    if (this.id === null || params.sessionId !== this.id) {
+      return;
+    }
+
+    const usage = grokUsageFromSessionNotification(params, this.defaultContextWindow);
+    if (!usage) return;
+
+    const used = usage.contextWindowUsedTokens ?? null;
+    const max = usage.contextWindowMaxTokens ?? null;
+    if (used === this.lastUsedTokens && max === this.lastMaxTokens) {
+      return;
+    }
+    this.lastUsedTokens = used;
+    this.lastMaxTokens = max;
+    this.pushEvent({
+      type: "usage_updated",
+      provider: this.provider,
+      usage,
+    });
+  }
 }
 
-// Grok is a catalog ACP provider, but it publishes live context-window tokens
-// on session/update `_meta.totalTokens` rather than ACP `usage_update`.
+// Grok publishes live context-window tokens on session/update `_meta.totalTokens`
+// rather than ACP `usage_update`. Reuse the shared session and emit the existing
+// usage_updated event.
 export class GrokACPAgentClient extends GenericACPAgentClient {
+  private readonly defaultContextWindow: number | null;
+
   constructor(options: GrokACPAgentClientOptions) {
-    const defaultContextWindow = readGrokDefaultContextWindow();
     super({
       logger: options.logger,
       command: options.command,
@@ -153,11 +135,14 @@ export class GrokACPAgentClient extends GenericACPAgentClient {
       providerId: options.providerId ?? "grok",
       label: options.label ?? "Grok",
       providerParams: options.providerParams,
-      sessionNotificationUsage: (params, context) =>
-        grokUsageFromSessionNotification(params, {
-          ...context,
-          defaultContextWindow,
-        }),
     });
+    this.defaultContextWindow = readGrokDefaultContextWindow();
+  }
+
+  protected override createAgentSession(
+    config: AgentSessionConfig,
+    options: ACPAgentSessionOptions,
+  ): ACPAgentSession {
+    return new GrokACPAgentSession(config, options, this.defaultContextWindow);
   }
 }


### PR DESCRIPTION
### Linked issue

N/A — Grok composer meter stays empty on desktop and mobile. Related to #1390 (generic ACP `usage_update` drop) and stale #3306 (Grok usage + quota). This PR is only the context-window ring.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The composer context-window ring renders only when `agent.lastUsage` has both `contextWindowMaxTokens` and `contextWindowUsedTokens`. Claude/Codex fill those fields through `usage_updated`. Grok is a catalog ACP provider, so it used the generic ACP session, which ignores `session/update` `_meta.totalTokens`.

Grok does not emit ACP `usage_update`. Map that existing `_meta` field onto the existing `usage_updated` event from a Grok session subclass. No new usage pipeline, no protocol/UI change.

### Goals

- Route `grok` through a dedicated ACP adapter, same as Cursor/Kimi.
- Reuse `ACPAgentSession.sessionUpdate` and emit the existing `usage_updated` snapshot.
- Read the window size once from Grok's `models_cache.json`.
- Deduplicate identical used/max pairs in the Grok session.

### Non-goals

- SuperGrok weekly quota / Host Usage billing (#3306).
- Generic ACP `usage_update` mapping (#3479 / #1390).
- Grok compaction timeline items (#3738).
- Per-session `signals.json` window size.
- A new meter component.

### QA

Automated, Linux:

```text
npx vitest run \
  packages/server/src/server/agent/providers/grok-acp-agent.test.ts \
  packages/server/src/server/agent/provider-registry.test.ts \
  packages/server/src/server/agent/providers/acp-agent.test.ts \
  --bail=1

Test Files  3 passed (3)
Tests       152 passed (152)

npm run typecheck
passed (pre-commit, all workspaces)

npm run lint -- <changed files>
Found 0 warnings and 0 errors.

npm run format:files -- <changed files>
passed
```

A Grok session given `session/update` `_meta.totalTokens: 11493` emits `usage_updated` with `contextWindowUsedTokens: 11493` and `contextWindowMaxTokens: 500000`. That is the same `lastUsage` payload `ContextWindowMeter` already reads. A second identical notification does not emit again.

Protocol: no schema change. `AgentUsage.contextWindowMaxTokens` / `contextWindowUsedTokens` are already optional.

Local live check: paired a real Grok session to this checkout's `127.0.0.1:6768` daemon. The composer context-window ring appeared and occupancy updated as expected.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             |        | Shared RN meter; no device run |
| Android         |        | Shared RN meter; no device run |
| Web             |        | No live composer click-through |
| Desktop macOS   |        | Shared web renderer |
| Desktop Windows |        | Shared web renderer |
| Desktop Linux   | x      | Adapter tests + live Grok composer ring against 6768 |

### Checklist

- [x] One focused change
- [x] Based directly on current `main`
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense