### PR TITLE
feat: add plugin notification sources

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -27,6 +27,7 @@ import { CommandCenterRootActions } from "@/command-center/root-registration";
 import { CommandCenterProvider } from "@/command-center/provider";
 import { CommandCenterWorkspaceActions } from "@/command-center/workspace-registration";
 import { PluginCommandCenterActions } from "@/plugins/command-center/registration";
+import { PluginNotificationSources } from "@/plugins/notification-sources";
 import { AddProjectFlowHost } from "@/components/add-project-flow-host";
 import { AppearanceStyleBoundary } from "@/components/appearance-style-boundary";
 import { WorktreeSetupCalloutSource } from "@/components/worktree-setup-callout-source";
@@ -594,6 +595,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
       <CommandCenterRootActions />
       <CommandCenterWorkspaceActions />
       <PluginCommandCenterActions />
+      <PluginNotificationSources />
       <WorkspacePinShortcutHandler />
       <CommandCenter />
       <AddProjectFlowHost />

--- a/packages/app/src/plugins/command-center/contributions.test.ts
+++ b/packages/app/src/plugins/command-center/contributions.test.ts
@@ -98,6 +98,7 @@ function plugin(onAgentSelect: AgentCommandItem["onSelect"]): InstalledPlugin {
       },
     ],
     attachmentSources: [],
+    notificationSources: [],
     themes: [],
   };
 }

--- a/packages/app/src/plugins/evaluate.test.ts
+++ b/packages/app/src/plugins/evaluate.test.ts
@@ -54,6 +54,27 @@ describe("evaluatePluginClientBundle", () => {
     ]);
   });
 
