### PR TITLE
fix(server): wait for delegated work before finish notifications

### DIFF
--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -28,6 +28,19 @@ interface CapturedLogger {
   nextRecord: Promise<void>;
 }
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 function createCapturedLogger(): CapturedLogger {
   const records: Array<Record<string, unknown>> = [];
   let resolveNextRecord!: () => void;
@@ -278,6 +291,131 @@ test("finish notifications tell the parent the child's last assistant message", 
     ),
   );
   expect(scenario.steerAttemptCount()).toBe(1);
+});
+
+test("finish notification waits for an asynchronously woken dispatcher", async () => {
+  const callerRecordRead = createDeferred<void>();
+  const grandchildRecordRead = createDeferred<void>();
+  const dispatcherPromptSent = createDeferred<void>();
+  const parentPrompts: string[] = [];
+  const dispatcherPrompts: string[] = [];
+  const subscribers = new Map<string, (event: AgentManagerEvent) => void>();
+  let dispatcherResponse = "The dispatcher is waiting for its grandchild.";
+
+  function createAgent(id: string, title: string, lifecycle: "idle" | "running"): ManagedAgent {
+    const agent: ManagedAgent = Object.create(null);
+    Reflect.set(agent, "id", id);
+    Reflect.set(agent, "lifecycle", lifecycle);
+    Reflect.set(agent, "config", { title });
+    Reflect.set(agent, "pendingPermissions", new Map());
+    return agent;
+  }
+
+  function emitState(agent: ManagedAgent): void {
+    subscribers.get(agent.id)?.({ type: "agent_state", agent });
+  }
+
+  const caller = createAgent("caller-agent", "Caller", "idle");
+  const dispatcher = createAgent("dispatcher-agent", "Dispatcher", "running");
+  const grandchild = createAgent("grandchild-agent", "Grandchild", "running");
+
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(agentManager, "getAgent", (agentId: string) => {
+    if (agentId === caller.id) return caller;
+    if (agentId === dispatcher.id) return dispatcher;
+    if (agentId === grandchild.id) return grandchild;
+    return null;
+  });
+  Reflect.set(
+    agentManager,
+    "subscribe",
+    (callback: (event: AgentManagerEvent) => void, options?: { agentId?: string }) => {
+      if (options?.agentId) {
+        subscribers.set(options.agentId, callback);
+      }
+      return () => {
+        if (options?.agentId) {
+          subscribers.delete(options.agentId);
+        }
+      };
+    },
+  );
+  Reflect.set(agentManager, "getLastAssistantMessage", async (agentId: string) => {
+    return agentId === dispatcher.id ? dispatcherResponse : null;
+  });
+  Reflect.set(agentManager, "tryRunOutOfBand", () => false);
+  Reflect.set(agentManager, "hasInFlightRun", () => false);
+  Reflect.set(agentManager, "steerOrReplaceActiveTurn", async () => ({ status: "inactive" }));
+  Reflect.set(agentManager, "streamAgent", (agentId: string, prompt: string) => {
+    if (agentId === caller.id) {
+      parentPrompts.push(prompt);
+    }
+    if (agentId === dispatcher.id) {
+      dispatcherPrompts.push(prompt);
+      dispatcherPromptSent.resolve();
+    }
+    return (async function* noop() {})();
+  });
+  Reflect.set(agentManager, "replaceAgentRun", async () => (async function* noop() {})());
+
+  const getAgentRecord = vi.fn(async (agentId: string) => {
+    if (agentId === caller.id) {
+      await callerRecordRead.promise;
+    }
+    if (agentId === grandchild.id) {
+      await grandchildRecordRead.promise;
+    }
+    const agent = agentManager.getAgent(agentId);
+    return agent ? { title: agent.config.title, labels: {} } : null;
+  });
+  const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+  Reflect.set(agentStorage, "get", getAgentRecord);
+
+  setupFinishNotification({
+    agentManager,
+    agentStorage,
+    childAgentId: dispatcher.id,
+    callerAgentId: caller.id,
+    logger: createTestLogger(),
+  });
+  setupFinishNotification({
+    agentManager,
+    agentStorage,
+    childAgentId: grandchild.id,
+    callerAgentId: dispatcher.id,
+    logger: createTestLogger(),
+  });
+
+  dispatcher.lifecycle = "idle";
+  emitState(dispatcher);
+  await vi.waitFor(() => expect(getAgentRecord).toHaveBeenCalledWith(caller.id));
+  expect(parentPrompts).toHaveLength(0);
+
+  grandchild.lifecycle = "idle";
+  emitState(grandchild);
+  await vi.waitFor(() => expect(getAgentRecord).toHaveBeenCalledWith(grandchild.id));
+  expect(parentPrompts).toHaveLength(0);
+  expect(dispatcherPrompts).toHaveLength(0);
+
+  callerRecordRead.resolve();
+  grandchildRecordRead.resolve();
+  await dispatcherPromptSent.promise;
+
+  expect(parentPrompts).toHaveLength(0);
+
+  dispatcher.lifecycle = "running";
+  emitState(dispatcher);
+  dispatcherResponse = "The dispatcher completed the grandchild follow-up.";
+  dispatcher.lifecycle = "idle";
+  emitState(dispatcher);
+
+  await vi.waitFor(() => expect(parentPrompts).toHaveLength(1));
+  expect(dispatcherPrompts).toHaveLength(1);
+  expect(parentPrompts[0]).toEqual(
+    formatSystemNotificationPrompt(
+      "Agent dispatcher-agent (Dispatcher) finished.\n\n<agent-response>\nThe dispatcher completed the grandchild follow-up.\n</agent-response>",
+    ),
+  );
 });
 
 test("finish notifications truncate oversized child responses", async () => {

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -111,6 +111,7 @@ function createFinishNotificationScenario(
     }
     return null;
   });
