### PR TITLE
fix: deduplicate runtime provider models

### DIFF
--- a/packages/app/src/command-center/agent-control-contributions.test.ts
+++ b/packages/app/src/command-center/agent-control-contributions.test.ts
@@ -200,6 +200,34 @@ describe("Command Center agent-control contributions", () => {
     expect(selections).toEqual(["claude:shared"]);
   });
 
+  it("deduplicates repeated model rows from one provider", () => {
+    const codex = provider({ id: "codex", label: "Codex" });
+    if (codex.modelSelection.kind !== "models") {
+      throw new Error("expected model selection rows");
+    }
+    const duplicate = {
+      ...codex,
+      modelSelection: {
+        ...codex.modelSelection,
+        rows: [...codex.modelSelection.rows, { ...codex.modelSelection.rows[0] }],
+      },
+    } satisfies ProviderSelectorProvider;
+
+    const contributions = buildAgentControlContributions(
+      makeSource({
+        models: {
+          providers: [duplicate],
+          selectedProvider: "codex",
+          selectedModelId: "shared",
+        },
+      }),
+    );
+
+    expect(contributions.filter((contribution) => contribution.group === "models")).toHaveLength(1);
+    expect(contributions[0]).toMatchObject({ id: "models:codex:shared" });
+    expect(selected(contributions[0])).toBe(true);
+  });
+
   it("publishes thinking choices only when selection is meaningful", () => {
     const selections: string[] = [];
     const contributions = buildAgentControlContributions(

--- a/packages/app/src/command-center/agent-control-contributions.ts
+++ b/packages/app/src/command-center/agent-control-contributions.ts
@@ -142,6 +142,7 @@ function buildContributions(
 
 function buildModelGroup(source: AgentControlContributionSource): CommandCenterChoiceGroup {
   const choices: CommandCenterChoice[] = [];
+  const choiceIds = new Set<string>();
   for (const provider of source.models.providers) {
     if (provider.modelSelection.kind !== "models") continue;
     const agentProvider = provider.id;
@@ -149,8 +150,15 @@ function buildModelGroup(source: AgentControlContributionSource): CommandCenterC
     for (const model of provider.modelSelection.rows) {
       if (!model.modelId) continue;
       const modelId = model.modelId;
+      const choiceId = `${provider.id}:${modelId}`;
+      // Runtime providers can temporarily expose the same model twice while a
+      // refreshed catalog replaces an older snapshot. Command Center choices
+      // use provider/model as their identity, so keep the first row rather than
+      // crashing the entire draft on duplicate upstream data.
+      if (choiceIds.has(choiceId)) continue;
+      choiceIds.add(choiceId);
       choices.push({
-        id: `${provider.id}:${modelId}`,
+        id: choiceId,
         path: [provider.label, model.modelLabel],
         keywords: [modelId],
         icon,

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -1697,6 +1697,24 @@ describe("model merging", () => {
 });
 
 describe("fetchCatalog", () => {
+  test("deduplicates repeated runtime model ids", async () => {
+    mockState.runtimeModels.set("codex", [
+      { provider: "codex", id: "shared-runtime", label: "First Runtime Label" },
+      { provider: "codex", id: "shared-runtime", label: "Duplicate Runtime Label" },
+    ]);
+
+    const registry = buildProviderRegistry(logger);
+    const catalog = await registry.codex.fetchCatalog({
+      scope: "workspace",
+      cwd: "/tmp/catalog",
+      force: false,
+    });
+
+    expect(catalog.models).toEqual([
+      { provider: "codex", id: "shared-runtime", label: "First Runtime Label" },
+    ]);
+  });
+
   test("returns merged models and modes from fetchCatalog", async () => {
     mockState.runtimeModels.set("codex", [
       { provider: "codex", id: "codex-runtime", label: "Codex Runtime" },

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -394,11 +394,21 @@ function mergeModelAdditions(
   baseModels: AgentModelDefinition[],
   modelAdditions: Array<ProviderProfileModel | AgentModelDefinition>,
 ): AgentModelDefinition[] {
+  // Runtime catalogs are external data and can temporarily contain the same
+  // model more than once while a provider refreshes its snapshot. Preserve the
+  // first row deterministically so every downstream provider/model identity is
+  // unique even when no configured model additions are present.
+  const mergedModels: AgentModelDefinition[] = [];
+  const modelIds = new Set<string>();
+  for (const model of baseModels) {
+    if (modelIds.has(model.id)) continue;
+    modelIds.add(model.id);
+    mergedModels.push(model);
+  }
   if (modelAdditions.length === 0) {
-    return baseModels;
+    return mergedModels;
   }
 
-  const mergedModels = [...baseModels];
   let hasAdditionalDefault = false;
 
   for (const model of modelAdditions) {


### PR DESCRIPTION
## Summary

- deduplicate runtime provider catalogs by model ID at the server boundary
- deduplicate provider/model choices again before registering Command Center contributions
- preserve the first row deterministically
- add server and app regression coverage reproducing the duplicate draft crash

## Why

A duplicated runtime model row currently survives `mergeModelAdditions()` whenever there are no configured additions. The app emits two identical `models:<provider>:<model>` contributions, and `createCommandCenterRegistry().replace()` crashes the entire draft. Provider catalogs are external/runtime data; normalize them at ingestion and retain a UI boundary guard.

Real reproduction:

```text
Duplicate Command Center contribution id: draft:srv_GX70W9ylO4mM:draft_msg_1787727628342_j94q8v8bl:models:codex:claude-opus-4-6
```

## Test plan

```text
packages/server/src/server/agent/provider-registry.test.ts
packages/app/src/command-center/registry.test.ts
packages/app/src/command-center/agent-control-contributions.test.ts

3 files passed; 63 tests passed
```