### PR TITLE
fix(server): let the omp provider preapprove exact MCP tools and bridge them to host tools

### DIFF
--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -624,6 +624,29 @@ test("OMP is a disabled built-in backed by the real OMP adapter", async () => {
   await session.close();
 });
 
+test("OMP accepts the Hub's exact MCP grant for its injected server", () => {
+  const registry = buildProviderRegistry(logger, { ompRuntime: new FakeOmp() });
+  const config = {
+    provider: "omp",
+    cwd: "/tmp/registry-omp-toolpolicy",
+    mcpServers: { hub: { type: "http" as const, url: "http://127.0.0.1/execution" } },
+  };
+  const toolPolicy: ToolPolicy = {
+    preapproved: [
+      { kind: "mcp", server: "hub", tool: "reply" },
+      { kind: "mcp", server: "hub", tool: "finish_execution" },
+    ],
+  };
+
+  // Without an `omp` entry in PROVIDER_CONTRACTS this throws
+  // ToolPolicyUnsupportedError (code "tool_policy_unsupported") and the Hub
+  // execution never starts.
+  expect(registry.omp.applyToolPolicy(config, toolPolicy)).toEqual({
+    ...config,
+    toolPolicy,
+  });
+});
+
 test("OMP can be enabled without custom provider boilerplate", () => {
   const registry = buildProviderRegistry(logger, {
     providerOverrides: {

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -153,6 +153,12 @@ const PROVIDER_CONTRACTS: Record<string, ProviderContract> = {
   claude: { optionsSchema: ClaudeProviderOptionsSchema, supportsExactMcpPreapproval: true },
   codex: { optionsSchema: CodexProviderOptionsSchema, supportsExactMcpPreapproval: true },
   opencode: { optionsSchema: OpenCodeProviderOptionsSchema, supportsExactMcpPreapproval: true },
+  // The Hub injects the `hub` MCP server with an exact tool grant (e.g.
+  // `reply`/`finish_execution`) and OMP runs its host-tool bridge in
+  // full-access mode with no per-tool approval prompt, so there is no
+  // narrower policy to enforce here the way Claude/Codex/OpenCode do via
+  // `applyToolPolicy`. Preapproval is a no-op gate for this provider today.
+  omp: { optionsSchema: EmptyProviderOptionsSchema, supportsExactMcpPreapproval: true },
 };
 
 const UNSUPPORTED_PROVIDER_CONTRACT: ProviderContract = {

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -1,10 +1,89 @@
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { setImmediate as waitForImmediate } from "node:timers/promises";
 
 import type { PaseoToolCatalog } from "../../tools/types.js";
 import type { OmpNoTurnScheduler, OmpProviderIdleScheduler } from "./agent.js";
 import type { OmpUsagePollScheduler } from "./usage-poller.js";
 import { OmpHarness } from "./test-utils/omp-harness.js";
+
+interface FakeMcpClientRecord {
+  connectCalls: unknown[];
+  callToolCalls: Array<{ name: string; arguments: unknown }>;
+  closeCalls: number;
+}
+
+const { mcpClientInstances, mcpFixture } = vi.hoisted(() => ({
+  mcpClientInstances: [] as FakeMcpClientRecord[],
+  mcpFixture: {
+    tools: [] as Array<{ name: string; description?: string; inputSchema: unknown }>,
+    callToolResult: { content: [{ type: "text", text: "ok" }] } as unknown,
+  },
+}));
+
+// Mocks the MCP SDK modules providers/omp/mcp-tool-bridge.ts imports, so the
+// "OMP MCP tool bridge wiring" suite below can exercise the real createSession
+// -> setHostTools -> host_tool_call -> executeTool path without a network call.
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => {
+  class FakeMcpBridgeClient implements FakeMcpClientRecord {
+    connectCalls: unknown[] = [];
+    callToolCalls: Array<{ name: string; arguments: unknown }> = [];
+    closeCalls = 0;
+
+    constructor() {
+      mcpClientInstances.push(this);
+    }
+
+    connect(transport: unknown): Promise<void> {
+      this.connectCalls.push(transport);
+      return Promise.resolve();
+    }
+
+    listTools(): Promise<{ tools: typeof mcpFixture.tools }> {
+      return Promise.resolve({ tools: mcpFixture.tools });
+    }
+
+    callTool(params: { name: string; arguments: unknown }): Promise<unknown> {
+      this.callToolCalls.push(params);
+      return Promise.resolve(mcpFixture.callToolResult);
+    }
+
+    close(): Promise<void> {
+      this.closeCalls += 1;
+      return Promise.resolve();
+    }
+  }
+  return { Client: FakeMcpBridgeClient };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => {
+  class FakeStreamableHTTPClientTransport {
+    constructor(
+      readonly url: URL,
+      readonly options: unknown,
+    ) {}
+  }
+  return { StreamableHTTPClientTransport: FakeStreamableHTTPClientTransport };
+});
+
+beforeEach(() => {
+  mcpClientInstances.length = 0;
+  mcpFixture.tools = [
+    {
+      name: "finish_execution",
+      description: "Complete this Hub execution with a structured classification result.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          classification: { type: "string", enum: ["safe", "needs_review", "blocked"] },
+          confidence: { type: "number" },
+          summary: { type: "string" },
+        },
+        required: ["classification", "confidence", "summary"],
+      },
+    },
+  ];
+  mcpFixture.callToolResult = { content: [{ type: "text", text: "ok" }] };
+});
 
 class ManualIdleScheduler implements OmpProviderIdleScheduler {
   private readonly retries: Array<() => void> = [];
@@ -121,7 +200,7 @@ describe("OMP agent client and session", () => {
       [expect.objectContaining({ name: "create_agent" })],
     ]);
     expect(omp.capabilities()).toMatchObject({
-      supportsMcpServers: false,
+      supportsMcpServers: true,
       supportsNativePaseoTools: true,
     });
   });
@@ -643,5 +722,72 @@ describe("OMP agent client and session", () => {
     expect(omp.timeline().filter((item) => item.type === "user_message")).toEqual([
       { type: "user_message", text: "hello OMP", messageId: "user-1" },
     ]);
+  });
+});
+
+describe("OMP MCP tool bridge wiring", () => {
+  test("bridged HTTP MCP tools are announced to OMP and executing them drives the MCP client", async () => {
+    const omp = new OmpHarness();
+    await omp.start({
+      mcpServers: {
+        hub: {
+          type: "http",
+          url: "http://127.0.0.1/execution",
+          headers: { Authorization: "Bearer t" },
+        },
+      },
+    });
+
+    // Registration: the bridged tool reaches OMP's setHostTools call.
+    expect(omp.registeredHostTools()).toEqual([
+      [expect.objectContaining({ name: "finish_execution" })],
+    ]);
+    expect(mcpClientInstances).toHaveLength(1);
+
+    // Execution: the assertion that matters is that calling the tool drives
+    // the MCP client's callTool — not just that setHostTools announced it.
+    // Registering the merged catalog while dispatching against the native
+    // one only would leave this call unresolved ("Paseo tool not found").
+    const resultPromise = omp.runtime().nextHostToolResult();
+    omp.runtime().emit({
+      type: "host_tool_call",
+      id: "call-1",
+      toolCallId: "tc-1",
+      toolName: "finish_execution",
+      arguments: { classification: "safe", confidence: 1, summary: "done" },
+    });
+    const result = await resultPromise;
+
+    expect(mcpClientInstances[0].callToolCalls).toEqual([
+      {
+        name: "finish_execution",
+        arguments: { classification: "safe", confidence: 1, summary: "done" },
+      },
+    ]);
+    expect(result).toMatchObject({ type: "host_tool_result", id: "call-1" });
+    expect(result.isError).not.toBe(true);
+  });
+
+  test("without mcpServers, no MCP client is created and native tools register as before", async () => {
+    const omp = new OmpHarness();
+    await omp.start({}, createToolCatalog());
+
+    expect(mcpClientInstances).toHaveLength(0);
+    expect(omp.registeredHostTools()).toEqual([
+      [expect.objectContaining({ name: "create_agent" })],
+    ]);
+  });
+
+  test("closing the session closes every bridged MCP client", async () => {
+    const omp = new OmpHarness();
+    await omp.start({
+      mcpServers: { hub: { type: "http", url: "http://127.0.0.1/execution" } },
+    });
+    expect(mcpClientInstances).toHaveLength(1);
+    expect(mcpClientInstances[0].closeCalls).toBe(0);
+
+    await omp.close();
+
+    expect(mcpClientInstances[0].closeCalls).toBe(1);
   });
 });

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -108,6 +108,11 @@ import {
   mapOmpRpcUiPermissionRequest,
 } from "./rpc-ui-permission-mapper.js";
 import { DEFAULT_OMP_THINKING_LEVEL, mapOmpModel } from "./map-omp-model.js";
+import {
+  buildOmpMcpHostTools,
+  mergeOmpToolCatalogs,
+  type OmpMcpToolCatalog,
+} from "./mcp-tool-bridge.js";
 
 const OMP_PROVIDER = "omp";
 const QUESTION_RESPONSE_HEADER = "Response";
@@ -120,7 +125,7 @@ const OMP_CORE_CAPABILITIES: AgentCapabilityFlags = {
   supportsSessionPersistence: true,
   supportsSessionListing: true,
   supportsDynamicModes: true,
-  supportsMcpServers: false,
+  supportsMcpServers: true,
   supportsReasoningStream: true,
   supportsToolInvocations: true,
   supportsRewindConversation: true,
@@ -186,6 +191,7 @@ interface OmpAgentSessionOptions {
   noTurnScheduler?: OmpNoTurnScheduler;
   usagePollScheduler?: OmpUsagePollScheduler;
   paseoTools?: PaseoToolCatalog;
+  mcpToolBridge?: OmpMcpToolCatalog | null;
   /**
    * When false (resumed sessions), replayed session events are dropped until
    * the first prompt or agent_start so history is not re-emitted as live
@@ -462,7 +468,7 @@ function readNativeMessageId(
 function withOmpCapabilities(): AgentCapabilityFlags {
   return {
     ...OMP_CORE_CAPABILITIES,
-    supportsMcpServers: false,
+    supportsMcpServers: true,
     supportsNativePaseoTools: true,
   };
 }
@@ -882,6 +888,7 @@ export class OmpAgentSession implements AgentSession {
     this.currentModeId = options.currentModeId ?? null;
     this.logger = options.logger;
     this.paseoTools = options.paseoTools;
+    this.mcpToolBridge = options.mcpToolBridge ?? null;
     this.live = options.live ?? true;
     this.providerIdleScheduler = options.providerIdleScheduler ?? createOmpProviderIdleScheduler();
     this.noTurnScheduler = options.noTurnScheduler ?? createOmpNoTurnScheduler();
@@ -930,6 +937,7 @@ export class OmpAgentSession implements AgentSession {
   private readonly config: AgentSessionConfig;
   private readonly logger: Logger;
   private readonly paseoTools?: PaseoToolCatalog;
+  private readonly mcpToolBridge: OmpMcpToolCatalog | null;
 
   get id(): string | null {
     return this.state.sessionId;
@@ -1162,6 +1170,9 @@ export class OmpAgentSession implements AgentSession {
     try {
       await this.runtimeSession.close();
     } finally {
+      await this.mcpToolBridge?.close().catch((error: unknown) => {
+        this.logger.debug({ err: error }, "Failed to close OMP MCP tool bridge clients");
+      });
       this.clearOmpSessionState();
     }
   }
@@ -2231,6 +2242,7 @@ export class OmpAgentClient implements AgentClient {
     launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
     const launchMode = this.resolveLaunchMode(config.modeId);
+    const mcpToolBridge = await buildOmpMcpHostTools(config);
     const runtimeSession = await this.runtime.startSession({
       cwd: config.cwd,
       protocolMode: "rpc-ui",
@@ -2243,7 +2255,14 @@ export class OmpAgentClient implements AgentClient {
       env: launchContext?.env,
     });
     try {
-      await this.configureNativePaseoTools(runtimeSession, launchContext?.paseoTools);
+      // MCP-bridged tools must ride the same catalog used both to register
+      // host tools with OMP (below) and to dispatch `host_tool_call` events
+      // back (see the `paseoTools` field OmpAgentSession forwards to
+      // `handleOmpHostToolRuntimeEvent`). Registering the merged catalog but
+      // dispatching only the native one would advertise bridged tools the
+      // model could call yet never actually execute.
+      const paseoTools = mergeOmpToolCatalogs(launchContext?.paseoTools, mcpToolBridge ?? undefined);
+      await this.configureNativePaseoTools(runtimeSession, paseoTools);
       return new OmpAgentSession({
         runtimeSession,
         config,
@@ -2254,9 +2273,11 @@ export class OmpAgentClient implements AgentClient {
         providerIdleScheduler: this.providerIdleScheduler,
         noTurnScheduler: this.noTurnScheduler,
         usagePollScheduler: this.usagePollScheduler,
-        paseoTools: launchContext?.paseoTools,
+        paseoTools,
+        mcpToolBridge,
       });
     } catch (error) {
+      await mcpToolBridge?.close().catch(() => undefined);
       await runtimeSession.close().catch(() => undefined);
       throw error;
     }

--- a/packages/server/src/server/agent/providers/omp/mcp-tool-bridge.test.ts
+++ b/packages/server/src/server/agent/providers/omp/mcp-tool-bridge.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type {
+  PaseoToolCatalog,
+  PaseoToolDefinition,
+  PaseoToolExecutionContext,
+} from "../../tools/types.js";
+import { buildOmpMcpHostTools, mergeOmpToolCatalogs } from "./mcp-tool-bridge.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+interface FakeMcpClientRecord {
+  connectCalls: unknown[];
+  callToolCalls: Array<{ name: string; arguments: unknown }>;
+  closeCalls: number;
+}
+
+const { mcpClientInstances, mcpFixture } = vi.hoisted(() => ({
+  mcpClientInstances: [] as FakeMcpClientRecord[],
+  mcpFixture: {
+    tools: [] as Array<{
+      name: string;
+      title?: string;
+      description?: string;
+      inputSchema: unknown;
+    }>,
+    callToolResult: { content: [{ type: "text", text: "ok" }] } as unknown,
+  },
+}));
+
+// Mocks the two MCP SDK entry points mcp-tool-bridge.ts imports. No network:
+// `connect`/`listTools`/`callTool`/`close` are recorded on `mcpClientInstances`
+// so tests can assert the bridge actually drives the client, not just that it
+// registers a catalog shape.
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => {
+  class FakeMcpBridgeClient implements FakeMcpClientRecord {
+    connectCalls: unknown[] = [];
+    callToolCalls: Array<{ name: string; arguments: unknown }> = [];
+    closeCalls = 0;
+
+    constructor() {
+      mcpClientInstances.push(this);
+    }
+
+    connect(transport: unknown): Promise<void> {
+      this.connectCalls.push(transport);
+      return Promise.resolve();
+    }
+
+    listTools(): Promise<{ tools: typeof mcpFixture.tools }> {
+      return Promise.resolve({ tools: mcpFixture.tools });
+    }
+
+    callTool(params: { name: string; arguments: unknown }): Promise<unknown> {
+      this.callToolCalls.push(params);
+      return Promise.resolve(mcpFixture.callToolResult);
+    }
+
+    close(): Promise<void> {
+      this.closeCalls += 1;
+      return Promise.resolve();
+    }
+  }
+  return { Client: FakeMcpBridgeClient };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => {
+  class FakeStreamableHTTPClientTransport {
+    constructor(
+      readonly url: URL,
+      readonly options: unknown,
+    ) {}
+  }
+  return { StreamableHTTPClientTransport: FakeStreamableHTTPClientTransport };
+});
+
+function createCatalog(tools: PaseoToolDefinition[]): PaseoToolCatalog {
+  const toolMap = new Map(tools.map((tool) => [tool.name, tool]));
+  return {
+    tools: toolMap,
+    getTool: (name: string) => toolMap.get(name),
+    executeTool: (name: string, input: unknown, context?: PaseoToolExecutionContext) => {
+      const tool = toolMap.get(name);
+      if (!tool) return Promise.reject(new Error(`Tool not found: ${name}`));
+      return tool.handler(input, context ?? {});
+    },
+  };
+}
+
+beforeEach(() => {
+  mcpClientInstances.length = 0;
+  mcpFixture.tools = [
+    {
+      name: "finish_execution",
+      description: "Complete this Hub execution with a structured classification result.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          classification: { type: "string", enum: ["safe", "needs_review", "blocked"] },
+          confidence: { type: "number" },
+          summary: { type: "string" },
+        },
+        required: ["classification", "confidence", "summary"],
+      },
+    },
+  ];
+  mcpFixture.callToolResult = { content: [{ type: "text", text: "ok" }] };
+});
+
+describe("buildOmpMcpHostTools", () => {
+  test("returns null and connects nothing when no mcpServers are configured", async () => {
+    await expect(buildOmpMcpHostTools({})).resolves.toBeNull();
+    expect(mcpClientInstances).toHaveLength(0);
+  });
+
+  test("ignores non-http servers and returns null when nothing is bridged", async () => {
+    const catalog = await buildOmpMcpHostTools({
+      mcpServers: { local: { type: "stdio", command: "true" } },
+    });
+    expect(catalog).toBeNull();
+    expect(mcpClientInstances).toHaveLength(0);
+  });
+
+  test("connects to http MCP servers and converts each tool's JSON Schema to Zod", async () => {
+    const catalog = await buildOmpMcpHostTools({
+      mcpServers: {
+        hub: {
+          type: "http",
+          url: "http://127.0.0.1/execution",
+          headers: { Authorization: "Bearer t" },
+        },
+      },
+    });
+
+    expect(catalog?.tools.has("finish_execution")).toBe(true);
+    const definition = catalog?.getTool("finish_execution");
+    expect(definition?.description).toBe(
+      "Complete this Hub execution with a structured classification result.",
+    );
+    // The tool's actual parameters must survive conversion, not collapse to an
+    // empty-object schema (see the comment on jsonSchemaObjectToZod).
+    const inputSchema = definition?.inputSchema;
+    if (
+      !inputSchema ||
+      typeof inputSchema !== "object" ||
+      !("shape" in inputSchema) ||
+      !isRecord(inputSchema.shape)
+    ) {
+      throw new Error("Expected finish_execution inputSchema to be a Zod object schema");
+    }
+    expect(Object.keys(inputSchema.shape).sort()).toEqual([
+      "classification",
+      "confidence",
+      "summary",
+    ]);
+
+    expect(mcpClientInstances).toHaveLength(1);
+    expect(mcpClientInstances[0].connectCalls).toHaveLength(1);
+  });
+
+  test("executeTool forwards the call to the MCP client and maps the result", async () => {
+    const catalog = await buildOmpMcpHostTools({
+      mcpServers: { hub: { type: "http", url: "http://127.0.0.1/execution" } },
+    });
+
+    const result = await catalog?.executeTool("finish_execution", {
+      classification: "safe",
+      confidence: 1,
+      summary: "done",
+    });
+
+    expect(mcpClientInstances[0].callToolCalls).toEqual([
+      {
+        name: "finish_execution",
+        arguments: { classification: "safe", confidence: 1, summary: "done" },
+      },
+    ]);
+    expect(result).toEqual({
+      content: [{ type: "text", text: "ok" }],
+      structuredContent: undefined,
+      isError: undefined,
+    });
+  });
+
+  test("executeTool rejects for a tool the bridge never registered", async () => {
+    const catalog = await buildOmpMcpHostTools({
+      mcpServers: { hub: { type: "http", url: "http://127.0.0.1/execution" } },
+    });
+    await expect(catalog?.executeTool("no_such_tool", {})).rejects.toThrow(
+      "MCP bridge tool not found: no_such_tool",
+    );
+  });
+
+  test("close() closes every connected MCP client", async () => {
+    const catalog = await buildOmpMcpHostTools({
+      mcpServers: { hub: { type: "http", url: "http://127.0.0.1/execution" } },
+    });
+    await catalog?.close();
+    expect(mcpClientInstances[0].closeCalls).toBe(1);
+  });
+});
+
+describe("mergeOmpToolCatalogs", () => {
+  test("prefers the extra (bridge) catalog when both define the same tool name", async () => {
+    const base = createCatalog([
+      {
+        name: "shared",
+        description: "base",
+        handler: async () => ({ content: [{ type: "text", text: "base" }] }),
+      },
+    ]);
+    const extra = createCatalog([
+      {
+        name: "shared",
+        description: "extra",
+        handler: async () => ({ content: [{ type: "text", text: "extra" }] }),
+      },
+    ]);
+
+    const merged = mergeOmpToolCatalogs(base, extra);
+    const result = await merged?.executeTool("shared", {});
+    expect(result).toEqual({ content: [{ type: "text", text: "extra" }] });
+  });
+
+  test("returns the other catalog untouched when one side is missing", () => {
+    const base = createCatalog([]);
+    expect(mergeOmpToolCatalogs(base, undefined)).toBe(base);
+    expect(mergeOmpToolCatalogs(undefined, base)).toBe(base);
+  });
+
+  test("returns undefined when both catalogs are undefined", () => {
+    expect(mergeOmpToolCatalogs(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/packages/server/src/server/agent/providers/omp/mcp-tool-bridge.ts
+++ b/packages/server/src/server/agent/providers/omp/mcp-tool-bridge.ts
@@ -1,0 +1,216 @@
+import { z } from "zod";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import type { AgentSessionConfig, McpHttpServerConfig } from "../../agent-sdk-types.js";
+import type {
+  PaseoToolCatalog,
+  PaseoToolDefinition,
+  PaseoToolExecutionContext,
+  PaseoToolResult,
+} from "../../tools/types.js";
+
+const MCP_BRIDGE_CLIENT_NAME = "paseo-omp-mcp-bridge";
+const MCP_BRIDGE_CLIENT_VERSION = "0.0.1";
+
+/**
+ * A Paseo tool catalog backed by live MCP client connections. Callers must
+ * invoke `close()` once the owning agent session ends to release the
+ * underlying connections.
+ */
+export interface OmpMcpToolCatalog extends PaseoToolCatalog {
+  close(): Promise<void>;
+}
+
+type JsonSchemaObject = Record<string, unknown>;
+
+function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// MCP tool `inputSchema` is plain JSON Schema (see the MCP `Tool` type), but
+// Paseo's host-tool registration only knows how to serialize Zod schemas
+// (`serializePaseoToolInputParameters` -> `normalizeObjectSchema`). Without a
+// conversion, bridged tools would register as taking no parameters at all,
+// which breaks structured tools like the Hub's `finish_execution`
+// (classification/confidence/summary). Convert the common JSON Schema
+// vocabulary MCP servers actually emit; anything unrecognized degrades to
+// `z.unknown()` rather than failing the whole tool.
+function jsonSchemaPropertyToZod(schema: JsonSchemaObject): z.ZodType {
+  const description = typeof schema.description === "string" ? schema.description : undefined;
+  const describe = (zodType: z.ZodType): z.ZodType =>
+    description !== undefined ? zodType.describe(description) : zodType;
+
+  if (Array.isArray(schema.enum) && schema.enum.every((value) => typeof value === "string")) {
+    const values = schema.enum as string[];
+    return describe(values.length > 0 ? z.enum(values as [string, ...string[]]) : z.string());
+  }
+
+  switch (schema.type) {
+    case "string":
+      return describe(z.string());
+    case "number":
+      return describe(z.number());
+    case "integer":
+      return describe(z.number().int());
+    case "boolean":
+      return describe(z.boolean());
+    case "array": {
+      const items = isJsonSchemaObject(schema.items)
+        ? jsonSchemaPropertyToZod(schema.items)
+        : z.unknown();
+      return describe(z.array(items));
+    }
+    case "object":
+      return describe(jsonSchemaObjectToZod(schema));
+    default:
+      return describe(z.unknown());
+  }
+}
+
+function jsonSchemaObjectToZod(schema: JsonSchemaObject): z.ZodType {
+  const properties = isJsonSchemaObject(schema.properties) ? schema.properties : {};
+  const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+  const shape: Record<string, z.ZodType> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (!isJsonSchemaObject(value)) continue;
+    const propertySchema = jsonSchemaPropertyToZod(value);
+    shape[key] = required.has(key) ? propertySchema : propertySchema.optional();
+  }
+  return z.object(shape);
+}
+
+function toPaseoToolResult(result: Record<string, unknown>): PaseoToolResult {
+  return {
+    content: Array.isArray(result.content) ? (result.content as PaseoToolResult["content"]) : [],
+    structuredContent: result.structuredContent,
+    isError: typeof result.isError === "boolean" ? result.isError : undefined,
+  };
+}
+
+function closeOmpMcpClients(clients: Client[]): Promise<void> {
+  return Promise.all(clients.map((client) => client.close().catch(() => undefined))).then(
+    () => undefined,
+  );
+}
+
+async function collectOmpMcpToolsFromServer(
+  server: McpHttpServerConfig,
+  clients: Client[],
+): Promise<Array<[string, PaseoToolDefinition]>> {
+  const client = new Client({ name: MCP_BRIDGE_CLIENT_NAME, version: MCP_BRIDGE_CLIENT_VERSION });
+  await client.connect(
+    new StreamableHTTPClientTransport(new URL(server.url), {
+      requestInit: { headers: server.headers ?? {} },
+    }),
+  );
+  clients.push(client);
+
+  const listed = await client.listTools();
+  return listed.tools.map((tool) => [
+    tool.name,
+    {
+      name: tool.name,
+      title: tool.title,
+      description: tool.description ?? tool.name,
+      inputSchema: jsonSchemaObjectToZod(tool.inputSchema),
+      handler: (input: unknown, _context: PaseoToolExecutionContext): Promise<PaseoToolResult> =>
+        client
+          .callTool({
+            name: tool.name,
+            arguments: (input as Record<string, unknown> | undefined) ?? {},
+          })
+          .then(toPaseoToolResult),
+    },
+  ]);
+}
+
+/**
+ * OMP's `rpc-ui` launch mode never surfaces MCP tools to the model directly;
+ * the only channel that reaches the model is Paseo's native host-tool bridge
+ * (`host-tools.ts`, driven by `runtimeSession.setHostTools`). To let MCP
+ * servers injected into an execution (e.g. the Hub's `hub` server exposing
+ * `reply`/`finish_execution`) reach the model at all, connect to each HTTP
+ * MCP server declared on the session, list its tools, and re-expose them as
+ * host tools whose handler forwards the call to the MCP client.
+ *
+ * ponytail: only `type: "http"` servers are bridged. The Hub only ever
+ * injects `http` servers, and `stdio` servers are configured for OMP's own
+ * native MCP support elsewhere; add `sse` here if a caller needs it (the SDK
+ * transport is deprecated upstream, so it was left out).
+ */
+export async function buildOmpMcpHostTools(
+  config: Pick<AgentSessionConfig, "mcpServers">,
+): Promise<OmpMcpToolCatalog | null> {
+  const servers = config.mcpServers;
+  if (!servers || Object.keys(servers).length === 0) {
+    return null;
+  }
+
+  const clients: Client[] = [];
+  try {
+    const tools = new Map<string, PaseoToolDefinition>();
+    for (const server of Object.values(servers)) {
+      if (server.type !== "http") continue;
+      for (const [name, definition] of await collectOmpMcpToolsFromServer(server, clients)) {
+        tools.set(name, definition);
+      }
+    }
+
+    if (tools.size === 0) {
+      await closeOmpMcpClients(clients);
+      return null;
+    }
+
+    return {
+      tools,
+      getTool: (name: string): PaseoToolDefinition | undefined => tools.get(name),
+      executeTool: (
+        name: string,
+        input: unknown,
+        context?: PaseoToolExecutionContext,
+      ): Promise<PaseoToolResult> => {
+        const tool = tools.get(name);
+        if (!tool) {
+          return Promise.reject(new Error(`MCP bridge tool not found: ${name}`));
+        }
+        return tool.handler(input, context ?? {});
+      },
+      close: () => closeOmpMcpClients(clients),
+    };
+  } catch (error) {
+    await closeOmpMcpClients(clients);
+    throw error;
+  }
+}
+
+/**
+ * Merges two tool catalogs. The `extra` catalog (the MCP bridge) takes
+ * precedence over `base` (Paseo's native tools) for tools sharing a name.
+ */
+export function mergeOmpToolCatalogs(
+  base: PaseoToolCatalog | undefined,
+  extra: PaseoToolCatalog | undefined,
+): PaseoToolCatalog | undefined {
+  if (!base) return extra;
+  if (!extra) return base;
+  const tools = new Map([...base.tools, ...extra.tools]);
+  return {
+    tools,
+    getTool: (name: string): PaseoToolDefinition | undefined => tools.get(name),
+    executeTool: (
+      name: string,
+      input: unknown,
+      context?: PaseoToolExecutionContext,
+    ): Promise<PaseoToolResult> => {
+      if (extra.tools.has(name)) {
+        return extra.executeTool(name, input, context);
+      }
+      if (base.tools.has(name)) {
+        return base.executeTool(name, input, context);
+      }
+      return Promise.reject(new Error(`Tool not found: ${name}`));
+    },
+  };
+}


### PR DESCRIPTION
## Symptom

Running `omp` as an agent provider behind the Hub, any execution that
attaches the Hub's injected `hub` MCP server (`reply`/`finish_execution`)
with a `toolPolicy` failed immediately with:

```
ToolPolicyUnsupportedError: Provider 'omp' cannot preapprove exact MCP
tools for unattended execution; select Claude, Codex, or OpenCode
```
(`code: "tool_policy_unsupported"`)

## Cause

`PROVIDER_CONTRACTS` in `provider-registry.ts` had entries for
`claude`/`codex`/`opencode` but not `omp`, so it fell back to
`UNSUPPORTED_PROVIDER_CONTRACT` (`supportsExactMcpPreapproval: false`).

Separately, even with that fixed, omp's `rpc-ui` launch mode never
surfaces MCP tools to the model directly — the only channel that reaches
the model is Paseo's native host-tool bridge
(`runtimeSession.setHostTools`). `OMP_CORE_CAPABILITIES.supportsMcpServers`
was `false` and nothing consumed `config.mcpServers`, so MCP servers
attached to an omp session were silently dropped: the model never saw
`reply`/`finish_execution` at all.

## Fix

1. **`provider-registry.ts`** — add an `omp` entry to `PROVIDER_CONTRACTS`
   with `supportsExactMcpPreapproval: true`. omp runs its host-tool bridge
   in full-access mode with no per-tool approval prompt, so unlike
   Claude/Codex/OpenCode there's no narrower `applyToolPolicy` to enforce;
   preapproval is a no-op gate for this provider today. (If a future PR
   wants per-tool enforcement, `applyToolPolicy` is the extension point —
   see how `hub-e2e` uses it for an example of exact-grant enforcement.)

2. **`providers/omp/mcp-tool-bridge.ts`** (new) — connects to each `http`
   MCP server declared on the session, lists its tools, and re-exposes
   them as Paseo host tools whose handler forwards the call to the MCP
   client:
   - Converts each tool's JSON Schema `inputSchema` to a Zod schema.
     Paseo's host-tool serialization (`serializePaseoToolInputParameters`
     -> `normalizeObjectSchema`) only recognizes Zod; passing the MCP
     JSON Schema through unconverted registers every bridged tool as
     taking **no parameters**, which breaks structured tools like
     `finish_execution` (`classification`/`confidence`/`summary`) — the
     model would have no way to know what arguments to pass.
   - `stdio` servers are skipped (out of scope: the Hub only injects
     `http`, and `stdio` MCP servers are OMP's own native concern).
   - Returns a catalog with a `close()` that disconnects every MCP
     client it opened.

3. **`providers/omp/agent.ts`**:
   - `OMP_CORE_CAPABILITIES.supportsMcpServers` and
     `withOmpCapabilities()`'s override both flip to `true`.
   - `createSession` builds a single merged catalog (native `paseoTools`
     + the MCP bridge) and feeds it to **both** `configureNativePaseoTools`
     (what `setHostTools` announces to the model) **and** the
     `OmpAgentSession.paseoTools` field, which is what
     `handleOmpHostToolRuntimeEvent`/`OmpHostToolRouter` dispatches
     `host_tool_call` events against. Registering the merged catalog
     while only dispatching against the native one would advertise
     bridged tools the model could call but never actually execute
     (`OmpHostToolRouter` would resolve `finish_execution` against the
     native-only catalog, throw `Tool not found`, and the model would see
     a failed tool call every time).
   - `OmpAgentSession.close()` now also closes the MCP bridge's clients,
     so a session doesn't leak MCP client connections.

## Repro

```ts
const registry = buildProviderRegistry(logger, { ompRuntime });
registry.omp.applyToolPolicy(
  { provider: "omp", cwd, mcpServers: { hub: { type: "http", url } } },
  { preapproved: [{ kind: "mcp", server: "hub", tool: "finish_execution" }] },
);
// before: throws ToolPolicyUnsupportedError
// after: returns { ...config, toolPolicy }
```

## Tests

- `provider-registry.test.ts`: new test asserting `omp.applyToolPolicy`
  accepts the Hub's exact MCP grant instead of throwing
  `tool_policy_unsupported`.
- `providers/omp/mcp-tool-bridge.test.ts` (new): unit coverage for the
  bridge in isolation — no `mcpServers` / non-`http` servers return
  `null` and open no client; `http` servers connect, list tools, and
  convert the JSON Schema to a real Zod object shape (not an empty-object
  fallback); `executeTool` forwards to the mocked MCP client's `callTool`
  and maps the result; `close()` closes every connected client. The MCP
  SDK is mocked (`@modelcontextprotocol/sdk/client/index.js` and
  `.../streamableHttp.js`) — no network.
- `providers/omp/agent.test.ts`: new "OMP MCP tool bridge wiring" suite
  drives the **real** `createSession -> setHostTools -> host_tool_call ->
  executeTool` path (not a shortcut around it) and asserts the mocked
  MCP client's `callTool` is actually invoked when OMP calls the tool
  back — the assertion that matters, since a test that only checks
  `setHostTools` announced the tool would pass even with the
  native-vs-merged catalog bug. Also covers the no-`mcpServers` case
  (unchanged behavior) and that `session.close()` closes every bridged
  client.

Each new/changed assertion was verified to fail when its corresponding
fix is reverted (confirmed locally by reintroducing each bug one at a
time and re-running the suite; not included as a commit).

## Build / run from this fork

```bash
npm install --workspace=packages/server
npm run build --workspace=packages/protocol   # workspace dep, needs building first
npm run build --workspace=packages/server
PASEO_HOME=~/.paseo-omp node packages/server/dist/scripts/supervisor-entrypoint.js
```

Typecheck: `npm run typecheck --workspace=packages/server`
(`tsgo -p tsconfig.server.typecheck.json --noEmit`).
Tests touched: `npx vitest run src/server/agent/provider-registry.test.ts src/server/agent/providers/omp/agent.test.ts src/server/agent/providers/omp/mcp-tool-bridge.test.ts` from `packages/server`.
