### PR TITLE
feat(app): group physical workspaces into logical sidebar rows

### DIFF
--- a/docs/superpowers/specs/2026-08-24-logical-workspaces-plugin-seam-design.md
+++ b/docs/superpowers/specs/2026-08-24-logical-workspaces-plugin-seam-design.md
@@ -1,0 +1,163 @@
+# Logical workspaces in the native Paseo sidebar
+
+## Scope and immutable delivery constraints
+
+This design targets the current upstream Paseo desktop and plugin APIs.
+
+Desktop installations must keep the official Developer ID/notarized application. This branch is an upstream
+candidate only: it must not be deployed as a custom Electron application or switched live. The
+runtime feature is delivered by a reloadable plugin after the required seam lands in an official
+signed Paseo release.
+
+## Why the v0.5.1 plugin API cannot implement this alone
+
+The exact `v0.5.1` API has four hard gaps:
+
+1. `addSidebarItem` contributes only one compact top-level row routed to a plugin surface. It
+   cannot contribute to or project the native Project/Workspace tree.
+2. A plugin surface is bound to one selected host. Equal installations are coalesced behind a
+   host picker, and plugin code cannot address another host at the same time.
+3. Plugin navigation is limited to registered plugin surfaces and panels. The runtime does not
+   expose Expo Router, the native workspace navigation action, or the workspace-layout store.
+4. `PluginWorkspaceSnapshot` omits workspace labels and is available only inside an already-open
+   workspace panel. It cannot drive a cross-host sidebar projection.
+
+A plugin could duplicate workspaces and history inside a custom surface, but it could not replace
+the native rows or open the selected native workspace. That would create a second sidebar instead
+of the requested native hierarchy.
+
+## Minimal upstream seam
+
+Add one declarative client contribution:
+
+```ts
+interface PluginSidebarWorkspaceGroupingContribution {
+  id: string;
+  logicalWorkspaceRefLabelPrefix: string;
+  defaultPlacementLabel: string;
+  retainedHistoryBindings?: readonly {
+    workspaceId: string;
+    physicalWorkspaceRef: string;
+    logicalWorkspaceRef: string;
+  }[];
+}
+
+interface PluginContext {
+  addSidebarWorkspaceGrouping(contribution: PluginSidebarWorkspaceGroupingContribution): void;
+}
+```
+
+The optional bindings are host-local exact native IDs generated from the layout history census;
+core adds the contributing host's `serverId`. They are not inferred from paths or titles and are
+not written back as labels. The contribution contains no UI, router, store, or callback access.
+Core Paseo keeps ownership of project grouping, native workspace identity, selection, status,
+history access, ordering, and navigation. The plugin only declares how reserved labels encode
+group membership and the default placement. Equal plugin/contribution IDs on several hosts form
+one namespace; a contribution only applies to workspaces on a host where that plugin is installed.
+
+This is the smallest update-safe seam: custom policy stays in a reloadable plugin, while native
+navigation remains inside the signed app. Removing or failing the plugin returns every physical
+workspace to the unmodified native list.
+
+## Reserved label contract
+
+Version 1 reserves the case-insensitive prefix `paseo:reserved:`. Reserved labels are never shown
+as user chips, manager rows, picker rows, or sidebar filter options.
+
+The logical-workspace plugin declares these exact values:
+
+```text
+paseo:reserved:v1:logical-workspace-ref=<logical_workspace_ref>
+paseo:reserved:v1:placement-role=default
+```
+
+`logical_workspace_ref` must match `[a-z0-9][a-z0-9._-]{0,127}` and is directly generable without
+escaping. Unknown or malformed
+reserved labels stay hidden but do not affect grouping. A default-role label without a valid
+logical ref is ignored. Core never infers groups from titles, paths, hosts, Git remotes, or user
+labels.
+
+## Native projection and data flow
+
+The existing `projectKey` pipeline remains unchanged and runs first:
+
+```text
+host Project descriptors -> native projectKey grouping -> SidebarProjectEntry
+workspace labels + plugin declaration -> logical rows within that one native Project
+```
+
+Grouping is scoped to one native Project and namespaced by plugin ID plus contribution ID. Thus an
+identical logical ref cannot merge Cars with Dom, and native Projects never become logical
+workspaces.
+
+A managed logical row owns every matching live physical placement. It shows one aggregate status and
+is selected whenever any member is the active route. Expanding it reveals the unchanged physical
+workspace rows, including host badges, context menus, and their separate agent/session histories.
+No registry row is archived, hidden from storage, renamed, or rewritten by the projection.
+
+A `retainedHistoryBinding` is the deliberate exception to live placement membership. Its native
+workspace remains live in storage, but is not a placement, target, default candidate, logical
+status input, Project-header status input, pinned row, shortcut, or Status-mode row. It is exposed
+only as `retainedAgentSources: {serverId, workspaceId}[]`. Core reads that source's native root
+sessions with the existing workspace-agent visibility policy and renders compact agent links below
+the logical row. Clicking one navigates directly to the exact native agent. Thus running and older
+sessions remain reachable without recreating the orphan as a third workspace row.
+
+Unmanaged workspaces keep the exact v0.5.1 row. In Status grouping ordinary live placements keep
+the exact v0.5.1 rows; successfully bound retained-history sources stay hidden there as well.
+Logical grouping otherwise changes only Project mode.
+
+## Deterministic target selection
+
+Pressing a logical row selects exactly one physical workspace in this order:
+
+1. the member already active in the current route;
+2. a member marked default;
+3. any remaining member.
+
+Within steps 2 and 3, prefer the most recent non-null `statusEnteredAt`, then compare `serverId`,
+then `workspaceId`. This handles several live native placement records without depending on
+arrival order. Multiple defaults are tolerated and remain
+deterministic; the inventory generator should still emit one default physical placement per
+logical ref.
+
+The logical status is the existing most-urgent aggregate across all hydrated members. The row
+title comes from the selected target (`title`, then native name), so the declared default controls
+display when placements have drifted titles.
+
+## Pinning, filtering, failures, and rollback
+
+Managed physical members remain inside their logical row instead of being hoisted individually to
+Pinned; logical pinning is intentionally not added in this slice. Their original `pinnedAt` data is
+not changed. Expanding the logical row still exposes each native member.
+
+User label filtering happens on physical assignments first; a logical row survives when at least
+one member matches. Reserved labels cannot be selected as filters. Host and Project filters retain
+their current semantics.
+
+Invalid plugin declarations are rejected during bundle evaluation. A resolver error, missing
+plugin, unsupported host, invalid ref, or absent labels fails open to native physical rows. The
+rollback is disabling/removing the plugin; no workspace registry migration is required.
+
+## Official desktop delivery boundary
+
+The client plugin cannot inject or replace this native projection in an unmodified v0.5.1 app.
+The changed renderer is the Expo output `packages/app/dist`, packaged by
+`packages/desktop/electron-builder.yml` as the signed app resource
+`Paseo.app/Contents/Resources/app-dist`; packaged `main.ts` loads that exact directory through
+`process.resourcesPath`. Replacing it locally changes a code-signed bundle resource and is not an
+acceptable update path for Developer ID, notarization, or preserved macOS TCC identity.
+
+Therefore this branch is only an upstream candidate. The seam must ship through Paseo's official
+build/sign/notarize pipeline, after which existing signed apps can install the official update
+and a reloadable layout plugin can activate the feature. There is no custom desktop build,
+resource replacement, or live switch in this work.
+
+## Verification boundary
+
+Tests must prove the reserved grammar and hiding, plugin contribution collection, preservation of
+native `projectKey` grouping, lossless physical membership, deterministic target selection,
+aggregate status, active selection, retained root-agent links, native-ID deduplication, and
+fail-open behavior. Run focused
+RED/GREEN tests first, then all app tests, plugin/protocol typechecks, and the full app typecheck.
+No desktop package is produced or installed by this work.

--- a/docs/superpowers/specs/2026-08-24-logical-workspaces-plugin-seam-design.md
+++ b/docs/superpowers/specs/2026-08-24-logical-workspaces-plugin-seam-design.md
@@ -125,6 +125,23 @@ The logical status is the existing most-urgent aggregate across all hydrated mem
 title comes from the selected target (`title`, then native name), so the declared default controls
 display when placements have drifted titles.
 
+## Native creation flow
+
+When exactly one compatible grouping contribution applies to the selected host, the native New
+Workspace screen shows a logical-workspace picker. It can create a new logical workspace or attach
+the new physical placement to an existing logical ref in the selected native Project. The reserved
+labels are part of the workspace-create request and are persisted in the initial registry record;
+there is no unlabeled intermediate row that can flash as a duplicate in the sidebar.
+
+A logical row offers `Add host` for the first Project host that does not already have a placement
+and can create one (Git worktree support or workspace multiplicity). The action opens the existing
+New Workspace screen on that host and preselects the logical ref. It does not invent a native
+Project placement: cross-host Project availability still comes from Paseo's native `projectKey`
+grouping, most commonly the same Git remote checked out on several hosts.
+
+Invalid route refs, an ambiguous grouping contribution, or a host without creation support fail
+open: no reserved labels are written and the ordinary native creation flow remains available.
+
 ## Pinning, filtering, failures, and rollback
 
 Managed physical members remain inside their logical row instead of being hoisted individually to

--- a/packages/app/src/app/new.tsx
+++ b/packages/app/src/app/new.tsx
@@ -9,18 +9,22 @@ export default function NewWorkspaceRoute() {
     name?: string;
     projectId?: string;
     draftId?: string;
+    logicalWorkspaceRef?: string;
   }>();
   const serverId = typeof params.serverId === "string" ? params.serverId : "";
   const sourceDirectory = typeof params.dir === "string" ? params.dir : undefined;
   const displayName = typeof params.name === "string" ? params.name : undefined;
   const projectId = typeof params.projectId === "string" ? params.projectId : undefined;
   const draftId = typeof params.draftId === "string" ? params.draftId : undefined;
