### PR TITLE
fix(server): leave plan mode when Copilot Allow All is selected

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -33,11 +33,11 @@ import type { ProcessTerminator, TreeKillTarget } from "../../../utils/tree-kill
 import {
   COPILOT_AGENT_FEATURE_OPTION,
   COPILOT_ALLOW_ALL_MODE_ID,
+  COPILOT_AUTOPILOT_MODE_ID,
   COPILOT_MODES,
   CopilotACPAgentClient,
   beforeCopilotModeWriter,
   transformCopilotConfigOptions,
-  transformCopilotModeId,
   transformCopilotSessionResponse,
   writeCopilotProviderMode,
 } from "./copilot-acp-agent.js";
@@ -297,7 +297,6 @@ function createCopilotSessionWithConfig(
       sessionResponseTransformer: transformCopilotSessionResponse,
       configOptionsTransformer: transformCopilotConfigOptions,
       configFeatureOptions: [COPILOT_AGENT_FEATURE_OPTION],
-      modeIdTransformer: transformCopilotModeId,
       providerModeWriter: writeCopilotProviderMode,
       beforeModeWriter: beforeCopilotModeWriter,
       capabilities: {
@@ -1450,18 +1449,145 @@ describe("ACPAgentSession Zed parity", () => {
       configId: "allow_all",
       value: "on",
     });
-    expect(setSessionMode).not.toHaveBeenCalled();
+    // Allow All is agent mode with permissions pre-granted, so restoring it on
+    // startup has to leave whatever mode the session came back in.
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
     await expect(session.getCurrentMode()).resolves.toBe(COPILOT_ALLOW_ALL_MODE_ID);
     expect(events.some((event) => event.type === "permission_requested")).toBe(false);
   });
 