+  it("collects a notification source with a bounded poll interval", () => {
+    const plugin = evaluatePluginClientBundle(
+      "review",
+      bundle(`
+        plugin.addNotificationSource({
+          id: "review-requests",
+          rpc: { name: "reviews.notifications", input: {}, output: {} },
+          intervalMs: 1000,
+        });
+      `),
+    );
+
+    expect(plugin.notificationSources).toEqual([
+      {
+        id: "review-requests",
+        rpc: { name: "reviews.notifications", input: {}, output: {} },
+        intervalMs: 15_000,
+      },
+    ]);
+  });
+
   it("collects contextual workspace panels and Command Center items", () => {
     const plugin = evaluatePluginClientBundle(
       "review",
@@ -187,6 +208,22 @@ describe("evaluatePluginClientBundle", () => {
         `),
       ),
     ).toThrow("Duplicate attachment source: issues");
+  });
+
+  it("rejects duplicate notification source ids", () => {
+    expect(() =>
+      evaluatePluginClientBundle(
+        "review",
+        bundle(`
+          const source = {
+            id: "review-requests",
+            rpc: { name: "reviews.notifications", input: {}, output: {} },
+          };
+          plugin.addNotificationSource(source);
+          plugin.addNotificationSource(source);
+        `),
+      ),
+    ).toThrow("Duplicate notification source: review-requests");
   });
 
   it("collects a contributed theme", () => {

--- a/packages/app/src/plugins/evaluate.ts
+++ b/packages/app/src/plugins/evaluate.ts
@@ -5,21 +5,25 @@ import * as ReactNative from "react-native";
 // eslint-disable-next-line no-restricted-imports -- plugin bundles receive TanStack's real runtime, not Paseo's query wrappers.
 import * as ReactQuery from "@tanstack/react-query";
 import * as Zod from "zod";
-import {
-  defineAttachmentSource,
-  defineRpc,
-  type PluginAttachmentSourceContribution,
-  type PluginCommandCenterItemContribution,
-  type PluginSidebarContribution,
-  type PluginSurfaceProps,
-  type PluginThemeContribution,
-  type PluginWorkspacePanelContribution,
-  usePaseo,
-  useAgent,
-  useWorkspace,
-  useRpc,
+import type {
+  PluginAttachmentSourceContribution,
+  PluginCommandCenterItemContribution,
+  PluginNotificationSourceContribution,
+  PluginSidebarContribution,
+  PluginSurfaceProps,
+  PluginThemeContribution,
+  PluginWorkspacePanelContribution,
 } from "@getpaseo/plugin";
-import { createPluginContext, type PluginRegistrationCollector } from "@getpaseo/plugin/host";
+// Namespaces, not named imports: the runtime shim below hands these straight to
+// plugin code, so it cannot drift behind the SDK's exports the way a
+// hand-written list does.
+import * as PluginSdk from "@getpaseo/plugin";
+import * as PluginServerSdk from "@getpaseo/plugin/server";
+import {
+  createPluginContext,
+  resolvePluginNotificationInterval,
+  type PluginRegistrationCollector,
+} from "@getpaseo/plugin/host";
 import type { EvaluatedPlugin } from "./types";
 import type { ComponentType } from "react";
 import { resolvePluginIcon } from "./icons";
@@ -61,6 +65,7 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
     workspacePanels: [],
     commandCenterItems: [],
     attachmentSources: [],
+    notificationSources: [],
     themes: [],
   };
   const surfaceIds = new Set<string>();
@@ -68,6 +73,7 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
   const workspacePanelIds = new Set<string>();
   const commandCenterItemIds = new Set<string>();
   const attachmentSourceIds = new Set<string>();
+  const notificationSourceIds = new Set<string>();
   const themeIds = new Set<string>();
   const pluginContext = createPluginContext({
     addSurface(surfaceId: string, Component: ComponentType<PluginSurfaceProps>) {
@@ -176,6 +182,21 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
         search: { ...contribution.search, name: method },
       });
     },
+    addNotificationSource(contribution: PluginNotificationSourceContribution) {
+      const normalizedId = requireId(contribution.id, "notification source id");
+      if (notificationSourceIds.has(normalizedId)) {
+        throw new Error(`Duplicate notification source: ${normalizedId}`);
+      }
+      const method = contribution.rpc?.name?.trim();
+      if (!method) throw new Error(`Notification source ${normalizedId} has no RPC`);
+      const intervalMs = resolvePluginNotificationInterval(contribution.intervalMs);
+      notificationSourceIds.add(normalizedId);
+      collector.notificationSources.push({
+        id: normalizedId,
+        rpc: { ...contribution.rpc, name: method },
+        intervalMs,
+      });
+    },
     addTheme(contribution: PluginThemeContribution) {
       const normalizedId = requireId(contribution.id, "theme id");
       if (themeIds.has(normalizedId)) throw new Error(`Duplicate theme: ${normalizedId}`);
@@ -188,19 +209,8 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
     if (name === "react") return React;
     if (name === "react/jsx-runtime") return ReactJsxRuntime;
     if (name === "react-native") return ReactNative;
-    if (name === "@getpaseo/plugin") {
-      return {
-        defineAttachmentSource,
-        defineRpc,
-        usePaseo,
-        useAgent,
-        useWorkspace,
-        useRpc,
-      };
-    }
-    if (name === "@getpaseo/plugin/server") {
-      return { defineAttachmentSource, defineRpc };
-    }
+    if (name === "@getpaseo/plugin") return PluginSdk;
+    if (name === "@getpaseo/plugin/server") return PluginServerSdk;
     if (name === "@tanstack/react-query") return ReactQuery;
     if (name === "zod") return Zod;
     throw new Error(`Module "${name}" is not available in plugin client code`);
@@ -244,6 +254,7 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
     workspacePanels: collector.workspacePanels as EvaluatedPlugin["workspacePanels"],
     commandCenterItems: collector.commandCenterItems,
     attachmentSources: collector.attachmentSources,
+    notificationSources: collector.notificationSources,
     themes: collector.themes,
   };
 }

--- a/packages/app/src/plugins/notification-receipts.ts
+++ b/packages/app/src/plugins/notification-receipts.ts
@@ -1,0 +1,85 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const RECEIPT_LIMIT = 256;
+const STORAGE_KEY_PREFIX = "plugin-notification-receipts";
+
+export interface PluginNotificationReceiptStorage {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+}
+
+export interface PluginNotificationReceiptScope {
+  serverId: string;
+  pluginId: string;
+  sourceId: string;
+}
+
+function storageKey(scope: PluginNotificationReceiptScope): string {
+  return [STORAGE_KEY_PREFIX, scope.serverId, scope.pluginId, scope.sourceId]
+    .map(encodeURIComponent)
+    .join(":");
+}
+
+function parseReceipts(serialized: string | null): string[] {
+  if (!serialized) return [];
+  try {
+    const parsed: unknown = JSON.parse(serialized);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((value): value is string => typeof value === "string")
+      .slice(-RECEIPT_LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+export class PluginNotificationReceiptStore {
+  private readonly receipts = new Map<string, string[]>();
+  private readonly operations = new Map<string, Promise<void>>();
+
+  constructor(private readonly storage: PluginNotificationReceiptStorage) {}
+
+  claim(scope: PluginNotificationReceiptScope, eventIds: readonly string[]): Promise<string[]> {
+    const key = storageKey(scope);
+    const previous = this.operations.get(key) ?? Promise.resolve();
+    const operation = previous.then(() => this.claimAfterPrevious(key, eventIds));
+    this.operations.set(
+      key,
+      operation.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    return operation;
+  }
+
+  private async claimAfterPrevious(key: string, eventIds: readonly string[]): Promise<string[]> {
+    let receipts = this.receipts.get(key);
+    if (!receipts) {
+      receipts = parseReceipts(await this.storage.getItem(key));
+    }
+
+    const seen = new Set(receipts);
+    const claimed: string[] = [];
+    for (const eventId of eventIds) {
+      if (seen.has(eventId)) continue;
+      seen.add(eventId);
+      claimed.push(eventId);
+    }
+    if (claimed.length === 0) {
+      this.receipts.set(key, receipts);
+      return [];
+    }
+
+    const nextReceipts = [...receipts, ...claimed].slice(-RECEIPT_LIMIT);
+    this.receipts.set(key, nextReceipts);
+    try {
+      await this.storage.setItem(key, JSON.stringify(nextReceipts));
+    } catch (error) {
+      console.warn("[Plugins] Failed to persist notification receipts", error);
+    }
+    return claimed;
+  }
+}
+
+export const pluginNotificationReceiptStore = new PluginNotificationReceiptStore(AsyncStorage);

--- a/packages/app/src/plugins/notification-sources.tsx
+++ b/packages/app/src/plugins/notification-sources.tsx
@@ -1,0 +1,98 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import type { PluginNotificationSourceContribution } from "@getpaseo/plugin";
+import { resolvePluginNotificationInterval } from "@getpaseo/plugin/host";
+import { useMemo } from "react";
+import { isNative } from "@/constants/platform";
+import { useFetchQuery } from "@/data/query";
+import { useHostRuntimeClient } from "@/runtime/host-runtime";
+import { pluginNotificationReceiptStore } from "./notification-receipts";
+import { createPluginNotifier, pollPluginNotificationSource } from "./notifications";
+import { useInstalledPlugins } from "./registry";
+import { createPluginSurfaceRuntime } from "./surface-runtime";
+import type { InstalledPlugin } from "./types";
+
+function PluginNotificationSourcePoller({
+  plugin,
+  source,
+}: {
+  plugin: InstalledPlugin;
+  source: PluginNotificationSourceContribution;
+}) {
+  const client = useHostRuntimeClient(plugin.serverId);
+  const runtime = useMemo(() => createPluginSurfaceRuntime(client, plugin.id), [client, plugin.id]);
+  const notifier = useMemo(
+    () =>
+      createPluginNotifier({
+        serverId: plugin.serverId,
+        pluginId: plugin.id,
+        surfaceIds: plugin.surfaces.map((surface) => surface.id),
+      }),
+    [plugin],
+  );
+
+  const intervalMs = resolvePluginNotificationInterval(source.intervalMs);
+  useFetchQuery({
+    queryKey: ["plugin-notification-source", plugin.serverId, plugin.id, source.id],
+    dataShape: "value",
+    enabled: runtime !== null,
+    refetchInterval: intervalMs,
+    refetchIntervalInBackground: true,
+    retry: false,
+    staleTimeMs: intervalMs,
+    queryFn: async () => {
+      if (!runtime) return null;
+      try {
+        return await pollPluginNotificationSource({
+          source,
+          scope: {
+            serverId: plugin.serverId,
+            pluginId: plugin.id,
+            sourceId: source.id,
+          },
+          invoke: runtime.invoke,
+          notifier,
+          receipts: pluginNotificationReceiptStore,
+          reportError(error) {
+            console.warn(
+              `[Plugins] Notification delivery failed for ${plugin.serverId}/${plugin.id}/${source.id}`,
+              error,
+            );
+          },
+        });
+      } catch (error) {
+        console.warn(
+          `[Plugins] Notification poll failed for ${plugin.serverId}/${plugin.id}/${source.id}`,
+          error,
+        );
+        return null;
+      }
+    },
+  });
+  return null;
+}
+
+function PluginInstallationNotificationSources({ plugin }: { plugin: InstalledPlugin }) {
+  if (plugin.notificationSources.length === 0) return null;
+  return (
+    <QueryClientProvider client={plugin.queryClient}>
+      {plugin.notificationSources.map((source) => (
+        <PluginNotificationSourcePoller
+          key={`${plugin.serverId}/${plugin.id}/${source.id}`}
+          plugin={plugin}
+          source={source}
+        />
+      ))}
+    </QueryClientProvider>
+  );
+}
+
+export function PluginNotificationSources() {
+  const plugins = useInstalledPlugins();
+  if (isNative) return null;
+  return plugins.map((plugin) => (
+    <PluginInstallationNotificationSources
+      key={`${plugin.serverId}/${plugin.id}`}
+      plugin={plugin}
+    />
+  ));
+}

--- a/packages/app/src/plugins/notifications.test.ts
+++ b/packages/app/src/plugins/notifications.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import { defineRpc, PluginNotificationPollResultSchema } from "@getpaseo/plugin";
+import { z } from "zod";
+import {
+  PluginNotificationReceiptStore,
+  type PluginNotificationReceiptStorage,
+} from "./notification-receipts";
+import { createPluginNotifier, pollPluginNotificationSource } from "./notifications";
+
+vi.mock("@/utils/os-notifications", () => ({ sendOsNotification: vi.fn() }));
+
+class MemoryStorage implements PluginNotificationReceiptStorage {
+  readonly values = new Map<string, string>();
+
+  async getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  async setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+const rpc = defineRpc({
+  name: "reviews.notifications",
+  input: z.object({}),
+  output: PluginNotificationPollResultSchema,
+});
+
+describe("plugin notifications", () => {
+  it("routes a validated notification through the host notification API", async () => {
+    const sendOsNotification = vi.fn(async () => true);
+    const notifier = createPluginNotifier(
+      { serverId: "host-1", pluginId: "review", surfaceIds: ["inbox"] },
+      { sendOsNotification },
+    );
+
+    await expect(
+      notifier.notify({
+        title: " Review requested ",
+        body: " PR #42 ",
+        surface: "inbox",
+      }),
+    ).resolves.toBe(true);
+    expect(sendOsNotification).toHaveBeenCalledWith({
+      title: "Review requested",
+      body: "PR #42",
+      data: {
+        serverId: "host-1",
+        pluginId: "review",
+        pluginSurfaceId: "inbox",
+      },
+    });
+  });
+
+  it("rejects a click target that the plugin did not contribute", async () => {
+    const notifier = createPluginNotifier(
+      { serverId: "host-1", pluginId: "review", surfaceIds: ["inbox"] },
+      { sendOsNotification: async () => true },
+    );
+
+    await expect(notifier.notify({ title: "Review", surface: "missing" })).rejects.toThrow(
+      "Plugin surface is unavailable: missing",
+    );
+  });
+
+  it("delivers each stable event once across updates and app restarts", async () => {
+    const storage = new MemoryStorage();
+    let receipts = new PluginNotificationReceiptStore(storage);
+    const notify = vi.fn(async () => true);
+    let response = {
+      notifications: [{ id: "review-42", title: "Review requested" }],
+    };
+    const input = {
+      source: { id: "review-requests", rpc },
+      scope: { serverId: "host-1", pluginId: "review", sourceId: "review-requests" },
+      invoke: vi.fn(async () => response),
+      notifier: { notify },
+      receipts,
+      reportError: vi.fn(),
+    };
+
+    await expect(pollPluginNotificationSource(input)).resolves.toEqual({
+      claimed: 1,
+      delivered: 1,
+    });
+
+    response = {
+      notifications: [{ id: "review-42", title: "Review updated" }],
+    };
+    await expect(pollPluginNotificationSource(input)).resolves.toEqual({
+      claimed: 0,
+      delivered: 0,
+    });
+
+    receipts = new PluginNotificationReceiptStore(storage);
+    await expect(pollPluginNotificationSource({ ...input, receipts })).resolves.toEqual({
+      claimed: 0,
+      delivered: 0,
+    });
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates event ids by host, plugin, and source", async () => {
+    const receipts = new PluginNotificationReceiptStore(new MemoryStorage());
+    const notifier = { notify: vi.fn(async () => true) };
+    const invoke = vi.fn(async () => ({
+      notifications: [{ id: "review-42", title: "Review requested" }],
+    }));
+    const base = {
+      source: { id: "review-requests", rpc },
+      invoke,
+      notifier,
+      receipts,
+      reportError: vi.fn(),
+    };
+
+    await pollPluginNotificationSource({
+      ...base,
+      scope: { serverId: "host-1", pluginId: "review", sourceId: "review-requests" },
+    });
+    await pollPluginNotificationSource({
+      ...base,
+      scope: { serverId: "host-2", pluginId: "review", sourceId: "review-requests" },
+    });
+
+    expect(notifier.notify).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/app/src/plugins/notifications.ts
+++ b/packages/app/src/plugins/notifications.ts
@@ -1,0 +1,85 @@
+import type { PluginNotificationSourceContribution } from "@getpaseo/plugin";
+import { PluginNotificationSchema, type PluginNotification } from "@getpaseo/plugin";
+import { readPluginNotificationSource } from "@getpaseo/plugin/host";
+import { sendOsNotification } from "@/utils/os-notifications";
+import type {
+  PluginNotificationReceiptScope,
+  PluginNotificationReceiptStore,
+} from "./notification-receipts";
+
+export interface PluginNotifierDeps {
+  sendOsNotification: typeof sendOsNotification;
+}
+
+export interface PluginNotifier {
+  notify(notification: PluginNotification): Promise<boolean>;
+}
+
+const defaultDeps: PluginNotifierDeps = { sendOsNotification };
+
+export interface PluginNotifierSource {
+  serverId: string;
+  pluginId: string;
+  /** Surface IDs the plugin registered, used to reject unroutable click targets. */
+  surfaceIds: readonly string[];
+}
+
+export function createPluginNotifier(
+  source: PluginNotifierSource,
+  deps: PluginNotifierDeps = defaultDeps,
+): PluginNotifier {
+  return {
+    async notify(notification: PluginNotification) {
+      const parsed = PluginNotificationSchema.parse(notification);
+      const surface = parsed.surface;
+      if (surface && !source.surfaceIds.includes(surface)) {
+        throw new Error(`Plugin surface is unavailable: ${surface}`);
+      }
+      return await deps.sendOsNotification({
+        title: parsed.title,
+        ...(parsed.body ? { body: parsed.body } : {}),
+        data: {
+          serverId: source.serverId,
+          pluginId: source.pluginId,
+          ...(surface ? { pluginSurfaceId: surface } : {}),
+          ...(parsed.workspaceId ? { workspaceId: parsed.workspaceId } : {}),
+          ...(parsed.agentId ? { agentId: parsed.agentId } : {}),
+        },
+      });
+    },
+  };
+}
+
+export async function pollPluginNotificationSource({
+  source,
+  scope,
+  invoke,
+  notifier,
+  receipts,
+  reportError,
+}: {
+  source: PluginNotificationSourceContribution;
+  scope: PluginNotificationReceiptScope;
+  invoke(method: string, input: unknown): Promise<unknown>;
+  notifier: PluginNotifier;
+  receipts: PluginNotificationReceiptStore;
+  reportError(error: unknown): void;
+}): Promise<{ claimed: number; delivered: number }> {
+  const result = await readPluginNotificationSource(source, invoke);
+  const claimedIds = new Set(
+    await receipts.claim(
+      scope,
+      result.notifications.map((notification) => notification.id),
+    ),
+  );
+  let delivered = 0;
+  for (const notification of result.notifications) {
+    if (!claimedIds.has(notification.id)) continue;
+    try {
+      if (await notifier.notify(notification)) delivered += 1;
+    } catch (error) {
+      reportError(error);
+    }
+  }
+  return { claimed: claimedIds.size, delivered };
+}

--- a/packages/app/src/plugins/sidebar-groups.test.ts
+++ b/packages/app/src/plugins/sidebar-groups.test.ts
@@ -22,6 +22,7 @@ function installed(serverId: string, contributionId = "main"): InstalledPlugin {
     workspacePanels: [],
     commandCenterItems: [],
     attachmentSources: [],
+    notificationSources: [],
     themes: [],
   };
 }

--- a/packages/app/src/plugins/surface-contribution.test.ts
+++ b/packages/app/src/plugins/surface-contribution.test.ts
@@ -27,6 +27,7 @@ function installation(
     workspacePanels: [],
     commandCenterItems: [],
     attachmentSources: [],
+    notificationSources: [],
     themes: [],
   };
 }

--- a/packages/app/src/plugins/theme.test.ts
+++ b/packages/app/src/plugins/theme.test.ts
@@ -55,6 +55,7 @@ function installed(serverId: string, themes: PluginThemeContribution[]): Install
     workspacePanels: [],
     commandCenterItems: [],
     attachmentSources: [],
+    notificationSources: [],
     themes,
   };
 }

--- a/packages/app/src/plugins/types.ts
+++ b/packages/app/src/plugins/types.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import type {
   PluginAttachmentSourceContribution,
   PluginCommandCenterItemContribution,
+  PluginNotificationSourceContribution,
   PluginSidebarContribution,
   PluginSurfaceContribution,
   PluginThemeContribution,
@@ -21,6 +22,7 @@ export interface EvaluatedPlugin {
   workspacePanels: EvaluatedPluginWorkspacePanelContribution[];
   commandCenterItems: PluginCommandCenterItemContribution[];
   attachmentSources: PluginAttachmentSourceContribution[];
+  notificationSources: PluginNotificationSourceContribution[];
   themes: PluginThemeContribution[];
 }
 
@@ -33,6 +35,7 @@ export interface InstalledPlugin extends EvaluatedPlugin {
 export type {
   PluginAttachmentSourceContribution,
   PluginCommandCenterItemContribution,
+  PluginNotificationSourceContribution,
   PluginSidebarContribution,
   PluginSurfaceContribution,
   PluginThemeContribution,

--- a/packages/app/src/plugins/workspace-panels/resolution.test.ts
+++ b/packages/app/src/plugins/workspace-panels/resolution.test.ts
@@ -24,6 +24,7 @@ function installed(): InstalledPlugin {
     ],
     commandCenterItems: [],
     attachmentSources: [],
+    notificationSources: [],
     themes: [],
   };
 }

--- a/packages/app/src/utils/notification-routing.test.ts
+++ b/packages/app/src/utils/notification-routing.test.ts
@@ -14,6 +14,8 @@ describe("resolveNotificationTarget", () => {
       agentId: "agent-456",
       workspaceId: null,
       terminalId: null,
+      pluginId: null,
+      pluginSurfaceId: null,
     });
   });
 
@@ -23,12 +25,16 @@ describe("resolveNotificationTarget", () => {
       agentId: null,
       workspaceId: null,
       terminalId: null,
+      pluginId: null,
+      pluginSurfaceId: null,
     });
     expect(resolveNotificationTarget(undefined)).toEqual({
       serverId: null,
       agentId: null,
       workspaceId: null,
       terminalId: null,
+      pluginId: null,
+      pluginSurfaceId: null,
     });
   });
 
@@ -44,6 +50,8 @@ describe("resolveNotificationTarget", () => {
       agentId: "agent-1",
       workspaceId: null,
       terminalId: null,
+      pluginId: null,
+      pluginSurfaceId: null,
     });
   });
 });
@@ -90,6 +98,28 @@ describe("buildNotificationRoute", () => {
   it("falls back to root when no server id is present", () => {
     expect(buildNotificationRoute({ agentId: "agent-legacy" })).toBe("/");
     expect(buildNotificationRoute(undefined)).toBe("/");
+  });
+
+  it("opens a plugin surface", () => {
+    expect(
+      buildNotificationRoute({
+        serverId: "srv-1",
+        pluginId: "review",
+        pluginSurfaceId: "inbox",
+      }),
+    ).toBe("/h/srv-1/plugin/review/surface/inbox");
+  });
+
+  it("prefers a workspace agent target over a plugin surface", () => {
+    expect(
+      buildNotificationRoute({
+        serverId: "srv-1",
+        workspaceId: "workspace-1",
+        agentId: "agent-1",
+        pluginId: "review",
+        pluginSurfaceId: "inbox",
+      }),
+    ).toBe("/h/srv-1/workspace/workspace-1?open=agent%3Aagent-1");
   });
 
   it("encodes path segments", () => {

--- a/packages/app/src/utils/notification-routing.ts
+++ b/packages/app/src/utils/notification-routing.ts
@@ -1,4 +1,5 @@
 import type { Href } from "expo-router";
+import { buildPluginSurfaceRoute } from "@/plugins/routes";
 import { buildHostRootRoute, buildHostWorkspaceOpenRoute } from "@/utils/host-routes";
 
 type NotificationData = Record<string, unknown> | null | undefined;
@@ -18,22 +19,30 @@ export function resolveNotificationTarget(data: NotificationData): {
   agentId: string | null;
   workspaceId: string | null;
   terminalId: string | null;
+  pluginId: string | null;
+  pluginSurfaceId: string | null;
 } {
   return {
     serverId: readNonEmptyString(data, "serverId"),
     agentId: readNonEmptyString(data, "agentId"),
     workspaceId: readNonEmptyString(data, "workspaceId"),
     terminalId: readNonEmptyString(data, "terminalId"),
+    pluginId: readNonEmptyString(data, "pluginId"),
+    pluginSurfaceId: readNonEmptyString(data, "pluginSurfaceId"),
   };
 }
 
 export function buildNotificationRoute(data: NotificationData): NotificationRoute {
-  const { serverId, agentId, workspaceId, terminalId } = resolveNotificationTarget(data);
+  const { serverId, agentId, workspaceId, terminalId, pluginId, pluginSurfaceId } =
+    resolveNotificationTarget(data);
   if (serverId && workspaceId && agentId) {
     return buildHostWorkspaceOpenRoute(serverId, workspaceId, `agent:${agentId}`);
   }
   if (serverId && workspaceId && terminalId) {
     return buildHostWorkspaceOpenRoute(serverId, workspaceId, `terminal:${terminalId}`);
+  }
+  if (serverId && pluginId && pluginSurfaceId) {
+    return buildPluginSurfaceRoute(serverId, pluginId, { kind: "surface", id: pluginSurfaceId });
   }
   if (serverId) {
     return buildHostRootRoute(serverId);

--- a/packages/cli/src/commands/plugin/scaffold.test.ts
+++ b/packages/cli/src/commands/plugin/scaffold.test.ts
@@ -50,7 +50,7 @@ describe("plugin scaffold", () => {
     await Promise.all([
       writeFile(
         path.join(directory, "inspect.shared.ts"),
-        `import { defineRpc } from "@getpaseo/plugin/server";
+        `import { defineRpc, PluginNotificationPollResultSchema } from "@getpaseo/plugin/server";
 import { z } from "zod";
 
 export const inspect = defineRpc({
@@ -58,19 +58,29 @@ export const inspect = defineRpc({
   input: z.object({}),
   output: z.object({ configured: z.boolean() }),
 });
+
+export const notifications = defineRpc({
+  name: "notifications",
+  input: z.object({}),
+  output: PluginNotificationPollResultSchema,
+});
 `,
       ),
       writeFile(
         path.join(directory, "inspect.server.ts"),
         `import type { PluginHandlerContext } from "@getpaseo/plugin/server";
 import type { output as ZodOutput } from "zod";
-import { inspect } from "./inspect.shared";
+import { inspect, notifications } from "./inspect.shared";
 
 export async function inspectConfig(
   _input: ZodOutput<typeof inspect.input>,
   { paseo }: PluginHandlerContext,
 ) {
   return { configured: Boolean((await paseo.config.get()).config) };
+}
+
+export function listNotifications() {
+  return { notifications: [] };
 }
 `,
       ),
@@ -113,12 +123,14 @@ export function AgentPanel({ workspaceId, agentId }: PluginAgentPanelProps) {
         path.join(directory, "index.ts"),
         `import type { PluginContext } from "@getpaseo/plugin";
 import { AgentPanel, Surface } from "./main.client";
-import { inspectConfig } from "./inspect.server";
-import { inspect } from "./inspect.shared";
+import { inspectConfig, listNotifications } from "./inspect.server";
+import { inspect, notifications } from "./inspect.shared";
 
 export default function contribute(plugin: PluginContext) {
   plugin.handle(inspect, inspectConfig);
+  plugin.handle(notifications, listNotifications);
   plugin.addSurface("main", Surface);
+  plugin.addNotificationSource({ id: "reviews", rpc: notifications });
   plugin.addWorkspacePanel({
     id: "review",
     title: "Review",

--- a/packages/cli/src/commands/plugin/scaffold.ts
+++ b/packages/cli/src/commands/plugin/scaffold.ts
@@ -29,6 +29,28 @@ const SDK_DECLARATIONS = `declare module "@getpaseo/plugin/server" {
     items: PluginAttachmentItem[];
   }
 
+  export interface PluginNotification {
+    title: string;
+    body?: string;
+    workspaceId?: string;
+    agentId?: string;
+    surface?: string;
+  }
+
+  export interface PluginNotificationEvent extends PluginNotification {
+    id: string;
+  }
+
+  export interface PluginNotificationPollResult {
+    notifications: PluginNotificationEvent[];
+  }
+
+  export interface PluginNotificationSourceContribution {
+    id: string;
+    rpc: PluginRpcContract;
+    intervalMs?: number;
+  }
+
   export interface PluginAttachmentSourceContribution {
     id: string;
     title: string;
@@ -54,6 +76,9 @@ const SDK_DECLARATIONS = `declare module "@getpaseo/plugin/server" {
 
   export const PluginAttachmentItemSchema: import("zod").ZodType<PluginAttachmentItem>;
   export const PluginAttachmentSearchPayloadSchema: import("zod").ZodType<PluginAttachmentSearchPayload>;
+  export const PluginNotificationSchema: import("zod").ZodType<PluginNotification>;
+  export const PluginNotificationEventSchema: import("zod").ZodType<PluginNotificationEvent>;
+  export const PluginNotificationPollResultSchema: import("zod").ZodType<PluginNotificationPollResult>;
 }
 
 declare module "@getpaseo/plugin" {
@@ -63,18 +88,27 @@ declare module "@getpaseo/plugin" {
   import type {
     PluginAttachmentSourceContribution,
     PluginHandlerContext,
+    PluginNotification,
+    PluginNotificationSourceContribution,
     PluginRpcContract,
   } from "@getpaseo/plugin/server";
 
   export {
     PluginAttachmentItemSchema,
     PluginAttachmentSearchPayloadSchema,
+    PluginNotificationEventSchema,
+    PluginNotificationPollResultSchema,
+    PluginNotificationSchema,
     defineAttachmentSource,
     defineRpc,
     type PluginAttachmentItem,
     type PluginAttachmentSearchPayload,
     type PluginAttachmentSourceContribution,
     type PluginHandlerContext,
+    type PluginNotification,
+    type PluginNotificationEvent,
+    type PluginNotificationPollResult,
+    type PluginNotificationSourceContribution,
     type PluginRpcContract,
   } from "@getpaseo/plugin/server";
 
@@ -224,6 +258,7 @@ declare module "@getpaseo/plugin" {
     addWorkspacePanel(contribution: PluginWorkspacePanelContribution): void;
     addCommandCenterItem(contribution: PluginCommandCenterItemContribution): void;
     addAttachmentSource(contribution: PluginAttachmentSourceContribution): void;
+    addNotificationSource(contribution: PluginNotificationSourceContribution): void;
     addTheme(contribution: PluginThemeContribution): void;
   }
 

--- a/packages/plugin/src/contracts.ts
+++ b/packages/plugin/src/contracts.ts
@@ -136,6 +136,14 @@ export interface PluginAttachmentSourceContribution {
   search: PluginRpcContract;
 }
 
+export interface PluginNotificationSourceContribution {
+  id: string;
+  /** RPC returning notification events. Called with an empty input object. */
+  rpc: PluginRpcContract;
+  /** Poll interval. Defaults to 60s; the host floors it at 15s. */
+  intervalMs?: number;
+}
+
 export interface PluginCommandCapabilities {
   paseo: PaseoApi;
   rpc<InputSchema extends ZodType, OutputSchema extends ZodType>(
@@ -200,6 +208,7 @@ export interface PluginContext {
   addWorkspacePanel(contribution: PluginWorkspacePanelContribution): void;
   addCommandCenterItem(contribution: PluginCommandCenterItemContribution): void;
   addAttachmentSource(contribution: PluginAttachmentSourceContribution): void;
+  addNotificationSource(contribution: PluginNotificationSourceContribution): void;
   addTheme(contribution: PluginThemeContribution): void;
 }
 

--- a/packages/plugin/src/host.ts
+++ b/packages/plugin/src/host.ts
@@ -4,12 +4,18 @@ import type {
   PluginAttachmentSourceContribution,
   PluginCommandCenterItemContribution,
   PluginContext,
+  PluginNotificationSourceContribution,
   PluginSidebarContribution,
   PluginSurfaceContribution,
   PluginSurfaceProps,
   PluginThemeContribution,
   PluginWorkspacePanelContribution,
 } from "./contracts.js";
+import {
+  PluginNotificationPollResultSchema,
+  readPluginNotificationSource,
+  resolvePluginNotificationInterval,
+} from "./notifications.js";
 import { PluginRpcProvider } from "./rpc-context.js";
 import { PaseoApiProvider } from "./paseo-context.js";
 import { callPluginRpc } from "./rpc.js";
@@ -21,6 +27,7 @@ interface PluginCollector {
   addWorkspacePanel(contribution: PluginWorkspacePanelContribution): void;
   addCommandCenterItem(contribution: PluginCommandCenterItemContribution): void;
   addAttachmentSource(contribution: PluginAttachmentSourceContribution): void;
+  addNotificationSource(contribution: PluginNotificationSourceContribution): void;
   addTheme(contribution: PluginThemeContribution): void;
 }
 
@@ -30,6 +37,7 @@ export interface PluginRegistrationCollector {
   workspacePanels: PluginWorkspacePanelContribution[];
   commandCenterItems: PluginCommandCenterItemContribution[];
   attachmentSources: PluginAttachmentSourceContribution[];
+  notificationSources: PluginNotificationSourceContribution[];
   themes: PluginThemeContribution[];
 }
 
@@ -42,6 +50,7 @@ export function createPluginContext(
   | "addWorkspacePanel"
   | "addCommandCenterItem"
   | "addAttachmentSource"
+  | "addNotificationSource"
   | "addTheme"
 > {
   return {
@@ -60,6 +69,9 @@ export function createPluginContext(
     addAttachmentSource(contribution) {
       collector.addAttachmentSource(contribution);
     },
+    addNotificationSource(contribution) {
+      collector.addNotificationSource(contribution);
+    },
     addTheme(contribution) {
       collector.addTheme(contribution);
     },
@@ -75,4 +87,11 @@ export async function searchPluginAttachments(
   return PluginAttachmentSearchPayloadSchema.parseAsync(output);
 }
 
-export { callPluginRpc, PaseoApiProvider, PluginRpcProvider };
+export {
+  callPluginRpc,
+  PaseoApiProvider,
+  PluginNotificationPollResultSchema,
+  PluginRpcProvider,
+  readPluginNotificationSource,
+  resolvePluginNotificationInterval,
+};

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -22,6 +22,7 @@ export type {
   PluginHostProps,
   PluginOpenPanelOptions,
   PluginPanelLocation,
+  PluginNotificationSourceContribution,
   PluginTheme,
   PluginSidebarContribution,
   PluginSurfaceContribution,
@@ -33,6 +34,14 @@ export type {
   PluginWorkspacePanelProps,
   PluginWorkspaceSnapshot,
 } from "./contracts.js";
+export {
+  PluginNotificationEventSchema,
+  PluginNotificationPollResultSchema,
+  PluginNotificationSchema,
+  type PluginNotification,
+  type PluginNotificationEvent,
+  type PluginNotificationPollResult,
+} from "./notifications.js";
 export { usePaseo } from "./paseo-context.js";
 export { useAgent, useWorkspace } from "./client-state.js";
 export { useRpc } from "./rpc-context.js";

--- a/packages/plugin/src/notifications.test.ts
+++ b/packages/plugin/src/notifications.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { defineRpc } from "./rpc.js";
+import {
+  MIN_PLUGIN_NOTIFICATION_INTERVAL_MS,
+  PluginNotificationPollResultSchema,
+  readPluginNotificationSource,
+  resolvePluginNotificationInterval,
+} from "./notifications.js";
+
+const poll = defineRpc({
+  name: "reviews.notifications",
+  input: z.object({}),
+  output: PluginNotificationPollResultSchema,
+});
+
+describe("plugin notification sources", () => {
+  it("reads and validates notification events through the declared RPC", async () => {
+    const invoke = vi.fn(async () => ({
+      notifications: [
+        {
+          id: "review-42",
+          title: "Review requested",
+          body: "feat: decouple notifications",
+          surface: "reviews",
+        },
+      ],
+    }));
+
+    await expect(
+      readPluginNotificationSource({ id: "review-requests", rpc: poll }, invoke),
+    ).resolves.toEqual({
+      notifications: [
+        {
+          id: "review-42",
+          title: "Review requested",
+          body: "feat: decouple notifications",
+          surface: "reviews",
+        },
+      ],
+    });
+    expect(invoke).toHaveBeenCalledWith("reviews.notifications", {});
+  });
+
+  it("rejects duplicate event ids in one poll", () => {
+    expect(() =>
+      PluginNotificationPollResultSchema.parse({
+        notifications: [
+          { id: "review-42", title: "First" },
+          { id: "review-42", title: "Second" },
+        ],
+      }),
+    ).toThrow("Duplicate notification id: review-42");
+  });
+
+  it("uses a default cadence and floors aggressive polling", () => {
+    expect(resolvePluginNotificationInterval()).toBe(60_000);
+    expect(resolvePluginNotificationInterval(1_000)).toBe(MIN_PLUGIN_NOTIFICATION_INTERVAL_MS);
+    expect(() => resolvePluginNotificationInterval(Number.NaN)).toThrow("positive finite number");
+  });
+});

--- a/packages/plugin/src/notifications.ts
+++ b/packages/plugin/src/notifications.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { PluginNotificationSourceContribution } from "./contracts.js";
+import { callPluginRpc } from "./rpc.js";
+
+export const DEFAULT_PLUGIN_NOTIFICATION_INTERVAL_MS = 60_000;
+export const MIN_PLUGIN_NOTIFICATION_INTERVAL_MS = 15_000;
+
+const PluginNotificationTargetIdSchema = z.string().trim().min(1).max(200);
+
+export const PluginNotificationSchema = z
+  .object({
+    title: z.string().trim().min(1).max(200),
+    body: z.string().trim().min(1).max(1_000).optional(),
+    workspaceId: PluginNotificationTargetIdSchema.optional(),
+    agentId: PluginNotificationTargetIdSchema.optional(),
+    surface: PluginNotificationTargetIdSchema.optional(),
+  })
+  .strict();
+
+export const PluginNotificationEventSchema = PluginNotificationSchema.extend({
+  /** Stable identity for this event. Reusing it prevents repeat notifications. */
+  id: z.string().trim().min(1).max(200),
+});
+
+export const PluginNotificationPollResultSchema = z
+  .object({
+    notifications: z.array(PluginNotificationEventSchema).max(20),
+  })
+  .strict()
+  .superRefine(({ notifications }, context) => {
+    const ids = new Set<string>();
+    for (const [index, notification] of notifications.entries()) {
+      if (ids.has(notification.id)) {
+        context.addIssue({
+          code: "custom",
+          message: `Duplicate notification id: ${notification.id}`,
+          path: ["notifications", index, "id"],
+        });
+      }
+      ids.add(notification.id);
+    }
+  });
+
+export type PluginNotification = z.infer<typeof PluginNotificationSchema>;
+export type PluginNotificationEvent = z.infer<typeof PluginNotificationEventSchema>;
+export type PluginNotificationPollResult = z.infer<typeof PluginNotificationPollResultSchema>;
+
+export function resolvePluginNotificationInterval(intervalMs?: number): number {
+  if (intervalMs === undefined) return DEFAULT_PLUGIN_NOTIFICATION_INTERVAL_MS;
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw new Error("Plugin notification interval must be a positive finite number");
+  }
+  return Math.max(MIN_PLUGIN_NOTIFICATION_INTERVAL_MS, Math.round(intervalMs));
+}
+
+export async function readPluginNotificationSource(
+  source: PluginNotificationSourceContribution,
+  invoke: (method: string, input: unknown) => Promise<unknown>,
+): Promise<PluginNotificationPollResult> {
+  const output = await callPluginRpc(source.rpc, invoke, {});
+  return PluginNotificationPollResultSchema.parseAsync(output);
+}

--- a/packages/plugin/src/server.ts
+++ b/packages/plugin/src/server.ts
@@ -7,6 +7,15 @@ export {
   type PluginAttachmentSearchPayload,
 } from "./attachments.js";
 export type { PluginAttachmentSourceContribution, PluginHandlerContext } from "./contracts.js";
+export {
+  PluginNotificationEventSchema,
+  PluginNotificationPollResultSchema,
+  PluginNotificationSchema,
+  type PluginNotification,
+  type PluginNotificationEvent,
+  type PluginNotificationPollResult,
+} from "./notifications.js";
+export type { PluginNotificationSourceContribution } from "./contracts.js";
 export { defineRpc, type PluginRpcContract } from "./rpc.js";
 
 export function defineAttachmentSource<Definition extends PluginAttachmentSourceContribution>(

--- a/packages/server/src/server/plugins/compiler.test.ts
+++ b/packages/server/src/server/plugins/compiler.test.ts
@@ -95,6 +95,7 @@ const ping = defineRpc({
 
 export default function contribute(plugin: PluginContext) {
   plugin.handle(ping, async () => ({ ok: true }));
+  plugin.addNotificationSource({ id: "status", rpc: ping });
   return () => undefined;
 }
 `,
@@ -105,6 +106,8 @@ export default function contribute(plugin: PluginContext) {
       expect(serverBundle).toContain(`${sdk}/server`);
       expect(clientBundle).not.toContain("Invalid plugin RPC method");
       expect(serverBundle).not.toContain("Invalid plugin RPC method");
+      expect(clientBundle).toContain("addNotificationSource");
+      expect(serverBundle).not.toContain("addNotificationSource");
     },
   );
 });

--- a/packages/server/src/server/plugins/compiler.ts
+++ b/packages/server/src/server/plugins/compiler.ts
@@ -81,6 +81,7 @@ const REGISTRATIONS_REMOVED_BY_TARGET: Record<PluginBuildTarget, ReadonlySet<str
     "addWorkspacePanel",
     "addCommandCenterItem",
     "addAttachmentSource",
+    "addNotificationSource",
     "addTheme",
   ]),
 };


