### PR TITLE
Keep mobile Changes and pull requests in Explorer

### DIFF
--- a/docs/explorer-sidebar.md
+++ b/docs/explorer-sidebar.md
@@ -27,6 +27,10 @@ On desktop, the shell is rendered outside the workspace split canvas so it divid
 workspace, including the header. It has its own persisted width and resize handle. Main-pane splits
 never read or modify that width.
 
+`packages/app/src/workspace-tabs/open-supporting-view.ts` owns semantic Changes and pull-request
+opens. Compact and wide native layouts select the matching Explorer tab; desktop layouts follow the
+source-specific side-pane preference. Callers request the content and never choose the shell.
+
 The persisted layout still contains the Explorer pane so tabs survive reloads. The renderer removes
 that pane from the workspace split tree and docks it separately. Persisted identifiers retain the
 literal `"explorer"` pane id and `explorerPaneIdByWorkspace` key for compatibility.
@@ -37,10 +41,11 @@ compatible tabs to main. Explorer tabs can be reordered, but the dock cannot be 
 an Explorer tab does not change workspace focus.
 
 Cmd+E selects Changes for Git workspaces and Files otherwise. Compact layouts use the combined
-full-screen Explorer overlay and close it after a file opens. Wide native layouts without pane
-splits use the same combined content in a resizable inline dock; opening a file leaves that dock
-visible. Both presentations keep their selection in the panel store and reuse the layout store's
-per-workspace Explorer width. They do not create a second Explorer lifecycle.
+full-screen Explorer overlay for Changes, Files, and pull requests, and close it after a file opens.
+Wide native layouts without pane splits use the same combined content in a resizable inline dock;
+opening a file leaves that dock visible. Both presentations keep their selection in the panel store
+and reuse the layout store's per-workspace Explorer width. They do not create a second Explorer
+lifecycle.
 
 ## Side pane
 

--- a/packages/app/e2e/browser/composer-diff-stat.spec.ts
+++ b/packages/app/e2e/browser/composer-diff-stat.spec.ts
@@ -90,8 +90,14 @@ test("composer diff stat opens the compact explorer instead of a Changes tab", a
       agentId: workspace.agentId,
     });
 
+    const closeExplorer = page
+      .getByTestId("explorer-header")
+      .getByRole("button", { name: "Close Explorer sidebar" });
+    await expect(closeExplorer).not.toBeInViewport();
+
     await page.getByTestId("composer-diff-stat-pill").click();
 
+    await expect(closeExplorer).toBeInViewport({ timeout: 30_000 });
     await expect(page.getByTestId("changes-header").filter({ visible: true }).first()).toBeVisible({
       timeout: 30_000,
     });

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -52,7 +52,7 @@ import {
   buildWorkspaceTabPersistenceKey,
   type WorkspaceDraftTabSetup,
 } from "@/workspace-tabs/model";
-import { openPreferredWorkspaceTarget } from "@/workspace-tabs/open-beside";
+import { openWorkspaceSupportingView } from "@/workspace-tabs/open-supporting-view";
 import { useSettings } from "@/hooks/use-settings";
 
 const EMPTY_PENDING_PERMISSIONS = new Map();
