### PR TITLE
fix(nix): package resolved node-pty prebuild

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -78,6 +78,13 @@ jobs:
               echo "$STATUS_JSON"
               curl --fail --silent --show-error http://127.0.0.1:6767/ >"$PASEO_HOME/web-ui.html"
               [[ -s "$PASEO_HOME/web-ui.html" ]]
+
+              TERMINAL_JSON="$(./result/bin/paseo terminal create \
+                --cwd "$PWD" \
+                --name nix-smoke \
+                --json)"
+              TERMINAL_ID="$(jq -er '.id' <<<"$TERMINAL_JSON")"
+              ./result/bin/paseo terminal kill "$TERMINAL_ID"
               exit 0
             fi
 

--- a/scripts/trace-daemon.mjs
+++ b/scripts/trace-daemon.mjs
@@ -14,6 +14,7 @@
 
 import { nodeFileTrace } from "@vercel/nft";
 import { glob } from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -29,6 +30,15 @@ const { sherpaPlatformPackageName } = await import(
 );
 
 const traceDesktop = process.env.PASEO_TRACE_DESKTOP === "1";
+
+const serverRequire = createRequire(path.join(REPO_ROOT, "packages/server/package.json"));
+const nodePtyPackageDir = path.dirname(serverRequire.resolve("node-pty/package.json"));
+const nodePtyPrebuildGlob = path.join(
+  path.relative(REPO_ROOT, nodePtyPackageDir),
+  "prebuilds",
+  `${process.platform}-${process.arch}`,
+  "**",
+);
 
 // Daemon entry points. Workers forked into their own Node processes have
 // independent require trees; nft does not follow fork boundaries, so trace
@@ -63,10 +73,9 @@ const additionalInputs = [
   "packages/cli/bin/paseo",
   // node-pty's compiled native addon. nft can't trace it because
   // node-pty loads it via `require(path.join(__dirname, 'prebuilds/<plat>/pty.node'))`
-  // with a runtime-computed platform suffix. Pin to the host platform —
-  // the Nix derivation builds for one platform at a time and ships only
-  // its own binaries.
-  `node_modules/node-pty/prebuilds/${process.platform}-${process.arch}/**`,
+  // with a runtime-computed platform suffix. Resolve from the server workspace
+  // so this follows npm whether it hoists node-pty or installs it locally.
+  nodePtyPrebuildGlob,
   // sherpa-onnx-node dynamically resolves a platform-specific native package.
   // Copy the wrapper plus the host platform package explicitly.
   "node_modules/sherpa-onnx-node/**",


### PR DESCRIPTION
### Linked issue

Closes #3249

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Opening a terminal from a Nix-installed Paseo fails when npm installs `node-pty` under the server workspace. The runtime tracer copies its JavaScript, but the explicit native-addon glob still points to `node_modules/node-pty` at the repository root. The resulting package is missing `pty.node`, so the terminal worker crashes.

Resolve `node-pty` from the server workspace before constructing the platform-specific prebuild glob. This includes the native addon in both hoisted and workspace-local npm layouts. Extend the existing Nix smoke test to create and kill a real terminal through the public CLI, so this packaging regression fails CI.

### Goals

- Include the native terminal addon in the Nix runtime closure.
- Follow npm's actual dependency location across workspace layouts.
- Verify terminal creation in the Linux Nix smoke job.

### Non-goals

- Change the `node-pty` version or terminal implementation.
- Change other installation methods.
- Expand the existing CI platform matrix.

### QA

#### Original reproduction

Reproduced with the first-party v0.5.2 Nix flake on Ubuntu 26.04 x86_64. `paseo terminal create --cwd /home/aral --name codex-upgrade-check --json` failed with:

```text
TERMINAL_CREATE_FAILED: Terminal worker is not running
```

The daemon log showed the workspace-local JavaScript failing to load its omitted addon:

```text
Error: Failed to load native module: pty.node, checked: build/Release, build/Debug, prebuilds/linux-x64
Cannot find module './prebuilds/linux-x64/pty.node'
Require stack:
- /nix/store/...-paseo-0.5.2/lib/paseo/packages/server/node_modules/node-pty/lib/utils.js
```

#### v0.8.0 validation — September 13, 2026

Applied this PR's unchanged fix to release v0.8.0 and built it on Linux x86_64. The reproducible patched revision is [Ar4l/paseo@8c767227](https://github.com/Ar4l/paseo/commit/8c767227d03dc7d81e8f2f6f42b330637de7d1ae).

The release tag has a stale `nix/npm-deps.hash`. The validation branch also corrects it to `sha256-gDB48rHd0K1VOAblaQlPP4XnKGHI8cAt9S09aRxx6b4=`, independently computed by Nix and matching upstream `main`. This release-only correction is already upstream; the PR diff remains focused on terminal packaging and its regression test.

Validation performed:

1. `nix build .#default -o /home/aral/paseo-v080-result --print-build-logs` succeeded, including daemon, CLI, bundled web UI, and native-library dependency checks.
2. Started the built CLI with `daemon start --foreground --no-relay --web-ui`, using a fresh temporary `PASEO_HOME` and `PASEO_LISTEN=127.0.0.1:16767`.
3. `curl --fail http://127.0.0.1:16767/` returned the bundled HTML. `paseo daemon status --json` reported `connectedDaemon: reachable` and `daemonVersion: 0.8.0`.
4. `paseo terminal create --host 127.0.0.1:16767 --cwd <temporary-workspace> --name nix-v080-smoke --json` created a terminal successfully.
5. Sent `printf 'PASEO_SMOKE_%s\n' 42` and Enter with `terminal send-keys`; `terminal capture --scrollback --json` contained the exact output line `PASEO_SMOKE_42`.
6. `terminal kill` returned `success: true`. Stopped the isolated daemon and its process group after the test.

```text
PASS: v0.8.0 daemon, web UI, terminal creation, shell execution, capture, and cleanup.
```

#### Original PR-head checks

The original v0.6.0 PR-head validation recorded successful `npm run format`, `npm run lint`, `npm run build:server`, and `npm run typecheck`, plus isolated terminal creation and removal. The v0.8.0 revalidation above uses the Nix build and runtime checks; it does not claim a fresh full-repository lint or typecheck run.

| Platform | Validation |
| --- | --- |
| Linux x86_64, Nix | v0.8.0 build, daemon, web serving, terminal creation, shell execution, output capture, terminal cleanup |
| Linux aarch64, Nix | Not tested locally |
| macOS, Nix | Not tested locally |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes (original PR-head validation)
- [x] `npm run lint` passes (original PR-head validation)
- [x] `npm run format` passes (original PR-head validation)
- [x] QA evidence
- [x] Tests added or updated where it made sense