+  Reflect.set(agentManager, "listAgents", () => [childAgent, callerAgent]);
   Reflect.set(agentManager, "subscribe", (callback: (event: AgentManagerEvent) => void) => {
     subscriber = callback;
     return () => {
@@ -121,7 +122,11 @@ function createFinishNotificationScenario(
     return options?.childLastAssistantMessage ?? null;
   });
   Reflect.set(agentManager, "tryRunOutOfBand", () => false);
-  Reflect.set(agentManager, "hasInFlightRun", () => Boolean(options?.parentPromptError));
+  Reflect.set(
+    agentManager,
+    "hasInFlightRun",
+    (agentId: string) => agentId === "caller-agent" && Boolean(options?.parentPromptError),
+  );
   Reflect.set(agentManager, "steerOrReplaceActiveTurn", async () => {
     steerAttemptCount += 1;
     return { status: "inactive" };
@@ -294,12 +299,14 @@ test("finish notifications tell the parent the child's last assistant message", 
 });
 
 test("finish notification waits for an asynchronously woken dispatcher", async () => {
-  const callerRecordRead = createDeferred<void>();
   const grandchildRecordRead = createDeferred<void>();
   const dispatcherPromptSent = createDeferred<void>();
   const parentPrompts: string[] = [];
   const dispatcherPrompts: string[] = [];
-  const subscribers = new Map<string, (event: AgentManagerEvent) => void>();
+  const subscribers = new Set<{
+    callback: (event: AgentManagerEvent) => void;
+    agentId?: string;
+  }>();
   let dispatcherResponse = "The dispatcher is waiting for its grandchild.";
 
   function createAgent(id: string, title: string, lifecycle: "idle" | "running"): ManagedAgent {
@@ -312,7 +319,11 @@ test("finish notification waits for an asynchronously woken dispatcher", async (
   }
 
   function emitState(agent: ManagedAgent): void {
-    subscribers.get(agent.id)?.({ type: "agent_state", agent });
+    for (const subscriber of subscribers) {
+      if (!subscriber.agentId || subscriber.agentId === agent.id) {
+        subscriber.callback({ type: "agent_state", agent });
+      }
+    }
   }
 
   const caller = createAgent("caller-agent", "Caller", "idle");
@@ -330,16 +341,14 @@ test("finish notification waits for an asynchronously woken dispatcher", async (
     agentManager,
     "subscribe",
     (callback: (event: AgentManagerEvent) => void, options?: { agentId?: string }) => {
-      if (options?.agentId) {
-        subscribers.set(options.agentId, callback);
-      }
+      const subscriber = { callback, agentId: options?.agentId };
+      subscribers.add(subscriber);
       return () => {
-        if (options?.agentId) {
-          subscribers.delete(options.agentId);
-        }
+        subscribers.delete(subscriber);
       };
     },
   );
+  Reflect.set(agentManager, "listAgents", () => [caller, dispatcher, grandchild]);
   Reflect.set(agentManager, "getLastAssistantMessage", async (agentId: string) => {
     return agentId === dispatcher.id ? dispatcherResponse : null;
   });
@@ -359,14 +368,21 @@ test("finish notification waits for an asynchronously woken dispatcher", async (
   Reflect.set(agentManager, "replaceAgentRun", async () => (async function* noop() {})());
 
   const getAgentRecord = vi.fn(async (agentId: string) => {
-    if (agentId === caller.id) {
-      await callerRecordRead.promise;
-    }
     if (agentId === grandchild.id) {
       await grandchildRecordRead.promise;
     }
     const agent = agentManager.getAgent(agentId);
-    return agent ? { title: agent.config.title, labels: {} } : null;
+    if (!agent) return null;
+    let parentAgentId: string | null = null;
+    if (agentId === dispatcher.id) {
+      parentAgentId = caller.id;
+    } else if (agentId === grandchild.id) {
+      parentAgentId = dispatcher.id;
+    }
+    return {
+      title: agent.config.title,
+      labels: parentAgentId ? { "paseo.parent-agent-id": parentAgentId } : {},
+    };
   });
   const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
   Reflect.set(agentStorage, "get", getAgentRecord);
@@ -388,7 +404,7 @@ test("finish notification waits for an asynchronously woken dispatcher", async (
 
   dispatcher.lifecycle = "idle";
   emitState(dispatcher);
-  await vi.waitFor(() => expect(getAgentRecord).toHaveBeenCalledWith(caller.id));
+  await Promise.resolve();
   expect(parentPrompts).toHaveLength(0);
 
   grandchild.lifecycle = "idle";
@@ -397,7 +413,6 @@ test("finish notification waits for an asynchronously woken dispatcher", async (
   expect(parentPrompts).toHaveLength(0);
   expect(dispatcherPrompts).toHaveLength(0);
 
-  callerRecordRead.resolve();
   grandchildRecordRead.resolve();
   await dispatcherPromptSent.promise;
 
@@ -620,6 +635,7 @@ it("does not notify archived callers", async () => {
       return null;
     }),
   );
+  Reflect.set(agentManager, "listAgents", () => [childAgent, callerAgent]);
   Reflect.set(
     agentManager,
     "subscribe",

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -303,10 +303,7 @@ test("finish notification waits for an asynchronously woken dispatcher", async (
   const dispatcherPromptSent = createDeferred<void>();
   const parentPrompts: string[] = [];
   const dispatcherPrompts: string[] = [];
-  const subscribers = new Set<{
-    callback: (event: AgentManagerEvent) => void;
-    agentId?: string;
-  }>();
+  const subscribers = new Set<(event: AgentManagerEvent) => void>();
   let dispatcherResponse = "The dispatcher is waiting for its grandchild.";
 
   function createAgent(id: string, title: string, lifecycle: "idle" | "running"): ManagedAgent {
@@ -320,9 +317,7 @@ test("finish notification waits for an asynchronously woken dispatcher", async (
 
   function emitState(agent: ManagedAgent): void {
     for (const subscriber of subscribers) {
-      if (!subscriber.agentId || subscriber.agentId === agent.id) {
-        subscriber.callback({ type: "agent_state", agent });
-      }
+      subscriber({ type: "agent_state", agent });
     }
   }
 
@@ -337,17 +332,10 @@ test("finish notification waits for an asynchronously woken dispatcher", async (
     if (agentId === grandchild.id) return grandchild;
     return null;
   });
-  Reflect.set(
-    agentManager,
-    "subscribe",
-    (callback: (event: AgentManagerEvent) => void, options?: { agentId?: string }) => {
-      const subscriber = { callback, agentId: options?.agentId };
-      subscribers.add(subscriber);
-      return () => {
-        subscribers.delete(subscriber);
-      };
-    },
-  );
+  Reflect.set(agentManager, "subscribe", (callback: (event: AgentManagerEvent) => void) => {
+    subscribers.add(callback);
+    return () => subscribers.delete(callback);
+  });
   Reflect.set(agentManager, "listAgents", () => [caller, dispatcher, grandchild]);
   Reflect.set(agentManager, "getLastAssistantMessage", async (agentId: string) => {
     return agentId === dispatcher.id ? dispatcherResponse : null;

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -8,6 +8,7 @@ import type {
 import type { AgentManager, ManagedAgent } from "./agent-manager.js";
 import type { AgentStorage } from "./agent-storage.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
+import { type FinishNotificationReason, watchAgentFinish } from "./finish-notifications.js";
 import { getParentAgentIdFromLabels } from "@getpaseo/protocol/agent-labels";
 import type { ActiveTurnBehavior } from "@getpaseo/protocol/messages";
 
@@ -337,8 +338,6 @@ export interface SetupFinishNotificationParams {
   logger: Logger;
 }
 
-type FinishNotificationReason = "finished" | "errored" | "needs permission" | "was closed";
-
 const FINISH_NOTIFICATION_MESSAGE_LIMIT = 4000;
 
 interface FinishNotificationBodyInput {
@@ -377,11 +376,6 @@ function formatFinishNotificationBody(params: FinishNotificationBodyInput): stri
   return sections.join("\n\n");
 }
 
-interface NotifySafelyOptions {
-  terminal?: boolean;
-  permissionRequest?: AgentPermissionRequest;
-}
-
 export function setupFinishNotification(params: SetupFinishNotificationParams): void {
   const {
     agentManager,
@@ -391,18 +385,6 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
     requireParentOwnership = false,
     logger,
   } = params;
-  let hasSeenRunning = false;
-  let stopped = false;
-  const notifiedPermissionRequestIds = new Set<string>();
-  let unsubscribe: (() => void) | null = null;
-  let notificationQueue = Promise.resolve();
-
-  function stop(): void {
-    if (stopped) return;
-    stopped = true;
-    unsubscribe?.();
-  }
-
   async function notify(
     reason: FinishNotificationReason,
     permissionRequest?: AgentPermissionRequest,
@@ -437,95 +419,12 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
     });
   }
 
-  function notifySafely(reason: FinishNotificationReason, options: NotifySafelyOptions = {}): void {
-    if (stopped) return;
-    if (options.terminal ?? true) stop();
-    notificationQueue = notificationQueue
-      .then(() => notify(reason, options.permissionRequest))
-      .catch((error) => {
-        logger.error(
-          { err: error, childAgentId, callerAgentId, reason },
-          "Failed to notify caller agent",
-        );
-      });
-  }
-
-  unsubscribe = agentManager.subscribe(
-    (event) => {
-      if (stopped) {
-        return;
-      }
-
-      if (event.type === "agent_state") {
-        for (const requestId of notifiedPermissionRequestIds) {
-          if (!event.agent.pendingPermissions.has(requestId)) {
-            notifiedPermissionRequestIds.delete(requestId);
-          }
-        }
-        if (event.agent.lifecycle === "running") {
-          if (event.agent.pendingPermissions.size === 0) {
-            hasSeenRunning = true;
-          }
-          return;
-        }
-        if (event.agent.lifecycle === "error") {
-          notifySafely("errored");
-          return;
-        }
-        if (event.agent.lifecycle === "idle" && hasSeenRunning) {
-          notifySafely("finished");
-          return;
-        }
-        if (event.agent.lifecycle === "closed") {
-          notifySafely("was closed");
-          return;
-        }
-        return;
-      }
-
-      if (event.type === "timeline_replacement") {
-        return;
-      }
-
-      if (event.event.type === "permission_requested") {
-        // A permission pause is an intermediate checkpoint. Forget the run
-        // observed before it so an idle state during follow-up startup cannot
-        // masquerade as the final completion.
-        hasSeenRunning = false;
-        if (!notifiedPermissionRequestIds.has(event.event.request.id)) {
-          notifiedPermissionRequestIds.add(event.event.request.id);
-          notifySafely("needs permission", {
-            terminal: false,
-            permissionRequest: event.event.request,
-          });
-        }
-        return;
-      }
-
-      if (event.event.type === "permission_resolved") {
-        notifiedPermissionRequestIds.delete(event.event.requestId);
-        const childAgent = agentManager.getAgent(childAgentId);
-        if (childAgent?.pendingPermissions.size === 0) {
-          hasSeenRunning = childAgent.lifecycle === "running";
-        }
-      }
-    },
-    { agentId: childAgentId, replayState: false },
-  );
-
-  // Check if the child is already running (catches the case where
-  // the lifecycle flipped before our subscribe call was processed).
-  // Do NOT treat an immediate "idle" as "finished" — the agent may
-  // not have started yet (streamAgent sets a pending run before
-  // transitioning to "running").
-  const childSnapshot = agentManager.getAgent(childAgentId);
-  if (!childSnapshot || childSnapshot.lifecycle === "closed") {
-    stop();
-    return;
-  }
-  if (childSnapshot.lifecycle === "running") {
-    hasSeenRunning = true;
-  } else if (childSnapshot.lifecycle === "error") {
-    notifySafely("errored");
-  }
+  watchAgentFinish({
+    agentManager,
+    childAgentId,
+    callerAgentId,
+    requireParentOwnership,
+    logger,
+    deliver: ({ reason, permissionRequest }) => notify(reason, permissionRequest),
+  });
 }

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -298,14 +298,14 @@ export async function sendPromptToAgent(
 
 export async function startCreatedAgentInitialPrompt(
   params: StartCreatedAgentInitialPromptParams,
-): Promise<ManagedAgent> {
+): Promise<{ liveSnapshot: ManagedAgent; disposition: PromptDispatchDisposition | null }> {
   const currentSnapshot = params.agentManager.getAgent(params.agentId) ?? params.snapshot ?? null;
   if (!currentSnapshot) {
     throw new Error(`Agent ${params.agentId} not found`);
   }
 
   if (params.prompt === null) {
-    return currentSnapshot;
+    return { liveSnapshot: currentSnapshot, disposition: null };
   }
 
   const dispatchResult = await startAgentRun(
@@ -326,7 +326,7 @@ export async function startCreatedAgentInitialPrompt(
   if (!refreshedSnapshot) {
     throw new Error(`Agent ${params.agentId} not found`);
   }
-  return refreshedSnapshot;
+  return { liveSnapshot: refreshedSnapshot, disposition: dispatchResult.disposition };
 }
 
 export interface SetupFinishNotificationParams {

--- a/packages/server/src/server/agent/create-agent/create.ts
+++ b/packages/server/src/server/agent/create-agent/create.ts
@@ -16,7 +16,11 @@ import type { AgentPromptInput, AgentRunOptions, AgentSessionConfig } from "../a
 import type { AgentStorage } from "../agent-storage.js";
 import type { AgentOwner } from "../agent-owner.js";
 import type { ProviderSnapshotManager } from "../provider-snapshot-manager.js";
-import { setupFinishNotification, startCreatedAgentInitialPrompt } from "../agent-prompt.js";
+import {
+  type PromptDispatchDisposition,
+  setupFinishNotification,
+  startCreatedAgentInitialPrompt,
+} from "../agent-prompt.js";
 import { resolveCreateAgentTitles } from "../create-agent-title.js";
 import { buildAgentPrompt } from "../prompt-attachments.js";
 import { normalizeClientMessageId, resolveClientMessageId } from "../../client-message-id.js";
@@ -125,6 +129,7 @@ export interface CreateAgentCommandResult {
   liveSnapshot: ManagedAgent;
   background: boolean;
   initialPromptStarted: boolean;
+  initialPromptDisposition: PromptDispatchDisposition | null;
   initialPromptError: unknown | null;
   createdWorktree?: CreatePaseoWorktreeWorkflowResult;
 }
@@ -191,6 +196,7 @@ export async function createAgentCommand(
 
   let liveSnapshot = snapshot;
   let initialPromptStarted = false;
+  let initialPromptDisposition: PromptDispatchDisposition | null = null;
   let initialPromptError: unknown | null = null;
   if (input.kind === "mcp") {
     input.onCreated?.({ agentId: snapshot.id, createdWorktree: resolved.createdWorktree ?? null });
@@ -198,11 +204,18 @@ export async function createAgentCommand(
   if (resolved.prompt !== undefined) {
     const sendResult = await sendInitialPrompt(dependencies, resolved, snapshot);
     initialPromptStarted = sendResult.started;
+    initialPromptDisposition = sendResult.disposition;
     liveSnapshot = sendResult.liveSnapshot;
     initialPromptError = sendResult.error ?? null;
   }
 
-  if (input.kind === "mcp" && input.notifyOnFinish && input.callerAgentId && initialPromptStarted) {
+  if (
+    input.kind === "mcp" &&
+    input.background &&
+    input.notifyOnFinish &&
+    input.callerAgentId &&
+    initialPromptDisposition === "turn_started"
+  ) {
     setupFinishNotification({
       agentManager: dependencies.agentManager,
       agentStorage: dependencies.agentStorage,
@@ -218,6 +231,7 @@ export async function createAgentCommand(
     liveSnapshot,
     background: resolved.background,
     initialPromptStarted,
+    initialPromptDisposition,
     initialPromptError,
     ...(resolved.createdWorktree ? { createdWorktree: resolved.createdWorktree } : {}),
   };
@@ -448,13 +462,18 @@ async function sendInitialPrompt(
   dependencies: CreateAgentCommandDependencies,
   resolved: ResolvedCreateAgent,
   snapshot: ManagedAgent,
-): Promise<{ started: boolean; liveSnapshot: ManagedAgent; error?: unknown }> {
+): Promise<{
+  started: boolean;
+  disposition: PromptDispatchDisposition | null;
+  liveSnapshot: ManagedAgent;
+  error?: unknown;
+}> {
   try {
     const prompt = resolved.prompt;
     if (prompt === undefined) {
-      return { started: false, liveSnapshot: snapshot };
+      return { started: false, disposition: null, liveSnapshot: snapshot };
     }
-    const liveSnapshot = await startCreatedAgentInitialPrompt({
+    const { liveSnapshot, disposition } = await startCreatedAgentInitialPrompt({
       agentManager: dependencies.agentManager,
       agentId: snapshot.id,
       snapshot,
@@ -462,16 +481,16 @@ async function sendInitialPrompt(
       runOptions: resolved.runOptions,
       logger: resolved.promptLogger ?? dependencies.logger,
     });
-    return { started: true, liveSnapshot };
+    return { started: true, disposition, liveSnapshot };
   } catch (error) {
     if (resolved.promptFailure === "throw") {
       throw error;
     }
     if (resolved.promptFailure === "return-error") {
-      return { started: false, liveSnapshot: snapshot, error };
+      return { started: false, disposition: null, liveSnapshot: snapshot, error };
     }
     dependencies.logger.error({ err: error, agentId: snapshot.id }, "Failed to run initial prompt");
-    return { started: false, liveSnapshot: snapshot };
+    return { started: false, disposition: null, liveSnapshot: snapshot };
   }
 }
 

--- a/packages/server/src/server/agent/create-agent/create.ts
+++ b/packages/server/src/server/agent/create-agent/create.ts
@@ -129,7 +129,7 @@ export interface CreateAgentCommandResult {
   liveSnapshot: ManagedAgent;
   background: boolean;
   initialPromptStarted: boolean;
-  initialPromptDisposition: PromptDispatchDisposition | null;
+  finishNotificationRegistered: boolean;
   initialPromptError: unknown | null;
   createdWorktree?: CreatePaseoWorktreeWorkflowResult;
 }
@@ -209,18 +209,18 @@ export async function createAgentCommand(
     initialPromptError = sendResult.error ?? null;
   }
 
-  if (
+  const finishNotificationRegistered =
     input.kind === "mcp" &&
     input.background &&
     input.notifyOnFinish &&
-    input.callerAgentId &&
-    initialPromptDisposition === "turn_started"
-  ) {
+    !!input.callerAgentId &&
+    initialPromptDisposition === "turn_started";
+  if (finishNotificationRegistered) {
     setupFinishNotification({
       agentManager: dependencies.agentManager,
       agentStorage: dependencies.agentStorage,
       childAgentId: snapshot.id,
-      callerAgentId: input.callerAgentId,
+      callerAgentId: input.callerAgentId!,
       requireParentOwnership: true,
       logger: dependencies.logger,
     });
@@ -231,7 +231,7 @@ export async function createAgentCommand(
     liveSnapshot,
     background: resolved.background,
     initialPromptStarted,
-    initialPromptDisposition,
+    finishNotificationRegistered,
     initialPromptError,
     ...(resolved.createdWorktree ? { createdWorktree: resolved.createdWorktree } : {}),
   };

--- a/packages/server/src/server/agent/finish-notifications.test.ts
+++ b/packages/server/src/server/agent/finish-notifications.test.ts
@@ -1,0 +1,392 @@
+import { expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { watchAgentFinish, type FinishNotificationDelivery } from "./finish-notifications.js";
+import { AgentManager, type AgentManagerEvent, type ManagedAgent } from "./agent-manager.js";
+import type { AgentPermissionRequest } from "./agent-sdk-types.js";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+interface DeliveredNotification extends FinishNotificationDelivery {
+  childAgentId: string;
+  callerAgentId: string;
+}
+
+interface CoordinatorScenario {
+  agentManager: AgentManager;
+  deliveries: DeliveredNotification[];
+  subscriptionOptions: Array<{ agentId?: string; replayState?: boolean } | undefined>;
+  activeSubscriptions(): number;
+  addAgent(
+    agentId: string,
+    lifecycle?: "idle" | "running" | "error" | "closed",
+    parentAgentId?: string,
+  ): void;
+  removeAgent(agentId: string): void;
+  setState(
+    agentId: string,
+    lifecycle: "idle" | "running" | "error" | "closed",
+    options?: { parentAgentId?: string | null; inFlight?: boolean },
+  ): void;
+  requestPermission(agentId: string, requestId: string): void;
+  resolvePermission(agentId: string, requestId: string): void;
+  watch(childAgentId: string, callerAgentId: string, requireParentOwnership?: boolean): void;
+}
+
+function createAgent(
+  agentId: string,
+  lifecycle: "idle" | "running" | "error" | "closed",
+  parentAgentId?: string,
+): ManagedAgent {
+  const agent: ManagedAgent = Object.create(null);
+  Reflect.set(agent, "id", agentId);
+  Reflect.set(agent, "lifecycle", lifecycle);
+  Reflect.set(agent, "config", { title: agentId });
+  Reflect.set(agent, "labels", parentAgentId ? { "paseo.parent-agent-id": parentAgentId } : {});
+  Reflect.set(agent, "pendingPermissions", new Map());
+  return agent;
+}
+
+function createPermission(requestId: string): AgentPermissionRequest {
+  return {
+    id: requestId,
+    provider: "codex",
+    kind: "tool",
+    name: "Run command",
+    description: "Run the requested command",
+    input: { command: "true" },
+  };
+}
+
+function createCoordinatorScenario(options?: {
+  deliver?: (delivery: DeliveredNotification, scenario: CoordinatorScenario) => Promise<void>;
+}): CoordinatorScenario {
+  const agents = new Map<string, ManagedAgent>();
+  const inFlight = new Set<string>();
+  const subscribers = new Set<(event: AgentManagerEvent) => void>();
+  const deliveries: DeliveredNotification[] = [];
+  const subscriptionOptions: Array<{ agentId?: string; replayState?: boolean } | undefined> = [];
+
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(agentManager, "listAgents", () => Array.from(agents.values()));
+  Reflect.set(agentManager, "getAgent", (agentId: string) => agents.get(agentId) ?? null);
+  Reflect.set(agentManager, "hasInFlightRun", (agentId: string) => inFlight.has(agentId));
+  Reflect.set(
+    agentManager,
+    "subscribe",
+    (
+      callback: (event: AgentManagerEvent) => void,
+      subscribeOptions?: { agentId?: string; replayState?: boolean },
+    ) => {
+      subscriptionOptions.push(subscribeOptions);
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+  );
+
+  function emit(event: AgentManagerEvent): void {
+    for (const subscriber of subscribers) {
+      subscriber(event);
+    }
+  }
+
+  const scenario: CoordinatorScenario = {
+    agentManager,
+    deliveries,
+    subscriptionOptions,
+    activeSubscriptions: () => subscribers.size,
+    addAgent(agentId, lifecycle = "idle", parentAgentId) {
+      agents.set(agentId, createAgent(agentId, lifecycle, parentAgentId));
+      if (lifecycle === "running") inFlight.add(agentId);
+    },
+    removeAgent(agentId) {
+      agents.delete(agentId);
+      inFlight.delete(agentId);
+    },
+    setState(agentId, lifecycle, stateOptions) {
+      const agent = agents.get(agentId);
+      if (!agent) throw new Error(`Agent ${agentId} is missing`);
+      Reflect.set(agent, "lifecycle", lifecycle);
+      if (stateOptions?.parentAgentId === null) {
+        Reflect.set(agent, "labels", {});
+      } else if (stateOptions?.parentAgentId) {
+        Reflect.set(agent, "labels", {
+          "paseo.parent-agent-id": stateOptions.parentAgentId,
+        });
+      }
+      if (stateOptions?.inFlight ?? lifecycle === "running") {
+        inFlight.add(agentId);
+      } else {
+        inFlight.delete(agentId);
+      }
+      emit({ type: "agent_state", agent });
+    },
+    requestPermission(agentId, requestId) {
+      const agent = agents.get(agentId);
+      if (!agent) throw new Error(`Agent ${agentId} is missing`);
+      const request = createPermission(requestId);
+      agent.pendingPermissions.set(requestId, request);
+      emit({
+        type: "agent_stream",
+        agentId,
+        event: { type: "permission_requested", provider: "codex", request },
+      });
+    },
+    resolvePermission(agentId, requestId) {
+      const agent = agents.get(agentId);
+      if (!agent) throw new Error(`Agent ${agentId} is missing`);
+      agent.pendingPermissions.delete(requestId);
+      emit({
+        type: "agent_stream",
+        agentId,
+        event: {
+          type: "permission_resolved",
+          provider: "codex",
+          requestId,
+          resolution: { behavior: "allow" },
+        },
+      });
+    },
+    watch(childAgentId, callerAgentId, requireParentOwnership = false) {
+      watchAgentFinish({
+        agentManager,
+        childAgentId,
+        callerAgentId,
+        requireParentOwnership,
+        logger: createTestLogger(),
+        deliver: async (delivery) => {
+          const captured = { childAgentId, callerAgentId, ...delivery };
+          deliveries.push(captured);
+          await options?.deliver?.(captured, scenario);
+        },
+      });
+    },
+  };
+  return scenario;
+}
+
+async function expectDeliveryCount(scenario: CoordinatorScenario, count: number): Promise<void> {
+  await vi.waitFor(() => expect(scenario.deliveries).toHaveLength(count));
+}
+
+test("ordinary completion is delivered exactly once through one global subscription", async () => {
+  const scenario = createCoordinatorScenario();
+  scenario.addAgent("caller");
+  scenario.addAgent("child", "idle", "caller");
+  scenario.watch("child", "caller", true);
+
+  scenario.setState("child", "running");
+  scenario.setState("child", "idle");
+  await expectDeliveryCount(scenario, 1);
+  scenario.setState("child", "idle");
+
+  expect(scenario.deliveries).toEqual([
+    { childAgentId: "child", callerAgentId: "caller", reason: "finished" },
+  ]);
+  expect(scenario.subscriptionOptions).toEqual([{ replayState: false }]);
+  expect(scenario.activeSubscriptions()).toBe(0);
+});
+
+test("a running label descendant blocks completion", async () => {
+  const scenario = createCoordinatorScenario();
+  scenario.addAgent("caller");
+  scenario.addAgent("child", "idle", "caller");
+  scenario.addAgent("descendant", "running", "child");
+  scenario.watch("child", "caller", true);
+
+  scenario.setState("child", "running");
+  scenario.setState("child", "idle");
+  await Promise.resolve();
+  expect(scenario.deliveries).toEqual([]);
+
+  scenario.setState("descendant", "idle");
+  await expectDeliveryCount(scenario, 1);
+});
+
+test("a queued descendant delivery blocks until the target follow-up is finally idle", async () => {
+  const releaseDelivery = createDeferred<void>();
+  const deliveryStarted = createDeferred<void>();
+  const scenario = createCoordinatorScenario({
+    deliver: async (delivery, current) => {
+      if (delivery.childAgentId !== "grandchild") return;
+      deliveryStarted.resolve();
+      await releaseDelivery.promise;
+      current.setState("dispatcher", "running", { inFlight: true });
+    },
+  });
+  scenario.addAgent("caller");
+  scenario.addAgent("dispatcher", "running", "caller");
+  scenario.addAgent("grandchild", "running", "dispatcher");
+  scenario.watch("dispatcher", "caller", true);
+  scenario.watch("grandchild", "dispatcher", true);
+
+  scenario.setState("dispatcher", "idle");
+  scenario.setState("grandchild", "idle");
+  await deliveryStarted.promise;
+  expect(scenario.deliveries.map((delivery) => delivery.childAgentId)).toEqual(["grandchild"]);
+
+  releaseDelivery.resolve();
+  await vi.waitFor(() => expect(scenario.agentManager.hasInFlightRun("dispatcher")).toBe(true));
+  expect(scenario.deliveries.map((delivery) => delivery.childAgentId)).toEqual(["grandchild"]);
+
+  scenario.setState("dispatcher", "idle", { inFlight: false });
+  await expectDeliveryCount(scenario, 2);
+  expect(scenario.deliveries.map((delivery) => delivery.childAgentId)).toEqual([
+    "grandchild",
+    "dispatcher",
+  ]);
+});
+
+test("transitive watcher dependencies drain from leaf to root", async () => {
+  const scenario = createCoordinatorScenario();
+  for (const agentId of ["root", "first", "second", "third"]) {
+    scenario.addAgent(agentId);
+  }
+  scenario.watch("first", "root");
+  scenario.watch("second", "first");
+  scenario.watch("third", "second");
+
+  for (const agentId of ["first", "second", "third"]) scenario.setState(agentId, "running");
+  scenario.setState("first", "idle");
+  scenario.setState("second", "idle");
+  scenario.setState("third", "idle");
+
+  await expectDeliveryCount(scenario, 3);
+  expect(scenario.deliveries.map((delivery) => delivery.childAgentId)).toEqual([
+    "third",
+    "second",
+    "first",
+  ]);
+});
+
+test.each([
+  { name: "self", edges: [["first", "first"]] },
+  {
+    name: "mutual",
+    edges: [
+      ["first", "second"],
+      ["second", "first"],
+    ],
+  },
+])("an entirely idle $name watcher cycle drains", async ({ edges }) => {
+  const scenario = createCoordinatorScenario();
+  scenario.addAgent("first");
+  scenario.addAgent("second");
+  for (const [childAgentId, callerAgentId] of edges) {
+    scenario.watch(childAgentId, callerAgentId);
+  }
+
+  scenario.setState("first", "running");
+  scenario.setState("second", "running");
+  scenario.setState("first", "idle");
+  scenario.setState("second", "idle");
+
+  await expectDeliveryCount(scenario, edges.length);
+});
+
+test("detaching a child releases its former parent", async () => {
+  const scenario = createCoordinatorScenario();
+  scenario.addAgent("root");
+  scenario.addAgent("parent", "running", "root");
+  scenario.addAgent("child", "running", "parent");
+  scenario.watch("parent", "root", true);
+  scenario.watch("child", "parent", true);
+
+  scenario.setState("parent", "idle");
+  scenario.setState("child", "idle", { parentAgentId: null });
+
+  await expectDeliveryCount(scenario, 1);
+  expect(scenario.deliveries).toEqual([
+    { childAgentId: "parent", callerAgentId: "root", reason: "finished" },
+  ]);
+});
+
+test("a temporarily missing reload snapshot waits for later state", async () => {
+  const scenario = createCoordinatorScenario();
+  scenario.addAgent("caller");
+  scenario.addAgent("child", "running", "caller");
+  scenario.watch("child", "caller", true);
+
+  scenario.removeAgent("child");
+  scenario.setState("caller", "idle");
+  await Promise.resolve();
+  expect(scenario.deliveries).toEqual([]);
+
+  scenario.addAgent("child", "idle", "caller");
+  scenario.setState("child", "idle");
+  await expectDeliveryCount(scenario, 1);
+});
+
+test.each(["skipped", "failed"])("a $s descendant delivery releases its ancestor", async (kind) => {
+  const scenario = createCoordinatorScenario({
+    deliver: async (delivery) => {
+      if (delivery.childAgentId === "child" && kind === "failed") {
+        throw new Error("delivery failed");
+      }
+    },
+  });
+  scenario.addAgent("root");
+  scenario.addAgent("parent", "running");
+  scenario.addAgent("child", "running");
+  scenario.watch("parent", "root");
+  scenario.watch("child", "parent");
+
+  scenario.setState("parent", "idle");
+  scenario.setState("child", "idle");
+
+  await expectDeliveryCount(scenario, 2);
+  expect(scenario.deliveries.map((delivery) => delivery.childAgentId)).toEqual(["child", "parent"]);
+});
+
+test("permission request IDs deduplicate until resolution without consuming terminal tracking", async () => {
+  const scenario = createCoordinatorScenario();
+  scenario.addAgent("caller");
+  scenario.addAgent("child", "running", "caller");
+  scenario.watch("child", "caller", true);
+
+  scenario.requestPermission("child", "permission-1");
+  scenario.requestPermission("child", "permission-1");
+  await expectDeliveryCount(scenario, 1);
+  scenario.resolvePermission("child", "permission-1");
+  scenario.requestPermission("child", "permission-1");
+  await expectDeliveryCount(scenario, 2);
+  scenario.resolvePermission("child", "permission-1");
+  scenario.setState("child", "running");
+  scenario.setState("child", "idle");
+
+  await expectDeliveryCount(scenario, 3);
+  expect(scenario.deliveries.map((delivery) => delivery.reason)).toEqual([
+    "needs permission",
+    "needs permission",
+    "finished",
+  ]);
+});
+
+test.each([
+  { lifecycle: "error" as const, reason: "errored" as const },
+  { lifecycle: "closed" as const, reason: "was closed" as const },
+])(
+  "a watched agent that becomes $lifecycle keeps terminal semantics",
+  async ({ lifecycle, reason }) => {
+    const scenario = createCoordinatorScenario();
+    scenario.addAgent("caller");
+    scenario.addAgent("child", "running", "caller");
+    scenario.watch("child", "caller", true);
+
+    scenario.setState("child", lifecycle);
+
+    await expectDeliveryCount(scenario, 1);
+    expect(scenario.deliveries[0]?.reason).toBe(reason);
+  },
+);

--- a/packages/server/src/server/agent/finish-notifications.test.ts
+++ b/packages/server/src/server/agent/finish-notifications.test.ts
@@ -28,6 +28,7 @@ interface CoordinatorScenario {
   deliveries: DeliveredNotification[];
   subscriptionOptions: Array<{ agentId?: string; replayState?: boolean } | undefined>;
   activeSubscriptions(): number;
+  evaluationCount(): number;
   addAgent(
     agentId: string,
     lifecycle?: "idle" | "running" | "error" | "closed",
@@ -77,9 +78,13 @@ function createCoordinatorScenario(options?: {
   const subscribers = new Set<(event: AgentManagerEvent) => void>();
   const deliveries: DeliveredNotification[] = [];
   const subscriptionOptions: Array<{ agentId?: string; replayState?: boolean } | undefined> = [];
+  let evaluationCount = 0;
 
   const agentManager: AgentManager = Object.create(AgentManager.prototype);
-  Reflect.set(agentManager, "listAgents", () => Array.from(agents.values()));
+  Reflect.set(agentManager, "listAgents", () => {
+    evaluationCount += 1;
+    return Array.from(agents.values());
+  });
   Reflect.set(agentManager, "getAgent", (agentId: string) => agents.get(agentId) ?? null);
   Reflect.set(agentManager, "hasInFlightRun", (agentId: string) => inFlight.has(agentId));
   Reflect.set(
@@ -106,6 +111,7 @@ function createCoordinatorScenario(options?: {
     deliveries,
     subscriptionOptions,
     activeSubscriptions: () => subscribers.size,
+    evaluationCount: () => evaluationCount,
     addAgent(agentId, lifecycle = "idle", parentAgentId) {
       agents.set(agentId, createAgent(agentId, lifecycle, parentAgentId));
       if (lifecycle === "running") inFlight.add(agentId);
@@ -179,6 +185,22 @@ function createCoordinatorScenario(options?: {
 async function expectDeliveryCount(scenario: CoordinatorScenario, count: number): Promise<void> {
   await vi.waitFor(() => expect(scenario.deliveries).toHaveLength(count));
 }
+
+test("permission stream events do not schedule graph evaluation", async () => {
+  const scenario = createCoordinatorScenario();
+  scenario.addAgent("caller");
+  scenario.addAgent("child", "running", "caller");
+  scenario.watch("child", "caller", true);
+  await vi.waitFor(() => expect(scenario.evaluationCount()).toBe(1));
+
+  scenario.requestPermission("child", "permission-1");
+  await expectDeliveryCount(scenario, 1);
+  expect(scenario.evaluationCount()).toBe(1);
+
+  scenario.resolvePermission("child", "permission-1");
+  await Promise.resolve();
+  expect(scenario.evaluationCount()).toBe(1);
+});
 
 test("ordinary completion is delivered exactly once through one global subscription", async () => {
   const scenario = createCoordinatorScenario();
@@ -349,7 +371,7 @@ test.each(["skipped", "failed"])("a $s descendant delivery releases its ancestor
   expect(scenario.deliveries.map((delivery) => delivery.childAgentId)).toEqual(["child", "parent"]);
 });
 
-test("permission request IDs deduplicate until resolution without consuming terminal tracking", async () => {
+test("permission requests deduplicate the same ID", async () => {
   const scenario = createCoordinatorScenario();
   scenario.addAgent("caller");
   scenario.addAgent("child", "running", "caller");
@@ -358,38 +380,8 @@ test("permission request IDs deduplicate until resolution without consuming term
   scenario.requestPermission("child", "permission-1");
   scenario.requestPermission("child", "permission-1");
   await expectDeliveryCount(scenario, 1);
-  scenario.resolvePermission("child", "permission-1");
-  scenario.requestPermission("child", "permission-1");
-  await expectDeliveryCount(scenario, 2);
-  scenario.resolvePermission("child", "permission-1");
-  scenario.setState("child", "running");
-  scenario.setState("child", "idle");
-
-  await expectDeliveryCount(scenario, 3);
-  expect(scenario.deliveries.map((delivery) => delivery.reason)).toEqual([
-    "needs permission",
-    "needs permission",
-    "finished",
-  ]);
+  expect(scenario.deliveries[0]?.reason).toBe("needs permission");
 });
-
-test.each([
-  { lifecycle: "error" as const, reason: "errored" as const },
-  { lifecycle: "closed" as const, reason: "was closed" as const },
-])(
-  "a watched agent that becomes $lifecycle keeps terminal semantics",
-  async ({ lifecycle, reason }) => {
-    const scenario = createCoordinatorScenario();
-    scenario.addAgent("caller");
-    scenario.addAgent("child", "running", "caller");
-    scenario.watch("child", "caller", true);
-
-    scenario.setState("child", lifecycle);
-
-    await expectDeliveryCount(scenario, 1);
-    expect(scenario.deliveries[0]?.reason).toBe(reason);
-  },
-);
 
 test.each([
   { lifecycle: "error" as const, reason: "errored" as const },

--- a/packages/server/src/server/agent/finish-notifications.test.ts
+++ b/packages/server/src/server/agent/finish-notifications.test.ts
@@ -390,3 +390,28 @@ test.each([
     expect(scenario.deliveries[0]?.reason).toBe(reason);
   },
 );
+
+test.each([
+  { lifecycle: "error" as const, reason: "errored" as const },
+  { lifecycle: "closed" as const, reason: "was closed" as const },
+])(
+  "a watched agent that becomes $lifecycle bypasses a running descendant watcher",
+  async ({ lifecycle, reason }) => {
+    const scenario = createCoordinatorScenario();
+    scenario.addAgent("caller");
+    scenario.addAgent("child", "running", "caller");
+    scenario.addAgent("descendant", "running", "child");
+    scenario.watch("child", "caller", true);
+    scenario.watch("descendant", "child", true);
+
+    scenario.setState("child", lifecycle);
+
+    await expectDeliveryCount(scenario, 1);
+    scenario.setState("child", lifecycle);
+    await Promise.resolve();
+    expect(scenario.deliveries).toEqual([
+      { childAgentId: "child", callerAgentId: "caller", reason },
+    ]);
+    expect(scenario.agentManager.hasInFlightRun("descendant")).toBe(true);
+  },
+);

--- a/packages/server/src/server/agent/finish-notifications.ts
+++ b/packages/server/src/server/agent/finish-notifications.ts
@@ -90,30 +90,20 @@ function refreshSubscription(coordinator: FinishCoordinator): void {
     coordinator.unsubscribe();
     coordinator.unsubscribe = null;
   }
-  if (coordinator.watchers.size === 0 && coordinator.pendingDeliveries.size === 0) {
-    coordinators.delete(coordinator.agentManager);
-  }
 }
 
 function handleEvent(coordinator: FinishCoordinator, event: AgentManagerEvent): void {
   if (event.type === "agent_state") {
     handleAgentState(coordinator, event.agent);
+    scheduleEvaluation(coordinator);
   } else if (event.type === "agent_stream") {
     handleAgentStream(coordinator, event.agentId, event.event);
   }
-  scheduleEvaluation(coordinator);
 }
 
 function handleAgentState(coordinator: FinishCoordinator, agent: ManagedAgent): void {
   for (const watcher of coordinator.watchers) {
     if (watcher.childAgentId !== agent.id) continue;
-    if (
-      watcher.requireParentOwnership &&
-      getParentAgentIdFromLabels(agent.labels) !== watcher.callerAgentId
-    ) {
-      coordinator.watchers.delete(watcher);
-      continue;
-    }
     for (const requestId of watcher.notifiedPermissionRequestIds) {
       if (!agent.pendingPermissions.has(requestId)) {
         watcher.notifiedPermissionRequestIds.delete(requestId);
@@ -127,7 +117,6 @@ function handleAgentState(coordinator: FinishCoordinator, agent: ManagedAgent): 
       watcher.terminalReason = "was closed";
     }
   }
-  refreshSubscription(coordinator);
 }
 
 function handleAgentStream(
@@ -251,7 +240,6 @@ function isTerminalCandidate(
   if (watcher.terminalReason) return true;
   const child = agentsById.get(watcher.childAgentId);
   if (!child || !watcher.hasSeenRunning || child.lifecycle !== "idle") return false;
-  if (coordinator.agentManager.hasInFlightRun(child.id)) return false;
   return !hasActiveReachableAgent(coordinator, child.id, agentsById, dependencies);
 }
 
@@ -261,8 +249,8 @@ function hasActiveReachableAgent(
   agentsById: Map<string, ManagedAgent>,
   dependencies: Map<string, Set<string>>,
 ): boolean {
-  const visited = new Set([rootAgentId]);
-  const pending = [...(dependencies.get(rootAgentId) ?? [])];
+  const visited = new Set<string>();
+  const pending = [rootAgentId];
   while (pending.length > 0) {
     const agentId = pending.pop()!;
     if (visited.has(agentId)) continue;
@@ -276,7 +264,7 @@ function hasActiveReachableAgent(
     }
     pending.push(...(dependencies.get(agentId) ?? []));
   }
-  return (coordinator.pendingDeliveries.get(rootAgentId) ?? 0) > 0;
+  return false;
 }
 
 function hasUnsettledDescendant(

--- a/packages/server/src/server/agent/finish-notifications.ts
+++ b/packages/server/src/server/agent/finish-notifications.ts
@@ -210,6 +210,7 @@ function evaluate(coordinator: FinishCoordinator): void {
 
   for (const watcher of candidates) {
     if (
+      !watcher.terminalReason &&
       hasUnsettledDescendant(
         watcher.childAgentId,
         dependencies,

--- a/packages/server/src/server/agent/finish-notifications.ts
+++ b/packages/server/src/server/agent/finish-notifications.ts
@@ -1,0 +1,336 @@
+import { getParentAgentIdFromLabels } from "@getpaseo/protocol/agent-labels";
+import type { Logger } from "pino";
+
+import type { AgentPermissionRequest } from "./agent-sdk-types.js";
+import type { AgentManager, AgentManagerEvent, ManagedAgent } from "./agent-manager.js";
+
+export type FinishNotificationReason = "finished" | "errored" | "needs permission" | "was closed";
+
+export interface FinishNotificationDelivery {
+  reason: FinishNotificationReason;
+  permissionRequest?: AgentPermissionRequest;
+}
+
+export interface WatchAgentFinishParams {
+  agentManager: AgentManager;
+  childAgentId: string;
+  callerAgentId: string;
+  requireParentOwnership?: boolean;
+  deliver(delivery: FinishNotificationDelivery): Promise<void>;
+  logger: Logger;
+}
+
+interface FinishWatcher extends WatchAgentFinishParams {
+  hasSeenRunning: boolean;
+  terminalReason: "errored" | "was closed" | null;
+  notifiedPermissionRequestIds: Set<string>;
+  deliveryTail: Promise<void>;
+}
+
+interface FinishCoordinator {
+  agentManager: AgentManager;
+  watchers: Set<FinishWatcher>;
+  pendingDeliveries: Map<string, number>;
+  unsubscribe: (() => void) | null;
+  evaluationScheduled: boolean;
+}
+
+const coordinators = new WeakMap<AgentManager, FinishCoordinator>();
+
+export function watchAgentFinish(params: WatchAgentFinishParams): void {
+  const snapshot = params.agentManager.getAgent(params.childAgentId);
+  if (snapshot?.lifecycle === "closed") {
+    return;
+  }
+  if (
+    snapshot &&
+    params.requireParentOwnership &&
+    getParentAgentIdFromLabels(snapshot.labels) !== params.callerAgentId
+  ) {
+    return;
+  }
+
+  const coordinator = getCoordinator(params.agentManager);
+  const hasSeenRunning =
+    snapshot?.lifecycle === "running" && snapshot.pendingPermissions.size === 0;
+  coordinator.watchers.add({
+    ...params,
+    hasSeenRunning,
+    terminalReason: snapshot?.lifecycle === "error" ? "errored" : null,
+    notifiedPermissionRequestIds: new Set(),
+    deliveryTail: Promise.resolve(),
+  });
+  refreshSubscription(coordinator);
+  scheduleEvaluation(coordinator);
+}
+
+function getCoordinator(agentManager: AgentManager): FinishCoordinator {
+  const existing = coordinators.get(agentManager);
+  if (existing) return existing;
+  const coordinator: FinishCoordinator = {
+    agentManager,
+    watchers: new Set(),
+    pendingDeliveries: new Map(),
+    unsubscribe: null,
+    evaluationScheduled: false,
+  };
+  coordinators.set(agentManager, coordinator);
+  return coordinator;
+}
+
+function refreshSubscription(coordinator: FinishCoordinator): void {
+  if (coordinator.watchers.size > 0 && !coordinator.unsubscribe) {
+    coordinator.unsubscribe = coordinator.agentManager.subscribe(
+      (event) => handleEvent(coordinator, event),
+      { replayState: false },
+    );
+    return;
+  }
+  if (coordinator.watchers.size === 0 && coordinator.unsubscribe) {
+    coordinator.unsubscribe();
+    coordinator.unsubscribe = null;
+  }
+  if (coordinator.watchers.size === 0 && coordinator.pendingDeliveries.size === 0) {
+    coordinators.delete(coordinator.agentManager);
+  }
+}
+
+function handleEvent(coordinator: FinishCoordinator, event: AgentManagerEvent): void {
+  if (event.type === "agent_state") {
+    handleAgentState(coordinator, event.agent);
+  } else if (event.type === "agent_stream") {
+    handleAgentStream(coordinator, event.agentId, event.event);
+  }
+  scheduleEvaluation(coordinator);
+}
+
+function handleAgentState(coordinator: FinishCoordinator, agent: ManagedAgent): void {
+  for (const watcher of coordinator.watchers) {
+    if (watcher.childAgentId !== agent.id) continue;
+    if (
+      watcher.requireParentOwnership &&
+      getParentAgentIdFromLabels(agent.labels) !== watcher.callerAgentId
+    ) {
+      coordinator.watchers.delete(watcher);
+      continue;
+    }
+    for (const requestId of watcher.notifiedPermissionRequestIds) {
+      if (!agent.pendingPermissions.has(requestId)) {
+        watcher.notifiedPermissionRequestIds.delete(requestId);
+      }
+    }
+    if (agent.lifecycle === "running" && agent.pendingPermissions.size === 0) {
+      watcher.hasSeenRunning = true;
+    } else if (agent.lifecycle === "error") {
+      watcher.terminalReason = "errored";
+    } else if (agent.lifecycle === "closed") {
+      watcher.terminalReason = "was closed";
+    }
+  }
+  refreshSubscription(coordinator);
+}
+
+function handleAgentStream(
+  coordinator: FinishCoordinator,
+  agentId: string,
+  event: Extract<AgentManagerEvent, { type: "agent_stream" }>["event"],
+): void {
+  for (const watcher of coordinator.watchers) {
+    if (watcher.childAgentId !== agentId) continue;
+    if (event.type === "permission_requested") {
+      watcher.hasSeenRunning = false;
+      if (!watcher.notifiedPermissionRequestIds.has(event.request.id)) {
+        watcher.notifiedPermissionRequestIds.add(event.request.id);
+        enqueueDelivery(watcher, {
+          reason: "needs permission",
+          permissionRequest: event.request,
+        });
+      }
+    } else if (event.type === "permission_resolved") {
+      watcher.notifiedPermissionRequestIds.delete(event.requestId);
+      const child = coordinator.agentManager.getAgent(agentId);
+      if (child?.pendingPermissions.size === 0) {
+        watcher.hasSeenRunning = child.lifecycle === "running";
+      }
+    }
+  }
+}
+
+function enqueueDelivery(watcher: FinishWatcher, delivery: FinishNotificationDelivery): void {
+  watcher.deliveryTail = watcher.deliveryTail
+    .then(() => watcher.deliver(delivery))
+    .catch((error: unknown) => {
+      watcher.logger.error(
+        {
+          err: error,
+          childAgentId: watcher.childAgentId,
+          callerAgentId: watcher.callerAgentId,
+          reason: delivery.reason,
+        },
+        "Failed to notify caller agent",
+      );
+    });
+}
+
+function scheduleEvaluation(coordinator: FinishCoordinator): void {
+  if (coordinator.evaluationScheduled) return;
+  coordinator.evaluationScheduled = true;
+  queueMicrotask(() => {
+    coordinator.evaluationScheduled = false;
+    evaluate(coordinator);
+  });
+}
+
+function evaluate(coordinator: FinishCoordinator): void {
+  if (coordinator.watchers.size === 0) return;
+  const agents = coordinator.agentManager.listAgents();
+  const agentsById = new Map(agents.map((agent) => [agent.id, agent]));
+
+  for (const watcher of coordinator.watchers) {
+    const child = agentsById.get(watcher.childAgentId);
+    if (
+      child &&
+      watcher.requireParentOwnership &&
+      getParentAgentIdFromLabels(child.labels) !== watcher.callerAgentId
+    ) {
+      coordinator.watchers.delete(watcher);
+    }
+  }
+  refreshSubscription(coordinator);
+  if (coordinator.watchers.size === 0) return;
+
+  const dependencies = buildDependencies(agents, coordinator.watchers);
+  const candidates = Array.from(coordinator.watchers).filter((watcher) =>
+    isTerminalCandidate(coordinator, watcher, agentsById, dependencies),
+  );
+  const candidateAgentIds = new Set(candidates.map((watcher) => watcher.childAgentId));
+  const activeWatcherAgentIds = new Set(
+    Array.from(coordinator.watchers, (watcher) => watcher.childAgentId),
+  );
+
+  for (const watcher of candidates) {
+    if (
+      hasUnsettledDescendant(
+        watcher.childAgentId,
+        dependencies,
+        activeWatcherAgentIds,
+        candidateAgentIds,
+      )
+    ) {
+      continue;
+    }
+    beginTerminalDelivery(coordinator, watcher);
+  }
+}
+
+function buildDependencies(
+  agents: ManagedAgent[],
+  watchers: Set<FinishWatcher>,
+): Map<string, Set<string>> {
+  const dependencies = new Map<string, Set<string>>();
+  function add(callerAgentId: string, childAgentId: string): void {
+    const children = dependencies.get(callerAgentId) ?? new Set<string>();
+    children.add(childAgentId);
+    dependencies.set(callerAgentId, children);
+  }
+  for (const agent of agents) {
+    const parentAgentId = getParentAgentIdFromLabels(agent.labels);
+    if (parentAgentId) add(parentAgentId, agent.id);
+  }
+  for (const watcher of watchers) add(watcher.callerAgentId, watcher.childAgentId);
+  return dependencies;
+}
+
+function isTerminalCandidate(
+  coordinator: FinishCoordinator,
+  watcher: FinishWatcher,
+  agentsById: Map<string, ManagedAgent>,
+  dependencies: Map<string, Set<string>>,
+): boolean {
+  if (watcher.terminalReason) return true;
+  const child = agentsById.get(watcher.childAgentId);
+  if (!child || !watcher.hasSeenRunning || child.lifecycle !== "idle") return false;
+  if (coordinator.agentManager.hasInFlightRun(child.id)) return false;
+  return !hasActiveReachableAgent(coordinator, child.id, agentsById, dependencies);
+}
+
+function hasActiveReachableAgent(
+  coordinator: FinishCoordinator,
+  rootAgentId: string,
+  agentsById: Map<string, ManagedAgent>,
+  dependencies: Map<string, Set<string>>,
+): boolean {
+  const visited = new Set([rootAgentId]);
+  const pending = [...(dependencies.get(rootAgentId) ?? [])];
+  while (pending.length > 0) {
+    const agentId = pending.pop()!;
+    if (visited.has(agentId)) continue;
+    visited.add(agentId);
+    const agent = agentsById.get(agentId);
+    if (!agent) return true;
+    const hasPendingDelivery = (coordinator.pendingDeliveries.get(agentId) ?? 0) > 0;
+    const isRunning = agent.lifecycle === "initializing" || agent.lifecycle === "running";
+    if (hasPendingDelivery || isRunning || coordinator.agentManager.hasInFlightRun(agentId)) {
+      return true;
+    }
+    pending.push(...(dependencies.get(agentId) ?? []));
+  }
+  return (coordinator.pendingDeliveries.get(rootAgentId) ?? 0) > 0;
+}
+
+function hasUnsettledDescendant(
+  rootAgentId: string,
+  dependencies: Map<string, Set<string>>,
+  activeWatcherAgentIds: Set<string>,
+  candidateAgentIds: Set<string>,
+): boolean {
+  const visited = new Set([rootAgentId]);
+  const pending = [...(dependencies.get(rootAgentId) ?? [])];
+  while (pending.length > 0) {
+    const agentId = pending.pop()!;
+    if (visited.has(agentId)) continue;
+    visited.add(agentId);
+    if (activeWatcherAgentIds.has(agentId)) {
+      if (!candidateAgentIds.has(agentId)) return true;
+      if (!isReachable(agentId, rootAgentId, dependencies)) return true;
+    }
+    pending.push(...(dependencies.get(agentId) ?? []));
+  }
+  return false;
+}
+
+function isReachable(
+  fromAgentId: string,
+  targetAgentId: string,
+  dependencies: Map<string, Set<string>>,
+): boolean {
+  const visited = new Set<string>();
+  const pending = [fromAgentId];
+  while (pending.length > 0) {
+    const agentId = pending.pop()!;
+    if (agentId === targetAgentId) return true;
+    if (visited.has(agentId)) continue;
+    visited.add(agentId);
+    pending.push(...(dependencies.get(agentId) ?? []));
+  }
+  return false;
+}
+
+function beginTerminalDelivery(coordinator: FinishCoordinator, watcher: FinishWatcher): void {
+  const pendingCount = coordinator.pendingDeliveries.get(watcher.callerAgentId) ?? 0;
+  coordinator.pendingDeliveries.set(watcher.callerAgentId, pendingCount + 1);
+  coordinator.watchers.delete(watcher);
+  refreshSubscription(coordinator);
+
+  enqueueDelivery(watcher, { reason: watcher.terminalReason ?? "finished" });
+  void watcher.deliveryTail.finally(() => {
+    const remaining = (coordinator.pendingDeliveries.get(watcher.callerAgentId) ?? 1) - 1;
+    if (remaining === 0) {
+      coordinator.pendingDeliveries.delete(watcher.callerAgentId);
+    } else {
+      coordinator.pendingDeliveries.set(watcher.callerAgentId, remaining);
+    }
+    refreshSubscription(coordinator);
+    scheduleEvaluation(coordinator);
+  });
+}

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -3126,6 +3126,52 @@ describe("create_agent MCP tool", () => {
     );
   });
 
+  it("does not register finish notifications for out-of-band initial prompts", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const parentAgent = {
+      id: "parent-agent",
+      cwd: existingCwd,
+      workspaceId: "wks_parent",
+      provider: "codex",
+      currentModeId: "full-access",
+    } as ManagedAgent;
+    const childAgent = {
+      id: "child-agent",
+      cwd: existingCwd,
+      lifecycle: "running",
+      currentModeId: null,
+      availableModes: [],
+      labels: { [PARENT_AGENT_ID_LABEL]: "parent-agent" },
+      pendingPermissions: new Map(),
+      config: { title: "Child" },
+    } as ManagedAgent;
+    spies.agentManager.getAgent.mockImplementation((agentId: string) => {
+      if (agentId === "parent-agent") return parentAgent;
+      if (agentId === "child-agent") return childAgent;
+      return null;
+    });
+    spies.agentManager.createAgent.mockResolvedValue(childAgent);
+    spies.agentManager.tryRunOutOfBand.mockReturnValue(true);
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+
+    const response = await registeredTool(server, "create_agent").handler({
+      ...subagentCurrentWorkspace(),
+      title: "Child",
+      provider: "codex/gpt-5.4",
+      initialPrompt: "Do work",
+    });
+
+    expect(spies.agentManager.subscribe).not.toHaveBeenCalled();
+    expect(response.structuredContent).not.toHaveProperty("guidance");
+  });
+
   it("creates detached caller agents without a parent label", async () => {
     const { agentManager, agentStorage, spies } = createTestDeps();
     spies.agentManager.getAgent.mockReturnValue({
@@ -3605,6 +3651,7 @@ describe("send_agent_prompt MCP tool", () => {
       lifecycle: "running",
       currentModeId: null,
       availableModes: [],
+      pendingPermissions: new Map(),
       config: { title: "Child" },
     } as ManagedAgent;
     spies.agentManager.getAgent.mockImplementation((agentId: string) => {
@@ -3642,6 +3689,48 @@ describe("send_agent_prompt MCP tool", () => {
     expect(response.structuredContent.guidance).toBe(
       "You will get notified when the prompted agent finishes, errors, or needs permission. Do not poll for status; continue with other work until the notification arrives.",
     );
+  });
+
+  it("does not register finish notifications for out-of-band prompts", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const parentAgent = {
+      id: "parent-agent",
+      cwd: existingCwd,
+      workspaceId: "wks_parent",
+      provider: "codex",
+      currentModeId: "full-access",
+    } as ManagedAgent;
+    const childAgent = {
+      id: "child-agent",
+      cwd: existingCwd,
+      lifecycle: "running",
+      currentModeId: null,
+      availableModes: [],
+      pendingPermissions: new Map(),
+      config: { title: "Child" },
+    } as ManagedAgent;
+    spies.agentManager.getAgent.mockImplementation((agentId: string) => {
+      if (agentId === "parent-agent") return parentAgent;
+      if (agentId === "child-agent") return childAgent;
+      return null;
+    });
+    spies.agentManager.tryRunOutOfBand.mockReturnValue(true);
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+
+    const response = await invokeToolWithParsedInput(registeredTool(server, "send_agent_prompt"), {
+      agentId: "child-agent",
+      prompt: "Follow up",
+    });
+
+    expect(spies.agentManager.subscribe).not.toHaveBeenCalled();
+    expect(response.structuredContent).not.toHaveProperty("guidance");
   });
 
   it("keeps top-level prompts blocking by default", async () => {

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -1435,6 +1435,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         snapshot,
         background: createdInBackground,
         initialPromptStarted,
+        initialPromptDisposition,
       } = await createAgentCommand(
         {
           agentManager,
@@ -1504,7 +1505,10 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       // Return immediately for async creation.
       const currentSnapshot = agentManager.getAgent(snapshot.id) ?? snapshot;
       const guidance =
-        callerAgentId && notifyOnFinish && initialPromptStarted
+        callerAgentId &&
+        notifyOnFinish &&
+        createdInBackground &&
+        initialPromptDisposition === "turn_started"
           ? "You will get notified when the created agent finishes, errors, or needs permission. Do not poll for status; continue with other work until the notification arrives."
           : undefined;
       const response = {
@@ -1881,9 +1885,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       background = Boolean(callerAgentId),
       notifyOnFinish = Boolean(callerAgentId),
     }) => {
-      const shouldNotifyOnFinish = Boolean(callerAgentId && notifyOnFinish && background);
-
-      await sendPromptToAgent({
+      const dispatchResult = await sendPromptToAgent({
         agentManager,
         agentStorage,
         agentId,
@@ -1891,6 +1893,12 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         sessionMode,
         logger: childLogger,
       });
+      const shouldNotifyOnFinish = Boolean(
+        callerAgentId &&
+        notifyOnFinish &&
+        background &&
+        dispatchResult.disposition === "turn_started",
+      );
 
       if (shouldNotifyOnFinish && callerAgentId) {
         setupFinishNotification({

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -1435,7 +1435,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         snapshot,
         background: createdInBackground,
         initialPromptStarted,
-        initialPromptDisposition,
+        finishNotificationRegistered,
       } = await createAgentCommand(
         {
           agentManager,
@@ -1504,13 +1504,9 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
 
       // Return immediately for async creation.
       const currentSnapshot = agentManager.getAgent(snapshot.id) ?? snapshot;
-      const guidance =
-        callerAgentId &&
-        notifyOnFinish &&
-        createdInBackground &&
-        initialPromptDisposition === "turn_started"
-          ? "You will get notified when the created agent finishes, errors, or needs permission. Do not poll for status; continue with other work until the notification arrives."
-          : undefined;
+      const guidance = finishNotificationRegistered
+        ? "You will get notified when the created agent finishes, errors, or needs permission. Do not poll for status; continue with other work until the notification arrives."
+        : undefined;
       const response = {
         content: [],
         structuredContent: ensureValidJson({


### PR DESCRIPTION
### Linked issue

Related to #2495. Durable delivery across daemon restarts remains out of scope.

### Type of change

- [x] Bug fix

### Reasoning

A parent delegates to a dispatcher, which delegates to a grandchild and briefly becomes idle. Previously the parent received that intermediate response before the dispatcher processed the grandchild's result.

The finish coordinator waits for reachable delegated work and pending notification deliveries. Once the dispatcher completes its follow-up, the parent receives one notification containing only that turn's response. Last-response extraction preserves chunk joining within a turn while separating adjacent assistant responses from different turns.

If a terminal result cannot be delivered, active observers of its caller receive an explicit delegated-result failure without the caller's stale response. This ends the one-shot subscriptions without retrying or changing agent lifecycle. Error and close notifications remain immediate, permission notifications remain serialized, and out-of-band prompts do not arm finish watchers.

### Real-daemon regression and before/after evidence

`packages/server/src/server/agent/finish-notifications.e2e.test.ts` starts the actual isolated daemon through its production bootstrap, uses agent-scoped HTTP MCP clients and a WebSocket observer, and substitutes only the deterministic provider adapter. Explicit barriers hold provider turns after `turn_started`.

Both `create_agent` and `send_agent_prompt` scenarios verify:

- No parent notification while the grandchild is running or the dispatcher follow-up is held.
- Exactly one parent delivery containing `DISPATCHER_FINAL`, without `WAITING_FOR_GRANDCHILD`.
- The final dispatcher response is present in its canonical WebSocket timeline.
- A subsequent dispatcher turn does not trigger another notification.

Command, run on macOS on 2026-09-09:

```sh
npx vitest run packages/server/src/server/agent/finish-notifications.e2e.test.ts --bail=1
```

Before, on `main` at `c172076bf`, using the same test and provider hook without production fixes: **FAIL**. The parent received `WAITING_FOR_GRANDCHILD` while the dispatcher's final follow-up was still held. Running the second case separately with `-t send_agent_prompt` also failed, delivering `READYWAITING_FOR_GRANDCHILD` prematurely.

On the rebased checkpoint `31c33bb28`, delivery timing was fixed but the result was still `WAITING_FOR_GRANDCHILDDISPATCHER_FINAL`. Turn-aware extraction fixed that additional defect.

After the fixes: **PASS, 2/2 daemon cases**. The latest run completed in 5.97 seconds. Additional focused checks: **14/14 coordinator tests**, **16/16 prompt tests**, including RED → GREEN for failed delivery and suppression of the stale response. Earlier validation of turn-aware extraction also passed **180/180 manager tests** and **4/4 timeline-store tests**.

`npm run typecheck`, `npm run lint`, and `npm run format` pass. Reproducibility notes are in `docs/ad-hoc-daemon-testing.md`.

### Scope and limitations

- The daemon and its HTTP/MCP/WebSocket paths are real; live-model behavior and restart durability were not tested.
- Barriers isolate the nested-flow regression. The pre-existing race between a very fast turn and watcher registration is not addressed.
- Quiescence still includes running descendants identified by parent labels, including descendants without a finish watcher. This policy is unchanged by the added failure handling.
- Failure injection is covered by focused coordinator/prompt tests; the daemon regression covers successful nested delivery.
- No UI or wire-schema changes. Linux and Windows validation is left to CI.