+  const logicalWorkspaceRef =
+    typeof params.logicalWorkspaceRef === "string" ? params.logicalWorkspaceRef : undefined;
   const screenKey = JSON.stringify([
     serverId,
     sourceDirectory ?? null,
     displayName ?? null,
     projectId ?? null,
     draftId ?? null,
+    logicalWorkspaceRef ?? null,
   ]);
 
   return (
@@ -32,6 +36,7 @@ export default function NewWorkspaceRoute() {
         displayName={displayName}
         projectId={projectId}
         draftId={draftId}
+        logicalWorkspaceRef={logicalWorkspaceRef}
       />
     </HostRouteBootstrapBoundary>
   );

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -52,6 +52,7 @@ import { useSidebarModel } from "@/components/sidebar/sidebar-model";
 import type { PinnedSidebarGroups } from "@/hooks/use-sidebar-pins";
 import { RetainedPanelActivity } from "@/components/retained-panel";
 import type { SidebarWorkspaceGroup } from "@/components/sidebar/sidebar-labels";
+import type { SidebarProjectWorkspaceRow } from "@/components/sidebar/sidebar-logical-workspaces";
 import type { SidebarProjectIconTarget } from "@/utils/sidebar-project-row-model";
 import { type SidebarGroupMode, useSidebarViewStore } from "@/stores/sidebar-view-store";
 import { useKeyboardShortcutsStore } from "@/stores/keyboard-shortcuts-store";
@@ -87,6 +88,7 @@ interface SidebarSharedProps {
   workspaceGroups: SidebarWorkspaceGroup[];
   projectIconTargets: SidebarProjectIconTarget[];
   pinnedGroups: PinnedSidebarGroups;
+  projectWorkspaceRowsByViewKey: ReadonlyMap<string, SidebarProjectWorkspaceRow[]>;
   projects: SidebarProjectEntry[];
   hasProjectsBeforeFilter: boolean;
   hasActiveProjectFilter: boolean;
@@ -153,6 +155,7 @@ export const LeftSidebar = memo(function LeftSidebar({ active }: { active: boole
     workspaceGroups,
     projectIconTargets,
     pinnedGroups,
+    projectWorkspaceRowsByViewKey,
     collapsedProjectKeys,
     toggleProjectCollapsed,
     groupMode,
@@ -252,6 +255,7 @@ export const LeftSidebar = memo(function LeftSidebar({ active }: { active: boole
     workspaceGroups,
     projectIconTargets,
     pinnedGroups,
+    projectWorkspaceRowsByViewKey,
     projects,
     hasProjectsBeforeFilter,
     hasActiveProjectFilter: resolvedProjectFilters.length > 0,
@@ -608,6 +612,7 @@ function MobileSidebar({
   workspaceGroups,
   projectIconTargets,
   pinnedGroups,
+  projectWorkspaceRowsByViewKey,
   projects,
   hasProjectsBeforeFilter,
   hasActiveProjectFilter,
@@ -728,6 +733,7 @@ function MobileSidebar({
             workspaceGroups={workspaceGroups}
             projectIconTargets={projectIconTargets}
             pinnedGroups={pinnedGroups}
+            projectWorkspaceRowsByViewKey={projectWorkspaceRowsByViewKey}
             projects={projects}
             hasProjectsBeforeFilter={hasProjectsBeforeFilter}
             hasActiveProjectFilter={hasActiveProjectFilter}
@@ -761,6 +767,7 @@ function DesktopSidebar({
   workspaceGroups,
   projectIconTargets,
   pinnedGroups,
+  projectWorkspaceRowsByViewKey,
   projects,
   hasProjectsBeforeFilter,
   hasActiveProjectFilter,
@@ -935,6 +942,7 @@ function DesktopSidebar({
             workspaceGroups={workspaceGroups}
             projectIconTargets={projectIconTargets}
             pinnedGroups={pinnedGroups}
+            projectWorkspaceRowsByViewKey={projectWorkspaceRowsByViewKey}
             projects={projects}
             hasProjectsBeforeFilter={hasProjectsBeforeFilter}
             hasActiveProjectFilter={hasActiveProjectFilter}

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -143,6 +143,7 @@ import { useClearWorkspaceAttention } from "@/hooks/use-clear-workspace-attentio
 import type { PrHint } from "@/git/use-pr-status-query";
 import {
   buildSidebarProjectRowModel,
+  resolveSidebarLogicalWorkspaceAddHostTarget,
   resolveSidebarProjectLocalPath,
   type SidebarProjectHostTarget,
   type SidebarProjectIconTarget,
@@ -1656,6 +1657,51 @@ function LogicalWorkspaceExpansionToggle({
   );
 }
 
+function LogicalWorkspaceAddHostRow({
+  logicalWorkspaceRef,
+  projectName,
+  target,
+  onWorkspacePress,
+}: {
+  logicalWorkspaceRef: string;
+  projectName: string;
+  target: SidebarProjectHostTarget;
+  onWorkspacePress?: () => void;
+}) {
+  const { t } = useTranslation();
+  const handlePress = useCallback(() => {
+    onWorkspacePress?.();
+    router.navigate(
+      buildNewWorkspaceRoute({
+        serverId: target.serverId,
+        sourceDirectory: target.iconWorkingDir,
+        displayName: projectName,
+        projectId: target.projectId,
+        logicalWorkspaceRef,
+      }) as Href,
+    );
+  }, [logicalWorkspaceRef, onWorkspacePress, projectName, target]);
+
+  return (
+    <Pressable
+      accessibilityRole={platformIsWeb ? undefined : "button"}
+      accessibilityLabel={t("sidebar.workspace.actions.addHost")}
+      onPress={handlePress}
+      style={({ hovered = false, pressed }) => [
+        styles.logicalWorkspaceAddHostRow,
+        hovered && !pressed && styles.logicalWorkspaceAddHostRowHovered,
+        pressed && styles.logicalWorkspaceAddHostRowPressed,
+      ]}
+      testID={`sidebar-logical-workspace-add-host-${logicalWorkspaceRef}`}
+    >
+      <ThemedPlus size={14} uniProps={foregroundMutedColorMapping} />
+      <Text style={styles.logicalWorkspaceAddHostText}>
+        {t("sidebar.workspace.actions.addHost")}
+      </Text>
+    </Pressable>
+  );
+}
+
 function WorkspaceRow({
   workspaceEntry,
   hostBadge,
@@ -1897,6 +1943,12 @@ function ProjectBlock({
   const renderLogicalWorkspaceRow = useCallback(
     (row: SidebarProjectLogicalWorkspaceRow) => {
       const expanded = expandedLogicalWorkspaceKeys.has(row.key);
+      const placementServerIds = new Set(row.placements.map((placement) => placement.serverId));
+      const addHostTarget = resolveSidebarLogicalWorkspaceAddHostTarget({
+        project,
+        occupiedServerIds: placementServerIds,
+        supportsMultiplicityByServerId,
+      });
       return (
         <View key={row.key} testID={`sidebar-logical-workspace-${row.logicalWorkspaceRef}`}>
           {renderWorkspaceRow(row.targetPlacement, {
@@ -1909,6 +1961,14 @@ function ProjectBlock({
               logicalWorkspaceKey={row.key}
               logicalWorkspaceRef={row.logicalWorkspaceRef}
               onToggle={toggleLogicalWorkspaceExpanded}
+            />
+          ) : null}
+          {addHostTarget ? (
+            <LogicalWorkspaceAddHostRow
+              logicalWorkspaceRef={row.logicalWorkspaceRef}
+              projectName={project.projectName}
+              target={addHostTarget}
+              onWorkspacePress={onWorkspacePress}
             />
           ) : null}
           {expanded ? (
@@ -1939,7 +1999,10 @@ function ProjectBlock({
       expandedLogicalWorkspaceKeys,
       placementSublabel,
       onWorkspacePress,
+      project.hosts,
+      project.projectName,
       renderWorkspaceRow,
+      supportsMultiplicityByServerId,
       toggleLogicalWorkspaceExpanded,
     ],
   );
@@ -2808,6 +2871,26 @@ const styles = StyleSheet.create((theme) => ({
   workspaceListContainer: {},
   logicalWorkspaceChildren: {
     paddingLeft: theme.spacing[4],
+  },
+  logicalWorkspaceAddHostRow: {
+    minHeight: 26,
+    marginLeft: theme.spacing[6],
+    marginRight: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.md,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+  },
+  logicalWorkspaceAddHostRowHovered: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  logicalWorkspaceAddHostRowPressed: {
+    backgroundColor: theme.colors.surface2,
+  },
+  logicalWorkspaceAddHostText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
   },
   retainedHistoryAgentList: {
     paddingLeft: theme.spacing[6],

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -24,6 +24,7 @@ import {
   type ComponentProps,
   type PropsWithChildren,
 } from "react";
+import { useShallow } from "zustand/shallow";
 import { useTranslation } from "react-i18next";
 import { router, usePathname, type Href } from "expo-router";
 import {
@@ -100,6 +101,12 @@ import type { SidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { SidebarStatusWorkspaceList } from "@/components/sidebar/sidebar-status-list";
 import type { SidebarWorkspaceGroup } from "@/components/sidebar/sidebar-labels";
 import {
+  sidebarStatusPlacementsFromRows,
+  type SidebarProjectLogicalWorkspaceRow,
+  type SidebarProjectWorkspaceRow,
+  type SidebarRetainedAgentSource,
+} from "@/components/sidebar/sidebar-logical-workspaces";
+import {
   SidebarWorkspaceContextMenu,
   SidebarWorkspaceMenu,
 } from "@/components/sidebar/sidebar-workspace-menu";
@@ -159,12 +166,18 @@ import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
 import type { HostBadgeModel } from "@/hosts/appearance";
 import { useHostBadges } from "@/hosts/use-host-badges";
 import { useSidebarRowItems } from "@/components/sidebar/display-preferences/model";
+import { useSessionStore, type Agent } from "@/stores/session-store";
+import { selectRetainedHistoryRootAgents } from "@/components/sidebar/sidebar-retained-history-agents";
+import { getProviderIcon } from "@/components/provider-icons";
+import { navigateToAgent } from "@/utils/navigate-to-agent";
+import { AgentStatusDot } from "@/components/agent-status-dot";
 
 const workspaceKeyExtractor = (workspace: SidebarWorkspacePlacement) => workspace.workspaceKey;
 
 const projectViewKeyExtractor = (project: SidebarProjectEntry) => project.viewKey;
 
 const WORKSPACE_STATUS_DOT_WIDTH = 14;
+const RETAINED_HISTORY_AGENT_ICON_SIZE = 14;
 const ThemedExternalLink = withUnistyles(ExternalLink);
 const ThemedGitPullRequest = withUnistyles(GitPullRequest);
 const ThemedLoadingSpinner = withUnistyles(LoadingSpinner);
@@ -244,6 +257,7 @@ interface SidebarWorkspaceListProps {
   /** What `useProjectIcons` is asked for, straight from the projection. See `SidebarProjection`. */
   projectIconTargets: SidebarProjectIconTarget[];
   pinnedGroups: PinnedSidebarGroups;
+  projectWorkspaceRowsByViewKey: ReadonlyMap<string, SidebarProjectWorkspaceRow[]>;
   projects: SidebarProjectEntry[];
   hasProjectsBeforeFilter: boolean;
   /** Whether a project filter is actually being applied — the resolved list, not the stored one. */
@@ -1530,6 +1544,118 @@ function areWorkspaceRowItemPropsEqual(
 
 const MemoWorkspaceRowItem = memo(WorkspaceRowItem, areWorkspaceRowItemPropsEqual);
 
+function RetainedHistoryAgentRow({
+  agent,
+  serverId,
+  workspaceId,
+  onWorkspacePress,
+}: {
+  agent: Agent;
+  serverId: string;
+  workspaceId: string;
+  onWorkspacePress?: () => void;
+}) {
+  const { t } = useTranslation();
+  const ProviderIcon = getProviderIcon(agent.provider);
+  const handlePress = useCallback(() => {
+    onWorkspacePress?.();
+    navigateToAgent({ serverId, workspaceId, agentId: agent.id, pin: true });
+  }, [agent.id, onWorkspacePress, serverId, workspaceId]);
+  const rowStyle = useCallback(
+    ({ pressed, hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.retainedHistoryAgentRow,
+      hovered && styles.retainedHistoryAgentRowHovered,
+      pressed && styles.workspaceRowPressed,
+    ],
+    [],
+  );
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={rowStyle}
+      testID={`sidebar-retained-history-agent-${serverId}-${agent.id}`}
+    >
+      <View style={styles.retainedHistoryAgentStatus}>
+        <AgentStatusDot
+          status={agent.status}
+          requiresAttention={agent.requiresAttention}
+          attentionReason={agent.attentionReason}
+          pendingPermissionCount={agent.pendingPermissions.length}
+          showInactive
+        />
+      </View>
+      <ProviderIcon
+        size={RETAINED_HISTORY_AGENT_ICON_SIZE}
+        color={styles.retainedHistoryAgentProviderIcon.color}
+      />
+      <Text style={styles.retainedHistoryAgentTitle} numberOfLines={1}>
+        {agent.title || t("agentList.fallbackTitle")}
+      </Text>
+    </Pressable>
+  );
+}
+
+function RetainedHistoryAgentLinks({
+  source,
+  onWorkspacePress,
+}: {
+  source: SidebarRetainedAgentSource;
+  onWorkspacePress?: () => void;
+}) {
+  const agents = useSessionStore(
+    useShallow((state) => {
+      const sessionAgents = state.sessions[source.serverId]?.agents;
+      return sessionAgents
+        ? selectRetainedHistoryRootAgents(sessionAgents, source.workspaceId)
+        : [];
+    }),
+  );
+  if (agents.length === 0) return null;
+
+  return (
+    <View
+      style={styles.retainedHistoryAgentList}
+      testID={`sidebar-retained-history-agents-${source.serverId}-${source.workspaceId}`}
+    >
+      {agents.map((agent) => (
+        <RetainedHistoryAgentRow
+          key={agent.id}
+          agent={agent}
+          serverId={source.serverId}
+          workspaceId={source.workspaceId}
+          onWorkspacePress={onWorkspacePress}
+        />
+      ))}
+    </View>
+  );
+}
+
+function LogicalWorkspaceExpansionToggle({
+  expanded,
+  logicalWorkspaceKey,
+  logicalWorkspaceRef,
+  onToggle,
+}: {
+  expanded: boolean;
+  logicalWorkspaceKey: string;
+  logicalWorkspaceRef: string;
+  onToggle: (logicalWorkspaceKey: string) => void;
+}) {
+  const handlePress = useCallback(
+    () => onToggle(logicalWorkspaceKey),
+    [logicalWorkspaceKey, onToggle],
+  );
+
+  return (
+    <SidebarGroupToggleRow
+      expanded={expanded}
+      onPress={handlePress}
+      testID={`sidebar-logical-workspace-toggle-${logicalWorkspaceRef}`}
+    />
+  );
+}
+
 function WorkspaceRow({
   workspaceEntry,
   hostBadge,
@@ -1593,6 +1719,7 @@ function WorkspaceRow({
 
 function ProjectBlock({
   project,
+  workspaceRows,
   workspaceEntriesByKey,
   collapsed,
   displayName,
@@ -1618,6 +1745,7 @@ function ProjectBlock({
   onToggleWorkspacePin,
 }: {
   project: SidebarProjectEntry;
+  workspaceRows: readonly SidebarProjectWorkspaceRow[];
   workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
   collapsed: boolean;
   displayName: string;
@@ -1643,11 +1771,19 @@ function ProjectBlock({
   onToggleWorkspacePin: ToggleSidebarWorkspacePin;
 }) {
   const {
-    visibleItems: visibleWorkspaces,
+    visibleItems: visibleWorkspaceRows,
     expanded: workspacesExpanded,
     canToggle: canToggleWorkspaces,
     toggleExpanded: toggleWorkspacesExpanded,
-  } = useLimitedSidebarGroup(project.workspaces);
+  } = useLimitedSidebarGroup(workspaceRows);
+  const [expandedLogicalWorkspaceKeys, setExpandedLogicalWorkspaceKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const hasLogicalWorkspaceRows = workspaceRows.some((row) => row.kind === "logical");
+  const visiblePhysicalWorkspaces = useMemo(
+    () => visibleWorkspaceRows.flatMap((row) => (row.kind === "physical" ? [row.placement] : [])),
+    [visibleWorkspaceRows],
+  );
   const rowModel = useMemo(
     () =>
       buildSidebarProjectRowModel({
@@ -1657,11 +1793,15 @@ function ProjectBlock({
       }),
     [collapsed, project, supportsMultiplicityByServerId],
   );
+  const statusPlacements = useMemo(
+    () => sidebarStatusPlacementsFromRows(workspaceRows),
+    [workspaceRows],
+  );
 
   // Collapsed rows hide their workspace rows, so the project row carries the most urgent
   // status among them; expanded rows leave the signal to the child rows themselves.
   const aggregateStatusBucket = useSidebarProjectStatusBucket({
-    workspaces: project.workspaces,
+    workspaces: statusPlacements,
     enabled: collapsed,
   });
 
@@ -1678,17 +1818,23 @@ function ProjectBlock({
         drag?: () => void;
         isDragging?: boolean;
         dragHandleProps?: DraggableListDragHandleProps;
+        workspaceEntry?: SidebarWorkspaceEntry | null;
+        canPin?: boolean;
+        leadingProjectName?: string | null;
       },
     ) => {
       return (
         <MemoWorkspaceRowItem
           workspace={item}
-          workspaceEntry={workspaceEntriesByKey.get(item.workspaceKey) ?? null}
+          workspaceEntry={
+            input?.workspaceEntry ?? workspaceEntriesByKey.get(item.workspaceKey) ?? null
+          }
           hostBadge={hostBadgeByServerId.get(item.serverId) ?? null}
+          leadingProjectName={input?.leadingProjectName}
           shortcutNumber={shortcutIndexByWorkspaceKey.get(item.workspaceKey) ?? null}
           showShortcutBadge={showShortcutBadges}
           canCopyBranchName={project.projectKind === "git"}
-          canPin={supportsPinningByServerId.get(item.serverId) === true}
+          canPin={input?.canPin ?? supportsPinningByServerId.get(item.serverId) === true}
           onToggleWorkspacePin={onToggleWorkspacePin}
           isCreating={creatingWorkspaceIds.has(item.workspaceId)}
           selectionEnabled={selectionEnabled}
@@ -1729,6 +1875,83 @@ function ProjectBlock({
       });
     },
     [renderWorkspaceRow],
+  );
+
+  const toggleLogicalWorkspaceExpanded = useCallback((logicalWorkspaceKey: string) => {
+    setExpandedLogicalWorkspaceKeys((current) => {
+      const next = new Set(current);
+      if (next.has(logicalWorkspaceKey)) next.delete(logicalWorkspaceKey);
+      else next.add(logicalWorkspaceKey);
+      return next;
+    });
+  }, []);
+
+  const placementSublabel = useCallback(
+    (placement: SidebarWorkspacePlacement) => {
+      const host = hostBadgeByServerId.get(placement.serverId)?.label ?? placement.serverId;
+      return `${host} · ${placement.workspaceId}`;
+    },
+    [hostBadgeByServerId],
+  );
+
+  const renderLogicalWorkspaceRow = useCallback(
+    (row: SidebarProjectLogicalWorkspaceRow) => {
+      const expanded = expandedLogicalWorkspaceKeys.has(row.key);
+      return (
+        <View key={row.key} testID={`sidebar-logical-workspace-${row.logicalWorkspaceRef}`}>
+          {renderWorkspaceRow(row.targetPlacement, {
+            workspaceEntry: row.displayEntry,
+            canPin: false,
+          })}
+          {row.placements.length > 1 ? (
+            <LogicalWorkspaceExpansionToggle
+              expanded={expanded}
+              logicalWorkspaceKey={row.key}
+              logicalWorkspaceRef={row.logicalWorkspaceRef}
+              onToggle={toggleLogicalWorkspaceExpanded}
+            />
+          ) : null}
+          {expanded ? (
+            <View
+              testID={`sidebar-logical-workspace-placements-${row.logicalWorkspaceRef}`}
+              style={styles.logicalWorkspaceChildren}
+            >
+              {row.placements.map((placement) => (
+                <View key={placement.workspaceKey}>
+                  {renderWorkspaceRow(placement, {
+                    leadingProjectName: placementSublabel(placement),
+                  })}
+                </View>
+              ))}
+            </View>
+          ) : null}
+          {row.retainedAgentSources.map((source) => (
+            <RetainedHistoryAgentLinks
+              key={`${source.serverId}:${source.workspaceId}`}
+              source={source}
+              onWorkspacePress={onWorkspacePress}
+            />
+          ))}
+        </View>
+      );
+    },
+    [
+      expandedLogicalWorkspaceKeys,
+      placementSublabel,
+      onWorkspacePress,
+      renderWorkspaceRow,
+      toggleLogicalWorkspaceExpanded,
+    ],
+  );
+
+  const renderProjectedWorkspaceRow = useCallback(
+    (row: SidebarProjectWorkspaceRow) =>
+      row.kind === "logical" ? (
+        renderLogicalWorkspaceRow(row)
+      ) : (
+        <View key={row.key}>{renderWorkspaceRow(row.placement)}</View>
+      ),
+    [renderLogicalWorkspaceRow, renderWorkspaceRow],
   );
 
   const handleWorkspaceDragEnd = useCallback(
@@ -1800,23 +2023,32 @@ function ProjectBlock({
 
   let projectChildren = null;
   if (!collapsed) {
-    if (project.workspaces.length > 0) {
+    if (workspaceRows.length > 0) {
       projectChildren = (
         <>
-          <DraggableList
-            testID={`sidebar-workspace-list-${project.viewKey}`}
-            data={visibleWorkspaces}
-            keyExtractor={workspaceKeyExtractor}
-            renderItem={renderWorkspace}
-            onDragEnd={handleWorkspaceDragEnd}
-            extraData={activeWorkspaceSelectionKey(activeWorkspaceSelection)}
-            scrollEnabled={false}
-            useDragHandle
-            nestable={useNestable}
-            simultaneousGestureRef={parentGestureRef}
-            gestureHostPresented={dragGestureHostPresented}
-            containerStyle={styles.workspaceListContainer}
-          />
+          {hasLogicalWorkspaceRows ? (
+            <View
+              testID={`sidebar-logical-workspace-list-${project.viewKey}`}
+              style={styles.workspaceListContainer}
+            >
+              {visibleWorkspaceRows.map(renderProjectedWorkspaceRow)}
+            </View>
+          ) : (
+            <DraggableList
+              testID={`sidebar-workspace-list-${project.viewKey}`}
+              data={visiblePhysicalWorkspaces}
+              keyExtractor={workspaceKeyExtractor}
+              renderItem={renderWorkspace}
+              onDragEnd={handleWorkspaceDragEnd}
+              extraData={activeWorkspaceSelectionKey(activeWorkspaceSelection)}
+              scrollEnabled={false}
+              useDragHandle
+              nestable={useNestable}
+              simultaneousGestureRef={parentGestureRef}
+              gestureHostPresented={dragGestureHostPresented}
+              containerStyle={styles.workspaceListContainer}
+            />
+          )}
           {canToggleWorkspaces ? (
             <SidebarGroupToggleRow
               expanded={workspacesExpanded}
@@ -1878,6 +2110,7 @@ type ProjectBlockProps = Parameters<typeof ProjectBlock>[0];
 function areProjectBlockPropsEqual(previous: ProjectBlockProps, next: ProjectBlockProps): boolean {
   return (
     previous.project === next.project &&
+    previous.workspaceRows === next.workspaceRows &&
     previous.workspaceEntriesByKey === next.workspaceEntriesByKey &&
     previous.collapsed === next.collapsed &&
     previous.displayName === next.displayName &&
@@ -1936,6 +2169,7 @@ export function SidebarWorkspaceList({
   workspaceGroups,
   projectIconTargets,
   pinnedGroups,
+  projectWorkspaceRowsByViewKey,
   projects,
   hasProjectsBeforeFilter,
   hasActiveProjectFilter,
@@ -2034,6 +2268,7 @@ export function SidebarWorkspaceList({
       <ProjectModeList
         projects={projects}
         pinnedGroups={pinnedGroups}
+        projectWorkspaceRowsByViewKey={projectWorkspaceRowsByViewKey}
         workspaceEntriesByKey={workspaceEntriesByKey}
         projectIconByProjectViewKey={projectIconByProjectViewKey}
         collapsedProjectKeys={collapsedProjectKeys}
@@ -2129,6 +2364,7 @@ function SidebarGroupedModeList({
 function ProjectModeList({
   projects,
   pinnedGroups,
+  projectWorkspaceRowsByViewKey,
   workspaceEntriesByKey,
   projectIconByProjectViewKey,
   collapsedProjectKeys,
@@ -2342,6 +2578,7 @@ function ProjectModeList({
         <MemoProjectBlock
           key={item.viewKey}
           project={item}
+          workspaceRows={projectWorkspaceRowsByViewKey.get(item.viewKey) ?? []}
           workspaceEntriesByKey={workspaceEntriesByKey}
           collapsed={collapsedProjectKeys.has(item.viewKey)}
           displayName={item.projectName}
@@ -2382,6 +2619,7 @@ function ProjectModeList({
       parentGestureRef,
       dragGestureHostPresented,
       projectIconByProjectViewKey,
+      projectWorkspaceRowsByViewKey,
       selectionEnabled,
       shortcutIndexByWorkspaceKey,
       showShortcutBadges,
@@ -2568,6 +2806,36 @@ const styles = StyleSheet.create((theme) => ({
     paddingBottom: theme.spacing[3],
   },
   workspaceListContainer: {},
+  logicalWorkspaceChildren: {
+    paddingLeft: theme.spacing[4],
+  },
+  retainedHistoryAgentList: {
+    paddingLeft: theme.spacing[6],
+  },
+  retainedHistoryAgentRow: {
+    minHeight: 30,
+    marginBottom: theme.spacing[0.5],
+    paddingHorizontal: theme.spacing[3],
+    borderRadius: theme.borderRadius.lg,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  retainedHistoryAgentRowHovered: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  retainedHistoryAgentStatus: {
+    width: theme.iconSize.sm,
+    alignItems: "center",
+  },
+  retainedHistoryAgentProviderIcon: {
+    color: theme.colors.foregroundMuted,
+  },
+  retainedHistoryAgentTitle: {
+    flex: 1,
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
   // Kept in step with `workspaceRow` above. It stands in a project's list where a workspace row
   // would be, so it takes that row's geometry and both of its fills.
   //

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -1947,7 +1947,7 @@ function ProjectBlock({
       const addHostTarget = resolveSidebarLogicalWorkspaceAddHostTarget({
         project,
         occupiedServerIds: placementServerIds,
-        ...(row.groupingServerIds ? { allowedServerIds: new Set(row.groupingServerIds) } : {}),
+        allowedServerIds: new Set(row.creationServerIds),
         supportsMultiplicityByServerId,
       });
       return (

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -1947,6 +1947,7 @@ function ProjectBlock({
       const addHostTarget = resolveSidebarLogicalWorkspaceAddHostTarget({
         project,
         occupiedServerIds: placementServerIds,
+        ...(row.groupingServerIds ? { allowedServerIds: new Set(row.groupingServerIds) } : {}),
         supportsMultiplicityByServerId,
       });
       return (

--- a/packages/app/src/components/sidebar/sidebar-labels.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-labels.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { encodeLogicalWorkspaceRefLabel } from "@getpaseo/protocol/workspace-labels";
 import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
 import { SIDEBAR_UNLABELLED_LABEL_KEY } from "@/stores/sidebar-view-store";
 import { filterWorkspacesByLabels } from "./sidebar-labels";
@@ -65,5 +66,23 @@ describe("sidebar label filtering", () => {
         labels: [SIDEBAR_UNLABELLED_LABEL_KEY],
       }).map((entry) => entry.workspaceId),
     ).toEqual(["blank"]);
+  });
+
+  test("treats reserved-only assignments as unlabelled and never matches them as a user filter", () => {
+    const reserved = encodeLogicalWorkspaceRefLabel("project-a-catalog");
+    const reservedOnly = workspace("reserved", [reserved]);
+
+    expect(
+      filterWorkspacesByLabels({
+        workspaces: [reservedOnly],
+        labels: [SIDEBAR_UNLABELLED_LABEL_KEY],
+      }).map((entry) => entry.workspaceId),
+    ).toEqual(["reserved"]);
+    expect(
+      filterWorkspacesByLabels({
+        workspaces: [reservedOnly],
+        labels: [reserved],
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/app/src/components/sidebar/sidebar-labels.ts
+++ b/packages/app/src/components/sidebar/sidebar-labels.ts
@@ -1,4 +1,4 @@
-import { workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
+import { isReservedWorkspaceLabel, workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
 import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
 import { SIDEBAR_UNLABELLED_LABEL_KEY, type SidebarLabelFilter } from "@/stores/sidebar-view-store";
 import type { StatusBucket, StatusGroup } from "@/hooks/sidebar-status-view-model";
@@ -31,12 +31,19 @@ export function filterWorkspacesByLabels(
 ): SidebarWorkspaceEntry[] {
   const { workspaces, labels } = input;
   if (labels.length === 0) return [...workspaces];
+  const userFilterLabels = labels.filter((label) => !isReservedWorkspaceLabel(label));
+  if (userFilterLabels.length === 0) return [];
   return workspaces.filter((workspace) => {
     // Whitespace-only names normalize away, so `size === 0` is exactly "carries no real label"
     // and the empty key can only ever mean Unlabelled.
-    const keys = new Set((workspace.labels ?? []).map(workspaceLabelKey).filter(Boolean));
+    const keys = new Set(
+      (workspace.labels ?? [])
+        .filter((label) => !isReservedWorkspaceLabel(label))
+        .map(workspaceLabelKey)
+        .filter(Boolean),
+    );
     const matches = (key: string) =>
       key === SIDEBAR_UNLABELLED_LABEL_KEY ? keys.size === 0 : keys.has(key);
-    return labels.some(matches);
+    return userFilterLabels.some(matches);
   });
 }

--- a/packages/app/src/components/sidebar/sidebar-logical-workspaces.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-logical-workspaces.test.ts
@@ -159,20 +159,30 @@ describe("logical workspace sidebar projection", () => {
     ).toEqual([projectB.workspaceKey]);
   });
 
-  it("carries the contributing plugin host namespace onto the logical row", () => {
+  it("allows creation only on project hosts with exactly the row's grouping namespace", () => {
     const member = placement({ id: "member", serverId: "host-a" });
+    const nativeProject = project("project-a", [member]);
+    nativeProject.hosts.push({
+      serverId: "host-b",
+      projectId: "project-a-host-b",
+      iconWorkingDir: "/projects/project-a",
+      worktreeSupport: "supported",
+    });
     const projection = buildSidebarLogicalWorkspaceProjection({
-      projects: [project("project-a", [member])],
+      projects: [nativeProject],
       workspaceEntriesByKey: new Map([
         [member.workspaceKey, entry(member, { ref: "project-a-catalog" })],
       ]),
-      groupings: [{ ...GROUPING, serverIds: ["host-a", "host-b"] }],
+      groupings: [
+        { ...GROUPING, serverIds: ["host-a", "host-b"] },
+        { ...GROUPING, key: "other/sidebar-workspace-grouping/main", serverIds: ["host-b"] },
+      ],
       activeWorkspaceSelection: null,
     });
 
     expect(
-      logicalRows(projection.rowsByProjectViewKey.get("project-a"))[0]?.groupingServerIds,
-    ).toEqual(["host-a", "host-b"]);
+      logicalRows(projection.rowsByProjectViewKey.get("project-a"))[0]?.creationServerIds,
+    ).toEqual(["host-a"]);
   });
 
   it("applies a host contribution only to native workspaces on that installed host", () => {

--- a/packages/app/src/components/sidebar/sidebar-logical-workspaces.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-logical-workspaces.test.ts
@@ -1,0 +1,511 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+  encodeLogicalWorkspaceRefLabel,
+} from "@getpaseo/protocol/workspace-labels";
+import type {
+  SidebarProjectEntry,
+  SidebarWorkspaceEntry,
+  SidebarWorkspacePlacement,
+} from "@/hooks/use-sidebar-workspaces-list";
+import {
+  buildSidebarLogicalWorkspaceProjection,
+  sidebarStatusPlacementsFromRows,
+  type SidebarLogicalWorkspaceGrouping,
+  type SidebarProjectLogicalWorkspaceRow,
+} from "./sidebar-logical-workspaces";
+
+const GROUPING: SidebarLogicalWorkspaceGrouping = {
+  key: "paseo-layout/sidebar-workspace-grouping/logical-workspaces",
+  logicalWorkspaceRefLabelPrefix: LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+  defaultPlacementLabel: DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+};
+
+function placement(input: {
+  id: string;
+  serverId?: string;
+  projectViewKey?: string;
+  name?: string;
+}): SidebarWorkspacePlacement {
+  const serverId = input.serverId ?? "host-a";
+  const projectViewKey = input.projectViewKey ?? "project-a";
+  return {
+    workspaceKey: `${serverId}:${input.id}`,
+    serverId,
+    workspaceId: input.id,
+    projectViewKey,
+    projectName: projectViewKey,
+    projectRootPath: `/projects/${projectViewKey}`,
+    workspaceDirectory: `/projects/${input.id}`,
+    projectKind: "git",
+    workspaceKind: "worktree",
+    name: input.name ?? input.id,
+  };
+}
+
+function entry(
+  value: SidebarWorkspacePlacement,
+  input: {
+    ref?: string;
+    labels?: string[];
+    isDefault?: boolean;
+    title?: string | null;
+    status?: SidebarWorkspaceEntry["statusBucket"];
+    statusEnteredAt?: string | null;
+  } = {},
+): SidebarWorkspaceEntry {
+  const labels = [
+    ...(input.labels ?? []),
+    ...(input.ref ? [encodeLogicalWorkspaceRefLabel(input.ref)] : []),
+    ...(input.isDefault ? [DEFAULT_WORKSPACE_PLACEMENT_LABEL] : []),
+  ];
+  return {
+    ...value,
+    workspaceDirectory: value.workspaceDirectory ?? `/projects/${value.workspaceId}`,
+    workspaceDirectoryLabel: value.workspaceId,
+    title: input.title ?? null,
+    pinnedAt: null,
+    labels,
+    currentBranch: "main",
+    statusBucket: input.status ?? "done",
+    statusEnteredAt: input.statusEnteredAt ? new Date(input.statusEnteredAt) : null,
+    archivingAt: null,
+    diffStat: null,
+    prHint: null,
+    archiveHasUncommittedChanges: null,
+    archiveUnpushedCommitCount: null,
+    scripts: [],
+    hasRunningScripts: false,
+  };
+}
+
+function project(viewKey: string, workspaces: SidebarWorkspacePlacement[]): SidebarProjectEntry {
+  const hosts = [...new Set(workspaces.map((workspace) => workspace.serverId))].map((serverId) => ({
+    serverId,
+    projectId: `${viewKey}-${serverId}`,
+    iconWorkingDir: `/projects/${viewKey}`,
+    worktreeSupport: "supported" as const,
+  }));
+  return {
+    viewKey,
+    projectName: viewKey,
+    projectKind: "git",
+    iconWorkingDir: `/projects/${viewKey}`,
+    hosts,
+    workspaces,
+  };
+}
+
+function fixtureServerId(physicalRef: string, index: number): string {
+  return `${physicalRef.split("-")[0]}-host-${index + 1}`;
+}
+
+function logicalRows(
+  rows: readonly (SidebarProjectLogicalWorkspaceRow | { kind: "physical" })[] | undefined,
+): SidebarProjectLogicalWorkspaceRow[] {
+  return (rows ?? []).filter(
+    (row): row is SidebarProjectLogicalWorkspaceRow => row.kind === "logical",
+  );
+}
+
+describe("logical workspace sidebar projection", () => {
+  it("fails open to the exact native rows when the plugin contribution is absent", () => {
+    const first = placement({ id: "first" });
+    const second = placement({ id: "second" });
+    const nativeProject = project("project-a", [first, second]);
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [nativeProject],
+      workspaceEntriesByKey: new Map([
+        [first.workspaceKey, entry(first, { ref: "project-a-catalog" })],
+        [second.workspaceKey, entry(second, { ref: "project-a-catalog" })],
+      ]),
+      groupings: [],
+      activeWorkspaceSelection: null,
+    });
+
+    const rows = projection.rowsByProjectViewKey.get("project-a");
+    expect(rows).toEqual([
+      { kind: "physical", key: first.workspaceKey, placement: first },
+      { kind: "physical", key: second.workspaceKey, placement: second },
+    ]);
+    expect(projection.managedWorkspaceKeys).toEqual(new Set());
+  });
+
+  it("groups only inside each native projectKey projection", () => {
+    const projectA = placement({ id: "project-a", projectViewKey: "project-a" });
+    const projectB = placement({ id: "project-b", projectViewKey: "project-b" });
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [project("project-a", [projectA]), project("project-b", [projectB])],
+      workspaceEntriesByKey: new Map([
+        [projectA.workspaceKey, entry(projectA, { ref: "shared-ref" })],
+        [projectB.workspaceKey, entry(projectB, { ref: "shared-ref" })],
+      ]),
+      groupings: [GROUPING],
+      activeWorkspaceSelection: null,
+    });
+
+    expect(logicalRows(projection.rowsByProjectViewKey.get("project-a"))).toHaveLength(1);
+    expect(logicalRows(projection.rowsByProjectViewKey.get("project-b"))).toHaveLength(1);
+    expect(
+      logicalRows(projection.rowsByProjectViewKey.get("project-a"))[0]?.placements.map(
+        (item) => item.workspaceKey,
+      ),
+    ).toEqual([projectA.workspaceKey]);
+    expect(
+      logicalRows(projection.rowsByProjectViewKey.get("project-b"))[0]?.placements.map(
+        (item) => item.workspaceKey,
+      ),
+    ).toEqual([projectB.workspaceKey]);
+  });
+
+  it("applies a host contribution only to native workspaces on that installed host", () => {
+    const mac = placement({ id: "mac", serverId: "host-a" });
+    const remote = placement({ id: "remote", serverId: "host-b" });
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [project("project-a", [mac, remote])],
+      workspaceEntriesByKey: new Map([
+        [mac.workspaceKey, entry(mac, { ref: "project-a-catalog" })],
+        [remote.workspaceKey, entry(remote, { ref: "project-a-catalog" })],
+      ]),
+      groupings: [{ ...GROUPING, serverIds: ["host-b"] }],
+      activeWorkspaceSelection: null,
+    });
+
+    expect(projection.rowsByProjectViewKey.get("project-a")).toMatchObject([
+      { kind: "physical", placement: { workspaceId: "mac" } },
+      { kind: "logical", placements: [{ workspaceId: "remote" }] },
+    ]);
+  });
+
+  it("keeps disjoint contribution namespaces active at the same time", () => {
+    const mac = placement({ id: "mac", serverId: "host-a" });
+    const remote = placement({ id: "remote", serverId: "host-b" });
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [project("project-a", [mac, remote])],
+      workspaceEntriesByKey: new Map([
+        [mac.workspaceKey, entry(mac, { ref: "project-a-catalog" })],
+        [remote.workspaceKey, entry(remote, { ref: "project-a-catalog" })],
+      ]),
+      groupings: [
+        { ...GROUPING, key: "layout-a/grouping/main", serverIds: ["host-a"] },
+        { ...GROUPING, key: "layout-b/grouping/main", serverIds: ["host-b"] },
+      ],
+      activeWorkspaceSelection: null,
+    });
+
+    expect(logicalRows(projection.rowsByProjectViewKey.get("project-a"))).toMatchObject([
+      { groupingKey: "layout-a/grouping/main", placements: [{ workspaceId: "mac" }] },
+      { groupingKey: "layout-b/grouping/main", placements: [{ workspaceId: "remote" }] },
+    ]);
+  });
+
+  it("fails open only the native identity claimed by two grouping namespaces", () => {
+    const mac = placement({ id: "mac", serverId: "host-a" });
+    const remote = placement({ id: "remote", serverId: "host-b" });
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [project("project-a", [mac, remote])],
+      workspaceEntriesByKey: new Map([
+        [mac.workspaceKey, entry(mac, { ref: "project-a-catalog" })],
+        [remote.workspaceKey, entry(remote, { ref: "project-a-catalog" })],
+      ]),
+      groupings: [
+        {
+          ...GROUPING,
+          key: "layout-a/grouping/main",
+          serverIds: ["host-a", "host-b"],
+        },
+        { ...GROUPING, key: "layout-b/grouping/main", serverIds: ["host-a"] },
+      ],
+      activeWorkspaceSelection: null,
+    });
+
+    expect(projection.rowsByProjectViewKey.get("project-a")).toMatchObject([
+      { kind: "physical", placement: { workspaceId: "mac" } },
+      {
+        kind: "logical",
+        groupingKey: "layout-a/grouping/main",
+        placements: [{ workspaceId: "remote" }],
+      },
+    ]);
+  });
+
+  it("chooses active, then default, then the deterministic newest remainder", () => {
+    const olderDefault = placement({ id: "a-default", serverId: "host-a" });
+    const newerActive = placement({ id: "b-active", serverId: "host-b" });
+    const entries = new Map([
+      [
+        olderDefault.workspaceKey,
+        entry(olderDefault, {
+          ref: "project-a-catalog",
+          isDefault: true,
+          statusEnteredAt: "2026-08-20T10:00:00.000Z",
+        }),
+      ],
+      [
+        newerActive.workspaceKey,
+        entry(newerActive, {
+          ref: "project-a-catalog",
+          statusEnteredAt: "2026-08-21T10:00:00.000Z",
+        }),
+      ],
+    ]);
+    const nativeProject = project("project-a", [olderDefault, newerActive]);
+    const build = (activeWorkspaceSelection: { serverId: string; workspaceId: string } | null) =>
+      logicalRows(
+        buildSidebarLogicalWorkspaceProjection({
+          projects: [nativeProject],
+          workspaceEntriesByKey: entries,
+          groupings: [GROUPING],
+          activeWorkspaceSelection,
+        }).rowsByProjectViewKey.get("project-a"),
+      )[0];
+
+    expect(
+      build({ serverId: newerActive.serverId, workspaceId: newerActive.workspaceId })
+        ?.targetPlacement.workspaceKey,
+    ).toBe(newerActive.workspaceKey);
+    expect(build(null)?.targetPlacement.workspaceKey).toBe(olderDefault.workspaceKey);
+
+    entries.set(
+      olderDefault.workspaceKey,
+      entry(olderDefault, {
+        ref: "project-a-catalog",
+        statusEnteredAt: "2026-08-20T10:00:00.000Z",
+      }),
+    );
+    expect(build(null)?.targetPlacement.workspaceKey).toBe(newerActive.workspaceKey);
+  });
+
+  it("deduplicates aliases by native identity while preserving distinct same-host placements", () => {
+    const first = placement({ id: "project-a-catalog-host-b-history-a", serverId: "host-b" });
+    const firstAlias = {
+      ...first,
+      workspaceKey: `${first.workspaceKey}:duplicate-alias`,
+    };
+    const second = placement({ id: "project-a-catalog-host-b-history-b", serverId: "host-b" });
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [project("project-a", [first, firstAlias, second])],
+      workspaceEntriesByKey: new Map([
+        [
+          first.workspaceKey,
+          entry(first, {
+            ref: "project-a-catalog",
+            title: "Części i katalogi",
+            status: "running",
+          }),
+        ],
+        [
+          firstAlias.workspaceKey,
+          entry(firstAlias, {
+            ref: "project-a-catalog",
+            title: "Części i katalogi",
+            status: "running",
+          }),
+        ],
+        [
+          second.workspaceKey,
+          entry(second, {
+            ref: "project-a-catalog",
+            isDefault: true,
+            title: "Części i katalogi",
+            status: "failed",
+          }),
+        ],
+      ]),
+      groupings: [GROUPING],
+      activeWorkspaceSelection: null,
+    });
+    const row = logicalRows(projection.rowsByProjectViewKey.get("project-a"))[0];
+
+    expect(row?.title).toBe("Części i katalogi");
+    expect(row?.displayEntry.statusBucket).toBe("failed");
+    expect(row?.targetPlacement.workspaceKey).toBe(second.workspaceKey);
+    expect(row?.placements.map((item) => item.workspaceKey)).toEqual([
+      first.workspaceKey,
+      second.workspaceKey,
+    ]);
+    expect(row?.placements.map((item) => item.workspaceId)).toEqual([
+      "project-a-catalog-host-b-history-a",
+      "project-a-catalog-host-b-history-b",
+    ]);
+    expect(projection.managedWorkspaceKeys).toEqual(
+      new Set([first.workspaceKey, firstAlias.workspaceKey, second.workspaceKey]),
+    );
+    expect(projection.rowsByProjectViewKey.get("project-a")).toHaveLength(1);
+  });
+
+  it("attaches a retained-live native workspace as history without making it a placement", () => {
+    const live = placement({ id: "wks_live_catalog", serverId: "host-b" });
+    const retained = placement({ id: "wks_retained_history", serverId: "host-b" });
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [project("project-a", [live, retained])],
+      workspaceEntriesByKey: new Map([
+        [
+          live.workspaceKey,
+          entry(live, {
+            ref: "project-a-catalog",
+            isDefault: true,
+            title: "Części i katalogi",
+            status: "done",
+          }),
+        ],
+        [
+          retained.workspaceKey,
+          entry(retained, {
+            title: "Części i katalogi",
+            status: "running",
+          }),
+        ],
+      ]),
+      groupings: [
+        {
+          ...GROUPING,
+          retainedHistoryBindings: [
+            {
+              serverId: "host-b",
+              workspaceId: retained.workspaceId,
+              physicalWorkspaceRef: "project-a-catalog-host-b",
+              logicalWorkspaceRef: "project-a-catalog",
+            },
+          ],
+        },
+      ],
+      activeWorkspaceSelection: null,
+    });
+    const rows = projection.rowsByProjectViewKey.get("project-a");
+    const row = logicalRows(rows)[0];
+
+    expect(rows).toHaveLength(1);
+    expect(row?.placements.map((item) => item.workspaceId)).toEqual([live.workspaceId]);
+    expect(row?.retainedAgentSources.map((item) => item.workspaceId)).toEqual([
+      retained.workspaceId,
+    ]);
+    expect(row?.targetPlacement.workspaceId).toBe(live.workspaceId);
+    expect(row?.statusBucket).toBe("done");
+    expect(projection.managedWorkspaceKeys).toEqual(
+      new Set([live.workspaceKey, retained.workspaceKey]),
+    );
+    expect(projection.retainedHistoryWorkspaceKeys).toEqual(new Set([retained.workspaceKey]));
+    expect(sidebarStatusPlacementsFromRows(rows ?? []).map((item) => item.workspaceId)).toEqual([
+      live.workspaceId,
+    ]);
+  });
+
+  it("fails open for a retained-history binding without a matching live logical workspace", () => {
+    const retained = placement({ id: "retained-only", serverId: "host-b" });
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [project("project-a", [retained])],
+      workspaceEntriesByKey: new Map([[retained.workspaceKey, entry(retained)]]),
+      groupings: [
+        {
+          ...GROUPING,
+          retainedHistoryBindings: [
+            {
+              serverId: "host-b",
+              workspaceId: retained.workspaceId,
+              physicalWorkspaceRef: "project-a-catalog-host-b",
+              logicalWorkspaceRef: "project-a-catalog",
+            },
+          ],
+        },
+      ],
+      activeWorkspaceSelection: null,
+    });
+
+    expect(projection.rowsByProjectViewKey.get("project-a")).toEqual([
+      { kind: "physical", key: retained.workspaceKey, placement: retained },
+    ]);
+    expect(projection.managedWorkspaceKeys).toEqual(new Set());
+    expect(projection.retainedHistoryWorkspaceKeys).toEqual(new Set());
+  });
+
+  it("keeps malformed, conflicting, and not-yet-hydrated placements native", () => {
+    const conflict = placement({ id: "conflict" });
+    const malformed = placement({ id: "malformed" });
+    const missing = placement({ id: "missing" });
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [project("project-a", [conflict, malformed, missing])],
+      workspaceEntriesByKey: new Map([
+        [
+          conflict.workspaceKey,
+          entry(conflict, {
+            labels: [
+              encodeLogicalWorkspaceRefLabel("project-a-catalog"),
+              encodeLogicalWorkspaceRefLabel("project-a-diagnostics"),
+            ],
+          }),
+        ],
+        [
+          malformed.workspaceKey,
+          entry(malformed, {
+            labels: ["paseo:reserved:v1:logical-workspace-ref=bad/ref"],
+          }),
+        ],
+      ]),
+      groupings: [GROUPING],
+      activeWorkspaceSelection: null,
+    });
+
+    expect(projection.rowsByProjectViewKey.get("project-a")).toEqual([
+      { kind: "physical", key: conflict.workspaceKey, placement: conflict },
+      { kind: "physical", key: malformed.workspaceKey, placement: malformed },
+      { kind: "physical", key: missing.workspaceKey, placement: missing },
+    ]);
+    expect(projection.managedWorkspaceKeys.size).toBe(0);
+  });
+
+  it("projects a 31 logical / 45 physical inventory without loss", () => {
+    const logicalFixture: Array<readonly [string, readonly string[]]> = [];
+    for (let logicalIndex = 0; logicalIndex < 31; logicalIndex += 1) {
+      const logicalRef = `project-${Math.floor(logicalIndex / 10) + 1}-workspace-${logicalIndex + 1}`;
+      let physicalCount = 1;
+      if (logicalIndex === 0) {
+        physicalCount = 3;
+      } else if (logicalIndex <= 12) {
+        physicalCount = 2;
+      }
+      const physicalRefs = [logicalRef];
+      for (let placementIndex = 1; placementIndex < physicalCount; placementIndex += 1) {
+        physicalRefs.push(`${logicalRef}-host-${placementIndex + 1}`);
+      }
+      logicalFixture.push([logicalRef, physicalRefs]);
+    }
+    const projectsByViewKey = new Map<string, SidebarWorkspacePlacement[]>();
+    const entries = new Map<string, SidebarWorkspaceEntry>();
+    for (const [logicalRef, physicalRefs] of logicalFixture) {
+      const viewKey = logicalRef.split("-")[0] ?? "unknown";
+      const projectPlacements = projectsByViewKey.get(viewKey) ?? [];
+      physicalRefs.forEach((physicalRef, index) => {
+        const value = placement({
+          id: physicalRef,
+          serverId: fixtureServerId(physicalRef, index),
+          projectViewKey: viewKey,
+        });
+        projectPlacements.push(value);
+        entries.set(value.workspaceKey, entry(value, { ref: logicalRef, isDefault: index === 0 }));
+      });
+      projectsByViewKey.set(viewKey, projectPlacements);
+    }
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [...projectsByViewKey].map(([viewKey, workspaces]) => project(viewKey, workspaces)),
+      workspaceEntriesByKey: entries,
+      groupings: [GROUPING],
+      activeWorkspaceSelection: null,
+    });
+    const projectedLogicalRows = [...projection.rowsByProjectViewKey.values()].flatMap(logicalRows);
+    const projectedPhysicalKeys: string[] = [];
+    for (const row of projectedLogicalRows) {
+      for (const item of row.placements) {
+        projectedPhysicalKeys.push(item.workspaceKey);
+      }
+    }
+
+    expect(logicalFixture).toHaveLength(31);
+    expect([...entries]).toHaveLength(45);
+    expect(projectedLogicalRows).toHaveLength(31);
+    expect(new Set(projectedPhysicalKeys).size).toBe(45);
+    expect(new Set(projectedPhysicalKeys)).toEqual(new Set(entries.keys()));
+    expect(projection.managedWorkspaceKeys).toEqual(new Set(entries.keys()));
+  });
+});

--- a/packages/app/src/components/sidebar/sidebar-logical-workspaces.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-logical-workspaces.test.ts
@@ -159,6 +159,22 @@ describe("logical workspace sidebar projection", () => {
     ).toEqual([projectB.workspaceKey]);
   });
 
+  it("carries the contributing plugin host namespace onto the logical row", () => {
+    const member = placement({ id: "member", serverId: "host-a" });
+    const projection = buildSidebarLogicalWorkspaceProjection({
+      projects: [project("project-a", [member])],
+      workspaceEntriesByKey: new Map([
+        [member.workspaceKey, entry(member, { ref: "project-a-catalog" })],
+      ]),
+      groupings: [{ ...GROUPING, serverIds: ["host-a", "host-b"] }],
+      activeWorkspaceSelection: null,
+    });
+
+    expect(
+      logicalRows(projection.rowsByProjectViewKey.get("project-a"))[0]?.groupingServerIds,
+    ).toEqual(["host-a", "host-b"]);
+  });
+
   it("applies a host contribution only to native workspaces on that installed host", () => {
     const mac = placement({ id: "mac", serverId: "host-a" });
     const remote = placement({ id: "remote", serverId: "host-b" });

--- a/packages/app/src/components/sidebar/sidebar-logical-workspaces.ts
+++ b/packages/app/src/components/sidebar/sidebar-logical-workspaces.ts
@@ -24,6 +24,7 @@ export interface SidebarProjectLogicalWorkspaceRow {
   kind: "logical";
   key: string;
   groupingKey: string;
+  groupingServerIds: string[] | null;
   logicalWorkspaceRef: string;
   title: string;
   statusBucket: SidebarWorkspaceEntry["statusBucket"];
@@ -375,6 +376,7 @@ function buildLogicalRow(input: {
     kind: "logical",
     key: JSON.stringify([input.grouping.key, input.projectViewKey, input.logicalWorkspaceRef]),
     groupingKey: input.grouping.key,
+    groupingServerIds: input.grouping.serverIds ? [...input.grouping.serverIds] : null,
     logicalWorkspaceRef: input.logicalWorkspaceRef,
     title,
     statusBucket,

--- a/packages/app/src/components/sidebar/sidebar-logical-workspaces.ts
+++ b/packages/app/src/components/sidebar/sidebar-logical-workspaces.ts
@@ -1,0 +1,423 @@
+import {
+  DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+  parseLogicalWorkspacePlacementLabels,
+} from "@getpaseo/protocol/workspace-labels";
+import type { ActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
+import type {
+  SidebarProjectEntry,
+  SidebarWorkspaceEntry,
+  SidebarWorkspacePlacement,
+} from "@/hooks/use-sidebar-workspaces-list";
+import type { PluginSidebarWorkspaceGrouping } from "@/plugins/sidebar-workspace-groupings";
+import { aggregateSidebarStateBuckets } from "@/utils/sidebar-agent-state";
+
+export type SidebarLogicalWorkspaceGrouping = PluginSidebarWorkspaceGrouping;
+
+export interface SidebarProjectPhysicalWorkspaceRow {
+  kind: "physical";
+  key: string;
+  placement: SidebarWorkspacePlacement;
+}
+
+export interface SidebarProjectLogicalWorkspaceRow {
+  kind: "logical";
+  key: string;
+  groupingKey: string;
+  logicalWorkspaceRef: string;
+  title: string;
+  statusBucket: SidebarWorkspaceEntry["statusBucket"];
+  placements: SidebarWorkspacePlacement[];
+  retainedAgentSources: SidebarRetainedAgentSource[];
+  targetPlacement: SidebarWorkspacePlacement;
+  displayEntry: SidebarWorkspaceEntry;
+}
+
+export interface SidebarRetainedAgentSource {
+  workspaceKey: string;
+  serverId: string;
+  workspaceId: string;
+}
+
+export type SidebarProjectWorkspaceRow =
+  | SidebarProjectPhysicalWorkspaceRow
+  | SidebarProjectLogicalWorkspaceRow;
+
+export interface SidebarLogicalWorkspaceProjection {
+  rowsByProjectViewKey: ReadonlyMap<string, SidebarProjectWorkspaceRow[]>;
+  managedWorkspaceKeys: ReadonlySet<string>;
+  retainedHistoryWorkspaceKeys: ReadonlySet<string>;
+}
+
+interface ManagedPlacement {
+  placement: SidebarWorkspacePlacement;
+  entry: SidebarWorkspaceEntry;
+  defaultPlacement: boolean;
+  workspaceKeys: string[];
+}
+
+interface RetainedHistoryPlacement {
+  placement: SidebarWorkspacePlacement;
+  workspaceKeys: string[];
+}
+
+interface NativePlacementIdentity {
+  placement: SidebarWorkspacePlacement;
+  workspaceKeys: string[];
+}
+
+interface ClassifiedLogicalGroup {
+  grouping: SidebarLogicalWorkspaceGrouping;
+  logicalWorkspaceRef: string;
+  members: ManagedPlacement[];
+}
+
+interface ClassifiedProjectPlacements {
+  groups: Map<string, ClassifiedLogicalGroup>;
+  groupIdentityByNativeIdentity: Map<string, string>;
+  retainedHistoryByGroupIdentity: Map<string, RetainedHistoryPlacement[]>;
+  retainedGroupIdentityByNativeIdentity: Map<string, string>;
+}
+
+interface RetainedHistoryCandidate {
+  grouping: SidebarLogicalWorkspaceGrouping;
+  binding: NonNullable<SidebarLogicalWorkspaceGrouping["retainedHistoryBindings"]>[number];
+}
+
+interface ProjectRowsResult {
+  rows: SidebarProjectWorkspaceRow[];
+  managedWorkspaceKeys: Set<string>;
+  retainedHistoryWorkspaceKeys: Set<string>;
+}
+
+/**
+ * Project boundaries come from Paseo's native projectKey projection before this function runs.
+ * This layer can replace physical rows only inside one such project; it never reparents or
+ * mutates a native workspace identity.
+ */
+export function buildSidebarLogicalWorkspaceProjection(input: {
+  projects: readonly SidebarProjectEntry[];
+  workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
+  groupings: readonly SidebarLogicalWorkspaceGrouping[];
+  activeWorkspaceSelection: ActiveWorkspaceSelection | null;
+}): SidebarLogicalWorkspaceProjection {
+  const groupings = resolveClosedGroupings(input.groupings);
+  const rowsByProjectViewKey = new Map<string, SidebarProjectWorkspaceRow[]>();
+  const managedWorkspaceKeys = new Set<string>();
+  const retainedHistoryWorkspaceKeys = new Set<string>();
+
+  for (const project of input.projects) {
+    const nativeIdentities = deduplicateNativePlacements(project.workspaces);
+    if (groupings.length === 0) {
+      rowsByProjectViewKey.set(
+        project.viewKey,
+        nativeIdentities.map((identity) => physicalRow(identity.placement)),
+      );
+      continue;
+    }
+
+    const classified = classifyProjectPlacements({
+      nativeIdentities,
+      workspaceEntriesByKey: input.workspaceEntriesByKey,
+      groupings,
+    });
+    const result = emitProjectRows({
+      projectViewKey: project.viewKey,
+      nativeIdentities,
+      classified,
+      activeWorkspaceSelection: input.activeWorkspaceSelection,
+    });
+    rowsByProjectViewKey.set(project.viewKey, result.rows);
+    addWorkspaceKeys(managedWorkspaceKeys, result.managedWorkspaceKeys);
+    addWorkspaceKeys(retainedHistoryWorkspaceKeys, result.retainedHistoryWorkspaceKeys);
+  }
+
+  return { rowsByProjectViewKey, managedWorkspaceKeys, retainedHistoryWorkspaceKeys };
+}
+
+function classifyProjectPlacements(input: {
+  nativeIdentities: readonly NativePlacementIdentity[];
+  workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
+  groupings: readonly SidebarLogicalWorkspaceGrouping[];
+}): ClassifiedProjectPlacements {
+  const groups = new Map<string, ClassifiedLogicalGroup>();
+  const groupIdentityByNativeIdentity = new Map<string, string>();
+  const retainedHistoryByGroupIdentity = new Map<string, RetainedHistoryPlacement[]>();
+  const retainedGroupIdentityByNativeIdentity = new Map<string, string>();
+  const retainedCandidates = indexRetainedHistoryCandidates(input.groupings);
+
+  for (const identity of input.nativeIdentities) {
+    const placement = identity.placement;
+    const nativeIdentity = nativeWorkspaceIdentity(placement.serverId, placement.workspaceId);
+    const retained = retainedCandidates.get(nativeIdentity) ?? [];
+    const entry = findWorkspaceEntry(identity, input.workspaceEntriesByKey);
+    if (retained.length > 1) continue;
+    const retainedCandidate = retained[0];
+    if (retainedCandidate && entry) {
+      const groupIdentity = logicalGroupIdentity(
+        retainedCandidate.grouping.key,
+        retainedCandidate.binding.logicalWorkspaceRef,
+      );
+      const members = retainedHistoryByGroupIdentity.get(groupIdentity) ?? [];
+      members.push({ placement, workspaceKeys: identity.workspaceKeys });
+      retainedHistoryByGroupIdentity.set(groupIdentity, members);
+      retainedGroupIdentityByNativeIdentity.set(nativeIdentity, groupIdentity);
+      continue;
+    }
+    if (!entry) continue;
+    const metadata = parseLogicalWorkspacePlacementLabels(entry.labels);
+    if (!metadata) continue;
+    const matchingGroupings = input.groupings.filter((grouping) =>
+      groupingAppliesToServer(grouping, placement.serverId),
+    );
+    if (matchingGroupings.length !== 1) continue;
+    const grouping = matchingGroupings[0];
+    if (!grouping) continue;
+    const groupIdentity = logicalGroupIdentity(grouping.key, metadata.logicalWorkspaceRef);
+    const group = groups.get(groupIdentity) ?? {
+      grouping,
+      logicalWorkspaceRef: metadata.logicalWorkspaceRef,
+      members: [],
+    };
+    group.members.push({
+      placement,
+      entry,
+      defaultPlacement: metadata.defaultPlacement,
+      workspaceKeys: identity.workspaceKeys,
+    });
+    groups.set(groupIdentity, group);
+    groupIdentityByNativeIdentity.set(nativeIdentity, groupIdentity);
+  }
+
+  return {
+    groups,
+    groupIdentityByNativeIdentity,
+    retainedHistoryByGroupIdentity,
+    retainedGroupIdentityByNativeIdentity,
+  };
+}
+
+function emitProjectRows(input: {
+  projectViewKey: string;
+  nativeIdentities: readonly NativePlacementIdentity[];
+  classified: ClassifiedProjectPlacements;
+  activeWorkspaceSelection: ActiveWorkspaceSelection | null;
+}): ProjectRowsResult {
+  const emittedGroupIdentities = new Set<string>();
+  const rows: SidebarProjectWorkspaceRow[] = [];
+  const managedWorkspaceKeys = new Set<string>();
+  const retainedHistoryWorkspaceKeys = new Set<string>();
+
+  for (const identity of input.nativeIdentities) {
+    const placement = identity.placement;
+    const nativeIdentity = nativeWorkspaceIdentity(placement.serverId, placement.workspaceId);
+    const retainedGroupIdentity =
+      input.classified.retainedGroupIdentityByNativeIdentity.get(nativeIdentity);
+    if (retainedGroupIdentity) {
+      if (input.classified.groups.has(retainedGroupIdentity)) continue;
+      rows.push(physicalRow(placement));
+      continue;
+    }
+
+    const groupIdentity = input.classified.groupIdentityByNativeIdentity.get(nativeIdentity);
+    if (!groupIdentity) {
+      rows.push(physicalRow(placement));
+      continue;
+    }
+    if (emittedGroupIdentities.has(groupIdentity)) continue;
+    emittedGroupIdentities.add(groupIdentity);
+
+    const group = input.classified.groups.get(groupIdentity);
+    if (!group) {
+      rows.push(physicalRow(placement));
+      continue;
+    }
+    const retainedHistory =
+      input.classified.retainedHistoryByGroupIdentity.get(groupIdentity) ?? [];
+    const logicalRow = buildLogicalRow({
+      projectViewKey: input.projectViewKey,
+      grouping: group.grouping,
+      logicalWorkspaceRef: group.logicalWorkspaceRef,
+      members: group.members,
+      retainedHistory,
+      activeWorkspaceSelection: input.activeWorkspaceSelection,
+    });
+    if (!logicalRow) {
+      for (const member of group.members) rows.push(physicalRow(member.placement));
+      continue;
+    }
+
+    rows.push(logicalRow);
+    for (const member of group.members) {
+      addWorkspaceKeys(managedWorkspaceKeys, member.workspaceKeys);
+    }
+    for (const retained of retainedHistory) {
+      addWorkspaceKeys(managedWorkspaceKeys, retained.workspaceKeys);
+      addWorkspaceKeys(retainedHistoryWorkspaceKeys, retained.workspaceKeys);
+    }
+  }
+
+  return { rows, managedWorkspaceKeys, retainedHistoryWorkspaceKeys };
+}
+
+function findWorkspaceEntry(
+  identity: NativePlacementIdentity,
+  workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>,
+): SidebarWorkspaceEntry | null {
+  for (const workspaceKey of identity.workspaceKeys) {
+    const entry = workspaceEntriesByKey.get(workspaceKey);
+    if (entry) return entry;
+  }
+  return null;
+}
+
+function addWorkspaceKeys(target: Set<string>, keys: Iterable<string>): void {
+  for (const key of keys) target.add(key);
+}
+
+export function sidebarStatusPlacementsFromRows(
+  rows: readonly SidebarProjectWorkspaceRow[],
+): SidebarWorkspacePlacement[] {
+  return rows.flatMap((row) => (row.kind === "logical" ? row.placements : [row.placement]));
+}
+
+function nativeWorkspaceIdentity(serverId: string, workspaceId: string): string {
+  return JSON.stringify([serverId, workspaceId]);
+}
+
+function deduplicateNativePlacements(
+  placements: readonly SidebarWorkspacePlacement[],
+): NativePlacementIdentity[] {
+  const byIdentity = new Map<string, NativePlacementIdentity>();
+  for (const placement of placements) {
+    const identity = nativeWorkspaceIdentity(placement.serverId, placement.workspaceId);
+    const existing = byIdentity.get(identity);
+    if (existing) {
+      existing.workspaceKeys.push(placement.workspaceKey);
+      continue;
+    }
+    byIdentity.set(identity, {
+      placement,
+      workspaceKeys: [placement.workspaceKey],
+    });
+  }
+  return [...byIdentity.values()];
+}
+
+function resolveClosedGroupings(
+  groupings: readonly SidebarLogicalWorkspaceGrouping[],
+): SidebarLogicalWorkspaceGrouping[] {
+  const compatible = groupings.filter(
+    (grouping) =>
+      grouping.logicalWorkspaceRefLabelPrefix === LOGICAL_WORKSPACE_REF_LABEL_PREFIX &&
+      grouping.defaultPlacementLabel === DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  );
+  const countsByKey = new Map<string, number>();
+  for (const grouping of compatible) {
+    countsByKey.set(grouping.key, (countsByKey.get(grouping.key) ?? 0) + 1);
+  }
+  return compatible
+    .filter((grouping) => countsByKey.get(grouping.key) === 1)
+    .sort((left, right) => left.key.localeCompare(right.key));
+}
+
+function indexRetainedHistoryCandidates(
+  groupings: readonly SidebarLogicalWorkspaceGrouping[],
+): Map<string, RetainedHistoryCandidate[]> {
+  const candidatesByIdentity = new Map<string, RetainedHistoryCandidate[]>();
+  for (const grouping of groupings) {
+    for (const binding of grouping.retainedHistoryBindings ?? []) {
+      if (!groupingAppliesToServer(grouping, binding.serverId)) continue;
+      const identity = nativeWorkspaceIdentity(binding.serverId, binding.workspaceId);
+      const candidates = candidatesByIdentity.get(identity) ?? [];
+      candidates.push({ grouping, binding });
+      candidatesByIdentity.set(identity, candidates);
+    }
+  }
+  return candidatesByIdentity;
+}
+
+function groupingAppliesToServer(
+  grouping: SidebarLogicalWorkspaceGrouping,
+  serverId: string,
+): boolean {
+  return !grouping.serverIds || grouping.serverIds.includes(serverId);
+}
+
+function logicalGroupIdentity(groupingKey: string, logicalWorkspaceRef: string): string {
+  return JSON.stringify([groupingKey, logicalWorkspaceRef]);
+}
+
+function physicalRow(placement: SidebarWorkspacePlacement): SidebarProjectPhysicalWorkspaceRow {
+  return { kind: "physical", key: placement.workspaceKey, placement };
+}
+
+function buildLogicalRow(input: {
+  projectViewKey: string;
+  grouping: SidebarLogicalWorkspaceGrouping;
+  logicalWorkspaceRef: string;
+  members: ManagedPlacement[];
+  retainedHistory: RetainedHistoryPlacement[];
+  activeWorkspaceSelection: ActiveWorkspaceSelection | null;
+}): SidebarProjectLogicalWorkspaceRow | null {
+  if (input.members.length === 0) return null;
+  const target = selectTarget(input.members, input.activeWorkspaceSelection);
+  if (!target) return null;
+  const statusBucket = aggregateSidebarStateBuckets(
+    input.members.map((member) => member.entry.statusBucket),
+  );
+  const aggregateStatusEnteredAt =
+    input.members
+      .filter((member) => member.entry.statusBucket === statusBucket)
+      .sort(compareManagedPlacements)[0]?.entry.statusEnteredAt ?? null;
+  const title = target.entry.title ?? target.entry.name;
+  return {
+    kind: "logical",
+    key: JSON.stringify([input.grouping.key, input.projectViewKey, input.logicalWorkspaceRef]),
+    groupingKey: input.grouping.key,
+    logicalWorkspaceRef: input.logicalWorkspaceRef,
+    title,
+    statusBucket,
+    placements: input.members.map((member) => member.placement),
+    retainedAgentSources: input.retainedHistory.map(({ placement }) => ({
+      workspaceKey: placement.workspaceKey,
+      serverId: placement.serverId,
+      workspaceId: placement.workspaceId,
+    })),
+    targetPlacement: target.placement,
+    displayEntry: {
+      ...target.entry,
+      title,
+      statusBucket,
+      statusEnteredAt: aggregateStatusEnteredAt,
+    },
+  };
+}
+
+function selectTarget(
+  members: readonly ManagedPlacement[],
+  activeWorkspaceSelection: ActiveWorkspaceSelection | null,
+): ManagedPlacement | null {
+  const active = members.find(
+    (member) =>
+      member.placement.serverId === activeWorkspaceSelection?.serverId &&
+      member.placement.workspaceId === activeWorkspaceSelection.workspaceId,
+  );
+  if (active) return active;
+  const defaults = members.filter((member) => member.defaultPlacement);
+  return [...(defaults.length > 0 ? defaults : members)].sort(compareManagedPlacements)[0] ?? null;
+}
+
+function compareManagedPlacements(left: ManagedPlacement, right: ManagedPlacement): number {
+  const leftTime = left.entry.statusEnteredAt?.getTime() ?? null;
+  const rightTime = right.entry.statusEnteredAt?.getTime() ?? null;
+  if (leftTime !== null && rightTime !== null && leftTime !== rightTime) {
+    return rightTime - leftTime;
+  }
+  if (leftTime !== null) return -1;
+  if (rightTime !== null) return 1;
+  return (
+    left.placement.serverId.localeCompare(right.placement.serverId) ||
+    left.placement.workspaceId.localeCompare(right.placement.workspaceId)
+  );
+}

--- a/packages/app/src/components/sidebar/sidebar-logical-workspaces.ts
+++ b/packages/app/src/components/sidebar/sidebar-logical-workspaces.ts
@@ -24,7 +24,7 @@ export interface SidebarProjectLogicalWorkspaceRow {
   kind: "logical";
   key: string;
   groupingKey: string;
-  groupingServerIds: string[] | null;
+  creationServerIds: string[];
   logicalWorkspaceRef: string;
   title: string;
   statusBucket: SidebarWorkspaceEntry["statusBucket"];
@@ -124,6 +124,8 @@ export function buildSidebarLogicalWorkspaceProjection(input: {
     });
     const result = emitProjectRows({
       projectViewKey: project.viewKey,
+      projectServerIds: project.hosts.map((host) => host.serverId),
+      groupings,
       nativeIdentities,
       classified,
       activeWorkspaceSelection: input.activeWorkspaceSelection,
@@ -200,6 +202,8 @@ function classifyProjectPlacements(input: {
 
 function emitProjectRows(input: {
   projectViewKey: string;
+  projectServerIds: readonly string[];
+  groupings: readonly SidebarLogicalWorkspaceGrouping[];
   nativeIdentities: readonly NativePlacementIdentity[];
   classified: ClassifiedProjectPlacements;
   activeWorkspaceSelection: ActiveWorkspaceSelection | null;
@@ -238,6 +242,11 @@ function emitProjectRows(input: {
     const logicalRow = buildLogicalRow({
       projectViewKey: input.projectViewKey,
       grouping: group.grouping,
+      creationServerIds: resolveGroupingCreationServerIds({
+        groupingKey: group.grouping.key,
+        projectServerIds: input.projectServerIds,
+        groupings: input.groupings,
+      }),
       logicalWorkspaceRef: group.logicalWorkspaceRef,
       members: group.members,
       retainedHistory,
@@ -345,6 +354,19 @@ function groupingAppliesToServer(
   return !grouping.serverIds || grouping.serverIds.includes(serverId);
 }
 
+function resolveGroupingCreationServerIds(input: {
+  groupingKey: string;
+  projectServerIds: readonly string[];
+  groupings: readonly SidebarLogicalWorkspaceGrouping[];
+}): string[] {
+  return input.projectServerIds.filter((serverId) => {
+    const matching = input.groupings.filter((grouping) =>
+      groupingAppliesToServer(grouping, serverId),
+    );
+    return matching.length === 1 && matching[0]?.key === input.groupingKey;
+  });
+}
+
 function logicalGroupIdentity(groupingKey: string, logicalWorkspaceRef: string): string {
   return JSON.stringify([groupingKey, logicalWorkspaceRef]);
 }
@@ -356,6 +378,7 @@ function physicalRow(placement: SidebarWorkspacePlacement): SidebarProjectPhysic
 function buildLogicalRow(input: {
   projectViewKey: string;
   grouping: SidebarLogicalWorkspaceGrouping;
+  creationServerIds: string[];
   logicalWorkspaceRef: string;
   members: ManagedPlacement[];
   retainedHistory: RetainedHistoryPlacement[];
@@ -376,7 +399,7 @@ function buildLogicalRow(input: {
     kind: "logical",
     key: JSON.stringify([input.grouping.key, input.projectViewKey, input.logicalWorkspaceRef]),
     groupingKey: input.grouping.key,
-    groupingServerIds: input.grouping.serverIds ? [...input.grouping.serverIds] : null,
+    creationServerIds: input.creationServerIds,
     logicalWorkspaceRef: input.logicalWorkspaceRef,
     title,
     statusBucket,

--- a/packages/app/src/components/sidebar/sidebar-model.tsx
+++ b/packages/app/src/components/sidebar/sidebar-model.tsx
@@ -17,12 +17,16 @@ import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
 import type { SidebarShortcutModel } from "@/utils/sidebar-shortcuts";
 import { buildSidebarProjection } from "./sidebar-projection";
 import type { SidebarProjectIconTarget } from "@/utils/sidebar-project-row-model";
+import type { SidebarProjectWorkspaceRow } from "./sidebar-logical-workspaces";
 import { filterWorkspacesByLabels, type SidebarWorkspaceGroup } from "./sidebar-labels";
 import { filterWorkspacesByProjects, resolveActiveProjectFilters } from "./sidebar-project-filter";
 import {
   hasAuthoritativeWorkspaceLabelCatalog,
   useWorkspaceLabelProjection,
 } from "@/workspace-labels";
+import { useInstalledPlugins } from "@/plugins/registry";
+import { resolvePluginSidebarWorkspaceGroupings } from "@/plugins/sidebar-workspace-groupings";
+import { useActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
 
 interface SidebarModel extends SidebarWorkspacesListResult {
   workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
@@ -40,6 +44,7 @@ interface SidebarModel extends SidebarWorkspacesListResult {
   workspaceGroups: SidebarWorkspaceGroup[];
   projectIconTargets: SidebarProjectIconTarget[];
   pinnedGroups: PinnedSidebarGroups;
+  projectWorkspaceRowsByViewKey: ReadonlyMap<string, SidebarProjectWorkspaceRow[]>;
   collapsedProjectKeys: ReadonlySet<string>;
   toggleProjectCollapsed: (projectViewKey: string) => void;
   shortcutModel: SidebarShortcutModel;
@@ -60,6 +65,12 @@ export function SidebarModelProvider({
   const projectFilters = useSidebarViewStore((state) => state.projectFilters);
   const reconcileLabelFilter = useSidebarViewStore((state) => state.reconcileLabelFilter);
   const { hosts: labelHosts } = useWorkspaceLabelProjection();
+  const installedPlugins = useInstalledPlugins();
+  const logicalWorkspaceGroupings = useMemo(
+    () => resolvePluginSidebarWorkspaceGroupings(installedPlugins),
+    [installedPlugins],
+  );
+  const activeWorkspaceSelection = useActiveWorkspaceSelection();
   const collapsedProjectKeys = useSidebarCollapsedSectionsStore(
     (state) => state.collapsedProjectKeys,
   );
@@ -95,7 +106,8 @@ export function SidebarModelProvider({
   // anything; the label filter reads `labels`, which only exists on an entry. Hydration opens a
   // live session-store subscription over every workspace on every visible host, so widening this
   // for a filter that does not need it costs a retained-but-inactive sidebar real work.
-  const needsWorkspaceEntries = groupMode !== "project" || hasActiveLabelFilter;
+  const needsWorkspaceEntries =
+    groupMode !== "project" || hasActiveLabelFilter || logicalWorkspaceGroupings.length > 0;
   const workspaceEntriesByKey = useSidebarWorkspaceEntries(
     list.workspacePlacements,
     active !== false || needsWorkspaceEntries,
@@ -145,29 +157,37 @@ export function SidebarModelProvider({
       pinnedKeys,
       pinnedWorkspaceOrder,
       workspaceEntriesByKey: filteredWorkspaceEntriesByKey,
+      inventoryProjects: list.projects,
+      inventoryWorkspaceEntriesByKey: workspaceEntriesByKey,
       projectNamesByViewKey: list.projectNamesByViewKey,
       groupMode,
       pinnedCollapsed,
       collapsedProjectKeys,
       collapsedWorkspaceGroupKeys,
+      logicalWorkspaceGroupings,
+      activeWorkspaceSelection,
     }),
     [
       collapsedProjectKeys,
       collapsedWorkspaceGroupKeys,
       groupMode,
       list.projectNamesByViewKey,
+      list.projects,
       filteredProjects,
       pinnedCollapsed,
       pinnedKeys,
       pinnedWorkspaceOrder,
       filteredWorkspaceEntriesByKey,
+      workspaceEntriesByKey,
+      logicalWorkspaceGroupings,
+      activeWorkspaceSelection,
     ],
   );
   const projection = useMemo(() => buildSidebarProjection(projectionInput), [projectionInput]);
   const value = useMemo(
     () => ({
       ...list,
-      projects: filteredProjects,
+      projects: projection.visibleProjects,
       allProjects: list.projects,
       resolvedProjectFilters,
       hasProjectsBeforeFilter: list.projects.length > 0,
@@ -176,6 +196,7 @@ export function SidebarModelProvider({
       workspaceGroups: projection.workspaceGroups,
       projectIconTargets: projection.projectIconTargets,
       pinnedGroups: projection.pinnedGroups,
+      projectWorkspaceRowsByViewKey: projection.projectWorkspaceRowsByViewKey,
       collapsedProjectKeys,
       toggleProjectCollapsed,
       shortcutModel: projection.shortcutModel,
@@ -185,7 +206,6 @@ export function SidebarModelProvider({
       collapsedProjectKeys,
       groupMode,
       list,
-      filteredProjects,
       projection,
       toggleProjectCollapsed,
       filteredWorkspaceEntriesByKey,

--- a/packages/app/src/components/sidebar/sidebar-projection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+  encodeLogicalWorkspaceRefLabel,
+} from "@getpaseo/protocol/workspace-labels";
 import type {
   SidebarProjectEntry,
   SidebarWorkspaceEntry,
@@ -172,5 +177,183 @@ describe("buildSidebarProjection", () => {
     expect(projection.shortcutModel.shortcutTargets).toEqual([
       { serverId: "srv", workspaceId: "unpinned" },
     ]);
+  });
+
+  it("keeps managed physical pins inside one logical project row without mutating pin data", () => {
+    const input = projectionInput();
+    const refLabel = encodeLogicalWorkspaceRefLabel("project-a-catalog");
+    const pinnedEntry = input.workspaceEntriesByKey.get("srv:pinned");
+    const unpinnedEntry = input.workspaceEntriesByKey.get("srv:unpinned");
+    if (!pinnedEntry || !unpinnedEntry) throw new Error("fixture entries missing");
+    const workspaceEntriesByKey = new Map([
+      [
+        pinnedEntry.workspaceKey,
+        { ...pinnedEntry, labels: [refLabel, DEFAULT_WORKSPACE_PLACEMENT_LABEL] },
+      ],
+      [unpinnedEntry.workspaceKey, { ...unpinnedEntry, labels: [refLabel] }],
+    ]);
+
+    const projection = buildSidebarProjection({
+      ...input,
+      workspaceEntriesByKey,
+      logicalWorkspaceGroupings: [
+        {
+          key: "paseo-layout/sidebar-workspace-grouping/logical-workspaces",
+          logicalWorkspaceRefLabelPrefix: LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+          defaultPlacementLabel: DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+        },
+      ],
+      activeWorkspaceSelection: null,
+    });
+
+    expect(projection.pinnedGroups.pinnedChats).toEqual([]);
+    expect(projection.pinnedGroups.unpinnedProjects[0]?.workspaces).toHaveLength(2);
+    expect(projection.projectWorkspaceRowsByViewKey.get("project")).toMatchObject([
+      {
+        kind: "logical",
+        logicalWorkspaceRef: "project-a-catalog",
+        placements: [
+          { workspaceKey: "srv:pinned", workspaceId: "pinned" },
+          { workspaceKey: "srv:unpinned", workspaceId: "unpinned" },
+        ],
+        targetPlacement: { workspaceKey: "srv:pinned", workspaceId: "pinned" },
+      },
+    ]);
+    expect(projection.shortcutModel.shortcutTargets).toEqual([
+      { serverId: "srv", workspaceId: "pinned" },
+    ]);
+    expect(input.pinnedKeys.pinnedWorkspaceKeys).toEqual(["srv:pinned"]);
+    expect(pinnedEntry.pinnedAt).toBeUndefined();
+  });
+
+  it("hides a bound retained agent source from pinned and Status rows", () => {
+    const input = projectionInput({ groupMode: "status" });
+    const retainedEntry = input.workspaceEntriesByKey.get("srv:pinned");
+    const liveEntry = input.workspaceEntriesByKey.get("srv:unpinned");
+    if (!retainedEntry || !liveEntry) throw new Error("fixture entries missing");
+    const refLabel = encodeLogicalWorkspaceRefLabel("project-a-catalog");
+
+    const projection = buildSidebarProjection({
+      ...input,
+      workspaceEntriesByKey: new Map([
+        [retainedEntry.workspaceKey, retainedEntry],
+        [liveEntry.workspaceKey, { ...liveEntry, labels: [refLabel] }],
+      ]),
+      logicalWorkspaceGroupings: [
+        {
+          key: "paseo-layout/sidebar-workspace-grouping/logical-workspaces",
+          logicalWorkspaceRefLabelPrefix: LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+          defaultPlacementLabel: DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+          retainedHistoryBindings: [
+            {
+              serverId: "srv",
+              workspaceId: retainedEntry.workspaceId,
+              physicalWorkspaceRef: "project-a-catalog-host-b",
+              logicalWorkspaceRef: "project-a-catalog",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(projection.pinnedGroups.pinnedChats).toEqual([]);
+    expect(
+      projection.workspaceGroups.flatMap((group) => group.rows).map((row) => row.workspaceId),
+    ).toEqual([liveEntry.workspaceId]);
+    expect(projection.shortcutModel.shortcutTargets).toEqual([
+      { serverId: liveEntry.serverId, workspaceId: liveEntry.workspaceId },
+    ]);
+  });
+
+  it("reattaches retained history after a user-label filter keeps only the live placement", () => {
+    const input = projectionInput();
+    const retainedEntry = input.workspaceEntriesByKey.get("srv:pinned");
+    const liveEntry = input.workspaceEntriesByKey.get("srv:unpinned");
+    if (!retainedEntry || !liveEntry) throw new Error("fixture entries missing");
+    const refLabel = encodeLogicalWorkspaceRefLabel("project-a-catalog");
+    const managedLiveEntry = { ...liveEntry, labels: [refLabel] };
+    const inventoryEntries = new Map([
+      [retainedEntry.workspaceKey, retainedEntry],
+      [managedLiveEntry.workspaceKey, managedLiveEntry],
+    ]);
+    const logicalWorkspaceGroupings = [
+      {
+        key: "paseo-layout/sidebar-workspace-grouping/logical-workspaces",
+        logicalWorkspaceRefLabelPrefix: LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+        defaultPlacementLabel: DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+        retainedHistoryBindings: [
+          {
+            serverId: "srv",
+            workspaceId: retainedEntry.workspaceId,
+            physicalWorkspaceRef: "project-a-catalog-host-b",
+            logicalWorkspaceRef: "project-a-catalog",
+          },
+        ],
+      },
+    ];
+
+    const projection = buildSidebarProjection({
+      ...input,
+      projects: [makeProject([managedLiveEntry])],
+      workspaceEntriesByKey: new Map([[managedLiveEntry.workspaceKey, managedLiveEntry]]),
+      inventoryProjects: input.projects,
+      inventoryWorkspaceEntriesByKey: inventoryEntries,
+      logicalWorkspaceGroupings,
+      activeWorkspaceSelection: null,
+    });
+
+    expect(projection.projectWorkspaceRowsByViewKey.get("project")).toMatchObject([
+      {
+        kind: "logical",
+        logicalWorkspaceRef: "project-a-catalog",
+        placements: [{ workspaceId: liveEntry.workspaceId }],
+        retainedAgentSources: [{ workspaceId: retainedEntry.workspaceId }],
+      },
+    ]);
+    expect(projection.pinnedGroups.pinnedChats).toEqual([]);
+    expect(projection.shortcutModel.shortcutTargets).toEqual([
+      { serverId: liveEntry.serverId, workspaceId: liveEntry.workspaceId },
+    ]);
+  });
+
+  it("does not let a retained-only label match reappear in Pinned, Status, or shortcuts", () => {
+    const input = projectionInput({ groupMode: "status" });
+    const retainedEntry = input.workspaceEntriesByKey.get("srv:pinned");
+    const liveEntry = input.workspaceEntriesByKey.get("srv:unpinned");
+    if (!retainedEntry || !liveEntry) throw new Error("fixture entries missing");
+    const refLabel = encodeLogicalWorkspaceRefLabel("project-a-catalog");
+    const managedLiveEntry = { ...liveEntry, labels: [refLabel] };
+    const inventoryEntries = new Map([
+      [retainedEntry.workspaceKey, retainedEntry],
+      [managedLiveEntry.workspaceKey, managedLiveEntry],
+    ]);
+
+    const projection = buildSidebarProjection({
+      ...input,
+      projects: [makeProject([retainedEntry])],
+      workspaceEntriesByKey: new Map([[retainedEntry.workspaceKey, retainedEntry]]),
+      inventoryProjects: input.projects,
+      inventoryWorkspaceEntriesByKey: inventoryEntries,
+      logicalWorkspaceGroupings: [
+        {
+          key: "paseo-layout/sidebar-workspace-grouping/logical-workspaces",
+          logicalWorkspaceRefLabelPrefix: LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+          defaultPlacementLabel: DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+          retainedHistoryBindings: [
+            {
+              serverId: "srv",
+              workspaceId: retainedEntry.workspaceId,
+              physicalWorkspaceRef: "project-a-catalog-host-b",
+              logicalWorkspaceRef: "project-a-catalog",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(projection.visibleProjects).toEqual([]);
+    expect(projection.pinnedGroups.pinnedChats).toEqual([]);
+    expect(projection.workspaceGroups).toEqual([]);
+    expect(projection.shortcutModel.shortcutTargets).toEqual([]);
   });
 });

--- a/packages/app/src/components/sidebar/sidebar-projection.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.ts
@@ -9,6 +9,7 @@ import type {
   SidebarWorkspaceEntry,
 } from "@/hooks/use-sidebar-workspaces-list";
 import type { SidebarGroupMode } from "@/stores/sidebar-view-store";
+import type { ActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
 import {
   resolveSidebarProjectIconTargets,
   type SidebarProjectIconTarget,
@@ -19,9 +20,16 @@ import {
   type SidebarShortcutSection,
 } from "@/utils/sidebar-shortcuts";
 import { statusWorkspaceGroups, type SidebarWorkspaceGroup } from "./sidebar-labels";
+import {
+  buildSidebarLogicalWorkspaceProjection,
+  type SidebarLogicalWorkspaceGrouping,
+  type SidebarProjectWorkspaceRow,
+} from "./sidebar-logical-workspaces";
 
 export interface SidebarProjection {
+  visibleProjects: SidebarProjectEntry[];
   pinnedGroups: PinnedSidebarGroups;
+  projectWorkspaceRowsByViewKey: ReadonlyMap<string, SidebarProjectWorkspaceRow[]>;
   workspaceGroups: SidebarWorkspaceGroup[];
   /**
    * The project icons this projection needs fetched, keyed by `projectViewKey` — one per project,
@@ -40,21 +48,64 @@ export interface SidebarProjectionInput {
   pinnedKeys: PinnedSidebarKeys;
   pinnedWorkspaceOrder: string[];
   workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
+  inventoryProjects?: readonly SidebarProjectEntry[];
+  inventoryWorkspaceEntriesByKey?: ReadonlyMap<string, SidebarWorkspaceEntry>;
   projectNamesByViewKey: Map<string, string>;
   groupMode: SidebarGroupMode;
   pinnedCollapsed: boolean;
   collapsedProjectKeys: ReadonlySet<string>;
   collapsedWorkspaceGroupKeys: ReadonlySet<string>;
+  logicalWorkspaceGroupings?: readonly SidebarLogicalWorkspaceGrouping[];
+  activeWorkspaceSelection?: ActiveWorkspaceSelection | null;
 }
 
 export function buildSidebarProjection(input: SidebarProjectionInput): SidebarProjection {
+  const groupings = input.logicalWorkspaceGroupings ?? [];
+  const activeWorkspaceSelection = input.activeWorkspaceSelection ?? null;
+  const inventoryLogicalProjection = buildSidebarLogicalWorkspaceProjection({
+    projects: input.inventoryProjects ?? input.projects,
+    workspaceEntriesByKey: input.inventoryWorkspaceEntriesByKey ?? input.workspaceEntriesByKey,
+    groupings,
+    activeWorkspaceSelection,
+  });
+  const visibleProjects = removeRetainedHistoryProjects(
+    input.projects,
+    inventoryLogicalProjection.retainedHistoryWorkspaceKeys,
+  );
+  const visibleWorkspaceEntries = removeRetainedHistoryEntries(
+    input.workspaceEntriesByKey,
+    inventoryLogicalProjection.retainedHistoryWorkspaceKeys,
+  );
+  const workspaceKeysHiddenFromPins =
+    input.groupMode === "project"
+      ? inventoryLogicalProjection.managedWorkspaceKeys
+      : inventoryLogicalProjection.retainedHistoryWorkspaceKeys;
+  const effectivePinnedKeys =
+    workspaceKeysHiddenFromPins.size === 0
+      ? input.pinnedKeys
+      : {
+          ...input.pinnedKeys,
+          pinnedWorkspaceKeys: input.pinnedKeys.pinnedWorkspaceKeys.filter(
+            (key) => !workspaceKeysHiddenFromPins.has(key),
+          ),
+        };
   const pinnedGroups = splitPinnedSidebarGroups({
-    projects: input.projects,
-    keys: input.pinnedKeys,
+    projects: visibleProjects,
+    keys: effectivePinnedKeys,
     pinnedWorkspaceOrder: input.pinnedWorkspaceOrder,
   });
-  const pinnedWorkspaceKeys = new Set(input.pinnedKeys.pinnedWorkspaceKeys);
-  const unpinnedWorkspaces = Array.from(input.workspaceEntriesByKey.values()).filter(
+  const visibleProjectProjection = buildSidebarLogicalWorkspaceProjection({
+    projects: pinnedGroups.unpinnedProjects,
+    workspaceEntriesByKey: visibleWorkspaceEntries,
+    groupings: input.groupMode === "project" ? groupings : [],
+    activeWorkspaceSelection,
+  });
+  const projectLogicalProjection =
+    input.groupMode === "project"
+      ? attachInventoryRetainedAgentSources(visibleProjectProjection, inventoryLogicalProjection)
+      : visibleProjectProjection;
+  const pinnedWorkspaceKeys = new Set(effectivePinnedKeys.pinnedWorkspaceKeys);
+  const unpinnedWorkspaces = Array.from(visibleWorkspaceEntries.values()).filter(
     (workspace) => !pinnedWorkspaceKeys.has(workspace.workspaceKey),
   );
   // One switch decides both what the list groups by and what the keyboard shortcuts walk, so the
@@ -69,7 +120,9 @@ export function buildSidebarProjection(input: SidebarProjectionInput): SidebarPr
   if (input.groupMode === "project") {
     sections.push(
       ...pinnedGroups.unpinnedProjects.map((project) => ({
-        workspaces: project.workspaces,
+        workspaces: (projectLogicalProjection.rowsByProjectViewKey.get(project.viewKey) ?? []).map(
+          (row) => (row.kind === "logical" ? row.targetPlacement : row.placement),
+        ),
         collapsed: input.collapsedProjectKeys.has(project.viewKey),
       })),
     );
@@ -83,11 +136,79 @@ export function buildSidebarProjection(input: SidebarProjectionInput): SidebarPr
   }
 
   return {
+    visibleProjects,
     pinnedGroups,
+    projectWorkspaceRowsByViewKey: projectLogicalProjection.rowsByProjectViewKey,
     workspaceGroups,
-    projectIconTargets: resolveSidebarProjectIconTargets(input.projects),
+    projectIconTargets: resolveSidebarProjectIconTargets(visibleProjects),
     shortcutModel: buildSidebarShortcutSections({ sections }),
   };
+}
+
+function removeRetainedHistoryProjects(
+  projects: readonly SidebarProjectEntry[],
+  retainedWorkspaceKeys: ReadonlySet<string>,
+): SidebarProjectEntry[] {
+  if (retainedWorkspaceKeys.size === 0) return [...projects];
+  const visibleProjects: SidebarProjectEntry[] = [];
+  for (const project of projects) {
+    const workspaces = project.workspaces.filter(
+      (workspace) => !retainedWorkspaceKeys.has(workspace.workspaceKey),
+    );
+    if (workspaces.length === project.workspaces.length) {
+      visibleProjects.push(project);
+      continue;
+    }
+    if (workspaces.length > 0 || project.workspaces.length === 0) {
+      visibleProjects.push({ ...project, workspaces });
+    }
+  }
+  return visibleProjects;
+}
+
+function removeRetainedHistoryEntries(
+  entries: ReadonlyMap<string, SidebarWorkspaceEntry>,
+  retainedWorkspaceKeys: ReadonlySet<string>,
+): ReadonlyMap<string, SidebarWorkspaceEntry> {
+  if (retainedWorkspaceKeys.size === 0) return entries;
+  const visibleEntries = new Map<string, SidebarWorkspaceEntry>();
+  for (const [key, entry] of entries) {
+    if (!retainedWorkspaceKeys.has(key)) visibleEntries.set(key, entry);
+  }
+  return visibleEntries;
+}
+
+function attachInventoryRetainedAgentSources(
+  visible: ReturnType<typeof buildSidebarLogicalWorkspaceProjection>,
+  inventory: ReturnType<typeof buildSidebarLogicalWorkspaceProjection>,
+): ReturnType<typeof buildSidebarLogicalWorkspaceProjection> {
+  if (inventory.retainedHistoryWorkspaceKeys.size === 0) return visible;
+  const inventoryLogicalRows = new Map(
+    [...inventory.rowsByProjectViewKey.values()]
+      .flat()
+      .filter((row) => row.kind === "logical")
+      .map((row) => [row.key, row]),
+  );
+  const rowsByProjectViewKey = new Map<string, SidebarProjectWorkspaceRow[]>();
+  for (const [projectViewKey, rows] of visible.rowsByProjectViewKey) {
+    rowsByProjectViewKey.set(
+      projectViewKey,
+      rows.map((row) => attachRetainedAgentSources(row, inventoryLogicalRows)),
+    );
+  }
+  return { ...visible, rowsByProjectViewKey };
+}
+
+function attachRetainedAgentSources(
+  row: SidebarProjectWorkspaceRow,
+  inventoryLogicalRows: ReadonlyMap<
+    string,
+    Extract<SidebarProjectWorkspaceRow, { kind: "logical" }>
+  >,
+): SidebarProjectWorkspaceRow {
+  if (row.kind !== "logical") return row;
+  const inventoryRow = inventoryLogicalRows.get(row.key);
+  return inventoryRow ? { ...row, retainedAgentSources: inventoryRow.retainedAgentSources } : row;
 }
 
 /** Project mode keeps its project headers and groups nothing; status mode groups the rows. */

--- a/packages/app/src/components/sidebar/sidebar-retained-history-agents.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-retained-history-agents.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { Agent } from "@/stores/session-store";
+import { selectRetainedHistoryRootAgents } from "./sidebar-retained-history-agents";
+
+function agent(input: {
+  id: string;
+  workspaceId: string;
+  parentAgentId?: string | null;
+  status?: Agent["status"];
+  archivedAt?: Date | null;
+  lastActivityAt?: string;
+}): Agent {
+  return {
+    id: input.id,
+    workspaceId: input.workspaceId,
+    parentAgentId: input.parentAgentId ?? null,
+    status: input.status ?? "idle",
+    archivedAt: input.archivedAt ?? null,
+    lastActivityAt: new Date(input.lastActivityAt ?? "2026-08-24T10:00:00.000Z"),
+  } as Agent;
+}
+
+describe("retained-history agent links", () => {
+  it("keeps live root agents reachable and excludes subagents, archives, and other workspaces", () => {
+    const firstCatalogAgent = agent({
+      id: "catalog-search-a",
+      workspaceId: "wks_orphan",
+      status: "running",
+    });
+    const secondCatalogAgent = agent({
+      id: "catalog-search-b",
+      workspaceId: "wks_orphan",
+      lastActivityAt: "2026-08-24T11:00:00.000Z",
+    });
+    const child = agent({
+      id: "child",
+      workspaceId: "wks_orphan",
+      parentAgentId: firstCatalogAgent.id,
+    });
+    const archived = agent({
+      id: "archived",
+      workspaceId: "wks_orphan",
+      archivedAt: new Date("2026-08-23T10:00:00.000Z"),
+    });
+    const other = agent({ id: "other", workspaceId: "wks_other", status: "running" });
+    const agents = new Map(
+      [firstCatalogAgent, secondCatalogAgent, child, archived, other].map((value) => [
+        value.id,
+        value,
+      ]),
+    );
+
+    expect(selectRetainedHistoryRootAgents(agents, " wks_orphan ").map((item) => item.id)).toEqual([
+      "catalog-search-a",
+      "catalog-search-b",
+    ]);
+  });
+
+  it("treats an agent whose parent belongs to another workspace as a workspace root", () => {
+    const parent = agent({ id: "parent", workspaceId: "wks_other" });
+    const movedRoot = agent({
+      id: "moved-root",
+      workspaceId: "wks_orphan",
+      parentAgentId: parent.id,
+    });
+    const agents = new Map([
+      [parent.id, parent],
+      [movedRoot.id, movedRoot],
+    ]);
+
+    expect(selectRetainedHistoryRootAgents(agents, "wks_orphan").map((item) => item.id)).toEqual([
+      "moved-root",
+    ]);
+  });
+});

--- a/packages/app/src/components/sidebar/sidebar-retained-history-agents.ts
+++ b/packages/app/src/components/sidebar/sidebar-retained-history-agents.ts
@@ -1,0 +1,30 @@
+import type { Agent } from "@/stores/session-store";
+import { normalizeWorkspaceOpaqueId } from "@/utils/workspace-identity";
+import { deriveWorkspaceAgentVisibility } from "@/workspace-tabs/agent-visibility";
+
+export function selectRetainedHistoryRootAgents(
+  agents: ReadonlyMap<string, Agent>,
+  workspaceId: string,
+): Agent[] {
+  const normalizedWorkspaceId = normalizeWorkspaceOpaqueId(workspaceId);
+  if (!normalizedWorkspaceId) return [];
+
+  const visibility = deriveWorkspaceAgentVisibility({
+    sessionAgents: agents instanceof Map ? agents : new Map(agents),
+    workspaceId: normalizedWorkspaceId,
+  });
+  const result = [...visibility.autoOpenAgentIds].flatMap((agentId) => {
+    const agent = agents.get(agentId);
+    return agent ? [agent] : [];
+  });
+
+  return result.sort((left, right) => {
+    const leftRunning = left.status === "running";
+    const rightRunning = right.status === "running";
+    if (leftRunning !== rightRunning) return leftRunning ? -1 : 1;
+    return (
+      right.lastActivityAt.getTime() - left.lastActivityAt.getTime() ||
+      left.id.localeCompare(right.id)
+    );
+  });
+}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1129,6 +1129,7 @@ export const ar: TranslationResources = {
       actions: {
         menu: "إجراءات Workspace",
         newWorkspace: "مساحة عمل جديدة",
+        addHost: "Add host",
         showMore: "عرض المزيد",
         showLess: "عرض أقل",
         createWorkspaceFor: "قم بإنشاء مساحة عمل جديدة لـ{{projectName}}",
@@ -1166,6 +1167,12 @@ export const ar: TranslationResources = {
     },
   },
   newWorkspace: {
+    logicalWorkspace: {
+      label: "Logical workspace",
+      new: "New logical workspace",
+      search: "Search logical workspaces",
+      tooltip: "Create a new logical workspace or add this host to an existing one",
+    },
     title: "مساحة عمل جديدة",
     create: "يخلق",
     isolation: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1138,6 +1138,7 @@ export const en = {
       actions: {
         menu: "Workspace actions",
         newWorkspace: "New workspace",
+        addHost: "Add host",
         showMore: "Show more",
         showLess: "Show less",
         createWorkspaceFor: "Create a new workspace for {{projectName}}",
@@ -1175,6 +1176,12 @@ export const en = {
     },
   },
   newWorkspace: {
+    logicalWorkspace: {
+      label: "Logical workspace",
+      new: "New logical workspace",
+      search: "Search logical workspaces",
+      tooltip: "Create a new logical workspace or add this host to an existing one",
+    },
     title: "New workspace",
     create: "Create",
     isolation: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1163,6 +1163,7 @@ export const es: TranslationResources = {
       actions: {
         menu: "AccionesWorkspace",
         newWorkspace: "Nuevo espacio de trabajo",
+        addHost: "Add host",
         showMore: "Mostrar más",
         showLess: "Mostrar menos",
         createWorkspaceFor: "Crea un nuevo espacio de trabajo para{{projectName}}",
@@ -1200,6 +1201,12 @@ export const es: TranslationResources = {
     },
   },
   newWorkspace: {
+    logicalWorkspace: {
+      label: "Logical workspace",
+      new: "New logical workspace",
+      search: "Search logical workspaces",
+      tooltip: "Create a new logical workspace or add this host to an existing one",
+    },
     title: "Nuevo espacio de trabajo",
     create: "Crear",
     isolation: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1163,6 +1163,7 @@ export const fr: TranslationResources = {
       actions: {
         menu: "ActionsWorkspace",
         newWorkspace: "Nouvel espace de travail",
+        addHost: "Add host",
         showMore: "Afficher plus",
         showLess: "Afficher moins",
         createWorkspaceFor: "Créer un nouvel espace de travail pour{{projectName}}",
@@ -1200,6 +1201,12 @@ export const fr: TranslationResources = {
     },
   },
   newWorkspace: {
+    logicalWorkspace: {
+      label: "Logical workspace",
+      new: "New logical workspace",
+      search: "Search logical workspaces",
+      tooltip: "Create a new logical workspace or add this host to an existing one",
+    },
     title: "Nouvel espace de travail",
     create: "Créer",
     isolation: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1141,6 +1141,7 @@ export const ja: TranslationResources = {
       actions: {
         menu: "ワークスペースアクション",
         newWorkspace: "新しいワークスペース",
+        addHost: "Add host",
         showMore: "さらに表示",
         showLess: "表示を減らす",
         createWorkspaceFor: "{{projectName}}の新しいワークスペースを作成",
@@ -1178,6 +1179,12 @@ export const ja: TranslationResources = {
     },
   },
   newWorkspace: {
+    logicalWorkspace: {
+      label: "Logical workspace",
+      new: "New logical workspace",
+      search: "Search logical workspaces",
+      tooltip: "Create a new logical workspace or add this host to an existing one",
+    },
     title: "新しいワークスペース",
     create: "作成",
     isolation: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1136,6 +1136,7 @@ export const ko: TranslationResources = {
       actions: {
         menu: "워크스페이스 작업",
         newWorkspace: "새 워크스페이스",
+        addHost: "Add host",
         showMore: "더 보기",
         showLess: "간략히 보기",
         createWorkspaceFor: "{{projectName}}을(를) 위한 새 워크스페이스 생성",
@@ -1173,6 +1174,12 @@ export const ko: TranslationResources = {
     },
   },
   newWorkspace: {
+    logicalWorkspace: {
+      label: "Logical workspace",
+      new: "New logical workspace",
+      search: "Search logical workspaces",
+      tooltip: "Create a new logical workspace or add this host to an existing one",
+    },
     title: "새 워크스페이스",
     create: "생성",
     isolation: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1154,6 +1154,7 @@ export const ptBR: TranslationResources = {
       actions: {
         menu: "Ações do workspace",
         newWorkspace: "Novo workspace",
+        addHost: "Add host",
         showMore: "Mostrar mais",
         showLess: "Mostrar menos",
         createWorkspaceFor: "Criar um novo workspace para {{projectName}}",
@@ -1191,6 +1192,12 @@ export const ptBR: TranslationResources = {
     },
   },
   newWorkspace: {
+    logicalWorkspace: {
+      label: "Logical workspace",
+      new: "New logical workspace",
+      search: "Search logical workspaces",
+      tooltip: "Create a new logical workspace or add this host to an existing one",
+    },
     title: "Novo workspace",
     create: "Criar",
     isolation: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1145,6 +1145,7 @@ export const ru: TranslationResources = {
       actions: {
         menu: "Действия рабочего пространства",
         newWorkspace: "Новое рабочее пространство",
+        addHost: "Add host",
         showMore: "Показать ещё",
         showLess: "Показать меньше",
         createWorkspaceFor: "Создать новое рабочее пространство для {{projectName}}",
@@ -1182,6 +1183,12 @@ export const ru: TranslationResources = {
     },
   },
   newWorkspace: {
+    logicalWorkspace: {
+      label: "Logical workspace",
+      new: "New logical workspace",
+      search: "Search logical workspaces",
+      tooltip: "Create a new logical workspace or add this host to an existing one",
+    },
     title: "Новое рабочее пространство",
     create: "Создать",
     isolation: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1119,6 +1119,7 @@ export const zhCN: TranslationResources = {
       actions: {
         menu: "Workspace 操作",
         newWorkspace: "新建 workspace",
+        addHost: "Add host",
         showMore: "显示更多",
         showLess: "收起",
         createWorkspaceFor: "为 {{projectName}} 新建 workspace",
@@ -1155,6 +1156,12 @@ export const zhCN: TranslationResources = {
     },
   },
   newWorkspace: {
+    logicalWorkspace: {
+      label: "Logical workspace",
+      new: "New logical workspace",
+      search: "Search logical workspaces",
+      tooltip: "Create a new logical workspace or add this host to an existing one",
+    },
     title: "新建 workspace",
     create: "创建",
     isolation: {

--- a/packages/app/src/plugins/evaluate.test.ts
+++ b/packages/app/src/plugins/evaluate.test.ts
@@ -290,4 +290,103 @@ describe("evaluatePluginClientBundle", () => {
       ),
     ).toThrow("setup exploded");
   });
+
+  it("collects one declarative native workspace grouping seam", () => {
+    const plugin = evaluatePluginClientBundle(
+      "paseo-layout",
+      bundle(`
+        plugin.addSidebarWorkspaceGrouping({
+          id: "logical-workspaces",
+          logicalWorkspaceRefLabelPrefix: "paseo:reserved:v1:logical-workspace-ref=",
+          defaultPlacementLabel: "paseo:reserved:v1:placement-role=default",
+          retainedHistoryBindings: [{
+            workspaceId: " wks_retained_history ",
+            physicalWorkspaceRef: "project-a-catalog-host-b",
+            logicalWorkspaceRef: "project-a-catalog",
+          }],
+        });
+      `),
+    );
+
+    expect(plugin.sidebarWorkspaceGroupings).toEqual([
+      {
+        id: "logical-workspaces",
+        logicalWorkspaceRefLabelPrefix: "paseo:reserved:v1:logical-workspace-ref=",
+        defaultPlacementLabel: "paseo:reserved:v1:placement-role=default",
+        retainedHistoryBindings: [
+          {
+            workspaceId: "wks_retained_history",
+            physicalWorkspaceRef: "project-a-catalog-host-b",
+            logicalWorkspaceRef: "project-a-catalog",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("rejects duplicate or non-v1 workspace grouping codecs", () => {
+    expect(() =>
+      evaluatePluginClientBundle(
+        "paseo-layout",
+        bundle(`
+          const grouping = {
+            id: "logical-workspaces",
+            logicalWorkspaceRefLabelPrefix: "paseo:reserved:v1:logical-workspace-ref=",
+            defaultPlacementLabel: "paseo:reserved:v1:placement-role=default",
+          };
+          plugin.addSidebarWorkspaceGrouping(grouping);
+          plugin.addSidebarWorkspaceGrouping(grouping);
+        `),
+      ),
+    ).toThrow("Duplicate sidebar workspace grouping: logical-workspaces");
+
+    expect(() =>
+      evaluatePluginClientBundle(
+        "paseo-layout",
+        bundle(`
+          plugin.addSidebarWorkspaceGrouping({
+            id: "logical-workspaces",
+            logicalWorkspaceRefLabelPrefix: "custom:logical=",
+            defaultPlacementLabel: "custom:default",
+          });
+        `),
+      ),
+    ).toThrow("must use the reserved v1 workspace label codec");
+
+    expect(() =>
+      evaluatePluginClientBundle(
+        "paseo-layout",
+        bundle(`
+          plugin.addSidebarWorkspaceGrouping({
+            id: "logical-workspaces",
+            logicalWorkspaceRefLabelPrefix: "paseo:reserved:v1:logical-workspace-ref=",
+            defaultPlacementLabel: "paseo:reserved:v1:placement-role=default",
+            retainedHistoryBindings: [{
+              workspaceId: "",
+              physicalWorkspaceRef: "project-a-catalog-host-b",
+              logicalWorkspaceRef: "project-a-catalog",
+            }],
+          });
+        `),
+      ),
+    ).toThrow("invalid retained-history workspace id");
+
+    expect(() =>
+      evaluatePluginClientBundle(
+        "paseo-layout",
+        bundle(`
+          plugin.addSidebarWorkspaceGrouping({
+            id: "logical-workspaces",
+            logicalWorkspaceRefLabelPrefix: "paseo:reserved:v1:logical-workspace-ref=",
+            defaultPlacementLabel: "paseo:reserved:v1:placement-role=default",
+            retainedHistoryBindings: [{
+              workspaceId: "old-workspace",
+              physicalWorkspaceRef: "project-a-catalog-host-b",
+              logicalWorkspaceRef: "project-a/parts",
+            }],
+          });
+        `),
+      ),
+    ).toThrow("invalid retained-history logical workspace ref");
+  });
 });

--- a/packages/app/src/plugins/evaluate.ts
+++ b/packages/app/src/plugins/evaluate.ts
@@ -6,11 +6,17 @@ import * as ReactNative from "react-native";
 import * as ReactQuery from "@tanstack/react-query";
 import * as Zod from "zod";
 import {
+  DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+  encodeLogicalWorkspaceRefLabel,
+} from "@getpaseo/protocol/workspace-labels";
+import {
   defineAttachmentSource,
   defineRpc,
   type PluginAttachmentSourceContribution,
   type PluginCommandCenterItemContribution,
   type PluginSidebarContribution,
+  type PluginSidebarWorkspaceGroupingContribution,
   type PluginSurfaceProps,
   type PluginThemeContribution,
   type PluginWorkspacePanelContribution,
@@ -33,10 +39,21 @@ function requireId(value: string, label: string): string {
   return id;
 }
 
+function requireWorkspaceRef(value: unknown, label: string): string {
+  const ref = typeof value === "string" ? value.trim() : "";
+  try {
+    encodeLogicalWorkspaceRefLabel(ref);
+  } catch {
+    throw new Error(`Sidebar workspace grouping has invalid retained-history ${label}`);
+  }
+  return ref;
+}
+
 export function evaluatePluginClientBundle(id: string, bundle: string): EvaluatedPlugin {
   const collector: PluginRegistrationCollector = {
     surfaces: [],
     sidebarItems: [],
+    sidebarWorkspaceGroupings: [],
     workspacePanels: [],
     commandCenterItems: [],
     attachmentSources: [],
@@ -44,6 +61,7 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
   };
   const surfaceIds = new Set<string>();
   const sidebarItemIds = new Set<string>();
+  const sidebarWorkspaceGroupingIds = new Set<string>();
   const workspacePanelIds = new Set<string>();
   const commandCenterItemIds = new Set<string>();
   const attachmentSourceIds = new Set<string>();
@@ -70,6 +88,62 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
         title: contribution.title.trim(),
         icon: contribution.icon.trim(),
         surface: requireId(contribution.surface, "sidebar surface id"),
+      });
+    },
+    addSidebarWorkspaceGrouping(contribution: PluginSidebarWorkspaceGroupingContribution) {
+      const normalizedId = requireId(contribution.id, "sidebar workspace grouping id");
+      if (sidebarWorkspaceGroupingIds.has(normalizedId)) {
+        throw new Error(`Duplicate sidebar workspace grouping: ${normalizedId}`);
+      }
+      const logicalWorkspaceRefLabelPrefix = contribution.logicalWorkspaceRefLabelPrefix.trim();
+      const defaultPlacementLabel = contribution.defaultPlacementLabel.trim();
+      if (
+        logicalWorkspaceRefLabelPrefix !== LOGICAL_WORKSPACE_REF_LABEL_PREFIX ||
+        defaultPlacementLabel !== DEFAULT_WORKSPACE_PLACEMENT_LABEL
+      ) {
+        throw new Error(
+          `Sidebar workspace grouping ${normalizedId} must use the reserved v1 workspace label codec`,
+        );
+      }
+      const retainedHistoryBindings = contribution.retainedHistoryBindings ?? [];
+      if (!Array.isArray(retainedHistoryBindings)) {
+        throw new Error(
+          `Sidebar workspace grouping ${normalizedId} has invalid retained-history bindings`,
+        );
+      }
+      const retainedWorkspaceIds = new Set<string>();
+      const normalizedRetainedHistoryBindings = retainedHistoryBindings.map((binding) => {
+        const workspaceId =
+          typeof binding?.workspaceId === "string" ? binding.workspaceId.trim() : "";
+        if (!workspaceId) {
+          throw new Error(
+            `Sidebar workspace grouping ${normalizedId} has invalid retained-history workspace id`,
+          );
+        }
+        if (retainedWorkspaceIds.has(workspaceId)) {
+          throw new Error(
+            `Sidebar workspace grouping ${normalizedId} has duplicate retained-history workspace id: ${workspaceId}`,
+          );
+        }
+        retainedWorkspaceIds.add(workspaceId);
+        return {
+          workspaceId,
+          physicalWorkspaceRef: requireWorkspaceRef(
+            binding.physicalWorkspaceRef,
+            "physical workspace ref",
+          ),
+          logicalWorkspaceRef: requireWorkspaceRef(
+            binding.logicalWorkspaceRef,
+            "logical workspace ref",
+          ),
+        };
+      });
+      sidebarWorkspaceGroupingIds.add(normalizedId);
+      collector.sidebarWorkspaceGroupings.push({
+        id: normalizedId,
+        logicalWorkspaceRefLabelPrefix,
+        defaultPlacementLabel,
+        retainedHistoryBindings: normalizedRetainedHistoryBindings,
       });
     },
     addWorkspacePanel(contribution: PluginWorkspacePanelContribution) {
@@ -213,6 +287,7 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
     cleanup,
     surfaces: collector.surfaces,
     sidebarItems: collector.sidebarItems,
+    sidebarWorkspaceGroupings: collector.sidebarWorkspaceGroupings,
     workspacePanels: collector.workspacePanels,
     commandCenterItems: collector.commandCenterItems,
     attachmentSources: collector.attachmentSources,

--- a/packages/app/src/plugins/sidebar-workspace-groupings.test.ts
+++ b/packages/app/src/plugins/sidebar-workspace-groupings.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+} from "@getpaseo/protocol/workspace-labels";
+import type { InstalledPlugin } from "./types";
+import { resolvePluginSidebarWorkspaceGroupings } from "./sidebar-workspace-groupings";
+
+function plugin(
+  serverId: string,
+  input: {
+    id?: string;
+    logicalWorkspaceRefLabelPrefix?: string;
+    defaultPlacementLabel?: string;
+    retainedHistoryBindings?: Array<{
+      workspaceId: string;
+      physicalWorkspaceRef: string;
+      logicalWorkspaceRef: string;
+    }>;
+  } = {},
+): InstalledPlugin {
+  return {
+    id: "paseo-layout",
+    serverId,
+    sidebarWorkspaceGroupings: [
+      {
+        id: input.id ?? "logical-workspaces",
+        logicalWorkspaceRefLabelPrefix:
+          input.logicalWorkspaceRefLabelPrefix ?? LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+        defaultPlacementLabel: input.defaultPlacementLabel ?? DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+        retainedHistoryBindings: input.retainedHistoryBindings,
+      },
+    ],
+  } as InstalledPlugin;
+}
+
+describe("plugin sidebar workspace groupings", () => {
+  it("coalesces the same declarative seam across hosts", () => {
+    expect(
+      resolvePluginSidebarWorkspaceGroupings([plugin("host-a"), plugin("host-b")]),
+    ).toEqual([
+      {
+        key: "paseo-layout/sidebar-workspace-grouping/logical-workspaces",
+        logicalWorkspaceRefLabelPrefix: LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+        defaultPlacementLabel: DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+        serverIds: ["host-a", "host-b"],
+        retainedHistoryBindings: [],
+      },
+    ]);
+  });
+
+  it("fails open when no plugin contributes the seam", () => {
+    expect(resolvePluginSidebarWorkspaceGroupings([])).toEqual([]);
+  });
+
+  it("fails open on a cross-host codec conflict instead of choosing by arrival order", () => {
+    expect(
+      resolvePluginSidebarWorkspaceGroupings([
+        plugin("host-a"),
+        plugin("host-b", {
+          logicalWorkspaceRefLabelPrefix: "paseo:reserved:v2:logical-workspace-ref=",
+        }),
+      ]),
+    ).toEqual([]);
+    expect(
+      resolvePluginSidebarWorkspaceGroupings([
+        plugin("host-b", {
+          logicalWorkspaceRefLabelPrefix: "paseo:reserved:v2:logical-workspace-ref=",
+        }),
+        plugin("host-a"),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("attaches server identity while coalescing host-local retained-history bindings", () => {
+    expect(
+      resolvePluginSidebarWorkspaceGroupings([
+        plugin("host-a"),
+        plugin("host-b", {
+          retainedHistoryBindings: [
+            {
+              workspaceId: "wks_retained_history",
+              physicalWorkspaceRef: "project-a-catalog-host-b",
+              logicalWorkspaceRef: "project-a-catalog",
+            },
+          ],
+        }),
+      ]),
+    ).toEqual([
+      {
+        key: "paseo-layout/sidebar-workspace-grouping/logical-workspaces",
+        logicalWorkspaceRefLabelPrefix: LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+        defaultPlacementLabel: DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+        serverIds: ["host-a", "host-b"],
+        retainedHistoryBindings: [
+          {
+            serverId: "host-b",
+            workspaceId: "wks_retained_history",
+            physicalWorkspaceRef: "project-a-catalog-host-b",
+            logicalWorkspaceRef: "project-a-catalog",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("drops only an ambiguous retained-history identity and keeps the codec fail-open", () => {
+    expect(
+      resolvePluginSidebarWorkspaceGroupings([
+        plugin("host-b", {
+          retainedHistoryBindings: [
+            {
+              workspaceId: "old-workspace",
+              physicalWorkspaceRef: "project-a-catalog-host-b",
+              logicalWorkspaceRef: "project-a-catalog",
+            },
+          ],
+        }),
+        plugin("host-b", {
+          retainedHistoryBindings: [
+            {
+              workspaceId: "old-workspace",
+              physicalWorkspaceRef: "project-a-catalog-host-b",
+              logicalWorkspaceRef: "project-a-diagnostics",
+            },
+          ],
+        }),
+      ]),
+    ).toEqual([
+      {
+        key: "paseo-layout/sidebar-workspace-grouping/logical-workspaces",
+        logicalWorkspaceRefLabelPrefix: LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+        defaultPlacementLabel: DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+        serverIds: ["host-b"],
+        retainedHistoryBindings: [],
+      },
+    ]);
+  });
+});

--- a/packages/app/src/plugins/sidebar-workspace-groupings.ts
+++ b/packages/app/src/plugins/sidebar-workspace-groupings.ts
@@ -1,0 +1,100 @@
+import type { InstalledPlugin } from "./types";
+
+export interface PluginSidebarWorkspaceGrouping {
+  key: string;
+  logicalWorkspaceRefLabelPrefix: string;
+  defaultPlacementLabel: string;
+  serverIds?: readonly string[];
+  retainedHistoryBindings?: readonly PluginSidebarWorkspaceRetainedHistoryBinding[];
+}
+
+export interface PluginSidebarWorkspaceRetainedHistoryBinding {
+  serverId: string;
+  workspaceId: string;
+  physicalWorkspaceRef: string;
+  logicalWorkspaceRef: string;
+}
+
+interface RetainedHistoryBindingDraft {
+  binding: PluginSidebarWorkspaceRetainedHistoryBinding;
+  conflict: boolean;
+}
+
+interface GroupingDraft extends Omit<PluginSidebarWorkspaceGrouping, "retainedHistoryBindings"> {
+  serverIds: string[];
+  retainedHistoryBindingsByIdentity: Map<string, RetainedHistoryBindingDraft>;
+  conflict: boolean;
+}
+
+/**
+ * Equal plugin/contribution ids form one cross-host namespace. A host disagreement is not a
+ * precedence question: choosing either codec by connection order could regroup native history,
+ * so the contribution fails open and physical rows remain visible.
+ */
+export function resolvePluginSidebarWorkspaceGroupings(
+  plugins: readonly InstalledPlugin[],
+): PluginSidebarWorkspaceGrouping[] {
+  const byKey = new Map<string, GroupingDraft>();
+  for (const plugin of plugins) {
+    for (const contribution of plugin.sidebarWorkspaceGroupings ?? []) {
+      const key = `${plugin.id}/sidebar-workspace-grouping/${contribution.id}`;
+      const existing = byKey.get(key);
+      if (!existing) {
+        byKey.set(key, {
+          key,
+          logicalWorkspaceRefLabelPrefix: contribution.logicalWorkspaceRefLabelPrefix,
+          defaultPlacementLabel: contribution.defaultPlacementLabel,
+          serverIds: [plugin.serverId],
+          retainedHistoryBindingsByIdentity: new Map(),
+          conflict: false,
+        });
+      } else if (
+        existing.logicalWorkspaceRefLabelPrefix !== contribution.logicalWorkspaceRefLabelPrefix ||
+        existing.defaultPlacementLabel !== contribution.defaultPlacementLabel
+      ) {
+        existing.conflict = true;
+      } else if (!existing.serverIds.includes(plugin.serverId)) {
+        existing.serverIds.push(plugin.serverId);
+      }
+
+      const draft = byKey.get(key);
+      if (!draft) continue;
+      for (const binding of contribution.retainedHistoryBindings ?? []) {
+        const identity = JSON.stringify([plugin.serverId, binding.workspaceId]);
+        const existingBinding = draft.retainedHistoryBindingsByIdentity.get(identity);
+        const resolved = { serverId: plugin.serverId, ...binding };
+        if (!existingBinding) {
+          draft.retainedHistoryBindingsByIdentity.set(identity, {
+            binding: resolved,
+            conflict: false,
+          });
+          continue;
+        }
+        if (
+          existingBinding.binding.physicalWorkspaceRef !== binding.physicalWorkspaceRef ||
+          existingBinding.binding.logicalWorkspaceRef !== binding.logicalWorkspaceRef
+        ) {
+          existingBinding.conflict = true;
+        }
+      }
+    }
+  }
+
+  return [...byKey.values()]
+    .filter((grouping) => !grouping.conflict)
+    .sort((left, right) => left.key.localeCompare(right.key))
+    .map((grouping) => ({
+      key: grouping.key,
+      logicalWorkspaceRefLabelPrefix: grouping.logicalWorkspaceRefLabelPrefix,
+      defaultPlacementLabel: grouping.defaultPlacementLabel,
+      serverIds: [...grouping.serverIds].sort(),
+      retainedHistoryBindings: [...grouping.retainedHistoryBindingsByIdentity.values()]
+        .filter((draft) => !draft.conflict)
+        .map((draft) => draft.binding)
+        .sort(
+          (left, right) =>
+            left.serverId.localeCompare(right.serverId) ||
+            left.workspaceId.localeCompare(right.workspaceId),
+        ),
+    }));
+}

--- a/packages/app/src/plugins/types.ts
+++ b/packages/app/src/plugins/types.ts
@@ -3,6 +3,7 @@ import type {
   PluginAttachmentSourceContribution,
   PluginCommandCenterItemContribution,
   PluginSidebarContribution,
+  PluginSidebarWorkspaceGroupingContribution,
   PluginSurfaceContribution,
   PluginThemeContribution,
   PluginWorkspacePanelContribution,
@@ -13,6 +14,7 @@ export interface EvaluatedPlugin {
   cleanup: () => void;
   surfaces: PluginSurfaceContribution[];
   sidebarItems: PluginSidebarContribution[];
+  sidebarWorkspaceGroupings?: PluginSidebarWorkspaceGroupingContribution[];
   workspacePanels: PluginWorkspacePanelContribution[];
   commandCenterItems: PluginCommandCenterItemContribution[];
   attachmentSources: PluginAttachmentSourceContribution[];
@@ -29,6 +31,7 @@ export type {
   PluginAttachmentSourceContribution,
   PluginCommandCenterItemContribution,
   PluginSidebarContribution,
+  PluginSidebarWorkspaceGroupingContribution,
   PluginSurfaceContribution,
   PluginThemeContribution,
   PluginWorkspacePanelContribution,

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -121,9 +121,12 @@ import { useNewWorkspaceProjectPicker } from "./new-workspace/project-picker";
 import { useInstalledPlugins } from "@/plugins/registry";
 import { resolvePluginSidebarWorkspaceGroupings } from "@/plugins/sidebar-workspace-groupings";
 import {
+  NEW_LOGICAL_WORKSPACE_OPTION_ID,
   buildInitialLogicalWorkspaceLabels,
   buildLogicalWorkspaceOptions,
+  buildLogicalWorkspaceSelectionScopeKey,
   resolveLogicalWorkspaceCreationGrouping,
+  resolveLogicalWorkspaceRefOption,
 } from "./new-workspace/logical-workspace-selection";
 import { useSidebarWorkspaceEntries } from "@/hooks/use-sidebar-workspace-entries";
 import { useSidebarWorkspacesList } from "@/hooks/use-sidebar-workspaces-list";
@@ -1757,20 +1760,23 @@ export function NewWorkspaceScreen({
   const [selectedLogicalWorkspaceRef, setSelectedLogicalWorkspaceRef] = useState<string | null>(
     initialLogicalWorkspaceRef,
   );
-  const logicalWorkspaceProjectRef = useRef<string | null>(null);
+  const logicalWorkspaceSelectionScope = buildLogicalWorkspaceSelectionScopeKey(
+    selectedProject?.viewKey ?? null,
+    logicalWorkspaceGrouping,
+  );
+  const logicalWorkspaceSelectionScopeRef = useRef<string | null>(null);
   useEffect(() => {
-    const projectViewKey = selectedProject?.viewKey ?? null;
     if (
-      logicalWorkspaceProjectRef.current !== null &&
-      logicalWorkspaceProjectRef.current !== projectViewKey
+      logicalWorkspaceSelectionScopeRef.current !== null &&
+      logicalWorkspaceSelectionScopeRef.current !== logicalWorkspaceSelectionScope
     ) {
       setSelectedLogicalWorkspaceRef(null);
     }
-    logicalWorkspaceProjectRef.current = projectViewKey;
-  }, [selectedProject?.viewKey]);
+    logicalWorkspaceSelectionScopeRef.current = logicalWorkspaceSelectionScope;
+  }, [logicalWorkspaceSelectionScope]);
   const logicalWorkspacePickerOptions = useMemo<ComboboxOptionType[]>(
     () => [
-      { id: "new", label: t("newWorkspace.logicalWorkspace.new") },
+      { id: NEW_LOGICAL_WORKSPACE_OPTION_ID, label: t("newWorkspace.logicalWorkspace.new") },
       ...logicalWorkspaceOptions.map((option) => ({
         id: option.logicalWorkspaceRef,
         label: option.title,
@@ -2090,7 +2096,7 @@ export function NewWorkspaceScreen({
   }, []);
 
   const handleSelectLogicalWorkspace = useCallback((id: string) => {
-    setSelectedLogicalWorkspaceRef(id === "new" ? null : id);
+    setSelectedLogicalWorkspaceRef(resolveLogicalWorkspaceRefOption(id));
     setLogicalWorkspacePickerOpen(false);
   }, []);
 
@@ -2401,7 +2407,7 @@ export function NewWorkspaceScreen({
       openState: logicalWorkspacePickerOpen,
       onOpenChange: handleLogicalWorkspacePickerOpenChange,
       options: logicalWorkspacePickerOptions,
-      value: selectedLogicalWorkspaceRef ?? "new",
+      value: selectedLogicalWorkspaceRef ?? NEW_LOGICAL_WORKSPACE_OPTION_ID,
       triggerLabel: logicalWorkspaceTriggerLabel,
       onSelect: handleSelectLogicalWorkspace,
     },

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -118,6 +118,15 @@ import {
 } from "./new-workspace-initial-context";
 import { buildNewWorkspaceProjectIconTargets } from "./new-workspace/project-icon-targets";
 import { useNewWorkspaceProjectPicker } from "./new-workspace/project-picker";
+import { useInstalledPlugins } from "@/plugins/registry";
+import { resolvePluginSidebarWorkspaceGroupings } from "@/plugins/sidebar-workspace-groupings";
+import {
+  buildInitialLogicalWorkspaceLabels,
+  buildLogicalWorkspaceOptions,
+  resolveLogicalWorkspaceCreationGrouping,
+} from "./new-workspace/logical-workspace-selection";
+import { useSidebarWorkspaceEntries } from "@/hooks/use-sidebar-workspace-entries";
+import { useSidebarWorkspacesList } from "@/hooks/use-sidebar-workspaces-list";
 
 const ThemedFolderPlus = withUnistyles(FolderPlus);
 const foregroundMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
@@ -177,6 +186,7 @@ interface NewWorkspaceScreenProps {
   projectId?: string;
   displayName?: string;
   draftId?: string;
+  logicalWorkspaceRef?: string;
 }
 
 // A terminal launch sends argv, not a message: there is nothing to attach and
@@ -809,6 +819,7 @@ async function createMultiplicityWorkspace(input: {
   ) => void;
   serverId: string;
   createFailedMessage: string;
+  labels?: string[];
 }): Promise<ReturnType<typeof normalizeWorkspaceDescriptor>> {
   const projectId = getHostProjectId(input.project, input.serverId);
   if (!projectId) throw new Error("Project is not available on the selected host");
@@ -832,6 +843,7 @@ async function createMultiplicityWorkspace(input: {
           projectId,
         },
     ...(firstAgentContext ? { firstAgentContext } : {}),
+    ...(input.labels ? { labels: input.labels } : {}),
   });
   if (payload.error || !payload.workspace) {
     throw new Error(payload.error ?? input.createFailedMessage);
@@ -1311,6 +1323,13 @@ interface NewWorkspaceFormStackInput {
     selectedServerId: string;
     onSelect: (id: string) => void;
   };
+  logicalWorkspace: FormPickerControl & {
+    visible: boolean;
+    options: ComboboxOptionType[];
+    value: string;
+    triggerLabel: string;
+    onSelect: (id: string) => void;
+  };
   isolation: FormPickerControl & {
     effectiveIsolation: "local" | "worktree";
     options: ComboboxOptionType[];
@@ -1342,7 +1361,7 @@ interface NewWorkspaceFormStackInput {
 function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactElement {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
-  const { isCompact, isPending, project, host, isolation, base, launch } = input;
+  const { isCompact, isPending, project, host, logicalWorkspace, isolation, base, launch } = input;
 
   const selectedHostLabel =
     host.allHosts.find((h) => h.serverId === host.selectedServerId)?.label ?? "Host";
@@ -1445,6 +1464,48 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
     </View>
   ) : null;
 
+  const logicalWorkspaceControl = logicalWorkspace.visible ? (
+    <View style={desktopControlStyle}>
+      <Tooltip>
+        <TooltipTrigger asChild triggerRefProp="ref">
+          <ComboboxTrigger
+            chevron={metaChevron}
+            ref={logicalWorkspace.anchorRef}
+            testID="new-workspace-logical-workspace-picker-trigger"
+            onPress={logicalWorkspace.open}
+            disabled={isPending}
+            style={badgePressableStyle}
+            accessibilityRole="button"
+            accessibilityLabel={t("newWorkspace.logicalWorkspace.label")}
+          >
+            <View style={styles.badgeIconBox}>
+              <Folder size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+            </View>
+            <Text style={styles.badgeText} numberOfLines={1}>
+              {logicalWorkspace.triggerLabel}
+            </Text>
+          </ComboboxTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="center" offset={8}>
+          <Text style={styles.tooltipText}>{t("newWorkspace.logicalWorkspace.tooltip")}</Text>
+        </TooltipContent>
+      </Tooltip>
+      <Combobox
+        options={logicalWorkspace.options}
+        value={logicalWorkspace.value}
+        onSelect={logicalWorkspace.onSelect}
+        searchable={logicalWorkspace.options.length > 6}
+        searchPlaceholder={t("newWorkspace.logicalWorkspace.search")}
+        title={t("newWorkspace.logicalWorkspace.label")}
+        open={logicalWorkspace.openState}
+        onOpenChange={logicalWorkspace.onOpenChange}
+        desktopPlacement="bottom-start"
+        desktopMinWidth={260}
+        anchorRef={logicalWorkspace.anchorRef}
+      />
+    </View>
+  ) : null;
+
   const isolationControl = isolation.canCreateWorktree ? (
     <View style={desktopControlStyle}>
       <IsolationPickerTrigger
@@ -1518,6 +1579,7 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
   return isCompact ? (
     <View testID="new-workspace-ref-picker-row" style={styles.formStack}>
       <FormRow>{projectControl}</FormRow>
+      {logicalWorkspaceControl ? <FormRow>{logicalWorkspaceControl}</FormRow> : null}
       {hostControl ? <FormRow>{hostControl}</FormRow> : null}
       {isolationControl ? <FormRow>{isolationControl}</FormRow> : null}
       {baseControl ? <FormRow>{baseControl}</FormRow> : null}
@@ -1529,6 +1591,7 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
   ) : (
     <View testID="new-workspace-ref-picker-row" style={styles.formStackDesktop}>
       {projectControl}
+      {logicalWorkspaceControl}
       {hostControl}
       {isolationControl}
       {baseControl}
@@ -1544,6 +1607,7 @@ export function NewWorkspaceScreen({
   projectId,
   displayName: displayNameProp,
   draftId,
+  logicalWorkspaceRef: logicalWorkspaceRefProp,
 }: NewWorkspaceScreenProps) {
   const queryClient = useQueryClient();
   const { theme } = useUnistyles();
@@ -1579,12 +1643,14 @@ export function NewWorkspaceScreen({
   const [pendingAction, setPendingAction] = useState<"chat" | "empty" | "terminal" | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
+  const [logicalWorkspacePickerOpen, setLogicalWorkspacePickerOpen] = useState(false);
   const openAddProjectPicker = useOpenAddProject();
   const [isolationPickerOpen, setIsolationPickerOpen] = useState(false);
   const [pickerSearchQuery, setPickerSearchQuery] = useState("");
   const [debouncedPickerSearchQuery, setDebouncedPickerSearchQuery] = useState("");
   const pickerAnchorRef = useRef<View>(null);
   const projectPickerAnchorRef = useRef<View>(null);
+  const logicalWorkspacePickerAnchorRef = useRef<View>(null);
   const isolationPickerAnchorRef = useRef<View>(null);
   const hostPickerAnchorRef = useRef<View | null>(null);
   const isDraftHandoffActive = useIsNewWorkspaceDraftHandoffActive({ draftId, selectedServerId });
@@ -1646,6 +1712,97 @@ export function NewWorkspaceScreen({
     lastActiveProject,
     allowAllProjects: supportsWorkspaceMultiplicity,
   });
+  const installedPlugins = useInstalledPlugins();
+  const logicalWorkspaceGroupings = useMemo(
+    () => resolvePluginSidebarWorkspaceGroupings(installedPlugins),
+    [installedPlugins],
+  );
+  const logicalWorkspaceGrouping = useMemo(
+    () => resolveLogicalWorkspaceCreationGrouping(logicalWorkspaceGroupings, selectedServerId),
+    [logicalWorkspaceGroupings, selectedServerId],
+  );
+  const logicalWorkspaceInventory = useSidebarWorkspacesList({
+    hostFilters: [],
+    enabled: logicalWorkspaceGrouping !== null,
+  });
+  const logicalWorkspaceEntries = useSidebarWorkspaceEntries(
+    logicalWorkspaceInventory.workspacePlacements,
+    logicalWorkspaceGrouping !== null,
+  );
+  const logicalWorkspaceOptions = useMemo(
+    () =>
+      logicalWorkspaceGrouping && selectedProject
+        ? buildLogicalWorkspaceOptions({
+            grouping: logicalWorkspaceGrouping,
+            workspaces: selectedProject.workspaceKeys.flatMap((workspaceKey) => {
+              const entry = logicalWorkspaceEntries.get(workspaceKey);
+              return entry
+                ? [
+                    {
+                      workspaceKey,
+                      serverId: entry.serverId,
+                      name: entry.name,
+                      title: entry.title,
+                      labels: entry.labels,
+                    },
+                  ]
+                : [];
+            }),
+          })
+        : [],
+    [logicalWorkspaceEntries, logicalWorkspaceGrouping, selectedProject],
+  );
+  const newLogicalWorkspaceRef = useRef(`lw-${generateMessageId().slice(4)}`);
+  const initialLogicalWorkspaceRef = logicalWorkspaceRefProp?.trim() || null;
+  const [selectedLogicalWorkspaceRef, setSelectedLogicalWorkspaceRef] = useState<string | null>(
+    initialLogicalWorkspaceRef,
+  );
+  const logicalWorkspaceProjectRef = useRef<string | null>(null);
+  useEffect(() => {
+    const projectViewKey = selectedProject?.viewKey ?? null;
+    if (
+      logicalWorkspaceProjectRef.current !== null &&
+      logicalWorkspaceProjectRef.current !== projectViewKey
+    ) {
+      setSelectedLogicalWorkspaceRef(null);
+    }
+    logicalWorkspaceProjectRef.current = projectViewKey;
+  }, [selectedProject?.viewKey]);
+  const logicalWorkspacePickerOptions = useMemo<ComboboxOptionType[]>(
+    () => [
+      { id: "new", label: t("newWorkspace.logicalWorkspace.new") },
+      ...logicalWorkspaceOptions.map((option) => ({
+        id: option.logicalWorkspaceRef,
+        label: option.title,
+      })),
+    ],
+    [logicalWorkspaceOptions, t],
+  );
+  const logicalWorkspaceTriggerLabel =
+    logicalWorkspaceOptions.find(
+      (option) => option.logicalWorkspaceRef === selectedLogicalWorkspaceRef,
+    )?.title ??
+    (selectedLogicalWorkspaceRef
+      ? selectedLogicalWorkspaceRef
+      : t("newWorkspace.logicalWorkspace.new"));
+  const initialWorkspaceLabels = useMemo(
+    () =>
+      logicalWorkspaceGrouping
+        ? buildInitialLogicalWorkspaceLabels({
+            grouping: logicalWorkspaceGrouping,
+            selection: selectedLogicalWorkspaceRef
+              ? {
+                  kind: "existing",
+                  logicalWorkspaceRef: selectedLogicalWorkspaceRef,
+                }
+              : {
+                  kind: "new",
+                  logicalWorkspaceRef: newLogicalWorkspaceRef.current,
+                },
+          })
+        : undefined,
+    [logicalWorkspaceGrouping, selectedLogicalWorkspaceRef],
+  );
   const projectIconTargets = useMemo(
     () => buildNewWorkspaceProjectIconTargets(projects, selectedServerId),
     [projects, selectedServerId],
@@ -1928,6 +2085,15 @@ export function NewWorkspaceScreen({
     setProjectPickerOpen(nextOpen);
   }, []);
 
+  const handleLogicalWorkspacePickerOpenChange = useCallback((nextOpen: boolean) => {
+    setLogicalWorkspacePickerOpen(nextOpen);
+  }, []);
+
+  const handleSelectLogicalWorkspace = useCallback((id: string) => {
+    setSelectedLogicalWorkspaceRef(id === "new" ? null : id);
+    setLogicalWorkspacePickerOpen(false);
+  }, []);
+
   const buildCreateWorktreeInput = useCallback(
     (input: {
       cwd: string;
@@ -1950,12 +2116,13 @@ export function NewWorkspaceScreen({
       return {
         cwd: selectedSourceDirectory,
         projectId: hostProjectId,
+        ...(initialWorkspaceLabels ? { labels: initialWorkspaceLabels } : {}),
         worktreeSlug: createNameId(),
         ...(firstAgentContext ? { firstAgentContext } : {}),
         ...input.checkoutRequest,
       };
     },
-    [selectedProject, selectedServerId, selectedSourceDirectory],
+    [initialWorkspaceLabels, selectedProject, selectedServerId, selectedSourceDirectory],
   );
 
   const ensureWorkspace = useCallback(
@@ -2002,6 +2169,7 @@ export function NewWorkspaceScreen({
             mergeWorkspaces,
             serverId: selectedServerId,
             createFailedMessage: t("newWorkspace.errors.createWorktreeFailed"),
+            labels: initialWorkspaceLabels,
           })
         : await createAndMergeWorkspace({
             client: connectedClient,
@@ -2017,6 +2185,7 @@ export function NewWorkspaceScreen({
       buildCreateWorktreeInput,
       createdWorkspace,
       effectiveIsolation,
+      initialWorkspaceLabels,
       mergeWorkspaces,
       queryClient,
       selectedItem,
@@ -2224,6 +2393,17 @@ export function NewWorkspaceScreen({
       onOpenChange: handleHostPickerOpenChange,
       anchorRef: hostPickerAnchorRef,
       open: openHostPicker,
+    },
+    logicalWorkspace: {
+      visible: logicalWorkspaceGrouping !== null,
+      anchorRef: logicalWorkspacePickerAnchorRef,
+      open: () => setLogicalWorkspacePickerOpen(true),
+      openState: logicalWorkspacePickerOpen,
+      onOpenChange: handleLogicalWorkspacePickerOpenChange,
+      options: logicalWorkspacePickerOptions,
+      value: selectedLogicalWorkspaceRef ?? "new",
+      triggerLabel: logicalWorkspaceTriggerLabel,
+      onSelect: handleSelectLogicalWorkspace,
     },
     isolation: {
       anchorRef: isolationPickerAnchorRef,

--- a/packages/app/src/screens/new-workspace/logical-workspace-selection.test.ts
+++ b/packages/app/src/screens/new-workspace/logical-workspace-selection.test.ts
@@ -5,9 +5,12 @@ import {
 } from "@getpaseo/protocol/workspace-labels";
 import type { PluginSidebarWorkspaceGrouping } from "@/plugins/sidebar-workspace-groupings";
 import {
+  NEW_LOGICAL_WORKSPACE_OPTION_ID,
   buildInitialLogicalWorkspaceLabels,
   buildLogicalWorkspaceOptions,
+  buildLogicalWorkspaceSelectionScopeKey,
   resolveLogicalWorkspaceCreationGrouping,
+  resolveLogicalWorkspaceRefOption,
 } from "./logical-workspace-selection";
 
 const grouping: PluginSidebarWorkspaceGrouping = {
@@ -99,5 +102,24 @@ describe("new workspace logical grouping", () => {
         selection: { kind: "existing", logicalWorkspaceRef: "invalid ref with spaces" },
       }),
     ).toBeUndefined();
+  });
+
+  it("keeps the legal logical ref 'new' distinct from the new-workspace sentinel", () => {
+    expect(resolveLogicalWorkspaceRefOption("new")).toBe("new");
+    expect(resolveLogicalWorkspaceRefOption(NEW_LOGICAL_WORKSPACE_OPTION_ID)).toBeNull();
+  });
+
+  it("scopes a selection to both the native project and plugin namespace", () => {
+    expect(buildLogicalWorkspaceSelectionScopeKey("project-a", grouping)).toBe(
+      JSON.stringify(["project-a", grouping.key]),
+    );
+    expect(
+      buildLogicalWorkspaceSelectionScopeKey("project-a", {
+        ...grouping,
+        key: "another/sidebar-workspace-grouping/logical-workspaces",
+      }),
+    ).not.toBe(buildLogicalWorkspaceSelectionScopeKey("project-a", grouping));
+    expect(buildLogicalWorkspaceSelectionScopeKey(null, grouping)).toBeNull();
+    expect(buildLogicalWorkspaceSelectionScopeKey("project-a", null)).toBeNull();
   });
 });

--- a/packages/app/src/screens/new-workspace/logical-workspace-selection.test.ts
+++ b/packages/app/src/screens/new-workspace/logical-workspace-selection.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+} from "@getpaseo/protocol/workspace-labels";
+import type { PluginSidebarWorkspaceGrouping } from "@/plugins/sidebar-workspace-groupings";
+import {
+  buildInitialLogicalWorkspaceLabels,
+  buildLogicalWorkspaceOptions,
+  resolveLogicalWorkspaceCreationGrouping,
+} from "./logical-workspace-selection";
+
+const grouping: PluginSidebarWorkspaceGrouping = {
+  key: "paseo-layout/sidebar-workspace-grouping/logical-workspaces",
+  logicalWorkspaceRefLabelPrefix: LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+  defaultPlacementLabel: DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  serverIds: ["mac", "nuc"],
+};
+
+describe("new workspace logical grouping", () => {
+  it("uses the one grouping installed for the selected host and fails open on ambiguity", () => {
+    expect(resolveLogicalWorkspaceCreationGrouping([grouping], "nuc")).toBe(grouping);
+    expect(resolveLogicalWorkspaceCreationGrouping([grouping], "vps")).toBeNull();
+    expect(
+      resolveLogicalWorkspaceCreationGrouping(
+        [grouping, { ...grouping, key: "other/logical" }],
+        "nuc",
+      ),
+    ).toBeNull();
+  });
+
+  it("lists each logical workspace once and takes its title from the default placement", () => {
+    const options = buildLogicalWorkspaceOptions({
+      grouping,
+      workspaces: [
+        {
+          workspaceKey: "nuc:parts",
+          serverId: "nuc",
+          name: "parts-nuc",
+          title: "Części i katalogi",
+          labels: [`${LOGICAL_WORKSPACE_REF_LABEL_PREFIX}cars-parts`],
+        },
+        {
+          workspaceKey: "mac:parts",
+          serverId: "mac",
+          name: "parts-mac",
+          title: "Części i katalogi",
+          labels: [
+            `${LOGICAL_WORKSPACE_REF_LABEL_PREFIX}cars-parts`,
+            DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+          ],
+        },
+        {
+          workspaceKey: "nuc:diagnostics",
+          serverId: "nuc",
+          name: "Diagnostyka",
+          title: null,
+          labels: [
+            `${LOGICAL_WORKSPACE_REF_LABEL_PREFIX}cars-diagnostics`,
+            DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+          ],
+        },
+      ],
+    });
+
+    expect(options).toEqual([
+      {
+        logicalWorkspaceRef: "cars-parts",
+        title: "Części i katalogi",
+        serverIds: ["mac", "nuc"],
+      },
+      {
+        logicalWorkspaceRef: "cars-diagnostics",
+        title: "Diagnostyka",
+        serverIds: ["nuc"],
+      },
+    ]);
+  });
+
+  it("marks only a newly-created logical workspace placement as the default", () => {
+    expect(
+      buildInitialLogicalWorkspaceLabels({
+        grouping,
+        selection: { kind: "new", logicalWorkspaceRef: "lw-new" },
+      }),
+    ).toEqual([`${LOGICAL_WORKSPACE_REF_LABEL_PREFIX}lw-new`, DEFAULT_WORKSPACE_PLACEMENT_LABEL]);
+    expect(
+      buildInitialLogicalWorkspaceLabels({
+        grouping,
+        selection: { kind: "existing", logicalWorkspaceRef: "cars-parts" },
+      }),
+    ).toEqual([`${LOGICAL_WORKSPACE_REF_LABEL_PREFIX}cars-parts`]);
+  });
+
+  it("fails open when a logical workspace ref from the route is invalid", () => {
+    expect(
+      buildInitialLogicalWorkspaceLabels({
+        grouping,
+        selection: { kind: "existing", logicalWorkspaceRef: "invalid ref with spaces" },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/app/src/screens/new-workspace/logical-workspace-selection.ts
+++ b/packages/app/src/screens/new-workspace/logical-workspace-selection.ts
@@ -1,0 +1,99 @@
+import {
+  DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+  encodeLogicalWorkspaceRefLabel,
+  parseLogicalWorkspacePlacementLabels,
+} from "@getpaseo/protocol/workspace-labels";
+import type { PluginSidebarWorkspaceGrouping } from "@/plugins/sidebar-workspace-groupings";
+
+export interface LogicalWorkspaceSource {
+  workspaceKey: string;
+  serverId: string;
+  name: string;
+  title: string | null;
+  labels: readonly string[] | null | undefined;
+}
+
+export interface LogicalWorkspaceOption {
+  logicalWorkspaceRef: string;
+  title: string;
+  serverIds: string[];
+}
+
+export type LogicalWorkspaceCreationSelection =
+  | { kind: "new"; logicalWorkspaceRef: string }
+  | { kind: "existing"; logicalWorkspaceRef: string };
+
+export function resolveLogicalWorkspaceCreationGrouping(
+  groupings: readonly PluginSidebarWorkspaceGrouping[],
+  serverId: string,
+): PluginSidebarWorkspaceGrouping | null {
+  const matching = groupings.filter(
+    (grouping) => !grouping.serverIds || grouping.serverIds.includes(serverId),
+  );
+  return matching.length === 1 ? (matching[0] ?? null) : null;
+}
+
+export function buildLogicalWorkspaceOptions(input: {
+  grouping: PluginSidebarWorkspaceGrouping;
+  workspaces: readonly LogicalWorkspaceSource[];
+}): LogicalWorkspaceOption[] {
+  const groups = new Map<string, Array<LogicalWorkspaceSource & { defaultPlacement: boolean }>>();
+
+  for (const workspace of input.workspaces) {
+    if (input.grouping.serverIds && !input.grouping.serverIds.includes(workspace.serverId)) {
+      continue;
+    }
+    const metadata = parseLogicalWorkspacePlacementLabels(workspace.labels);
+    if (!metadata) continue;
+    const members = groups.get(metadata.logicalWorkspaceRef) ?? [];
+    members.push({ ...workspace, defaultPlacement: metadata.defaultPlacement });
+    groups.set(metadata.logicalWorkspaceRef, members);
+  }
+
+  return [...groups.entries()]
+    .map(([logicalWorkspaceRef, members]) => {
+      const ordered = [...members].sort(
+        (left, right) =>
+          Number(right.defaultPlacement) - Number(left.defaultPlacement) ||
+          left.serverId.localeCompare(right.serverId) ||
+          left.workspaceKey.localeCompare(right.workspaceKey),
+      );
+      const display = ordered[0];
+      if (!display) return null;
+      return {
+        logicalWorkspaceRef,
+        title: display.title ?? display.name,
+        serverIds: [...new Set(members.map((member) => member.serverId))].sort(),
+      };
+    })
+    .filter((option): option is LogicalWorkspaceOption => option !== null)
+    .sort(
+      (left, right) =>
+        left.title.localeCompare(right.title, undefined, {
+          numeric: true,
+          sensitivity: "base",
+        }) || left.logicalWorkspaceRef.localeCompare(right.logicalWorkspaceRef),
+    );
+}
+
+export function buildInitialLogicalWorkspaceLabels(input: {
+  grouping: PluginSidebarWorkspaceGrouping;
+  selection: LogicalWorkspaceCreationSelection;
+}): string[] | undefined {
+  if (
+    input.grouping.logicalWorkspaceRefLabelPrefix !== LOGICAL_WORKSPACE_REF_LABEL_PREFIX ||
+    input.grouping.defaultPlacementLabel !== DEFAULT_WORKSPACE_PLACEMENT_LABEL
+  ) {
+    return undefined;
+  }
+  let logicalWorkspaceRefLabel: string;
+  try {
+    logicalWorkspaceRefLabel = encodeLogicalWorkspaceRefLabel(input.selection.logicalWorkspaceRef);
+  } catch {
+    return undefined;
+  }
+  const labels = [logicalWorkspaceRefLabel];
+  if (input.selection.kind === "new") labels.push(input.grouping.defaultPlacementLabel);
+  return labels;
+}

--- a/packages/app/src/screens/new-workspace/logical-workspace-selection.ts
+++ b/packages/app/src/screens/new-workspace/logical-workspace-selection.ts
@@ -24,6 +24,19 @@ export type LogicalWorkspaceCreationSelection =
   | { kind: "new"; logicalWorkspaceRef: string }
   | { kind: "existing"; logicalWorkspaceRef: string };
 
+export const NEW_LOGICAL_WORKSPACE_OPTION_ID = "__new-logical-workspace__";
+
+export function resolveLogicalWorkspaceRefOption(optionId: string): string | null {
+  return optionId === NEW_LOGICAL_WORKSPACE_OPTION_ID ? null : optionId;
+}
+
+export function buildLogicalWorkspaceSelectionScopeKey(
+  projectViewKey: string | null,
+  grouping: PluginSidebarWorkspaceGrouping | null,
+): string | null {
+  return projectViewKey && grouping ? JSON.stringify([projectViewKey, grouping.key]) : null;
+}
+
 export function resolveLogicalWorkspaceCreationGrouping(
   groupings: readonly PluginSidebarWorkspaceGrouping[],
   serverId: string,

--- a/packages/app/src/stores/sidebar-view-store.test.ts
+++ b/packages/app/src/stores/sidebar-view-store.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StateStorage } from "zustand/middleware";
+import { encodeLogicalWorkspaceRefLabel } from "@getpaseo/protocol/workspace-labels";
 import {
   createSidebarViewStorage,
   hasActiveSidebarLabelFilter,
@@ -184,6 +185,23 @@ describe("sidebar view store", () => {
         labelFilter: { labels: [" Urgent ", "BLOCKED", "urgent"], match: "all" },
       }).labelFilter,
     ).toEqual({ labels: ["urgent", "blocked"] });
+  });
+
+  it("drops reserved keys from persisted, toggled, and reconciled user filters", () => {
+    const reserved = encodeLogicalWorkspaceRefLabel("project-a-catalog");
+    expect(
+      migrateSidebarViewState({
+        labelFilter: { labels: [reserved, "paseo:reserved:future:unknown", "Urgent"] },
+      }).labelFilter,
+    ).toEqual({ labels: ["urgent"] });
+
+    const store = useSidebarViewStore.getState();
+    store.toggleLabelFilter(reserved);
+    expect(useSidebarViewStore.getState().labelFilter).toEqual({ labels: [] });
+
+    useSidebarViewStore.setState({ labelFilter: { labels: [reserved, "urgent"] } });
+    store.reconcileLabelFilter([reserved, "Urgent"]);
+    expect(useSidebarViewStore.getState().labelFilter).toEqual({ labels: ["urgent"] });
   });
 
   it("toggles multiple projects into and out of the filter", () => {

--- a/packages/app/src/stores/sidebar-view-store.ts
+++ b/packages/app/src/stores/sidebar-view-store.ts
@@ -2,14 +2,14 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
 import { persist, type StateStorage } from "zustand/middleware";
 import { z } from "zod";
-import { workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
+import { isReservedWorkspaceLabel, workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
 import { createValidatedPersistStorage } from "@/storage/validated-persist-storage";
 
 export type SidebarGroupMode = "project" | "status";
 
 const SIDEBAR_VIEW_STORAGE_KEY = "sidebar-view";
 const LEGACY_SIDEBAR_GROUP_MODE_STORAGE_KEY = "sidebar-group-mode";
-const SIDEBAR_VIEW_STORE_VERSION = 6;
+const SIDEBAR_VIEW_STORE_VERSION = 7;
 
 /**
  * The key standing for "this workspace carries no labels at all".
@@ -31,7 +31,7 @@ export interface SidebarLabelFilter {
 }
 
 export function hasActiveSidebarLabelFilter(filter: SidebarLabelFilter): boolean {
-  return filter.labels.length > 0;
+  return filter.labels.some((label) => !isReservedWorkspaceLabel(label));
 }
 
 /**
@@ -155,7 +155,9 @@ export function migrateSidebarViewState(persistedState: unknown): SidebarViewPer
  * state that was written by an older build of this page rather than by the current one.
  */
 function normalizeSidebarLabelFilter(filter: SidebarLabelFilter): SidebarLabelFilter {
-  const labels = new Set(filter.labels.map(workspaceLabelKey));
+  const labels = new Set(
+    filter.labels.filter((label) => !isReservedWorkspaceLabel(label)).map(workspaceLabelKey),
+  );
   return { labels: [...labels] };
 }
 
@@ -191,6 +193,7 @@ export const useSidebarViewStore = create<SidebarViewStoreState>()(
       clearProjectFilters: () => set({ projectFilters: [] }),
       toggleLabelFilter: (name) =>
         set((state) => {
+          if (isReservedWorkspaceLabel(name)) return state;
           const key = workspaceLabelKey(name);
           const labels = state.labelFilter.labels.includes(key)
             ? state.labelFilter.labels.filter((label) => label !== key)
@@ -200,9 +203,13 @@ export const useSidebarViewStore = create<SidebarViewStoreState>()(
       clearLabelFilter: () => set({ labelFilter: emptyLabelFilter() }),
       reconcileLabelFilter: (labels) =>
         set((state) => {
-          const available = new Set(labels.map(workspaceLabelKey));
+          const available = new Set(
+            labels.filter((label) => !isReservedWorkspaceLabel(label)).map(workspaceLabelKey),
+          );
           const next = state.labelFilter.labels.filter(
-            (label) => label === SIDEBAR_UNLABELLED_LABEL_KEY || available.has(label),
+            (label) =>
+              !isReservedWorkspaceLabel(label) &&
+              (label === SIDEBAR_UNLABELLED_LABEL_KEY || available.has(label)),
           );
           if (next.length === state.labelFilter.labels.length) return state;
           return { labelFilter: { labels: next } };

--- a/packages/app/src/utils/host-routes.test.ts
+++ b/packages/app/src/utils/host-routes.test.ts
@@ -241,6 +241,20 @@ describe("global routes", () => {
       }),
     ).toBe("/new?serverId=local&dir=%2Frepo%2Fproject&draftId=draft-1");
   });
+
+  it("buildNewWorkspaceRoute carries a logical workspace to attach", () => {
+    expect(
+      buildNewWorkspaceRoute({
+        serverId: "nuc",
+        sourceDirectory: "/repo/project",
+        displayName: "Cars",
+        projectId: "project-cars",
+        logicalWorkspaceRef: "cars-parts",
+      }),
+    ).toBe(
+      "/new?serverId=nuc&dir=%2Frepo%2Fproject&name=Cars&projectId=project-cars&logicalWorkspaceRef=cars-parts",
+    );
+  });
 });
 
 describe("host settings section slugs", () => {

--- a/packages/app/src/utils/host-routes.ts
+++ b/packages/app/src/utils/host-routes.ts
@@ -438,6 +438,7 @@ interface NewWorkspaceRouteOptions {
   displayName?: string;
   projectId?: string;
   draftId?: string;
+  logicalWorkspaceRef?: string;
 }
 
 function buildNewWorkspaceSearch(options: NewWorkspaceRouteOptions): string {
@@ -457,6 +458,9 @@ function buildNewWorkspaceSearch(options: NewWorkspaceRouteOptions): string {
   }
   if (options.draftId) {
     params.set("draftId", options.draftId);
+  }
+  if (options.logicalWorkspaceRef) {
+    params.set("logicalWorkspaceRef", options.logicalWorkspaceRef);
   }
   return params.toString();
 }

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -97,6 +97,32 @@ describe("buildSidebarProjectRowModel", () => {
     ).toMatchObject({ serverId: "host-c", iconWorkingDir: "/repo/c" });
   });
 
+  it("does not target a host outside the logical grouping namespace", () => {
+    const groupedProject = project({
+      hosts: [
+        {
+          serverId: "host-a",
+          iconWorkingDir: "/repo/a",
+          worktreeSupport: "supported" as const,
+        },
+        {
+          serverId: "host-b",
+          iconWorkingDir: "/repo/b",
+          worktreeSupport: "supported" as const,
+        },
+      ],
+    });
+
+    expect(
+      resolveSidebarLogicalWorkspaceAddHostTarget({
+        project: groupedProject,
+        occupiedServerIds: new Set(["host-a"]),
+        allowedServerIds: new Set(["host-a"]),
+        supportsMultiplicityByServerId: new Map(),
+      }),
+    ).toBeNull();
+  });
+
   it("renders a non-git single-workspace project as an expandable section", () => {
     const result = buildSidebarProjectRowModel({
       project: project({

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -92,6 +92,7 @@ describe("buildSidebarProjectRowModel", () => {
       resolveSidebarLogicalWorkspaceAddHostTarget({
         project: groupedProject,
         occupiedServerIds: new Set(["host-a"]),
+        allowedServerIds: new Set(["host-a", "host-b", "host-c"]),
         supportsMultiplicityByServerId: new Map([["host-b", false]]),
       }),
     ).toMatchObject({ serverId: "host-c", iconWorkingDir: "/repo/c" });

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -5,6 +5,7 @@ import type {
 } from "@/hooks/use-sidebar-workspaces-list";
 import {
   buildSidebarProjectRowModel,
+  resolveSidebarLogicalWorkspaceAddHostTarget,
   resolveSidebarProjectIconTarget,
   resolveSidebarProjectIconTargets,
   resolveSidebarProjectLocalPath,
@@ -65,6 +66,37 @@ function project(overrides: ProjectOverrides = {}): SidebarProjectEntry {
 }
 
 describe("buildSidebarProjectRowModel", () => {
+  it("targets only a missing host that can create a logical workspace placement", () => {
+    const groupedProject = project({
+      projectKind: "directory",
+      hosts: [
+        {
+          serverId: "host-a",
+          iconWorkingDir: "/repo/a",
+          worktreeSupport: "unsupported" as const,
+        },
+        {
+          serverId: "host-b",
+          iconWorkingDir: "/repo/b",
+          worktreeSupport: "unsupported" as const,
+        },
+        {
+          serverId: "host-c",
+          iconWorkingDir: "/repo/c",
+          worktreeSupport: "supported" as const,
+        },
+      ],
+    });
+
+    expect(
+      resolveSidebarLogicalWorkspaceAddHostTarget({
+        project: groupedProject,
+        occupiedServerIds: new Set(["host-a"]),
+        supportsMultiplicityByServerId: new Map([["host-b", false]]),
+      }),
+    ).toMatchObject({ serverId: "host-c", iconWorkingDir: "/repo/c" });
+  });
+
   it("renders a non-git single-workspace project as an expandable section", () => {
     const result = buildSidebarProjectRowModel({
       project: project({

--- a/packages/app/src/utils/sidebar-project-row-model.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.ts
@@ -102,10 +102,12 @@ function resolveNewWorkspaceTarget(
 export function resolveSidebarLogicalWorkspaceAddHostTarget(input: {
   project: SidebarProjectEntry;
   occupiedServerIds: ReadonlySet<string>;
+  allowedServerIds?: ReadonlySet<string>;
   supportsMultiplicityByServerId: ReadonlyMap<string, boolean>;
 }): SidebarProjectHostTarget | null {
   for (const host of input.project.hosts) {
     if (input.occupiedServerIds.has(host.serverId)) continue;
+    if (input.allowedServerIds && !input.allowedServerIds.has(host.serverId)) continue;
     if (
       host.worktreeSupport === "unsupported" &&
       !input.supportsMultiplicityByServerId.get(host.serverId)

--- a/packages/app/src/utils/sidebar-project-row-model.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.ts
@@ -99,6 +99,25 @@ function resolveNewWorkspaceTarget(
   return null;
 }
 
+export function resolveSidebarLogicalWorkspaceAddHostTarget(input: {
+  project: SidebarProjectEntry;
+  occupiedServerIds: ReadonlySet<string>;
+  supportsMultiplicityByServerId: ReadonlyMap<string, boolean>;
+}): SidebarProjectHostTarget | null {
+  for (const host of input.project.hosts) {
+    if (input.occupiedServerIds.has(host.serverId)) continue;
+    if (
+      host.worktreeSupport === "unsupported" &&
+      !input.supportsMultiplicityByServerId.get(host.serverId)
+    ) {
+      continue;
+    }
+    const target = hostTarget(host);
+    if (target) return target;
+  }
+  return null;
+}
+
 function projectTrailingAction(
   project: SidebarProjectEntry,
   supportsMultiplicityByServerId: ReadonlyMap<string, boolean>,

--- a/packages/app/src/utils/sidebar-project-row-model.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.ts
@@ -102,12 +102,12 @@ function resolveNewWorkspaceTarget(
 export function resolveSidebarLogicalWorkspaceAddHostTarget(input: {
   project: SidebarProjectEntry;
   occupiedServerIds: ReadonlySet<string>;
-  allowedServerIds?: ReadonlySet<string>;
+  allowedServerIds: ReadonlySet<string>;
   supportsMultiplicityByServerId: ReadonlyMap<string, boolean>;
 }): SidebarProjectHostTarget | null {
   for (const host of input.project.hosts) {
     if (input.occupiedServerIds.has(host.serverId)) continue;
-    if (input.allowedServerIds && !input.allowedServerIds.has(host.serverId)) continue;
+    if (!input.allowedServerIds.has(host.serverId)) continue;
     if (
       host.worktreeSupport === "unsupported" &&
       !input.supportsMultiplicityByServerId.get(host.serverId)

--- a/packages/app/src/workspace-labels/index.test.ts
+++ b/packages/app/src/workspace-labels/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
 import {
+  DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  encodeLogicalWorkspaceRefLabel,
+} from "@getpaseo/protocol/workspace-labels";
+import {
   buildWorkspaceLabelPickerRows,
   createWorkspaceLabelManagerModel,
   createWorkspaceLabelPickerModel,
@@ -15,6 +19,59 @@ import {
 // step. There is nothing left here to assert that the compiler does not.
 
 describe("workspace label projection", () => {
+  test("hides every reserved label surface without deleting the raw catalog", () => {
+    const rawLabels = [
+      { name: "Urgent", color: "red" as const },
+      { name: encodeLogicalWorkspaceRefLabel("project-a-catalog"), color: "indigo" as const },
+      { name: DEFAULT_WORKSPACE_PLACEMENT_LABEL, color: "indigo" as const },
+      { name: "paseo:reserved:future:unknown", color: "indigo" as const },
+      { name: "paseo:reserved:v1:logical-workspace-ref=bad/ref", color: "indigo" as const },
+    ];
+    const hostsById: Record<string, WorkspaceLabelHostSnapshot> = {
+      "host-a": {
+        serverId: "host-a",
+        status: "online",
+        error: null,
+        labels: rawLabels,
+      },
+    };
+
+    const projection = projectWorkspaceLabels(hostsById, "host-a");
+    expect(projection.labels).toEqual([{ name: "Urgent", color: "red" }]);
+    expect(projection.hosts[0]?.labels).toEqual([{ name: "Urgent", color: "red" }]);
+    expect(projection.targetHost?.labels).toEqual([{ name: "Urgent", color: "red" }]);
+    expect(
+      selectWorkspaceLabelDefinitions({
+        hostsById,
+        serverId: "host-a",
+        names: rawLabels.map((label) => label.name),
+      }),
+    ).toEqual([{ name: "Urgent", color: "red" }]);
+    expect(
+      buildWorkspaceLabelPickerRows({
+        labels: rawLabels,
+        assigned: rawLabels.map((label) => label.name),
+      }),
+    ).toEqual([{ name: "Urgent", color: "red", assigned: true }]);
+    expect(
+      mergeWorkspaceLabelCatalogs({ catalogs: [{ serverId: "host-a", labels: rawLabels }] }),
+    ).toEqual([{ name: "Urgent", color: "red" }]);
+
+    const manager = createWorkspaceLabelManagerModel({
+      update: async () => ({}),
+      inspectDelete: async () => ({ affectedWorkspaceCount: 0 }),
+      delete: async () => undefined,
+    });
+    manager.syncHosts([
+      { serverId: "host-a", label: "Alpha", status: "online", labels: rawLabels },
+    ]);
+    expect(manager.snapshot().labels).toEqual([{ name: "Urgent", color: "red" }]);
+
+    // Projection is a privacy/UI boundary, not a destructive data migration.
+    expect(hostsById["host-a"]?.labels).toBe(rawLabels);
+    expect(rawLabels).toHaveLength(5);
+  });
+
   test("does not treat a failed online catalog as authoritative", () => {
     expect(
       hasAuthoritativeWorkspaceLabelCatalog([

--- a/packages/app/src/workspace-labels/index.ts
+++ b/packages/app/src/workspace-labels/index.ts
@@ -1,5 +1,6 @@
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import {
+  isReservedWorkspaceLabel,
   workspaceLabelKey,
   type WorkspaceLabelDefinition,
 } from "@getpaseo/protocol/workspace-labels";
@@ -74,15 +75,26 @@ export function projectWorkspaceLabels(
   hostsById: Readonly<Record<string, WorkspaceLabelHostSnapshot>>,
   targetServerId?: string,
 ): WorkspaceLabelProjection {
-  const hosts = Object.values(hostsById);
+  const hosts = Object.values(hostsById).map((host) => ({
+    serverId: host.serverId,
+    labels: filterUserWorkspaceLabelDefinitions(host.labels),
+    status: host.status,
+    error: host.error,
+  }));
   const catalogs = hosts
     .filter((host) => host.status === "online")
     .map((host) => ({ serverId: host.serverId, labels: host.labels }));
   return {
     hosts,
     labels: mergeWorkspaceLabelCatalogs({ catalogs, targetServerId }),
-    targetHost: targetServerId ? hostsById[targetServerId] : undefined,
+    targetHost: targetServerId ? hosts.find((host) => host.serverId === targetServerId) : undefined,
   };
+}
+
+export function filterUserWorkspaceLabelDefinitions(
+  labels: readonly WorkspaceLabelDefinition[],
+): WorkspaceLabelDefinition[] {
+  return labels.filter((label) => !isReservedWorkspaceLabel(label.name));
 }
 
 /** Reactive cross-host projection. Consumers do not reconstruct replica eligibility or precedence. */
@@ -122,12 +134,14 @@ export function selectWorkspaceLabelDefinitions(input: {
 }): readonly WorkspaceLabelDefinition[] {
   const { hostsById, serverId, names } = input;
   if (!names || names.length === 0) return EMPTY_LABEL_DEFINITIONS;
-  const catalog = hostsById[serverId]?.labels ?? [];
+  const catalog = filterUserWorkspaceLabelDefinitions(hostsById[serverId]?.labels ?? []);
   const byKey = new Map(catalog.map((label) => [workspaceLabelKey(label.name), label]));
-  return names.flatMap((name) => {
-    const definition = byKey.get(workspaceLabelKey(name));
-    return definition ? [definition] : [];
-  });
+  return names
+    .filter((name) => !isReservedWorkspaceLabel(name))
+    .flatMap((name) => {
+      const definition = byKey.get(workspaceLabelKey(name));
+      return definition ? [definition] : [];
+    });
 }
 
 const EMPTY_LABEL_DEFINITIONS: readonly WorkspaceLabelDefinition[] = [];

--- a/packages/app/src/workspace-labels/internal/merge.ts
+++ b/packages/app/src/workspace-labels/internal/merge.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceLabelDefinition } from "@getpaseo/protocol/workspace-labels";
-import { workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
+import { isReservedWorkspaceLabel, workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
 
 export interface HostLabelCatalog {
   serverId: string;
@@ -18,6 +18,7 @@ export function mergeWorkspaceLabelCatalogs(input: {
   const merged = new Map<string, WorkspaceLabelDefinition>();
   for (const catalog of ordered) {
     for (const label of catalog.labels) {
+      if (isReservedWorkspaceLabel(label.name)) continue;
       const key = workspaceLabelKey(label.name);
       if (!merged.has(key)) merged.set(key, label);
     }

--- a/packages/app/src/workspace-labels/internal/picker-model.ts
+++ b/packages/app/src/workspace-labels/internal/picker-model.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceLabelDefinition } from "@getpaseo/protocol/workspace-labels";
-import { workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
+import { isReservedWorkspaceLabel, workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
 
 export interface WorkspaceLabelPickerRow extends WorkspaceLabelDefinition {
   assigned: boolean;
@@ -17,9 +17,11 @@ export function buildWorkspaceLabelPickerRows(input: {
   assigned: readonly string[];
 }): WorkspaceLabelPickerRow[] {
   const assigned = new Set(input.assigned.map(workspaceLabelKey));
-  return input.labels.map((label) => ({
-    name: label.name,
-    color: label.color,
-    assigned: assigned.has(workspaceLabelKey(label.name)),
-  }));
+  return input.labels
+    .filter((label) => !isReservedWorkspaceLabel(label.name))
+    .map((label) => ({
+      name: label.name,
+      color: label.color,
+      assigned: assigned.has(workspaceLabelKey(label.name)),
+    }));
 }

--- a/packages/app/src/workspace-labels/internal/workflow-model.ts
+++ b/packages/app/src/workspace-labels/internal/workflow-model.ts
@@ -1,4 +1,5 @@
 import {
+  isReservedWorkspaceLabel,
   normalizeWorkspaceLabelName,
   workspaceLabelKey,
   type WorkspaceLabelDefinition,
@@ -67,6 +68,7 @@ export class WorkspaceLabelPickerModel extends ObservableModel {
   }
 
   toggle(label: WorkspaceLabelDefinition, assigned: boolean): Promise<boolean> {
+    if (isReservedWorkspaceLabel(label.name)) return Promise.resolve(false);
     const key = workspaceLabelKey(label.name);
     const inFlight = this.pending.get(key);
     if (inFlight) return inFlight;
@@ -163,7 +165,10 @@ export class WorkspaceLabelManagerModel extends ObservableModel {
   snapshot = (): WorkspaceLabelManagerSnapshot => this.currentSnapshot;
 
   syncHosts(hosts: readonly WorkspaceLabelManagerHost[]): void {
-    this.hosts = hosts;
+    this.hosts = hosts.map((host) => ({
+      ...host,
+      labels: host.labels.filter((label) => !isReservedWorkspaceLabel(label.name)),
+    }));
     if (!this.operation && !hosts.some((host) => host.serverId === this.serverId)) {
       this.serverId = hosts[0]?.serverId ?? "";
       this.draft = null;
@@ -181,7 +186,7 @@ export class WorkspaceLabelManagerModel extends ObservableModel {
 
   /** Open the edit view on a label, seeded with what that label currently is. */
   edit(label: WorkspaceLabelDefinition): void {
-    if (this.operation) return;
+    if (this.operation || isReservedWorkspaceLabel(label.name)) return;
     this.draft = { name: label.name, draftName: label.name, color: label.color };
     this.error = null;
     this.commit();
@@ -305,6 +310,7 @@ export class WorkspaceLabelManagerModel extends ObservableModel {
         draft !== null &&
         editing !== null &&
         draftName.length > 0 &&
+        !isReservedWorkspaceLabel(draftName) &&
         (draftName !== editing.name || draft.color !== editing.color),
     };
   }

--- a/packages/app/src/workspace-labels/picker.tsx
+++ b/packages/app/src/workspace-labels/picker.tsx
@@ -11,6 +11,7 @@ import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
 import { Plus } from "lucide-react-native";
 import {
+  isReservedWorkspaceLabel,
   normalizeWorkspaceLabelName,
   WORKSPACE_LABEL_COLORS,
   type WorkspaceLabelColor,
@@ -225,7 +226,7 @@ function WorkspaceLabelCreatePage({
 
   const submit = useCallback(() => {
     const trimmed = normalizeWorkspaceLabelName(name);
-    if (!trimmed || pending) return;
+    if (!trimmed || isReservedWorkspaceLabel(trimmed) || pending) return;
     setPending(true);
     setError(null);
     workspaceLabels
@@ -260,7 +261,7 @@ function WorkspaceLabelCreatePage({
       </View>
       <MenuSeparator />
       <MenuItem
-        disabled={offline || !normalizeWorkspaceLabelName(name)}
+        disabled={offline || !normalizeWorkspaceLabelName(name) || isReservedWorkspaceLabel(name)}
         status={pending ? "pending" : "idle"}
         pendingLabel={t("workspaceLabels.creating")}
         closeOnSelect={false}

--- a/packages/cli/src/commands/plugin/scaffold.test.ts
+++ b/packages/cli/src/commands/plugin/scaffold.test.ts
@@ -118,6 +118,16 @@ import { inspect } from "./inspect.shared";
 
 export default function contribute(plugin: PluginContext) {
   plugin.handle(inspect, inspectConfig);
+  plugin.addSidebarWorkspaceGrouping({
+    id: "logical-workspaces",
+    logicalWorkspaceRefLabelPrefix: "paseo:reserved:v1:logical-workspace-ref=",
+    defaultPlacementLabel: "paseo:reserved:v1:placement-role=default",
+    retainedHistoryBindings: [{
+      workspaceId: "old-workspace",
+      physicalWorkspaceRef: "project-a-catalog-host-b",
+      logicalWorkspaceRef: "project-a-catalog",
+    }],
+  });
   plugin.addSurface("main", Surface);
   plugin.addWorkspacePanel({
     id: "review",

--- a/packages/cli/src/commands/plugin/scaffold.ts
+++ b/packages/cli/src/commands/plugin/scaffold.ts
@@ -154,6 +154,19 @@ declare module "@getpaseo/plugin" {
     surface: string;
   }
 
+  export interface PluginSidebarWorkspaceGroupingContribution {
+    id: string;
+    logicalWorkspaceRefLabelPrefix: string;
+    defaultPlacementLabel: string;
+    retainedHistoryBindings?: readonly PluginSidebarWorkspaceRetainedHistoryBinding[];
+  }
+
+  export interface PluginSidebarWorkspaceRetainedHistoryBinding {
+    workspaceId: string;
+    physicalWorkspaceRef: string;
+    logicalWorkspaceRef: string;
+  }
+
   export interface PluginThemeColors {
     background: string;
     foreground: string;
@@ -218,6 +231,7 @@ declare module "@getpaseo/plugin" {
     ): void;
     addSurface(id: string, Component: ComponentType<PluginSurfaceProps>): void;
     addSidebarItem(contribution: PluginSidebarContribution): void;
+    addSidebarWorkspaceGrouping(contribution: PluginSidebarWorkspaceGroupingContribution): void;
     addWorkspacePanel(contribution: PluginWorkspacePanelContribution): void;
     addCommandCenterItem(contribution: PluginCommandCenterItemContribution): void;
     addAttachmentSource(contribution: PluginAttachmentSourceContribution): void;

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -381,6 +381,7 @@ export interface CreatePaseoWorktreeInput extends Pick<
   CreatePaseoWorktreeRequest,
   | "cwd"
   | "projectId"
+  | "labels"
   | "worktreeSlug"
   | "firstAgentContext"
   | "refName"
@@ -4170,6 +4171,7 @@ export class DaemonClient {
         type: "create_paseo_worktree_request",
         cwd: input.cwd,
         ...(input.projectId !== undefined ? { projectId: input.projectId } : {}),
+        ...(input.labels !== undefined ? { labels: input.labels } : {}),
         worktreeSlug: input.worktreeSlug,
         ...(input.firstAgentContext !== undefined
           ? { firstAgentContext: input.firstAgentContext }
@@ -4187,6 +4189,7 @@ export class DaemonClient {
     input: {
       source: WorkspaceCreateRequest["source"];
       title?: string;
+      labels?: string[];
       firstAgentContext?: WorkspaceCreateRequest["firstAgentContext"];
     },
     requestId?: string,
@@ -4197,6 +4200,7 @@ export class DaemonClient {
         type: "workspace.create.request",
         source: input.source,
         ...(input.title !== undefined ? { title: input.title } : {}),
+        ...(input.labels !== undefined ? { labels: input.labels } : {}),
         ...(input.firstAgentContext !== undefined
           ? { firstAgentContext: input.firstAgentContext }
           : {}),

--- a/packages/plugin/src/contracts.ts
+++ b/packages/plugin/src/contracts.ts
@@ -102,6 +102,26 @@ export interface PluginSidebarContribution {
   surface: string;
 }
 
+/**
+ * Declarative opt-in to a core-owned native Project sidebar projection.
+ *
+ * The plugin declares only a closed label codec. Paseo keeps ownership of native workspace
+ * identity, history, status, ordering, routing, and the fail-open physical fallback.
+ */
+export interface PluginSidebarWorkspaceGroupingContribution {
+  id: string;
+  logicalWorkspaceRefLabelPrefix: string;
+  defaultPlacementLabel: string;
+  /** Host-local native workspaces kept live only to retain their existing agent history. */
+  retainedHistoryBindings?: readonly PluginSidebarWorkspaceRetainedHistoryBinding[];
+}
+
+export interface PluginSidebarWorkspaceRetainedHistoryBinding {
+  workspaceId: string;
+  physicalWorkspaceRef: string;
+  logicalWorkspaceRef: string;
+}
+
 export interface PluginThemeColors {
   background: string;
   foreground: string;
@@ -190,6 +210,7 @@ export interface PluginContext {
   ): void;
   addSurface(id: string, Component: ComponentType<PluginSurfaceProps>): void;
   addSidebarItem(contribution: PluginSidebarContribution): void;
+  addSidebarWorkspaceGrouping(contribution: PluginSidebarWorkspaceGroupingContribution): void;
   addWorkspacePanel(contribution: PluginWorkspacePanelContribution): void;
   addCommandCenterItem(contribution: PluginCommandCenterItemContribution): void;
   addAttachmentSource(contribution: PluginAttachmentSourceContribution): void;

--- a/packages/plugin/src/host.ts
+++ b/packages/plugin/src/host.ts
@@ -5,6 +5,7 @@ import type {
   PluginCommandCenterItemContribution,
   PluginContext,
   PluginSidebarContribution,
+  PluginSidebarWorkspaceGroupingContribution,
   PluginSurfaceContribution,
   PluginSurfaceProps,
   PluginThemeContribution,
@@ -18,6 +19,7 @@ import type { ComponentType } from "react";
 interface PluginCollector {
   addSurface(id: string, Component: ComponentType<PluginSurfaceProps>): void;
   addSidebarItem(contribution: PluginSidebarContribution): void;
+  addSidebarWorkspaceGrouping(contribution: PluginSidebarWorkspaceGroupingContribution): void;
   addWorkspacePanel(contribution: PluginWorkspacePanelContribution): void;
   addCommandCenterItem(contribution: PluginCommandCenterItemContribution): void;
   addAttachmentSource(contribution: PluginAttachmentSourceContribution): void;
@@ -27,6 +29,7 @@ interface PluginCollector {
 export interface PluginRegistrationCollector {
   surfaces: PluginSurfaceContribution[];
   sidebarItems: PluginSidebarContribution[];
+  sidebarWorkspaceGroupings: PluginSidebarWorkspaceGroupingContribution[];
   workspacePanels: PluginWorkspacePanelContribution[];
   commandCenterItems: PluginCommandCenterItemContribution[];
   attachmentSources: PluginAttachmentSourceContribution[];
@@ -39,6 +42,7 @@ export function createPluginContext(
   PluginContext,
   | "addSurface"
   | "addSidebarItem"
+  | "addSidebarWorkspaceGrouping"
   | "addWorkspacePanel"
   | "addCommandCenterItem"
   | "addAttachmentSource"
@@ -50,6 +54,9 @@ export function createPluginContext(
     },
     addSidebarItem(contribution) {
       collector.addSidebarItem(contribution);
+    },
+    addSidebarWorkspaceGrouping(contribution) {
+      collector.addSidebarWorkspaceGrouping(contribution);
     },
     addWorkspacePanel(contribution) {
       collector.addWorkspacePanel(contribution);

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -22,6 +22,8 @@ export type {
   PluginHostProps,
   PluginTheme,
   PluginSidebarContribution,
+  PluginSidebarWorkspaceGroupingContribution,
+  PluginSidebarWorkspaceRetainedHistoryBinding,
   PluginSurfaceContribution,
   PluginSurfaceProps,
   PluginThemeColors,

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2358,6 +2358,9 @@ export const CreatePaseoWorktreeRequestSchema = z.object({
   type: z.literal("create_paseo_worktree_request"),
   cwd: z.string(),
   projectId: z.string().optional(),
+  // Initial assignments are persisted with the workspace so plugin metadata is
+  // visible on the first emitted descriptor, never as a second-step mutation.
+  labels: z.array(z.string()).optional(),
   worktreeSlug: z.string().optional(),
   nameContext: z.string().optional(),
   attachments: AgentAttachmentsSchema.optional(),
@@ -2456,6 +2459,8 @@ export const WorkspaceCreateRequestSchema = z.object({
   requestId: z.string(),
   // Optional user-set title applied to the created workspace.
   title: z.string().optional(),
+  // Optional initial label assignments, committed atomically with the record.
+  labels: z.array(z.string()).optional(),
   // Optional prompt context for workspace-level name/branch generation.
   firstAgentContext: FirstAgentContextSchema.optional(),
   source: z.discriminatedUnion("kind", [

--- a/packages/protocol/src/messages.workspaces.test.ts
+++ b/packages/protocol/src/messages.workspaces.test.ts
@@ -1163,6 +1163,10 @@ describe("workspace message schemas", () => {
     const newDirectory = WorkspaceCreateRequestSchema.parse({
       type: "workspace.create.request",
       requestId: "req-dir",
+      labels: [
+        "paseo:reserved:v1:logical-workspace-ref=lw-parts",
+        "paseo:reserved:v1:placement-role=default",
+      ],
       source: {
         kind: "directory",
         path: "/tmp/repo",
@@ -1170,5 +1174,9 @@ describe("workspace message schemas", () => {
     });
     expect(newDirectory.type).toBe("workspace.create.request");
     expect(newDirectory.source.kind).toBe("directory");
+    expect(newDirectory.labels).toEqual([
+      "paseo:reserved:v1:logical-workspace-ref=lw-parts",
+      "paseo:reserved:v1:placement-role=default",
+    ]);
   });
 });

--- a/packages/protocol/src/workspace-labels.test.ts
+++ b/packages/protocol/src/workspace-labels.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+  LOGICAL_WORKSPACE_REF_LABEL_PREFIX,
+  RESERVED_WORKSPACE_LABEL_COLOR,
+  encodeLogicalWorkspaceRefLabel,
+  isReservedWorkspaceLabel,
+  parseLogicalWorkspacePlacementLabels,
+} from "./workspace-labels.js";
+
+describe("reserved workspace labels", () => {
+  it("publishes one closed v1 codec with a stable catalog color", () => {
+    expect(LOGICAL_WORKSPACE_REF_LABEL_PREFIX).toBe("paseo:reserved:v1:logical-workspace-ref=");
+    expect(DEFAULT_WORKSPACE_PLACEMENT_LABEL).toBe("paseo:reserved:v1:placement-role=default");
+    expect(RESERVED_WORKSPACE_LABEL_COLOR).toBe("indigo");
+    expect(encodeLogicalWorkspaceRefLabel("project-a-catalog")).toBe(
+      "paseo:reserved:v1:logical-workspace-ref=project-a-catalog",
+    );
+  });
+
+  it.each(["", "Cars-parts", "-project-a-catalog", "project-a/parts", "project-a parts", `a${"b".repeat(128)}`])(
+    "refuses an invalid logical workspace ref: %s",
+    (ref) => {
+      expect(() => encodeLogicalWorkspaceRefLabel(ref)).toThrow("Invalid logical workspace ref");
+    },
+  );
+
+  it("recognizes the whole reserved namespace without exposing malformed values", () => {
+    expect(isReservedWorkspaceLabel("paseo:reserved:v1:logical-workspace-ref=project-a-catalog")).toBe(
+      true,
+    );
+    expect(isReservedWorkspaceLabel(" PASEO:RESERVED:future:unknown ")).toBe(true);
+    expect(isReservedWorkspaceLabel("Urgent")).toBe(false);
+  });
+
+  it("parses one valid ref and an optional default marker", () => {
+    expect(
+      parseLogicalWorkspacePlacementLabels([
+        "Urgent",
+        encodeLogicalWorkspaceRefLabel("project-a-catalog"),
+        DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+      ]),
+    ).toEqual({ logicalWorkspaceRef: "project-a-catalog", defaultPlacement: true });
+    expect(
+      parseLogicalWorkspacePlacementLabels([
+        encodeLogicalWorkspaceRefLabel("project-a-catalog"),
+        "paseo:reserved:future:unknown",
+      ]),
+    ).toEqual({ logicalWorkspaceRef: "project-a-catalog", defaultPlacement: false });
+  });
+
+  it("ignores malformed and unknown reserved labels deterministically", () => {
+    expect(
+      parseLogicalWorkspacePlacementLabels([
+        "paseo:reserved:v1:logical-workspace-ref=bad/ref",
+        "paseo:reserved:v2:logical-workspace-ref=project-a-catalog",
+        DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+      ]),
+    ).toBeNull();
+    expect(
+      parseLogicalWorkspacePlacementLabels([
+        "paseo:reserved:v1:logical-workspace-ref=bad/ref",
+        encodeLogicalWorkspaceRefLabel("project-a-catalog"),
+        "paseo:reserved:future:unknown",
+      ]),
+    ).toEqual({ logicalWorkspaceRef: "project-a-catalog", defaultPlacement: false });
+  });
+
+  it("fails open to an unmanaged physical workspace when valid refs conflict", () => {
+    expect(
+      parseLogicalWorkspacePlacementLabels([
+        encodeLogicalWorkspaceRefLabel("project-a-catalog"),
+        encodeLogicalWorkspaceRefLabel("project-a-diagnostics"),
+        DEFAULT_WORKSPACE_PLACEMENT_LABEL,
+      ]),
+    ).toBeNull();
+    expect(parseLogicalWorkspacePlacementLabels([DEFAULT_WORKSPACE_PLACEMENT_LABEL])).toBeNull();
+  });
+});

--- a/packages/protocol/src/workspace-labels.ts
+++ b/packages/protocol/src/workspace-labels.ts
@@ -18,10 +18,66 @@ export interface WorkspaceLabelDefinition {
   color: WorkspaceLabelColor;
 }
 
+export const RESERVED_WORKSPACE_LABEL_PREFIX = "paseo:reserved:";
+export const LOGICAL_WORKSPACE_REF_LABEL_PREFIX = "paseo:reserved:v1:logical-workspace-ref=";
+export const DEFAULT_WORKSPACE_PLACEMENT_LABEL = "paseo:reserved:v1:placement-role=default";
+export const RESERVED_WORKSPACE_LABEL_COLOR: WorkspaceLabelColor = "indigo";
+
+const LOGICAL_WORKSPACE_REF = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+
+export interface LogicalWorkspacePlacementLabels {
+  logicalWorkspaceRef: string;
+  defaultPlacement: boolean;
+}
+
 export function normalizeWorkspaceLabelName(name: string): string {
   return name.replace(/\s+/g, " ").trim();
 }
 
 export function workspaceLabelKey(name: string): string {
   return normalizeWorkspaceLabelName(name).toLowerCase();
+}
+
+/** Reserved labels are data-plane metadata, never user-facing catalog entries. */
+export function isReservedWorkspaceLabel(name: string): boolean {
+  return workspaceLabelKey(name).startsWith(RESERVED_WORKSPACE_LABEL_PREFIX);
+}
+
+export function encodeLogicalWorkspaceRefLabel(logicalWorkspaceRef: string): string {
+  if (!LOGICAL_WORKSPACE_REF.test(logicalWorkspaceRef)) {
+    throw new Error(`Invalid logical workspace ref: ${logicalWorkspaceRef}`);
+  }
+  return `${LOGICAL_WORKSPACE_REF_LABEL_PREFIX}${logicalWorkspaceRef}`;
+}
+
+/**
+ * Decode the closed v1 placement codec without guessing from titles, paths, or remotes.
+ * Unknown and malformed reserved labels stay in storage but do not participate. Two distinct
+ * valid refs are ambiguous, so the physical workspace fails open as unmanaged.
+ */
+export function parseLogicalWorkspacePlacementLabels(
+  labels: readonly string[] | null | undefined,
+): LogicalWorkspacePlacementLabels | null {
+  const refs = new Set<string>();
+  let defaultPlacement = false;
+  const logicalPrefixKey = LOGICAL_WORKSPACE_REF_LABEL_PREFIX.toLowerCase();
+  const defaultPlacementKey = DEFAULT_WORKSPACE_PLACEMENT_LABEL.toLowerCase();
+
+  for (const label of labels ?? []) {
+    const normalized = normalizeWorkspaceLabelName(label);
+    const key = normalized.toLowerCase();
+    if (key === defaultPlacementKey) {
+      defaultPlacement = true;
+      continue;
+    }
+    if (!key.startsWith(logicalPrefixKey)) continue;
+    const logicalWorkspaceRef = normalized.slice(LOGICAL_WORKSPACE_REF_LABEL_PREFIX.length);
+    if (LOGICAL_WORKSPACE_REF.test(logicalWorkspaceRef)) refs.add(logicalWorkspaceRef);
+  }
+
+  if (refs.size !== 1) return null;
+  return {
+    logicalWorkspaceRef: refs.values().next().value as string,
+    defaultPlacement,
+  };
 }

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -33,6 +33,7 @@ import { runWithGitCommandPriority } from "../utils/run-git-command.js";
 export interface CreatePaseoWorktreeInput extends CreateWorktreeCoreInput {
   projectId?: string;
   title?: string;
+  labels?: string[];
 }
 
 export interface CreatePaseoWorktreeResult {
@@ -99,6 +100,7 @@ async function createPaseoWorktreeWithPriority(
       branch: createdWorktree.worktree.branchName || null,
       baseBranch: resolveIntentBaseBranch(createdWorktree.intent),
       title: input.title?.trim() || resolveFirstAgentPromptTitle(input.firstAgentContext),
+      labels: input.labels,
       expectsInitialAgent: Boolean(input.firstAgentContext),
     });
 

--- a/packages/server/src/server/plugins/compiler.test.ts
+++ b/packages/server/src/server/plugins/compiler.test.ts
@@ -108,3 +108,36 @@ export default function contribute(plugin: PluginContext) {
     },
   );
 });
+
+describe("plugin target registration stripping", () => {
+  it("keeps the native sidebar seam in the client bundle and strips it from server code", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-plugin-compiler-"));
+    temporaryDirectories.push(directory);
+    const entryPath = path.join(directory, "index.ts");
+    await writeFile(
+      entryPath,
+      `import type { PluginContext } from "@getpaseo/plugin";
+
+export default function contribute(plugin: PluginContext) {
+  plugin.addSidebarWorkspaceGrouping({
+    id: "logical-workspaces",
+    logicalWorkspaceRefLabelPrefix: "paseo:reserved:v1:logical-workspace-ref=",
+    defaultPlacementLabel: "paseo:reserved:v1:placement-role=default",
+    retainedHistoryBindings: [{
+      workspaceId: "old-workspace",
+      physicalWorkspaceRef: "project-a-catalog-host-b",
+      logicalWorkspaceRef: "project-a-catalog",
+    }],
+  });
+  return () => undefined;
+}
+`,
+    );
+
+    const { clientBundle, serverBundle } = await compilePlugin(entryPath);
+    expect(clientBundle).toContain("addSidebarWorkspaceGrouping");
+    expect(clientBundle).toContain("old-workspace");
+    expect(serverBundle).not.toContain("addSidebarWorkspaceGrouping");
+    expect(serverBundle).not.toContain("old-workspace");
+  });
+});

--- a/packages/server/src/server/plugins/compiler.ts
+++ b/packages/server/src/server/plugins/compiler.ts
@@ -78,6 +78,7 @@ const REGISTRATIONS_REMOVED_BY_TARGET: Record<PluginBuildTarget, ReadonlySet<str
   server: new Set([
     "addSurface",
     "addSidebarItem",
+    "addSidebarWorkspaceGrouping",
     "addWorkspacePanel",
     "addCommandCenterItem",
     "addAttachmentSource",

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -5853,7 +5853,10 @@ export class Session {
       cwd,
       explicitTitle ?? promptTitle,
       request.source.projectId,
-      { expectsInitialAgent: Boolean(request.firstAgentContext) },
+      {
+        expectsInitialAgent: Boolean(request.firstAgentContext),
+        labels: request.labels,
+      },
     );
     await this.syncWorkspaceGitObserverForWorkspace(workspace);
     const descriptor = await this.describeWorkspaceRecord(workspace);
@@ -5928,6 +5931,7 @@ export class Session {
         githubPrNumber: source.githubPrNumber,
         firstAgentContext: request.firstAgentContext,
         title: request.title,
+        labels: request.labels,
       },
       source.baseBranch
         ? { resolveDefaultBranch: async () => source.baseBranch as string }

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -9415,6 +9415,10 @@ test("workspace.create.request attaches a directory workspace to its explicit ac
   await session.handleMessage({
     type: "workspace.create.request",
     requestId: "req-explicit-project",
+    labels: [
+      "paseo:reserved:v1:logical-workspace-ref=lw-explicit",
+      "paseo:reserved:v1:placement-role=default",
+    ],
     source: { kind: "directory", path: REPO_CWD, projectId: "prj_explicit" },
   });
 
@@ -9429,6 +9433,10 @@ test("workspace.create.request attaches a directory workspace to its explicit ac
   expect(workspaces.get(workspaceId as string)).toMatchObject({
     cwd: REPO_CWD,
     projectId: "prj_explicit",
+    labels: [
+      "paseo:reserved:v1:logical-workspace-ref=lw-explicit",
+      "paseo:reserved:v1:placement-role=default",
+    ],
   });
 });
 

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
@@ -502,8 +502,25 @@ test("createWorkspaceForDirectory always mints a fresh workspace even when one a
 test("directory creation persists the live branch and a trimmed title", async () => {
   const repo = path.join(tmpDir, "repo");
   gitRoots.add(repo);
-  const workspace = await provisioning.createWorkspaceForDirectory(repo, "  Focused work  ");
-  expect(workspace).toMatchObject({ branch: "main", title: "Focused work" });
+  const workspace = await provisioning.createWorkspaceForDirectory(
+    repo,
+    "  Focused work  ",
+    undefined,
+    {
+      labels: [
+        "paseo:reserved:v1:logical-workspace-ref=lw-focused",
+        "paseo:reserved:v1:placement-role=default",
+      ],
+    },
+  );
+  expect(workspace).toMatchObject({
+    branch: "main",
+    title: "Focused work",
+    labels: [
+      "paseo:reserved:v1:logical-workspace-ref=lw-focused",
+      "paseo:reserved:v1:placement-role=default",
+    ],
+  });
 });
 
 test("createWorkspaceForDirectory honors an explicit active project without cwd containment", async () => {

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -43,6 +43,7 @@ export interface CreateWorktreeWorkspaceInput {
   branch: string | null;
   baseBranch: string | null;
   title: string | null;
+  labels?: string[];
   expectsInitialAgent?: boolean;
 }
 
@@ -57,7 +58,7 @@ export interface WorkspaceProvisioningService {
     cwd: string,
     title?: string | null,
     projectId?: string,
-    context?: { expectsInitialAgent?: boolean },
+    context?: { expectsInitialAgent?: boolean; labels?: string[] },
   ): Promise<PersistedWorkspaceRecord>;
   createWorkspaceForWorktree(
     input: CreateWorktreeWorkspaceInput,
@@ -186,7 +187,7 @@ export function createWorkspaceProvisioningService(deps: {
     cwd: string,
     title?: string | null,
     projectId?: string,
-    context?: { expectsInitialAgent?: boolean },
+    context?: { expectsInitialAgent?: boolean; labels?: string[] },
   ): Promise<PersistedWorkspaceRecord> {
     const normalizedCwd = resolve(cwd);
     const checkout = await workspaceGitService.getCheckout(normalizedCwd);
@@ -200,6 +201,7 @@ export function createWorkspaceProvisioningService(deps: {
       projectId: project.projectId,
       ...initialWorkspacePlacement({ source: "checkout", cwd: normalizedCwd, checkout }),
       title: title?.trim() || null,
+      labels: context?.labels,
       createdAt: timestamp,
       updatedAt: timestamp,
     });
@@ -232,6 +234,7 @@ export function createWorkspaceProvisioningService(deps: {
         mainRepoRoot: repoRoot,
       }),
       title: input.title,
+      labels: input.labels,
       createdAt: timestamp,
       updatedAt: timestamp,
     });

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -520,6 +520,7 @@ export async function handleCreatePaseoWorktreeRequest(
       {
         cwd: request.cwd,
         projectId: request.projectId,
+        labels: request.labels,
         worktreeSlug: request.worktreeSlug,
         firstAgentContext: normalizeFirstAgentContext(request),
         refName: request.refName,


### PR DESCRIPTION
## Summary

- add a reserved label contract for logical workspace membership and default placement
- add a declarative plugin contribution that groups physical workspaces across hosts in the native project sidebar
- preserve physical workspace identity, host placement, navigation, status, filters, and retained session history
- fail open to the existing physical workspace list when the contribution is absent or invalid

## Verification

- targeted app sidebar and plugin-evaluation suites pass
- protocol, plugin SDK, CLI scaffold, and server compiler suites pass
- affected package and dependent package typechecks pass
- full repository lint passes with 0 warnings and 0 errors
- public fixtures contain only generic projects, hosts, and workspace IDs

This change does not modify or migrate workspace registry records. It adds a projection layer over the existing host-owned inventory.