### PR TITLE
fix(server): report archived agents correctly over MCP

### DIFF
--- a/packages/server/src/server/agent/agent-projections.ts
+++ b/packages/server/src/server/agent/agent-projections.ts
@@ -26,6 +26,13 @@ interface ProjectionOptions {
   title?: string | null;
   createdAt?: string;
   internal?: boolean;
+  /**
+   * Archive timestamp, supplied by a caller holding the stored record. A live
+   * managed agent cannot know this: an archived agent is resumed back into
+   * memory to serve a history read, so being in the manager is not evidence
+   * that it is active. Storage stays the single owner.
+   */
+  archivedAt?: string | null;
 }
 
 interface RecentProviderSessionProjectionOptions {
@@ -135,6 +142,7 @@ export function toAgentPayload(
     persistence: projectPersistenceHandleForWire(agent.persistence),
     title: options?.title ?? null,
     labels: agent.labels,
+    archivedAt: options?.archivedAt ?? null,
   };
 
   const usage = sanitizeUsage(agent.lastUsage);

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -5502,6 +5502,109 @@ describe("agent snapshot MCP serialization", () => {
     expect(new Set(agentIds)).toEqual(new Set(["in-cwd", "in-child-cwd", "stored-in-cwd"]));
   });
 
+  // An archived agent is resumed back into memory whenever something reads its
+  // history, so its id can appear in listAgents while its stored record is
+  // archived. The stored branch drops such a record as already-live, so archive
+  // filtering has to run on the combined list or the agent comes back as active.
+  it("excludes an archived agent that is also live from list_agents", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const now = new Date().toISOString();
+    const archivedRecord = createStoredRecord({
+      id: "resumed-archived",
+      cwd: "/tmp/workspace",
+      updatedAt: now,
+      lastActivityAt: now,
+      archivedAt: now,
+    });
+    spies.agentManager.getAgent.mockReturnValue(
+      createManagedAgent({ id: "caller-agent", cwd: "/tmp/workspace" }),
+    );
+    spies.agentManager.listAgents.mockReturnValue([
+      createManagedAgent({ id: "resumed-archived", cwd: "/tmp/workspace" }),
+      createManagedAgent({ id: "in-cwd", cwd: "/tmp/workspace" }),
+    ]);
+    spies.agentStorage.list.mockResolvedValue([archivedRecord]);
+    spies.agentStorage.get.mockImplementation(async (id: string) =>
+      id === "resumed-archived" ? archivedRecord : null,
+    );
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      logger,
+      providerSnapshotManager: createClaudeOnlyManager(),
+      callerAgentId: "caller-agent",
+    });
+    const tool = registeredTool(server, "list_agents");
+    const response = await tool.handler({});
+
+    expect(agentsOf(response).map((agent) => agent.id)).toEqual(["in-cwd"]);
+  });
+
+  it("reports the archive timestamp of a live archived agent when archives are requested", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const now = new Date().toISOString();
+    const archivedRecord = createStoredRecord({
+      id: "resumed-archived",
+      cwd: "/tmp/workspace",
+      updatedAt: now,
+      lastActivityAt: now,
+      archivedAt: now,
+    });
+    spies.agentManager.getAgent.mockReturnValue(
+      createManagedAgent({ id: "caller-agent", cwd: "/tmp/workspace" }),
+    );
+    spies.agentManager.listAgents.mockReturnValue([
+      createManagedAgent({ id: "resumed-archived", cwd: "/tmp/workspace" }),
+    ]);
+    spies.agentStorage.list.mockResolvedValue([archivedRecord]);
+    spies.agentStorage.get.mockImplementation(async (id: string) =>
+      id === "resumed-archived" ? archivedRecord : null,
+    );
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      logger,
+      providerSnapshotManager: createClaudeOnlyManager(),
+      callerAgentId: "caller-agent",
+    });
+    const tool = registeredTool(server, "list_agents");
+    const response = await tool.handler({ includeArchived: true });
+
+    const agents = agentsOf(response);
+    expect(agents.map((agent) => agent.id)).toEqual(["resumed-archived"]);
+    expect(agents[0]?.archivedAt).toBe(now);
+  });
+
+  // A structural guard, not a mutation test: it passes on the unfixed code too,
+  // and it would not catch a managed copy of the timestamp either, since the
+  // fixture seeds no stale managed state. What it pins is narrower and still
+  // worth pinning: the reported value follows the stored record, so clearing
+  // that record -- which is all unarchiveSnapshot does -- is immediately
+  // visible over MCP.
+  it("reports a live agent as unarchived as soon as its stored record is cleared", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    spies.agentManager.getAgent.mockReturnValue(
+      createManagedAgent({ id: "resumed-archived", cwd: "/tmp/workspace" }),
+    );
+    spies.agentStorage.get.mockResolvedValue(
+      createStoredRecord({ id: "resumed-archived", cwd: "/tmp/workspace", archivedAt: null }),
+    );
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      logger,
+      providerSnapshotManager: createClaudeOnlyManager(),
+    });
+    const tool = registeredTool(server, "get_agent_status");
+    const response = await tool.handler({ agentId: "resumed-archived" });
+
+    const snapshot = z.record(z.string(), z.unknown()).parse(response.structuredContent.snapshot);
+    expect(snapshot.archivedAt ?? null).toBeNull();
+  });
+
   it("allows explicit cwd, status, archive, time, and limit filters for list_agents", async () => {
     const { agentManager, agentStorage, spies } = createTestDeps();
     const now = Date.now();

--- a/packages/server/src/server/agent/mcp-shared.ts
+++ b/packages/server/src/server/agent/mcp-shared.ts
@@ -5,7 +5,7 @@ import type { AgentPermissionRequest } from "./agent-sdk-types.js";
 import type { AgentManager, ManagedAgent, WaitForAgentResult } from "./agent-manager.js";
 import { curateAgentActivity } from "./activity-curator.js";
 import { selectItemsByProjectedLimit } from "./timeline-projection.js";
-import type { AgentStorage } from "./agent-storage.js";
+import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
 import { serializeAgentSnapshot } from "../messages.js";
 import { StoredScheduleSchema } from "@getpaseo/protocol/schedule/types";
 import type { AgentProvider } from "./agent-sdk-types.js";
@@ -196,27 +196,36 @@ export function sanitizePermissionRequest(
   return sanitized;
 }
 
-export async function resolveAgentTitle(
+async function resolveAgentStorageRecord(
   agentStorage: AgentStorage,
   agentId: string,
   logger: Logger,
-): Promise<string | null> {
+): Promise<StoredAgentRecord | null> {
   try {
-    const record = await agentStorage.get(agentId);
-    return record?.title ?? null;
+    return (await agentStorage.get(agentId)) ?? null;
   } catch (error) {
-    logger.error({ err: error, agentId }, "Failed to load agent title");
+    logger.error({ err: error, agentId }, "Failed to load agent record");
     return null;
   }
 }
 
+// Storage owns the archive timestamp, and a live snapshot cannot carry it: an
+// archived agent is resumed back into memory to serve a history read (see the
+// `purpose: "history"` resume in agent-loading), so presence in the manager is
+// not evidence that the agent is active. Merge the stored record here, the same
+// way the WebSocket path does in Session.enrichAgentPayload, rather than
+// copying the value onto the managed agent, where it would be a second source
+// of truth that unarchive has to remember to clear.
 export async function serializeSnapshotWithMetadata(
   agentStorage: AgentStorage,
   snapshot: ManagedAgent,
   logger: Logger,
 ) {
-  const title = await resolveAgentTitle(agentStorage, snapshot.id, logger);
-  return serializeAgentSnapshot(snapshot, { title });
+  const record = await resolveAgentStorageRecord(agentStorage, snapshot.id, logger);
+  return serializeAgentSnapshot(snapshot, {
+    title: record?.title ?? null,
+    archivedAt: record?.archivedAt ?? null,
+  });
 }
 
 export function parseDurationString(input: string): number {

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -2043,14 +2043,18 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       const registeredProviderIds = new Set(providerSnapshotManager.listRegisteredProviderIds());
       const storedAgents = storedRecords
         .filter((record) => !record.internal && !liveIds.has(record.id))
-        .filter((record) => includeArchived || !record.archivedAt)
         .filter(
           (record) =>
             includeArchived || isStoredAgentProviderAvailable(record, registeredProviderIds),
         )
         .map((record) => buildStoredAgentPayload(record, registeredProviderIds));
+      // Archive filtering belongs on the combined list, not the stored branch
+      // alone. An archived agent that is also live -- resumed into memory to
+      // serve a history read -- arrives through liveAgents, so filtering only
+      // the stored side returns it as though it were active.
       const agents = [...liveAgents, ...storedAgents]
         .map(toAgentListItemPayload)
+        .filter((agent) => includeArchived || !agent.archivedAt)
         .filter((agent) => !requestedCwd || isSameOrDescendantPath(requestedCwd, agent.cwd))
         .filter((agent) => !statusFilter || statusFilter.has(agent.status))
         .filter((agent) => !agent.archivedAt || resolveAgentListActivityTime(agent) >= sinceMs)

--- a/packages/server/src/server/messages.ts
+++ b/packages/server/src/server/messages.ts
@@ -16,7 +16,7 @@ function validateStreamEventPayload(payload: unknown): AgentStreamEventPayload |
 
 export function serializeAgentSnapshot(
   agent: ManagedAgent,
-  options?: { title?: string | null },
+  options?: { title?: string | null; archivedAt?: string | null },
 ): AgentSnapshotPayload {
   return toAgentPayload(agent, options);
 }


### PR DESCRIPTION
`list_agents` can return an archived agent as a live one, with `archivedAt: null`, from a default call.

## Why

An archived agent is resumed back into memory whenever something reads its history — `agent-loading.ts` passes `{ purpose: "history" }` to `resumeAgentFromPersistence` precisely when `record.archivedAt` is set. Its id is then in the manager's map, so `list_agents` classifies it as live, and the stored branch drops it because that branch filters out anything already live:

```ts
.filter((record) => !record.internal && !liveIds.has(record.id))
```

The stored record is the only carrier of the archive timestamp, so both the value and the archive filter go with it. Two consequences, both reachable from a default call:

- **The timestamp is lost.** `serializeSnapshotWithMetadata` merged only the title from storage, so the agent is reported with `archivedAt: null`. A caller reconciling ownership from that list can conclude an archived agent is still running.
- **`includeArchived: false` returns it anyway.** The archive filter ran only on the stored branch, so nothing on the live branch was ever filtered.

The protocol declares `archivedAt` as `z.string().nullable().optional()`, so the omission validated silently.

## The fix

Storage stays the single owner of the timestamp. The MCP boundary merges the stored record — reusing the storage read that was already happening for the title — and `archivedAt` becomes a projection option supplied by a caller holding the record, alongside `title`. Archive filtering moves to the combined live-plus-stored list.

This is the pattern the WebSocket path already uses in `Session.enrichAgentPayload`; this change brings the MCP path in line with it rather than introducing a new mechanism.

**The rejected alternative** was copying the timestamp onto the managed agent. It is worse: `unarchiveSnapshot` clears only the stored record and then notifies, so a managed copy would survive the unarchive and report a live agent as archived until it was reloaded. A second owner of state that one transition forgets to update is exactly the bug being fixed, in mirror image.

## Tests

Three cases on the existing `mcp-server.test.ts` harness, which previously modelled an archived record only when it was *not* also live:

| Test | Without the fix |
|---|---|
| Default list excludes an archived agent that is also live | `expected [ 'resumed-archived', 'in-cwd' ] to deeply equal [ 'in-cwd' ]` |
| `includeArchived: true` reports the real timestamp | `expected null to be '…'` |
| A cleared stored record reads as unarchived | passes — structural guard, labelled as such |

The first two are mutation-killing and pin the observable MCP result. The third passes on unfixed code too; its comment says so rather than implying otherwise.

## Compatibility

Additive. `archivedAt` was already nullable and optional in the protocol and already populated on the stored path, so consumers that read it keep working and consumers that ignore it are unaffected.

Full server suite: no new failures against `main` — 1986 passing vs 1983 on a pristine baseline run on the same machine, the difference being the three tests added here. `oxlint`, `oxfmt`, and the workspace typecheck are clean.