### PR TITLE
fix(omp): recover the session when its CLI process dies

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -30,8 +30,17 @@ workflows all live in the CLI process, and the completion notification that woul
 agent never arrives. A runtime that dies mid-turn is reported by whatever is draining its stream, but
 between turns nothing is watching, so the agent sits at `idle` looking healthy while its background
 work is gone. Report that exit as a turn failure so the agent lands in `error` with a timeline entry.
-Only the Claude provider does this today; the others still report a death only when a turn happens to
-be in flight.
+Claude and OMP do this today; the others still report a death only when a turn happens to be in
+flight.
+
+Reporting the death is not enough on its own when the whole session lives in one process. OMP has no
+per-turn process to respawn: its session, tool calls, and subagents all share a single long-running
+CLI, and once that transport is disposed every later prompt in the chat fails against it. So the OMP
+provider also relaunches lazily on the next prompt, against the session file it already holds, which
+restores the same native session and lets the user keep typing in the same chat. Claude reaches the
+same outcome by respawning its query on the next write. A session with nothing to resume — an
+internal `--no-session` chat, or a crash before the session file existed — comes back as a fresh
+conversation and announces the new session ID so persistence is repointed rather than left stale.
 
 ### Cancellation
 

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -442,6 +442,63 @@ describe("OMP agent client and session", () => {
     expect(omp.completedTurnCount()).toBe(0);
   });
 
