### PR TITLE
Fix persisted workspace layouts with no visible pane

### DIFF
--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -720,6 +720,19 @@ function normalizeNode(node: unknown): SplitNodeInternal | null {
   return null;
 }
 
+function findFirstPane(node: SplitNodeInternal): SplitPaneInternal | null {
+  if (node.kind === "pane") {
+    return node.pane;
+  }
+  for (const child of node.group.children) {
+    const pane = findFirstPane(child);
+    if (pane) {
+      return pane;
+    }
+  }
+  return null;
+}
+
 function reorderTabsForPane(input: ReorderTabsForPaneInput): SplitPaneInternal {
   const nextIds = normalizeTabIds(input.tabIds);
   const byId = new Map(input.pane.tabs.map((tab) => [tab.tabId, tab]));
@@ -1003,15 +1016,32 @@ export function normalizeLayout(layout: unknown): WorkspaceLayout {
   }
 
   const rawLayout = layout as WorkspaceLayout;
-  const root = normalizeNode(rawLayout.root) ?? asInternalNode(createDefaultLayout().root);
+  let root = normalizeNode(rawLayout.root) ?? asInternalNode(createDefaultLayout().root);
   const focusedPaneId =
     rawLayout.focusedPaneId === null ? null : trimNonEmpty(rawLayout.focusedPaneId);
-  const resolvedFocusedPaneId =
-    focusedPaneId === null
-      ? null
-      : ((focusedPaneId && findPaneById(root, focusedPaneId)?.id) ??
-        collectAllPanes(root)[0]?.id ??
-        DEFAULT_PANE_ID);
+
+  // Older persisted layouts can leave every real pane hidden. Repair that boundary
+  // here so tab placement always receives a pane that belongs to the visible tree.
+  if (collectAllPanes(root).length === 0) {
+    const paneToReveal =
+      findPaneById(root, focusedPaneId) ??
+      findPaneById(root, DEFAULT_PANE_ID) ??
+      findFirstPane(root);
+    invariant(paneToReveal, "Normalized workspace layout must contain a pane");
+    root = updatePaneInTree(root, {
+      paneId: paneToReveal.id,
+      updater: (pane) => ({ ...pane, hidden: undefined }),
+    });
+  }
+
+  const firstVisiblePane = collectAllPanes(root)[0];
+  invariant(firstVisiblePane, "Normalized workspace layout must have a visible pane");
+  let resolvedFocusedPaneId: string | null = null;
+  if (focusedPaneId !== null) {
+    const focusedPane = findPaneById(root, focusedPaneId);
+    resolvedFocusedPaneId =
+      focusedPane && focusedPane.hidden !== true ? focusedPane.id : firstVisiblePane.id;
+  }
 
   const normalizedLayout = {
     root,
@@ -1252,11 +1282,9 @@ function resolvePlacementPane(input: {
   // `collectAllPanes` skips hidden panes, so a focused-but-hidden pane — the side
   // panel between a reveal and a hide — falls through to a pane the user can see.
   const focusedCandidate = findPaneById(input.layout.root, input.layout.focusedPaneId);
-  const focusedPane =
-    (focusedCandidate?.hidden === true ? null : focusedCandidate) ??
-    collectAllPanes(input.layout.root)[0] ??
-    findPaneById(createDefaultLayout().root, DEFAULT_PANE_ID);
-  invariant(focusedPane, "Workspace layout must always have a pane");
+  const panes = collectAllPanes(input.layout.root);
+  const focusedPane = (focusedCandidate?.hidden === true ? null : focusedCandidate) ?? panes[0];
+  invariant(focusedPane, "Workspace layout must always have a visible pane");
   if (
     (input.placement.mode !== "ambient" && input.placement.mode !== "prefer") ||
     focusedPane.id !== input.sidePanelPaneId ||
@@ -1268,7 +1296,6 @@ function resolvePlacementPane(input: {
   // `collectAllPanes` skips hidden panes, so the chain falls back to the side panel
   // pane itself only when it is the sole visible pane. The side panel is the only
   // pane anything ever hides, so today that means "the side panel is the only pane".
-  const panes = collectAllPanes(input.layout.root);
   return (panes.find((pane) => pane.id === DEFAULT_PANE_ID && pane.id !== focusedPane.id) ??
     panes.find((pane) => pane.id !== focusedPane.id) ??
     focusedPane) as SplitPaneInternal;

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -164,6 +164,53 @@ describe("workspace-layout-store helpers", () => {
     expect(restoredTabs.every((tab) => !persistedIds.has(tab.tabId))).toBe(true);
   });
 
+  it("rehydrates and reconciles an all-hidden persisted workspace in its real pane", async () => {
+    const workspaceKey = "server:workspace";
+    const sidePanelPaneId = "pane-side-panel";
+    await AsyncStorage.setItem(
+      "workspace-layout-state",
+      JSON.stringify({
+        state: {
+          layoutByWorkspace: {
+            [workspaceKey]: {
+              root: createPane({ id: sidePanelPaneId, tabIds: [], hidden: true }),
+              focusedPaneId: "main",
+            },
+          },
+          splitSizesByWorkspace: {},
+          explorerPaneIdByWorkspace: { [workspaceKey]: sidePanelPaneId },
+        },
+        version: 1,
+      }),
+    );
+    const restored = createWorkspaceLayoutStore(createDeterministicWorkspaceLayoutIds());
+    await restored.persist.rehydrate();
+
+    expect(() =>
+      restored.getState().reconcileTabs(workspaceKey, {
+        agentsHydrated: true,
+        terminalsHydrated: true,
+        activeAgentIds: [],
+        autoOpenAgentIds: [],
+        knownAgentIds: [],
+        knownTerminalIds: [],
+        standaloneTerminalIds: [],
+        hasActivePendingDraftCreate: false,
+      }),
+    ).not.toThrow();
+
+    const state = restored.getState();
+    const layout = state.layoutByWorkspace[workspaceKey];
+    const tabs = collectAllTabs(layout.root);
+    expect(collectAllPanes(layout.root).map((pane) => pane.id)).toEqual([sidePanelPaneId]);
+    expect(layout.focusedPaneId).toBe(sidePanelPaneId);
+    expect(state.sidePanelPaneIdByWorkspace[workspaceKey]).toBe(sidePanelPaneId);
+    expect(findPaneById(layout.root, "main")).toBeNull();
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]?.target.kind).toBe("draft");
+    expect(findPaneById(layout.root, sidePanelPaneId)?.tabIds).toEqual([tabs[0]?.tabId]);
+  });
+
   it("finds panes and tabs across nested groups", () => {
     const root: SplitNode = {
       kind: "group",
@@ -258,6 +305,64 @@ describe("workspace-layout-store helpers", () => {
     expect(collectAllTabs(root).map((tab) => tab.tabId)).toEqual(["tab-a"]);
     expect(collectAllPanes(root)).toEqual([]);
     expect(getFocusedBrowserId({ root, focusedPaneId: "hidden" })).toBeNull();
+  });
+
+  it("repairs a normalized layout that has no visible pane", () => {
+    const layout = normalizeLayout({
+      root: createPane({ id: "explorer", tabIds: [], hidden: true }),
+      focusedPaneId: "main",
+    });
+
+    expect(findPaneById(layout.root, "explorer")).toEqual({
+      id: "explorer",
+      tabIds: [],
+      focusedTabId: null,
+      tabs: [],
+    });
+    expect(collectAllPanes(layout.root).map((pane) => pane.id)).toEqual(["explorer"]);
+    expect(layout.focusedPaneId).toBe("explorer");
+  });
+
+  it("reveals the focused pane when every pane is hidden", () => {
+    const layout = normalizeLayout({
+      root: {
+        kind: "group",
+        group: {
+          id: "group-root",
+          direction: "horizontal",
+          sizes: [0.5, 0.5],
+          children: [
+            createPane({ id: "main", tabIds: ["tab-a"], hidden: true }),
+            createPane({ id: "focused", tabIds: ["tab-b"], hidden: true }),
+          ],
+        },
+      },
+      focusedPaneId: "focused",
+    });
+
+    expect(collectAllPanes(layout.root).map((pane) => pane.id)).toEqual(["focused"]);
+    expect(layout.focusedPaneId).toBe("focused");
+  });
+
+  it("preserves null focus while revealing main from an all-hidden layout", () => {
+    const layout = normalizeLayout({
+      root: {
+        kind: "group",
+        group: {
+          id: "group-root",
+          direction: "horizontal",
+          sizes: [0.5, 0.5],
+          children: [
+            createPane({ id: "first", tabIds: ["tab-a"], hidden: true }),
+            createPane({ id: "main", tabIds: ["tab-b"], hidden: true }),
+          ],
+        },
+      },
+      focusedPaneId: null,
+    });
+
+    expect(collectAllPanes(layout.root).map((pane) => pane.id)).toEqual(["main"]);
+    expect(layout.focusedPaneId).toBeNull();
   });
 });
 


### PR DESCRIPTION
### Linked issue

Closes #3806

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A persisted workspace can contain panes but have none visible. `normalizeLayout` kept that topology and could resolve focus to `main` even when `main` was absent. Reconciliation then selected a fresh default-layout pane that was not part of the real split tree and failed when replacing its initial New tab.

This repairs the existing tree at the normalization boundary by revealing one real pane, then makes tab placement require a visible pane from that tree.

### Goals

- Recover persisted layouts with no visible pane without resetting their tabs or split tree.
- Keep non-null focus on a visible pane while preserving explicit null focus.
- Prevent placement from returning a pane detached from the workspace tree.
- Cover the reported hydration and empty-workspace reconciliation path.

### Non-goals

- Identify the historical action that first persisted the invalid topology.
- Change the persistence schema or version.
- Change valid Side panel behavior or tab placement preferences.

### QA

Regression before the implementation:

```text
FAIL  packages/app/src/stores/workspace-layout-store.test.ts > workspace-layout-store helpers > repairs a normalized layout that has no visible pane
AssertionError: expected pane without `hidden` to deeply equal received pane with `hidden: true`

Test Files  1 failed (1)
Tests       1 failed | 114 skipped (115)
```

Focused test file after the implementation:

```text
$ npx vitest run packages/app/src/stores/workspace-layout-store.test.ts --bail=1
Test Files  1 passed (1)
Tests       118 passed (118)
Duration    516ms
```

Repository checks:

```text
$ npm run lint -- packages/app/src/stores/workspace-layout-actions.ts packages/app/src/stores/workspace-layout-store.test.ts
Found 0 warnings and 0 errors.

$ npm run format:check:files -- packages/app/src/stores/workspace-layout-actions.ts packages/app/src/stores/workspace-layout-store.test.ts
All matched files use the correct format.

$ npm run build:server
Process exited with code 0.

$ npm run typecheck
All workspace typecheck scripts exited with code 0.
```

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Shared store logic covered by Vitest. |
| Android | No | Shared store logic covered by Vitest. |
| Web | No manual UI run | Persisted hydration/reconciliation path covered by Vitest. |
| Desktop macOS | Yes, fixture-level | Original 0.5.1 crash state reproduced; fixed path covered against current `main`. |
| Desktop Windows | No | Shared store logic covered by Vitest. |
| Desktop Linux | No | Shared store logic covered by Vitest. |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
