### PR TITLE
feat(client): expose paseo.projects.list() through the public SDK

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -139,8 +139,8 @@ RPC contracts validate inputs and outputs in both the app and plugin subprocess.
 typed async function. Use the host-provided `@tanstack/react-query` for request state and caching;
 Paseo gives each plugin installation its own query client.
 
-`usePaseo()` and the handler's `{ paseo }` context expose the same `PaseoApi`: workspaces, agents,
-providers, and daemon config. They do not expose connection lifecycle. A surface borrows the
+`usePaseo()` and the handler's `{ paseo }` context expose the same `PaseoApi`: projects,
+workspaces, agents, providers, and daemon config. They do not expose connection lifecycle. A surface borrows the
 selected host's existing connection; switching the screen's host changes both `usePaseo()` and
 `useRpc()` to that host. An offline selected host fails there and never falls through to another
 installation. A server handler owns an IPC-backed daemon session for the life of its subprocess.

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -63,6 +63,7 @@ function parseSentSessionMessage(data: string | ArrayBuffer | Uint8Array | undef
   draftConfig?: unknown;
   filter?: unknown;
   page?: unknown;
+  sync?: unknown;
   text?: string;
 } {
   if (typeof data !== "string") {
@@ -224,10 +225,82 @@ test("createPaseoApi borrows daemon capabilities without exposing connection own
 
   const paseo = createPaseoApi(daemonClient);
 
-  expect(Object.keys(paseo).sort()).toEqual(["agents", "config", "providers", "workspaces"]);
+  expect(Object.keys(paseo).sort()).toEqual([
+    "agents",
+    "config",
+    "projects",
+    "providers",
+    "workspaces",
+  ]);
   expect("connect" in paseo).toBe(false);
   expect("close" in paseo).toBe(false);
   expect("skills" in paseo.agents).toBe(false);
+});
+
+test("project actions list registered projects through the existing RPC", async () => {
+  const { client, ws } = await connectClient();
+
+  const listPromise = client.projects.list({
+    requestId: "projects-list-request",
+    sync: { generation: "daemon-generation", afterSeq: 7 },
+  });
+  expect(parseSentSessionMessage(ws.sent.at(-1))).toMatchObject({
+    type: "project.list.request",
+    requestId: "projects-list-request",
+    sync: { generation: "daemon-generation", afterSeq: 7 },
+  });
+
+  ws.message(
+    sessionMessage({
+      type: "project.list.response",
+      payload: {
+        requestId: "projects-list-request",
+        projects: [
+          {
+            projectId: "project_sdk",
+            projectKey: "sdk",
+            projectDisplayName: "SDK",
+            projectCustomName: null,
+            projectCustomIconRevision: null,
+            projectIconRevision: "icon-revision",
+            projectRootPath: "/repo/sdk",
+            projectKind: "git",
+            syncSeq: 8,
+          },
+        ],
+        sync: {
+          generation: "daemon-generation",
+          headSeq: 8,
+          mode: "changes",
+          removals: [],
+        },
+      },
+    }),
+  );
+
+  await expect(listPromise).resolves.toEqual({
+    requestId: "projects-list-request",
+    projects: [
+      {
+        projectId: "project_sdk",
+        projectKey: "sdk",
+        projectDisplayName: "SDK",
+        projectCustomName: null,
+        projectCustomIconRevision: null,
+        projectIconRevision: "icon-revision",
+        projectRootPath: "/repo/sdk",
+        projectKind: "git",
+        syncSeq: 8,
+      },
+    ],
+    sync: {
+      generation: "daemon-generation",
+      headSeq: 8,
+      mode: "changes",
+      removals: [],
+    },
+  });
+  await client.close();
 });
 
 test("agent actions list the daemon directory without exposing the low-level client", async () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -8,11 +8,14 @@ import type {
   ListProviderFeaturesRequestMessage,
   ListProviderFeaturesResponseMessage,
   ListProviderModelsResponseMessage,
+  ProjectListRequestMessage,
+  ProjectListResponseMessage,
   ListProviderModesResponseMessage,
   MutableDaemonConfig,
   MutableDaemonConfigPatch,
   ProviderDiagnosticResponseMessage,
   ProjectPlacementPayload,
+  WorkspaceProjectDescriptorPayload,
   RefreshProvidersSnapshotResponseMessage,
   SendAgentMessageRequest,
   SessionOutboundMessage,
@@ -77,6 +80,11 @@ export interface PaseoClientConfig {
 export type PaseoWorkspace = WorkspaceDescriptorPayload;
 export type PaseoAgent = AgentSnapshotPayload;
 export type PaseoAgentListOptions = FetchAgentsOptions;
+export type PaseoProject = WorkspaceProjectDescriptorPayload;
+export type PaseoProjectListOptions = Omit<ProjectListRequestMessage, "type" | "requestId"> & {
+  requestId?: string;
+};
+export type PaseoProjectListResult = ProjectListResponseMessage["payload"];
 
 export interface PaseoAgentListResult {
   requestId: string;
@@ -141,6 +149,10 @@ export interface PaseoWorkspaceHandle {
    * the daemon should start streaming workspace directory updates.
    */
   subscribe(handler: (update: PaseoWorkspaceUpdate) => void): () => void;
+}
+
+export interface PaseoProjectActions {
+  list(options?: PaseoProjectListOptions): Promise<PaseoProjectListResult>;
 }
 
 export interface PaseoWorkspaceActions {
@@ -356,6 +368,7 @@ export interface PaseoConfigActions {
 
 export interface PaseoApi {
   readonly workspaces: PaseoWorkspaceActions;
+  readonly projects: PaseoProjectActions;
   readonly agents: PaseoAgentActions;
   readonly providers: PaseoProviderActions;
   readonly config: PaseoConfigActions;
@@ -412,6 +425,9 @@ export function createPaseoApi(daemonClient: DaemonClient): PaseoApi {
   const createWorkspaceHandle = createWorkspaceHandleFactory(daemonClient, createAgent);
 
   return {
+    projects: {
+      list: (options) => daemonClient.listProjects(options),
+    },
     workspaces: {
       list: (options) => daemonClient.fetchWorkspaces(options),
       ref: (workspace) => createWorkspaceHandle(workspace),

--- a/public-docs/plugins/reference.md
+++ b/public-docs/plugins/reference.md
@@ -426,7 +426,7 @@ function PullRequestAction() {
 }
 ```
 
-The returned API covers workspaces, agents, providers, and daemon config. See the [SDK API reference](/docs/sdk/reference) for its methods. Connection lifecycle methods are intentionally absent because Paseo owns the connection.
+The returned API covers projects, workspaces, agents, providers, and daemon config. See the [SDK API reference](/docs/sdk/reference) for its methods. Connection lifecycle methods are intentionally absent because Paseo owns the connection.
 
 ## Add plugin-specific backend behavior
 

--- a/public-docs/sdk/reference.md
+++ b/public-docs/sdk/reference.md
@@ -95,6 +95,12 @@ Creation options include `config`, `cwd`, `parent`, `title`, `prompt`, `env`, `o
 
 `agent.timeline.subscribe(handler)` listens for stream events belonging to the agent and returns a local unsubscribe function.
 
+## `client.projects`
+
+| Method           | Result                   | Behavior                                                                      |
+| ---------------- | ------------------------ | ----------------------------------------------------------------------------- |
+| `list(options?)` | `PaseoProjectListResult` | Lists every registered project, including projects with no active workspaces. |
+
 ## `client.workspaces`
 
 | Method                   | Result                        | Behavior                                                                          |


### PR DESCRIPTION
## Problem

Plugins have to infer projects from active workspaces, so they miss registered projects that have no active workspaces.

## Change

Expose `paseo.projects.list()` through the public SDK. This only surfaces the existing `project.list` RPC; it adds no protocol messages or daemon behavior.

Fixes #3834

## QA evidence

```text
$ npm run typecheck
> paseo@0.5.2 typecheck
> npm run typecheck --workspaces --if-present
...
> @getpaseo/cli@0.5.2 typecheck
> tsgo --noEmit

$ npm run lint
> paseo@0.5.2 lint
> oxlint

Found 0 warnings and 0 errors.
Finished in 664ms on 3796 files with 177 rules using 16 threads.

$ npx vitest run packages/client/src/index.test.ts --bail=1
Test Files  1 passed (1)
Tests  12 passed (12)
Duration  3.59s
```

## Platforms tested

SDK-only and platform-independent. Verified through the client SDK unit test and repository-wide typecheck and lint.