@@ -453,15 +453,15 @@ export function WorkspaceDraftAgentTab({
       if (attachment.kind !== "review") {
         return;
       }
-      openPreferredWorkspaceTarget({
+      openWorkspaceSupportingView({
+        view: "changes",
         isCompact: isCompactFormFactor,
         workspaceKey: buildWorkspaceTabPersistenceKey({ serverId, workspaceId: workspaceId ?? "" }),
-        target: { kind: "working_diff" },
-        source: "changesLinks",
+        checkout: { serverId, cwd: composerState.workingDir, isGit: true },
         preferences: openInSidePane,
       });
     },
-    [isCompactFormFactor, openInSidePane, serverId, workspaceId],
+    [composerState.workingDir, isCompactFormFactor, openInSidePane, serverId, workspaceId],
   );
 
   const {

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -92,7 +92,6 @@ import {
   toolbarLabelTriggerStyle,
 } from "@/components/ui/toolbar-label-trigger";
 import { FOCUSED_PANE_PLACEMENT, useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
-import { usePanelStore } from "@/stores/panel-store";
 import type { WorkspaceTabPlacement } from "@/stores/workspace-layout-actions";
 import type { WorkspaceTabTarget } from "@/workspace-tabs/model";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
@@ -103,7 +102,7 @@ import { DiffTooLargeState } from "@/git/diff-too-large-state";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
 import { PullRequestStateIcon } from "@/git/pull-request-state-icon";
 import { openExternalUrl } from "@/utils/open-external-url";
-import { openPreferredWorkspaceTarget } from "@/workspace-tabs/open-beside";
+import { openWorkspaceSupportingView } from "@/workspace-tabs/open-supporting-view";
 import type { OpenInSidePanePreferences } from "@/hooks/use-settings";
 
 export type { GitActionId, GitAction, GitActions } from "@/git/policy";
@@ -1530,7 +1529,6 @@ function useDiffTabNavigation({
     () => buildWorkspaceTabPersistenceKey({ serverId, workspaceId: workspaceId ?? cwd }),
     [cwd, serverId, workspaceId],
   );
-  const showMobileAgent = usePanelStore((state) => state.showMobileAgent);
   const openDiff = useCallback(() => {
     if (!persistenceKey || isMobile) {
       return;
@@ -1547,15 +1545,14 @@ function useDiffTabNavigation({
   );
   const openPullRequest = useCallback(() => {
     if (!persistenceKey) return;
-    openPreferredWorkspaceTarget({
+    openWorkspaceSupportingView({
+      view: "pull-request",
       isCompact: isMobile,
       workspaceKey: persistenceKey,
-      target: { kind: "pull_request" },
-      source: "pullRequests",
+      checkout: { serverId, cwd, isGit: true },
       preferences: openInSidePane,
     });
-    if (isMobile) showMobileAgent();
-  }, [isMobile, openInSidePane, persistenceKey, showMobileAgent]);
+  }, [cwd, isMobile, openInSidePane, persistenceKey, serverId]);
   return {
     openDiff,
     openCommit,

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -94,7 +94,7 @@ import {
 } from "@/stores/session-store";
 import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
-import { openPreferredWorkspaceTarget } from "@/workspace-tabs/open-beside";
+import { openWorkspaceSupportingView } from "@/workspace-tabs/open-supporting-view";
 import { useSettings } from "@/hooks/use-settings";
 import type { Theme } from "@/styles/theme";
 import type { PendingPermission } from "@/types/shared";
@@ -1349,6 +1349,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
         <AgentTracks
           serverId={serverId}
           workspaceId={workspaceId}
+          cwd={cwd}
           subagentRows={subagentRows}
           tasks={tasks}
           archiveFinishedStatus={archiveFinishedSubagents.status}
@@ -1617,15 +1618,15 @@ function ActiveAgentComposer({
       if (attachment.kind !== "review") {
         return;
       }
-      openPreferredWorkspaceTarget({
+      openWorkspaceSupportingView({
+        view: "changes",
         isCompact: isCompactFormFactor,
         workspaceKey: buildWorkspaceTabPersistenceKey({ serverId, workspaceId }),
-        target: { kind: "working_diff" },
-        source: "changesLinks",
+        checkout: { serverId, cwd, isGit: true },
         preferences: openInSidePane,
       });
     },
-    [isCompactFormFactor, openInSidePane, serverId, workspaceId],
+    [cwd, isCompactFormFactor, openInSidePane, serverId, workspaceId],
   );
 
   const handleClientSlashCommand = useCallback(

--- a/packages/app/src/panels/agent-tracks.tsx
+++ b/packages/app/src/panels/agent-tracks.tsx
@@ -18,6 +18,7 @@ import type { TodoEntry } from "@/types/stream";
 import { navigateToAgent } from "@/utils/navigate-to-agent";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 import { openPreferredWorkspaceTarget } from "@/workspace-tabs/open-beside";
+import { openWorkspaceSupportingView } from "@/workspace-tabs/open-supporting-view";
 
 /**
  * The pane's ambient context — workspace changes, subagents, and tasks — as a row of pills above
@@ -29,6 +30,7 @@ import { openPreferredWorkspaceTarget } from "@/workspace-tabs/open-beside";
 export const AgentTracks = memo(function AgentTracks({
   serverId,
   workspaceId,
+  cwd,
   subagentRows,
   tasks,
   archiveFinishedStatus,
@@ -36,6 +38,7 @@ export const AgentTracks = memo(function AgentTracks({
 }: {
   serverId: string;
   workspaceId: string;
+  cwd: string;
   subagentRows: SubagentRow[];
   tasks: TodoEntry[] | undefined;
   archiveFinishedStatus: ArchiveFinishedStatus;
@@ -96,14 +99,14 @@ export const AgentTracks = memo(function AgentTracks({
     if (!workspaceKey) {
       return;
     }
-    openPreferredWorkspaceTarget({
+    openWorkspaceSupportingView({
+      view: "changes",
       isCompact,
       workspaceKey,
-      target: { kind: "working_diff" },
-      source: "changesLinks",
+      checkout: { serverId, cwd, isGit: true },
       preferences: openInSidePane,
     });
-  }, [isCompact, openInSidePane, workspaceKey]);
+  }, [cwd, isCompact, openInSidePane, serverId, workspaceKey]);
 
   if (!hasWorkspaceDiffStat && !hasAgentTracks({ subagentRows, tasks, archiveFinishedStatus })) {
     return null;

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -56,6 +56,7 @@ import {
   openPreferredWorkspaceTarget,
   openWorkspaceTargetBeside,
 } from "@/workspace-tabs/open-beside";
+import { openWorkspaceSupportingView } from "@/workspace-tabs/open-supporting-view";
 import { type ExplorerCheckoutContext } from "@/stores/explorer-checkout-context";
 import { traceInstant } from "@/performance/native-trace";
 import { useSessionStore, type WorkspaceDescriptor } from "@/stores/session-store";
@@ -2984,6 +2985,16 @@ function WorkspaceScreenContent({
           });
           return true;
         }
+        if (action.target === "pull-request") {
+          openWorkspaceSupportingView({
+            view: "pull-request",
+            isCompact: isMobile,
+            workspaceKey: persistenceKey,
+            checkout: activeExplorerCheckout,
+            preferences: openInSidePane,
+          });
+          return true;
+        }
         openWorkspaceTabFocused(persistenceKey, target, FOCUSED_PANE_PLACEMENT);
         return true;
       }
@@ -3006,6 +3017,7 @@ function WorkspaceScreenContent({
       activeExplorerCheckout,
       focusedPaneTabState.pane?.id,
       isMobile,
+      openInSidePane,
       openWorkspaceTabFocused,
       persistenceKey,
     ],

--- a/packages/app/src/workspace-tabs/explorer-sidebar.ts
+++ b/packages/app/src/workspace-tabs/explorer-sidebar.ts
@@ -7,12 +7,13 @@ import {
 } from "@/stores/workspace-layout-store";
 import type { WorkspaceTabTarget } from "@/workspace-tabs/model";
 
-export type ExplorerSidebarView = "changes" | "files";
+export type ExplorerSidebarView = "changes" | "files" | "pr";
 export type ExplorerSidebarPresentation = "overlay" | "dock" | "pane";
 
 const VIEW_TARGETS: Record<ExplorerSidebarView, WorkspaceTabTarget> = {
   changes: { kind: "changes_tree" },
   files: { kind: "files" },
+  pr: { kind: "pull_request" },
 };
 
 export interface ExplorerSidebarQuery {

--- a/packages/app/src/workspace-tabs/open-supporting-view.test.ts
+++ b/packages/app/src/workspace-tabs/open-supporting-view.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(async () => null),
+    setItem: vi.fn(async () => undefined),
+    removeItem: vi.fn(async () => undefined),
+  },
+}));
+
+import { DEFAULT_APP_SETTINGS } from "@/hooks/use-settings";
+import { usePanelStore } from "@/stores/panel-store";
+import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
+import { openWorkspaceSupportingView } from "@/workspace-tabs/open-supporting-view";
+
+const WORKSPACE_KEY = "server-1:workspace-1";
+const CHECKOUT = { serverId: "server-1", cwd: "/tmp/repo", isGit: true };
+
+beforeEach(() => {
+  usePanelStore.setState({
+    mobilePanel: { target: "agent", revision: 0 },
+    explorerTab: "files",
+    explorerTabByCheckout: {},
+  });
+  useWorkspaceLayoutStore.setState({
+    layoutByWorkspace: {},
+    explorerSidebarPaneIdByWorkspace: {},
+    sidePaneIdByWorkspace: {},
+    splitSizesByWorkspace: {},
+  });
+});
+
+describe("openWorkspaceSupportingView", () => {
+  it.each([
+    ["changes", "changes"],
+    ["pull-request", "pr"],
+  ] as const)("opens %s in the compact Explorer", (view, explorerTab) => {
+    openWorkspaceSupportingView({
+      view,
+      isCompact: true,
+      workspaceKey: WORKSPACE_KEY,
+      checkout: CHECKOUT,
+      preferences: DEFAULT_APP_SETTINGS.openInSidePane,
+    });
+
+    expect(usePanelStore.getState().mobilePanel.target).toBe("file-explorer");
+    expect(usePanelStore.getState().explorerTab).toBe(explorerTab);
+    expect(useWorkspaceLayoutStore.getState().layoutByWorkspace[WORKSPACE_KEY]).toBeUndefined();
+  });
+
+  it("uses the combined Explorer dock on native layouts without pane splits", () => {
+    openWorkspaceSupportingView({
+      view: "pull-request",
+      isCompact: false,
+      supportsPaneSplits: false,
+      workspaceKey: WORKSPACE_KEY,
+      checkout: CHECKOUT,
+      preferences: DEFAULT_APP_SETTINGS.openInSidePane,
+    });
+
+    expect(usePanelStore.getState().mobilePanel.target).toBe("file-explorer");
+    expect(usePanelStore.getState().explorerTab).toBe("pr");
+  });
+});

--- a/packages/app/src/workspace-tabs/open-supporting-view.ts
+++ b/packages/app/src/workspace-tabs/open-supporting-view.ts
@@ -1,0 +1,66 @@
+import type { OpenInSidePanePreferences } from "@/hooks/use-settings";
+import type { ExplorerCheckoutContext } from "@/stores/explorer-checkout-context";
+import {
+  openExplorerSidebarView,
+  usesCompactExplorerSidebar,
+  type ExplorerSidebarView,
+} from "@/workspace-tabs/explorer-sidebar";
+import type { WorkspaceTabTarget } from "@/workspace-tabs/model";
+import {
+  openPreferredWorkspaceTarget,
+  type OpenInSidePaneSource,
+} from "@/workspace-tabs/open-beside";
+
+export type WorkspaceSupportingView = "changes" | "pull-request";
+
+interface SupportingViewRoute {
+  explorerView: ExplorerSidebarView;
+  target: WorkspaceTabTarget;
+  source: OpenInSidePaneSource;
+}
+
+const SUPPORTING_VIEW_ROUTES: Record<WorkspaceSupportingView, SupportingViewRoute> = {
+  changes: {
+    explorerView: "changes",
+    target: { kind: "working_diff" },
+    source: "changesLinks",
+  },
+  "pull-request": {
+    explorerView: "pr",
+    target: { kind: "pull_request" },
+    source: "pullRequests",
+  },
+};
+
+interface OpenWorkspaceSupportingViewInput {
+  view: WorkspaceSupportingView;
+  isCompact: boolean;
+  workspaceKey: string | null;
+  checkout: ExplorerCheckoutContext | null;
+  preferences: OpenInSidePanePreferences;
+  supportsPaneSplits?: boolean;
+}
+
+/** Opens supporting workspace content in the shell appropriate for the current layout. */
+export function openWorkspaceSupportingView(
+  input: OpenWorkspaceSupportingViewInput,
+): string | null {
+  const route = SUPPORTING_VIEW_ROUTES[input.view];
+  if (usesCompactExplorerSidebar(input)) {
+    openExplorerSidebarView({
+      isCompact: input.isCompact,
+      supportsPaneSplits: input.supportsPaneSplits,
+      workspaceKey: input.workspaceKey,
+      checkout: input.checkout,
+      view: route.explorerView,
+    });
+    return null;
+  }
+  return openPreferredWorkspaceTarget({
+    isCompact: input.isCompact,
+    workspaceKey: input.workspaceKey,
+    target: route.target,
+    source: route.source,
+    preferences: input.preferences,
+  });
+}


### PR DESCRIPTION
### Linked issue

Refs #3826

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Tapping the composer diff pill or opening a pull request on compact layouts now reveals the swipeable Explorer and selects the requested view. The Explorer rewrite routed these semantic actions through ordinary workspace tabs, so the same content appeared in the center pane while the Explorer remained closed.

A single workspace-support capability now owns the presentation choice: compact and wide native layouts use the combined Explorer, while desktop layouts retain their source-specific side-pane preferences. Review attachment pills and the supporting pull-request command use the same route, so leaf components no longer choose a shell.

### Goals

- Always open composer Changes links in the Explorer on compact layouts.
- Always open pull requests in the Explorer on compact layouts.
- Preserve desktop focused-pane and configured side-pane behavior.
- Cover compact routing with shell-aware automation that cannot pass on center-pane content.

### Non-goals

- Change explicit primary tab launches for diffs or pull requests.
- Change Explorer visuals, gestures, or panel animation.
- Change desktop placement preferences.

### QA

Red reproduction:

- `npm --prefix packages/app run test:e2e -- e2e/browser/composer-diff-stat.spec.ts --grep "compact explorer"`
- Failed because the accessible Explorer close control never entered the viewport after tapping the pill.

Green verification:

- `npm --prefix packages/app run test -- src/workspace-tabs/open-supporting-view.test.ts src/workspace-tabs/explorer-sidebar.test.ts --bail=1` — 2 files, 7 tests passed.
- `npm --prefix packages/app run test:e2e -- e2e/browser/composer-diff-stat.spec.ts` — 3 browser journeys passed, covering compact Explorer, configured desktop side pane, and default desktop focused pane.
- `npm run typecheck` — passed all workspaces.
- `npm run lint` — 0 warnings and 0 errors.
- `npm run format:check` — all files formatted.

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| Web compact | Yes | Real Playwright browser at 390 × 844. |
| Web desktop | Yes | Real Playwright browser at 1400 × 900. |
| Wide native layout | Automated route coverage | Verifies the combined Explorer dock is selected when pane splits are unavailable. |
| iOS | No | Shared routing path; no simulator run. |
| Android | No | Shared routing path; no emulator run. |
| Electron/macOS | No | Desktop routing behavior is covered in browser; wrapper not exercised. |
| Windows/Linux desktop | No | No platform-specific code changed. |

### Risk surface

The change affects semantic Changes and pull-request entry points plus Command Center supporting PR navigation. Explicit workspace-tab launches continue through the existing generic tab path. The main risk is a desktop placement regression; the focused-pane and side-pane E2E journeys remain green.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense