### PR TITLE
fix(app): expose Explorer sidebar configuration

### DIFF
--- a/docs/explorer-sidebar.md
+++ b/docs/explorer-sidebar.md
@@ -38,11 +38,13 @@ The persisted layout still contains the Explorer pane so tabs survive reloads. T
 that pane from the workspace split tree and docks it separately. Persisted identifiers retain the
 literal `"explorer"` pane id and `explorerPaneIdByWorkspace` key for compatibility.
 
-The tab rail has no inline add or close controls. Its context menu opens a New Tab launcher and
-toggles Files, Changes, and Explorer-compatible workspace-scoped plugin panels from the shared
-launch catalog. Individual tab menus close instances or move compatible tabs to main. Explorer tabs
-can be reordered, but the dock cannot be split. Selecting an Explorer tab does not change workspace
-focus.
+The tab rail has no inline add or close controls. Its trailing **More actions** button and
+blank-area context menu open the same configuration menu: a New Tab launcher plus toggles for the
+singleton Files and Changes views and Explorer-compatible workspace-scoped plugin panels from the
+shared launch catalog. In Electron the button is no-drag while the remaining non-interactive rail
+stays draggable. Individual tab menus close instances or move compatible tabs to main. Explorer
+tabs can be reordered, but the dock cannot be split. Selecting an Explorer tab does not change
+workspace focus.
 
 Cmd+E shows or hides Explorer without changing its selected view. Compact layouts use the combined
 full-screen Explorer overlay for Changes, Files, and pull requests, and close it after a file opens.