### PR DESCRIPTION
### Linked issue

None

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Plugins need a bounded way to surface important backend events while their UI is closed. Existing plugin contributions run through mounted UI or explicit user actions, so they do not provide a lifecycle or receipt model for OS notification delivery.

This adds an `addNotificationSource` contribution backed by a typed RPC. Paseo polls each source for every connected plugin installation, validates returned events, records stable event IDs before delivery, and sends them through the existing desktop and browser notification path.

### Goals

- Poll every connected host installation with a 60-second default and 15-second floor.
- Bound each response to 20 validated events.
- Persist the last 256 event IDs per host, plugin, and source so updates and app restarts do not re-notify the same event.
- Route notification clicks to a registered plugin surface, workspace, or agent.
- Update plugin compilation and scaffold-generated declarations for the contribution.

### Non-goals

- Remote mobile push notifications.
- Background execution while the Paseo app is not running.
- A general daemon-to-app event channel.
- Immediate notifications from mounted plugin UI.
- Cross-device notification receipt synchronization.

### QA

```text
npm run build:server
exit 0

npm run typecheck
exit 0

npm run lint
Found 0 warnings and 0 errors.

npm run format:check
All matched files use the correct format.

Focused notification, routing, compiler, and scaffold tests
5 files passed, 28 tests passed
```

`packages/app/src/plugins/evaluate.test.ts` remains blocked locally by the existing Vitest `Unexpected token 'typeof'` import failure from `react-native-web`; the same failure reproduces on the untouched checkout. The app and SDK typechecks cover the new registration path.

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Local plugin sources are disabled; mobile notifications require remote push |
| Android | No | Local plugin sources are disabled; mobile notifications require remote push |
| Web | Automated | Validation, deduplication, persistence, and click routing covered |
| Desktop macOS | No manual run | Uses the existing desktop notification sender |
| Desktop Windows | No | Not available |
| Desktop Linux | No | Not available |

This remains a draft until desktop or browser delivery has manual QA evidence.

### Checklist

- [x] One standalone change based on `main`
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] Automated QA evidence
- [x] Tests added or updated where it made sense
