### PR TITLE
fix(desktop): make desktop-settings.json forward-compatible

### DIFF
--- a/packages/desktop/src/settings/desktop-settings.test.ts
+++ b/packages/desktop/src/settings/desktop-settings.test.ts
@@ -278,4 +278,89 @@ describe("desktop-settings", () => {
     });
     expect(ignoredSecondMigration).toEqual(migrated);
   });
+
+  it("keeps keys written by another build across a patch", async () => {
+    const userDataPath = await createTempUserDataDir();
+    directories.add(userDataPath);
+    await writeFile(
+      settingsFilePath(userDataPath),
+      JSON.stringify({
+        version: 1,
+        futureDocumentKey: "kept",
+        settings: {
+          releaseChannel: "beta",
+          tray: { enabled: true },
+          daemon: { manageBuiltInDaemon: true, keepRunningAfterQuit: false, futureFlag: 7 },
+        },
+        migrations: {
+          legacyRendererSettingsImported: true,
+          daemonStopOnQuitDefaultApplied: true,
+          futureMigrationApplied: true,
+        },
+      }),
+    );
+    const store = createDesktopSettingsStore({ userDataPath });
+
+    const next = await store.patch({ notifications: { playSound: false } });
+    const persisted = JSON.parse(await readFile(settingsFilePath(userDataPath), "utf8")) as {
+      futureDocumentKey: string;
+      settings: { releaseChannel: string; tray: unknown; daemon: Record<string, unknown> };
+      migrations: Record<string, boolean>;
+    };
+
+    expect(persisted.settings.tray).toEqual({ enabled: true });
+    expect(persisted.settings.daemon.futureFlag).toBe(7);
+    expect(persisted.migrations.futureMigrationApplied).toBe(true);
+    expect(persisted.futureDocumentKey).toBe("kept");
+    expect(persisted.settings.releaseChannel).toBe("beta");
+    expect(next).toEqual({
+      releaseChannel: "beta",
+      notifications: { playSound: false },
+      daemon: { manageBuiltInDaemon: true, keepRunningAfterQuit: false },
+    });
+  });
+
+  it("keeps keys written by another build across the legacy renderer migration", async () => {
+    const userDataPath = await createTempUserDataDir();
+    directories.add(userDataPath);
+    await writeFile(
+      settingsFilePath(userDataPath),
+      JSON.stringify({
+        version: 1,
+        settings: { tray: { enabled: true } },
+        migrations: { legacyRendererSettingsImported: false, daemonStopOnQuitDefaultApplied: true },
+      }),
+    );
+    const store = createDesktopSettingsStore({ userDataPath });
+
+    await store.migrateLegacyRendererSettings({ releaseChannel: "beta" });
+    const persisted = JSON.parse(await readFile(settingsFilePath(userDataPath), "utf8")) as {
+      settings: { releaseChannel: string; tray: unknown };
+    };
+
+    expect(persisted.settings.tray).toEqual({ enabled: true });
+    expect(persisted.settings.releaseChannel).toBe("beta");
+  });
+
+  it("replaces an unusable modelled value on the write path", async () => {
+    const userDataPath = await createTempUserDataDir();
+    directories.add(userDataPath);
+    await writeFile(
+      settingsFilePath(userDataPath),
+      JSON.stringify({
+        version: 1,
+        settings: { releaseChannel: "nightly", tray: { enabled: true } },
+        migrations: { legacyRendererSettingsImported: true, daemonStopOnQuitDefaultApplied: true },
+      }),
+    );
+    const store = createDesktopSettingsStore({ userDataPath });
+
+    await store.patch({ notifications: { playSound: false } });
+    const persisted = JSON.parse(await readFile(settingsFilePath(userDataPath), "utf8")) as {
+      settings: { releaseChannel: string; tray: unknown };
+    };
+
+    expect(persisted.settings.releaseChannel).toBe("stable");
+    expect(persisted.settings.tray).toEqual({ enabled: true });
+  });
 });