--- a/packages/app/src/screens/workspace/explorer-sidebar-tab-configuration.test.ts
+++ b/packages/app/src/screens/workspace/explorer-sidebar-tab-configuration.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildExplorerSidebarConfigurationEntries,
+  EXPLORER_SIDEBAR_CONFIGURATION_TRIGGER,
+} from "@/screens/workspace/explorer-sidebar-tab-configuration";
+import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+import type { WorkspaceTabLaunchItem } from "@/workspace-tabs/launcher";
+
+function createFilesTab(): WorkspaceTabDescriptor {
+  return {
+    key: "files",
+    tabId: "files",
+    kind: "files",
+    target: { kind: "files" },
+  };
+}
+
+function hasFilesTab(tabs: WorkspaceTabDescriptor[]): boolean {
+  return tabs.some((tab) => tab.target.kind === "files");
+}
+
+function removeTab(tabs: WorkspaceTabDescriptor[], tabId: string): WorkspaceTabDescriptor[] {
+  return tabs.filter((tab) => tab.tabId !== tabId);
+}
+
+function createFilesConfigurationHarness() {
+  let tabs: WorkspaceTabDescriptor[] = [createFilesTab()];
+  const launch = vi.fn((_destination: Parameters<WorkspaceTabLaunchItem["launch"]>[0]) => {
+    if (!hasFilesTab(tabs)) {
+      tabs = [...tabs, createFilesTab()];
+    }
+  });
+  const onCloseTab = vi.fn((tabId: string) => {
+    tabs = removeTab(tabs, tabId);
+  });
+  const filesItem: WorkspaceTabLaunchItem = {
+    id: "files",
+    label: "Files",
+    disabled: false,
+    panelKind: "files",
+    toggleTarget: { kind: "files" },
+    launch,
+  };
+
+  return {
+    launch,
+    onCloseTab,
+    get tabs() {
+      return tabs;
+    },
+    buildEntries() {
+      return buildExplorerSidebarConfigurationEntries({
+        items: [filesItem],
+        tabs,
+        paneId: "explorer",
+        onCloseTab,
+      });
+    },
+  };
+}
+
+describe("Explorer sidebar tab configuration", () => {
+  it("closes and restores the Files singleton without launching a duplicate", () => {
+    const harness = createFilesConfigurationHarness();
+
+    let entries = harness.buildEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ selected: true, disabled: false });
+    entries[0]?.onSelect();
+
+    expect(harness.onCloseTab).toHaveBeenCalledWith("files");
+    expect(harness.tabs).toEqual([]);
+
+    entries = harness.buildEntries();
+    expect(entries[0]).toMatchObject({ selected: false, disabled: false });
+    entries[0]?.onSelect();
+
+    expect(harness.launch).toHaveBeenCalledWith({ kind: "open", paneId: "explorer" });
+    expect(hasFilesTab(harness.tabs)).toBe(true);
+    expect(harness.tabs).toHaveLength(1);
+
+    entries = harness.buildEntries();
+    expect(entries[0]).toMatchObject({ selected: true, disabled: false });
+    entries[0]?.onSelect();
+
+    expect(harness.launch).toHaveBeenCalledTimes(1);
+  });
+
+  it("describes a direct menu trigger that opts out of the draggable titlebar region", () => {
+    expect(EXPLORER_SIDEBAR_CONFIGURATION_TRIGGER).toEqual({
+      kind: "menu",
+      labelKey: "workspace.git.actions.moreActions",
+      testID: "explorer-sidebar-configuration-menu-trigger",
+      titlebarStyle: {
+        WebkitAppRegion: "no-drag",
+      },
+    });
+  });
+
+  it("matches workspace plugin panels by their complete target identity", () => {
+    const firstTarget = {
+      kind: "plugin" as const,
+      pluginId: "example",
+      panelId: "first",
+      context: "workspace" as const,
+    };
+    const secondTarget = { ...firstTarget, panelId: "second" };
+    const firstItem: WorkspaceTabLaunchItem = {
+      id: "plugin:example:first",
+      label: "First",
+      disabled: false,
+      panelKind: "plugin",
+      toggleTarget: firstTarget,
+      launch: vi.fn(),
+    };
+    const secondItem: WorkspaceTabLaunchItem = {
+      id: "plugin:example:second",
+      label: "Second",
+      disabled: false,
+      panelKind: "plugin",
+      toggleTarget: secondTarget,
+      launch: vi.fn(),
+    };
+    const tabs: WorkspaceTabDescriptor[] = [
+      {
+        key: "plugin:example:first",
+        tabId: "first-tab",
+        kind: "plugin",
+        target: firstTarget,
+      },
+    ];
+
+    const entries = buildExplorerSidebarConfigurationEntries({
+      items: [firstItem, secondItem],
+      tabs,
+      paneId: "explorer",
+      onCloseTab: vi.fn(),
+    });
+
+    expect(entries.map((entry) => entry.selected)).toEqual([true, false]);
+  });
+});

--- a/packages/app/src/screens/workspace/explorer-sidebar-tab-configuration.ts
+++ b/packages/app/src/screens/workspace/explorer-sidebar-tab-configuration.ts
@@ -1,0 +1,51 @@
+import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+import { workspaceTabTargetsEqual } from "@/workspace-tabs/identity";
+import type { WorkspaceTabLaunchItem } from "@/workspace-tabs/launcher";
+
+export const EXPLORER_SIDEBAR_CONFIGURATION_TRIGGER = {
+  kind: "menu",
+  labelKey: "workspace.git.actions.moreActions",
+  testID: "explorer-sidebar-configuration-menu-trigger",
+  titlebarStyle: {
+    WebkitAppRegion: "no-drag",
+  },
+} as const;
+
+export interface ExplorerSidebarConfigurationEntry {
+  item: WorkspaceTabLaunchItem;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}
+
+export function buildExplorerSidebarConfigurationEntries({
+  items,
+  tabs,
+  paneId,
+  onCloseTab,
+}: {
+  items: readonly WorkspaceTabLaunchItem[];
+  tabs: readonly WorkspaceTabDescriptor[];
+  paneId: string;
+  onCloseTab: (tabId: string) => Promise<void> | void;
+}): ExplorerSidebarConfigurationEntry[] {
+  return items.map((item) => {
+    const target = item.toggleTarget;
+    const tab =
+      target === null
+        ? null
+        : (tabs.find((candidate) => workspaceTabTargetsEqual(target, candidate.target)) ?? null);
+    return {
+      item,
+      selected: Boolean(tab),
+      disabled: !tab && item.disabled,
+      onSelect: () => {
+        if (tab) {
+          void onCloseTab(tab.tabId);
+          return;
+        }
+        item.launch({ kind: "open", paneId });
+      },
+    };
+  });
+}

