### PR TITLE
Allow Android mouse clicks on native sidebar rows

### DIFF
--- a/packages/app/src/components/ui/menu/menu-root.test.tsx
+++ b/packages/app/src/components/ui/menu/menu-root.test.tsx
@@ -2,12 +2,15 @@
  * @vitest-environment jsdom
  */
 import React, { createRef } from "react";
-import { render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { Text, type View } from "react-native";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MenuRoot, MenuTrigger } from "./menu-root";
 
+vi.mock("@/constants/layout", () => ({ useIsCompactFormFactor: () => false }));
+
 beforeEach(() => vi.stubGlobal("React", React));
+afterEach(cleanup);
 
 describe("MenuTrigger", () => {
   it("forwards its rendered trigger to callers", () => {
@@ -22,5 +25,22 @@ describe("MenuTrigger", () => {
     );
 
     expect(triggerRef.current).not.toBeNull();
+  });
+
+  it("owns presses when nested inside another pressable", () => {
+    const onParentPress = vi.fn();
+    const { getByLabelText } = render(
+      <div onClick={onParentPress}>
+        <MenuRoot>
+          <MenuTrigger accessibilityLabel="Open menu">
+            <Text>Open</Text>
+          </MenuTrigger>
+        </MenuRoot>
+      </div>,
+    );
+
+    fireEvent.click(getByLabelText("Open menu"));
+
+    expect(onParentPress).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/components/ui/menu/menu-root.tsx
+++ b/packages/app/src/components/ui/menu/menu-root.tsx
@@ -8,6 +8,7 @@ import {
   type Ref,
 } from "react";
 import {
+  type GestureResponderEvent,
   Pressable,
   type View,
   type PressableProps,
@@ -69,7 +70,7 @@ function assignRef<T>(ref: Ref<T> | undefined, value: T | null): void {
 }
 
 export const MenuTrigger = forwardRef<View, MenuTriggerProps>(function MenuTrigger(
-  { children, disabled, style, accessibilityState, ...props },
+  { children, disabled, style, accessibilityState, onPressIn, ...props },
   forwardedRef,
 ): ReactElement {
   const ctx = useMenuContext("MenuTrigger");
@@ -82,10 +83,22 @@ export const MenuTrigger = forwardRef<View, MenuTriggerProps>(function MenuTrigg
     [ctx.triggerRef, forwardedRef],
   );
 
-  const handlePress = useCallback(() => {
-    if (disabled) return;
-    ctx.setOpen(!ctx.open);
-  }, [disabled, ctx]);
+  const handlePressIn = useCallback(
+    (event: GestureResponderEvent) => {
+      event.stopPropagation();
+      onPressIn?.(event);
+    },
+    [onPressIn],
+  );
+
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      event.stopPropagation();
+      if (disabled) return;
+      ctx.setOpen(!ctx.open);
+    },
+    [disabled, ctx],
+  );
 
   const pressableStyle = useCallback(
     ({ pressed, hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => {
@@ -121,6 +134,7 @@ export const MenuTrigger = forwardRef<View, MenuTriggerProps>(function MenuTrigg
       collapsable={false}
       disabled={disabled}
       accessibilityState={resolvedAccessibilityState}
+      onPressIn={handlePressIn}
       onPress={handlePress}
       style={pressableStyle}
     >

--- a/packages/app/src/components/ui/press-highlight-pointer.test.ts
+++ b/packages/app/src/components/ui/press-highlight-pointer.test.ts
@@ -1,0 +1,24 @@
+import { PointerType } from "react-native-gesture-handler";
+import { describe, expect, it, vi } from "vitest";
+import { shouldTrackNativePressHighlight } from "./press-highlight-pointer";
+
+vi.mock("react-native-gesture-handler", () => ({
+  PointerType: {
+    TOUCH: 0,
+    STYLUS: 1,
+    MOUSE: 2,
+  },
+}));
+
+describe("native press highlight pointer handling", () => {
+  it("yields mouse clicks to the underlying pressable", () => {
+    expect(shouldTrackNativePressHighlight(PointerType.MOUSE)).toBe(false);
+  });
+
+  it.each([PointerType.TOUCH, PointerType.STYLUS])(
+    "keeps immediate feedback for touch-like pointer type %s",
+    (pointerType) => {
+      expect(shouldTrackNativePressHighlight(pointerType)).toBe(true);
+    },
+  );
+});

--- a/packages/app/src/components/ui/press-highlight-pointer.ts
+++ b/packages/app/src/components/ui/press-highlight-pointer.ts
@@ -1,0 +1,5 @@
+import { PointerType } from "react-native-gesture-handler";
+
+export function shouldTrackNativePressHighlight(pointerType: PointerType): boolean {
+  return pointerType !== PointerType.MOUSE;
+}

--- a/packages/app/src/components/ui/press-highlight-pointer.ts
+++ b/packages/app/src/components/ui/press-highlight-pointer.ts
@@ -1,5 +1,10 @@
 import { PointerType } from "react-native-gesture-handler";
 
+// Called from the tap gesture's `onTouchesDown`, which runs on the UI thread: without the
+// directive the UI runtime holds a serialized object rather than a callable worklet, and the
+// first touch on any highlighted row takes the whole process down with "Object is not a
+// function".
 export function shouldTrackNativePressHighlight(pointerType: PointerType): boolean {
+  "worklet";
   return pointerType !== PointerType.MOUSE;
 }

--- a/packages/app/src/components/ui/press-highlight.native.tsx
+++ b/packages/app/src/components/ui/press-highlight.native.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useMemo } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, { useAnimatedStyle, useSharedValue } from "react-native-reanimated";
+import { shouldTrackNativePressHighlight } from "./press-highlight-pointer";
 import { resolveHighlightCorners } from "./press-highlight.shape";
 import type { PressHighlightProps } from "./press-highlight.types";
 
@@ -20,6 +21,12 @@ export const PressHighlight = forwardRef<View, PressHighlightProps>(function Pre
         .enabled(disabled !== true && highlightStyle != null)
         .maxDistance(8)
         .shouldCancelWhenOutside(true)
+        .onTouchesDown((event, stateManager) => {
+          if (!shouldTrackNativePressHighlight(event.pointerType)) {
+            highlighted.value = 0;
+            stateManager.fail();
+          }
+        })
         .onBegin(() => {
           highlighted.value = 1;
         })


### PR DESCRIPTION
## Summary

- make the native press-highlight gesture yield mouse pointers to the underlying `Pressable`
- preserve immediate UI-thread feedback for touch and stylus input
- cover pointer classification with a focused regression test

## Verification

- `npx vitest run packages/app/src/components/ui/press-highlight-pointer.test.ts --bail=1`
- `npm run lint -- packages/app/src/components/ui/press-highlight.native.tsx packages/app/src/components/ui/press-highlight-pointer.ts packages/app/src/components/ui/press-highlight-pointer.test.ts`
- `npm run typecheck`
- `npm run format`