--- a/packages/desktop/src/settings/desktop-settings.ts
+++ b/packages/desktop/src/settings/desktop-settings.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { z } from "zod";
+
 import type { AppReleaseChannel } from "../features/auto-updater.js";
 
 export interface DesktopSettings {
@@ -19,19 +21,6 @@ interface DesktopSettingsPatch {
   releaseChannel?: AppReleaseChannel;
   notifications?: Partial<DesktopSettings["notifications"]>;
   daemon?: Partial<DesktopSettings["daemon"]>;
-}
-
-interface PersistedDesktopSettingsDocument {
-  version: 1;
-  settings: DesktopSettings;
-  migrations: {
-    legacyRendererSettingsImported: boolean;
-    // Installs created before the stop-on-quit default persisted the old
-    // `keepRunningAfterQuit: true` default to disk, so the new default alone
-    // would only reach fresh installs. Reset it once; a later explicit toggle
-    // persists this flag and is never overridden again.
-    daemonStopOnQuitDefaultApplied: boolean;
-  };
 }
 
 export interface DesktopSettingsStore {
@@ -53,18 +42,57 @@ export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
 
 const DESKTOP_SETTINGS_FILENAME = "desktop-settings.json";
 
+const ReleaseChannelSchema = z.enum(["stable", "beta"]);
+
+const NotificationsSchema = z
+  .looseObject({
+    playSound: z.boolean().catch(DEFAULT_DESKTOP_SETTINGS.notifications.playSound),
+  })
+  .catch(() => ({ ...DEFAULT_DESKTOP_SETTINGS.notifications }));
+
+const DaemonSchema = z
+  .looseObject({
+    manageBuiltInDaemon: z.boolean().catch(DEFAULT_DESKTOP_SETTINGS.daemon.manageBuiltInDaemon),
+    keepRunningAfterQuit: z.boolean().catch(DEFAULT_DESKTOP_SETTINGS.daemon.keepRunningAfterQuit),
+  })
+  .catch(() => ({ ...DEFAULT_DESKTOP_SETTINGS.daemon }));
+
+const DesktopSettingsSchema = z
+  .looseObject({
+    releaseChannel: ReleaseChannelSchema.catch(DEFAULT_DESKTOP_SETTINGS.releaseChannel),
+    notifications: NotificationsSchema,
+    daemon: DaemonSchema,
+  })
+  .catch(() => buildDefaultSettings());
+
+const MigrationsSchema = z
+  .looseObject({
+    legacyRendererSettingsImported: z.boolean().catch(false),
+    daemonStopOnQuitDefaultApplied: z.boolean().catch(false),
+  })
+  .catch(() => ({
+    legacyRendererSettingsImported: false,
+    daemonStopOnQuitDefaultApplied: false,
+  }));
+
+const PersistedDocumentSchema = z
+  .looseObject({
+    version: z.literal(1).catch(1),
+    settings: DesktopSettingsSchema,
+    migrations: MigrationsSchema,
+  })
+  .catch(() => buildDefaultDocument());
+
+type StoredDesktopSettings = z.output<typeof DesktopSettingsSchema>;
+type PersistedDesktopSettingsDocument = z.output<typeof PersistedDocumentSchema>;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function coerceReleaseChannel(value: unknown): AppReleaseChannel | null {
-  if (value === "beta") {
-    return "beta";
-  }
-  if (value === "stable") {
-    return "stable";
-  }
-  return null;
+  const result = ReleaseChannelSchema.safeParse(value);
+  return result.success ? result.data : null;
 }
 
 function coerceBoolean(value: unknown): boolean | null {
@@ -75,14 +103,18 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error;
 }
 
+function buildDefaultSettings(): StoredDesktopSettings {
+  return {
+    releaseChannel: DEFAULT_DESKTOP_SETTINGS.releaseChannel,
+    notifications: { ...DEFAULT_DESKTOP_SETTINGS.notifications },
+    daemon: { ...DEFAULT_DESKTOP_SETTINGS.daemon },
+  };
+}
+
 function buildDefaultDocument(): PersistedDesktopSettingsDocument {
   return {
     version: 1,
-    settings: {
-      releaseChannel: DEFAULT_DESKTOP_SETTINGS.releaseChannel,
-      notifications: { ...DEFAULT_DESKTOP_SETTINGS.notifications },
-      daemon: { ...DEFAULT_DESKTOP_SETTINGS.daemon },
-    },
+    settings: buildDefaultSettings(),
     migrations: {
       legacyRendererSettingsImported: false,
       daemonStopOnQuitDefaultApplied: true,
@@ -90,42 +122,15 @@ function buildDefaultDocument(): PersistedDesktopSettingsDocument {
   };
 }
 
-function coerceDesktopSettings(input: unknown): DesktopSettings {
-  const result: DesktopSettings = {
-    releaseChannel: DEFAULT_DESKTOP_SETTINGS.releaseChannel,
-    notifications: { ...DEFAULT_DESKTOP_SETTINGS.notifications },
-    daemon: { ...DEFAULT_DESKTOP_SETTINGS.daemon },
+function toDesktopSettings(stored: StoredDesktopSettings): DesktopSettings {
+  return {
+    releaseChannel: stored.releaseChannel,
+    notifications: { playSound: stored.notifications.playSound },
+    daemon: {
+      manageBuiltInDaemon: stored.daemon.manageBuiltInDaemon,
+      keepRunningAfterQuit: stored.daemon.keepRunningAfterQuit,
+    },
   };
-
-  if (!isRecord(input)) {
-    return result;
-  }
-
-  const releaseChannel = coerceReleaseChannel(input.releaseChannel);
-  if (releaseChannel) {
-    result.releaseChannel = releaseChannel;
-  }
-
-  if (isRecord(input.notifications)) {
-    const playSound = coerceBoolean(input.notifications.playSound);
-    if (playSound !== null) {
-      result.notifications.playSound = playSound;
-    }
-  }
-
-  if (isRecord(input.daemon)) {
-    const manageBuiltInDaemon = coerceBoolean(input.daemon.manageBuiltInDaemon);
-    if (manageBuiltInDaemon !== null) {
-      result.daemon.manageBuiltInDaemon = manageBuiltInDaemon;
-    }
-
-    const keepRunningAfterQuit = coerceBoolean(input.daemon.keepRunningAfterQuit);
-    if (keepRunningAfterQuit !== null) {
-      result.daemon.keepRunningAfterQuit = keepRunningAfterQuit;
-    }
-  }
-
-  return result;
 }
 
 function coerceDesktopSettingsPatch(input: unknown): DesktopSettingsPatch {
@@ -134,7 +139,6 @@ function coerceDesktopSettingsPatch(input: unknown): DesktopSettingsPatch {
   }
 
   const patch: DesktopSettingsPatch = {};
-
   const releaseChannel = coerceReleaseChannel(input.releaseChannel);
   if (releaseChannel) {
     patch.releaseChannel = releaseChannel;
@@ -187,10 +191,11 @@ function pickDesktopSettingsFromLegacyRendererSettings(
 }
 
 function mergeDesktopSettings(
-  current: DesktopSettings,
+  current: StoredDesktopSettings,
   patch: DesktopSettingsPatch,
-): DesktopSettings {
+): StoredDesktopSettings {
   return {
+    ...current,
     releaseChannel: patch.releaseChannel ?? current.releaseChannel,
     notifications: { ...current.notifications, ...patch.notifications },
     daemon: { ...current.daemon, ...patch.daemon },
@@ -202,30 +207,21 @@ function hasLegacyRendererOwnedPatch(patch: DesktopSettingsPatch): boolean {
 }
 
 function coerceDocument(input: unknown): PersistedDesktopSettingsDocument {
-  if (!isRecord(input)) {
-    return buildDefaultDocument();
-  }
-
-  const settings = coerceDesktopSettings(input.settings);
-  const migrations = isRecord(input.migrations)
-    ? {
-        legacyRendererSettingsImported: input.migrations.legacyRendererSettingsImported === true,
-        daemonStopOnQuitDefaultApplied: input.migrations.daemonStopOnQuitDefaultApplied === true,
-      }
-    : {
-        legacyRendererSettingsImported: false,
-        daemonStopOnQuitDefaultApplied: false,
-      };
-
-  if (!migrations.daemonStopOnQuitDefaultApplied) {
-    settings.daemon.keepRunningAfterQuit = DEFAULT_DESKTOP_SETTINGS.daemon.keepRunningAfterQuit;
-    migrations.daemonStopOnQuitDefaultApplied = true;
+  const document = PersistedDocumentSchema.parse(input);
+  if (document.migrations.daemonStopOnQuitDefaultApplied) {
+    return document;
   }
 
   return {
-    version: 1,
-    settings,
-    migrations,
+    ...document,
+    settings: {
+      ...document.settings,
+      daemon: {
+        ...document.settings.daemon,
+        keepRunningAfterQuit: DEFAULT_DESKTOP_SETTINGS.daemon.keepRunningAfterQuit,
+      },
+    },
+    migrations: { ...document.migrations, daemonStopOnQuitDefaultApplied: true },
   };
 }
 
@@ -272,12 +268,6 @@ export function createDesktopSettingsStore({
     return document;
   }
 
-  async function loadWritableDocument(): Promise<PersistedDesktopSettingsDocument> {
-    const document = await loadDocument();
-    await persistDocument(document);
-    return document;
-  }
-
   async function initializeLegacyRendererMigration(): Promise<PersistedDesktopSettingsDocument> {
     try {
       return await loadDocument();
@@ -291,11 +281,11 @@ export function createDesktopSettingsStore({
   return {
     async get(): Promise<DesktopSettings> {
       const document = await loadDocument();
-      return document.settings;
+      return toDesktopSettings(document.settings);
     },
 
     async patch(patch: unknown): Promise<DesktopSettings> {
-      const current = await loadWritableDocument();
+      const current = await loadDocument();
       const coercedPatch = coerceDesktopSettingsPatch(patch);
       const next = mergeDesktopSettings(current.settings, coercedPatch);
       await persistDocument({
@@ -308,13 +298,13 @@ export function createDesktopSettingsStore({
             hasLegacyRendererOwnedPatch(coercedPatch),
         },
       });
-      return next;
+      return toDesktopSettings(next);
     },
 
     async migrateLegacyRendererSettings(legacySettings: unknown): Promise<DesktopSettings> {
       const current = await initializeLegacyRendererMigration();
       if (current.migrations.legacyRendererSettingsImported) {
-        return current.settings;
+        return toDesktopSettings(current.settings);
       }
 
       const next = mergeDesktopSettings(
@@ -329,7 +319,7 @@ export function createDesktopSettingsStore({
           legacyRendererSettingsImported: true,
         },
       });
-      return next;
+      return toDesktopSettings(next);
     },
   };
 }


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Reasoning

The desktop settings store rebuilds `desktop-settings.json` from a fixed key list on every write, so a key the running build does not model is deleted. Two Paseo builds that share a user data directory erase each other's settings, which happens after a rollback, a channel switch, or when a source build runs next to an installed one.

### Goals

- A key that the running build does not model survives a read and a write. This covers a whole unknown section, an unknown field inside a known section, an unknown migration flag, and an unknown key at the document root.
- A known field with an unusable value is still replaced by its default, on the write path as well as the read path. Carrying unknown keys must not become carrying invalid ones.
- Uses the same technique as your app settings fix in #3787: `z.looseObject`, a `.catch()` per field, and a write that merges the known settings on top of what is on disk. `zod` is already a desktop dependency, so there is no new package.
- Each patch reads the current file and writes inside one queued transaction. Two patches that run at the same time both land, and a patch merges onto what another build wrote after this process last read the file.

### Non-goals

- This gives additive-key compatibility, not general compatibility with a future release. A value that the running build does not recognise in a field it does model, such as a new `releaseChannel`, is still replaced by the default. That limit comes from validating known fields at all, and #3787 has it too.
- The document version is now carried and never rewritten, so an older build cannot make a newer one re-run a migration it already applied. Nothing reads or acts on that number. A real migration framework is out of scope.
- `packages/app/src/desktop/settings/desktop-settings.ts` holds a second hand-written parser and a duplicate of `DesktopSettings`. The renderer only sends sparse patches, so it is not a data-loss path. Moving the shared types into `packages/protocol` is a separate change.
- The on-disk layout is untouched. Moving migration bookkeeping out of the settings document, the way `packages/app/src/hooks/use-settings/keys.ts` does it, is its own compatibility event and needs your call first.

### QA

**Tests:**

- `packages/desktop/src/settings/desktop-settings.test.ts` (extended) - survival of unknown keys at all four levels across `patch()` and across the legacy renderer migration, replacement of an unusable known value on the write path, two concurrent patches, a patch that merges onto a file another build rewrote after the last read, an unreadable file, a carried document version, and the aliasing guard on the `.catch()` fallbacks.

Each of the three fixes was checked by reverting it and confirming exactly one test turns red and no others.

**Desktop run.** I seeded the dev user data directory with a settings document that a newer build could have written: a `settings.tray` section, a `migrations.someFutureMigrationApplied` flag, a `futureDocumentKey` at the document root, and `"version": 2`. None of those exist in this build. I started the desktop app, opened Settings, and switched the notification sound off, which is a `patch()` and the write that used to lose the keys.

The file after the write:

```json
{
  "version": 2,
  "settings": {
    "releaseChannel": "stable",
    "notifications": { "playSound": false },
    "daemon": { "manageBuiltInDaemon": true, "keepRunningAfterQuit": false },
    "tray": { "enabled": true }
  },
  "migrations": {
    "legacyRendererSettingsImported": true,
    "daemonStopOnQuitDefaultApplied": true,
    "someFutureMigrationApplied": true
  },
  "futureDocumentKey": "written by a newer build"
}
```

The toggle landed, all four unmodelled entries survived, and the version stayed at 2. The file was also byte identical between app start and the toggle, so a read does not rewrite it.

For the before half I ran the `main` version of the module against the same seed and the same patch. It writes:

```json
{
  "version": 1,
  "settings": {
    "releaseChannel": "stable",
    "notifications": { "playSound": false },
    "daemon": { "manageBuiltInDaemon": true, "keepRunningAfterQuit": false }
  },
  "migrations": {
    "legacyRendererSettingsImported": true,
    "daemonStopOnQuitDefaultApplied": true
  }
}
```

The `tray` section, the unknown migration flag and the document root key are gone after one toggle, and the version drops from 2 to 1.

Tested on desktop (Electron, macOS). Not tested: Windows and Linux desktop.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