+  test("reports a turn_failed notice when the OMP process dies while idle", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
+
+    expect(omp.turnFailures()).toEqual(["OMP process exited with code 1"]);
+  });
+
+  test("ignores a process_exit that races an intentional close", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    await omp.close();
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 0" });
+
+    expect(omp.turnFailures()).toEqual([]);
+  });
+  test("recovers on the next prompt after an idle process exit", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
+    await omp.runPromptAfterRuntimeExit("continue", "recovered response");
+
+    expect(omp.runtimeSessionCount()).toBe(2);
+    expect(omp.turnFailures()).toEqual(["OMP process exited with code 1"]);
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("relaunches against the dead session file", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    const sessionFile = omp.runtime().state.sessionFile;
+
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
+    await omp.runPromptAfterRuntimeExit("continue", "recovered response");
+
+    expect(sessionFile).toBe("/tmp/omp-session");
+    expect(omp.runtimeLaunchSessions()).toEqual([undefined, sessionFile]);
+  });
+
+  test("reports relaunch failure and retries recovery on a later prompt", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    const recoveryError = new Error("relaunch failed");
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
+    omp.failNextRuntimeStart(recoveryError);
+
+    await omp.startTurnAfterRuntimeExit("first retry");
+    expect(omp.turnFailures()).toEqual(["OMP process exited with code 1", "relaunch failed"]);
+
+    await omp.runPromptAfterRuntimeExit("second retry", "recovered response");
+    expect(omp.runtimeSessionCount()).toBe(2);
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
   test("preserves a correlated invoked result over a local-only prompt ack", async () => {
     const omp = new OmpHarness();
     await omp.start();

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -6,6 +6,10 @@ import type { OmpNoTurnScheduler, OmpProviderIdleScheduler } from "./agent.js";
 import type { OmpUsagePollScheduler } from "./usage-poller.js";
 import { OmpHarness } from "./test-utils/omp-harness.js";
 
+// Mirrors the user-facing copy handleProcessExit wraps the raw exit reason in.
+const runtimeExitNotice = (reason: string): string =>
+  `${reason}. Any tool calls or subagents it had running were terminated with it.`;
+
 class ManualIdleScheduler implements OmpProviderIdleScheduler {
   private readonly retries: Array<() => void> = [];
   private readonly waiters: Array<{ count: number; resolve: () => void }> = [];
@@ -448,7 +452,7 @@ describe("OMP agent client and session", () => {
 
     omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
 
-    expect(omp.turnFailures()).toEqual(["OMP process exited with code 1"]);
+    expect(omp.turnFailures()).toEqual([runtimeExitNotice("OMP process exited with code 1")]);
   });
 
   test("ignores a process_exit that races an intentional close", async () => {
@@ -460,6 +464,7 @@ describe("OMP agent client and session", () => {
 
     expect(omp.turnFailures()).toEqual([]);
   });
+
   test("recovers on the next prompt after an idle process exit", async () => {
     const omp = new OmpHarness();
     await omp.start();
@@ -468,7 +473,7 @@ describe("OMP agent client and session", () => {
     await omp.runPromptAfterRuntimeExit("continue", "recovered response");
 
     expect(omp.runtimeSessionCount()).toBe(2);
-    expect(omp.turnFailures()).toEqual(["OMP process exited with code 1"]);
+    expect(omp.turnFailures()).toEqual([runtimeExitNotice("OMP process exited with code 1")]);
     expect(omp.completedTurnCount()).toBe(1);
   });
 
@@ -484,6 +489,85 @@ describe("OMP agent client and session", () => {
     expect(omp.runtimeLaunchSessions()).toEqual([undefined, sessionFile]);
   });
 
+  test("closes the dead runtime once the replacement is adopted", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    const dead = omp.runtime();
+
+    dead.emit({ type: "process_exit", error: "OMP process exited with code 1" });
+    await omp.runPromptAfterRuntimeExit("continue", "recovered response");
+
+    expect(dead.closed).toBe(true);
+    expect(omp.runtime().closed).toBe(false);
+  });
+
+  test("discards a relaunch that lands after the session was closed", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
+    // Start the turn without awaiting so close() lands while the relaunch is
+    // still in flight - the leak this guards is a live CLI nothing owns.
+    const turn = omp.startTurnDetached("continue");
+    await omp.close();
+    await turn;
+    await waitForImmediate();
+
+    expect(omp.runtimeSessions().every((session) => session.closed)).toBe(true);
+  });
+
+  test("recovers an internal session without adopting a session file", async () => {
+    const omp = new OmpHarness();
+    await omp.start({ internal: true });
+
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
+    await omp.runPromptAfterRuntimeExit("continue", "recovered response");
+
+    expect(omp.runtimeLaunchSessions()).toEqual([undefined, undefined]);
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("announces the new session id when recovery cannot resume the old one", async () => {
+    const omp = new OmpHarness();
+    await omp.start({ internal: true });
+    const deadSessionId = omp.runtime().state.sessionId;
+
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
+    await omp.runPromptAfterRuntimeExit("continue", "recovered response");
+
+    const recoveredSessionId = omp.runtime().state.sessionId;
+    expect(recoveredSessionId).not.toBe(deadSessionId);
+    expect(omp.threadStartedSessionIds()).toEqual([recoveredSessionId]);
+  });
+
+  test("keeps the session id and announces nothing when the file is resumed", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    const deadSessionId = omp.runtime().state.sessionId;
+
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
+    await omp.runPromptAfterRuntimeExit("continue", "recovered response");
+
+    expect(omp.runtime().state.sessionId).toBe(deadSessionId);
+    expect(omp.threadStartedSessionIds()).toEqual([]);
+  });
+
+  test("recovers a resumed session against its session file", async () => {
+    const omp = new OmpHarness();
+    await omp.resume({
+      user: { id: "user-history", text: "earlier question" },
+      assistant: { id: "assistant-history", text: "earlier answer" },
+    });
+
+    omp.runtime().emit({ type: "process_exit", error: "OMP process exited with code 1" });
+    await omp.runPromptAfterRuntimeExit("continue", "recovered response");
+
+    const launches = omp.runtimeLaunchSessions();
+    expect(launches.length).toBe(2);
+    expect(launches[1]).toBe(launches[0]);
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
   test("reports relaunch failure and retries recovery on a later prompt", async () => {
     const omp = new OmpHarness();
     await omp.start();
@@ -492,7 +576,10 @@ describe("OMP agent client and session", () => {
     omp.failNextRuntimeStart(recoveryError);
 
     await omp.startTurnAfterRuntimeExit("first retry");
-    expect(omp.turnFailures()).toEqual(["OMP process exited with code 1", "relaunch failed"]);
+    expect(omp.turnFailures()).toEqual([
+      runtimeExitNotice("OMP process exited with code 1"),
+      "relaunch failed",
+    ]);
 
     await omp.runPromptAfterRuntimeExit("second retry", "recovered response");
     expect(omp.runtimeSessionCount()).toBe(2);

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -177,6 +177,8 @@ interface StartTurnResult {
 
 interface OmpAgentSessionOptions {
   runtimeSession: OmpRuntimeSession;
+  /** Relaunches the OMP CLI for this session. Omitted when the session cannot be recovered. */
+  restartRuntime?: (sessionFile: string | null) => Promise<OmpRuntimeSession>;
   config: AgentSessionConfig;
   initialState: OmpSessionState;
   currentModeId?: string | null;
@@ -874,9 +876,9 @@ export class OmpAgentSession implements AgentSession {
   private closed = false;
   private live: boolean;
   private readonly emittedUserMessageIds = new Set<string>();
-
   constructor(options: OmpAgentSessionOptions) {
     this.runtimeSession = options.runtimeSession;
+    this.restartRuntime = options.restartRuntime;
     this.config = options.config;
     this.state = options.initialState;
     this.currentModeId = options.currentModeId ?? null;
@@ -910,6 +912,17 @@ export class OmpAgentSession implements AgentSession {
     this.runtimeSession.onEvent((event) => {
       this.handleRuntimeEvent(event);
     });
+    this.subscribeSubagents();
+  }
+
+  private runtimeSession: OmpRuntimeSession;
+  private readonly restartRuntime?: OmpAgentSessionOptions["restartRuntime"];
+  private readonly config: AgentSessionConfig;
+  private readonly logger: Logger;
+  private readonly paseoTools?: PaseoToolCatalog;
+  private runtimeDead = false;
+
+  private subscribeSubagents(): void {
     void this.runtimeSession.setSubagentSubscription("events").catch((eventsError: unknown) => {
       this.logger.debug(
         { err: eventsError },
@@ -925,11 +938,6 @@ export class OmpAgentSession implements AgentSession {
         });
     });
   }
-
-  private readonly runtimeSession: OmpRuntimeSession;
-  private readonly config: AgentSessionConfig;
-  private readonly logger: Logger;
-  private readonly paseoTools?: PaseoToolCatalog;
 
   get id(): string | null {
     return this.state.sessionId;
@@ -947,6 +955,25 @@ export class OmpAgentSession implements AgentSession {
     });
   }
 
+  private async ensureRuntimeAlive(): Promise<void> {
+    if (!this.runtimeDead) {
+      return;
+    }
+    if (!this.restartRuntime) {
+      throw new Error("OMP session cannot be recovered because runtime restart is unavailable");
+    }
+    const previous = this.runtimeSession;
+    const next = await this.restartRuntime(this.state.sessionFile ?? null);
+    clearOmpHostToolState(previous);
+    this.runtimeSession = next;
+    this.runtimeDead = false;
+    next.onEvent((event) => {
+      this.handleRuntimeEvent(event);
+    });
+    this.state = await next.getState();
+    this.subscribeSubagents();
+    this.live = true;
+  }
   async startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<StartTurnResult> {
     if (this.activeTurnId) {
       throw new Error("An OMP turn is already active");
@@ -968,6 +995,7 @@ export class OmpAgentSession implements AgentSession {
 
     void (async () => {
       try {
+        await this.ensureRuntimeAlive();
         const ack = await this.runtimeSession.prompt(payload.text, payload.images);
         this.activePromptRequestId = ack.requestId ?? null;
         const correlatedResult = ack.requestId
@@ -1774,13 +1802,23 @@ export class OmpAgentSession implements AgentSession {
     this.logger.debug({ event }, "Dropped unknown OMP runtime event");
   }
 
+  // OMP's whole session lives inside a single long-running CLI process, so when
+  // it dies every tool call and subagent dies with it. A death mid-turn is
+  // reported by the turn's own catch handler, but a death between turns is
+  // observed by nothing else: the agent would keep looking idle while every
+  // later prompt rejects against a disposed transport. Emit the failure so the
+  // client sees what was lost, and mark the runtime dead so the next prompt
+  // relaunches it through `ensureRuntimeAlive`. Guard on `this.closed` because
+  // an intentional close() also tears down the process and races this same
+  // notification.
   private handleProcessExit(error: string): void {
+    if (this.closed) {
+      return;
+    }
+    this.runtimeDead = true;
     this.usagePoller.stopTurn();
     this.terminalizeActiveWork();
     this.subagentIndex.clear(this.runtimeSession);
-    if (!this.activeTurnId) {
-      return;
-    }
     const turnId = this.activeTurnId;
     this.activeTurnId = null;
     this.activeClientMessageId = null;
@@ -1791,7 +1829,7 @@ export class OmpAgentSession implements AgentSession {
     this.emit({
       type: "turn_failed",
       provider: this.provider,
-      turnId,
+      ...(turnId ? { turnId } : {}),
       error,
     });
   }
@@ -2231,7 +2269,7 @@ export class OmpAgentClient implements AgentClient {
     launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
     const launchMode = this.resolveLaunchMode(config.modeId);
-    const runtimeSession = await this.runtime.startSession({
+    const startInput: OmpStartSessionInput = {
       cwd: config.cwd,
       protocolMode: "rpc-ui",
       model: config.model,
@@ -2241,11 +2279,26 @@ export class OmpAgentClient implements AgentClient {
       extraArgs: launchMode.extraArgs,
       systemPrompt: composeSystemPromptParts(config.systemPrompt, config.daemonAppendSystemPrompt),
       env: launchContext?.env,
-    });
+    };
+    const runtimeSession = await this.runtime.startSession(startInput);
+    const restartRuntime = async (sessionFile: string | null): Promise<OmpRuntimeSession> => {
+      const next = await this.runtime.startSession({
+        ...startInput,
+        ...(!startInput.noSession && sessionFile ? { session: sessionFile } : {}),
+      });
+      try {
+        await this.configureNativePaseoTools(next, launchContext?.paseoTools);
+        return next;
+      } catch (error) {
+        await next.close().catch(() => undefined);
+        throw error;
+      }
+    };
     try {
       await this.configureNativePaseoTools(runtimeSession, launchContext?.paseoTools);
       return new OmpAgentSession({
         runtimeSession,
+        restartRuntime,
         config,
         initialState: await runtimeSession.getState(),
         currentModeId: launchMode.modeId,
@@ -2274,20 +2327,32 @@ export class OmpAgentClient implements AgentClient {
 
     const persistenceMetadata = parsePersistenceMetadata(handle.metadata);
     const resumeConfig = buildResumeConfig(persistenceMetadata, overrides, this.provider);
-
     const launchMode = this.resolveLaunchMode(resumeConfig.modeId);
-    const runtimeSession = await this.runtime.startSession(
-      buildResumeStartInput({
-        resumeConfig,
-        sessionFile,
-        launchContext,
-        launchMode,
-      }),
-    );
+    const startInput: OmpStartSessionInput = buildResumeStartInput({
+      resumeConfig,
+      sessionFile,
+      launchContext,
+      launchMode,
+    });
+    const runtimeSession = await this.runtime.startSession(startInput);
+    const restartRuntime = async (nextSessionFile: string | null): Promise<OmpRuntimeSession> => {
+      const next = await this.runtime.startSession({
+        ...startInput,
+        ...(nextSessionFile ? { session: nextSessionFile } : {}),
+      });
+      try {
+        await this.configureNativePaseoTools(next, launchContext?.paseoTools);
+        return next;
+      } catch (error) {
+        await next.close().catch(() => undefined);
+        throw error;
+      }
+    };
     try {
       await this.configureNativePaseoTools(runtimeSession, launchContext?.paseoTools);
       return new OmpAgentSession({
         runtimeSession,
+        restartRuntime,
         config: resumeConfig.config,
         initialState: await runtimeSession.getState(),
         currentModeId: launchMode.modeId,
@@ -2304,7 +2369,6 @@ export class OmpAgentClient implements AgentClient {
       throw error;
     }
   }
-
   async fetchCatalog(
     options: FetchCatalogOptions,
     context?: ProviderRefreshContext,

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -177,8 +177,11 @@ interface StartTurnResult {
 
 interface OmpAgentSessionOptions {
   runtimeSession: OmpRuntimeSession;
-  /** Relaunches the OMP CLI for this session. Omitted when the session cannot be recovered. */
-  restartRuntime?: (sessionFile: string | null) => Promise<OmpRuntimeSession>;
+  /**
+   * Relaunches the OMP CLI for this session against the given session file,
+   * or as a fresh conversation when there is nothing to resume.
+   */
+  restartRuntime: (sessionFile: string | null) => Promise<OmpRuntimeSession>;
   config: AgentSessionConfig;
   initialState: OmpSessionState;
   currentModeId?: string | null;
@@ -875,7 +878,15 @@ export class OmpAgentSession implements AgentSession {
   private readonly usagePoller: OmpUsagePoller;
   private closed = false;
   private live: boolean;
+  private runtimeDead = false;
   private readonly emittedUserMessageIds = new Set<string>();
+  private runtimeSession: OmpRuntimeSession;
+  private unsubscribeRuntime: (() => void) | null = null;
+  private readonly restartRuntime: OmpAgentSessionOptions["restartRuntime"];
+  private readonly config: AgentSessionConfig;
+  private readonly logger: Logger;
+  private readonly paseoTools?: PaseoToolCatalog;
+
   constructor(options: OmpAgentSessionOptions) {
     this.runtimeSession = options.runtimeSession;
     this.restartRuntime = options.restartRuntime;
@@ -909,18 +920,11 @@ export class OmpAgentSession implements AgentSession {
       normalizeOmpThinkingOption(options.config.thinkingOptionId) ??
       this.state.thinkingLevel ??
       null;
-    this.runtimeSession.onEvent((event) => {
+    this.unsubscribeRuntime = this.runtimeSession.onEvent((event) => {
       this.handleRuntimeEvent(event);
     });
     this.subscribeSubagents();
   }
-
-  private runtimeSession: OmpRuntimeSession;
-  private readonly restartRuntime?: OmpAgentSessionOptions["restartRuntime"];
-  private readonly config: AgentSessionConfig;
-  private readonly logger: Logger;
-  private readonly paseoTools?: PaseoToolCatalog;
-  private runtimeDead = false;
 
   private subscribeSubagents(): void {
     void this.runtimeSession.setSubagentSubscription("events").catch((eventsError: unknown) => {
@@ -959,21 +963,43 @@ export class OmpAgentSession implements AgentSession {
     if (!this.runtimeDead) {
       return;
     }
-    if (!this.restartRuntime) {
-      throw new Error("OMP session cannot be recovered because runtime restart is unavailable");
-    }
     const previous = this.runtimeSession;
+    const previousSessionId = this.state.sessionId;
     const next = await this.restartRuntime(this.state.sessionFile ?? null);
+    // close() can land while the replacement is still starting. It tears down
+    // whatever `runtimeSession` pointed at then — the dead process — so adopting
+    // `next` here would leave a live CLI that nothing owns and no later close()
+    // reaches. Discard it instead.
+    if (this.closed) {
+      await next.close().catch(() => undefined);
+      throw new Error("OMP session was closed while its runtime was relaunching");
+    }
+    // Drop the dead runtime's subscription before adopting the replacement, so a
+    // late frame from the old transport cannot mark the new process dead.
+    this.unsubscribeRuntime?.();
+    this.unsubscribeRuntime = null;
     clearOmpHostToolState(previous);
+    await previous.close().catch(() => undefined);
     this.runtimeSession = next;
     this.runtimeDead = false;
-    next.onEvent((event) => {
+    this.unsubscribeRuntime = next.onEvent((event) => {
       this.handleRuntimeEvent(event);
     });
     this.state = await next.getState();
     this.subscribeSubagents();
     this.live = true;
+    if (this.state.sessionId !== previousSessionId) {
+      // An unrecoverable session (no file, or an internal --no-session chat)
+      // comes back as a different native conversation. Announce it so the
+      // manager repoints persistence instead of holding a stale handle.
+      this.emit({
+        type: "thread_started",
+        provider: this.provider,
+        sessionId: this.state.sessionId,
+      });
+    }
   }
+
   async startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<StartTurnResult> {
     if (this.activeTurnId) {
       throw new Error("An OMP turn is already active");
@@ -1185,6 +1211,8 @@ export class OmpAgentSession implements AgentSession {
       return;
     }
     this.closed = true;
+    this.unsubscribeRuntime?.();
+    this.unsubscribeRuntime = null;
     this.usagePoller.close();
     this.cancelNoTurnPromptCompletion();
     try {
@@ -1816,6 +1844,10 @@ export class OmpAgentSession implements AgentSession {
       return;
     }
     this.runtimeDead = true;
+    this.logger.warn(
+      { err: error, sessionId: this.state.sessionId },
+      "OMP runtime exited unexpectedly",
+    );
     this.usagePoller.stopTurn();
     this.terminalizeActiveWork();
     this.subagentIndex.clear(this.runtimeSession);
@@ -1830,7 +1862,7 @@ export class OmpAgentSession implements AgentSession {
       type: "turn_failed",
       provider: this.provider,
       ...(turnId ? { turnId } : {}),
-      error,
+      error: `${error}. Any tool calls or subagents it had running were terminated with it.`,
     });
   }
 
@@ -2281,19 +2313,7 @@ export class OmpAgentClient implements AgentClient {
       env: launchContext?.env,
     };
     const runtimeSession = await this.runtime.startSession(startInput);
-    const restartRuntime = async (sessionFile: string | null): Promise<OmpRuntimeSession> => {
-      const next = await this.runtime.startSession({
-        ...startInput,
-        ...(!startInput.noSession && sessionFile ? { session: sessionFile } : {}),
-      });
-      try {
-        await this.configureNativePaseoTools(next, launchContext?.paseoTools);
-        return next;
-      } catch (error) {
-        await next.close().catch(() => undefined);
-        throw error;
-      }
-    };
+    const restartRuntime = this.buildRestartRuntime(startInput, launchContext);
     try {
       await this.configureNativePaseoTools(runtimeSession, launchContext?.paseoTools);
       return new OmpAgentSession({
@@ -2313,6 +2333,31 @@ export class OmpAgentClient implements AgentClient {
       await runtimeSession.close().catch(() => undefined);
       throw error;
     }
+  }
+
+  /**
+   * Builds the relaunch used to recover this session after its CLI process dies.
+   * `session` is overlaid only when there is a file to resume and the session
+   * was not launched with `--no-session`, so an internal chat comes back clean
+   * instead of adopting an unrelated conversation.
+   */
+  private buildRestartRuntime(
+    startInput: OmpStartSessionInput,
+    launchContext?: AgentLaunchContext,
+  ): (sessionFile: string | null) => Promise<OmpRuntimeSession> {
+    return async (sessionFile: string | null): Promise<OmpRuntimeSession> => {
+      const next = await this.runtime.startSession({
+        ...startInput,
+        ...(!startInput.noSession && sessionFile ? { session: sessionFile } : {}),
+      });
+      try {
+        await this.configureNativePaseoTools(next, launchContext?.paseoTools);
+        return next;
+      } catch (error) {
+        await next.close().catch(() => undefined);
+        throw error;
+      }
+    };
   }
 
   async resumeSession(
@@ -2335,19 +2380,7 @@ export class OmpAgentClient implements AgentClient {
       launchMode,
     });
     const runtimeSession = await this.runtime.startSession(startInput);
-    const restartRuntime = async (nextSessionFile: string | null): Promise<OmpRuntimeSession> => {
-      const next = await this.runtime.startSession({
-        ...startInput,
-        ...(nextSessionFile ? { session: nextSessionFile } : {}),
-      });
-      try {
-        await this.configureNativePaseoTools(next, launchContext?.paseoTools);
-        return next;
-      } catch (error) {
-        await next.close().catch(() => undefined);
-        throw error;
-      }
-    };
+    const restartRuntime = this.buildRestartRuntime(startInput, launchContext);
     try {
       await this.configureNativePaseoTools(runtimeSession, launchContext?.paseoTools);
       return new OmpAgentSession({

--- a/packages/server/src/server/agent/providers/omp/session-recovery.local.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/omp/session-recovery.local.e2e.test.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,6 +16,17 @@ import type { OmpRuntimeSession } from "./runtime.js";
 // Evidence is written to OMP_REPRO_EVIDENCE (default $TMPDIR/omp-repro-evidence.json)
 // because the server vitest setup silences console output.
 const OMP_COMMAND = process.env.OMP_COMMAND ?? "omp";
+
+// Skip rather than fail when the binary is absent: `npm run test:e2e:local`
+// collects this file on machines that have no omp installed.
+const ompAvailable = ((): boolean => {
+  try {
+    execFileSync(OMP_COMMAND, ["--version"], { encoding: "utf8", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+})();
 
 interface ProcessExit {
   code: number | null;
@@ -89,7 +100,7 @@ async function promptOutcome(session: OmpRuntimeSession, message: string): Promi
   );
 }
 
-describe("OMP runtime session after its CLI process dies", () => {
+describe.skipIf(!ompAvailable)("OMP runtime session after its CLI process dies", () => {
   const evidence: Record<string, unknown> = { ompCommand: OMP_COMMAND };
 
   async function recordEvidence(): Promise<void> {
@@ -171,6 +182,10 @@ describe("OMP runtime session after its CLI process dies", () => {
     const { runtime, children, nextSpawn } = createRuntime();
     const client = new OmpAgentClient({ logger: pino({ level: "silent" }), runtime });
     const session = await client.createSession({ provider: "omp", cwd });
+    const seen: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      seen.push(event);
+    });
 
     expect(children.length).toBe(1);
     const child = children.at(0);
@@ -182,10 +197,17 @@ describe("OMP runtime session after its CLI process dies", () => {
     const failure = await reported;
 
     // The next prompt in the SAME session relaunches the CLI instead of
-    // rejecting forever. Arm the spawn watcher before prompting.
+    // rejecting forever, and the turn has to actually run to completion in the
+    // replacement process. Arm the watchers before prompting.
     const relaunched = nextSpawn();
+    const settled = nextMatchingEvent(
+      session,
+      (event) => event.type === "turn_completed" || event.type === "turn_failed",
+    );
     await session.startTurn("Reply with exactly: RECOVERED");
     const replacement = await relaunched;
+    const outcome = await settled;
+    const replied = seen.some((event) => JSON.stringify(event).includes("RECOVERED"));
 
     evidence.agentRecoversInPlace = {
       childExit: exit,
@@ -193,11 +215,16 @@ describe("OMP runtime session after its CLI process dies", () => {
       runtimeProcessesSpawned: children.length,
       killedPid: child.pid ?? null,
       relaunchedPid: replacement.pid ?? null,
+      turnOutcome: outcome.type,
+      turnFailure: outcome.type === "turn_failed" ? outcome.error : null,
+      assistantAnswered: replied,
     };
     await recordEvidence();
 
     expect(children.length).toBe(2);
     expect(replacement.pid).not.toBe(child.pid);
+    expect(outcome.type).toBe("turn_completed");
+    expect(replied).toBe(true);
     await session.close();
-  }, 120_000);
+  }, 180_000);
 });

--- a/packages/server/src/server/agent/providers/omp/session-recovery.local.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/omp/session-recovery.local.e2e.test.ts
@@ -1,0 +1,203 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import pino from "pino";
+import { describe, expect, test } from "vitest";
+
+import type { AgentSession, AgentStreamEvent } from "../../agent-sdk-types.js";
+import { OmpAgentClient } from "./agent.js";
+import { OmpCliRuntime } from "./cli-runtime.js";
+import type { OmpRuntimeSession } from "./runtime.js";
+
+// Reproduction + fix verification for the OMP session-recovery defect. Needs a
+// real `omp` on PATH (or OMP_COMMAND pointing at it), so it is a local-only e2e.
+//
+// Evidence is written to OMP_REPRO_EVIDENCE (default $TMPDIR/omp-repro-evidence.json)
+// because the server vitest setup silences console output.
+const OMP_COMMAND = process.env.OMP_COMMAND ?? "omp";
+
+interface ProcessExit {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+interface Harness {
+  runtime: OmpCliRuntime;
+  children: ChildProcessWithoutNullStreams[];
+  /** Resolves the next time the runtime spawns an omp process. */
+  nextSpawn(): Promise<ChildProcessWithoutNullStreams>;
+}
+
+function createRuntime(): Harness {
+  const children: ChildProcessWithoutNullStreams[] = [];
+  let pendingSpawn: ((child: ChildProcessWithoutNullStreams) => void) | null = null;
+  const runtime = new OmpCliRuntime({
+    logger: pino({ level: "silent" }),
+    command: [OMP_COMMAND],
+    spawnProcess: (launch) => {
+      const [command, ...args] = launch.argv;
+      const spawned = spawn(command, args, {
+        cwd: launch.cwd,
+        stdio: "pipe",
+        env: { ...process.env, ...launch.env },
+      }) as ChildProcessWithoutNullStreams;
+      children.push(spawned);
+      const resolveSpawn = pendingSpawn;
+      pendingSpawn = null;
+      resolveSpawn?.(spawned);
+      return spawned;
+    },
+  });
+  return {
+    runtime,
+    children,
+    nextSpawn: () => {
+      const { promise, resolve } = Promise.withResolvers<ChildProcessWithoutNullStreams>();
+      pendingSpawn = resolve;
+      return promise;
+    },
+  };
+}
+
+// SIGKILL is what the Linux OOM killer sends.
+async function oomKill(child: ChildProcessWithoutNullStreams): Promise<ProcessExit> {
+  const { promise, resolve } = Promise.withResolvers<ProcessExit>();
+  child.once("exit", (code, signal) => resolve({ code, signal }));
+  child.kill("SIGKILL");
+  return promise;
+}
+
+function nextMatchingEvent(
+  session: AgentSession,
+  predicate: (event: AgentStreamEvent) => boolean,
+): Promise<AgentStreamEvent> {
+  const { promise, resolve } = Promise.withResolvers<AgentStreamEvent>();
+  const unsubscribe = session.subscribe((event) => {
+    if (predicate(event)) {
+      unsubscribe();
+      resolve(event);
+    }
+  });
+  return promise;
+}
+
+async function promptOutcome(session: OmpRuntimeSession, message: string): Promise<string> {
+  return session.prompt(message).then(
+    () => "ACCEPTED",
+    (error: unknown) => (error instanceof Error ? error.message : String(error)),
+  );
+}
+
+describe("OMP runtime session after its CLI process dies", () => {
+  const evidence: Record<string, unknown> = { ompCommand: OMP_COMMAND };
+
+  async function recordEvidence(): Promise<void> {
+    await writeFile(
+      process.env.OMP_REPRO_EVIDENCE ?? join(tmpdir(), "omp-repro-evidence.json"),
+      `${JSON.stringify(evidence, null, 2)}\n`,
+      "utf8",
+    );
+  }
+
+  test("the dead runtime session rejects every later prompt", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omp-session-recovery-"));
+    const { runtime, children } = createRuntime();
+    const session = await runtime.startSession({ cwd, protocolMode: "rpc-ui" });
+
+    // The live session answers RPC before the kill.
+    const state = await session.getState();
+    expect(state.sessionId.length).toBeGreaterThan(0);
+
+    const child = children.at(0);
+    if (!child) throw new Error("omp child was never spawned");
+    const exit = await oomKill(child);
+
+    // The defect at the transport layer: the session object is still there but
+    // every request is rejected from now on.
+    const first = await promptOutcome(session, "hello");
+    const second = await promptOutcome(session, "are you there?");
+
+    evidence.deadRuntimeSession = {
+      liveSessionId: state.sessionId,
+      killedPid: child.pid ?? null,
+      childExit: exit,
+      promptAfterDeath: { first, second },
+    };
+    await recordEvidence();
+
+    expect(first).toBe("OMP RPC process is closed");
+    expect(second).toBe("OMP RPC process is closed");
+  }, 60_000);
+
+  test("relaunching against the same session file restores the same session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omp-session-resume-"));
+    const sessionFile = join(cwd, "session.jsonl");
+    const { runtime, children } = createRuntime();
+
+    const first = await runtime.startSession({ cwd, protocolMode: "rpc-ui", session: sessionFile });
+    const before = await first.getState();
+    expect(before.sessionId.length).toBeGreaterThan(0);
+
+    const firstChild = children.at(0);
+    if (!firstChild) throw new Error("omp child was never spawned");
+    const exit = await oomKill(firstChild);
+    expect(await promptOutcome(first, "dead")).toBe("OMP RPC process is closed");
+
+    // This is what the fix does automatically: relaunch against the same
+    // session file and keep serving the same chat.
+    const second = await runtime.startSession({
+      cwd,
+      protocolMode: "rpc-ui",
+      session: sessionFile,
+    });
+    const after = await second.getState();
+
+    evidence.relaunchKeepsSession = {
+      sessionFile,
+      sessionIdBeforeKill: before.sessionId,
+      childExit: exit,
+      sessionIdAfterRelaunch: after.sessionId,
+      sameSession: before.sessionId === after.sessionId,
+    };
+    await recordEvidence();
+
+    expect(after.sessionId).toBe(before.sessionId);
+    await second.close();
+  }, 90_000);
+
+  test("the agent session recovers on the next prompt after an OOM kill", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omp-agent-recovery-"));
+    const { runtime, children, nextSpawn } = createRuntime();
+    const client = new OmpAgentClient({ logger: pino({ level: "silent" }), runtime });
+    const session = await client.createSession({ provider: "omp", cwd });
+
+    expect(children.length).toBe(1);
+    const child = children.at(0);
+    if (!child) throw new Error("omp child was never spawned");
+
+    // The death is reported even though no turn was running.
+    const reported = nextMatchingEvent(session, (event) => event.type === "turn_failed");
+    const exit = await oomKill(child);
+    const failure = await reported;
+
+    // The next prompt in the SAME session relaunches the CLI instead of
+    // rejecting forever. Arm the spawn watcher before prompting.
+    const relaunched = nextSpawn();
+    await session.startTurn("Reply with exactly: RECOVERED");
+    const replacement = await relaunched;
+
+    evidence.agentRecoversInPlace = {
+      childExit: exit,
+      reportedFailure: failure.type === "turn_failed" ? failure.error : null,
+      runtimeProcessesSpawned: children.length,
+      killedPid: child.pid ?? null,
+      relaunchedPid: replacement.pid ?? null,
+    };
+    await recordEvidence();
+
+    expect(children.length).toBe(2);
+    expect(replacement.pid).not.toBe(child.pid);
+    await session.close();
+  }, 120_000);
+});

--- a/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
@@ -58,18 +58,31 @@ export class FakeOmp implements OmpRuntime {
     FakeOmpSubagentSubscriptionLevel,
     Error
   >();
+  private readonly queuedStartErrors: Error[] = [];
+  private readonly sessionIdsByFile = new Map<string, string>();
+  private sessionIdCounter = 0;
 
   constructor(command: [string, ...string[]] = ["omp"]) {
     this.command = command;
   }
 
   async startSession(input: OmpStartSessionInput): Promise<FakeOmpSession> {
+    const startError = this.queuedStartErrors.shift();
+    if (startError) {
+      throw startError;
+    }
     const launch = buildOmpLaunch({
       command: this.command,
       session: input,
     });
     this.recordedLaunches.push(launch);
-    const session = new FakeOmpSession(launch);
+    // Real omp restores the same session id when reopening a session file, and
+    // mints a new one when there is nothing to resume. Model both so recovery
+    // tests can tell a resumed chat from a fresh one.
+    const resumed = launch.session ? this.sessionIdsByFile.get(launch.session) : undefined;
+    const sessionId = resumed ?? `omp-session-${(this.sessionIdCounter += 1)}`;
+    const session = new FakeOmpSession(launch, sessionId);
+    this.sessionIdsByFile.set(session.state.sessionFile, sessionId);
     session.commands = this.queuedCommands.shift() ?? [];
     for (const [level, error] of this.queuedSubagentSubscriptionErrors) {
       session.subagentSubscriptionErrors.set(level, error);
@@ -83,8 +96,16 @@ export class FakeOmp implements OmpRuntime {
     this.queuedCommands.push(commands);
   }
 
+  failNextStartSession(error: Error): void {
+    this.queuedStartErrors.push(error);
+  }
+
   failNextSubagentSubscription(level: FakeOmpSubagentSubscriptionLevel, error: Error): void {
     this.queuedSubagentSubscriptionErrors.set(level, error);
+  }
+
+  allSessions(): FakeOmpSession[] {
+    return [...this.sessions];
   }
 
   latestSession(): FakeOmpSession {
@@ -150,7 +171,7 @@ export class FakeOmpSession implements OmpRuntimeSession {
   private activeHeldPrompt: { promise: Promise<void>; reject: (error: Error) => void } | null =
     null;
 
-  constructor(launch: OmpRuntimeLaunch) {
+  constructor(launch: OmpRuntimeLaunch, sessionId = "omp-session-1") {
     this.state = {
       model: null,
       thinkingLevel: "medium",
@@ -158,7 +179,7 @@ export class FakeOmpSession implements OmpRuntimeSession {
       isCompacting: false,
       autoCompactionEnabled: true,
       sessionFile: launch.session ?? "/tmp/omp-session",
-      sessionId: "omp-session-1",
+      sessionId,
       messageCount: 0,
       queuedMessageCount: 0,
     };

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -20,7 +20,7 @@ import {
 } from "../agent.js";
 import type { OmpUsagePollScheduler } from "../usage-poller.js";
 import type { OmpAgentMessage, OmpRpcSlashCommand } from "../rpc-types.js";
-import { FakeOmp } from "./fake-omp.js";
+import { FakeOmp, type FakeOmpSession } from "./fake-omp.js";
 
 const CWD = "/tmp/paseo-omp-agent-test";
 
@@ -83,12 +83,7 @@ export class OmpHarness {
   }
 
   failNextRuntimeStart(error: Error): void {
-    const runtime = this.omp;
-    const startSession = runtime.startSession.bind(runtime);
-    runtime.startSession = async () => {
-      runtime.startSession = startSession;
-      throw error;
-    };
+    this.omp.failNextStartSession(error);
   }
 
   runtimeSessionCount(): number {
@@ -223,6 +218,19 @@ export class OmpHarness {
     runtime.finishTurn();
     return await run;
   }
+
+  /**
+   * Starts a turn without awaiting it, so a test can interleave another
+   * lifecycle call (a close, say) with the relaunch it triggers.
+   */
+  startTurnDetached(input: string): Promise<{ turnId: string }> {
+    return this.requireSession().startTurn(input);
+  }
+
+  runtimeSessions(): FakeOmpSession[] {
+    return this.omp.allSessions();
+  }
+
   async startTurnAfterRuntimeExit(input: string): Promise<void> {
     await this.requireSession().startTurn(input);
     await waitForImmediate();
@@ -546,6 +554,12 @@ export class OmpHarness {
 
   turnFailures(): string[] {
     return this.events.flatMap((event) => (event.type === "turn_failed" ? [event.error] : []));
+  }
+
+  threadStartedSessionIds(): string[] {
+    return this.events.flatMap((event) =>
+      event.type === "thread_started" ? [event.sessionId] : [],
+    );
   }
 
   async close(): Promise<void> {

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -82,8 +82,30 @@ export class OmpHarness {
     });
   }
 
+  failNextRuntimeStart(error: Error): void {
+    const runtime = this.omp;
+    const startSession = runtime.startSession.bind(runtime);
+    runtime.startSession = async () => {
+      runtime.startSession = startSession;
+      throw error;
+    };
+  }
+
+  runtimeSessionCount(): number {
+    return this.omp.recordedLaunches.length;
+  }
+
+  async waitForRuntimeSessionCount(count: number): Promise<void> {
+    while (this.runtimeSessionCount() < count) {
+      await waitForImmediate();
+    }
+  }
   queueCommands(commands: OmpRpcSlashCommand[]): void {
     this.omp.queueCommands(commands);
+  }
+
+  runtimeLaunchSessions(): Array<string | undefined> {
+    return this.omp.recordedLaunches.map((launch) => launch.session);
   }
 
   failEventSubscription(error: Error): void {
@@ -186,6 +208,24 @@ export class OmpHarness {
     runtime.streamAssistantText(output);
     runtime.finishTurn();
     return await run;
+  }
+
+  async runPromptAfterRuntimeExit(input: string, output: string): Promise<unknown> {
+    const session = this.requireSession();
+    const run = session.run(input);
+    await this.waitForRuntimeSessionCount(2);
+    const promptStarted = this.omp.latestSession().nextPrompt();
+    await promptStarted;
+    const runtime = this.omp.latestSession();
+    runtime.beginTurn();
+    runtime.acceptPrompt(input, "user-1");
+    runtime.streamAssistantText(output);
+    runtime.finishTurn();
+    return await run;
+  }
+  async startTurnAfterRuntimeExit(input: string): Promise<void> {
+    await this.requireSession().startTurn(input);
+    await waitForImmediate();
   }
 
   async startPromptWithEmptyAgentEnd(
@@ -502,6 +542,10 @@ export class OmpHarness {
 
   canceledTurnCount(): number {
     return this.events.filter((event) => event.type === "turn_canceled").length;
+  }
+
+  turnFailures(): string[] {
+    return this.events.flatMap((event) => (event.type === "turn_failed" ? [event.error] : []));
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
### Linked issue

Closes #3838

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

An OMP session lives inside one long-running `omp` CLI process. When that process dies — the OOM killer is the easy way to hit it, with several agents running at once — the chat it was serving is finished. Two things go wrong: a death **between turns** is never reported (`handleProcessExit` returned early when no turn was active), so the agent keeps rendering as idle with an enabled composer; and the transport is disposed permanently, so every later prompt in that chat rejects with `OMP RPC process is closed`. The user's only way forward is to create a new agent and tell it to resume — abandoning the chat they were in.

The recovery mechanism already existed and was simply unused: relaunching `omp` with `--session <sessionFile>` returns the **same session id**, so the conversation survives. Claude and Codex already do exactly this shape of lazy respawn on the next write. OMP was the only provider where a runtime death ended the chat.

So: report the death when it happens, and relaunch on the next prompt in the same chat. The user keeps typing where they were.

### Goals

- Emit `turn_failed` when the OMP process dies between turns, so the client sees the death instead of an agent that looks idle forever.
- Relaunch the CLI on the next prompt in the same session, against the session file the state already carries, so the same chat continues.
- Keep the same session id across the relaunch (verified against real `omp`).
- Leave a failed relaunch recoverable: report it and retry on a later prompt rather than latching a dead state.
- Never leave an orphan `omp` process behind: a chat closed or archived mid-relaunch disposes the replacement.
- Announce the new session id when the old conversation genuinely cannot be resumed, so the manager's persistence never points at an id the CLI no longer owns.
- Keep the blast radius inside the OMP provider — no protocol change, no client change, no shared manager behavior change.

### Non-goals

- No mid-turn resurrection. A death during a turn is still reported by that turn's own catch handler and the turn is still lost; only the *next* prompt recovers.
- No transcript replay or history reconstruction. Recovery is native session resume via `--session`, not re-streaming. I verified this empirically against real `omp`: relaunching a session that has 20 events of history emits zero replay events, only `notice` + `available_commands_update`.
- Internal sessions (`--no-session`) have no file to relaunch against, so they come back as a clean process and announce the new session id rather than pretending the old one survived.
- No new UI affordance. This makes the existing composer work again rather than adding a "restart" control.
- No changes to the other providers.

### QA

Platform table:

| Surface | Tested |
| --- | --- |
| Daemon / server (Linux) | Yes — real `omp` 17.3.3, plus unit tests |
| iOS / Android / Web / Desktop | Not tested — no client or protocol change in this PR |
| macOS / Windows | Not tested — Linux only box |

All real-provider evidence below is one run of `session-recovery.local.e2e.test.ts` (local-only: it needs `omp` on PATH, and skips instead of failing when the binary is absent).

```
$ OMP_COMMAND=/root/.local/bin/omp npx vitest run \
    src/server/agent/providers/omp/session-recovery.local.e2e.test.ts --reporter=verbose

 ✓ the dead runtime session rejects every later prompt 1883ms
 ✓ relaunching against the same session file restores the same session 3658ms
 ✓ the agent session recovers on the next prompt after an OOM kill 5762ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

#### 1. Reproducing the bug against real `omp`

`SIGKILL` (what the OOM killer sends) on the spawned child, then prompt twice on the same session:

```json
{
  "liveSessionId": "01a03858-597f-7000-b1e5-d0bf761f49a0",
  "killedPid": 3650238,
  "childExit": { "code": null, "signal": "SIGKILL" },
  "promptAfterDeath": {
    "first": "OMP RPC process is closed",
    "second": "OMP RPC process is closed"
  }
}
```

#### 2. The mechanism the fix relies on

Relaunching against the same session file after the same kill returns the same session id:

```json
{
  "sessionFile": "/tmp/omp-session-resume-x3ZdS1/session.jsonl",
  "sessionIdBeforeKill": "01a03858-6077-7000-98e1-19e6092d3c5a",
  "childExit": { "code": null, "signal": "SIGKILL" },
  "sessionIdAfterRelaunch": "01a03858-6077-7000-98e1-19e6092d3c5a",
  "sameSession": true
}
```

#### 3. The fix working end to end against real `omp`

Kill the process, then prompt the same agent session. The death is reported, the prompt relaunches the CLI as a different pid, and **the turn actually runs to completion in the replacement process** — `turn_completed`, with the model's answer present in the event stream:

```json
{
  "childExit": { "code": null, "signal": "SIGKILL" },
  "reportedFailure": "OMP RPC process exited with code null and signal SIGKILL. Any tool calls or subagents it had running were terminated with it.",
  "runtimeProcessesSpawned": 2,
  "killedPid": 3650622,
  "relaunchedPid": 3650794,
  "turnOutcome": "turn_completed",
  "turnFailure": null,
  "assistantAnswered": true
}
```

#### 4. Unit coverage

`agent.test.ts` goes 28 upstream → 39. The eleven added tests:

```
✓ reports a turn_failed notice when the OMP process dies while idle
✓ ignores a process_exit that races an intentional close
✓ recovers on the next prompt after an idle process exit
✓ relaunches against the dead session file
✓ closes the dead runtime once the replacement is adopted
✓ discards a relaunch that lands after the session was closed
✓ recovers an internal session without adopting a session file
✓ announces the new session id when recovery cannot resume the old one
✓ keeps the session id and announces nothing when the file is resumed
✓ recovers a resumed session against its session file
✓ reports relaunch failure and retries recovery on a later prompt

 Test Files  1 passed (1)
      Tests  39 passed (39)
```

#### 5. Proof the unit coverage is real

Two separate mutations, each against the current tree.

**a. Remove the recovery call.** Deleting only `await this.ensureRuntimeAlive()` from `startTurn` fails 8 of the 11 — seven time out waiting for a relaunch that never comes, one asserts the missing second failure — while all 31 others pass:

```
× recovers on the next prompt after an idle process exit           → Test timed out in 30000ms
× relaunches against the dead session file                         → Test timed out in 30000ms
× closes the dead runtime once the replacement is adopted          → Test timed out in 30000ms
× recovers an internal session without adopting a session file     → Test timed out in 30000ms
× announces the new session id when recovery cannot resume the old → Test timed out in 30000ms
× keeps the session id and announces nothing when the file is resumed → Test timed out in 30000ms
× recovers a resumed session against its session file              → Test timed out in 30000ms
× reports relaunch failure and retries recovery on a later prompt  → expected [ Array(1) ] to deeply equal [ …(2) ]

 Tests  8 failed | 31 passed (39)
```

**b. Remove the close-race guard.** That mutation does not touch the orphan-process defect, so it needs its own proof. Deleting only the `if (this.closed)` re-check in `ensureRuntimeAlive` — i.e. reverting to the first commit's code — fails exactly the test written for it:

```
× discards a relaunch that lands after the session was closed 29ms
  → expected false to be true // Object.is equality

 Tests  1 failed | 38 skipped (39)
```

#### 6. Gates

```
$ npm run typecheck    → exit 0, 0 errors
$ npm run lint         → Found 0 warnings and 0 errors
$ npm run format:check → All matched files use the correct format
```

Also re-run by lefthook on every commit in this branch.

#### 7. Review round (second commit)

I reviewed the first commit before asking anyone else to, and it had eight defects. All are fixed in `eb671e4`, and the critical one deserves calling out:

- **Orphan process on a close race.** `ensureRuntimeAlive` did not re-check `closed` after the relaunch awaited, so closing or archiving the chat mid-relaunch closed only the already-dead session and left the *new* `omp` running forever — carrying the caller env (including `PASEO_AGENT_ID`) and re-registered Paseo host tools, at ~1.4GB RSS. An OOM leak inside the OOM fix. It now disposes the replacement; §5b is the regression proof.
- The dead runtime's event subscription is torn down and the dead session closed once the replacement is adopted, so a late `process_exit` from the old transport cannot clear the recovered turn or emit a second `turn_failed`.
- A session that cannot resume (internal `--no-session`, or a crash before the session file existed) announces the new id with `thread_started`.
- The two near-identical `restartRuntime` closures are one `buildRestartRuntime` factory; `restartRuntime` became a required option instead of optional-with-a-throw, since both construction sites always pass it.
- `handleProcessExit` splits the structured log from the user-facing copy the way the Claude provider does.
- `docs/agent-lifecycle.md` no longer claims only Claude recovers in place — this PR makes that line false.
- The test harness replaces a `startSession` monkey-patch with a typed `failNextStartSession` port on the fake, and the fake now models real `omp`'s session-id behavior (same file restores the id, no file mints a new one) so recovery tests can tell a resumed chat from a fresh one.
- The local e2e gained a binary gate (`describe.skipIf`) and now asserts the recovered turn completes, instead of only counting spawned processes.

One review finding I disproved rather than fixed: two reviewers independently claimed relaunching with `--session` replays history into the live timeline as duplicate rows. The probe in the Non-goals section refutes it — zero replay events — so nothing was changed for it.

Note on the two pre-existing notification tests: the `turn_failed`-on-idle-death behavior and its two tests were work I had already written locally against this same defect; they are part of this change because reporting the death is what makes the recovery observable.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