--- a/packages/app/src/screens/workspace/explorer-sidebar-tab-rail.tsx
+++ b/packages/app/src/screens/workspace/explorer-sidebar-tab-rail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState, type ComponentType, type ReactNode } from "react";
 import { Text, View } from "react-native";
-import { ArrowLeftToLine, Plus, X } from "lucide-react-native";
+import { ArrowLeftToLine, Ellipsis, Plus, X } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
 import Animated from "react-native-reanimated";
@@ -16,23 +16,27 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { DropdownMenu, DropdownMenuContent } from "@/components/ui/dropdown-menu";
+import { MenuItem, MenuSeparator } from "@/components/ui/menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { titlebarDragSurfaceStyle } from "@/components/desktop/titlebar-drag-region";
 import { WORKSPACE_SECONDARY_HEADER_HEIGHT } from "@/constants/layout";
 import { iconButtonChromeGlyphSize } from "@/components/ui/icon-button-chrome";
 import { HEADER_CONTROL_HEIGHT } from "@/components/ui/control-geometry";
+import { ToolbarButton } from "@/components/ui/pane-content-toolbar";
 import {
   WorkspaceTabIcon,
   WorkspaceTabPresentationResolver,
   type WorkspaceTabPresentation,
 } from "@/screens/workspace/workspace-tab-presentation";
+import {
+  buildExplorerSidebarConfigurationEntries,
+  EXPLORER_SIDEBAR_CONFIGURATION_TRIGGER,
+  type ExplorerSidebarConfigurationEntry,
+} from "@/screens/workspace/explorer-sidebar-tab-configuration";
 import type { WorkspaceDesktopTabRowItem } from "@/screens/workspace/workspace-desktop-tabs-row";
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
-import {
-  useWorkspaceTabLaunchCatalog,
-  type WorkspaceTabLaunchItem,
-} from "@/workspace-tabs/launcher";
-import { workspaceTabTargetsEqual } from "@/workspace-tabs/identity";
+import { useWorkspaceTabLaunchCatalog } from "@/workspace-tabs/launcher";
 import type { PanelIconProps } from "@/panels/panel-registry";
 import { panelTargetSupportsHost } from "@/plugins/workspace-panels/locations";
 import type { Theme } from "@/styles/theme";