-  test("accepts Copilot's legacy autopilot mode ID as Allow All", async () => {
+  test("selecting Copilot Allow All from plan mode leaves plan mode and enables allow_all", async () => {
     const setSessionConfigOption = vi.fn(async () => ({
       configOptions: [
         copilotModeConfigOption("https://agentclientprotocol.com/protocol/session-modes#agent"),
         copilotAllowAllConfigOption("on"),
       ],
     }));
+    const setSessionMode = vi.fn(async () => undefined);
+    const session = createCopilotSessionWithConfig();
+    prepareConfiguredOverrideSession(session, {
+      currentMode: "https://agentclientprotocol.com/protocol/session-modes#plan",
+      availableModes: COPILOT_MODES,
+      configOptions: [
+        copilotModeConfigOption("https://agentclientprotocol.com/protocol/session-modes#plan"),
+        copilotAllowAllConfigOption("off"),
+      ],
+      connection: { setSessionConfigOption, setSessionMode },
+    });
+
+    await session.setMode(COPILOT_ALLOW_ALL_MODE_ID);
+
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
+    expect(setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      configId: "allow_all",
+      value: "on",
+    });
+    // The mode write has to land first: leaving #autopilot reverts allow_all to
+    // off, so flipping the flag first would let a later mode write clobber it.
+    expect(setSessionMode.mock.invocationCallOrder[0]!).toBeLessThan(
+      setSessionConfigOption.mock.invocationCallOrder[0]!,
+    );
+    await expect(session.getCurrentMode()).resolves.toBe(COPILOT_ALLOW_ALL_MODE_ID);
+  });
+
+  test("selecting Copilot Allow All from autopilot keeps allow_all on after the mode write", async () => {
+    // Copilot reverts allow_all to off when a session leaves #autopilot.
+    let allowAll: "on" | "off" = "on";
+    const setSessionMode = vi.fn(async () => {
+      allowAll = "off";
+      return undefined;
+    });
+    const setSessionConfigOption = vi.fn(async (input: { value: string }) => {
+      allowAll = input.value === "on" ? "on" : "off";
+      return {
+        configOptions: [
+          copilotModeConfigOption("https://agentclientprotocol.com/protocol/session-modes#agent"),
+          copilotAllowAllConfigOption(allowAll),
+        ],
+      };
+    });
+    const session = createCopilotSessionWithConfig();
+    prepareConfiguredOverrideSession(session, {
+      currentMode: COPILOT_AUTOPILOT_MODE_ID,
+      availableModes: COPILOT_MODES,
+      configOptions: [
+        copilotModeConfigOption(COPILOT_AUTOPILOT_MODE_ID),
+        copilotAllowAllConfigOption("on"),
+      ],
+      connection: { setSessionConfigOption, setSessionMode },
+    });
+
+    await session.setMode(COPILOT_ALLOW_ALL_MODE_ID);
+
+    expect(allowAll).toBe("on");
+  });
+
+  test("exposes Copilot autopilot alongside the synthesised Allow All mode", () => {
+    const transformed = transformCopilotSessionResponse({
+      modes: {
+        currentModeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+        availableModes: [
+          {
+            id: "https://agentclientprotocol.com/protocol/session-modes#agent",
+            name: "Agent",
+          },
+          { id: COPILOT_AUTOPILOT_MODE_ID, name: "Autopilot" },
+        ],
+      },
+      configOptions: [
+        copilotModeConfigOption("https://agentclientprotocol.com/protocol/session-modes#agent"),
+        copilotAllowAllConfigOption("off"),
+      ],
+    } as Parameters<typeof transformCopilotSessionResponse>[0]);
+
+    expect(transformed.modes?.availableModes?.map((mode) => mode.id)).toEqual([
+      "https://agentclientprotocol.com/protocol/session-modes#agent",
+      COPILOT_AUTOPILOT_MODE_ID,
+      COPILOT_ALLOW_ALL_MODE_ID,
+    ]);
+
+    const [modeOption] = transformCopilotConfigOptions([
+      copilotModeConfigOption("https://agentclientprotocol.com/protocol/session-modes#agent"),
+      copilotAllowAllConfigOption("off"),
+    ]);
+    const choices = modeOption?.type === "select" ? modeOption.options : [];
+    expect(choices.map((choice) => ("value" in choice ? choice.value : ""))).toContain(
+      COPILOT_AUTOPILOT_MODE_ID,
+    );
+  });
+
+  test("reports Copilot autopilot as autopilot even though it turns allow_all on", () => {
+    const transformed = transformCopilotSessionResponse({
+      modes: {
+        currentModeId: COPILOT_AUTOPILOT_MODE_ID,
+        availableModes: [{ id: COPILOT_AUTOPILOT_MODE_ID, name: "Autopilot" }],
+      },
+      configOptions: [
+        copilotModeConfigOption(COPILOT_AUTOPILOT_MODE_ID),
+        copilotAllowAllConfigOption("on"),
+      ],
+    } as Parameters<typeof transformCopilotSessionResponse>[0]);
+
+    expect(transformed.modes?.currentModeId).toBe(COPILOT_AUTOPILOT_MODE_ID);
+
+    const [modeOption] = transformCopilotConfigOptions([
+      copilotModeConfigOption(COPILOT_AUTOPILOT_MODE_ID),
+      copilotAllowAllConfigOption("on"),
+    ]);
+    expect(modeOption?.type === "select" ? modeOption.currentValue : null).toBe(
+      COPILOT_AUTOPILOT_MODE_ID,
+    );
+  });
+
+  test("selecting Copilot autopilot uses the ACP mode path and leaves allow_all to Copilot", async () => {
+    const setSessionConfigOption = vi.fn(async () => ({ configOptions: [] }));
     const setSessionMode = vi.fn(async () => undefined);
     const session = createCopilotSessionWithConfig();
     prepareConfiguredOverrideSession(session, {
@@ -1474,15 +1600,49 @@ describe("ACPAgentSession Zed parity", () => {
       connection: { setSessionConfigOption, setSessionMode },
     });
 
-    await session.setMode("https://agentclientprotocol.com/protocol/session-modes#autopilot");
+    await session.setMode(COPILOT_AUTOPILOT_MODE_ID);
 
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: COPILOT_AUTOPILOT_MODE_ID,
+    });
+    expect(setSessionConfigOption).not.toHaveBeenCalled();
+    await expect(session.getCurrentMode()).resolves.toBe(COPILOT_AUTOPILOT_MODE_ID);
+  });
+
+  test("switching Copilot from Allow All to autopilot hands the flag back to Copilot", async () => {
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [
+        copilotModeConfigOption(COPILOT_AUTOPILOT_MODE_ID),
+        copilotAllowAllConfigOption("off"),
+      ],
+    }));
+    const setSessionMode = vi.fn(async () => undefined);
+    const session = createCopilotSessionWithConfig(COPILOT_ALLOW_ALL_MODE_ID);
+    prepareConfiguredOverrideSession(session, {
+      currentMode: COPILOT_ALLOW_ALL_MODE_ID,
+      availableModes: COPILOT_MODES,
+      configOptions: [
+        copilotModeConfigOption(COPILOT_ALLOW_ALL_MODE_ID),
+        copilotAllowAllConfigOption("on"),
+      ],
+      connection: { setSessionConfigOption, setSessionMode },
+    });
+
+    await session.setMode(COPILOT_AUTOPILOT_MODE_ID);
+
+    // Paseo releases its own flag, then Copilot re-enables it on entering
+    // autopilot; Paseo never sets allow_all on for autopilot itself.
+    expect(setSessionConfigOption).toHaveBeenCalledTimes(1);
     expect(setSessionConfigOption).toHaveBeenCalledWith({
       sessionId: "session-1",
       configId: "allow_all",
-      value: "on",
+      value: "off",
     });
