### PR TITLE
feat: add plugin navigation and sidebar badges

### DIFF
--- a/packages/app/src/components/sidebar/sidebar-header-row.tsx
+++ b/packages/app/src/components/sidebar/sidebar-header-row.tsx
@@ -29,6 +29,8 @@ interface SidebarHeaderRowProps {
    */
   variant?: SidebarHeaderRowVariant;
   shortcutKeys?: ShortcutKey[][] | null;
+  /** Count pill on the trailing edge. Zero and below render nothing. */
+  badgeCount?: number;
 }
 
 export function SidebarHeaderRow({
@@ -41,6 +43,7 @@ export function SidebarHeaderRow({
   accessibilityLabel,
   variant = "header",
   shortcutKeys = null,
+  badgeCount = 0,
 }: SidebarHeaderRowProps) {
   const ThemedIcon = useMemo(() => withUnistyles(Icon), [Icon]);
 
@@ -68,13 +71,14 @@ export function SidebarHeaderRow({
             uniProps={isHighlighted ? foregroundColorMapping : foregroundMutedColorMapping}
           />
           <SidebarHeaderRowLabel label={label} isHighlighted={isHighlighted} />
+          {badgeCount > 0 ? <SidebarHeaderRowBadge count={badgeCount} /> : null}
           {shortcutKeys && Boolean(state.hovered) ? (
             <Shortcut chord={shortcutKeys} style={styles.shortcut} />
           ) : null}
         </>
       );
     },
-    [ThemedIcon, isActive, label, shortcutKeys],
+    [ThemedIcon, badgeCount, isActive, label, shortcutKeys],
   );
 
   return (
@@ -106,6 +110,18 @@ function SidebarHeaderRowLabel({
     [isHighlighted],
   );
   return <Text style={labelStyle}>{label}</Text>;
+}
+
+const BADGE_OVERFLOW_THRESHOLD = 99;
+
+function SidebarHeaderRowBadge({ count }: { count: number }) {
+  return (
+    <View style={styles.badge}>
+      <Text style={styles.badgeText}>
+        {count > BADGE_OVERFLOW_THRESHOLD ? `${BADGE_OVERFLOW_THRESHOLD}+` : count}
+      </Text>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create((theme) => ({
@@ -155,6 +171,21 @@ const styles = StyleSheet.create((theme) => ({
   },
   labelHighlighted: {
     color: theme.colors.foreground,
+  },
+  badge: {
+    marginLeft: "auto",
+    minWidth: 18,
+    paddingHorizontal: theme.spacing[1.5],
+    paddingVertical: 1,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.surfaceSidebarHover,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  badgeText: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.foregroundMuted,
   },
   shortcut: {
     marginLeft: "auto",

--- a/packages/app/src/plugins/command-center/contributions.test.ts
+++ b/packages/app/src/plugins/command-center/contributions.test.ts
@@ -124,6 +124,7 @@ function createRuntime(pluginId: string) {
   });
   return {
     paseo: createPaseoApi(client),
+    navigation: { openWorkspace() {}, openExternal: async () => undefined },
     invoke: async (method: string, input: unknown) => {
       expect(pluginId).toBe("review");
       expect(method).toBe("review.inspect");
@@ -141,6 +142,8 @@ describe("plugin Command Center contributions", () => {
       state: stateSource(),
       navigation: {
         openSurface() {},
+        openWorkspace() {},
+        openExternal: async () => undefined,
         openWorkspacePanel() {},
         openAgentPanel() {},
       },
@@ -180,6 +183,7 @@ describe("plugin Command Center contributions", () => {
       receivedPaseo = context.paseo;
       rpcValue = (await context.rpc(inspect, { value: 4 })).value;
       context.openSurface("main");
+      context.openWorkspace("workspace-9", { agentId: "agent-9" });
       context.openPanel("details", { location: "explorer" });
     });
     const runtime = createRuntime("review");
@@ -192,6 +196,12 @@ describe("plugin Command Center contributions", () => {
       navigation: {
         openSurface(pluginId, surfaceId) {
           opened.push(`${pluginId}/surface/${surfaceId}`);
+        },
+        openWorkspace(workspaceId, options) {
+          opened.push(`workspace/${workspaceId}/${options?.agentId ?? ""}`);
+        },
+        async openExternal(url) {
+          opened.push(`external/${url}`);
         },
         openWorkspacePanel(pluginId, panelId, location) {
           opened.push(`${pluginId}/workspace/${panelId}/${location}`);
@@ -209,7 +219,11 @@ describe("plugin Command Center contributions", () => {
 
     expect(rpcValue).toBe(5);
     expect(receivedPaseo).toBe(runtime.paseo);
-    expect(opened).toEqual(["review/surface/main", "review/agent/details/agent-1/explorer"]);
+    expect(opened).toEqual([
+      "review/surface/main",
+      "workspace/workspace-9/agent-9",
+      "review/agent/details/agent-1/explorer",
+    ]);
   });
 
   it("removes every contribution when its installation disappears", () => {
@@ -222,6 +236,8 @@ describe("plugin Command Center contributions", () => {
         agentId: agent.id,
         navigation: {
           openSurface() {},
+          openWorkspace() {},
+          openExternal: async () => undefined,
           openWorkspacePanel() {},
           openAgentPanel() {},
         },

--- a/packages/app/src/plugins/command-center/contributions.ts
+++ b/packages/app/src/plugins/command-center/contributions.ts
@@ -1,5 +1,9 @@
 import { callPluginRpc } from "@getpaseo/plugin/host";
-import type { PluginCommandCapabilities, PluginPanelLocation } from "@getpaseo/plugin";
+import type {
+  PluginCommandCapabilities,
+  PluginOpenWorkspaceOptions,
+  PluginPanelLocation,
+} from "@getpaseo/plugin";
 import type { PluginClientStateSource } from "@getpaseo/plugin/host";
 import type { CommandCenterContribution } from "@/command-center/contributions";
 import { getCommandCenterIcon } from "@/command-center/icon";
@@ -10,6 +14,8 @@ import type { InstalledPlugin } from "../types";
 
 export interface PluginCommandCenterNavigation {
   openSurface(pluginId: string, surfaceId: string): void;
+  openWorkspace(workspaceId: string, options?: PluginOpenWorkspaceOptions): void;
+  openExternal(url: string): Promise<void>;
   openWorkspacePanel(pluginId: string, panelId: string, location: PluginPanelLocation): void;
   openAgentPanel(
     pluginId: string,
@@ -42,6 +48,12 @@ function capabilities(
         throw new Error(`Plugin surface is unavailable: ${surfaceId}`);
       }
       navigation.openSurface(plugin.id, surfaceId);
+    },
+    openWorkspace(workspaceId, options) {
+      navigation.openWorkspace(workspaceId, options);
+    },
+    openExternal(url) {
+      return navigation.openExternal(url);
     },
   };
 }

--- a/packages/app/src/plugins/command-center/registration.tsx
+++ b/packages/app/src/plugins/command-center/registration.tsx
@@ -13,6 +13,7 @@ import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
 import type { PluginPanelLocation } from "@getpaseo/plugin";
 import { normalizeWorkspaceOpaqueId } from "@/utils/workspace-identity";
 import { createPluginClientStateSource } from "../client-state/source";
+import { createPluginNavigation } from "../navigation";
 import { buildPluginSurfaceRoute, hostIdFromPathname } from "../routes";
 import { useInstalledPlugins } from "../registry";
 import { createPluginSurfaceRuntime } from "../surface-runtime";
@@ -57,7 +58,7 @@ export function PluginCommandCenterActions() {
     return buildPluginCommandCenterContributions({
       plugins,
       runtime(pluginId) {
-        const runtime = createPluginSurfaceRuntime(client, pluginId);
+        const runtime = createPluginSurfaceRuntime(client, pluginId, serverId);
         if (!runtime) throw new Error("Plugin host is offline");
         return runtime;
       },
@@ -65,6 +66,12 @@ export function PluginCommandCenterActions() {
       workspaceId: workspaceExists ? workspaceId : null,
       agentId: agentExists ? focusedAgentId : null,
       navigation: {
+        openWorkspace(targetWorkspaceId, options) {
+          createPluginNavigation(serverId).openWorkspace(targetWorkspaceId, options);
+        },
+        openExternal(url) {
+          return createPluginNavigation(serverId).openExternal(url);
+        },
         openSurface(pluginId, surfaceId) {
           router.push(
             buildPluginSurfaceRoute(serverId, pluginId, { kind: "surface", id: surfaceId }),

--- a/packages/app/src/plugins/evaluate.test.ts
+++ b/packages/app/src/plugins/evaluate.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import * as PluginSdk from "@getpaseo/plugin";
+import * as PluginServerSdk from "@getpaseo/plugin/server";
 import { evaluatePluginClientBundle } from "./evaluate";
 
 function bundle(body: string): string {
@@ -8,6 +10,52 @@ function bundle(body: string): string {
     return module.exports;
   })`;
 }
+
+/** Bundle that captures what the runtime shim hands back for a specifier. */
+function requiringBundle(specifier: string): string {
+  return `(function(require) {
+    const module = { exports: {} };
+    const sdk = require(${JSON.stringify(specifier)});
+    module.exports.default = function(plugin) {
+      plugin.addSurface("main", function() { return null; });
+      globalThis.__pluginSdkUnderTest = sdk;
+      return function() {};
+    };
+    return module.exports;
+  })`;
+}
+
+describe("plugin client runtime modules", () => {
+  // The shim is what plugin code actually imports. When it is a hand-written
+  // list it drifts behind the SDK and every new export fails at call time with
+  // "is not a function" — these assert the whole surface reaches plugin code.
+  it("hands plugin code every @getpaseo/plugin export", () => {
+    evaluatePluginClientBundle("example", requiringBundle("@getpaseo/plugin"));
+    const sdk = (globalThis as { __pluginSdkUnderTest?: Record<string, unknown> })
+      .__pluginSdkUnderTest;
+
+    expect(Object.keys(sdk ?? {}).sort()).toEqual(Object.keys(PluginSdk).sort());
+    for (const hook of ["usePaseo", "useRpc", "useWorkspace", "useAgent", "useOpenWorkspace"]) {
+      expect(typeof sdk?.[hook]).toBe("function");
+    }
+  });
+
+  it("hands plugin code every @getpaseo/plugin/server export", () => {
+    evaluatePluginClientBundle("example", requiringBundle("@getpaseo/plugin/server"));
+    const sdk = (globalThis as { __pluginSdkUnderTest?: Record<string, unknown> })
+      .__pluginSdkUnderTest;
+
+    expect(Object.keys(sdk ?? {}).sort()).toEqual(Object.keys(PluginServerSdk).sort());
+    expect(sdk?.PluginSidebarBadgeSchema).toBeDefined();
+    expect(typeof sdk?.defineRpc).toBe("function");
+  });
+
+  it("refuses a module plugin code has no business importing", () => {
+    expect(() => evaluatePluginClientBundle("example", requiringBundle("node:fs"))).toThrow(
+      /not available in plugin client code/,
+    );
+  });
+});
 
 describe("evaluatePluginClientBundle", () => {
   it("collects a surface and its sidebar placement", () => {
@@ -265,6 +313,47 @@ describe("evaluatePluginClientBundle", () => {
         `),
       ),
     ).toThrow("Duplicate theme: mocha");
+  });
+
+  it("carries a sidebar badge contract through to the installed contribution", () => {
+    const plugin = evaluatePluginClientBundle(
+      "example",
+      bundle(`
+        function Surface() { return null; }
+        plugin.addSurface("main", Surface);
+        plugin.addSidebarItem({
+          id: "main",
+          title: "Example",
+          icon: "Blocks",
+          surface: "main",
+          badge: { rpc: { name: "example.badge", input: {}, output: {} }, intervalMs: 30000 },
+        });
+      `),
+    );
+
+    expect(plugin.sidebarItems[0]?.badge).toEqual({
+      rpc: { name: "example.badge", input: {}, output: {} },
+      intervalMs: 30000,
+    });
+  });
+
+  it("rejects a sidebar badge without a usable RPC contract", () => {
+    expect(() =>
+      evaluatePluginClientBundle(
+        "example",
+        bundle(`
+          function Surface() { return null; }
+          plugin.addSurface("main", Surface);
+          plugin.addSidebarItem({
+            id: "main",
+            title: "Example",
+            icon: "Blocks",
+            surface: "main",
+            badge: { rpc: {} },
+          });
+        `),
+      ),
+    ).toThrow("invalid badge RPC");
   });
 
   it("rejects a sidebar placement whose surface does not exist", () => {

--- a/packages/app/src/plugins/evaluate.ts
+++ b/packages/app/src/plugins/evaluate.ts
@@ -5,20 +5,19 @@ import * as ReactNative from "react-native";
 // eslint-disable-next-line no-restricted-imports -- plugin bundles receive TanStack's real runtime, not Paseo's query wrappers.
 import * as ReactQuery from "@tanstack/react-query";
 import * as Zod from "zod";
-import {
-  defineAttachmentSource,
-  defineRpc,
-  type PluginAttachmentSourceContribution,
-  type PluginCommandCenterItemContribution,
-  type PluginSidebarContribution,
-  type PluginSurfaceProps,
-  type PluginThemeContribution,
-  type PluginWorkspacePanelContribution,
-  usePaseo,
-  useAgent,
-  useWorkspace,
-  useRpc,
+import type {
+  PluginAttachmentSourceContribution,
+  PluginCommandCenterItemContribution,
+  PluginSidebarContribution,
+  PluginSurfaceProps,
+  PluginThemeContribution,
+  PluginWorkspacePanelContribution,
 } from "@getpaseo/plugin";
+// Namespaces, not named imports: the runtime shim below hands these straight to
+// plugin code, so it cannot drift behind the SDK's exports the way a
+// hand-written list does.
+import * as PluginSdk from "@getpaseo/plugin";
+import * as PluginServerSdk from "@getpaseo/plugin/server";
 import { createPluginContext, type PluginRegistrationCollector } from "@getpaseo/plugin/host";
 import type { EvaluatedPlugin } from "./types";
 import type { ComponentType } from "react";
@@ -86,11 +85,16 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
       if (!contribution.icon.trim()) throw new Error(`Sidebar item ${normalizedId} has no icon`);
       resolvePluginIcon(contribution.icon.trim());
       sidebarItemIds.add(normalizedId);
+      const badge = contribution.badge;
+      if (badge && typeof badge.rpc?.name !== "string") {
+        throw new Error(`Sidebar item ${normalizedId} has an invalid badge RPC`);
+      }
       collector.sidebarItems.push({
         id: normalizedId,
         title: contribution.title.trim(),
         icon: contribution.icon.trim(),
         surface: requireId(contribution.surface, "sidebar surface id"),
+        ...(badge ? { badge } : {}),
       });
     },
     addWorkspacePanel(contribution: PluginWorkspacePanelContribution) {
@@ -188,19 +192,8 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
     if (name === "react") return React;
     if (name === "react/jsx-runtime") return ReactJsxRuntime;
     if (name === "react-native") return ReactNative;
-    if (name === "@getpaseo/plugin") {
-      return {
-        defineAttachmentSource,
-        defineRpc,
-        usePaseo,
-        useAgent,
-        useWorkspace,
-        useRpc,
-      };
-    }
-    if (name === "@getpaseo/plugin/server") {
-      return { defineAttachmentSource, defineRpc };
-    }
+    if (name === "@getpaseo/plugin") return PluginSdk;
+    if (name === "@getpaseo/plugin/server") return PluginServerSdk;
     if (name === "@tanstack/react-query") return ReactQuery;
     if (name === "zod") return Zod;
     throw new Error(`Module "${name}" is not available in plugin client code`);

--- a/packages/app/src/plugins/navigation.test.ts
+++ b/packages/app/src/plugins/navigation.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPluginNavigation, type PluginNavigationDeps } from "./navigation";
+
+function deps() {
+  return {
+    navigateToWorkspace: vi.fn(() => "/workspace-route"),
+    navigateToAgent: vi.fn(() => "/agent-route"),
+    openExternalUrl: vi.fn(async () => undefined),
+  } as unknown as PluginNavigationDeps & {
+    navigateToWorkspace: ReturnType<typeof vi.fn>;
+    navigateToAgent: ReturnType<typeof vi.fn>;
+    openExternalUrl: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("createPluginNavigation", () => {
+  it("opens a workspace on the plugin's own host", () => {
+    const spies = deps();
+    createPluginNavigation("host-a", spies).openWorkspace("workspace-1");
+
+    expect(spies.navigateToWorkspace).toHaveBeenCalledWith({
+      serverId: "host-a",
+      workspaceId: "workspace-1",
+    });
+    expect(spies.navigateToAgent).not.toHaveBeenCalled();
+  });
+
+  it("focuses and pins an agent when one is named", () => {
+    const spies = deps();
+    createPluginNavigation("host-a", spies).openWorkspace("workspace-1", { agentId: "agent-1" });
+
+    expect(spies.navigateToAgent).toHaveBeenCalledWith({
+      serverId: "host-a",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      pin: true,
+    });
+    expect(spies.navigateToWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("honours an explicit pin choice", () => {
+    const spies = deps();
+    createPluginNavigation("host-a", spies).openWorkspace("workspace-1", {
+      agentId: "agent-1",
+      pin: false,
+    });
+
+    expect(spies.navigateToAgent).toHaveBeenCalledWith(expect.objectContaining({ pin: false }));
+  });
+
+  it("opens a workspace on an explicitly selected host", () => {
+    const spies = deps();
+    createPluginNavigation("host-a", spies).openWorkspace("workspace-1", {
+      agentId: "agent-1",
+      serverId: "host-b",
+    });
+
+    expect(spies.navigateToAgent).toHaveBeenCalledWith({
+      serverId: "host-b",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      pin: true,
+    });
+  });
+
+  it("rejects a blank workspace id instead of navigating somewhere arbitrary", () => {
+    const spies = deps();
+    expect(() => createPluginNavigation("host-a", spies).openWorkspace("  ")).toThrow(
+      /workspace id/,
+    );
+    expect(spies.navigateToWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("hands an http(s) URL to the OS browser", async () => {
+    const spies = deps();
+    await createPluginNavigation("host-a", spies).openExternal(
+      "https://github.com/acme/api/pull/7",
+    );
+
+    expect(spies.openExternalUrl).toHaveBeenCalledWith("https://github.com/acme/api/pull/7");
+  });
+
+  it("refuses a scheme the browser opener would silently drop", async () => {
+    const spies = deps();
+    const navigation = createPluginNavigation("host-a", spies);
+
+    await expect(navigation.openExternal("file:///etc/passwd")).rejects.toThrow(/http\(s\)/);
+    await expect(navigation.openExternal("not a url")).rejects.toThrow(/absolute URL/);
+    expect(spies.openExternalUrl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/plugins/navigation.ts
+++ b/packages/app/src/plugins/navigation.ts
@@ -1,0 +1,62 @@
+import type { PluginNavigation, PluginOpenWorkspaceOptions } from "@getpaseo/plugin";
+import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store";
+import { navigateToAgent } from "@/utils/navigate-to-agent";
+import { openExternalUrl } from "@/utils/open-external-url";
+
+export interface PluginNavigationDeps {
+  navigateToWorkspace: typeof navigateToWorkspace;
+  navigateToAgent: typeof navigateToAgent;
+  openExternalUrl: typeof openExternalUrl;
+}
+
+const defaultDeps: PluginNavigationDeps = { navigateToWorkspace, navigateToAgent, openExternalUrl };
+
+const EXTERNAL_URL_PROTOCOLS = new Set(["http:", "https:"]);
+
+/**
+ * Host-owned navigation handed to plugin surfaces, panels, and Command Center
+ * callbacks. Plugin code addresses workspaces by ID only; route shapes, tab
+ * preparation, and pinning stay here.
+ */
+export function createPluginNavigation(
+  serverId: string,
+  deps: PluginNavigationDeps = defaultDeps,
+): PluginNavigation {
+  return {
+    openWorkspace(workspaceId: string, options?: PluginOpenWorkspaceOptions) {
+      const targetWorkspaceId = workspaceId.trim();
+      if (!targetWorkspaceId) throw new Error("openWorkspace requires a workspace id");
+      const targetServerId = options?.serverId?.trim() || serverId;
+      const agentId = options?.agentId?.trim();
+      if (agentId) {
+        deps.navigateToAgent({
+          serverId: targetServerId,
+          agentId,
+          workspaceId: targetWorkspaceId,
+          pin: options?.pin ?? true,
+        });
+        return;
+      }
+      deps.navigateToWorkspace({
+        serverId: targetServerId,
+        workspaceId: targetWorkspaceId,
+        ...(options?.pin === undefined ? {} : { pin: options.pin }),
+      });
+    },
+    async openExternal(url: string) {
+      // openExternalUrl silently drops anything it will not open. A plugin
+      // handing over a bad URL should hear about it instead of watching
+      // nothing happen.
+      let protocol: string;
+      try {
+        protocol = new URL(url).protocol;
+      } catch {
+        throw new Error(`openExternal requires an absolute URL: ${url}`);
+      }
+      if (!EXTERNAL_URL_PROTOCOLS.has(protocol)) {
+        throw new Error(`openExternal only opens http(s) URLs: ${url}`);
+      }
+      await deps.openExternalUrl(url);
+    },
+  };
+}

--- a/packages/app/src/plugins/project-catalog.test.ts
+++ b/packages/app/src/plugins/project-catalog.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectSummary } from "@/utils/projects";
+import { toPluginProjectSnapshots } from "./project-catalog";
+
+describe("toPluginProjectSnapshots", () => {
+  it("preserves cross-host project placement and freezes the plugin snapshot", () => {
+    const source: ProjectSummary[] = [
+      {
+        viewKey: "remote:github.com/acme/app",
+        projectName: "acme/app",
+        hosts: [
+          {
+            serverId: "host-a",
+            projectId: "project-a",
+            projectName: "acme/app",
+            projectCustomName: null,
+            projectKind: "git",
+            serverName: "Laptop",
+            isOnline: true,
+            repoRoot: "/code/app",
+            workspaceCount: 0,
+            workspaces: [],
+          },
+        ],
+        totalWorkspaceCount: 0,
+        hostCount: 1,
+        onlineHostCount: 1,
+      },
+    ];
+
+    const result = toPluginProjectSnapshots(source);
+
+    expect(result).toEqual([
+      {
+        projectKey: "remote:github.com/acme/app",
+        projectName: "acme/app",
+        placements: [
+          {
+            serverId: "host-a",
+            serverName: "Laptop",
+            projectId: "project-a",
+            projectName: "acme/app",
+            projectRootPath: "/code/app",
+            projectKind: "git",
+            isOnline: true,
+          },
+        ],
+      },
+    ]);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result[0]?.placements)).toBe(true);
+    expect(Object.isFrozen(result[0]?.placements[0])).toBe(true);
+  });
+});

--- a/packages/app/src/plugins/project-catalog.ts
+++ b/packages/app/src/plugins/project-catalog.ts
@@ -1,0 +1,28 @@
+import type { PluginProjectSnapshot } from "@getpaseo/plugin";
+import type { ProjectSummary } from "@/utils/projects";
+
+export function toPluginProjectSnapshots(
+  projects: readonly ProjectSummary[],
+): readonly PluginProjectSnapshot[] {
+  return Object.freeze(
+    projects.map((project) =>
+      Object.freeze({
+        projectKey: project.viewKey,
+        projectName: project.projectCustomName ?? project.projectName,
+        placements: Object.freeze(
+          project.hosts.map((placement) =>
+            Object.freeze({
+              serverId: placement.serverId,
+              serverName: placement.serverName,
+              projectId: placement.projectId,
+              projectName: placement.projectCustomName ?? placement.projectName,
+              projectRootPath: placement.repoRoot,
+              projectKind: placement.projectKind,
+              isOnline: placement.isOnline,
+            }),
+          ),
+        ),
+      }),
+    ),
+  );
+}

--- a/packages/app/src/plugins/runtime-boundary.tsx
+++ b/packages/app/src/plugins/runtime-boundary.tsx
@@ -1,6 +1,15 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { PaseoApiProvider, PluginRpcProvider } from "@getpaseo/plugin/host";
-import type { ReactNode } from "react";
+import {
+  PaseoApiProvider,
+  PluginNavigationProvider,
+  PluginProjectProvider,
+  PluginRpcProvider,
+} from "@getpaseo/plugin/host";
+import { createPaseoApi, type PaseoApi } from "@getpaseo/client";
+import { useCallback, useMemo, useRef, type ReactNode } from "react";
+import { useProjects } from "@/hooks/use-projects";
+import { getHostRuntimeStore } from "@/runtime/host-runtime";
+import { toPluginProjectSnapshots } from "./project-catalog";
 import type { InstalledPlugin } from "./types";
 import type { PluginSurfaceRuntime } from "./surface-runtime";
 
@@ -13,10 +22,28 @@ export function PluginRuntimeBoundary({
   runtime: PluginSurfaceRuntime;
   children: ReactNode;
 }) {
+  const { projects } = useProjects();
+  const projectSnapshots = useMemo(() => toPluginProjectSnapshots(projects), [projects]);
+  const paseoByServerId = useRef(new Map<string, { client: object; paseo: PaseoApi }>());
+  const resolvePaseo = useCallback((serverId: string): PaseoApi | null => {
+    const snapshot = getHostRuntimeStore().getSnapshot(serverId);
+    if (snapshot?.connectionStatus !== "online" || !snapshot.client) return null;
+    const cached = paseoByServerId.current.get(serverId);
+    if (cached?.client === snapshot.client) return cached.paseo;
+    const paseo = createPaseoApi(snapshot.client);
+    paseoByServerId.current.set(serverId, { client: snapshot.client, paseo });
+    return paseo;
+  }, []);
   return (
     <QueryClientProvider client={plugin.queryClient}>
       <PaseoApiProvider paseo={runtime.paseo}>
-        <PluginRpcProvider invoke={runtime.invoke}>{children}</PluginRpcProvider>
+        <PluginProjectProvider projects={projectSnapshots} resolvePaseo={resolvePaseo}>
+          <PluginRpcProvider invoke={runtime.invoke}>
+            <PluginNavigationProvider navigation={runtime.navigation}>
+              {children}
+            </PluginNavigationProvider>
+          </PluginRpcProvider>
+        </PluginProjectProvider>
       </PaseoApiProvider>
     </QueryClientProvider>
   );

--- a/packages/app/src/plugins/sidebar-badge.test.ts
+++ b/packages/app/src/plugins/sidebar-badge.test.ts
@@ -1,0 +1,48 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import type { InstalledPlugin } from "./types";
+import { pluginSidebarBadgeQueryKey, setPluginSidebarBadgeCount } from "./sidebar-badge";
+
+function installedPlugin(): InstalledPlugin {
+  return {
+    id: "review",
+    serverId: "host-a",
+    clientBundle: "",
+    cleanup() {},
+    queryClient: new QueryClient(),
+    surfaces: [],
+    sidebarItems: [
+      {
+        id: "inbox",
+        title: "Reviews",
+        icon: "GitPullRequestArrow",
+        surface: "inbox",
+        badge: { rpc: {} as never },
+      },
+    ],
+    workspacePanels: [],
+    commandCenterItems: [],
+    attachmentSources: [],
+    themes: [],
+  };
+}
+
+describe("setPluginSidebarBadgeCount", () => {
+  it("updates the mounted badge query immediately", () => {
+    const plugin = installedPlugin();
+
+    setPluginSidebarBadgeCount(plugin, "inbox", 0);
+
+    expect(
+      plugin.queryClient.getQueryData(
+        pluginSidebarBadgeQueryKey(plugin.serverId, plugin.id, "inbox"),
+      ),
+    ).toEqual({ count: 0 });
+  });
+
+  it("rejects an item that did not contribute a badge", () => {
+    expect(() => setPluginSidebarBadgeCount(installedPlugin(), "missing", 1)).toThrow(
+      /does not have a badge/,
+    );
+  });
+});

--- a/packages/app/src/plugins/sidebar-badge.ts
+++ b/packages/app/src/plugins/sidebar-badge.ts
@@ -1,0 +1,59 @@
+import { PluginSidebarBadgeSchema } from "@getpaseo/plugin";
+import { readPluginSidebarBadge, resolvePluginSidebarBadgeInterval } from "@getpaseo/plugin/host";
+import { useFetchQuery } from "@/data/query";
+import { useHostRuntimeClient } from "@/runtime/host-runtime";
+import type { PluginSidebarTarget } from "./sidebar-groups";
+import type { InstalledPlugin } from "./types";
+
+const NO_BADGE = 0;
+
+export function pluginSidebarBadgeQueryKey(serverId: string, pluginId: string, itemId: string) {
+  return ["plugin-sidebar-badge", serverId, pluginId, itemId] as const;
+}
+
+export function setPluginSidebarBadgeCount(
+  plugin: Pick<InstalledPlugin, "id" | "queryClient" | "serverId" | "sidebarItems">,
+  itemId: string,
+  count: number,
+): void {
+  const item = plugin.sidebarItems.find((candidate) => candidate.id === itemId);
+  if (!item?.badge) {
+    throw new Error(`Plugin sidebar item ${itemId} does not have a badge`);
+  }
+  const badge = PluginSidebarBadgeSchema.parse({ count });
+  plugin.queryClient.setQueryData(
+    pluginSidebarBadgeQueryKey(plugin.serverId, plugin.id, itemId),
+    badge,
+  );
+}
+
+/**
+ * Polls the badge RPC of whichever installation the sidebar row currently
+ * points at. The row is mounted app-wide, so this is the one plugin poll that
+ * runs without a surface being open — keep it cheap and keep the floor on
+ * `intervalMs` in the SDK, not here.
+ */
+export function usePluginSidebarBadgeCount(target: PluginSidebarTarget): number {
+  const { plugin, item } = target;
+  const client = useHostRuntimeClient(plugin.serverId);
+  const intervalMs = resolvePluginSidebarBadgeInterval(item.badge?.intervalMs);
+  const badge = useFetchQuery(
+    {
+      queryKey: pluginSidebarBadgeQueryKey(plugin.serverId, plugin.id, item.id),
+      queryFn: async () => {
+        if (!client) throw new Error("Plugin host is offline");
+        const invoke = (method: string, input: unknown) =>
+          client.invokePluginRpc(plugin.id, method, input);
+        return (await readPluginSidebarBadge(item, invoke)) ?? { count: NO_BADGE };
+      },
+      enabled: Boolean(item.badge && client),
+      dataShape: "value",
+      staleTimeMs: intervalMs,
+      refetchInterval: intervalMs,
+      retry: false,
+    },
+    plugin.queryClient,
+  );
+  // A failing or offline badge poll shows no badge rather than a stale count.
+  return badge.error ? NO_BADGE : (badge.data?.count ?? NO_BADGE);
+}

--- a/packages/app/src/plugins/sidebar-items.tsx
+++ b/packages/app/src/plugins/sidebar-items.tsx
@@ -8,6 +8,7 @@ import {
   getPreferredPluginContributionHost,
   rememberPluginContributionHost,
 } from "./contribution-host";
+import { usePluginSidebarBadgeCount } from "./sidebar-badge";
 import {
   groupPluginSidebarContributions,
   type PluginSidebarGroup,
@@ -54,6 +55,7 @@ function PluginSidebarItemRow({
   onBeforeNavigate?: () => void;
 }) {
   const target = selectTarget(group, currentHostId);
+  const badgeCount = usePluginSidebarBadgeCount(target);
   const route = buildPluginSurfaceRoute(target.plugin.serverId, group.pluginId, {
     kind: "sidebar",
     id: group.contributionId,
@@ -79,6 +81,7 @@ function PluginSidebarItemRow({
       isActive={isActive}
       testID={`plugin-sidebar-${group.pluginId}-${group.contributionId}`}
       variant="compact"
+      badgeCount={badgeCount}
     />
   );
 }

--- a/packages/app/src/plugins/surface-runtime.test.tsx
+++ b/packages/app/src/plugins/surface-runtime.test.tsx
@@ -52,7 +52,7 @@ function borrowFromAppProvider(paseo: PaseoApi): PaseoApi {
 describe("plugin surface host runtime", () => {
   it("creates a PR worktree and agent through usePaseo on the selected app host", async () => {
     const selected = clientWithWorkspace("workspace-a");
-    const runtime = createPluginSurfaceRuntime(selected.client, "workspace-plugin");
+    const runtime = createPluginSurfaceRuntime(selected.client, "workspace-plugin", "host-a");
     if (!runtime) throw new Error("Expected selected host runtime");
 
     const paseo = borrowFromAppProvider(runtime.paseo);
@@ -78,8 +78,8 @@ describe("plugin surface host runtime", () => {
   it("switches all plugin calls when the selected host changes", async () => {
     const hostA = clientWithWorkspace("workspace-a");
     const hostB = clientWithWorkspace("workspace-b");
-    const first = createPluginSurfaceRuntime(hostA.client, "same-plugin");
-    const second = createPluginSurfaceRuntime(hostB.client, "same-plugin");
+    const first = createPluginSurfaceRuntime(hostA.client, "same-plugin", "host-a");
+    const second = createPluginSurfaceRuntime(hostB.client, "same-plugin", "host-b");
     if (!first || !second) throw new Error("Expected online host runtimes");
 
     await first.invoke("host", {});
@@ -95,7 +95,7 @@ describe("plugin surface host runtime", () => {
   it("keeps an offline selected host unavailable instead of borrowing another host", () => {
     const otherHost = clientWithWorkspace("workspace-online");
 
-    expect(createPluginSurfaceRuntime(null, "same-plugin")).toBeNull();
+    expect(createPluginSurfaceRuntime(null, "same-plugin", "host-a")).toBeNull();
     expect(otherHost.createWorkspace).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/plugins/surface-runtime.ts
+++ b/packages/app/src/plugins/surface-runtime.ts
@@ -1,18 +1,23 @@
 import { createPaseoApi, type PaseoApi } from "@getpaseo/client";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import type { PluginNavigation } from "@getpaseo/plugin";
+import { createPluginNavigation } from "./navigation";
 
 export interface PluginSurfaceRuntime {
   paseo: PaseoApi;
+  navigation: PluginNavigation;
   invoke(method: string, input: unknown): Promise<unknown>;
 }
 
 export function createPluginSurfaceRuntime(
   client: DaemonClient | null,
   pluginId: string,
+  serverId: string,
 ): PluginSurfaceRuntime | null {
   if (!client) return null;
   return {
     paseo: createPaseoApi(client),
+    navigation: createPluginNavigation(serverId),
     invoke: (method, input) => client.invokePluginRpc(pluginId, method, input),
   };
 }

--- a/packages/app/src/plugins/surface-screen.tsx
+++ b/packages/app/src/plugins/surface-screen.tsx
@@ -14,6 +14,7 @@ import { useHostRuntimeClient, useHosts } from "@/runtime/host-runtime";
 import type { Theme } from "@/styles/theme";
 import type { ShortcutKey } from "@/utils/format-shortcut";
 import { resolvePluginIcon } from "./icons";
+import { setPluginSidebarBadgeCount } from "./sidebar-badge";
 import { toPluginTheme } from "./theme";
 import { useInstalledPlugin, usePluginInstallations } from "./registry";
 import { buildPluginSurfaceRoute } from "./routes";
@@ -66,9 +67,18 @@ function SurfaceRenderer({
   host: PluginSurfaceProps["host"];
   theme: PluginTheme;
 }) {
+  const updateSidebarBadge = useCallback(
+    (itemId: string, count: number) => setPluginSidebarBadgeCount(plugin, itemId, count),
+    [plugin],
+  );
   return (
     <PluginRuntimeBoundary plugin={plugin} runtime={runtime}>
-      <Surface theme={theme} host={host} layout={layout} />
+      <Surface
+        theme={theme}
+        host={host}
+        layout={layout}
+        setSidebarBadgeCount={updateSidebarBadge}
+      />
     </PluginRuntimeBoundary>
   );
 }
@@ -159,7 +169,10 @@ export function PluginSurfaceScreen() {
   const installations = usePluginInstallations(pluginId);
   const hosts = useHosts();
   const client = useHostRuntimeClient(serverId);
-  const runtime = useMemo(() => createPluginSurfaceRuntime(client, pluginId), [client, pluginId]);
+  const runtime = useMemo(
+    () => createPluginSurfaceRuntime(client, pluginId, serverId),
+    [client, pluginId, serverId],
+  );
   const compact = useIsCompactFormFactor();
   const { sidebarItem, surface } = useMemo(
     () => resolvePluginSurfaceContribution(plugin, identity),

--- a/packages/app/src/plugins/workspace-panels/panel.tsx
+++ b/packages/app/src/plugins/workspace-panels/panel.tsx
@@ -54,8 +54,8 @@ function PluginPanelBody({ theme }: { theme: PluginTheme }) {
   });
   const client = useHostRuntimeClient(serverId);
   const runtime = useMemo(
-    () => createPluginSurfaceRuntime(client, target.pluginId),
-    [client, target.pluginId],
+    () => createPluginSurfaceRuntime(client, target.pluginId, serverId),
+    [client, serverId, target.pluginId],
   );
   const compact = useIsCompactFormFactor();
   const hosts = useHosts();

--- a/packages/app/src/schedules/schedule-project-targets.test.ts
+++ b/packages/app/src/schedules/schedule-project-targets.test.ts
@@ -24,6 +24,7 @@ function makeHost(overrides: Partial<ProjectSummary["hosts"][number]>) {
     projectId: "project-1",
     projectName: "Project",
     projectCustomName: null,
+    projectKind: "git" as const,
     serverName: "Host 1",
     isOnline: true,
     repoRoot: "/tmp/project",

--- a/packages/app/src/screens/projects-screen.test.tsx
+++ b/packages/app/src/screens/projects-screen.test.tsx
@@ -227,6 +227,7 @@ function hostEntry(overrides: Partial<ProjectHostEntry> = {}): ProjectHostEntry 
     projectId: "project-a",
     projectName: "Project",
     projectCustomName: null,
+    projectKind: "git",
     serverName: "alpha",
     isOnline: true,
     repoRoot: "/home/me/proj",

--- a/packages/app/src/utils/projects.ts
+++ b/packages/app/src/utils/projects.ts
@@ -17,6 +17,7 @@ export interface ProjectHostEntry {
   projectId: string;
   projectName: string;
   projectCustomName: string | null;
+  projectKind: ProjectDescriptor["projectKind"];
   serverName: string;
   isOnline: boolean;
   repoRoot: string;
@@ -84,6 +85,7 @@ interface HostGroup {
   projectId: string;
   projectName: string;
   projectCustomName: string | null;
+  projectKind: ProjectDescriptor["projectKind"];
   serverName: string;
   isOnline: boolean;
   workspaces: WorkspaceDescriptor[];
@@ -104,16 +106,33 @@ interface ProjectGroup {
 function findProjectMetadata(
   host: ProjectHost,
   projectId: string,
-): { customName: string | null; displayName: string } | null {
+): {
+  customName: string | null;
+  displayName: string;
+  projectKind: ProjectDescriptor["projectKind"];
+} | null {
   for (const project of host.projects) {
     if (project.projectId === projectId) {
       return {
         customName: project.projectCustomName ?? null,
         displayName: project.projectDisplayName,
+        projectKind: project.projectKind,
       };
     }
   }
   return null;
+}
+
+function resolveProjectKind(
+  host: ProjectHost,
+  projectId: string,
+  metadata: ReturnType<typeof findProjectMetadata>,
+): ProjectDescriptor["projectKind"] {
+  if (metadata) return metadata.projectKind;
+  return (
+    host.workspaces.find((workspace) => workspace.projectId === projectId)?.projectKind ??
+    "directory"
+  );
 }
 
 function buildHostProjectEntries(hosts: ProjectHost[]): HostProjectListItem[] {
@@ -153,6 +172,7 @@ function toHostEntry(group: HostGroup): ProjectHostEntry {
     projectId: group.projectId,
     projectName: group.projectName,
     projectCustomName: group.projectCustomName,
+    projectKind: group.projectKind,
     serverName: group.serverName,
     isOnline: group.isOnline,
     repoRoot,
@@ -222,6 +242,7 @@ function addHostProjects(
         projectId,
         projectName: customName?.displayName ?? hostProject.projectName,
         projectCustomName: customName?.customName ?? null,
+        projectKind: resolveProjectKind(host, projectId, customName),
         serverName: host.serverName,
         isOnline: host.isOnline,
         workspaces: [],

--- a/packages/cli/src/commands/plugin/scaffold.test.ts
+++ b/packages/cli/src/commands/plugin/scaffold.test.ts
@@ -80,17 +80,36 @@ export async function inspectConfig(
 import { Text } from "react-native";
 import {
   type PluginAgentPanelProps,
+  useOpenWorkspace,
   useAgent,
   usePaseo,
+  usePaseoHost,
+  useProjects,
   useWorkspace,
 } from "@getpaseo/plugin";
 
 export function Surface() {
   const paseo = usePaseo();
+  const project = useProjects()[0];
+  const placement = project?.placements[0] ?? null;
+  const projectHost = usePaseoHost(placement?.serverId ?? null);
+  const openWorkspace = useOpenWorkspace();
   const createWorkspace = () => paseo.workspaces.create({
     source: { kind: "directory", path: "/repo" },
   });
+  const createProjectWorkspace = async () => {
+    if (!placement || !projectHost) return;
+    const workspace = await projectHost.workspaces.create({
+      source: {
+        kind: "directory",
+        path: placement.projectRootPath,
+        projectId: placement.projectId,
+      },
+    });
+    openWorkspace(workspace.id, { serverId: placement.serverId });
+  };
   void createWorkspace;
+  void createProjectWorkspace;
   return <Text>Paseo API</Text>;
 }
 

--- a/packages/cli/src/commands/plugin/scaffold.ts
+++ b/packages/cli/src/commands/plugin/scaffold.ts
@@ -54,6 +54,14 @@ const SDK_DECLARATIONS = `declare module "@getpaseo/plugin/server" {
 
   export const PluginAttachmentItemSchema: import("zod").ZodType<PluginAttachmentItem>;
   export const PluginAttachmentSearchPayloadSchema: import("zod").ZodType<PluginAttachmentSearchPayload>;
+
+  export interface PluginSidebarBadge { count: number; }
+  export const PluginSidebarBadgeSchema: import("zod").ZodType<PluginSidebarBadge>;
+
+  export interface PluginSidebarBadgeContribution {
+    rpc: PluginRpcContract;
+    intervalMs?: number;
+  }
 }
 
 declare module "@getpaseo/plugin" {
@@ -69,6 +77,7 @@ declare module "@getpaseo/plugin" {
   export {
     PluginAttachmentItemSchema,
     PluginAttachmentSearchPayloadSchema,
+    PluginSidebarBadgeSchema,
     defineAttachmentSource,
     defineRpc,
     type PluginAttachmentItem,
@@ -76,6 +85,8 @@ declare module "@getpaseo/plugin" {
     type PluginAttachmentSourceContribution,
     type PluginHandlerContext,
     type PluginRpcContract,
+    type PluginSidebarBadge,
+    type PluginSidebarBadgeContribution,
   } from "@getpaseo/plugin/server";
 
   export interface PluginTheme {
@@ -95,7 +106,25 @@ declare module "@getpaseo/plugin" {
     layout: { compact: boolean; platform: "ios" | "android" | "web" };
   }
 
-  export interface PluginSurfaceProps extends PluginHostProps {}
+  export interface PluginSurfaceProps extends PluginHostProps {
+    setSidebarBadgeCount?(itemId: string, count: number): void;
+  }
+
+  export interface PluginProjectPlacementSnapshot {
+    readonly serverId: string;
+    readonly serverName: string;
+    readonly projectId: string;
+    readonly projectName: string;
+    readonly projectRootPath: string;
+    readonly projectKind: "git" | "non_git" | "directory";
+    readonly isOnline: boolean;
+  }
+
+  export interface PluginProjectSnapshot {
+    readonly projectKey: string;
+    readonly projectName: string;
+    readonly placements: readonly PluginProjectPlacementSnapshot[];
+  }
 
   export interface PluginWorkspaceSnapshot {
     readonly id: string;
@@ -146,6 +175,17 @@ declare module "@getpaseo/plugin" {
   export type PluginPanelLocation = "workspace" | "explorer";
   export interface PluginOpenPanelOptions { location?: PluginPanelLocation; }
 
+  export interface PluginOpenWorkspaceOptions {
+    agentId?: string;
+    pin?: boolean;
+    serverId?: string;
+  }
+
+  export interface PluginNavigation {
+    openWorkspace(workspaceId: string, options?: PluginOpenWorkspaceOptions): void;
+    openExternal(url: string): Promise<void>;
+  }
+
   export type PluginWorkspacePanelContribution =
     | { id: string; title: string; icon: string; locations?: readonly PluginPanelLocation[]; context: "workspace"; Component: ComponentType<PluginWorkspacePanelProps> }
     | { id: string; title: string; icon: string; locations?: readonly PluginPanelLocation[]; context: "agent"; Component: ComponentType<PluginAgentPanelProps> };
@@ -155,6 +195,7 @@ declare module "@getpaseo/plugin" {
     title: string;
     icon: string;
     surface: string;
+    badge?: PluginSidebarBadgeContribution;
   }
 
   export interface PluginThemeColors {
@@ -187,6 +228,8 @@ declare module "@getpaseo/plugin" {
       input: ZodInput<InputSchema>,
     ): Promise<ZodOutput<OutputSchema>>;
     openSurface(id: string): void;
+    openWorkspace(workspaceId: string, options?: PluginOpenWorkspaceOptions): void;
+    openExternal(url: string): Promise<void>;
   }
 
   export interface PluginGlobalCommandContext extends PluginCommandCapabilities {
@@ -236,6 +279,10 @@ declare module "@getpaseo/plugin" {
 
   export function usePaseo(): PaseoApi;
 
+  export function useProjects(): readonly PluginProjectSnapshot[];
+
+  export function usePaseoHost(serverId: string | null): PaseoApi | null;
+
   export function useWorkspace<Selection>(
     workspaceId: string,
     selector: (workspace: PluginWorkspaceSnapshot) => Selection,
@@ -245,6 +292,13 @@ declare module "@getpaseo/plugin" {
     agentId: string,
     selector: (agent: PluginAgentSnapshot) => Selection,
   ): Selection | null;
+
+  export function useOpenWorkspace(): (
+    workspaceId: string,
+    options?: PluginOpenWorkspaceOptions,
+  ) => void;
+
+  export function useOpenExternal(): (url: string) => Promise<void>;
 }
 `;
 

--- a/packages/plugin/src/badges.test.ts
+++ b/packages/plugin/src/badges.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  PLUGIN_SIDEBAR_BADGE_DEFAULT_INTERVAL_MS,
+  PLUGIN_SIDEBAR_BADGE_MIN_INTERVAL_MS,
+  PluginSidebarBadgeSchema,
+  resolvePluginSidebarBadgeInterval,
+} from "./badges.js";
+import { readPluginSidebarBadge } from "./host.js";
+import { defineRpc } from "./rpc.js";
+
+const badgeRpc = defineRpc({
+  name: "reviews.badge",
+  input: z.object({}),
+  output: PluginSidebarBadgeSchema,
+});
+
+const item = { id: "inbox", title: "Reviews", icon: "Inbox", surface: "inbox" };
+
+describe("resolvePluginSidebarBadgeInterval", () => {
+  it("defaults when the plugin says nothing", () => {
+    expect(resolvePluginSidebarBadgeInterval(undefined)).toBe(
+      PLUGIN_SIDEBAR_BADGE_DEFAULT_INTERVAL_MS,
+    );
+  });
+
+  it("floors an interval that would hammer the plugin", () => {
+    expect(resolvePluginSidebarBadgeInterval(1)).toBe(PLUGIN_SIDEBAR_BADGE_MIN_INTERVAL_MS);
+  });
+
+  it("keeps a slower interval the plugin asked for", () => {
+    expect(resolvePluginSidebarBadgeInterval(300_000)).toBe(300_000);
+  });
+
+  it("ignores a non-finite interval", () => {
+    expect(resolvePluginSidebarBadgeInterval(Number.NaN)).toBe(
+      PLUGIN_SIDEBAR_BADGE_DEFAULT_INTERVAL_MS,
+    );
+  });
+});
+
+describe("readPluginSidebarBadge", () => {
+  it("returns null for a sidebar item with no badge", async () => {
+    await expect(readPluginSidebarBadge(item, async () => ({ count: 3 }))).resolves.toBeNull();
+  });
+
+  it("calls the badge RPC with an empty input and parses the count", async () => {
+    const calls: { method: string; input: unknown }[] = [];
+    const badge = await readPluginSidebarBadge(
+      { ...item, badge: { rpc: badgeRpc } },
+      async (method, input) => {
+        calls.push({ method, input });
+        return { count: 7 };
+      },
+    );
+
+    expect(calls).toEqual([{ method: "reviews.badge", input: {} }]);
+    expect(badge).toEqual({ count: 7 });
+  });
+
+  it("rejects a count the schema does not allow", async () => {
+    await expect(
+      readPluginSidebarBadge({ ...item, badge: { rpc: badgeRpc } }, async () => ({ count: -1 })),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/plugin/src/badges.ts
+++ b/packages/plugin/src/badges.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+/**
+ * A sidebar badge is a count the host polls for. `0` clears the badge, so a
+ * plugin never has to distinguish "nothing to show" from "not loaded yet".
+ */
+export const PluginSidebarBadgeSchema = z.object({
+  count: z.number().int().min(0),
+});
+
+export type PluginSidebarBadge = z.infer<typeof PluginSidebarBadgeSchema>;
+
+export const PLUGIN_SIDEBAR_BADGE_DEFAULT_INTERVAL_MS = 60_000;
+export const PLUGIN_SIDEBAR_BADGE_MIN_INTERVAL_MS = 15_000;
+
+export function resolvePluginSidebarBadgeInterval(intervalMs: number | undefined): number {
+  if (intervalMs === undefined || !Number.isFinite(intervalMs)) {
+    return PLUGIN_SIDEBAR_BADGE_DEFAULT_INTERVAL_MS;
+  }
+  return Math.max(PLUGIN_SIDEBAR_BADGE_MIN_INTERVAL_MS, Math.floor(intervalMs));
+}

--- a/packages/plugin/src/contracts.ts
+++ b/packages/plugin/src/contracts.ts
@@ -26,7 +26,30 @@ export interface PluginHostProps {
   };
 }
 
-export interface PluginSurfaceProps extends PluginHostProps {}
+export interface PluginSurfaceProps extends PluginHostProps {
+  /**
+   * Updates a contributed sidebar item's visible badge without waiting for its
+   * next poll. Older hosts omit this callback.
+   */
+  setSidebarBadgeCount?(itemId: string, count: number): void;
+}
+
+export interface PluginProjectPlacementSnapshot {
+  readonly serverId: string;
+  readonly serverName: string;
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly projectRootPath: string;
+  readonly projectKind: "git" | "non_git" | "directory";
+  readonly isOnline: boolean;
+}
+
+export interface PluginProjectSnapshot {
+  /** Cross-host identity shared by placements of the same project. */
+  readonly projectKey: string;
+  readonly projectName: string;
+  readonly placements: readonly PluginProjectPlacementSnapshot[];
+}
 
 export interface PluginWorkspaceSnapshot {
   readonly id: string;
@@ -69,6 +92,29 @@ export interface PluginOpenPanelOptions {
   location?: PluginPanelLocation;
 }
 
+export interface PluginOpenWorkspaceOptions {
+  /** Focus this agent inside the workspace instead of its default tab. */
+  agentId?: string;
+  /** Pin the opened tab. Defaults to true when `agentId` is set. */
+  pin?: boolean;
+  /** Navigate on this host instead of the plugin installation's selected host. */
+  serverId?: string;
+}
+
+/**
+ * In-app navigation the host performs on a plugin's behalf. Plugins never get
+ * router access; this is the whole navigation surface.
+ */
+export interface PluginNavigation {
+  openWorkspace(workspaceId: string, options?: PluginOpenWorkspaceOptions): void;
+  /**
+   * Hands an http(s) URL to the OS browser. Plugin code cannot do this itself:
+   * `Linking.openURL` reaches `window.open`, which Paseo's desktop shell turns
+   * into an in-app browser tab rather than leaving the app.
+   */
+  openExternal(url: string): Promise<void>;
+}
+
 interface PluginWorkspacePanelBase {
   id: string;
   title: string;
@@ -102,11 +148,19 @@ export interface PluginSurfaceContribution {
   Component: ComponentType<PluginSurfaceProps>;
 }
 
+export interface PluginSidebarBadgeContribution {
+  /** RPC returning `{ count }`. Called with an empty input object. */
+  rpc: PluginRpcContract;
+  /** Poll interval. Defaults to 60s; the host floors it at 15s. */
+  intervalMs?: number;
+}
+
 export interface PluginSidebarContribution {
   id: string;
   title: string;
   icon: string;
   surface: string;
+  badge?: PluginSidebarBadgeContribution;
 }
 
 export interface PluginThemeColors {
@@ -143,6 +197,8 @@ export interface PluginCommandCapabilities {
     input: ZodInput<InputSchema>,
   ): Promise<ZodOutput<OutputSchema>>;
   openSurface(id: string): void;
+  openWorkspace(workspaceId: string, options?: PluginOpenWorkspaceOptions): void;
+  openExternal(url: string): Promise<void>;
 }
 
 export interface PluginGlobalCommandContext extends PluginCommandCapabilities {

--- a/packages/plugin/src/host.ts
+++ b/packages/plugin/src/host.ts
@@ -1,4 +1,5 @@
 import { PluginAttachmentSearchPayloadSchema } from "./attachments.js";
+import { PluginSidebarBadgeSchema, resolvePluginSidebarBadgeInterval } from "./badges.js";
 export { PluginClientStateProvider, type PluginClientStateSource } from "./client-state.js";
 import type {
   PluginAttachmentSourceContribution,
@@ -10,8 +11,10 @@ import type {
   PluginThemeContribution,
   PluginWorkspacePanelContribution,
 } from "./contracts.js";
+import { PluginNavigationProvider } from "./navigation-context.js";
 import { PluginRpcProvider } from "./rpc-context.js";
 import { PaseoApiProvider } from "./paseo-context.js";
+import { PluginProjectProvider } from "./project-context.js";
 import { callPluginRpc } from "./rpc.js";
 import type { ComponentType } from "react";
 
@@ -66,6 +69,15 @@ export function createPluginContext(
   };
 }
 
+export async function readPluginSidebarBadge(
+  contribution: PluginSidebarContribution,
+  invoke: (method: string, input: unknown) => Promise<unknown>,
+) {
+  if (!contribution.badge) return null;
+  const output = await callPluginRpc(contribution.badge.rpc, invoke, {});
+  return PluginSidebarBadgeSchema.parseAsync(output);
+}
+
 export async function searchPluginAttachments(
   source: PluginAttachmentSourceContribution,
   invoke: (method: string, input: unknown) => Promise<unknown>,
@@ -75,4 +87,11 @@ export async function searchPluginAttachments(
   return PluginAttachmentSearchPayloadSchema.parseAsync(output);
 }
 
-export { callPluginRpc, PaseoApiProvider, PluginRpcProvider };
+export {
+  callPluginRpc,
+  resolvePluginSidebarBadgeInterval,
+  PaseoApiProvider,
+  PluginProjectProvider,
+  PluginNavigationProvider,
+  PluginRpcProvider,
+};

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,3 +1,4 @@
+export { PluginSidebarBadgeSchema, type PluginSidebarBadge } from "./badges.js";
 export {
   PluginAttachmentItemSchema,
   PluginAttachmentSearchPayloadSchema,
@@ -20,9 +21,14 @@ export type {
   PluginGlobalCommandContext,
   PluginHandlerContext,
   PluginHostProps,
+  PluginNavigation,
   PluginOpenPanelOptions,
+  PluginOpenWorkspaceOptions,
   PluginPanelLocation,
+  PluginProjectPlacementSnapshot,
+  PluginProjectSnapshot,
   PluginTheme,
+  PluginSidebarBadgeContribution,
   PluginSidebarContribution,
   PluginSurfaceContribution,
   PluginSurfaceProps,
@@ -34,5 +40,7 @@ export type {
   PluginWorkspaceSnapshot,
 } from "./contracts.js";
 export { usePaseo } from "./paseo-context.js";
+export { usePaseoHost, useProjects } from "./project-context.js";
 export { useAgent, useWorkspace } from "./client-state.js";
 export { useRpc } from "./rpc-context.js";
+export { useOpenExternal, useOpenWorkspace } from "./navigation-context.js";

--- a/packages/plugin/src/navigation-context.tsx
+++ b/packages/plugin/src/navigation-context.tsx
@@ -1,0 +1,42 @@
+import { createContext, useCallback, useContext, type ReactNode } from "react";
+import type { PluginNavigation, PluginOpenWorkspaceOptions } from "./contracts.js";
+
+const PluginNavigationContext = createContext<PluginNavigation | null>(null);
+
+export function PluginNavigationProvider({
+  children,
+  navigation,
+}: {
+  children: ReactNode;
+  navigation: PluginNavigation;
+}) {
+  return (
+    <PluginNavigationContext.Provider value={navigation}>
+      {children}
+    </PluginNavigationContext.Provider>
+  );
+}
+
+export function useOpenExternal(): (url: string) => Promise<void> {
+  const navigation = useContext(PluginNavigationContext);
+  if (!navigation) {
+    throw new Error("useOpenExternal must run inside a contributed plugin surface");
+  }
+  return useCallback((url: string) => navigation.openExternal(url), [navigation]);
+}
+
+export function useOpenWorkspace(): (
+  workspaceId: string,
+  options?: PluginOpenWorkspaceOptions,
+) => void {
+  const navigation = useContext(PluginNavigationContext);
+  if (!navigation) {
+    throw new Error("useOpenWorkspace must run inside a contributed plugin surface");
+  }
+  return useCallback(
+    (workspaceId: string, options?: PluginOpenWorkspaceOptions) => {
+      navigation.openWorkspace(workspaceId, options);
+    },
+    [navigation],
+  );
+}

--- a/packages/plugin/src/project-context.tsx
+++ b/packages/plugin/src/project-context.tsx
@@ -1,0 +1,38 @@
+import type { PaseoApi } from "@getpaseo/client";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { PluginProjectSnapshot } from "./contracts.js";
+
+interface PluginProjectContextValue {
+  projects: readonly PluginProjectSnapshot[];
+  resolvePaseo(serverId: string): PaseoApi | null;
+}
+
+const PluginProjectContext = createContext<PluginProjectContextValue | null>(null);
+
+export function PluginProjectProvider({
+  children,
+  projects,
+  resolvePaseo,
+}: PluginProjectContextValue & { children: ReactNode }) {
+  const value = useMemo(() => ({ projects, resolvePaseo }), [projects, resolvePaseo]);
+  return <PluginProjectContext.Provider value={value}>{children}</PluginProjectContext.Provider>;
+}
+
+function usePluginProjectContext(): PluginProjectContextValue {
+  const context = useContext(PluginProjectContext);
+  if (!context) {
+    throw new Error("Project hooks must run inside a contributed plugin surface");
+  }
+  return context;
+}
+
+/** All known Paseo projects, grouped across every connected host. */
+export function useProjects(): readonly PluginProjectSnapshot[] {
+  return usePluginProjectContext().projects;
+}
+
+/** Borrow an online host's existing Paseo connection. */
+export function usePaseoHost(serverId: string | null): PaseoApi | null {
+  const context = usePluginProjectContext();
+  return serverId ? context.resolvePaseo(serverId) : null;
+}

--- a/packages/plugin/src/server.ts
+++ b/packages/plugin/src/server.ts
@@ -1,12 +1,17 @@
 import type { PluginAttachmentSourceContribution } from "./contracts.js";
 
+export { PluginSidebarBadgeSchema, type PluginSidebarBadge } from "./badges.js";
 export {
   PluginAttachmentItemSchema,
   PluginAttachmentSearchPayloadSchema,
   type PluginAttachmentItem,
   type PluginAttachmentSearchPayload,
 } from "./attachments.js";
-export type { PluginAttachmentSourceContribution, PluginHandlerContext } from "./contracts.js";
+export type {
+  PluginAttachmentSourceContribution,
+  PluginHandlerContext,
+  PluginSidebarBadgeContribution,
+} from "./contracts.js";
 export { defineRpc, type PluginRpcContract } from "./rpc.js";
 
 export function defineAttachmentSource<Definition extends PluginAttachmentSourceContribution>(

--- a/packages/server/src/server/plugins/plugin-paseo-api.e2e.test.ts
+++ b/packages/server/src/server/plugins/plugin-paseo-api.e2e.test.ts
@@ -103,6 +103,144 @@ export default function contribute(plugin: PluginContext) {
   }
 }, 60_000);
 
+test("plugin subprocess receives the whole server SDK, not a hand-picked subset", async () => {
+  const pluginDirectory = await mkdtemp(path.join(tmpdir(), "paseo-sdk-plugin-"));
+  roots.push(pluginDirectory);
+  await writeFile(
+    path.join(pluginDirectory, "paseo-plugin.json"),
+    JSON.stringify({ id: "sdk-surface" }),
+  );
+  // Imports every value export the server SDK offers. When the subprocess hands
+  // back a hand-written subset instead of the module, these are undefined and
+  // the plugin fails at load or first call.
+  await writeFile(
+    path.join(pluginDirectory, "index.tsx"),
+    `import {
+  PluginAttachmentItemSchema,
+  PluginAttachmentSearchPayloadSchema,
+  PluginSidebarBadgeSchema,
+  defineAttachmentSource,
+  defineRpc,
+  type PluginContext,
+} from "@getpaseo/plugin/server";
+import { z } from "zod";
+
+const badge = defineRpc({
+  name: "badge",
+  input: z.object({}),
+  output: PluginSidebarBadgeSchema,
+});
+
+const search = defineRpc({
+  name: "search",
+  input: z.object({ query: z.string() }),
+  output: PluginAttachmentSearchPayloadSchema,
+});
+
+export default function contribute(plugin: PluginContext) {
+  plugin.handle(badge, () => ({ count: 3 }));
+  plugin.handle(search, () => ({ items: [] }));
+  void defineAttachmentSource;
+  void PluginAttachmentItemSchema;
+  return () => undefined;
+}`,
+  );
+
+  const daemon = await createTestPaseoDaemon();
+  const client = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    appVersion: "0.4.0",
+  });
+
+  try {
+    await client.connect();
+    await client.patchDaemonConfig({ pluginsEnabled: true });
+    await expect(client.installDirectoryPlugin(pluginDirectory)).resolves.toMatchObject({
+      id: "sdk-surface",
+      status: "running",
+    });
+
+    await expect(client.invokePluginRpc("sdk-surface", "badge", {})).resolves.toEqual({ count: 3 });
+    await expect(
+      client.invokePluginRpc("sdk-surface", "search", { query: "anything" }),
+    ).resolves.toEqual({ items: [] });
+
+    await client.removePlugin("sdk-surface");
+  } finally {
+    await client.close().catch(() => undefined);
+    await daemon.close();
+  }
+}, 60_000);
+
+test("reload is not stalled or crashed by a handler that answers after shutdown", async () => {
+  const pluginDirectory = await mkdtemp(path.join(tmpdir(), "paseo-late-reply-"));
+  roots.push(pluginDirectory);
+  await writeFile(
+    path.join(pluginDirectory, "paseo-plugin.json"),
+    JSON.stringify({ id: "late-reply" }),
+  );
+  // Answers long after the host stops the plugin. Before send() checked the
+  // channel, the late reply threw ERR_IPC_CHANNEL_CLOSED and took the
+  // subprocess down with an unhandled 'error' event.
+  await writeFile(
+    path.join(pluginDirectory, "index.tsx"),
+    `import { defineRpc, type PluginContext } from "@getpaseo/plugin/server";
+import { z } from "zod";
+
+const slow = defineRpc({
+  name: "slow",
+  input: z.object({}),
+  output: z.object({ done: z.boolean() }),
+});
+
+export default function contribute(plugin: PluginContext) {
+  plugin.handle(slow, async () => {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    return { done: true };
+  });
+  return () => undefined;
+}`,
+  );
+
+  const daemon = await createTestPaseoDaemon();
+  const client = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    appVersion: "0.4.0",
+  });
+
+  try {
+    await client.connect();
+    await client.patchDaemonConfig({ pluginsEnabled: true });
+    await expect(client.installDirectoryPlugin(pluginDirectory)).resolves.toMatchObject({
+      id: "late-reply",
+      status: "running",
+    });
+
+    // Leave a handler running, then reload out from under it.
+    const pending = client.invokePluginRpc("late-reply", "slow", {}).catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const reloadStarted = Date.now();
+    await expect(client.reloadPlugin("late-reply")).resolves.toMatchObject({
+      id: "late-reply",
+      status: "running",
+    });
+    expect(Date.now() - reloadStarted).toBeLessThan(15_000);
+
+    await pending;
+    // Reload retains the log tail, so the discarded subprocess's output is
+    // still readable here.
+    const logs = await client.getPluginLogs("late-reply");
+    expect(logs.map((entry) => entry.message).join("\n")).not.toContain("ERR_IPC_CHANNEL_CLOSED");
+
+    await expect(client.invokePluginRpc("late-reply", "slow", {})).resolves.toEqual({ done: true });
+    await client.removePlugin("late-reply");
+  } finally {
+    await client.close().catch(() => undefined);
+    await daemon.close();
+  }
+}, 60_000);
+
 test("daemon config reload enables and disables configured plugins without restarting", async () => {
   const pluginDirectory = await mkdtemp(path.join(tmpdir(), "paseo-reload-plugin-"));
   const paseoHomeRoot = await mkdtemp(path.join(tmpdir(), "paseo-reload-home-"));

--- a/packages/server/src/server/plugins/plugin-process.ts
+++ b/packages/server/src/server/plugins/plugin-process.ts
@@ -1,11 +1,9 @@
 import type { PluginProcessMessage, PluginProcessRequest } from "./plugin-process-protocol.js";
 import { createRequire } from "node:module";
-import {
-  defineAttachmentSource,
-  defineRpc,
-  type PluginHandlerContext,
-  type PluginRpcContract,
-} from "@getpaseo/plugin/server";
+import type { PluginHandlerContext, PluginRpcContract } from "@getpaseo/plugin/server";
+// Namespace, not named imports: this is handed straight to plugin code, so a
+// hand-written list silently drops any export the SDK adds later.
+import * as PluginServerSdk from "@getpaseo/plugin/server";
 import { createPaseoApi, type PaseoApi } from "@getpaseo/client";
 import { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { createPluginDaemonTransportFactory } from "./daemon-transport.js";
@@ -25,17 +23,34 @@ let paseo: PaseoApi | null = null;
 let stopping = false;
 const nodeRequire = createRequire(import.meta.url);
 
+// process.send throws ERR_IPC_CHANNEL_CLOSED once the host closes the channel,
+// and an unhandled throw here kills the subprocess with a stack that looks like
+// a plugin crash. A handler that resolves after shutdown has nobody to answer,
+// so dropping the reply is the whole correct behaviour.
+function canSend(): boolean {
+  return typeof process.send === "function" && process.connected;
+}
+
 function send(message: PluginProcessMessage): void {
-  process.send?.(message);
+  if (!canSend()) return;
+  try {
+    process.send?.(message);
+  } catch {
+    // The channel closed between the check and the write.
+  }
 }
 
 function sendAndWait(message: PluginProcessMessage): Promise<void> {
   return new Promise((resolve) => {
-    if (!process.send) {
+    if (!canSend()) {
       resolve();
       return;
     }
-    process.send(message, () => resolve());
+    try {
+      process.send?.(message, () => resolve());
+    } catch {
+      resolve();
+    }
   });
 }
 
@@ -62,7 +77,10 @@ function register(contract: PluginRpcContract, handler: RpcHandler): void {
   handlers.set(method, { contract: { ...contract, name: method }, handler });
 }
 
-const pluginAuthorRuntime = { defineAttachmentSource, defineRpc };
+// Both SDK specifiers resolve to the server surface here. A shared module that
+// reaches for a client hook in the subprocess is a bug in the plugin, not
+// something to paper over with a stub.
+const pluginAuthorRuntime = PluginServerSdk;
 
 function runtimeRequire(name: string): unknown {
   if (isPluginSdkSpecifier(name)) return pluginAuthorRuntime;


### PR DESCRIPTION
<img width="323" height="174" alt="Plugin review inbox" src="https://github.com/user-attachments/assets/90636d97-8637-4402-aca2-59bac52e98bd" />

### Linked issue

None

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Plugins can render surfaces, but they cannot navigate into a Paseo workspace, choose a project placement on another connected host, open a URL in the system browser, or expose lightweight state in the sidebar. Implementing those behaviors inside a plugin would duplicate app routing and host-selection logic.

This adds host-owned APIs for those workflows. Plugins can navigate to registered surfaces and workspaces, read a cross-host project catalog, target an online host explicitly, open external HTTP links, and attach a polled count to a sidebar contribution. Paseo retains ownership of routing, host selection, polling limits, and sidebar rendering.

### Goals

- Let plugin surfaces and Command Center actions open registered plugin surfaces and Paseo workspaces without receiving router access.
- Expose project placements across hosts and require explicit host selection for cross-host actions.
- Let plugins open external HTTP and HTTPS links through the host.
- Let a sidebar contribution declare a bounded count RPC and update its mounted count immediately.
- Keep plugin state isolated by selected installation and host.
- Update scaffold-generated declarations for the SDK contracts.
- Cover client evaluation, navigation, project aggregation, sidebar counts, scaffold output, and daemon plugin API behavior.

### Non-goals

- Mobile-specific behavior.
- Direct Expo Router or workspace-layout store access for plugins.
- Automatic fallback to another host when a selected host is offline.

### QA

Automated validation from a clean worktree based on current upstream main:

```text
npm run build:server
exit 0

npm run typecheck
exit 0

npm run lint
Found 0 warnings and 0 errors.

npm run format:check
All matched files use the correct format.

App focused tests
8 files passed, 47 tests passed

Plugin SDK badge tests
1 file passed, 7 tests passed

CLI scaffold tests
1 file passed, 3 tests passed

Daemon plugin API integration
1 file passed, 4 tests passed
```

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Shared React Native APIs covered by typecheck and unit tests |
| Android | No | Shared React Native APIs covered by typecheck and unit tests |
| Web | No manual run | Client behavior covered by focused tests |
| Desktop macOS | Yes | Exercised with a local review-inbox plugin against a local daemon |
| Desktop Windows | No | Not available |
| Desktop Linux | No | Not available |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
