### PR TITLE
fix(server): give the web UI connection hint an explicit port

### DIFF
--- a/packages/server/src/server/bootstrap-web-ui.test.ts
+++ b/packages/server/src/server/bootstrap-web-ui.test.ts
@@ -110,6 +110,44 @@ describe("daemon web UI bootstrap", () => {
     });
   });
 
+  test("spells out the scheme default port when the Host header omits it", async () => {
+    const distDir = await createWebUiDist();
+
+    daemonHandle = await createTestPaseoDaemon({
+      mcpEnabled: false,
+      webUi: {
+        enabled: true,
+        distDir,
+      },
+    });
+
+    // A browser reaching a proxy that terminates TLS on 443 sends a Host header
+    // with no port at all. The app rejects a portless `listen`, so the daemon
+    // has to supply the default itself.
+    const httpsHint = readInjectedConnectionHint(
+      await fetchDaemonWebUi({
+        port: daemonHandle.port,
+        headers: { host: "paseo.example.test", "x-forwarded-proto": "https" },
+      }),
+    );
+    const httpHint = readInjectedConnectionHint(
+      await fetchDaemonWebUi({
+        port: daemonHandle.port,
+        headers: { host: "paseo.example.test" },
+      }),
+    );
+    const ipv6Hint = readInjectedConnectionHint(
+      await fetchDaemonWebUi({
+        port: daemonHandle.port,
+        headers: { host: "[::1]", "x-forwarded-proto": "https" },
+      }),
+    );
+
+    expect(httpsHint.listen).toBe("paseo.example.test:443");
+    expect(httpHint.listen).toBe("paseo.example.test:80");
+    expect(ipv6Hint.listen).toBe("[::1]:443");
+  });
+
   test("ignores forwarded HTTPS when proxy trust is disabled", async () => {
     const distDir = await createWebUiDist();
 

--- a/packages/server/src/server/web-ui.ts
+++ b/packages/server/src/server/web-ui.ts
@@ -250,6 +250,22 @@ function serializeInlineScriptJson(value: unknown): string {
     .replace(/&/g, "\\u0026");
 }
 
+/**
+ * A Host header carries no port when the client used the scheme's default one,
+ * which is what every browser sends to a proxy terminating TLS on 443. The app
+ * parses `listen` with parseHostPort, which requires an explicit port and
+ * rejects the value outright, so the hint has to spell the port out.
+ */
+function hasExplicitPort(host: string): boolean {
+  if (host.startsWith("[")) {
+    // IPv6 literals are bracketed: [::1] has no port, [::1]:443 does.
+    const end = host.indexOf("]");
+    return end !== -1 && /^:\d{1,5}$/.test(host.slice(end + 1));
+  }
+  const colon = host.indexOf(":");
+  return colon !== -1 && colon === host.lastIndexOf(":") && /^\d{1,5}$/.test(host.slice(colon + 1));
+}
+
 function injectConnectionHint(
   html: string,
   req: Parameters<RequestHandler>[0],
@@ -258,7 +274,7 @@ function injectConnectionHint(
   const host = typeof req.headers.host === "string" ? req.headers.host : "";
   const useTls = req.protocol === "https";
   const hint = {
-    listen: host,
+    listen: host && !hasExplicitPort(host) ? `${host}:${useTls ? 443 : 80}` : host,
     useTls,
     label,
   };


### PR DESCRIPTION
### Linked issue

Closes #1842

Related implementations: #2618 and #3754.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

When a browser reaches the daemon-served web UI through a proxy on the scheme's default port, the `Host` header has no port. The daemon injects that value as the initial connection hint, but the app requires an explicit `host:port`. A new browser profile therefore rejects the hint and falls back to its own `localhost:6767` instead of connecting to the daemon.

Add the scheme default (`443` for HTTPS and `80` for HTTP) when the header omits a port. Keep explicit ports unchanged and handle bracketed IPv6 hosts. This stays on the producer side, where the daemon knows the request scheme, instead of weakening the shared client parser.

This is a narrower server-only alternative to #2618 and #3754.

### Goals

- Make first-run browser web bootstrap work behind a TLS-terminating proxy on port 443.
- Emit port 80 or 443 only when the `Host` header has no explicit port.
- Preserve explicit ports and bracketed IPv6 hosts.
- Cover the real daemon bootstrap path with a regression test.

### Non-goals

- Change trusted-proxy or `X-Forwarded-Host` handling.
- Add a client-side fallback for portless connection strings.
- Change the connection UI or native app behavior.

### QA

[Raw Linux evidence for the exact PR head](https://github.com/getpaseo/paseo/pull/3832#issuecomment-5406658240)

Manual:

- Browser web with the daemon running on Linux: tested the affected reverse-proxy flow and confirmed that it connects with this change.
- Not manually tested on macOS or Windows. Native apps are not affected by this server-rendered bootstrap hint.

Automated evidence from the fork PR:

- `bootstrap-web-ui.test.ts`: 3 passed.
- Negative control: reverting only `web-ui.ts` fails the new assertion (`expected 'paseo.example.test' to be 'paseo.example.test:443'`) while the two existing tests still pass.
- `web-ui.test.ts` and `config-web-ui.test.ts`: 27 passed.
- The pre-commit hook passed lint, format, and typecheck across all workspaces.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
