### PR TITLE
feat: add durable subagent queues and collapsible work tree

### DIFF
--- a/packages/app/src/agent-queue/use-agent-queue.ts
+++ b/packages/app/src/agent-queue/use-agent-queue.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import type { AgentQueuedPromptPayload } from "@getpaseo/protocol/messages";
+import { useSessionStore } from "@/stores/session-store";
+
+const EMPTY_PROMPTS: AgentQueuedPromptPayload[] = [];
+
+export function useAgentQueuePrompts(input: {
+  serverId: string;
+  agentId: string;
+}): AgentQueuedPromptPayload[] {
+  const client = useSessionStore((state) => state.sessions[input.serverId]?.client ?? null);
+  const supported = useSessionStore(
+    (state) => state.sessions[input.serverId]?.serverInfo?.features?.agentQueue === true,
+  );
+  const prompts = useSessionStore(
+    (state) =>
+      state.sessions[input.serverId]?.agentQueuePrompts.get(input.agentId) ?? EMPTY_PROMPTS,
+  );
+  const setPrompts = useSessionStore((state) => state.setAgentQueuePrompts);
+
+  useEffect(() => {
+    if (!client || !supported) return;
+    void client
+      .listAgentQueue(input.agentId)
+      .then((payload) => {
+        if (!payload.error) setPrompts(input.serverId, input.agentId, payload.prompts);
+        return undefined;
+      })
+      .catch(() => undefined);
+  }, [client, input.agentId, input.serverId, setPrompts, supported]);
+
+  return supported ? prompts : EMPTY_PROMPTS;
+}

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -117,7 +117,10 @@ import type {
   WorkspaceComposerAttachment,
 } from "@/attachments/types";
 import type { PickedFile } from "@/attachments/picked-file";
-import { resolveComposerAttachmentSubmitFormat } from "@/composer/attachments/submit";
+import {
+  resolveComposerAttachmentSubmitFormat,
+  splitComposerAttachmentsForSubmit,
+} from "@/composer/attachments/submit";
 import { composerWorkspaceAttachment } from "@/composer/attachments/workspace";
 import { useWorkspaceAttachmentsForScopes } from "@/attachments/workspace-attachments-store";
 import { droppedItemsToPickedFiles } from "@/composer/attachments/drop";
