### PR TITLE
fix(cli): use cross-platform Node shebang

### DIFF
--- a/packages/cli/bin/paseo
+++ b/packages/cli/bin/paseo
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --disable-warning=DEP0040
+#!/usr/bin/env node
 import '../dist/index.js'
 

--- a/packages/cli/src/bin-entrypoint.test.ts
+++ b/packages/cli/src/bin-entrypoint.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const entrypoint = fileURLToPath(new URL("../bin/paseo", import.meta.url));
+
+describe("CLI bin entrypoint", () => {
+  it("uses a cross-platform Node shebang", () => {
+    const [shebang] = readFileSync(entrypoint, "utf8").split(/\r?\n/u);
+
+    expect(shebang).toBe("#!/usr/bin/env node");
+  });
+});


### PR DESCRIPTION
## Summary

- replace `#!/usr/bin/env -S node --disable-warning=DEP0040` with `#!/usr/bin/env node`
- add a regression test for the published CLI entrypoint

## Why

Bun-generated Windows shims treat `-S` as the interpreter executable and every command fails before startup:

```text
error: interpreter executable "-S" not found in %PATH%
Bun failed to remap this bin to its proper location within node_modules.
```

The Node warning flag is nonessential; the plain shebang works on Windows and POSIX.

## Test plan

```text
packages/cli/src/bin-entrypoint.test.ts: 1 passed
```