### PR TITLE
fix(app): align the scrolling diff order with the Changes tree

### DIFF
--- a/packages/app/e2e/browser/changes-pane.spec.ts
+++ b/packages/app/e2e/browser/changes-pane.spec.ts
@@ -19,6 +19,10 @@ interface WorkspaceFixtureOptions {
   includeDeletedFile?: boolean;
   includeNestedFolders?: boolean;
   includeRenamedFile?: boolean;
+  // A root-level file whose name sorts BEFORE the root-level "src" directory.
+  // zz-untracked.txt cannot stand in for it: "src" < "zz", so that file lands
+  // last whether paths are compared whole or segment by segment.
+  includeRootFileSortingFirst?: boolean;
   includeUntrackedFile?: boolean;
 }
 
@@ -459,6 +463,31 @@ test("changes tree aligns every file status after its diff stat", async ({ page 
   ]);
   if (!statBounds || !statusBounds) throw new Error("Changes tree trailing status has no bounds");
   expect(statusBounds.x - (statBounds.x + statBounds.width)).toBeGreaterThanOrEqual(8);
+});
+
+test("the scrolling diff lists files in changes tree order", async ({ page }) => {
+  const workspace = await createWorkspaceWithMountedTabDiff({
+    includeNestedFolders: true,
+    includeRootFileSortingFirst: true,
+  });
+  await useUnwrappedDiffLines(page);
+  await openWorkspaceChanges(page, workspace);
+
+  const tree = changesTree(page);
+  const treeNames = tree.locator('[data-testid^="diff-tree-file-"][data-testid$="-name"]');
+  const diffNames = page.locator('[data-testid^="diff-file-"][data-testid$="-name"]');
+
+  // Directories sort before files at every level, so the root note lands last
+  // even though "a-root-note.txt" compares below "src/..." as a whole string.
+  const expected = ["changed.ts", "root.ts", "use-mounted-tab-set.ts", "a-root-note.txt"];
+
+  // Equal counts also prove no folder is collapsed: flattenDiffTree drops the
+  // descendants of a collapsed folder, which would make the tree a subsequence
+  // of the diff rather than a match, and mask a real ordering difference.
+  await expect(treeNames).toHaveCount(expected.length);
+  await expect(diffNames).toHaveCount(expected.length);
+  await expect(treeNames).toHaveText(expected);
+  await expect(diffNames).toHaveText(expected);
 });
 
 test("changes context menu recursively collapses descendant folders", async ({ page }) => {
@@ -1284,6 +1313,9 @@ async function createWorkspaceWithMountedTabDiff(
   await writeFile(path.join(repo.path, "src/use-mounted-tab-set.ts"), AFTER);
   if (options.includeUntrackedFile) {
     await writeFile(path.join(repo.path, "zz-untracked.txt"), "remove me\n");
+  }
+  if (options.includeRootFileSortingFirst) {
+    await writeFile(path.join(repo.path, "a-root-note.txt"), "root note\n");
   }
   if (options.includeDeletedFile) {
     await unlink(path.join(repo.path, "src/zz-deleted.ts"));

--- a/packages/app/src/git/diff-order.test.ts
+++ b/packages/app/src/git/diff-order.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { compareCheckoutDiffPaths, orderCheckoutDiffFiles } from "./diff-order";
+import { orderCheckoutDiffFiles } from "./diff-order";
 
 function createFile(path: string, additions = 0) {
   return {
@@ -12,21 +12,51 @@ function createFile(path: string, additions = 0) {
   };
 }
 
+function order(paths: string[]): string[] {
+  return orderCheckoutDiffFiles(paths.map((path) => createFile(path))).map((file) => file.path);
+}
+
 describe("checkout diff ordering", () => {
-  it("compares paths deterministically", () => {
-    expect(compareCheckoutDiffPaths("a.ts", "b.ts")).toBeLessThan(0);
-    expect(compareCheckoutDiffPaths("b.ts", "a.ts")).toBeGreaterThan(0);
-    expect(compareCheckoutDiffPaths("same.ts", "same.ts")).toBe(0);
+  it("sorts sibling files by name", () => {
+    expect(order(["zeta.ts", "alpha.ts", "beta.ts"])).toEqual(["alpha.ts", "beta.ts", "zeta.ts"]);
   });
 
-  it("sorts files by path", () => {
-    const ordered = orderCheckoutDiffFiles([
-      createFile("zeta.ts"),
-      createFile("alpha.ts"),
-      createFile("beta.ts"),
-    ]);
+  it("puts a directory before a file that sits beside it", () => {
+    expect(order(["z.ts", "a/b.ts"])).toEqual(["a/b.ts", "z.ts"]);
+  });
 
-    expect(ordered.map((file) => file.path)).toEqual(["alpha.ts", "beta.ts", "zeta.ts"]);
+  it("keeps loose root files below root directories", () => {
+    // The reported bug: comparing whole paths byte-for-byte put ".gitlab-ci.yml"
+    // first (because "." < "b"), while the tree rail listed it last.
+    expect(
+      order([
+        ".gitlab-ci.yml",
+        "process-compose.yaml",
+        "bin/lib/node-stamp.sh",
+        "samera-one/package.json",
+      ]),
+    ).toEqual([
+      "bin/lib/node-stamp.sh",
+      "samera-one/package.json",
+      ".gitlab-ci.yml",
+      "process-compose.yaml",
+    ]);
+  });
+
+  it("ranks a nested directory above a shallower file with the same prefix", () => {
+    // "src/a.ts" < "src/a/z.ts" as whole strings, but "a" is a directory here.
+    expect(order(["src/a.ts", "src/a/z.ts"])).toEqual(["src/a/z.ts", "src/a.ts"]);
+  });
+
+  it("orders a directory ahead of a file sharing its name", () => {
+    // Converting an extensionless file into a directory puts both in one diff.
+    expect(order(["bin/stack", "bin/stack/run"])).toEqual(["bin/stack/run", "bin/stack"]);
+  });
+
+  it("returns lists too short to reorder untouched", () => {
+    const single = [createFile("only.ts")];
+    expect(orderCheckoutDiffFiles([])).toEqual([]);
+    expect(orderCheckoutDiffFiles(single)).toBe(single);
   });
 
   it("preserves relative order for equal paths", () => {

--- a/packages/app/src/git/diff-order.ts
+++ b/packages/app/src/git/diff-order.ts
@@ -1,19 +1,18 @@
-import type { SubscribeCheckoutDiffResponse } from "@getpaseo/protocol/messages";
+import type { ParsedDiffFile } from "@getpaseo/protocol/messages";
+import { buildDiffTree, flattenDiffTree } from "@/git/diff-tree";
 
-type ParsedDiffFile = SubscribeCheckoutDiffResponse["payload"]["files"][number];
-
-export function compareCheckoutDiffPaths(left: string, right: string): number {
-  if (left === right) {
-    return 0;
-  }
-  return left < right ? -1 : 1;
-}
-
+// The Changes tree is the single ordering authority: `sortTree` (diff-tree.ts)
+// ranks directories before files within a level, then compares names. Surfaces
+// that render the flat file list — the scrolling diff — derive their order from
+// the tree here instead of reimplementing the rule, so the two cannot disagree.
 export function orderCheckoutDiffFiles(files: ParsedDiffFile[]): ParsedDiffFile[] {
   if (files.length < 2) {
     return files;
   }
-  const ordered = [...files];
-  ordered.sort((a, b) => compareCheckoutDiffPaths(a.path, b.path));
-  return ordered;
+  // Path compression only merges display rows for single-child directory
+  // chains, so it is skipped; the collapsed set is empty because the flat list
+  // always carries every file, whatever the rail has collapsed.
+  return flattenDiffTree(buildDiffTree(files), new Set()).flatMap((row) =>
+    row.kind === "file" ? [row.file] : [],
+  );
 }

--- a/packages/app/src/git/diff-tree.ts
+++ b/packages/app/src/git/diff-tree.ts
@@ -1,8 +1,13 @@
 import type { ParsedDiffFile } from "@/git/use-diff-query";
 
-// Builds a directory hierarchy from the flat, path-sorted `ParsedDiffFile[]` the
-// Changes view renders. The tree renders on every form factor, consistent with
-// the Files explorer.
+// Builds a directory hierarchy from the `ParsedDiffFile[]` the Changes view
+// renders. The tree renders on every form factor, consistent with the Files
+// explorer.
+//
+// `sortTree` below is the single ordering authority for the Changes view. The
+// flat scrolling diff does not sort for itself — `orderCheckoutDiffFiles`
+// (diff-order.ts) builds this tree and reads its file sequence back out — so
+// changing `sortTree` reorders both surfaces together, by construction.
 //
 // Directory nodes are keyed by their FULL uncompressed path (e.g. "packages/app/src").
 // That path is the stable identity used to persist folder-collapse state, so the
@@ -55,8 +60,8 @@ function sortTree(node: DiffTreeDirNode): void {
       // directories before files within a level
       return a.kind === "dir" ? -1 : 1;
     }
-    // Plain ASCII comparison, matching compareCheckoutDiffPaths (diff-order.ts)
-    // so the tree order is consistent with the rest of the Changes view.
+    // Plain ASCII, not localeCompare: the order must not shift with the
+    // device locale, and every surface derives from this comparison.
     if (a.name === b.name) return 0;
     return a.name < b.name ? -1 : 1;
   });


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Reasoning

In the Changes view the tree rail and the scrolling diff list the same files in a different order, so scrolling the diff does not walk the tree from top to bottom. The tree puts directories before files at each level of the path, while the diff compares the whole path byte by byte, so a root file such as `.gitlab-ci.yml` opens the diff but sits below every directory in the tree. Reviewing a change means reading one order and clicking in the other. This PR makes the tree the single ordering authority and derives the flat order from it.

### Goals

- The scrolling diff lists files in the same order as the Changes tree, on every platform.
- One ordering rule exists in one place: `sortTree` in `git/diff-tree.ts`. The flat list derives from the tree instead of reimplementing the rule.
- Clicking a tree row still scrolls to the matching file, and the folder collapse state still works.

### Non-goals

- Commit diffs are unchanged. `CommitDiffPanel` renders no tree rail, so there is no second order to disagree with, and sorting it would only replace git's own order with ours.
- The daemon keeps its whole-path sort in `checkout-git.ts`. Fixing this in the client means a daemon that is not updated also gets the fix, per `docs/protocol-compatibility.md`. The CLI and other clients keep the old order.

### QA

**Repro.** A checkout with changes in both a root-level file and a directory. The tree rail showed `bin/…`, `samera-one/…`, then `.gitlab-ci.yml` and `process-compose.yaml`. The scrolling diff opened with `.gitlab-ci.yml`.

**Before / after.** Desktop app (Electron, macOS), the same worktree with an untracked root file `foo.txt` next to changed directories. Before, `foo.txt` is first in the diff and last in the tree. After, it is last in both, and the diff reads top to bottom in tree order.

Before:

<img width="1123" height="408" alt="image" src="https://github.com/user-attachments/assets/7f9539ab-9c89-41db-a10d-7978a2ec9108" />

After:

<img width="1193" height="849" alt="image" src="https://github.com/user-attachments/assets/35f7c013-b307-459b-be5a-d3e6322b4e48" />


I also clicked tree rows after the change and confirmed each one still scrolls to its file, and opened a commit from the Commits list and confirmed its file order is unchanged.

**Tested on:** desktop (Electron, macOS). **Not tested by hand on:** iOS, Android, browser web. The browser end-to-end test below runs the Changes view in a real browser against a real daemon.

**The test that proves it.** `packages/app/e2e/browser/changes-pane.spec.ts` compares what the tree renders against what the diff renders. To show the test is not vacuous I reverted `diff-order.ts` to the old comparator and ran it again. The tree assertion still passed and the diff assertion failed with the reported order:

```
Expected: ["changed.ts", "root.ts", "use-mounted-tab-set.ts", "a-root-note.txt"]
Received: ["a-root-note.txt", "use-mounted-tab-set.ts", "changed.ts", "root.ts"]
```

The old fixture could not have caught this. It only wrote `src/…` files plus a root `zz-untracked.txt`, and `"src" < "zz"`, so that file sorts last under both rules. The fixture now writes `a-root-note.txt`, which sorts first as a whole string and last in the tree. The test also asserts equal row counts in both surfaces, because `flattenDiffTree` drops the children of a collapsed folder, which would make the tree a subsequence of the diff and hide a real difference.

**Tests:**

- `packages/app/src/git/diff-order.test.ts` — rewritten around `orderCheckoutDiffFiles`: sibling files, a directory before a file beside it, loose root files below root directories (the reported case), a nested directory above a shallower file with the same prefix, a directory ahead of a file sharing its name, lists too short to reorder, and stability on equal paths. 7 tests, green.
- `packages/app/e2e/browser/changes-pane.spec.ts` — the tree-versus-diff order agreement test above. All 33 tests in the file green.

**Commands:**

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run format:check` — pass
- `npx vitest run packages/app/src/git/diff-order.test.ts packages/app/src/git/diff-tree.test.ts` — 22 pass
- `npx playwright test changes-pane.spec.ts --project=browser` — 33 pass

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