@@ -1235,6 +1238,9 @@ function ComposerContentImpl({
   const supportsForgeSearch = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.forgeSearch === true,
   );
+  const supportsAgentQueue = useSessionStore(
+    (state) => state.sessions[serverId]?.serverInfo?.features?.agentQueue === true,
+  );
   const githubAutoAttach = useComposerGithubAutoAttach({
     text: userInput,
     remoteUrl: resolveCheckoutRemoteUrl(checkoutStatusQuery.status),
@@ -1502,7 +1508,30 @@ function ComposerContentImpl({
   );
 
   const queueMessage = useCallback(
-    (queuedMessage: string, queuedAttachments: ComposerAttachment[]) => {
+    async (queuedMessage: string, queuedAttachments: ComposerAttachment[]) => {
+      const wireAttachments = splitComposerAttachmentsForSubmit(queuedAttachments, {
+        format: resolveComposerAttachmentSubmitFormat({
+          supportsForgeAttachments: supportsForgeSearch,
+        }),
+      });
+      if (client && supportsAgentQueue && wireAttachments.images.length === 0) {
+        try {
+          const response = await client.createAgentQueuePrompt({
+            agentId,
+            text: queuedMessage,
+            attachments: wireAttachments.attachments,
+          });
+          if (response.error) throw new Error(response.error);
+          replaceUserInput("");
+          setSelectedAttachments([]);
+          resetSuppression();
+          clearSentAttachments(queuedAttachments);
+          return;
+        } catch (error) {
+          setSendError(error instanceof Error ? error.message : t("composer.errors.failedToSend"));
+          return;
+        }
+      }
       const result = queueComposerMessage({
         agentId,
         text: queuedMessage,
@@ -1518,11 +1547,16 @@ function ComposerContentImpl({
     },
     [
       agentId,
+      client,
       clearSentAttachments,
       queueWriter,
       resetSuppression,
       setSelectedAttachments,
       replaceUserInput,
+      setSendError,
+      supportsAgentQueue,
+      supportsForgeSearch,
+      t,
     ],
   );
 
@@ -1860,7 +1894,7 @@ function ComposerContentImpl({
       if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
         return;
       }
-      queueMessage(payload.text, outgoingAttachments);
+      void queueMessage(payload.text, outgoingAttachments);
     },
     [attachments, buildOutgoingAttachments, queueMessage, runClientSlashCommand],
   );

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -354,6 +354,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
   const setWorkspaces = useSessionStore((state) => state.setWorkspaces);
   const flushAgentLastActivity = useSessionStore((state) => state.flushAgentLastActivity);
   const setPendingPermissions = useSessionStore((state) => state.setPendingPermissions);
+  const setAgentQueuePrompts = useSessionStore((state) => state.setAgentQueuePrompts);
   const updateSessionServerInfo = useSessionStore((state) => state.updateSessionServerInfo);
   const setViewedTimelineSync = useSessionStore((state) => state.setViewedTimelineSync);
   const upsertWorkspaceSetupProgress = useWorkspaceSetupStore((state) => state.upsertProgress);
@@ -799,6 +800,11 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
       useProviderSubagentStore.getState().applyUpdate(serverId, message.payload);
     });
 
+    const unsubAgentQueueUpdate = client.on("agent.queue.update", (message) => {
+      if (message.type !== "agent.queue.update") return;
+      setAgentQueuePrompts(serverId, message.payload.agentId, message.payload.prompts);
+    });
+
     const unsubScriptStatusUpdate = client.on("script_status_update", (message) => {
       if (message.type !== "script_status_update") return;
       setWorkspaces(serverId, (prev) => patchWorkspaceScripts(prev, message.payload));
@@ -992,6 +998,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
       unsubAgentStream();
       unsubAgentTimeline();
       unsubProviderSubagentUpdate();
+      unsubAgentQueueUpdate();
       unsubAgentAttention();
       unsubScriptStatusUpdate();
       unsubCheckoutStatusUpdate();
@@ -1022,6 +1029,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
     setAgents,
     setWorkspaces,
     setPendingPermissions,
+    setAgentQueuePrompts,
     notifyAgentAttention,
     recoverTimelineGap,
     applyWorkspaceSetupProgress,

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1694,6 +1694,10 @@ export const ar: TranslationResources = {
     archiveTooltip: "أرشفة الوكيل الفرعي",
     archiveFinishedAction: "أرشفة الوكلاء الفرعيين المكتملين",
     archiveFinishedRetry: "إعادة المحاولة ({{failed}}/{{total}})",
+    stopAction: "Stop {{label}}",
+    stopAllAction: "Stop all active",
+    stopAllConfirmTitle: "Stop all active work?",
+    stopAllConfirmMessage: "This will interrupt {{count}} active subagent(s): {{names}}.",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1704,6 +1704,10 @@ export const en = {
     archiveTooltip: "Archive subagent",
     archiveFinishedAction: "Archive finished subagents",
     archiveFinishedRetry: "Retry ({{failed}}/{{total}})",
+    stopAction: "Stop {{label}}",
+    stopAllAction: "Stop all active",
+    stopAllConfirmTitle: "Stop all active work?",
+    stopAllConfirmMessage: "This will interrupt {{count}} active subagent(s): {{names}}.",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1740,6 +1740,10 @@ export const es: TranslationResources = {
     archiveTooltip: "Subagente de archivo",
     archiveFinishedAction: "Archivar subagentes finalizados",
     archiveFinishedRetry: "Reintentar ({{failed}}/{{total}})",
+    stopAction: "Stop {{label}}",
+    stopAllAction: "Stop all active",
+    stopAllConfirmTitle: "Stop all active work?",
+    stopAllConfirmMessage: "This will interrupt {{count}} active subagent(s): {{names}}.",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1744,6 +1744,10 @@ export const fr: TranslationResources = {
     archiveTooltip: "Sous-agent d'archivage",
     archiveFinishedAction: "Archiver les sous-agents terminés",
     archiveFinishedRetry: "Réessayer ({{failed}}/{{total}})",
+    stopAction: "Stop {{label}}",
+    stopAllAction: "Stop all active",
+    stopAllConfirmTitle: "Stop all active work?",
+    stopAllConfirmMessage: "This will interrupt {{count}} active subagent(s): {{names}}.",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1711,6 +1711,10 @@ export const ja: TranslationResources = {
     archiveTooltip: "サブエージェントをアーカイブ",
     archiveFinishedAction: "完了したサブエージェントをアーカイブ",
     archiveFinishedRetry: "再試行 ({{failed}}/{{total}})",
+    stopAction: "Stop {{label}}",
+    stopAllAction: "Stop all active",
+    stopAllConfirmTitle: "Stop all active work?",
+    stopAllConfirmMessage: "This will interrupt {{count}} active subagent(s): {{names}}.",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1704,6 +1704,10 @@ export const ko: TranslationResources = {
     archiveTooltip: "서브에이전트 보관",
     archiveFinishedAction: "완료된 하위 에이전트 보관",
     archiveFinishedRetry: "다시 시도 ({{failed}}/{{total}})",
+    stopAction: "Stop {{label}}",
+    stopAllAction: "Stop all active",
+    stopAllConfirmTitle: "Stop all active work?",
+    stopAllConfirmMessage: "This will interrupt {{count}} active subagent(s): {{names}}.",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1726,6 +1726,10 @@ export const ptBR: TranslationResources = {
     archiveTooltip: "Arquivar subagente",
     archiveFinishedAction: "Arquivar subagentes concluídos",
     archiveFinishedRetry: "Tentar novamente ({{failed}}/{{total}})",
+    stopAction: "Stop {{label}}",
+    stopAllAction: "Stop all active",
+    stopAllConfirmTitle: "Stop all active work?",
+    stopAllConfirmMessage: "This will interrupt {{count}} active subagent(s): {{names}}.",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1724,6 +1724,10 @@ export const ru: TranslationResources = {
     archiveTooltip: "Архивировать субагента",
     archiveFinishedAction: "Архивировать завершенные субагенты",
     archiveFinishedRetry: "Повторить ({{failed}}/{{total}})",
+    stopAction: "Stop {{label}}",
+    stopAllAction: "Stop all active",
+    stopAllConfirmTitle: "Stop all active work?",
+    stopAllConfirmMessage: "This will interrupt {{count}} active subagent(s): {{names}}.",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1673,6 +1673,10 @@ export const zhCN: TranslationResources = {
     archiveTooltip: "归档 subagent",
     archiveFinishedAction: "归档已完成的 subagent",
     archiveFinishedRetry: "重试 ({{failed}}/{{total}})",
+    stopAction: "Stop {{label}}",
+    stopAllAction: "Stop all active",
+    stopAllConfirmTitle: "Stop all active work?",
+    stopAllConfirmMessage: "This will interrupt {{count}} active subagent(s): {{names}}.",
   },
   panels: {
     draft: {

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -98,7 +98,11 @@ import { openSidePanelView } from "@/workspace-tabs/side-panel";
 import type { Theme } from "@/styles/theme";
 import type { PendingPermission } from "@/types/shared";
 import type { StreamItem, TodoEntry } from "@/types/stream";
-import { useArchiveFinishedSubagents, useSubagentsForParent } from "@/subagents";
+import {
+  useArchiveFinishedSubagents,
+  useSubagentTreeForParent,
+  useSubagentsForParent,
+} from "@/subagents";
 import { getInitDeferred, getInitKey } from "@/utils/agent-initialization";
 import { derivePendingPermissionKey, normalizeAgentSnapshot } from "@/utils/agent-snapshots";
 import { applyLegacyDaemonWorkspaceOwnership } from "@/workspace/legacy-daemon-workspaces";
@@ -1251,6 +1255,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
 }) {
   const { t } = useTranslation();
   const subagentRows = useSubagentsForParent({ serverId, parentAgentId: agentId });
+  const subagentTree = useSubagentTreeForParent({ serverId, parentAgentId: agentId });
   const tasks = useSessionStore((state): TodoEntry[] | undefined =>
     state.sessions[serverId]?.agentTasks.get(agentId),
   );
@@ -1352,6 +1357,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
           workspaceId={workspaceId}
           cwd={cwd}
           subagentRows={subagentRows}
+          subagentTree={subagentTree}
           tasks={tasks}
           archiveFinishedStatus={archiveFinishedSubagents.status}
           onArchiveFinished={archiveFinishedSubagents.archiveFinished}

--- a/packages/app/src/panels/agent-tracks.tsx
+++ b/packages/app/src/panels/agent-tracks.tsx
@@ -118,6 +118,7 @@ export const AgentTracks = memo(function AgentTracks({
     <ComposerTrackBar>
       <AgentTaskList tasks={tasks} />
       <SubagentsTrack
+        serverId={serverId}
         rows={subagentRows}
         tree={subagentTree}
         onOpenSubagent={handleOpenSubagent}

--- a/packages/app/src/panels/agent-tracks.tsx
+++ b/packages/app/src/panels/agent-tracks.tsx
@@ -9,6 +9,7 @@ import { useSettings } from "@/hooks/use-settings";
 import { useSessionStore } from "@/stores/session-store";
 import {
   type ArchiveFinishedStatus,
+  type SubagentTreeNode,
   useArchiveSubagent,
   useDetachSubagent,
   type SubagentRow,
@@ -31,6 +32,7 @@ export const AgentTracks = memo(function AgentTracks({
   workspaceId,
   cwd,
   subagentRows,
+  subagentTree,
   tasks,
   archiveFinishedStatus,
   onArchiveFinished,
@@ -39,6 +41,7 @@ export const AgentTracks = memo(function AgentTracks({
   workspaceId: string;
   cwd: string;
   subagentRows: SubagentRow[];
+  subagentTree?: SubagentTreeNode[];
   tasks: TodoEntry[] | undefined;
   archiveFinishedStatus: ArchiveFinishedStatus;
   onArchiveFinished: () => void;
@@ -116,6 +119,7 @@ export const AgentTracks = memo(function AgentTracks({
       <AgentTaskList tasks={tasks} />
       <SubagentsTrack
         rows={subagentRows}
+        tree={subagentTree}
         onOpenSubagent={handleOpenSubagent}
         onOpenProviderSubagent={handleOpenProviderSubagent}
         onArchiveSubagent={archiveSubagent}

--- a/packages/app/src/panels/agent-tracks.tsx
+++ b/packages/app/src/panels/agent-tracks.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, type ReactElement } from "react";
+import { memo, useCallback, useMemo, type ReactElement } from "react";
+import { useTranslation } from "react-i18next";
 import { WorkspaceDiffStatPill } from "@/composer/diff-stat-pill";
 import { useWorkspaceHasDiffStat } from "@/composer/workspace-diff-stat";
 import { AgentTaskList } from "@/composer/task-list";
@@ -19,6 +20,7 @@ import type { TodoEntry } from "@/types/stream";
 import { navigateToAgent } from "@/utils/navigate-to-agent";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 import { openSupportingTab, toggleSupportingTab } from "@/workspace-tabs/side-panel";
+import { confirmDialog } from "@/utils/confirm-dialog";
 
 /**
  * The pane's ambient context — workspace changes, subagents, and tasks — as a row of pills above
@@ -46,6 +48,7 @@ export const AgentTracks = memo(function AgentTracks({
   archiveFinishedStatus: ArchiveFinishedStatus;
   onArchiveFinished: () => void;
 }): ReactElement | null {
+  const { t } = useTranslation();
   const { tabId, openTab } = usePaneContext();
   const hasWorkspaceDiffStat = useWorkspaceHasDiffStat(serverId, workspaceId);
   const isCompact = useIsCompactFormFactor();
@@ -59,6 +62,40 @@ export const AgentTracks = memo(function AgentTracks({
   );
   const archiveSubagent = useArchiveSubagent({ serverId });
   const detachSubagent = useDetachSubagent({ serverId });
+  const client = useSessionStore((state) => state.sessions[serverId]?.client ?? null);
+  const activeManagedSubagentIds = useMemo(
+    () =>
+      subagentRows
+        .filter((row) => row.kind === "paseo" && row.status === "running")
+        .map((row) => row.id),
+    [subagentRows],
+  );
+  const handleStopSubagent = useCallback(
+    (agentId: string) => {
+      if (!client) return;
+      void client.cancelAgent(agentId).catch(() => undefined);
+    },
+    [client],
+  );
+  const handleStopAllActive = useCallback(async () => {
+    if (!client || activeManagedSubagentIds.length === 0) return;
+    const names = subagentRows
+      .filter((row) => activeManagedSubagentIds.includes(row.id))
+      .map((row) => row.title)
+      .join(", ");
+    const confirmed = await confirmDialog({
+      title: t("subagents.stopAllConfirmTitle"),
+      message: t("subagents.stopAllConfirmMessage", {
+        count: activeManagedSubagentIds.length,
+        names,
+      }),
+      confirmLabel: t("subagents.stopAllAction"),
+      cancelLabel: t("common.actions.cancel"),
+      destructive: true,
+    });
+    if (!confirmed) return;
+    await Promise.all(activeManagedSubagentIds.map((agentId) => client.cancelAgent(agentId)));
+  }, [activeManagedSubagentIds, client, subagentRows, t]);
   const handleOpenSubagent = useCallback(
     (subagentId: string) => {
       const session = useSessionStore.getState().sessions[serverId];
@@ -127,6 +164,8 @@ export const AgentTracks = memo(function AgentTracks({
         onArchiveFinished={onArchiveFinished}
         archiveFinishedStatus={archiveFinishedStatus}
         onDetachSubagent={canDetachSubagents ? detachSubagent : undefined}
+        onStopSubagent={handleStopSubagent}
+        onStopAllActive={activeManagedSubagentIds.length > 0 ? handleStopAllActive : undefined}
       />
       <WorkspaceDiffStatPill
         serverId={serverId}

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -480,6 +480,7 @@ function createDefaultDeps(): HostRuntimeControllerDeps {
     : undefined;
   const appCapabilities = {
     [CLIENT_CAPS.selectiveAgentTimeline]: true,
+    [CLIENT_CAPS.agentQueue]: true,
     ...browserAutomationCapabilities,
   };
 

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -39,6 +39,7 @@ import type {
   ServerCapabilities,
   WorkspaceDescriptorPayload,
   WorkspaceProjectDescriptorPayload,
+  AgentQueuedPromptPayload,
 } from "@getpaseo/protocol/messages";
 import {
   normalizeWorkspaceOpaqueId,
@@ -446,6 +447,8 @@ export interface SessionState {
     string,
     Array<{ id: string; text: string; attachments: ComposerAttachment[] }>
   >;
+  // Capability-gated daemon queue; survives reconnects and other devices.
+  agentQueuePrompts: Map<string, AgentQueuedPromptPayload[]>;
 }
 
 // Global store state
@@ -634,6 +637,11 @@ interface SessionStoreActions {
           prev: Map<string, Array<{ id: string; text: string; attachments: ComposerAttachment[] }>>,
         ) => Map<string, Array<{ id: string; text: string; attachments: ComposerAttachment[] }>>),
   ) => void;
+  setAgentQueuePrompts: (
+    serverId: string,
+    agentId: string,
+    prompts: AgentQueuedPromptPayload[],
+  ) => void;
 
   // Hydration
   setHasHydratedAgents: (serverId: string, hydrated: boolean) => void;
@@ -687,6 +695,7 @@ function createInitialSessionState(
     pendingPermissions: new Map(),
     fileExplorer: new Map(),
     queuedMessages: new Map(),
+    agentQueuePrompts: new Map(),
   };
 }
 
@@ -1929,6 +1938,22 @@ export const useSessionStore = create<SessionStore>()(
             sessions: {
               ...prev.sessions,
               [serverId]: { ...session, queuedMessages: nextValue },
+            },
+          };
+        });
+      },
+
+      setAgentQueuePrompts: (serverId, agentId, prompts) => {
+        set((prev) => {
+          const session = prev.sessions[serverId];
+          if (!session) return prev;
+          const nextPrompts = new Map(session.agentQueuePrompts);
+          nextPrompts.set(agentId, prompts);
+          return {
+            ...prev,
+            sessions: {
+              ...prev.sessions,
+              [serverId]: { ...session, agentQueuePrompts: nextPrompts },
             },
           };
         });

--- a/packages/app/src/subagents/index.ts
+++ b/packages/app/src/subagents/index.ts
@@ -1,5 +1,10 @@
-export type { SubagentRow } from "./select";
-export { selectSubagentsForParent, useSubagentsForParent } from "./select";
+export type { SubagentRow, SubagentTreeNode } from "./select";
+export {
+  buildSubagentTree,
+  selectSubagentsForParent,
+  useSubagentTreeForParent,
+  useSubagentsForParent,
+} from "./select";
 export { useArchiveSubagent, type UseArchiveSubagentInput } from "./use-archive-subagent";
 export { useDetachSubagent, type UseDetachSubagentInput } from "./use-detach-subagent";
 export { resolveCloseAgentTabPolicy, type CloseAgentTabPolicy } from "./close-tab-policy";

--- a/packages/app/src/subagents/select.test.ts
+++ b/packages/app/src/subagents/select.test.ts
@@ -1,6 +1,10 @@
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { afterEach, describe, expect, it } from "vitest";
-import { selectProviderSubagentsForParent, selectSubagentsForParent } from "./select";
+import {
+  buildSubagentTree,
+  selectProviderSubagentsForParent,
+  selectSubagentsForParent,
+} from "./select";
 import { useProviderSubagentStore } from "./provider-store";
 import { useSessionStore, type Agent } from "@/stores/session-store";
 
@@ -199,6 +203,29 @@ describe("selectSubagentsForParent", () => {
 
     expect(parentRows.map((row) => row.id)).toEqual(["child"]);
     expect(childRows.map((row) => row.id)).toEqual(["grandchild"]);
+  });
+
+  it("projects managed descendants recursively with stable depth and keys", () => {
+    setAgents([
+      makeAgent({ id: "parent" }),
+      makeAgent({ id: "child", parentAgentId: "parent" }),
+      makeAgent({ id: "grandchild", parentAgentId: "child" }),
+    ]);
+
+    const tree = buildSubagentTree(
+      useSessionStore.getState(),
+      useProviderSubagentStore.getState(),
+      { serverId: SERVER_ID, parentAgentId: "parent" },
+      EMPTY_PENDING_ARCHIVE_IDS,
+      true,
+    );
+
+    expect(tree.map((node) => ({ key: node.key, depth: node.depth, id: node.row.id }))).toEqual([
+      { key: "agent:child", depth: 0, id: "child" },
+    ]);
+    expect(
+      tree[0]?.children.map((node) => ({ key: node.key, depth: node.depth, id: node.row.id })),
+    ).toEqual([{ key: "agent:grandchild", depth: 1, id: "grandchild" }]);
   });
 
   it("sorts by createdAt ascending", () => {

--- a/packages/app/src/subagents/select.test.ts
+++ b/packages/app/src/subagents/select.test.ts
@@ -228,6 +228,50 @@ describe("selectSubagentsForParent", () => {
     ).toEqual([{ key: "agent:grandchild", depth: 1, id: "grandchild" }]);
   });
 
+  it("nests provider descendants only when their adapter supplies ancestry", () => {
+    setAgents([makeAgent({ id: "parent" })]);
+    useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        id: "provider-root",
+        parentAgentId: "parent",
+        provider: "codex",
+        title: "Root child",
+        description: null,
+        status: "running",
+        createdAt: "2026-03-08T10:01:00.000Z",
+        updatedAt: "2026-03-08T10:01:00.000Z",
+        toolCallId: "call-root",
+      },
+    });
+    useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        id: "provider-nested",
+        parentAgentId: "parent",
+        parentSubagentId: "provider-root",
+        provider: "codex",
+        title: "Nested child",
+        description: null,
+        status: "running",
+        createdAt: "2026-03-08T10:02:00.000Z",
+        updatedAt: "2026-03-08T10:02:00.000Z",
+        toolCallId: "call-nested",
+      },
+    });
+
+    const tree = buildSubagentTree(
+      useSessionStore.getState(),
+      useProviderSubagentStore.getState(),
+      { serverId: SERVER_ID, parentAgentId: "parent" },
+      EMPTY_PENDING_ARCHIVE_IDS,
+      true,
+    );
+
+    expect(tree.map((node) => node.row.id)).toEqual(["provider-root"]);
+    expect(tree[0]?.children.map((node) => node.row.id)).toEqual(["provider-nested"]);
+  });
+
   it("sorts by createdAt ascending", () => {
     setAgents([
       makeAgent({ id: "parent" }),

--- a/packages/app/src/subagents/select.ts
+++ b/packages/app/src/subagents/select.ts
@@ -23,6 +23,7 @@ export interface ProviderSubagentRow {
   kind: "provider";
   id: string;
   parentAgentId: string;
+  parentSubagentId?: string | null;
   provider: ProviderSubagentDescriptorPayload["provider"];
   // `title` is the subagent type ("Explore", "general-purpose") and repeats across a fan-out;
   // `description` is the task it was given. Both are carried so presentation can choose which
@@ -102,14 +103,34 @@ export function buildSubagentTree(
       { serverId: params.serverId, parentAgentId },
       providerSubagentsSupported,
     );
-    return sortRows([...managed, ...provider]).map((row): SubagentTreeNode => {
+    const buildProviderNode = (
+      row: ProviderSubagentRow,
+      providerDepth: number,
+      providerAncestors: ReadonlySet<string>,
+    ): SubagentTreeNode => {
+      const key = treeKey(row);
+      const nextAncestors = new Set(providerAncestors);
+      nextAncestors.add(key);
+      const children = provider
+        .filter(
+          (candidate) =>
+            candidate.parentSubagentId === row.id && !nextAncestors.has(treeKey(candidate)),
+        )
+        .map((candidate) => buildProviderNode(candidate, providerDepth + 1, nextAncestors));
+      return { key, row, depth: providerDepth, children };
+    };
+    const providerRoots = provider.filter((row) => (row.parentSubagentId ?? null) === null);
+    return sortRows([...managed, ...providerRoots]).map((row): SubagentTreeNode => {
       const nextAncestors = new Set(ancestors);
       if (row.kind === "paseo") nextAncestors.add(row.id);
       return {
         key: treeKey(row),
         row,
         depth,
-        children: row.kind === "paseo" ? buildForParent(row.id, depth + 1, nextAncestors) : [],
+        children:
+          row.kind === "paseo"
+            ? buildForParent(row.id, depth + 1, nextAncestors)
+            : buildProviderNode(row, depth, new Set()).children,
       };
     });
   };
@@ -160,6 +181,7 @@ export function selectProviderSubagentsForParent(
       kind: "provider",
       id: subagent.id,
       parentAgentId: subagent.parentAgentId,
+      parentSubagentId: subagent.parentSubagentId ?? null,
       provider: subagent.provider,
       title: subagent.title,
       description: subagent.description,

--- a/packages/app/src/subagents/select.ts
+++ b/packages/app/src/subagents/select.ts
@@ -38,6 +38,13 @@ export interface ProviderSubagentRow {
 
 export type SubagentRow = PaseoSubagentRow | ProviderSubagentRow;
 
+export interface SubagentTreeNode {
+  key: string;
+  row: SubagentRow;
+  depth: number;
+  children: SubagentTreeNode[];
+}
+
 type SessionStoreSnapshot = ReturnType<typeof useSessionStore.getState>;
 type ProviderSubagentStoreSnapshot = ReturnType<typeof useProviderSubagentStore.getState>;
 
@@ -49,7 +56,7 @@ interface SelectSubagentsParams {
 const EMPTY_SUBAGENT_ROWS: SubagentRow[] = [];
 const EMPTY_PROVIDER_SUBAGENT_ROWS: ProviderSubagentRow[] = [];
 
-function toSubagentRow(agent: Agent): SubagentRow {
+function toSubagentRow(agent: Agent): PaseoSubagentRow {
   return {
     kind: "paseo",
     id: agent.id,
@@ -61,6 +68,52 @@ function toSubagentRow(agent: Agent): SubagentRow {
     requiresAttention: agent.requiresAttention,
     createdAt: agent.createdAt,
   };
+}
+
+function treeKey(row: SubagentRow): string {
+  return row.kind === "paseo" ? `agent:${row.id}` : `provider:${row.parentAgentId}:${row.id}`;
+}
+
+function sortRows(rows: SubagentRow[]): SubagentRow[] {
+  return rows.sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime());
+}
+
+export function buildSubagentTree(
+  state: SessionStoreSnapshot,
+  providerState: ProviderSubagentStoreSnapshot,
+  params: SelectSubagentsParams,
+  pendingArchiveIds: ReadonlySet<string>,
+  providerSubagentsSupported: boolean,
+): SubagentTreeNode[] {
+  const agents = state.sessions[params.serverId]?.agents;
+  if (!agents) return [];
+  const buildForParent = (parentAgentId: string, depth: number, ancestors: ReadonlySet<string>) => {
+    const managed = Array.from(agents.values())
+      .filter(
+        (agent) =>
+          !agent.archivedAt &&
+          !pendingArchiveIds.has(agent.id) &&
+          agent.parentAgentId === parentAgentId &&
+          !ancestors.has(agent.id),
+      )
+      .map(toSubagentRow);
+    const provider = selectProviderSubagentsForParent(
+      providerState,
+      { serverId: params.serverId, parentAgentId },
+      providerSubagentsSupported,
+    );
+    return sortRows([...managed, ...provider]).map((row): SubagentTreeNode => {
+      const nextAncestors = new Set(ancestors);
+      if (row.kind === "paseo") nextAncestors.add(row.id);
+      return {
+        key: treeKey(row),
+        row,
+        depth,
+        children: row.kind === "paseo" ? buildForParent(row.id, depth + 1, nextAncestors) : [],
+      };
+    });
+  };
+  return buildForParent(params.parentAgentId, 0, new Set([params.parentAgentId]));
 }
 
 export function selectSubagentsForParent(
@@ -150,4 +203,27 @@ export function useSubagentsForParent(params: SelectSubagentsParams): SubagentRo
     rows.sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime());
     return rows;
   }, [paseoRows, providerRows]);
+}
+
+export function useSubagentTreeForParent(params: SelectSubagentsParams): SubagentTreeNode[] {
+  const pendingArchiveIds = usePendingArchiveAgentIds(params.serverId);
+  const supported = useSessionStore(
+    (state) => state.sessions[params.serverId]?.serverInfo?.features?.providerSubagents === true,
+  );
+  const providerState = useProviderSubagentStore();
+  const tree = useStoreWithEqualityFn(
+    useSessionStore,
+    (state) => buildSubagentTree(state, providerState, params, pendingArchiveIds, supported),
+    equal,
+  );
+  const client = useSessionStore((state) => state.sessions[params.serverId]?.client ?? null);
+
+  useEffect(() => {
+    if (!client || !supported) return;
+    void refreshProviderSubagents(client, params.serverId, params.parentAgentId).catch(
+      () => undefined,
+    );
+  }, [client, params.parentAgentId, params.serverId, supported]);
+
+  return tree;
 }

--- a/packages/app/src/subagents/track.tsx
+++ b/packages/app/src/subagents/track.tsx
@@ -79,6 +79,10 @@ function flattenSubagentTree(
   return result;
 }
 
+function collectSubagentRows(nodes: SubagentTreeNode[]): SubagentRow[] {
+  return nodes.flatMap((node) => [node.row, ...collectSubagentRows(node.children)]);
+}
+
 /** Leading and action glyphs share one size so rows keep a single icon column. */
 const ROW_ICON_SIZE = 14;
 
@@ -105,9 +109,10 @@ export function SubagentsTrack({
   const { t } = useTranslation();
   const [collapsedKeys, setCollapsedKeys] = useState<Set<string>>(new Set());
   const [expandedFinishedKeys, setExpandedFinishedKeys] = useState<Set<string>>(new Set());
+  const treeNodes = useMemo(() => tree ?? toFlatTree(rows), [rows, tree]);
   const visibleRows = useMemo(
-    () => flattenSubagentTree(tree ?? toFlatTree(rows), collapsedKeys, expandedFinishedKeys),
-    [collapsedKeys, expandedFinishedKeys, rows, tree],
+    () => flattenSubagentTree(treeNodes, collapsedKeys, expandedFinishedKeys),
+    [collapsedKeys, expandedFinishedKeys, treeNodes],
   );
   const toggleExpanded = useCallback((node: SubagentTreeNode, expanded: boolean) => {
     setCollapsedKeys((current) => {
@@ -132,7 +137,7 @@ export function SubagentsTrack({
 
   const flatRows = visibleRows.map(({ node }) => node.row);
   const pill = buildSubagentPillPresentation(t, flatRows);
-  const finishedCount = countFinishedSubagents(flatRows);
+  const finishedCount = countFinishedSubagents(collectSubagentRows(treeNodes));
   const showArchiveFinished = finishedCount > 0 || isArchivingFinished || isArchiveFinishedFailed;
 
   return (

--- a/packages/app/src/subagents/track.tsx
+++ b/packages/app/src/subagents/track.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useMemo, type ReactElement } from "react";
+import { useCallback, useMemo, useState, type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
-import { Archive, Unlink } from "lucide-react-native";
+import { Archive, ChevronDown, ChevronRight, Unlink } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { getProviderIcon } from "@/components/provider-icons";
 import { ComposerTrackActions, ComposerTrackPill, ComposerTrackRow } from "@/composer/tracks";
@@ -13,7 +13,7 @@ import {
   type WorkspaceTabPresentation,
 } from "@/screens/workspace/workspace-tab-presentation";
 import type { Theme } from "@/styles/theme";
-import type { SubagentRow } from "./select";
+import type { SubagentRow, SubagentTreeNode } from "./select";
 import type { ArchiveFinishedStatus } from "./use-archive-finished";
 import {
   buildSubagentPillPresentation,
@@ -22,6 +22,8 @@ import {
 } from "./track-presentation";
 
 const ThemedArchive = withUnistyles(Archive);
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedChevronRight = withUnistyles(ChevronRight);
 const ThemedUnlink = withUnistyles(Unlink);
 
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
@@ -31,6 +33,7 @@ const foregroundMutedColorMapping = (theme: Theme) => ({
 
 export interface SubagentsTrackProps {
   rows: SubagentRow[];
+  tree?: SubagentTreeNode[];
   onOpenSubagent: (id: string) => void;
   onOpenProviderSubagent: (parentAgentId: string, subagentId: string) => void;
   onArchiveSubagent: (id: string) => void;
@@ -40,6 +43,41 @@ export interface SubagentsTrackProps {
 }
 
 const IDLE_ARCHIVE_FINISHED_STATUS: ArchiveFinishedStatus = { kind: "idle" };
+
+function toFlatTree(rows: SubagentRow[]): SubagentTreeNode[] {
+  return rows.map((row) => ({
+    key: row.kind === "paseo" ? `agent:${row.id}` : `provider:${row.parentAgentId}:${row.id}`,
+    row,
+    depth: 0,
+    children: [],
+  }));
+}
+
+function isFinishedRow(row: SubagentRow): boolean {
+  return row.kind === "paseo"
+    ? row.status === "idle" || row.status === "closed" || row.status === "error"
+    : row.status !== "running";
+}
+
+function flattenSubagentTree(
+  nodes: SubagentTreeNode[],
+  collapsedKeys: ReadonlySet<string>,
+  expandedFinishedKeys: ReadonlySet<string>,
+): Array<{ node: SubagentTreeNode; expanded: boolean }> {
+  const result: Array<{ node: SubagentTreeNode; expanded: boolean }> = [];
+  for (const node of nodes) {
+    const isFinished = isFinishedRow(node.row) && !node.row.requiresAttention;
+    const expanded =
+      node.children.length > 0 &&
+      !collapsedKeys.has(node.key) &&
+      (!isFinished || expandedFinishedKeys.has(node.key));
+    result.push({ node, expanded });
+    if (expanded) {
+      result.push(...flattenSubagentTree(node.children, collapsedKeys, expandedFinishedKeys));
+    }
+  }
+  return result;
+}
 
 /** Leading and action glyphs share one size so rows keep a single icon column. */
 const ROW_ICON_SIZE = 14;
@@ -56,6 +94,7 @@ function buildRowPresentation(row: SubagentRow): WorkspaceTabPresentation {
 
 export function SubagentsTrack({
   rows,
+  tree,
   onOpenSubagent,
   onOpenProviderSubagent,
   onArchiveSubagent,
@@ -64,15 +103,36 @@ export function SubagentsTrack({
   onDetachSubagent,
 }: SubagentsTrackProps): ReactElement | null {
   const { t } = useTranslation();
+  const [collapsedKeys, setCollapsedKeys] = useState<Set<string>>(new Set());
+  const [expandedFinishedKeys, setExpandedFinishedKeys] = useState<Set<string>>(new Set());
+  const visibleRows = useMemo(
+    () => flattenSubagentTree(tree ?? toFlatTree(rows), collapsedKeys, expandedFinishedKeys),
+    [collapsedKeys, expandedFinishedKeys, rows, tree],
+  );
+  const toggleExpanded = useCallback((node: SubagentTreeNode, expanded: boolean) => {
+    setCollapsedKeys((current) => {
+      const next = new Set(current);
+      if (expanded) next.add(node.key);
+      else next.delete(node.key);
+      return next;
+    });
+    setExpandedFinishedKeys((current) => {
+      const next = new Set(current);
+      if (expanded) next.delete(node.key);
+      else next.add(node.key);
+      return next;
+    });
+  }, []);
 
   const isArchivingFinished = archiveFinishedStatus.kind === "archiving";
   const isArchiveFinishedFailed = archiveFinishedStatus.kind === "failed";
-  if (rows.length === 0 && !isArchivingFinished && !isArchiveFinishedFailed) {
+  if (visibleRows.length === 0 && !isArchivingFinished && !isArchiveFinishedFailed) {
     return null;
   }
 
-  const pill = buildSubagentPillPresentation(t, rows);
-  const finishedCount = countFinishedSubagents(rows);
+  const flatRows = visibleRows.map(({ node }) => node.row);
+  const pill = buildSubagentPillPresentation(t, flatRows);
+  const finishedCount = countFinishedSubagents(flatRows);
   const showArchiveFinished = finishedCount > 0 || isArchivingFinished || isArchiveFinishedFailed;
 
   return (
@@ -83,7 +143,7 @@ export function SubagentsTrack({
       panelTitle={t("subagents.title")}
     >
       {showArchiveFinished && onArchiveFinished ? (
-        <ComposerTrackActions divided={rows.length > 0}>
+        <ComposerTrackActions divided={visibleRows.length > 0}>
           <ArchiveFinishedRow
             status={archiveFinishedStatus}
             disabled={isArchivingFinished}
@@ -91,10 +151,15 @@ export function SubagentsTrack({
           />
         </ComposerTrackActions>
       ) : null}
-      {rows.map((row) => (
+      {visibleRows.map(({ node, expanded }) => (
         <SubagentsTrackRow
-          key={row.id}
-          row={row}
+          key={node.key}
+          row={node.row}
+          node={node}
+          depth={node.depth}
+          hasChildren={node.children.length > 0}
+          expanded={expanded}
+          onToggleExpanded={toggleExpanded}
           onOpenSubagent={onOpenSubagent}
           onOpenProviderSubagent={onOpenProviderSubagent}
           onArchiveSubagent={onArchiveSubagent}
@@ -165,6 +230,11 @@ function ArchiveFinishedRow({
 
 interface SubagentsTrackRowProps {
   row: SubagentRow;
+  node: SubagentTreeNode;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+  onToggleExpanded: (node: SubagentTreeNode, expanded: boolean) => void;
   onOpenSubagent: (id: string) => void;
   onOpenProviderSubagent: (parentAgentId: string, subagentId: string) => void;
   onArchiveSubagent: (id: string) => void;
@@ -173,6 +243,11 @@ interface SubagentsTrackRowProps {
 
 function SubagentsTrackRow({
   row,
+  node,
+  depth,
+  hasChildren,
+  expanded,
+  onToggleExpanded,
   onOpenSubagent,
   onOpenProviderSubagent,
   onArchiveSubagent,
@@ -196,11 +271,34 @@ function SubagentsTrackRow({
   const handleDetachPress = useCallback(() => {
     onDetachSubagent?.(row.id);
   }, [onDetachSubagent, row.id]);
+  const handleToggleExpanded = useCallback(
+    () => onToggleExpanded(node, expanded),
+    [expanded, node, onToggleExpanded],
+  );
   const actionsAlwaysVisible = isNative || isCompact;
 
   const renderRow = useCallback(
     ({ active }: { active: boolean }) => (
       <>
+        <View style={[styles.depthRail, { width: depth * 12 }]} />
+        {hasChildren ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`${expanded ? "Collapse" : "Expand"} ${displayLabel}`}
+            testID={`subagents-track-disclosure-${row.id}`}
+            onPress={handleToggleExpanded}
+            hitSlop={6}
+            style={styles.disclosure}
+          >
+            {expanded ? (
+              <ThemedChevronDown size={ROW_ICON_SIZE} uniProps={foregroundMutedColorMapping} />
+            ) : (
+              <ThemedChevronRight size={ROW_ICON_SIZE} uniProps={foregroundMutedColorMapping} />
+            )}
+          </Pressable>
+        ) : (
+          <View style={styles.disclosure} />
+        )}
         <WorkspaceTabIcon presentation={presentation} backdrop={active ? "surface2" : "surface1"} />
         <Text style={styles.rowLabel} numberOfLines={1}>
           {displayLabel}
@@ -224,9 +322,13 @@ function SubagentsTrackRow({
     [
       actionsAlwaysVisible,
       displayLabel,
+      depth,
+      expanded,
       handleArchivePress,
       handleDetachPress,
+      hasChildren,
       onDetachSubagent,
+      handleToggleExpanded,
       presentation,
       row.kind,
       row.id,
@@ -332,6 +434,20 @@ function SubagentActionButton({
 }
 
 const styles = StyleSheet.create((theme) => ({
+  depthRail: {
+    flexShrink: 0,
+    alignSelf: "stretch",
+    borderLeftWidth: 1,
+    borderLeftColor: theme.colors.border,
+    marginLeft: theme.spacing[1],
+  },
+  disclosure: {
+    width: ROW_ICON_SIZE,
+    height: ROW_ICON_SIZE,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
   // `flexBasis: "auto"` rather than `flex: 1`: a zero-basis label contributes nothing to the row's
   // intrinsic width, so the panel measures itself at its floor and truncates every label at once.
   rowLabel: {

--- a/packages/app/src/subagents/track.tsx
+++ b/packages/app/src/subagents/track.tsx
@@ -1,13 +1,15 @@
-import { useCallback, useMemo, useState, type ReactElement } from "react";
+import { Fragment, useCallback, useMemo, useState, type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
-import { Archive, ChevronDown, ChevronRight, Unlink } from "lucide-react-native";
+import { Archive, ChevronDown, ChevronRight, Play, Unlink } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { getProviderIcon } from "@/components/provider-icons";
 import { ComposerTrackActions, ComposerTrackPill, ComposerTrackRow } from "@/composer/tracks";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { isNative } from "@/constants/platform";
+import { useAgentQueuePrompts } from "@/agent-queue/use-agent-queue";
+import { useSessionStore } from "@/stores/session-store";
 import {
   WorkspaceTabIcon,
   type WorkspaceTabPresentation,
@@ -24,6 +26,7 @@ import {
 const ThemedArchive = withUnistyles(Archive);
 const ThemedChevronDown = withUnistyles(ChevronDown);
 const ThemedChevronRight = withUnistyles(ChevronRight);
+const ThemedPlay = withUnistyles(Play);
 const ThemedUnlink = withUnistyles(Unlink);
 
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
@@ -32,6 +35,7 @@ const foregroundMutedColorMapping = (theme: Theme) => ({
 });
 
 export interface SubagentsTrackProps {
+  serverId: string;
   rows: SubagentRow[];
   tree?: SubagentTreeNode[];
   onOpenSubagent: (id: string) => void;
@@ -97,6 +101,7 @@ function buildRowPresentation(row: SubagentRow): WorkspaceTabPresentation {
 }
 
 export function SubagentsTrack({
+  serverId,
   rows,
   tree,
   onOpenSubagent,
@@ -157,19 +162,23 @@ export function SubagentsTrack({
         </ComposerTrackActions>
       ) : null}
       {visibleRows.map(({ node, expanded }) => (
-        <SubagentsTrackRow
-          key={node.key}
-          row={node.row}
-          node={node}
-          depth={node.depth}
-          hasChildren={node.children.length > 0}
-          expanded={expanded}
-          onToggleExpanded={toggleExpanded}
-          onOpenSubagent={onOpenSubagent}
-          onOpenProviderSubagent={onOpenProviderSubagent}
-          onArchiveSubagent={onArchiveSubagent}
-          onDetachSubagent={onDetachSubagent}
-        />
+        <Fragment key={node.key}>
+          <SubagentsTrackRow
+            row={node.row}
+            node={node}
+            depth={node.depth}
+            hasChildren={node.children.length > 0}
+            expanded={expanded}
+            onToggleExpanded={toggleExpanded}
+            onOpenSubagent={onOpenSubagent}
+            onOpenProviderSubagent={onOpenProviderSubagent}
+            onArchiveSubagent={onArchiveSubagent}
+            onDetachSubagent={onDetachSubagent}
+          />
+          {node.row.kind === "paseo" ? (
+            <AgentQueueRows serverId={serverId} agentId={node.row.id} depth={node.depth + 1} />
+          ) : null}
+        </Fragment>
       ))}
     </ComposerTrackPill>
   );
@@ -227,6 +236,84 @@ function ArchiveFinishedRow({
       // pressing it shows up. Dismissing would hide the thing the press produces.
       closeOnSelect={false}
       onPress={onPress}
+    >
+      {renderRow}
+    </ComposerTrackRow>
+  );
+}
+
+function AgentQueueRows({
+  serverId,
+  agentId,
+  depth,
+}: {
+  serverId: string;
+  agentId: string;
+  depth: number;
+}): ReactElement | null {
+  const prompts = useAgentQueuePrompts({ serverId, agentId });
+  if (prompts.length === 0) return null;
+  return (
+    <>
+      {prompts.map((prompt) => (
+        <QueuedPromptTrackRow
+          key={prompt.id}
+          serverId={serverId}
+          agentId={agentId}
+          promptId={prompt.id}
+          text={prompt.text}
+          depth={depth}
+        />
+      ))}
+    </>
+  );
+}
+
+function QueuedPromptTrackRow({
+  serverId,
+  agentId,
+  promptId,
+  text,
+  depth,
+}: {
+  serverId: string;
+  agentId: string;
+  promptId: string;
+  text: string;
+  depth: number;
+}): ReactElement {
+  const { t } = useTranslation();
+  const client = useSessionStore((state) => state.sessions[serverId]?.client ?? null);
+  const handleSendNow = useCallback(() => {
+    if (!client) return;
+    void client.sendAgentQueuePromptNow(agentId, promptId).catch(() => undefined);
+  }, [agentId, client, promptId]);
+  const renderRow = useCallback(
+    ({ active }: { active: boolean }) => (
+      <>
+        <View style={[styles.depthRail, { width: depth * 12 }]} />
+        <View style={styles.disclosure} />
+        <Text style={styles.queuePreview} numberOfLines={1}>
+          {text}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t("composer.attachments.sendQueuedMessageNow")}
+          onPress={handleSendNow}
+          hitSlop={6}
+          style={active ? styles.queueActionActive : styles.queueAction}
+        >
+          <ThemedPlay size={ROW_ICON_SIZE} uniProps={foregroundMutedColorMapping} />
+        </Pressable>
+      </>
+    ),
+    [depth, handleSendNow, t, text],
+  );
+  return (
+    <ComposerTrackRow
+      accessibilityLabel={text}
+      testID={`subagents-track-queued-${promptId}`}
+      onPress={handleSendNow}
     >
       {renderRow}
     </ComposerTrackRow>
@@ -452,6 +539,22 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     justifyContent: "center",
     flexShrink: 0,
+  },
+  queuePreview: {
+    flexGrow: 1,
+    flexShrink: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foregroundMuted,
+  },
+  queueAction: {
+    padding: theme.spacing[1],
+    borderRadius: theme.borderRadius.sm,
+  },
+  queueActionActive: {
+    padding: theme.spacing[1],
+    borderRadius: theme.borderRadius.sm,
+    backgroundColor: theme.colors.surface2,
   },
   // `flexBasis: "auto"` rather than `flex: 1`: a zero-basis label contributes nothing to the row's
   // intrinsic width, so the panel measures itself at its floor and truncates every label at once.

--- a/packages/app/src/subagents/track.tsx
+++ b/packages/app/src/subagents/track.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback, useMemo, useState, type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
-import { Archive, ChevronDown, ChevronRight, Play, Unlink } from "lucide-react-native";
+import { Archive, ChevronDown, ChevronRight, Play, Square, Unlink } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { getProviderIcon } from "@/components/provider-icons";
 import { ComposerTrackActions, ComposerTrackPill, ComposerTrackRow } from "@/composer/tracks";
@@ -27,6 +27,7 @@ const ThemedArchive = withUnistyles(Archive);
 const ThemedChevronDown = withUnistyles(ChevronDown);
 const ThemedChevronRight = withUnistyles(ChevronRight);
 const ThemedPlay = withUnistyles(Play);
+const ThemedSquare = withUnistyles(Square);
 const ThemedUnlink = withUnistyles(Unlink);
 
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
@@ -44,6 +45,8 @@ export interface SubagentsTrackProps {
   onArchiveFinished?: () => void;
   archiveFinishedStatus?: ArchiveFinishedStatus;
   onDetachSubagent?: (id: string) => void;
+  onStopSubagent?: (id: string) => void;
+  onStopAllActive?: () => void;
 }
 
 const IDLE_ARCHIVE_FINISHED_STATUS: ArchiveFinishedStatus = { kind: "idle" };
@@ -110,6 +113,8 @@ export function SubagentsTrack({
   onArchiveFinished,
   archiveFinishedStatus = IDLE_ARCHIVE_FINISHED_STATUS,
   onDetachSubagent,
+  onStopSubagent,
+  onStopAllActive,
 }: SubagentsTrackProps): ReactElement | null {
   const { t } = useTranslation();
   const [collapsedKeys, setCollapsedKeys] = useState<Set<string>>(new Set());
@@ -152,6 +157,11 @@ export function SubagentsTrack({
       accessibilityLabel={pill.accessibilityLabel}
       panelTitle={t("subagents.title")}
     >
+      {onStopAllActive ? (
+        <ComposerTrackActions divided={visibleRows.length > 0}>
+          <StopAllRow onPress={onStopAllActive} />
+        </ComposerTrackActions>
+      ) : null}
       {showArchiveFinished && onArchiveFinished ? (
         <ComposerTrackActions divided={visibleRows.length > 0}>
           <ArchiveFinishedRow
@@ -174,6 +184,7 @@ export function SubagentsTrack({
             onOpenProviderSubagent={onOpenProviderSubagent}
             onArchiveSubagent={onArchiveSubagent}
             onDetachSubagent={onDetachSubagent}
+            onStopSubagent={onStopSubagent}
           />
           {node.row.kind === "paseo" ? (
             <AgentQueueRows serverId={serverId} agentId={node.row.id} depth={node.depth + 1} />
@@ -237,6 +248,29 @@ function ArchiveFinishedRow({
       closeOnSelect={false}
       onPress={onPress}
     >
+      {renderRow}
+    </ComposerTrackRow>
+  );
+}
+
+function StopAllRow({ onPress }: { onPress: () => void }): ReactElement {
+  const { t } = useTranslation();
+  const renderRow = useCallback(
+    ({ active }: { active: boolean }) => (
+      <>
+        <ThemedSquare
+          size={ROW_ICON_SIZE}
+          uniProps={active ? foregroundColorMapping : foregroundMutedColorMapping}
+        />
+        <Text style={styles.rowLabel} numberOfLines={1}>
+          {t("subagents.stopAllAction")}
+        </Text>
+      </>
+    ),
+    [t],
+  );
+  return (
+    <ComposerTrackRow accessibilityLabel={t("subagents.stopAllAction")} onPress={onPress}>
       {renderRow}
     </ComposerTrackRow>
   );
@@ -331,6 +365,7 @@ interface SubagentsTrackRowProps {
   onOpenProviderSubagent: (parentAgentId: string, subagentId: string) => void;
   onArchiveSubagent: (id: string) => void;
   onDetachSubagent?: (id: string) => void;
+  onStopSubagent?: (id: string) => void;
 }
 
 function SubagentsTrackRow({
@@ -344,6 +379,7 @@ function SubagentsTrackRow({
   onOpenProviderSubagent,
   onArchiveSubagent,
   onDetachSubagent,
+  onStopSubagent,
 }: SubagentsTrackRowProps): ReactElement {
   const { t } = useTranslation();
   const isCompact = useIsCompactFormFactor();
@@ -363,6 +399,9 @@ function SubagentsTrackRow({
   const handleDetachPress = useCallback(() => {
     onDetachSubagent?.(row.id);
   }, [onDetachSubagent, row.id]);
+  const handleStopPress = useCallback(() => {
+    onStopSubagent?.(row.id);
+  }, [onStopSubagent, row.id]);
   const handleToggleExpanded = useCallback(
     () => onToggleExpanded(node, expanded),
     [expanded, node, onToggleExpanded],
@@ -406,6 +445,7 @@ function SubagentsTrackRow({
             displayLabel={displayLabel}
             visible={actionsAlwaysVisible || active}
             onDetachPress={onDetachSubagent ? handleDetachPress : undefined}
+            onStopPress={row.status === "running" ? handleStopPress : undefined}
             onArchivePress={handleArchivePress}
           />
         ) : null}
@@ -420,10 +460,12 @@ function SubagentsTrackRow({
       handleDetachPress,
       hasChildren,
       onDetachSubagent,
+      handleStopPress,
       handleToggleExpanded,
       presentation,
       row.kind,
       row.id,
+      row.status,
     ],
   );
 
@@ -444,12 +486,14 @@ function SubagentRowActions({
   visible,
   onDetachPress,
   onArchivePress,
+  onStopPress,
 }: {
   rowId: string;
   displayLabel: string;
   visible: boolean;
   onDetachPress?: () => void;
   onArchivePress: () => void;
+  onStopPress?: () => void;
 }): ReactElement {
   const { t } = useTranslation();
   return (
@@ -467,6 +511,16 @@ function SubagentRowActions({
           onPress={onDetachPress}
         />
       ) : null}
+      {onStopPress ? (
+        <SubagentActionButton
+          accessibilityLabel={t("subagents.stopAction", { label: displayLabel })}
+          testID={`subagents-track-stop-${rowId}`}
+          tooltipLabel={t("subagents.stopAction", { label: displayLabel })}
+          icon="stop"
+          visible={visible}
+          onPress={onStopPress}
+        />
+      ) : null}
       <SubagentActionButton
         accessibilityLabel={t("subagents.archiveAction", { label: displayLabel })}
         testID={`subagents-track-archive-${rowId}`}
@@ -479,12 +533,15 @@ function SubagentRowActions({
   );
 }
 
-type SubagentActionIcon = "archive" | "detach";
+type SubagentActionIcon = "archive" | "detach" | "stop";
 
 function renderSubagentActionIcon(icon: SubagentActionIcon, isActive: boolean): ReactElement {
   const uniProps = isActive ? foregroundColorMapping : foregroundMutedColorMapping;
   if (icon === "detach") {
     return <ThemedUnlink size={ROW_ICON_SIZE} uniProps={uniProps} />;
+  }
+  if (icon === "stop") {
+    return <ThemedSquare size={ROW_ICON_SIZE} uniProps={uniProps} />;
   }
   return <ThemedArchive size={ROW_ICON_SIZE} uniProps={uniProps} />;
 }

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -738,6 +738,7 @@ test("advertises client capabilities in hello", async () => {
     protocolVersion: 1,
     capabilities: {
       compact_provider_snapshots: true,
+      agent_queue: true,
       custom_mode_icons: true,
       project_updates: true,
       provider_subagents: true,

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2966,6 +2966,49 @@ export class DaemonClient {
     return payload;
   }
 
+  async listAgentQueue(
+    agentId: string,
+    requestId?: string,
+  ): Promise<Extract<SessionOutboundMessage, { type: "agent.queue.list.response" }>["payload"]> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: { type: "agent.queue.list.request", agentId },
+      responseType: "agent.queue.list.response",
+    });
+  }
+
+  async createAgentQueuePrompt(input: {
+    agentId: string;
+    text: string;
+    attachments?: import("@getpaseo/protocol/messages").AgentAttachment[];
+    requestId?: string;
+  }): Promise<Extract<SessionOutboundMessage, { type: "agent.queue.create.response" }>["payload"]> {
+    return this.sendCorrelatedSessionRequest({
+      requestId: input.requestId,
+      message: {
+        type: "agent.queue.create.request",
+        agentId: input.agentId,
+        text: input.text,
+        ...(input.attachments ? { attachments: input.attachments } : {}),
+      },
+      responseType: "agent.queue.create.response",
+    });
+  }
+
+  async sendAgentQueuePromptNow(
+    agentId: string,
+    promptId: string,
+    requestId?: string,
+  ): Promise<
+    Extract<SessionOutboundMessage, { type: "agent.queue.send_now.response" }>["payload"]
+  > {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: { type: "agent.queue.send_now.request", agentId, promptId },
+      responseType: "agent.queue.send_now.response",
+    });
+  }
+
   async setAgentTimelineSubscription(agentIds: string[]): Promise<void> {
     // COMPAT(selectiveAgentTimeline): added in v0.1.106. Old daemons keep their
     // legacy global stream and do not understand this RPC. Remove after
@@ -5558,6 +5601,7 @@ export class DaemonClient {
           [CLIENT_CAPS.providerSubagents]: true,
           [CLIENT_CAPS.projectUpdates]: true,
           [CLIENT_CAPS.compactProviderSnapshots]: true,
+          [CLIENT_CAPS.agentQueue]: true,
           ...this.config.capabilities,
         },
         ...(this.config.appVersion ? { appVersion: this.config.appVersion } : {}),

--- a/packages/protocol/src/client-capabilities.ts
+++ b/packages/protocol/src/client-capabilities.ts
@@ -24,6 +24,9 @@ export const CLIENT_CAPS = {
   // provider catalogs with shared thinking sets and may revalidate by content hash.
   // Remove the legacy snapshot encoding after 2027-02-04.
   compactProviderSnapshots: "compact_provider_snapshots",
+  // COMPAT(agentQueue): added in v0.5.x. Capable clients receive daemon-owned
+  // queue snapshots instead of renderer-local queued prompts.
+  agentQueue: "agent_queue",
   browserHost: "browser_host",
 } as const;
 

--- a/packages/protocol/src/messages.agent-queue.test.ts
+++ b/packages/protocol/src/messages.agent-queue.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { SessionInboundMessageSchema, SessionOutboundMessageSchema } from "./messages.js";
+
+test("parses daemon-owned agent queue messages", () => {
+  const request = SessionInboundMessageSchema.parse({
+    type: "agent.queue.create.request",
+    agentId: "agent-1",
+    text: "continue with tests",
+    requestId: "request-1",
+  });
+  expect(request.type).toBe("agent.queue.create.request");
+
+  const update = SessionOutboundMessageSchema.parse({
+    type: "agent.queue.update",
+    payload: {
+      agentId: "agent-1",
+      prompts: [
+        {
+          id: "prompt-1",
+          agentId: "agent-1",
+          text: "continue with tests",
+          attachments: [],
+          createdAt: "2026-08-24T12:00:00.000Z",
+          createdByClientId: "client-1",
+        },
+      ],
+    },
+  });
+  expect(update.type).toBe("agent.queue.update");
+});

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1744,6 +1744,50 @@ export const ProviderSubagentTimelineRequestMessageSchema = z.object({
   limit: z.number().int().nonnegative().optional(),
 });
 
+export const AgentQueueListRequestMessageSchema = z.object({
+  type: z.literal("agent.queue.list.request"),
+  agentId: z.string(),
+  requestId: z.string(),
+});
+
+export const AgentQueueCreateRequestMessageSchema = z.object({
+  type: z.literal("agent.queue.create.request"),
+  agentId: z.string(),
+  text: z.string(),
+  attachments: z.array(AgentAttachmentSchema).optional(),
+  requestId: z.string(),
+});
+
+export const AgentQueueUpdateRequestMessageSchema = z.object({
+  type: z.literal("agent.queue.update.request"),
+  agentId: z.string(),
+  promptId: z.string(),
+  text: z.string(),
+  attachments: z.array(AgentAttachmentSchema).optional(),
+  requestId: z.string(),
+});
+
+export const AgentQueueReorderRequestMessageSchema = z.object({
+  type: z.literal("agent.queue.reorder.request"),
+  agentId: z.string(),
+  promptIds: z.array(z.string()),
+  requestId: z.string(),
+});
+
+export const AgentQueueDeleteRequestMessageSchema = z.object({
+  type: z.literal("agent.queue.delete.request"),
+  agentId: z.string(),
+  promptId: z.string(),
+  requestId: z.string(),
+});
+
+export const AgentQueueSendNowRequestMessageSchema = z.object({
+  type: z.literal("agent.queue.send_now.request"),
+  agentId: z.string(),
+  promptId: z.string(),
+  requestId: z.string(),
+});
+
 export const SetAgentTimelineSubscriptionRequestMessageSchema = z.object({
   type: z.literal("agent.timeline.set_subscription.request"),
   agentIds: z.array(z.string()),
@@ -3021,6 +3065,12 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   AgentTimelineListPromptsRequestMessageSchema,
   ProviderSubagentListRequestMessageSchema,
   ProviderSubagentTimelineRequestMessageSchema,
+  AgentQueueListRequestMessageSchema,
+  AgentQueueCreateRequestMessageSchema,
+  AgentQueueUpdateRequestMessageSchema,
+  AgentQueueReorderRequestMessageSchema,
+  AgentQueueDeleteRequestMessageSchema,
+  AgentQueueSendNowRequestMessageSchema,
   SetAgentTimelineSubscriptionRequestMessageSchema,
   AgentForkContextRequestMessageSchema,
   SetAgentModeRequestMessageSchema,
@@ -3373,6 +3423,8 @@ export const ServerInfoStatusPayloadSchema = z
         agentForkContextCursor: z.boolean().optional(),
         // COMPAT(providerSubagents): added in v0.1.107, remove gate after 2027-01-12.
         providerSubagents: z.boolean().optional(),
+        // COMPAT(agentQueue): added in v0.5.x.
+        agentQueue: z.boolean().optional(),
         // COMPAT(workspacePinning): added in v0.1.107, remove gate after 2027-01-12.
         workspacePinning: z.boolean().optional(),
         // COMPAT(hubRelationship): added in v0.1.X, drop the gate when floor >= v0.1.X.
@@ -4303,6 +4355,61 @@ export const ProviderSubagentDescriptorPayloadSchema = z.object({
 export type ProviderSubagentDescriptorPayload = z.infer<
   typeof ProviderSubagentDescriptorPayloadSchema
 >;
+
+export const AgentQueuedPromptPayloadSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  text: z.string(),
+  attachments: z.array(AgentAttachmentSchema),
+  createdAt: z.string(),
+  createdByClientId: z.string(),
+});
+
+const AgentQueueOperationPayloadSchema = z.object({
+  requestId: z.string(),
+  agentId: z.string(),
+  prompts: z.array(AgentQueuedPromptPayloadSchema),
+  prompt: AgentQueuedPromptPayloadSchema.nullable().optional(),
+  error: z.string().nullable(),
+});
+
+export const AgentQueueListResponseMessageSchema = z.object({
+  type: z.literal("agent.queue.list.response"),
+  payload: AgentQueueOperationPayloadSchema,
+});
+
+export const AgentQueueCreateResponseMessageSchema = z.object({
+  type: z.literal("agent.queue.create.response"),
+  payload: AgentQueueOperationPayloadSchema,
+});
+
+export const AgentQueueUpdateResponseMessageSchema = z.object({
+  type: z.literal("agent.queue.update.response"),
+  payload: AgentQueueOperationPayloadSchema,
+});
+
+export const AgentQueueReorderResponseMessageSchema = z.object({
+  type: z.literal("agent.queue.reorder.response"),
+  payload: AgentQueueOperationPayloadSchema,
+});
+
+export const AgentQueueDeleteResponseMessageSchema = z.object({
+  type: z.literal("agent.queue.delete.response"),
+  payload: AgentQueueOperationPayloadSchema,
+});
+
+export const AgentQueueSendNowResponseMessageSchema = z.object({
+  type: z.literal("agent.queue.send_now.response"),
+  payload: AgentQueueOperationPayloadSchema,
+});
+
+export const AgentQueueUpdateMessageSchema = z.object({
+  type: z.literal("agent.queue.update"),
+  payload: z.object({
+    agentId: z.string(),
+    prompts: z.array(AgentQueuedPromptPayloadSchema),
+  }),
+});
 
 export const ProviderSubagentListResponseMessageSchema = z.object({
   type: z.literal("agent.provider_subagents.list.response"),
@@ -6227,6 +6334,13 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   ProviderSubagentListResponseMessageSchema,
   ProviderSubagentTimelineResponseMessageSchema,
   ProviderSubagentUpdateMessageSchema,
+  AgentQueueListResponseMessageSchema,
+  AgentQueueCreateResponseMessageSchema,
+  AgentQueueUpdateResponseMessageSchema,
+  AgentQueueReorderResponseMessageSchema,
+  AgentQueueDeleteResponseMessageSchema,
+  AgentQueueSendNowResponseMessageSchema,
+  AgentQueueUpdateMessageSchema,
   SetAgentTimelineSubscriptionResponseMessageSchema,
   AgentAttentionRequiredMessageSchema,
   AgentForkContextResponseMessageSchema,
@@ -6424,6 +6538,13 @@ export type WorkspaceScriptStartResponseMessage = z.infer<
 export type WorkspaceScriptStopResponseMessage = z.infer<
   typeof WorkspaceScriptStopResponseMessageSchema
 >;
+export type AgentQueuedPromptPayload = z.infer<typeof AgentQueuedPromptPayloadSchema>;
+export type AgentQueueListRequestMessage = z.infer<typeof AgentQueueListRequestMessageSchema>;
+export type AgentQueueCreateRequestMessage = z.infer<typeof AgentQueueCreateRequestMessageSchema>;
+export type AgentQueueUpdateRequestMessage = z.infer<typeof AgentQueueUpdateRequestMessageSchema>;
+export type AgentQueueReorderRequestMessage = z.infer<typeof AgentQueueReorderRequestMessageSchema>;
+export type AgentQueueDeleteRequestMessage = z.infer<typeof AgentQueueDeleteRequestMessageSchema>;
+export type AgentQueueSendNowRequestMessage = z.infer<typeof AgentQueueSendNowRequestMessageSchema>;
 export type LegacyListAvailableEditorsResponseMessage = z.infer<
   typeof LegacyListAvailableEditorsResponseMessageSchema
 >;
@@ -6830,6 +6951,7 @@ export const WSHelloMessageSchema = z.object({
       [CLIENT_CAPS.providerSubagents]: z.boolean().optional(),
       [CLIENT_CAPS.projectUpdates]: z.boolean().optional(),
       [CLIENT_CAPS.compactProviderSnapshots]: z.boolean().optional(),
+      [CLIENT_CAPS.agentQueue]: z.boolean().optional(),
       [CLIENT_CAPS.browserHost]: BrowserAutomationHostCapabilitySchema.optional(),
     })
     .passthrough()

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -4347,6 +4347,19 @@ export const ProviderSubagentDescriptorPayloadSchema = z.object({
   updatedAt: z.string(),
   toolCallId: z.string().nullable(),
   cwd: z.string().nullable().optional(),
+  // Provider adapters emit these only when native ancestry is explicit.
+  parentSubagentId: z.string().nullable().optional(),
+  depth: z.number().int().nonnegative().nullable().optional(),
+  capabilities: z
+    .object({
+      canOpen: z.boolean(),
+      canPrompt: z.boolean(),
+      canQueue: z.boolean(),
+      canSteer: z.boolean(),
+      canStop: z.boolean(),
+    })
+    .nullable()
+    .optional(),
   // Compact provider-owned context for the shared track. Providers choose what belongs here and
   // format it for display; clients must not parse provider-specific facts out of this string.
   subtitle: z.string().nullable().optional(),

--- a/packages/server/src/server/agent/agent-queue-store.test.ts
+++ b/packages/server/src/server/agent/agent-queue-store.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { AgentQueueStore } from "./agent-queue-store.js";
+
+const directories: string[] = [];
+
+async function createStore() {
+  const directory = await mkdtemp(path.join(tmpdir(), "paseo-agent-queue-"));
+  directories.push(directory);
+  return {
+    directory,
+    store: new AgentQueueStore(directory, () => new Date("2026-08-24T12:00:00.000Z")),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+test("persists FIFO prompts and supports a later store instance", async () => {
+  const { directory, store } = await createStore();
+  const first = await store.enqueue({ agentId: "agent-1", text: "first", createdByClientId: "a" });
+  const second = await store.enqueue({
+    agentId: "agent-1",
+    text: "second",
+    createdByClientId: "b",
+  });
+  expect((await store.list("agent-1")).map((prompt) => prompt.text)).toEqual(["first", "second"]);
+
+  const persisted = JSON.parse(
+    await readFile(path.join(directory, "queues", "agent-1.json"), "utf8"),
+  );
+  expect(persisted.prompts.map((prompt: { id: string }) => prompt.id)).toEqual([
+    first.id,
+    second.id,
+  ]);
+});
+
+test("serializes concurrent mutations and rejects incomplete reorders", async () => {
+  const { store } = await createStore();
+  const [first, second, third] = await Promise.all(
+    ["first", "second", "third"].map((text) =>
+      store.enqueue({ agentId: "agent-1", text, createdByClientId: "client" }),
+    ),
+  );
+  await expect(store.reorder("agent-1", [first.id])).rejects.toThrow("every prompt");
+  const reordered = await store.reorder("agent-1", [third.id, second.id, first.id]);
+  expect(reordered.map((prompt) => prompt.id)).toEqual([third.id, second.id, first.id]);
+  expect((await store.take("agent-1"))?.id).toBe(third.id);
+});

--- a/packages/server/src/server/agent/agent-queue-store.ts
+++ b/packages/server/src/server/agent/agent-queue-store.ts
@@ -26,6 +26,7 @@ export class AgentQueueStore {
   private readonly promptsByAgent = new Map<string, AgentQueuedPrompt[]>();
   private readonly loadPromises = new Map<string, Promise<void>>();
   private readonly writesByAgent = new Map<string, Promise<void>>();
+  private readonly listeners = new Set<(agentId: string, prompts: AgentQueuedPrompt[]) => void>();
 
   constructor(
     private readonly agentRoot: string,
@@ -67,16 +68,17 @@ export class AgentQueueStore {
     attachments?: AgentAttachment[];
   }): Promise<AgentQueuedPrompt | null> {
     const text = input.text.trim();
-    if (!text && !input.attachments?.length) {
-      throw new Error("Queued prompt needs text or an attachment");
-    }
     return this.mutate(input.agentId, (current) => {
       const index = current.findIndex((prompt) => prompt.id === input.promptId);
       if (index < 0) return { next: current, value: null };
+      const attachments = input.attachments ?? current[index]!.attachments;
+      if (!text && attachments.length === 0) {
+        throw new Error("Queued prompt needs text or an attachment");
+      }
       const updated: AgentQueuedPrompt = {
         ...current[index]!,
         text,
-        attachments: [...(input.attachments ?? [])],
+        attachments: [...attachments],
       };
       const next = [...current];
       next[index] = updated;
@@ -124,6 +126,11 @@ export class AgentQueueStore {
     await this.mutate(agentId, () => ({ next: [], value: undefined }));
   }
 
+  subscribe(listener: (agentId: string, prompts: AgentQueuedPrompt[]) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
   private async mutate<T>(
     agentId: string,
     mutation: (current: AgentQueuedPrompt[]) => { next: AgentQueuedPrompt[]; value: T },
@@ -142,6 +149,13 @@ export class AgentQueueStore {
         const result = mutation(this.promptsByAgent.get(agentId) ?? []);
         this.promptsByAgent.set(agentId, result.next);
         await writeJsonFileAtomic(this.filePath(agentId), { prompts: result.next });
+        for (const listener of this.listeners) {
+          try {
+            listener(agentId, result.next.map(clone));
+          } catch {
+            // Queue persistence remains authoritative if a presentation subscriber fails.
+          }
+        }
         resolveValue(result.value);
         return undefined;
       })

--- a/packages/server/src/server/agent/agent-queue-store.ts
+++ b/packages/server/src/server/agent/agent-queue-store.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+import { writeJsonFileAtomic } from "../atomic-file.js";
+import { AgentAttachmentSchema, type AgentAttachment } from "../messages.js";
+
+const QUEUED_PROMPT_SCHEMA = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  text: z.string(),
+  attachments: z.array(AgentAttachmentSchema),
+  createdAt: z.string(),
+  createdByClientId: z.string(),
+});
+
+const QUEUE_FILE_SCHEMA = z.object({ prompts: z.array(QUEUED_PROMPT_SCHEMA).default([]) });
+
+export type AgentQueuedPrompt = z.infer<typeof QUEUED_PROMPT_SCHEMA>;
+
+function clone(prompt: AgentQueuedPrompt): AgentQueuedPrompt {
+  return { ...prompt, attachments: [...prompt.attachments] };
+}
+
+export class AgentQueueStore {
+  private readonly promptsByAgent = new Map<string, AgentQueuedPrompt[]>();
+  private readonly loadPromises = new Map<string, Promise<void>>();
+  private readonly writesByAgent = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly agentRoot: string,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async list(agentId: string): Promise<AgentQueuedPrompt[]> {
+    await this.load(agentId);
+    return (this.promptsByAgent.get(agentId) ?? []).map(clone);
+  }
+
+  async enqueue(input: {
+    agentId: string;
+    text: string;
+    attachments?: AgentAttachment[];
+    createdByClientId: string;
+  }): Promise<AgentQueuedPrompt> {
+    const text = input.text.trim();
+    if (!text && !input.attachments?.length) {
+      throw new Error("Queued prompt needs text or an attachment");
+    }
+    return this.mutate(input.agentId, (current) => {
+      const prompt: AgentQueuedPrompt = {
+        id: randomUUID(),
+        agentId: input.agentId,
+        text,
+        attachments: [...(input.attachments ?? [])],
+        createdAt: this.now().toISOString(),
+        createdByClientId: input.createdByClientId,
+      };
+      return { next: [...current, prompt], value: prompt };
+    });
+  }
+
+  async update(input: {
+    agentId: string;
+    promptId: string;
+    text: string;
+    attachments?: AgentAttachment[];
+  }): Promise<AgentQueuedPrompt | null> {
+    const text = input.text.trim();
+    if (!text && !input.attachments?.length) {
+      throw new Error("Queued prompt needs text or an attachment");
+    }
+    return this.mutate(input.agentId, (current) => {
+      const index = current.findIndex((prompt) => prompt.id === input.promptId);
+      if (index < 0) return { next: current, value: null };
+      const updated: AgentQueuedPrompt = {
+        ...current[index]!,
+        text,
+        attachments: [...(input.attachments ?? [])],
+      };
+      const next = [...current];
+      next[index] = updated;
+      return { next, value: updated };
+    });
+  }
+
+  async reorder(agentId: string, promptIds: string[]): Promise<AgentQueuedPrompt[]> {
+    return this.mutate(agentId, (current) => {
+      if (promptIds.length !== current.length || new Set(promptIds).size !== current.length) {
+        throw new Error("Queue reorder must contain every prompt exactly once");
+      }
+      const byId = new Map(current.map((prompt) => [prompt.id, prompt]));
+      const next = promptIds.map((id) => byId.get(id));
+      if (next.some((prompt) => !prompt))
+        throw new Error("Queue reorder contains an unknown prompt");
+      return { next: next as AgentQueuedPrompt[], value: next as AgentQueuedPrompt[] };
+    });
+  }
+
+  async delete(agentId: string, promptId: string): Promise<AgentQueuedPrompt | null> {
+    return this.mutate(agentId, (current) => {
+      const removed = current.find((prompt) => prompt.id === promptId) ?? null;
+      return { next: current.filter((prompt) => prompt.id !== promptId), value: removed };
+    });
+  }
+
+  async take(agentId: string, promptId?: string): Promise<AgentQueuedPrompt | null> {
+    return this.mutate(agentId, (current) => {
+      const index = promptId ? current.findIndex((prompt) => prompt.id === promptId) : 0;
+      if (index < 0 || !current[index]) return { next: current, value: null };
+      const prompt = current[index];
+      return { next: current.filter((_, candidate) => candidate !== index), value: prompt };
+    });
+  }
+
+  async restoreFront(prompt: AgentQueuedPrompt): Promise<void> {
+    await this.mutate(prompt.agentId, (current) => ({
+      next: [prompt, ...current.filter((candidate) => candidate.id !== prompt.id)],
+      value: undefined,
+    }));
+  }
+
+  async clear(agentId: string): Promise<void> {
+    await this.mutate(agentId, () => ({ next: [], value: undefined }));
+  }
+
+  private async mutate<T>(
+    agentId: string,
+    mutation: (current: AgentQueuedPrompt[]) => { next: AgentQueuedPrompt[]; value: T },
+  ): Promise<T> {
+    const previous = this.writesByAgent.get(agentId) ?? Promise.resolve();
+    let resolveValue!: (value: T) => void;
+    let rejectValue!: (error: unknown) => void;
+    const value = new Promise<T>((resolve, reject) => {
+      resolveValue = resolve;
+      rejectValue = reject;
+    });
+    const write = previous
+      .catch(() => undefined)
+      .then(async () => {
+        await this.load(agentId);
+        const result = mutation(this.promptsByAgent.get(agentId) ?? []);
+        this.promptsByAgent.set(agentId, result.next);
+        await writeJsonFileAtomic(this.filePath(agentId), { prompts: result.next });
+        resolveValue(result.value);
+        return undefined;
+      })
+      .catch((error) => {
+        rejectValue(error);
+        return undefined;
+      });
+    const tracked = write.finally(() => {
+      if (this.writesByAgent.get(agentId) === tracked) this.writesByAgent.delete(agentId);
+    });
+    this.writesByAgent.set(agentId, tracked);
+    return value;
+  }
+
+  private async load(agentId: string): Promise<void> {
+    if (this.promptsByAgent.has(agentId)) return;
+    const existing = this.loadPromises.get(agentId);
+    if (existing) return existing;
+    const loading = (async () => {
+      try {
+        const raw = await fs.readFile(this.filePath(agentId), "utf8");
+        const parsed = QUEUE_FILE_SCHEMA.safeParse(JSON.parse(raw));
+        this.promptsByAgent.set(agentId, parsed.success ? parsed.data.prompts : []);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          this.promptsByAgent.set(agentId, []);
+          return;
+        }
+        throw error;
+      }
+    })();
+    this.loadPromises.set(agentId, loading);
+    try {
+      await loading;
+    } finally {
+      this.loadPromises.delete(agentId);
+    }
+  }
+
+  private filePath(agentId: string): string {
+    return path.join(this.agentRoot, "queues", `${agentId}.json`);
+  }
+}

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -9,6 +9,7 @@ import { toStoredAgentRecord } from "./agent-projections.js";
 import type { ManagedAgent } from "./agent-manager.js";
 import type { AgentSessionConfig } from "./agent-sdk-types.js";
 import { AgentOwnerSchema, daemonExecutionKey, type DaemonAgentOwner } from "./agent-owner.js";
+import { AgentQueueStore } from "./agent-queue-store.js";
 
 const SERIALIZABLE_CONFIG_SCHEMA = z
   .object({
@@ -106,10 +107,12 @@ export class AgentStorage {
   private baseDir: string;
   private loadPromise: Promise<StoredAgentRecord[]> | null = null;
   private logger: Logger;
+  readonly queueStore: AgentQueueStore;
 
   constructor(baseDir: string, logger: Logger) {
     this.baseDir = baseDir;
     this.logger = logger.child({ module: "agent", component: "agent-storage" });
+    this.queueStore = new AgentQueueStore(baseDir);
   }
 
   async initialize(): Promise<void> {

--- a/packages/server/src/server/agent/provider-subagents/store.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.ts
@@ -22,6 +22,15 @@ export interface ProviderSubagentDescriptor {
   toolCallId: string | null;
   cwd: string | null;
   subtitle: string | null;
+  parentSubagentId: string | null;
+  depth: number | null;
+  capabilities: {
+    canOpen: boolean;
+    canPrompt: boolean;
+    canQueue: boolean;
+    canSteer: boolean;
+    canStop: boolean;
+  } | null;
 }
 
 export type ProviderSubagentInputEvent =
@@ -38,6 +47,9 @@ export type ProviderSubagentInputEvent =
       toolCallId?: string | null;
       cwd?: string | null;
       subtitle?: string | null;
+      parentSubagentId?: string | null;
+      depth?: number | null;
+      capabilities?: ProviderSubagentDescriptor["capabilities"];
       timestamp?: string;
     }
   | {
@@ -123,6 +135,9 @@ export class ProviderSubagentStore {
       toolCallId: stickyField(event.toolCallId, previous?.toolCallId),
       cwd: stickyField(event.cwd, previous?.cwd),
       subtitle: stickyField(event.subtitle, previous?.subtitle),
+      parentSubagentId: stickyField(event.parentSubagentId, previous?.parentSubagentId),
+      depth: stickyField(event.depth, previous?.depth),
+      capabilities: stickyField(event.capabilities, previous?.capabilities),
     };
     this.descriptors.set(key, subagent);
     return { type: "upsert", subagent };

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -5555,6 +5555,14 @@ export class CodexAppServerAgentSession implements AgentSession {
         description: detail.description ?? null,
         status: providerStatus,
         toolCallId: state.callId,
+        ...(state.parentCallId
+          ? {
+              parentSubagentId:
+                Array.from(
+                  this.subAgentCallsByCallId.get(state.parentCallId)?.childThreadIds ?? [],
+                ).sort()[0] ?? null,
+            }
+          : {}),
       },
     });
   }

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -151,6 +151,54 @@ test("cancel_agent_request reports refusal only through its response", async () 
   ]);
 });
 
+test("agent queue RPC persists a prompt and returns the canonical snapshot", async () => {
+  const messages: SessionOutboundMessage[] = [];
+  const prompt = {
+    id: "prompt-1",
+    agentId: "agent-1",
+    text: "continue with tests",
+    attachments: [],
+    createdAt: "2026-08-24T12:00:00.000Z",
+    createdByClientId: "test-client",
+  };
+  const queueStore = {
+    subscribe: vi.fn(() => () => {}),
+    enqueue: vi.fn(async () => prompt),
+    list: vi.fn(async () => [prompt]),
+  };
+  const session = createSessionForTest({
+    messages,
+    agentStorage: {
+      get: vi.fn(async () => ({ id: "agent-1" })),
+      queueStore,
+    },
+  });
+
+  await session.handleMessage({
+    type: "agent.queue.create.request",
+    agentId: "agent-1",
+    text: "continue with tests",
+    requestId: "queue-create",
+  });
+
+  expect(queueStore.enqueue).toHaveBeenCalledWith({
+    agentId: "agent-1",
+    text: "continue with tests",
+    attachments: undefined,
+    createdByClientId: "test-client",
+  });
+  expect(messages).toContainEqual({
+    type: "agent.queue.create.response",
+    payload: {
+      requestId: "queue-create",
+      agentId: "agent-1",
+      prompts: [prompt],
+      prompt,
+      error: null,
+    },
+  });
+});
+
 test("legacy cancel_agent_request reports refusal through the activity log", async () => {
   const agentId = "11111111-1111-4111-8111-111111111111";
   const messages: SessionOutboundMessage[] = [];

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2692,6 +2692,7 @@ export class Session {
     // Drain queued persistence from the just-closed agent before removing its
     // durable snapshot, otherwise an in-flight background write can recreate it.
     await this.agentManager.flush();
+    await this.agentStorage.queueStore.clear(agentId);
 
     try {
       await this.agentStorage.remove(agentId);

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2741,6 +2741,7 @@ export class Session {
       },
       agentId,
     );
+    await this.agentStorage.queueStore.clear(agentId);
 
     if (this.agentUpdates.hasSubscription()) {
       const payload = await this.agentUpdates.emitStoredRecord(archivedRecord);

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -691,6 +691,7 @@ export class Session {
   private readonly clientCapabilitiesBySource = new Map<object, ReadonlySet<ClientCapability>>();
   private readonly defaultTimelineSubscriptionSource = {};
   private unsubscribeTerminalWorkspaceContributionEvents: (() => void) | null = null;
+  private unsubscribeAgentQueueUpdates: (() => void) | null = null;
   private readonly agentUpdates: AgentUpdatesService;
   private workspaceUpdatesSubscription: WorkspaceUpdatesSubscriptionState | null = null;
   private readonly workspaceLabelService: WorkspaceLabelService | null;
@@ -830,6 +831,12 @@ export class Session {
     });
     this.agentManager = agentManager;
     this.agentStorage = agentStorage;
+    this.unsubscribeAgentQueueUpdates = this.agentStorage.queueStore.subscribe(
+      (agentId, prompts) => {
+        if (!this.supports(CLIENT_CAPS.agentQueue)) return;
+        this.emit({ type: "agent.queue.update", payload: { agentId, prompts } });
+      },
+    );
     this.projectRegistry = projectRegistry;
     this.workspaceRegistry = workspaceRegistry;
     this.directorySync = resolveDirectorySync(directorySync);
@@ -2184,6 +2191,13 @@ export class Session {
         return this.handleProviderSubagentListRequest(msg);
       case "agent.provider_subagents.timeline.get.request":
         return this.handleProviderSubagentTimelineRequest(msg);
+      case "agent.queue.list.request":
+      case "agent.queue.create.request":
+      case "agent.queue.update.request":
+      case "agent.queue.reorder.request":
+      case "agent.queue.delete.request":
+      case "agent.queue.send_now.request":
+        return this.handleAgentQueueRequest(msg);
       case "agent.timeline.set_subscription.request": {
         const agentIds = [...new Set(msg.agentIds)].sort();
         if (
@@ -7100,6 +7114,92 @@ export class Session {
     }
   }
 
+  private async handleAgentQueueRequest(
+    msg: Extract<SessionInboundMessage, { type: `agent.queue.${string}.request` }>,
+  ): Promise<void> {
+    const responseType = {
+      "agent.queue.list.request": "agent.queue.list.response",
+      "agent.queue.create.request": "agent.queue.create.response",
+      "agent.queue.update.request": "agent.queue.update.response",
+      "agent.queue.reorder.request": "agent.queue.reorder.response",
+      "agent.queue.delete.request": "agent.queue.delete.response",
+      "agent.queue.send_now.request": "agent.queue.send_now.response",
+    } as const;
+    try {
+      if (!(await this.agentStorage.get(msg.agentId))) {
+        throw new Error("Agent not found");
+      }
+      let prompt = null;
+      switch (msg.type) {
+        case "agent.queue.create.request":
+          prompt = await this.agentStorage.queueStore.enqueue({
+            agentId: msg.agentId,
+            text: msg.text,
+            attachments: msg.attachments,
+            createdByClientId: this.clientId,
+          });
+          break;
+        case "agent.queue.update.request":
+          prompt = await this.agentStorage.queueStore.update({
+            agentId: msg.agentId,
+            promptId: msg.promptId,
+            text: msg.text,
+            attachments: msg.attachments,
+          });
+          break;
+        case "agent.queue.reorder.request":
+          await this.agentStorage.queueStore.reorder(msg.agentId, msg.promptIds);
+          break;
+        case "agent.queue.delete.request":
+          prompt = await this.agentStorage.queueStore.delete(msg.agentId, msg.promptId);
+          break;
+        case "agent.queue.send_now.request": {
+          const queued = await this.agentStorage.queueStore.take(msg.agentId, msg.promptId);
+          if (!queued) break;
+          try {
+            await sendPromptToAgent({
+              agentManager: this.agentManager,
+              agentStorage: this.agentStorage,
+              agentId: msg.agentId,
+              prompt: buildAgentPrompt(queued.text, undefined, queued.attachments),
+              activeTurnBehavior: "interrupt",
+              clearPendingPermissions: true,
+              logger: this.sessionLogger,
+            });
+            prompt = queued;
+          } catch (error) {
+            await this.agentStorage.queueStore.restoreFront(queued);
+            throw error;
+          }
+          break;
+        }
+        case "agent.queue.list.request":
+          break;
+      }
+      const prompts = await this.agentStorage.queueStore.list(msg.agentId);
+      this.emit({
+        type: responseType[msg.type],
+        payload: {
+          requestId: msg.requestId,
+          agentId: msg.agentId,
+          prompts,
+          ...(prompt ? { prompt } : {}),
+          error: null,
+        },
+      });
+    } catch (error) {
+      this.emit({
+        type: responseType[msg.type],
+        payload: {
+          requestId: msg.requestId,
+          agentId: msg.agentId,
+          prompts: [],
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+
   private async handleAgentForkContextRequest(
     msg: Extract<SessionInboundMessage, { type: "agent.fork_context.request" }>,
   ): Promise<void> {
@@ -7459,6 +7559,8 @@ export class Session {
       this.unsubscribeTerminalWorkspaceContributionEvents();
       this.unsubscribeTerminalWorkspaceContributionEvents = null;
     }
+    this.unsubscribeAgentQueueUpdates?.();
+    this.unsubscribeAgentQueueUpdates = null;
     this.providerCatalogSession.dispose();
 
     await this.voiceSession.cleanup();

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -684,6 +684,7 @@ export class Session {
   private unsubscribePluginChanges: (() => void) | null = null;
   private unsubscribeWorkspaceMutations: (() => void) | null = null;
   private registryMutationQueue: Promise<void> = Promise.resolve();
+  private readonly queueDrainInFlight = new Set<string>();
   private projectUpdateQueue: Promise<void> = Promise.resolve();
   private isCleanedUp = false;
   private viewedTimelineAgentIds = new Set<string>();
@@ -1639,6 +1640,9 @@ export class Session {
             "agent.session.forward_update",
           );
           void this.agentUpdates.forwardLiveAgent(event.agent);
+          if (event.agent.lifecycle === "idle" && event.agent.activeForegroundTurnId === null) {
+            void this.drainAgentQueue(event.agent.id);
+          }
           return;
         }
 
@@ -7197,6 +7201,31 @@ export class Session {
           error: error instanceof Error ? error.message : String(error),
         },
       });
+    }
+  }
+
+  private async drainAgentQueue(agentId: string): Promise<void> {
+    if (this.queueDrainInFlight.has(agentId)) return;
+    this.queueDrainInFlight.add(agentId);
+    try {
+      const queued = await this.agentStorage.queueStore.take(agentId);
+      if (!queued) return;
+      try {
+        await sendPromptToAgent({
+          agentManager: this.agentManager,
+          agentStorage: this.agentStorage,
+          agentId,
+          prompt: buildAgentPrompt(queued.text, undefined, queued.attachments),
+          activeTurnBehavior: "interrupt",
+          clearPendingPermissions: true,
+          logger: this.sessionLogger,
+        });
+      } catch (error) {
+        await this.agentStorage.queueStore.restoreFront(queued);
+        this.sessionLogger.warn({ err: error, agentId }, "Failed to drain queued agent prompt");
+      }
+    } finally {
+      this.queueDrainInFlight.delete(agentId);
     }
   }
 

--- a/packages/server/src/server/test-utils/session-stubs.ts
+++ b/packages/server/src/server/test-utils/session-stubs.ts
@@ -45,6 +45,9 @@ export function asAgentStorage(stub: {
   return createStub<SessionOptions["agentStorage"]>({
     listByProviderSession: async () => [],
     listByWorkspace: async () => [],
+    queueStore: {
+      subscribe: () => () => {},
+    },
     ...stub,
   });
 }

--- a/packages/server/src/server/test-utils/session-stubs.ts
+++ b/packages/server/src/server/test-utils/session-stubs.ts
@@ -47,6 +47,7 @@ export function asAgentStorage(stub: {
     listByWorkspace: async () => [],
     queueStore: {
       subscribe: () => () => {},
+      clear: async () => {},
     },
     ...stub,
   });

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1724,6 +1724,7 @@ export class VoiceAssistantWebSocketServer {
         agentForkContextCursor: true,
         // COMPAT(providerSubagents): added in v0.1.107, remove gate after 2027-01-12.
         providerSubagents: true,
+        agentQueue: true,
         // COMPAT(workspacePinning): added in v0.1.107, remove gate after 2027-01-12.
         workspacePinning: true,
         // COMPAT(hubRelationship): added in v0.1.X, drop the gate when floor >= v0.1.X.


### PR DESCRIPTION
## Summary

- Add daemon-owned, per-agent queues with atomic persistence, FIFO/reorder/delete/send-now operations, live updates, automatic idle drain, and cleanup on archive/delete.
- Move the standard composer queue path to the daemon queue for text and structured attachments.
- Render managed children recursively with collapse state, provider ancestry metadata, queued child rows, and managed stop / Stop all active controls.
- Project observed Codex nested subagent relationships without guessing other-provider ancestry.

## Evidence

- `npm run format:check`, `npm run lint -- --deny-warnings`, and full `npm run typecheck` pass.
- Focused protocol/client/app/server coverage: 394 tests passing.

## Follow-up

Image attachment staging and the richer Queue/Steer instruction sheet are intentionally left for a follow-up; this PR establishes the durable queue and safe controls they depend on.