### PR TITLE
fix: make Codex Windows hooks exit cleanly

### DIFF
--- a/docs/terminal-activity.md
+++ b/docs/terminal-activity.md
@@ -106,11 +106,10 @@ The installed hook command keeps the config portable and resolves the CLI at run
 [ -n "$PASEO_TERMINAL_ID" ] && "${PASEO_HOOK_CLI:-paseo}" hooks claude <event>
 ```
 
-Codex also receives the Windows equivalent:
-
-```bat
-if defined PASEO_TERMINAL_ID (if defined PASEO_HOOK_CLI ("%PASEO_HOOK_CLI%" hooks codex <event>) else (paseo hooks codex <event>))
-```
+Codex's Windows command is a quote-free `powershell.exe -EncodedCommand` payload. Codex wraps
+`commandWindows` in quotes before it invokes `cmd.exe`, so nested CMD parentheses, embedded
+quotes, and `%VAR%` expansion are unsafe. The encoded command keeps the same terminal-id guard,
+CLI override, and fallback behavior as the POSIX command.
 
 The daemon resolves the current CLI through `PASEO_CLI` when its launcher supplies one, or through the npm package shim for standalone installs. Terminal setup exposes that resolved executable to hooks as `PASEO_HOOK_CLI`; desktop and other daemon launchers do not know about the hook-specific variable. The generated command falls back to bare `paseo` if the hook env is missing and no-ops outside Paseo terminals because the `PASEO_TERMINAL_ID` gate remains first. Paseo also prepends the resolved CLI directory to each terminal `PATH` as a secondary fallback. All other behavior lives in `paseo hooks`: read the env, map the event, POST activity, and no-op/fail-open when anything is missing or unavailable.
 

--- a/packages/server/src/terminal/agent-hooks/agent-hook-installer.ts
+++ b/packages/server/src/terminal/agent-hooks/agent-hook-installer.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -145,8 +146,20 @@ export function buildAgentHookWindowsCommand<TConfig>(
   provider: AgentHookProvider<TConfig>,
   event: AgentHookEventDefinition,
 ): string {
-  const hookArgs = `hooks ${windowsToken(provider.id)} ${windowsToken(event.event)}`;
-  return `if defined PASEO_TERMINAL_ID (if defined PASEO_HOOK_CLI ("%PASEO_HOOK_CLI%" ${hookArgs}) else (paseo ${hookArgs})) else (exit /b 0)`;
+  const hookArgs = `'hooks' ${powershellToken(provider.id)} ${powershellToken(event.event)}`;
+  const script = [
+    "if ([string]::IsNullOrEmpty($env:PASEO_TERMINAL_ID)) { exit 0 }",
+    "$hookCli = $env:PASEO_HOOK_CLI",
+    "if ([string]::IsNullOrEmpty($hookCli)) { $hookCli = 'paseo' }",
+    `& $hookCli ${hookArgs}`,
+    "$hookSucceeded = $?",
+    "$hookExitCode = $LASTEXITCODE",
+    "if ($hookSucceeded) { if ($null -ne $hookExitCode) { exit $hookExitCode }; exit 0 }",
+    "if ($null -ne $hookExitCode) { exit $hookExitCode }",
+    "exit 1",
+  ].join("\n");
+  const encodedScript = Buffer.from(script, "utf16le").toString("base64");
+  return `powershell.exe -NoProfile -NonInteractive -EncodedCommand ${encodedScript}`;
 }
 
 function installAgentHookPluginFile(
@@ -239,9 +252,6 @@ function shellToken(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-function windowsToken(value: string): string {
-  if (/^[A-Za-z0-9_./:-]+$/.test(value)) {
-    return value;
-  }
-  return `"${value.replaceAll('"', '\\"')}"`;
+function powershellToken(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
 }

--- a/packages/server/src/terminal/agent-hooks/codex/codex-settings.ts
+++ b/packages/server/src/terminal/agent-hooks/codex/codex-settings.ts
@@ -77,7 +77,7 @@ export const codexHooksFormat: AgentHookConfigFormat<CodexHooksFile> = {
     return provider.events.every((event) =>
       normalizeMatchers(hooks[event.event]).some((entry) =>
         normalizeCommandHooks(entry.hooks).some((hook) =>
-          hasPaseoCommands(hook, install.hookMarker),
+          hasPaseoCommands(hook, install.hookMarker, buildAgentHookWindowsCommand(provider, event)),
         ),
       ),
     );
@@ -115,9 +115,14 @@ function removePaseoHooks(value: unknown, marker: string): CodexMatcherGroup[] {
   return entries;
 }
 
-function hasPaseoCommands(hook: CodexCommandHook, marker: string): boolean {
+function hasPaseoCommands(
+  hook: CodexCommandHook,
+  marker: string,
+  expectedWindowsCommand: string,
+): boolean {
   return (
-    commandFieldContainsMarker(hook.command, marker) && windowsCommandContainsMarker(hook, marker)
+    commandFieldContainsMarker(hook.command, marker) &&
+    windowsCommandContainsMarker(hook, marker, expectedWindowsCommand)
   );
 }
 
@@ -127,10 +132,17 @@ function commandContainsMarker(hook: CodexCommandHook, marker: string): boolean 
   );
 }
 
-function windowsCommandContainsMarker(hook: CodexCommandHook, marker: string): boolean {
+function windowsCommandContainsMarker(
+  hook: CodexCommandHook,
+  marker: string,
+  expectedWindowsCommand?: string,
+): boolean {
   return (
     commandFieldContainsMarker(hook.commandWindows, marker) ||
-    commandFieldContainsMarker(hook.command_windows, marker)
+    commandFieldContainsMarker(hook.command_windows, marker) ||
+    (expectedWindowsCommand !== undefined &&
+      (hook.commandWindows === expectedWindowsCommand ||
+        hook.command_windows === expectedWindowsCommand))
   );
 }
 

--- a/packages/server/src/terminal/agent-hooks/codex/codex.test.ts
+++ b/packages/server/src/terminal/agent-hooks/codex/codex.test.ts
@@ -1,9 +1,13 @@
+import { Buffer } from "node:buffer";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { isPlatform } from "../../../test-utils/platform.js";
 import {
   agentHooksAreInstalled,
+  buildAgentHookWindowsCommand,
   installAgentHooks,
   uninstallAgentHooks,
 } from "../agent-hook-installer.js";
@@ -69,13 +73,94 @@ describe("Codex terminal agent hooks", () => {
       expect(commandHooks(config, event.event)).toEqual([
         {
           command: `if [ -n "$PASEO_TERMINAL_ID" ]; then "\${PASEO_HOOK_CLI:-paseo}" hooks codex ${event.event}; fi`,
-          commandWindows: `if defined PASEO_TERMINAL_ID (if defined PASEO_HOOK_CLI ("%PASEO_HOOK_CLI%" hooks codex ${event.event}) else (paseo hooks codex ${event.event})) else (exit /b 0)`,
+          commandWindows: buildAgentHookWindowsCommand(codexAgentHookProvider, event),
         },
       ]);
     }
     expect(secondInstall.changed).toBe(false);
     expect(agentHooksAreInstalled(codexAgentHookProvider, { configDir })).toBe(true);
   });
+
+  it("builds a quote-free Windows hook command", () => {
+    const event = codexAgentHookProvider.events[0];
+    const command = buildAgentHookWindowsCommand(codexAgentHookProvider, event);
+    const prefix = "powershell.exe -NoProfile -NonInteractive -EncodedCommand ";
+
+    expect(command.startsWith(prefix)).toBe(true);
+    expect(command).not.toContain('"');
+
+    const encodedScript = command.slice(prefix.length);
+    expect(Buffer.from(encodedScript, "base64").toString("utf16le")).toBe(
+      [
+        "if ([string]::IsNullOrEmpty($env:PASEO_TERMINAL_ID)) { exit 0 }",
+        "$hookCli = $env:PASEO_HOOK_CLI",
+        "if ([string]::IsNullOrEmpty($hookCli)) { $hookCli = 'paseo' }",
+        "& $hookCli 'hooks' 'codex' 'UserPromptSubmit'",
+        "$hookSucceeded = $?",
+        "$hookExitCode = $LASTEXITCODE",
+        "if ($hookSucceeded) { if ($null -ne $hookExitCode) { exit $hookExitCode }; exit 0 }",
+        "if ($null -ne $hookExitCode) { exit $hookExitCode }",
+        "exit 1",
+      ].join("\n"),
+    );
+  });
+
+  it.skipIf(!isPlatform("win32")).each(codexAgentHookProvider.events)(
+    "$event Windows hook command exits 0 without a Paseo terminal through Codex's cmd wrapper",
+    (event) => {
+      const command = buildAgentHookWindowsCommand(codexAgentHookProvider, event);
+      const env = { ...process.env };
+      delete env.PASEO_TERMINAL_ID;
+      delete env.PASEO_HOOK_CLI;
+
+      const result = spawnSync(
+        process.env.ComSpec ?? process.env.COMSPEC ?? "cmd.exe",
+        ["/d", "/s", "/c", `"${command}"`],
+        {
+          env,
+          stdio: "ignore",
+          windowsHide: true,
+          windowsVerbatimArguments: true,
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+    },
+  );
+
+  it.skipIf(!isPlatform("win32"))(
+    "runs a PASEO_HOOK_CLI cmd shim through Codex's cmd wrapper",
+    () => {
+      const hookDir = createTempDir("paseo-codex-hook-cli-");
+      const hookCli = join(hookDir, "paseo hook.cmd");
+      const outputPath = join(hookDir, "hook-output.txt");
+      writeFileSync(hookCli, `@echo off\r\necho %* > "${outputPath}"\r\nexit /b 0\r\n`);
+
+      const command = buildAgentHookWindowsCommand(
+        codexAgentHookProvider,
+        codexAgentHookProvider.events[0],
+      );
+      const result = spawnSync(
+        process.env.ComSpec ?? process.env.COMSPEC ?? "cmd.exe",
+        ["/d", "/s", "/c", `"${command}"`],
+        {
+          env: {
+            ...process.env,
+            PASEO_TERMINAL_ID: "paseo-codex-terminal",
+            PASEO_HOOK_CLI: hookCli,
+          },
+          stdio: "ignore",
+          windowsHide: true,
+          windowsVerbatimArguments: true,
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(readFileSync(outputPath, "utf8").trim()).toBe("hooks codex UserPromptSubmit");
+    },
+  );
 
   it("preserves unrelated user hooks", () => {
     const configDir = createTempDir("paseo-codex-config-preserve-");


### PR DESCRIPTION
Fixes #3632

## Summary
- replace nested CMD hook commands with a quote-free PowerShell encoded payload
- keep Codex hook installation detection idempotent when the Windows command is opaque
- cover Codex's CMD wrapper and a space-containing hook CLI path on Windows

## Verification
- `npx vitest run packages/server/src/terminal/agent-hooks/codex/codex.test.ts --bail=1` — 15 passed
- `npm run typecheck --workspace=@getpaseo/server`
- `npm run lint -- docs/terminal-activity.md packages/server/src/terminal/agent-hooks/agent-hook-installer.ts packages/server/src/terminal/agent-hooks/codex/codex-settings.ts packages/server/src/terminal/agent-hooks/codex/codex.test.ts`

## QA — Windows runtime verification (2026-09-07)

Performed a fresh real-environment Windows smoke test with Codex CLI `0.153.4` and an isolated generated hook configuration (not only unit tests).

- Sent Codex a minimal read-only prompt; it returned `OK` and exited with code `0`.
- A test shim observed both `UserPromptSubmit` and `Stop`, each invoking the built Paseo CLI.
- The local Paseo activity route observed the expected transition: `working` → `idle (finished)`.
- The `cmd.exe` wrapper path with no `PASEO_TERMINAL_ID` exited cleanly with code `0`.
- Confirmed the generated Windows command contains no embedded quotes, which is the condition that breaks when Codex applies its outer CMD wrapper.

This is targeted Windows process-level runtime QA. It is not a GUI click-through or a claim of cross-platform coverage.