### PR TITLE
feat(plugin): expose semantic surface, border, and status tokens to PluginTheme

### DIFF
--- a/packages/app/src/plugins/theme.test.ts
+++ b/packages/app/src/plugins/theme.test.ts
@@ -64,10 +64,15 @@ describe("toPluginTheme", () => {
     expect(toPluginTheme(lightTheme)).toEqual({
       colors: {
         surface0: lightTheme.colors.surface0,
+        surface1: lightTheme.colors.surface1,
+        surface2: lightTheme.colors.surface2,
+        border: lightTheme.colors.border,
         foreground: lightTheme.colors.foreground,
         foregroundMuted: lightTheme.colors.foregroundMuted,
         accent: lightTheme.colors.accent,
         accentForeground: lightTheme.colors.accentForeground,
+        statusSuccess: lightTheme.colors.statusSuccess,
+        statusWarning: lightTheme.colors.statusWarning,
         statusDanger: lightTheme.colors.statusDanger,
       },
     });

--- a/packages/app/src/plugins/theme.ts
+++ b/packages/app/src/plugins/theme.ts
@@ -5,10 +5,15 @@ export function toPluginTheme(theme: Theme): PluginTheme {
   return {
     colors: {
       surface0: theme.colors.surface0,
+      surface1: theme.colors.surface1,
+      surface2: theme.colors.surface2,
+      border: theme.colors.border,
       foreground: theme.colors.foreground,
       foregroundMuted: theme.colors.foregroundMuted,
       accent: theme.colors.accent,
       accentForeground: theme.colors.accentForeground,
+      statusSuccess: theme.colors.statusSuccess,
+      statusWarning: theme.colors.statusWarning,
       statusDanger: theme.colors.statusDanger,
     },
   };

--- a/packages/cli/src/commands/plugin/scaffold.ts
+++ b/packages/cli/src/commands/plugin/scaffold.ts
@@ -81,10 +81,15 @@ declare module "@getpaseo/plugin" {
   export interface PluginTheme {
     readonly colors: {
       readonly surface0: string;
+      readonly surface1: string;
+      readonly surface2: string;
+      readonly border: string;
       readonly foreground: string;
       readonly foregroundMuted: string;
       readonly accent: string;
       readonly accentForeground: string;
+      readonly statusSuccess: string;
+      readonly statusWarning: string;
       readonly statusDanger: string;
     };
   }

--- a/packages/plugin/src/contracts.ts
+++ b/packages/plugin/src/contracts.ts
@@ -6,10 +6,15 @@ import type { PluginRpcContract } from "./rpc.js";
 export interface PluginTheme {
   readonly colors: {
     readonly surface0: string;
+    readonly surface1: string;
+    readonly surface2: string;
+    readonly border: string;
     readonly foreground: string;
     readonly foregroundMuted: string;
     readonly accent: string;
     readonly accentForeground: string;
+    readonly statusSuccess: string;
+    readonly statusWarning: string;
     readonly statusDanger: string;
   };
 }

--- a/public-docs/plugins/reference.md
+++ b/public-docs/plugins/reference.md
@@ -156,8 +156,13 @@ Recreate styles when `theme` or `layout.compact` changes.
 | `theme.colors.foreground`       | Every primary `Text`       | Titles and body copy                |
 | `theme.colors.foregroundMuted`  | Secondary `Text`           | Labels and supporting copy          |
 | `theme.colors.surface0`         | Root view                  | Panel background                    |
+| `theme.colors.surface1`         | Raised surfaces            | Cards and panels                    |
+| `theme.colors.surface2`         | Control surfaces           | Inputs and secondary controls       |
+| `theme.colors.border`           | Surface boundaries         | Borders and dividers                |
 | `theme.colors.accent`           | Primary action fills       | Buttons and selected states         |
 | `theme.colors.accentForeground` | Text on an accent fill     | Button labels                       |
+| `theme.colors.statusSuccess`    | Success feedback           | Success messages and indicators     |
+| `theme.colors.statusWarning`    | Warning feedback           | Warning messages and indicators     |
 | `theme.colors.statusDanger`     | Failure copy               | Error messages and destructive text |
 | `layout.compact`                | Padding and stacking       | `true` on mobile and narrow windows |
 | `layout.platform`               | Platform-specific behavior | `ios`, `android`, or `web`          |


### PR DESCRIPTION
## Problem

Plugins currently receive too few semantic colors to distinguish root, raised, and control surfaces or render success and warning states. They must reconstruct host theme variants themselves.

Fixes #3746

## Changes

- Add readonly `surface1`, `surface2`, `border`, `statusSuccess`, and `statusWarning` fields to `PluginTheme.colors`.
- Map each field directly from the active host theme.
- Keep the CLI-generated declaration and public plugin reference aligned.

This is additive. Existing tokens are unchanged, existing plugin bundles continue to use them, and newer plugins can opt into the additional semantic colors.

## QA evidence

### Typecheck

```text
$ npm run typecheck

> paseo@0.5.2 typecheck
> npm run typecheck --workspaces --if-present
> @getpaseo/expo-two-way-audio@0.5.2 typecheck
> tsgo --noEmit
> @getpaseo/highlight@0.5.2 typecheck
> tsgo --noEmit
> @getpaseo/plugin@0.5.2 typecheck
> tsgo --noEmit && tsgo -p tsconfig.examples.json --noEmit
> @getpaseo/protocol@0.5.2 pretypecheck
> npm run generate:validators
> @getpaseo/protocol@0.5.2 generate:validators
> node scripts/generate-validation-aot.mjs
generated src/generated/validation/ws-outbound.aot.ts from codegen/ws-outbound.compile.ts (WSOutboundMessageSchema)
> @getpaseo/protocol@0.5.2 typecheck
> tsgo --noEmit
> @getpaseo/client@0.5.2 typecheck
> tsgo --noEmit
> @getpaseo/server@0.5.2 typecheck
> tsgo -p tsconfig.server.typecheck.json --noEmit
> @getpaseo/app@0.5.2 typecheck
> tsgo --noEmit
> @getpaseo/relay@0.5.2 typecheck
> tsgo --noEmit
> @getpaseo/website@0.5.2 typecheck
> tsgo --noEmit
> @getpaseo/desktop@0.5.2 typecheck
> tsgo --noEmit -p tsconfig.json
> @getpaseo/cli@0.5.2 typecheck
> tsgo --noEmit
```

### Lint

```text
$ npm run lint

> paseo@0.5.2 lint
> oxlint

Found 0 warnings and 0 errors.
Finished in 1.1s on 3796 files with 177 rules using 16 threads.
```

### Targeted test

```text
$ cd packages/app && npx vitest run src/plugins/theme.test.ts --bail=1

 RUN  v4.1.7 /home/omer/.paseo/worktrees/09uv9x51/feat-plugin-theme-semantic-tokens/packages/app

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  13:04:30
   Duration  1.28s (transform 835ms, setup 38ms, import 1.15s, tests 6ms, environment 0ms)
```

## Platforms tested

tests + typecheck only; no UI change — mapping is platform-independent