-    expect(setSessionMode).not.toHaveBeenCalled();
-    await expect(session.getCurrentMode()).resolves.toBe(COPILOT_ALLOW_ALL_MODE_ID);
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: COPILOT_AUTOPILOT_MODE_ID,
+    });
   });
 
   test("switching Copilot away from Allow All turns allow_all off before setting the ACP mode", async () => {

--- a/packages/server/src/server/agent/providers/copilot-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/copilot-acp-agent.ts
@@ -37,7 +37,7 @@ const COPILOT_CAPABILITIES: AgentCapabilityFlags = {
 
 const COPILOT_AGENT_MODE_ID = "https://agentclientprotocol.com/protocol/session-modes#agent";
 const COPILOT_PLAN_MODE_ID = "https://agentclientprotocol.com/protocol/session-modes#plan";
-const COPILOT_AUTOPILOT_MODE_ID =
+export const COPILOT_AUTOPILOT_MODE_ID =
   "https://agentclientprotocol.com/protocol/session-modes#autopilot";
 export const COPILOT_ALLOW_ALL_MODE_ID = "allow-all";
 const COPILOT_ALLOW_ALL_CONFIG_ID = "allow_all";
@@ -67,6 +67,11 @@ export const COPILOT_MODES: AgentMode[] = [
     description: "Plan mode for creating and executing multi-step plans",
   },
   {
+    id: COPILOT_AUTOPILOT_MODE_ID,
+    label: "Autopilot",
+    description: "Copilot's own unattended mode: it approves requests and skips prompts.",
+  },
+  {
     id: COPILOT_ALLOW_ALL_MODE_ID,
     label: "Allow All",
     description: "Automatically approves all Copilot tool, path, and URL requests.",
@@ -89,7 +94,6 @@ export class CopilotACPAgentClient extends ACPAgentClient {
       sessionResponseTransformer: transformCopilotSessionResponse,
       configOptionsTransformer: transformCopilotConfigOptions,
       configFeatureOptions: [COPILOT_AGENT_FEATURE_OPTION],
-      modeIdTransformer: transformCopilotModeId,
       providerModeWriter: writeCopilotProviderMode,
       beforeModeWriter: beforeCopilotModeWriter,
       capabilities: COPILOT_CAPABILITIES,
@@ -136,18 +140,16 @@ export function transformCopilotSessionResponse(
     modes: {
       ...response.modes,
       availableModes: response.modes.availableModes
-        ?.filter(
-          (mode) => mode.id !== COPILOT_AUTOPILOT_MODE_ID && mode.id !== COPILOT_ALLOW_ALL_MODE_ID,
-        )
+        ?.filter((mode) => mode.id !== COPILOT_ALLOW_ALL_MODE_ID)
         .concat({
           id: COPILOT_ALLOW_ALL_MODE_ID,
           name: "Allow All",
           description: "Automatically approves all Copilot tool, path, and URL requests.",
         }),
-      currentModeId: allowAllEnabled
-        ? COPILOT_ALLOW_ALL_MODE_ID
-        : (transformCopilotModeId(response.modes.currentModeId ?? COPILOT_AGENT_MODE_ID) ??
-          COPILOT_AGENT_MODE_ID),
+      currentModeId: resolveCopilotCurrentModeId(
+        response.modes.currentModeId ?? COPILOT_AGENT_MODE_ID,
+        allowAllEnabled,
+      ),
     },
   };
 }
@@ -162,10 +164,7 @@ export function transformCopilotConfigOptions(
     }
     // Trust Copilot's allow_all config value as the source of truth when it changes in-process.
     const options = flattenCopilotModeOptions(option.options)
-      .filter(
-        (choice) =>
-          choice.value !== COPILOT_AUTOPILOT_MODE_ID && choice.value !== COPILOT_ALLOW_ALL_MODE_ID,
-      )
+      .filter((choice) => choice.value !== COPILOT_ALLOW_ALL_MODE_ID)
       .concat({
         value: COPILOT_ALLOW_ALL_MODE_ID,
         name: "Allow All",
@@ -173,9 +172,7 @@ export function transformCopilotConfigOptions(
       });
     return {
       ...option,
-      currentValue: allowAllEnabled
-        ? COPILOT_ALLOW_ALL_MODE_ID
-        : (transformCopilotModeId(option.currentValue) ?? COPILOT_AGENT_MODE_ID),
+      currentValue: resolveCopilotCurrentModeId(option.currentValue, allowAllEnabled),
       options,
     };
   });
@@ -195,20 +192,31 @@ function flattenCopilotModeOptions(
   return flattened;
 }
 
-export function transformCopilotModeId(modeId: string): string | null {
-  return modeId === COPILOT_AUTOPILOT_MODE_ID ? COPILOT_AGENT_MODE_ID : modeId;
+// Autopilot turns allow_all on by itself, so allow_all alone cannot tell the two
+// apart: only a session that is not in autopilot reports the synthesised Allow
+// All mode.
+function resolveCopilotCurrentModeId(modeId: string, allowAllEnabled: boolean): string {
+  if (modeId === COPILOT_AUTOPILOT_MODE_ID) {
+    return COPILOT_AUTOPILOT_MODE_ID;
+  }
+  return allowAllEnabled ? COPILOT_ALLOW_ALL_MODE_ID : modeId;
 }
 
 export async function writeCopilotProviderMode(
   context: ACPProviderModeWriterContext,
 ): Promise<ACPProviderModeWriteResult> {
-  // COMPAT(copilotAutopilotMode): added in v0.1.75, remove after 2026-11-12 once old clients no longer send Copilot's old ACP autopilot mode ID.
-  const requestsAllowAll =
-    context.requestedModeId === COPILOT_ALLOW_ALL_MODE_ID ||
-    context.requestedModeId === COPILOT_AUTOPILOT_MODE_ID;
-  if (!requestsAllowAll) {
+  if (context.requestedModeId !== COPILOT_ALLOW_ALL_MODE_ID) {
     return { handled: false };
   }
+  // Allow All is Paseo's own mode: it is agent mode with permissions pre-granted.
+  // `mode` and `allow_all` are independent Copilot config options, so a session
+  // left in #plan keeps its plan framing and refuses to edit even with the flag
+  // on. The mode write goes first because leaving #autopilot makes Copilot
+  // revert allow_all to off, which would clobber the flag if it were set first.
+  await context.connection.setSessionMode({
+    sessionId: context.sessionId,
+    modeId: COPILOT_AGENT_MODE_ID,
+  });
   const response = await context.connection.setSessionConfigOption({
     sessionId: context.sessionId,
     configId: COPILOT_ALLOW_ALL_CONFIG_ID,


### PR DESCRIPTION
Closes #3855

## Problem

Selecting Allow All while a Copilot session is in Plan mode left the session in `#plan`: Paseo reported Allow All while the model kept its plan-mode framing and refused to edit. `writeCopilotProviderMode` only flipped the `allow_all` config option and returned `handled: true`, so `setModeWithSelection` returned before `setSessionMode` was called.

## Fix

- Allow All now writes the session mode (`#agent`) as well as `allow_all=on`. Mode first, then the flag: leaving `#autopilot` makes Copilot revert `allow_all` to `off`, so the reverse order clobbers the write.
- `#autopilot` is no longer filtered out of the mode list, and its id is no longer remapped to `#agent`.
- The current mode is resolved from the session mode before the `allow_all` flag, so an autopilot session is no longer reported as Allow All.

## QA

Ordering verified against the real CLI (Copilot CLI 1.0.80), raw `config_option_update` after each step:

```
mode first, flag second  ->  ✅
  set_mode autopilot:              mode=autopilot  allow_all=on
  set_mode #agent:                 mode=agent      allow_all=off
  set_config_option allow_all=on:  mode=agent      allow_all=on

flag first, mode second  ->  ❌
  set_config_option allow_all=on:  mode=autopilot  allow_all=on
  set_mode #agent:                 mode=agent      allow_all=off
```

From `#plan` neither order touches the flag, so `#autopilot` is the only starting state where it matters.

**Platforms:** implemented and unit-tested on macOS; the ACP captures above were taken on Linux with Copilot CLI 1.0.80. Not tested on Windows; the change is not platform-specific.
