### PR TITLE
Keep manually checked desktop updates available

### DIFF
--- a/packages/desktop/e2e/support/runtime.ts
+++ b/packages/desktop/e2e/support/runtime.ts
@@ -58,6 +58,7 @@ export interface DesktopRuntimeConfig {
   updateAvailable?: boolean;
   latestVersion?: string;
   updateReadyToInstall?: boolean;
+  manualUpdateBypassesRollout?: boolean;
   slowInstall?: boolean;
   /** Initial PID reported by desktop_daemon_status. Defaults to null. */
   daemonPid?: number | null;
@@ -139,6 +140,7 @@ export async function installDesktopRuntime(
     let daemonRunning = true;
     let currentPid: number | null = cfg.daemonPid ?? null;
     let startCount = 0;
+    let manualUpdateAdmitted = false;
     window.__desktopDaemonStartRequested = false;
 
     function buildDaemonStatus() {
@@ -175,6 +177,33 @@ export async function installDesktopRuntime(
       }
     }
 
+    function buildAppUpdateCheckResult(hasUpdate: boolean, readyToInstall: boolean) {
+      return {
+        hasUpdate,
+        readyToInstall,
+        currentVersion: "1.0.0",
+        latestVersion: hasUpdate ? (cfg.latestVersion ?? "1.2.3") : null,
+        body: null,
+        date: null,
+      };
+    }
+
+    function checkAppUpdate(intent: unknown) {
+      if (!cfg.manualUpdateBypassesRollout) {
+        return buildAppUpdateCheckResult(
+          cfg.updateAvailable === true,
+          cfg.updateAvailable === true && (cfg.updateReadyToInstall ?? true),
+        );
+      }
+
+      if (intent === "manual") {
+        manualUpdateAdmitted = true;
+        return buildAppUpdateCheckResult(true, false);
+      }
+
+      return buildAppUpdateCheckResult(manualUpdateAdmitted, manualUpdateAdmitted);
+    }
+
     const desktopBridge: {
       platform: string;
       invoke: (command: string, args?: Record<string, unknown>) => Promise<unknown>;
@@ -192,23 +221,7 @@ export async function installDesktopRuntime(
       platform: "darwin",
       invoke: async (command: string, args?: Record<string, unknown>) => {
         if (command === "check_app_update") {
-          return cfg.updateAvailable
-            ? {
-                hasUpdate: true,
-                readyToInstall: cfg.updateReadyToInstall ?? true,
-                currentVersion: "1.0.0",
-                latestVersion: cfg.latestVersion ?? "1.2.3",
-                body: null,
-                date: null,
-              }
-            : {
-                hasUpdate: false,
-                readyToInstall: false,
-                currentVersion: "1.0.0",
-                latestVersion: null,
-                body: null,
-                date: null,
-              };
+          return checkAppUpdate(args?.intent);
         }
 
         if (command === "install_app_update") {
@@ -351,6 +364,14 @@ export async function expectPendingUpdateCheckResult(page: Page, version: string
   ).toBeVisible();
   await expect(page.getByText(`Ready to install: ${normalizedVersion}`)).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Update" })).toBeDisabled();
+}
+
+export async function expectReadyUpdateCheckResult(page: Page, version: string): Promise<void> {
+  const normalizedVersion = `v${version.replace(/^v/i, "")}`;
+  await expect(page.getByText(`Ready to install: ${normalizedVersion}`)).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole("button", { name: `Update to ${normalizedVersion}` })).toBeEnabled();
 }
 
 export async function clickInstallUpdate(page: Page): Promise<void> {

--- a/packages/desktop/e2e/updates.spec.ts
+++ b/packages/desktop/e2e/updates.spec.ts
@@ -14,6 +14,7 @@ import {
   expectUpdateBanner,
   clickCheckForUpdates,
   expectPendingUpdateCheckResult,
+  expectReadyUpdateCheckResult,
   clickInstallUpdate,
   expectInstallInProgress,
   interceptDaemonManagementConfirmDialog,
@@ -85,6 +86,20 @@ test.describe("Desktop updates", () => {
     await clickCheckForUpdates(page);
 
     await expectPendingUpdateCheckResult(page, "1.2.3");
+  });
+
+  test("manual update remains available after the automatic rollout recheck", async ({ page }) => {
+    await installDesktopRuntime(page, {
+      serverId: getServerId(),
+      latestVersion: "1.2.3",
+      manualUpdateBypassesRollout: true,
+    });
+    await gotoAppShell(page);
+    await openDesktopAboutSettings(page);
+
+    await clickCheckForUpdates(page);
+    await expectPendingUpdateCheckResult(page, "1.2.3");
+    await expectReadyUpdateCheckResult(page, "1.2.3");
   });
 });
 

--- a/packages/desktop/src/features/app-update-service.test.ts
+++ b/packages/desktop/src/features/app-update-service.test.ts
@@ -208,6 +208,76 @@ describe("app update service", () => {
     });
   });
 
+  it("keeps a manually admitted update after a rollout-gated automatic recheck", async () => {
+    const { runtime, service } = createService();
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "manual",
+    });
+    runtime.finishUpdateDownload(rolledOutUpdate);
+
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+    const result = await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+
+    expect(result).toMatchObject({
+      hasUpdate: true,
+      readyToInstall: true,
+      latestVersion: "1.2.4",
+    });
+  });
+
+  it("keeps preparing a manually admitted update after a rollout-gated automatic recheck", async () => {
+    const { runtime, service } = createService();
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "manual",
+    });
+
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+    const result = await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+
+    expect(result).toMatchObject({
+      hasUpdate: true,
+      readyToInstall: false,
+      latestVersion: "1.2.4",
+    });
+  });
+
+  it("clears a cached update when the manifest no longer contains it", async () => {
+    const { runtime, service } = createService();
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "manual",
+    });
+    runtime.finishUpdateDownload(rolledOutUpdate);
+
+    runtime.nextCheck(null);
+    const result = await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+
+    expect(result.hasUpdate).toBe(false);
+  });
+
   it("waits for an automatic poll before starting a manual rollout-bypassing check", async () => {
     const { runtime, service } = createService();
     const automaticCheck = runtime.deferNextCheck();

--- a/packages/desktop/src/features/app-update-service.ts
+++ b/packages/desktop/src/features/app-update-service.ts
@@ -38,7 +38,6 @@ export interface AppUpdateRuntimeConfiguration {
   shouldAdmitUpdate(info: RuntimeUpdateInfo): boolean | Promise<boolean>;
   onUpdateAvailable(info: RuntimeUpdateInfo): void;
   onUpdateDownloaded(info: RuntimeUpdateInfo): void;
-  onUpdateNotAvailable(): void;
   onError(error: unknown): void;
 }
 
@@ -147,6 +146,24 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     preparingUpdateVersion = null;
   }
 
+  function buildPreviouslyAdmittedUpdateResult(
+    currentVersion: string,
+    checkedInfo: RuntimeUpdateInfo,
+  ): AppUpdateCheckResult | null {
+    const info = cachedUpdateInfo;
+    if (!info || info.version === currentVersion || info.version !== checkedInfo.version) {
+      return null;
+    }
+
+    return buildCheckResult({
+      currentVersion,
+      hasUpdate: true,
+      readyToInstall: isReadyToInstallVersion(info.version),
+      info,
+      errorMessage: preparationError?.version === info.version ? preparationError.message : null,
+    });
+  }
+
   function configureRuntime(releaseChannel: AppReleaseChannel, intent: AppUpdateCheckIntent): void {
     if (configuredReleaseChannel !== releaseChannel) {
       clearUpdateState();
@@ -185,9 +202,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
         if (preparationError?.version === info.version) {
           preparationError = null;
         }
-      },
-      onUpdateNotAvailable() {
-        clearUpdateState();
       },
       onError(error) {
         if (preparingUpdateVersion) {
@@ -233,7 +247,24 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
 
       try {
         const result = await deps.runtime.checkForUpdates();
-        if (!result || !result.updateInfo || !result.isUpdateAvailable) {
+        if (!result || !result.updateInfo) {
+          clearUpdateState();
+          return buildCheckResult({
+            currentVersion,
+            hasUpdate: false,
+            readyToInstall: false,
+          });
+        }
+
+        if (!result.isUpdateAvailable) {
+          const admittedUpdate = buildPreviouslyAdmittedUpdateResult(
+            currentVersion,
+            result.updateInfo,
+          );
+          if (admittedUpdate) {
+            return admittedUpdate;
+          }
+
           clearUpdateState();
           return buildCheckResult({
             currentVersion,

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -138,9 +138,6 @@ class ElectronAppUpdateRuntime implements AppUpdateRuntime {
     autoUpdater.on("update-downloaded", (info) => {
       input.onUpdateDownloaded(info as RuntimeUpdateInfo);
     });
-    autoUpdater.on("update-not-available", () => {
-      input.onUpdateNotAvailable();
-    });
     autoUpdater.on("error", (error) => {
       if (isUpdateChannelNotPublished(error)) return;
       input.onError(error);


### PR DESCRIPTION
Manual desktop update checks now stay available through background readiness polling, even when the user is outside the stable rollout. Users can download and install the update they explicitly requested instead of seeing it revert to “Up to date” ten seconds later.

### Linked issue

None — community bug report reproduced locally.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A manual check correctly bypassed the stable rollout, but the pending download's ten-second automatic readiness check reapplied the rollout gate. The updater had two writers for unavailable state: the runtime event and the completed check. Both cleared the already-admitted update, so the renderer changed from “Downloading…” to “Up to date.”

The update service now owns the unavailable transition. If a check rejects the exact version already admitted and cached, that admission remains valid. A missing release or a different newer release still clears the cache, preserving newest-eligible revalidation and fail-closed quit-time installation.

### Goals

- Keep a manually admitted stable update visible while it downloads and after it is ready.
- Preserve automatic discovery of newer eligible releases.
- Refuse an older cached update when a different newer release is still gated.
- Clear cached state when the release disappears from the manifest.
- Lock the ten-second user journey down with service and desktop renderer coverage.

### Non-goals

- Change the 36-hour stable rollout or polling cadence.
- Consolidate the existing renderer updater consumers and polling effects.
- Change beta behavior or automatic-install preferences.

### QA

Red reproduction before the fix:

```text
npx vitest run packages/desktop/src/features/app-update-service.test.ts --bail=1
FAIL keeps a manually admitted update after a rollout-gated automatic recheck
Expected: update 1.2.4 ready
Received: no update, version 1.2.3
```

After the fix:

```text
npx vitest run packages/desktop/src/features/app-update-rollout.test.ts packages/desktop/src/features/app-update-service.test.ts packages/desktop/src/features/auto-updater.test.ts packages/app/src/desktop/updates/desktop-app-updater.test.ts packages/app/src/desktop/updates/desktop-updates.test.ts packages/app/src/desktop/updates/resolve-update-callout.test.ts --bail=1
6 files passed, 92 tests passed

npm --workspace @getpaseo/desktop run test:e2e:renderer -- e2e/updates.spec.ts
10 passed

npm --workspace @getpaseo/desktop run build:main
passed

npm run format
passed

npm run lint
0 warnings, 0 errors

npm run typecheck
all workspaces passed
```

The new E2E journey exercised: manual **Check** → `Downloading…` → ten-second automatic readiness check → `Ready to install`, with the Update button enabled. It passed three times, including twice as part of the complete desktop updater/daemon-management spec.

Tested on the desktop renderer and Electron IPC boundary on macOS. The updater service and rollout boundary are covered directly with deterministic runtime fakes. A packaged installer update was not run; Windows and Linux packaged behavior were not manually exercised.

### Risk surface

The change is confined to main-process update cache ownership. Same-version admission becomes monotonic for the current app session; different-version and missing-manifest results retain their previous clearing behavior. Existing tests cover newer admitted releases, newer gated releases, offline validation, stale downloads, explicit install, and quit-time install.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