@@ -209,46 +213,51 @@ function CatalogIcon({
 
 const ThemedCatalogIcon = withUnistyles(CatalogIcon);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
+const ThemedEllipsis = withUnistyles(Ellipsis);
 const ThemedPlus = withUnistyles(Plus);
 const ThemedX = withUnistyles(X);
 
-function ExplorerSidebarConfigurationItem({
-  item,
-  paneId,
-  tab,
-  onCloseTab,
-}: {
-  item: WorkspaceTabLaunchItem;
-  paneId: string;
-  tab: WorkspaceTabDescriptor | null;
-  onCloseTab: (tabId: string) => Promise<void> | void;
-}) {
+function ExplorerSidebarConfigurationItem({ entry }: { entry: ExplorerSidebarConfigurationEntry }) {
   const leading = useMemo(() => {
-    return item.Icon ? <ThemedCatalogIcon Icon={item.Icon} uniProps={mutedColorMapping} /> : null;
-  }, [item.Icon]);
-  const handleSelect = useCallback(() => {
-    if (tab) {
-      void onCloseTab(tab.tabId);
-      return;
-    }
-    item.launch({ kind: "open", paneId });
-  }, [item, onCloseTab, paneId, tab]);
+    return entry.item.Icon ? (
+      <ThemedCatalogIcon Icon={entry.item.Icon} uniProps={mutedColorMapping} />
+    ) : null;
+  }, [entry.item.Icon]);
 
   return (
-    <ContextMenuItem
+    <MenuItem
       leading={leading}
-      selected={Boolean(tab)}
+      selected={entry.selected}
       showSelectedCheck
-      disabled={!tab && item.disabled}
-      onSelect={handleSelect}
+      disabled={entry.disabled}
+      onSelect={entry.onSelect}
     >
-      {item.label}
-    </ContextMenuItem>
+      {entry.item.label}
+    </MenuItem>
   );
 }
 
-function catalogItemMatchesTab(item: WorkspaceTabLaunchItem, tab: WorkspaceTabDescriptor): boolean {
-  return item.toggleTarget !== null && workspaceTabTargetsEqual(item.toggleTarget, tab.target);
+function ExplorerSidebarConfigurationMenuItems({
+  entries,
+  onCreateNewTab,
+}: {
+  entries: ExplorerSidebarConfigurationEntry[];
+  onCreateNewTab: () => void;
+}) {
+  const { t } = useTranslation();
+  const newTabLeading = useMemo(() => <ThemedPlus size={14} uniProps={mutedColorMapping} />, []);
+
+  return (
+    <>
+      <MenuItem leading={newTabLeading} onSelect={onCreateNewTab}>
+        {t("workspace.tabs.actions.newTab")}
+      </MenuItem>
+      <MenuSeparator />
+      {entries.map((entry) => (
+        <ExplorerSidebarConfigurationItem key={entry.item.id} entry={entry} />
+      ))}
+    </>
+  );
 }
 
 export function ExplorerSidebarTabRail({
@@ -276,7 +285,16 @@ export function ExplorerSidebarTabRail({
     () => groups.flatMap((group) => group.items).filter((item) => item.toggleTarget !== null),
     [groups],
   );
-  const newTabLeading = useMemo(() => <ThemedPlus size={14} uniProps={mutedColorMapping} />, []);
+  const configurationEntries = useMemo(
+    () =>
+      buildExplorerSidebarConfigurationEntries({
+        items: singletonConfigurationItems,
+        tabs: tabs.map((item) => item.tab),
+        paneId,
+        onCloseTab,
+      }),
+    [onCloseTab, paneId, singletonConfigurationItems, tabs],
+  );
   const handleDragEnd = useCallback(
     (nextTabs: WorkspaceDesktopTabRowItem[]) => onReorderTabs(nextTabs.map((item) => item.tab)),
     [onReorderTabs],
@@ -366,24 +384,40 @@ export function ExplorerSidebarTabRail({
             rightStyle={scrollBoundary.rightShadeStyle}
           />
         </View>
+        <DropdownMenu>
+          <ToolbarButton
+            kind={EXPLORER_SIDEBAR_CONFIGURATION_TRIGGER.kind}
+            label={t(EXPLORER_SIDEBAR_CONFIGURATION_TRIGGER.labelKey)}
+            testID={EXPLORER_SIDEBAR_CONFIGURATION_TRIGGER.testID}
+            style={[
+              styles.configurationMenuTrigger,
+              EXPLORER_SIDEBAR_CONFIGURATION_TRIGGER.titlebarStyle as never,
+            ]}
+          >
+            <ThemedEllipsis size={14} uniProps={mutedColorMapping} />
+          </ToolbarButton>
+          <DropdownMenuContent
+            side="bottom"
+            align="end"
+            offset={4}
+            width={200}
+            testID="explorer-sidebar-tab-configuration"
+          >
+            <ExplorerSidebarConfigurationMenuItems
+              entries={configurationEntries}
+              onCreateNewTab={onCreateNewTab}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
         {trailingAccessory ? (
           <View style={styles.trailingAccessory}>{trailingAccessory}</View>
         ) : null}
       </ContextMenuTrigger>
       <ContextMenuContent align="start" minWidth={200} testID="explorer-sidebar-tab-configuration">
-        <ContextMenuItem leading={newTabLeading} onSelect={onCreateNewTab}>
-          {t("workspace.tabs.actions.newTab")}
-        </ContextMenuItem>
-        <ContextMenuSeparator />
-        {singletonConfigurationItems.map((item) => (
-          <ExplorerSidebarConfigurationItem
-            key={item.id}
-            item={item}
-            paneId={paneId}
-            tab={tabs.find(({ tab }) => catalogItemMatchesTab(item, tab))?.tab ?? null}
-            onCloseTab={onCloseTab}
-          />
-        ))}
+        <ExplorerSidebarConfigurationMenuItems
+          entries={configurationEntries}
+          onCreateNewTab={onCreateNewTab}
+        />
       </ContextMenuContent>
     </ContextMenu>
   );
@@ -408,6 +442,9 @@ const styles = StyleSheet.create((theme) => ({
     paddingHorizontal: 4,
   },
   trailingAccessory: {
+    marginRight: 4,
+  },
+  configurationMenuTrigger: {
     marginRight: 4,
   },
   tabSlot: {


### PR DESCRIPTION
### Linked issue

Closes #3889

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

On Windows Electron, the blank Explorer tab rail is a window drag region, so its renderer context-menu handler is not a reliable way to reach the Explorer configuration menu. After closing the singleton Files tab, users can be left with no discoverable way to restore it.

This change adds a direct More actions dropdown control that is excluded from the drag region. The dropdown and existing blank-area context menu consume the same configuration entries, so Files and Changes keep one toggle implementation while the rest of the rail remains draggable.

### Goals

- Make the Explorer configuration menu directly reachable without first opening another menu.
- Let users restore the singleton Files tab after closing it.
- Preserve the draggable non-interactive tab rail and existing per-tab context menus.
- Keep the dropdown and blank-area context menu configuration entries in sync.
- Add focused regression coverage for singleton restore and the direct no-drag trigger contract.

### Non-goals

- Change Electron drag-region behavior globally.
- Redesign Explorer tab persistence or lifecycle.
- Remove the existing blank-area context menu on platforms where it works.
- Change the Files or Changes panel implementations.

### QA

Reported Windows reproduction before the change:

1. Open Explorer with Files and Changes visible.
2. Close Files from its tab context menu.
3. Hide and reopen Explorer.
4. Right-click the blank tab rail area.
5. The configuration menu does not open, leaving Files unavailable through the normal UI.

Post-fix interaction recording:

https://github.com/user-attachments/assets/3aad5a13-8f9b-4f15-a3df-0acc491c59dd


Automated verification:

    npx vitest run packages/app/src/screens/workspace/explorer-sidebar-tab-configuration.test.ts --bail=1
    PASS: 1 file, 2 tests

    npm run format
    PASS: 4,086 files formatted/checked

    npm run lint
    PASS: 0 warnings, 0 errors

    npm run typecheck
    PASS: all workspaces

    git diff --check
    PASS

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Not manually tested |
| Android | No | Not manually tested |
| Web | No | Not manually tested |
| Desktop macOS | No | Not manually tested |
| Desktop Windows | Yes | Post-fix interaction verified; recording attached above |
| Desktop Linux | No | Not manually tested |

Manual Windows QA completed:

- [x] The More actions button opens directly with no other menu open.
- [x] Files can be closed and restored through the dropdown.
- [x] Blank rail space still drags the window.
- [x] Per-tab context menus still work.
- [x] The post-fix Windows recording is attached above.

### Checklist

- [x] One focused change
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
