### PR TITLE
feat(cli): open projects from paths that don't exist yet via --create

### DIFF
--- a/packages/cli/src/classify.test.ts
+++ b/packages/cli/src/classify.test.ts
@@ -1,8 +1,13 @@
-import { mkdirSync, mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { classifyInvocation, isExistingDirectory, isPathLikeArg } from "./classify.js";
+import {
+  classifyInvocation,
+  isExistingDirectory,
+  isPathLikeArg,
+  resolveCreatableDirectory,
+} from "./classify.js";
 
 const knownCommands = new Set(["ls", "run", "status"]);
 
@@ -164,6 +169,132 @@ describe("classifyInvocation", () => {
   });
 });
 
+describe("classifyInvocation --create", () => {
+  it("classifies --create with a missing absolute path as create-project", () => {
+    const parentDir = mkdtempSync(path.join(tmpdir(), "paseo-classify-create-"));
+    const missingDir = path.join(parentDir, "newproject");
+
+    expect(
+      classifyInvocation({
+        argv: ["--create", missingDir],
+        knownCommands,
+        cwd: parentDir,
+      }),
+    ).toEqual({
+      kind: "create-project",
+      resolvedPath: missingDir,
+    });
+  });
+
+  it("classifies --create with a missing nested relative path as create-project", () => {
+    const parentDir = mkdtempSync(path.join(tmpdir(), "paseo-classify-create-nested-"));
+    const missingDir = path.join(parentDir, "deep", "nested", "project");
+
+    expect(
+      classifyInvocation({
+        argv: ["--create", path.relative(parentDir, missingDir)],
+        knownCommands,
+        cwd: parentDir,
+      }),
+    ).toEqual({
+      kind: "create-project",
+      resolvedPath: missingDir,
+    });
+  });
+
+  it("classifies --create with an existing directory as open-project", () => {
+    const parentDir = mkdtempSync(path.join(tmpdir(), "paseo-classify-create-existing-"));
+    const projectDir = path.join(parentDir, "existing");
+    mkdirSync(projectDir);
+
+    expect(
+      classifyInvocation({
+        argv: ["--create", projectDir],
+        knownCommands,
+        cwd: parentDir,
+      }),
+    ).toEqual({
+      kind: "open-project",
+      resolvedPath: projectDir,
+    });
+  });
+
+  it("expands ~ in --create targets", () => {
+    const homeRelative = "~/paseo-classify-create-home-target";
+
+    expect(
+      classifyInvocation({
+        argv: ["--create", homeRelative],
+        knownCommands,
+        cwd: process.cwd(),
+      }),
+    ).toEqual({
+      kind: "create-project",
+      resolvedPath: path.join(homedir(), "paseo-classify-create-home-target"),
+    });
+  });
+
+  it("falls back to CLI mode when --create has no target", () => {
+    expect(
+      classifyInvocation({
+        argv: ["--create"],
+        knownCommands,
+        cwd: process.cwd(),
+      }),
+    ).toEqual({ kind: "cli", argv: ["--create"] });
+  });
+
+  it("falls back to CLI mode when the --create target is another flag", () => {
+    expect(
+      classifyInvocation({
+        argv: ["--create", "--json"],
+        knownCommands,
+        cwd: process.cwd(),
+      }),
+    ).toEqual({ kind: "cli", argv: ["--create", "--json"] });
+  });
+
+  it("falls back to CLI mode when the --create target already exists as a file", () => {
+    const parentDir = mkdtempSync(path.join(tmpdir(), "paseo-classify-create-file-"));
+    const filePath = path.join(parentDir, "file.txt");
+    writeFileSync(filePath, "");
+
+    expect(
+      classifyInvocation({
+        argv: ["--create", filePath],
+        knownCommands,
+        cwd: parentDir,
+      }),
+    ).toEqual({ kind: "cli", argv: ["--create", filePath] });
+  });
+
+  it("treats an existing root target as an idempotent open-project", () => {
+    expect(
+      classifyInvocation({
+        argv: ["--create", "/"],
+        knownCommands,
+        cwd: process.cwd(),
+      }),
+    ).toEqual({ kind: "open-project", resolvedPath: "/" });
+  });
+
+  it("keeps --create ahead of known command matching", () => {
+    const parentDir = mkdtempSync(path.join(tmpdir(), "paseo-classify-create-cmd-"));
+    const missingDir = path.join(parentDir, "status");
+
+    expect(
+      classifyInvocation({
+        argv: ["--create", "status"],
+        knownCommands,
+        cwd: parentDir,
+      }),
+    ).toEqual({
+      kind: "create-project",
+      resolvedPath: missingDir,
+    });
+  });
+});
+
 describe("path helpers", () => {
   it("detects path-like prefixes", () => {
     expect(isPathLikeArg(".")).toBe(true);
@@ -184,5 +315,20 @@ describe("path helpers", () => {
 
     expect(isExistingDirectory({ pathArg: "project", cwd: parentDir })).toBe(true);
     expect(isExistingDirectory({ pathArg: "missing", cwd: parentDir })).toBe(false);
+  });
+
+  it("resolves creatable directories and rejects existing entries and roots", () => {
+    const parentDir = mkdtempSync(path.join(tmpdir(), "paseo-classify-creatable-"));
+    const existingDir = path.join(parentDir, "existing");
+    mkdirSync(existingDir);
+    const existingFile = path.join(parentDir, "file.txt");
+    writeFileSync(existingFile, "");
+
+    expect(resolveCreatableDirectory({ pathArg: "brand-new", cwd: parentDir })).toBe(
+      path.join(parentDir, "brand-new"),
+    );
+    expect(resolveCreatableDirectory({ pathArg: "existing", cwd: parentDir })).toBeNull();
+    expect(resolveCreatableDirectory({ pathArg: "file.txt", cwd: parentDir })).toBeNull();
+    expect(resolveCreatableDirectory({ pathArg: "/", cwd: parentDir })).toBeNull();
   });
 });

--- a/packages/cli/src/classify.ts
+++ b/packages/cli/src/classify.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 
 export type CliInvocation =
   | { kind: "cli"; argv: string[] }
-  | { kind: "open-project"; resolvedPath: string };
+  | { kind: "open-project"; resolvedPath: string }
+  | { kind: "create-project"; resolvedPath: string };
+
+export const createProjectFlag = "--create";
 
 export function isPathLikeArg(arg: string): boolean {
   return (
@@ -41,6 +44,21 @@ export function isExistingDirectory(input: { pathArg: string; cwd: string }): bo
   return statSync(resolvedPath).isDirectory();
 }
 
+export function resolveCreatableDirectory(input: { pathArg: string; cwd: string }): string | null {
+  const resolvedPath = path.resolve(input.cwd, expandUserPath(input.pathArg));
+
+  if (resolvedPath === path.parse(resolvedPath).root) {
+    return null;
+  }
+
+  try {
+    statSync(resolvedPath);
+    return null;
+  } catch {
+    return resolvedPath;
+  }
+}
+
 export function classifyInvocation(input: {
   argv: string[];
   knownCommands: ReadonlySet<string>;
@@ -49,6 +67,10 @@ export function classifyInvocation(input: {
   const [firstArg] = input.argv;
   if (!firstArg) {
     return { kind: "cli", argv: input.argv };
+  }
+
+  if (firstArg === createProjectFlag) {
+    return classifyCreateProjectInvocation(input);
   }
 
   if (firstArg.startsWith("-")) {
@@ -64,6 +86,27 @@ export function classifyInvocation(input: {
       kind: "open-project",
       resolvedPath: path.resolve(input.cwd, expandUserPath(firstArg)),
     };
+  }
+
+  return { kind: "cli", argv: input.argv };
+}
+
+function classifyCreateProjectInvocation(input: { argv: string[]; cwd: string }): CliInvocation {
+  const [, targetArg] = input.argv;
+  if (!targetArg || targetArg.startsWith("-")) {
+    return { kind: "cli", argv: input.argv };
+  }
+
+  if (isExistingDirectory({ pathArg: targetArg, cwd: input.cwd })) {
+    return {
+      kind: "open-project",
+      resolvedPath: path.resolve(input.cwd, expandUserPath(targetArg)),
+    };
+  }
+
+  const creatablePath = resolveCreatableDirectory({ pathArg: targetArg, cwd: input.cwd });
+  if (creatablePath) {
+    return { kind: "create-project", resolvedPath: creatablePath };
   }
 
   return { kind: "cli", argv: input.argv };

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { spawnProcess } from "@getpaseo/server";
@@ -91,8 +91,15 @@ function launchDesktop(args: string[]): void {
   spawnDetached(desktopApp, args);
 }
 
-export async function openDesktopWithProject(projectPath: string): Promise<void> {
+export async function openDesktopWithProject(
+  projectPath: string,
+  options: { createIfMissing?: boolean } = {},
+): Promise<void> {
   try {
+    if (options.createIfMissing && !existsSync(projectPath)) {
+      mkdirSync(projectPath, { recursive: true });
+      process.stdout.write(`Created directory: ${projectPath}\n`);
+    }
     launchDesktop([projectPath]);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -72,4 +72,45 @@ describe("runCli", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("classifies --create with a missing directory as a create-project invocation", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "paseo-cli-run-create-"));
+    const missingDir = path.join(root, "fresh", "project");
+
+    try {
+      expect(
+        createCliParseArgv({
+          argv: ["--create", missingDir],
+          cwd: root,
+          nodeArgv: ["node", "paseo"],
+        }),
+      ).toEqual({
+        kind: "create-project",
+        resolvedPath: missingDir,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies --create with an existing directory as an open-project invocation", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "paseo-cli-run-create-open-"));
+    const project = path.join(root, "existing");
+    mkdirSync(project);
+
+    try {
+      expect(
+        createCliParseArgv({
+          argv: ["--create", project],
+          cwd: root,
+          nodeArgv: ["node", "paseo"],
+        }),
+      ).toEqual({
+        kind: "open-project",
+        resolvedPath: project,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -11,7 +11,7 @@ export function createCliParseArgv(input: {
   argv: string[];
   cwd: string;
   nodeArgv?: [string, string];
-}): string[] | { kind: "open-project"; resolvedPath: string } {
+}): string[] | { kind: "open-project" | "create-project"; resolvedPath: string } {
   const program = createCli();
   const knownCommands = new Set(program.commands.map((command) => command.name()));
   const invocation = classifyInvocation({
@@ -20,7 +20,7 @@ export function createCliParseArgv(input: {
     cwd: input.cwd,
   });
 
-  if (invocation.kind === "open-project") {
+  if (invocation.kind !== "cli") {
     return invocation;
   }
 
@@ -43,7 +43,9 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
   });
 
   if (!Array.isArray(parseArgv)) {
-    await openDesktopWithProject(parseArgv.resolvedPath);
+    await openDesktopWithProject(parseArgv.resolvedPath, {
+      createIfMissing: parseArgv.kind === "create-project",
+    });
     return typeof process.exitCode === "number" ? process.exitCode : 0;
   }
 


### PR DESCRIPTION
## Problem

`paseo <path>` opens the desktop app when the path exists, but a path-like arg pointing to a missing directory falls through to commander and dies with `error: unknown command '<path>'`. There is no way to bootstrap a new project folder straight from the CLI — you must mkdir first, then run paseo again.

Muxy solves the same problem with an explicit create intent (`muxy create-project <path> --create` → `FileManager.createDirectory(withIntermediateDirectories: true)` → open). This PR ports that flow to Paseo's CLI.

## Change

New classification in `packages/cli/src`:

- `classify.ts`
  - new invocation kind `{ kind: "create-project", resolvedPath }`
  - new helper `resolveCreatableDirectory()`: resolves/normalizes the target, rejects filesystem roots and existing files, returns `null` otherwise
  - first-arg `--create <path>` is intercepted before the flag short-circuit:
    - existing directory → `open-project` (idempotent, same as plain `paseo <path>`)
    - missing path → `create-project`
    - bare flag / another flag / existing file → falls back to CLI mode (commander errors as before)
- `run.ts`: dispatches both project kinds to `openDesktopWithProject`, with `createIfMissing: true` only for `create-project`
- `commands/open.ts`: `openDesktopWithProject(path, { createIfMissing })` does `mkdirSync(recursive)` before launching and prints `Created directory: <path>`

Usage:

```bash
paseo ~/dev/new-app          # unchanged: requires the dir to exist
paseo --create ~/dev/new-app # creates ~/dev/new-app (mkdir -p) and opens it
paseo --create ~/existing    # idempotent: just opens it
paseo ./typo                 # unchanged: still a CLI error
```

## Tests

- `npx vitest run src/classify.test.ts src/run.test.ts --bail=1` → 30 passed
  - new cases: missing absolute/nested-relative/\~/bare targets, existing dir (→ open-project), file target, root target, `--create` ahead of known-command matching, dispatch through `createCliParseArgv`
- `npm run typecheck --workspace=@getpaseo/cli` clean
- `npm run lint` clean on all touched files, repo formatted with oxfmt

## QA evidence (macOS 15, arm64)

Real CLI runs against a dev daemon via `npm run cli --`:

- `npm run cli --silent -- --create /tmp/paseo-e2e-smoke/deep/nested/project` → printed `Created directory: .../deep/nested/project`, verified on disk with `ls`, desktop app launched with the new project
- re-run on the now-existing path → exit 0, no duplicate creation notice
- `--create <file>` → `error: unknown option '--create'` (rejected)
- plain missing path without the flag → legacy `unknown command` error preserved

Not tested: Windows path shapes beyond unit tests (no Windows machine available); Linux desktop launch paths are untouched by this change.

Maintainer edits enabled.