### PR TITLE
fix: refresh worktree PR detection

### DIFF
--- a/packages/app/src/git/actions-split-button.tsx
+++ b/packages/app/src/git/actions-split-button.tsx
@@ -23,6 +23,7 @@ interface GitActionsSplitButtonProps {
   gitActions: GitActions;
   hideLabels?: boolean;
   menuOnly?: boolean;
+  onMenuOpen?: () => void;
 }
 
 interface GitActionMenuItemProps {
@@ -79,6 +80,7 @@ export function GitActionsSplitButton({
   gitActions,
   hideLabels,
   menuOnly = false,
+  onMenuOpen,
 }: GitActionsSplitButtonProps) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
@@ -137,6 +139,14 @@ export function GitActionsSplitButton({
     ],
     [gitActions.menu, gitActions.primary, gitActions.secondary],
   );
+  const handleMenuOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        onMenuOpen?.();
+      }
+    },
+    [onMenuOpen],
+  );
 
   if (menuOnly) {
     if (menuOnlyActions.length === 0) {
@@ -144,7 +154,7 @@ export function GitActionsSplitButton({
     }
 
     return (
-      <DropdownMenu>
+      <DropdownMenu onOpenChange={handleMenuOpenChange}>
         <DropdownMenuTrigger
           testID="changes-actions-menu-trigger"
           style={menuOnlyTriggerStyle}
@@ -210,7 +220,7 @@ export function GitActionsSplitButton({
             )}
           </Pressable>
           {gitActions.secondary.length > 0 ? (
-            <DropdownMenu>
+            <DropdownMenu onOpenChange={handleMenuOpenChange}>
               <DropdownMenuTrigger
                 testID="changes-primary-cta-caret"
                 style={caretTriggerStyle}
@@ -242,7 +252,7 @@ export function GitActionsSplitButton({
         </View>
       ) : null}
       {gitActions.menu.length > 0 ? (
-        <DropdownMenu>
+        <DropdownMenu onOpenChange={handleMenuOpenChange}>
           <DropdownMenuTrigger
             testID="changes-overflow-menu"
             hitSlop={8}

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -468,6 +468,7 @@ interface ChangesRepositoryToolbarModel {
   branchName: string | null;
   cwd: string;
   gitActions: GitActions | null;
+  onRefreshPrStatus: (() => void) | null;
   pullRequest: ChangesPullRequestLinkModel | null;
   serverId: string;
   workspaceId?: string | null;
@@ -498,6 +499,7 @@ interface BuildChangesHeaderModelInput {
   gitActions: GitActions;
   mode: ChangesToolbarMode;
   onOpenPullRequest: () => void;
+  onRefreshPrStatus: () => void;
   onSelectBase: () => void;
   onSelectUncommitted: () => void;
   pullRequest: PrHint | null;
@@ -515,6 +517,7 @@ function buildChangesHeaderModel(input: BuildChangesHeaderModelInput): {
       branchName: input.branchName,
       cwd: input.cwd,
       gitActions: input.compact ? input.gitActions : null,
+      onRefreshPrStatus: input.compact ? input.onRefreshPrStatus : null,
       pullRequest: input.pullRequest
         ? { ...input.pullRequest, onOpen: input.onOpenPullRequest }
         : null,
@@ -645,7 +648,13 @@ function ChangesRepositoryToolbar({
             <ChangesPullRequestExternalLink compact={compact} model={model.pullRequest} />
           </>
         ) : null}
-        {model.gitActions ? <GitActionsSplitButton gitActions={model.gitActions} menuOnly /> : null}
+        {model.gitActions ? (
+          <GitActionsSplitButton
+            gitActions={model.gitActions}
+            menuOnly
+            onMenuOpen={model.onRefreshPrStatus ?? undefined}
+          />
+        ) : null}
       </ChangesToolbarTrailing>
     </ChangesToolbarRow>
   );
@@ -1880,7 +1889,7 @@ export function ChangesSurface({
     () => computeBaseRefLabel(baseRef, t("workspace.git.diff.base")),
     [baseRef, t],
   );
-  const { gitActions, branchLabel } = useGitActions({
+  const { gitActions, branchLabel, refreshPrStatus } = useGitActions({
     serverId,
     cwd,
     icons: GIT_ACTION_ICONS,
@@ -2003,6 +2012,7 @@ export function ChangesSurface({
         gitActions,
         mode: toolbarMode,
         onOpenPullRequest: handleOpenPullRequest,
+        onRefreshPrStatus: refreshPrStatus,
         onSelectBase: handleSelectBase,
         onSelectUncommitted: handleSelectUncommitted,
         pullRequest: selectPrHintFromStatus(pullRequestStatus, forge),
@@ -2022,6 +2032,7 @@ export function ChangesSurface({
       isMobile,
       forge,
       pullRequestStatus,
+      refreshPrStatus,
       selectedDiffStat,
       serverId,
       toolbarMode,

--- a/packages/app/src/git/use-actions.tsx
+++ b/packages/app/src/git/use-actions.tsx
@@ -205,6 +205,7 @@ interface UseGitActionsResult {
   gitActions: GitActions;
   branchLabel: string;
   isGit: boolean;
+  refreshPrStatus: () => void;
 }
 
 interface UseWorkspaceScreenArchiveControllerInput {
@@ -331,11 +332,15 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
     status: prStatus,
     githubFeaturesEnabled,
     forge,
+    refetch: refetchPrStatus,
   } = useCheckoutPrStatusQuery({
     serverId,
     cwd,
     enabled: isGit,
   });
+  const refreshPrStatus = useCallback(() => {
+    void refetchPrStatus();
+  }, [refetchPrStatus]);
   const prIcon = useMemo(() => renderForgePrIcon(forge), [forge]);
   const baseRefLabel = useMemo(
     () => formatBaseRefLabel(baseRef, t("workspace.git.diff.base")),
@@ -865,7 +870,7 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
     [gitActionsInput, baseRefLabel, hasPullRequest, forge, t],
   );
 
-  return { gitActions, branchLabel, isGit };
+  return { gitActions, branchLabel, isGit, refreshPrStatus };
 }
 
 function translateGitActions(

--- a/packages/app/src/git/use-pr-status-query.ts
+++ b/packages/app/src/git/use-pr-status-query.ts
@@ -58,6 +58,7 @@ export function useCheckoutPrStatusQuery({
     isFetching: query.isFetching,
     isError: query.isError,
     error: query.error,
+    refetch: query.refetch,
   };
 }
 

--- a/packages/app/src/git/workspace-actions.tsx
+++ b/packages/app/src/git/workspace-actions.tsx
@@ -8,11 +8,11 @@ interface WorkspaceActionsProps {
 }
 
 export function WorkspaceActions({ serverId, cwd }: WorkspaceActionsProps) {
-  const { gitActions } = useGitActions({
+  const { gitActions, refreshPrStatus } = useGitActions({
     serverId,
     cwd,
     icons: GIT_ACTION_ICONS,
   });
 
-  return <GitActionsSplitButton gitActions={gitActions} />;
+  return <GitActionsSplitButton gitActions={gitActions} onMenuOpen={refreshPrStatus} />;
 }

--- a/packages/server/src/server/session/checkout/checkout-session.test.ts
+++ b/packages/server/src/server/session/checkout/checkout-session.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import pino from "pino";
 import {
   type CheckoutDiffSubscriber,
@@ -200,6 +200,10 @@ function createGitSnapshot(
     },
     forge: { featuresEnabled: false, pullRequest: null, error: null },
   };
+}
+
+async function createMainGitSnapshot(cwd: string): Promise<WorkspaceGitRuntimeSnapshot> {
+  return createGitSnapshot(cwd, "main");
 }
 
 describe("CheckoutSession", () => {
@@ -1413,8 +1417,9 @@ describe("CheckoutSession", () => {
 
   describe("pr status", () => {
     it("builds a pr status response from the git snapshot", async () => {
+      const getSnapshot = vi.fn(createMainGitSnapshot);
       const { checkout, emitted } = makeCheckoutSession({
-        git: { getSnapshot: async (cwd) => createGitSnapshot(cwd, "main") },
+        git: { getSnapshot },
       });
 
       await checkout.handleCheckoutPrStatusRequest({
@@ -1429,6 +1434,11 @@ describe("CheckoutSession", () => {
           payload: expect.objectContaining({ cwd: "/repo", requestId: "ps1" }),
         },
       ]);
+      expect(getSnapshot).toHaveBeenCalledWith("/repo", {
+        force: true,
+        includeForge: true,
+        reason: "pr-status",
+      });
     });
 
     it("reports non-auth status errors as errors instead of sign-in setup", async () => {

--- a/packages/server/src/server/session/checkout/checkout-session.ts
+++ b/packages/server/src/server/session/checkout/checkout-session.ts
@@ -1095,7 +1095,11 @@ export class CheckoutSession {
     const { cwd, requestId } = msg;
 
     try {
-      const snapshot = await this.workspaceGitService.getSnapshot(cwd);
+      const snapshot = await this.workspaceGitService.getSnapshot(cwd, {
+        force: true,
+        includeForge: true,
+        reason: "pr-status",
+      });
       this.host.emit({
         type: "checkout_pr_status_response",
         payload: buildCheckoutPrStatusPayloadFromSnapshot({


### PR DESCRIPTION
### Linked issue

Closes #3864

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Paseo's Git/GitHub actions can keep showing **Create PR** after a Pull Request already exists for the current worktree branch. The PR-status RPC was reading the existing git snapshot, so the app could render actions from stale forge state. This change makes explicit PR-status requests force a fresh forge-aware git snapshot, then refetches that status when the Git actions menu opens so the listbox has current PR state before choosing between **Create PR** and **View PR**.

### Goals

- Force PR-status requests to refresh forge-backed PR metadata.
- Refresh PR status when the Git/GitHub actions menu opens.
- Keep the behavior focused on the existing PR-status and actions surfaces.
- Add coverage that the daemon PR-status request asks WorkspaceGit for a forced forge snapshot.

### Non-goals

- Change PR creation behavior.
- Change background polling cadence.
- Redesign Git actions or PR lookup semantics beyond avoiding stale status for this user flow.

### QA

Automated checks run locally:

- `npm run format` passed.
- `npm run lint` passed with `Found 0 warnings and 0 errors`.
- `npm run typecheck` passed.
- `npx vitest run packages/server/src/server/session/checkout/checkout-session.test.ts --bail=1` passed with `1 passed` test file and `38 passed` tests.
- `git diff --check` passed.

Manual UI evidence is not attached yet. This PR is opened as a draft for team evaluation because the repo's contributing guide asks for screenshot or video evidence for UI-touching changes.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense
