### PR TITLE
fix(claude): add a selectable Opus 5 1M model entry

### DIFF
--- a/packages/cli/tests/15-provider.test.ts
+++ b/packages/cli/tests/15-provider.test.ts
@@ -58,6 +58,11 @@ const EXPECTED_CLAUDE_MODELS = [
     descriptionFragment: "Latest release",
   },
   {
+    id: "claude-opus-5[1m]",
+    model: "Opus 5 1M",
+    descriptionFragment: "1M context window",
+  },
+  {
     id: "claude-fable-5",
     model: "Fable 5",
     descriptionFragment: "Most powerful",

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -425,6 +425,7 @@ describe("ClaudeAgentClient.fetchCatalog", () => {
 
       expect(models.map((m) => m.id)).toEqual([
         "claude-opus-5",
+        "claude-opus-5[1m]",
         "claude-fable-5",
         "claude-fable-5[1m]",
         "claude-opus-4-8[1m]",

--- a/packages/server/src/server/agent/providers/claude/model-manifest.ts
+++ b/packages/server/src/server/agent/providers/claude/model-manifest.ts
@@ -46,6 +46,16 @@ export const CLAUDE_MODEL_MANIFEST = [
     supportsFastMode: true,
   },
   {
+    id: "claude-opus-5[1m]",
+    label: "Opus 5 1M",
+    description: "Opus 5 with 1M context window",
+    minimumClaudeCodeVersion: "2.1.219",
+    contextWindowMaxTokens: 1_000_000,
+    effortLevels: CLAUDE_EFFORT_LEVELS.xhigh,
+    supportsThinkingDisabled: true,
+    supportsFastMode: true,
+  },
+  {
     id: "claude-fable-5",
     // COMPAT(claudeFable5OneMillionId): added in v0.3.0, remove after 2027-02-06 once pre-v0.3.0 app preferences are outside support.
     aliases: ["claude-fable-5[1m]"],

--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -51,6 +51,7 @@ describe("getClaudeModels", () => {
     const models = getClaudeModels();
     expect(models.map((m) => m.id)).toEqual([
       "claude-opus-5",
+      "claude-opus-5[1m]",
       "claude-fable-5",
       "claude-fable-5[1m]",
       "claude-opus-4-8[1m]",
@@ -82,6 +83,7 @@ describe("getClaudeModels", () => {
     expect(contextWindows).toEqual(
       new Map([
         ["claude-opus-5", 1_000_000],
+        ["claude-opus-5[1m]", 1_000_000],
         ["claude-fable-5", 1_000_000],
         ["claude-fable-5[1m]", 1_000_000],
         ["claude-opus-4-8[1m]", 1_000_000],
@@ -430,24 +432,41 @@ describe("findClaudeModel", () => {
 });
 
 describe("Claude Opus 5 catalog", () => {
-  it("offers a single Opus 5 entry with a 1M context window", () => {
+  it("offers both Opus 5 spellings as selectable entries", () => {
     const opus5Models = getClaudeModels()
       .filter((model) => model.id.startsWith("claude-opus-5"))
-      .map(({ id, label, contextWindowMaxTokens }) => ({ id, label, contextWindowMaxTokens }));
+      .map(({ id, isSelectable, label, contextWindowMaxTokens }) => ({
+        id,
+        isSelectable,
+        label,
+        contextWindowMaxTokens,
+      }));
 
     expect(opus5Models).toEqual([
-      { id: "claude-opus-5", label: "Opus 5", contextWindowMaxTokens: 1_000_000 },
+      {
+        id: "claude-opus-5",
+        isSelectable: undefined,
+        label: "Opus 5",
+        contextWindowMaxTokens: 1_000_000,
+      },
+      {
+        id: "claude-opus-5[1m]",
+        isSelectable: undefined,
+        label: "Opus 5 1M",
+        contextWindowMaxTokens: 1_000_000,
+      },
     ]);
   });
 
-  it("resolves retired and dated Opus 5 IDs to the single catalog entry", () => {
-    expect(findClaudeModel("claude-opus-5[1m]")?.id).toBe("claude-opus-5");
+  it("resolves each Opus 5 spelling, dated or not, to its own catalog entry", () => {
+    expect(findClaudeModel("claude-opus-5")?.id).toBe("claude-opus-5");
+    expect(findClaudeModel("claude-opus-5[1m]")?.id).toBe("claude-opus-5[1m]");
     expect(findClaudeModel("claude-opus-5-20260724")?.id).toBe("claude-opus-5");
-    expect(findClaudeModel("claude-opus-5-20260724[1m]")?.id).toBe("claude-opus-5");
+    expect(findClaudeModel("claude-opus-5-20260724[1m]")?.id).toBe("claude-opus-5[1m]");
     expect(findClaudeModel("claude-opus-5[1m]")?.contextWindowMaxTokens).toBe(1_000_000);
   });
 
-  it("keeps disabled thinking available for agents persisted on the retired 1M ID", () => {
+  it("keeps disabled thinking available on the 1M ID", () => {
     expect(resolveClaudeDisabledThinkingForModel("claude-opus-5[1m]")).toEqual({
       supported: true,
       fallbackThinkingOptionId: "high",


### PR DESCRIPTION
## Problem

#3000: since v0.2.4, Opus 5 at 1M context cannot be selected from the model
picker, and the remaining `claude-opus-5` entry advertises a window that
third-party endpoints do not deliver.

#2497 (`f91a984`) removed the `claude-opus-5[1m]` manifest entry and flipped the
plain entry from `200_000` to `1_000_000`, on the premise that Opus 5 is always 1M.

That premise holds on a first-party endpoint, where Claude Code resolves Opus 5's
native 1M window without the suffix. It does not hold when `ANTHROPIC_BASE_URL`
points at a gateway or proxy: the client only sends the `context-1m-2025-08-07`
beta for the suffixed id, so a picker-started session runs at 200k while the
catalog says 1M.

Every other family already ships both spellings — `claude-sonnet-5` beside
`claude-sonnet-5[1m]`, same for opus-4-8, 4-7 and 4-6. Opus 5 is the only one
that lost its 1M entry.

## Fix

Add `claude-opus-5[1m]` back as its own manifest entry, same shape as the other
paired families. `claude-opus-5` keeps `defaultPriority: 2`, so the default
selection is unchanged.

No alias is added: a real entry already makes a persisted `claude-opus-5[1m]`
preference resolve to itself, which is the only thing an alias would have bought.

## Relationship to #3727

#3727 targets the same bug but adds `aliases: ["claude-opus-5[1m]"]` on the plain
entry *and* a separate `claude-opus-5[1m]` manifest entry. Those collide:
`getClaudeManifestModels()` emits one definition per alias *and* one per manifest
entry, so the catalog ends up with a duplicate id. Running that branch:

```
entries whose id startsWith 'claude-opus-5': 3
   id="claude-opus-5"     label="Opus 5"    isSelectable=undefined isDefault=true
   id="claude-opus-5[1m]" label="Opus 5"    isSelectable=false
   id="claude-opus-5[1m]" label="Opus 5 1M" isSelectable=undefined
DUPLICATE ids in catalog: [["claude-opus-5[1m]",2]]
```

Its own updated assertions expect two Opus 5 entries, so those tests do not pass
as written. No checks have run on that branch.

## QA evidence

Platform: macOS (Darwin 25.6.0), Node 24.19.0. Server + CLI only; no app/UI code
is touched by this change, so no screenshots.

```
packages/server $ CLAUDE_CONFIG_DIR=<empty> npx vitest run \
    src/server/agent/providers/claude/models.test.ts
Test Files  1 passed (1)      Tests  37 passed (37)

packages/server $ CLAUDE_CONFIG_DIR=<empty> npx vitest run \
    src/server/agent/providers/claude/agent.test.ts
Test Files  1 passed (1)      Tests  74 passed (74)

packages/cli $ npx tsx tests/15-provider.test.ts
✓ Test 6: provider models claude lists canonical model aliases

packages/server $ npm run typecheck      # exit 0
$ npm run lint -- <the four changed files>   # 0 warnings, 0 errors
```

Note on `models.test.ts`: `createCatalogClient` does not pass `configDir`, so
`getClaudeModelsWithSettings` reads the *real* `~/.claude/settings.json` of
whoever runs the suite. On a machine that sets `ANTHROPIC_DEFAULT_OPUS_MODEL`,
`addSettingsModel` injects that id and the version-gating test fails — on
unmodified `main` too. Not touched here; flagging it as a separate pre-existing
issue.
