### PR TITLE
fix(app): show selected workspace in light theme

### DIFF
--- a/packages/app/e2e/browser/appearance-theme-picker.spec.ts
+++ b/packages/app/e2e/browser/appearance-theme-picker.spec.ts
@@ -18,6 +18,33 @@ test("shows Pure black in the appearance picker", async ({ page }, testInfo) => 
   });
 });
 
+test("keeps the selected workspace visible in Light", async ({ page }, testInfo) => {
+  const workspace = await seedWorkspace({
+    repoPrefix: "light-selected-workspace-",
+    title: "Selected workspace",
+  });
+
+  try {
+    await page.addInitScript(() => {
+      localStorage.setItem("@paseo:app-settings", JSON.stringify({ theme: "light" }));
+    });
+    await gotoAppShell(page);
+
+    const row = page.getByTestId(`sidebar-workspace-row-${getServerId()}:${workspace.workspaceId}`);
+    await expect(row).toBeVisible({ timeout: 30_000 });
+    await row.click();
+
+    await expect(row).toHaveAttribute("aria-selected", "true");
+    await expect(row).toHaveCSS("background-color", "rgb(228, 228, 231)");
+    await page.screenshot({
+      path: testInfo.outputPath("light-selected-workspace.png"),
+      fullPage: true,
+    });
+  } finally {
+    await workspace.cleanup();
+  }
+});
+
 test("keeps the selected workspace visible in Pure black", async ({ page }, testInfo) => {
   const workspace = await seedWorkspace({
     repoPrefix: "pure-black-selected-workspace-",

--- a/packages/app/src/styles/theme.test.ts
+++ b/packages/app/src/styles/theme.test.ts
@@ -68,13 +68,16 @@ describe("Pure black theme", () => {
 });
 
 describe("Sidebar interaction surfaces", () => {
-  it.each([lightTheme, darkTheme])(
-    "derives hover and selection from the surface scale",
-    (theme) => {
-      expect(theme.colors.surfaceSidebarHover).toBe(theme.colors.surface1);
-      expect(theme.colors.surfaceSidebarSelected).toBe(theme.colors.surface2);
-    },
-  );
+  it("keeps Light selection distinct from the sidebar surface", () => {
+    expect(lightTheme.colors.surfaceSidebarHover).toBe(lightTheme.colors.surface1);
+    expect(lightTheme.colors.surfaceSidebarSelected).toBe(lightTheme.colors.surface3);
+    expect(lightTheme.colors.surfaceSidebarSelected).not.toBe(lightTheme.colors.surfaceSidebar);
+  });
+
+  it("derives Dark hover and selection from the first two raised surfaces", () => {
+    expect(darkTheme.colors.surfaceSidebarHover).toBe(darkTheme.colors.surface1);
+    expect(darkTheme.colors.surfaceSidebarSelected).toBe(darkTheme.colors.surface2);
+  });
 });
 
 describe("Built-in light theme", () => {

--- a/packages/app/src/styles/theme.ts
+++ b/packages/app/src/styles/theme.ts
@@ -254,7 +254,7 @@ export function buildLightSemanticColors(tint: LightThemeConfig) {
     surfaceDiffEmpty: tint.surfaceDiffEmpty,
     surfaceSidebar: tint.surfaceSidebar,
     surfaceSidebarHover: tint.surface1,
-    surfaceSidebarSelected: tint.surface2,
+    surfaceSidebarSelected: tint.surface3,
     surfaceWorkspace: tint.surface0,
     interactionHighlight: "rgba(0, 0, 0, 0.06)",
 


### PR DESCRIPTION
### Linked issue

Closes #3918

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

In the Light theme, the selected workspace row used `surface2`. The Light sidebar also uses the same color, so selecting a workspace changed its accessibility state and opened it without adding a visible selection highlight.

This changes the Light selection color to `surface3`. The existing Dark and Pure black selection colors remain unchanged.

### Goals

- Make the active workspace visually distinguishable in the Light theme.
- Preserve the selected row's existing interaction and accessibility behavior.
- Cover the visual result in a real browser regression test.

### Non-goals

- Change workspace navigation or selection state.
- Change Dark or Pure black theme colors.
- Redesign sidebar interaction states.

### QA

#### Reproduction before the fix

1. Opened Paseo in Chrome and selected the Light theme.
2. Added two workspaces and selected one from the sidebar.
3. Confirmed that the workspace opened and the row had `aria-selected="true"`.
4. Compared the selected row with the sidebar background.

Observed values:

```text
Selected row:
  aria-selected: true
  background: rgb(244, 244, 245)

Unselected row:
  aria-selected: false
  background: transparent

Light sidebar background:
  rgb(244, 244, 245)
```

Before screenshot:

![Selected workspace without a visible Light-theme highlight](https://gist.githubusercontent.com/wdaubney/fcbf1592cc31e6b2e7e7c9fc814e2ba0/raw/facc24343767861c4d7b3b743c8d249887238ea2/paseo-light-workspace-selection-comparison.png)

#### Confirmation after the fix

The browser regression test selected a workspace through the UI and confirmed both its accessibility state and computed background color.

```text
$ CI=1 E2E_WORKERS=1 npm run test:e2e --workspace=@getpaseo/app -- e2e/browser/appearance-theme-picker.spec.ts --grep "keeps the selected workspace visible in Light" --retries=0

Running 1 test using 1 worker
✓ 1 [browser] › e2e/browser/appearance-theme-picker.spec.ts › keeps the selected workspace visible in Light
1 passed
```

Web after screenshot:

![Selected workspace with a visible Light-theme highlight in Chrome](https://gist.githubusercontent.com/wdaubney/fcbf1592cc31e6b2e7e7c9fc814e2ba0/raw/7bd09a689293ca162cacf23ac1a542640a0d055c/paseo-3918-after-web.png)

The Linux desktop check used the real Electron app and its isolated development daemon. After selecting the workspace, CDP returned:

```json
{
  "url": "http://localhost:57928/h/srv_p8SmDald9q6M/workspace/wks_efda47aa2ea5f0d4",
  "selected": "true",
  "background": "rgb(228, 228, 231)",
  "screenshot": "/tmp/paseo-3918-after-electron-linux.png"
}
```

Electron Linux after screenshot:

![Selected workspace with a visible Light-theme highlight in Electron on Linux](https://gist.githubusercontent.com/wdaubney/fcbf1592cc31e6b2e7e7c9fc814e2ba0/raw/c95e39a3917c81d2262eea1bda5c2118ea201bfd/paseo-3918-after-electron-linux.png)

#### Automated checks

```text
$ npx vitest run packages/app/src/styles/theme.test.ts --bail=1
Test Files  1 passed (1)
Tests       9 passed (9)

$ npm run typecheck
@getpaseo/expo-two-way-audio typecheck: passed
@getpaseo/highlight typecheck: passed
@getpaseo/plugin typecheck: passed
@getpaseo/protocol typecheck: passed
@getpaseo/client typecheck: passed
@getpaseo/server typecheck: passed
@getpaseo/app typecheck: passed
@getpaseo/relay typecheck: passed
@getpaseo/website typecheck: passed
@getpaseo/desktop typecheck: passed
@getpaseo/cli typecheck: passed

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format
Finished on 4083 files.

$ git diff --check
[no output]
```

#### Platform coverage

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | No macOS or iOS simulator is available in this environment. |
| Android | No | No Android SDK or emulator is installed in this environment. |
| Web | Yes | Chrome. Real Playwright browser and isolated daemon. |
| Desktop macOS | No | No macOS host is available in this environment. |
| Desktop Windows | No | No Windows host is available in this environment. |
| Desktop Linux | Yes | Real Electron development app and isolated daemon. |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
