### PR TITLE
feat(cli): import sessions into existing workspaces

### DIFF
--- a/packages/cli/src/commands/agent/import.test.ts
+++ b/packages/cli/src/commands/agent/import.test.ts
@@ -31,7 +31,7 @@ describe("resolveImportCwd", () => {
     );
   });
 
-  it("accepts pi as an import provider", async () => {
+  it("imports a provider session into the requested workspace", async () => {
     importAgent.mockResolvedValueOnce({
       id: "agent-1",
       status: "idle",
@@ -45,6 +45,7 @@ describe("resolveImportCwd", () => {
       {
         provider: "pi",
         cwd: "/tmp/project",
+        workspace: "wks-existing",
       },
       {} as never,
     );
@@ -53,6 +54,7 @@ describe("resolveImportCwd", () => {
       provider: "pi",
       sessionId: "pi-session-1",
       cwd: "/tmp/project",
+      workspaceId: "wks-existing",
     });
     expect(result.data.provider).toBe("pi");
   });

--- a/packages/cli/src/commands/agent/import.ts
+++ b/packages/cli/src/commands/agent/import.ts
@@ -11,6 +11,7 @@ export function addImportOptions(cmd: Command): Command {
     .argument("<id>", "Provider session/thread ID to import")
     .requiredOption("--provider <provider>", "Agent provider id")
     .option("--cwd <path>", "Working directory for providers that require it")
+    .option("--workspace <workspace-id>", "Import into an existing workspace")
     .option(
       "--label <key=value>",
       "Add label(s) to the agent (can be used multiple times)",
@@ -22,6 +23,7 @@ export function addImportOptions(cmd: Command): Command {
 export interface AgentImportOptions extends CommandOptions {
   provider?: string;
   cwd?: string;
+  workspace?: string;
   label?: string[];
   host?: string;
 }
@@ -136,6 +138,7 @@ export async function runImportCommand(
       provider,
       sessionId,
       cwd,
+      ...(options.workspace ? { workspaceId: options.workspace } : {}),
       ...(Object.keys(labels).length > 0 ? { labels } : {}),
     });
 


### PR DESCRIPTION
## Workflow

Links discussion #3841.

Terminal-created provider sessions can belong to an existing repository workspace. The CLI currently omits the `workspaceId` already supported by `import_agent_request`, `DaemonClient.importAgent`, and daemon import placement, so every CLI import provisions a new workspace.

This adds:

```sh
paseo import --provider pi --cwd /repo --workspace wks_123 <session-id>
```

Omitting `--workspace` preserves current behavior. The daemon retains ownership of active-workspace and cwd-match validation.

## QA evidence

Platform tested: macOS. No app/UI surfaces changed.

```text
$ npx vitest run packages/cli/src/commands/agent/import.test.ts --bail=1
Test Files  1 passed (1)
Tests       4 passed (4)

$ npm run typecheck --workspace=@getpaseo/cli
# exited 0

$ npm run lint -- packages/cli/src/commands/agent/import.ts packages/cli/src/commands/agent/import.test.ts
Found 0 warnings and 0 errors.

$ npm run format:check -- packages/cli/src/commands/agent/import.ts packages/cli/src/commands/agent/import.test.ts
All matched files use the correct format.

$ npm run build:server
# protocol, client, server, and CLI builds exited 0
```

The pre-commit hook also ran repository-wide workspace typechecks successfully.

Not tested: Windows or Linux CLI execution.
