### PR TITLE
feat(server): recover agents after daemon restart

### DIFF
--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -7,6 +7,7 @@ services:
     image: ghcr.io/getpaseo/paseo:latest
     container_name: paseo
     restart: unless-stopped
+    stop_grace_period: 30s
     ports:
       - "6767:6767"
     environment:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -78,6 +78,11 @@ container. It cannot keep an in-flight provider process alive: a replacement sti
 turn. The recovered agent retains its conversation and can continue from the provider's persisted
 session.
 
+Two cases are deliberately not resumed. An agent you cancelled just before the restart stays
+cancelled, even when the container died before the cancellation finished settling, so a replacement
+never revives a run you stopped. An agent that fails recovery three times is parked as an error and
+reported instead of being retried on every subsequent start.
+
 ## Installing Agents
 
 The base image does not preinstall Claude Code, Codex, OpenCode, Copilot, Pi, or

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -59,6 +59,7 @@ services:
   paseo:
     image: ghcr.io/getpaseo/paseo:latest
     restart: unless-stopped
+    stop_grace_period: 30s
     ports:
       - "6767:6767"
     environment:
@@ -67,6 +68,15 @@ services:
       - ./paseo-home:/home/paseo
       - ./workspace:/workspace
 ```
+
+The `/home/paseo` mount preserves Paseo records and provider session handles. On daemon startup,
+Paseo resumes eligible agents interrupted while running. An unavailable provider or expired
+provider conversation becomes an attention error instead of retrying on every restart.
+
+`stop_grace_period: 30s` gives the daemon time to flush state before Docker replaces the
+container. It cannot keep an in-flight provider process alive: a replacement still interrupts that
+turn. The recovered agent retains its conversation and can continue from the provider's persisted
+session.
 
 ## Installing Agents
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -70,6 +70,7 @@ import {
   AgentRunState,
   type ForegroundTurnWaiter,
   type PendingForegroundRun,
+  type TrackedAgentRun,
 } from "./agent-run-state.js";
 import { invokeRewindCapability, type RewindMode } from "./rewind/rewind.js";
 import { isSystemInjectedEnvelope } from "./agent-prompt.js";
@@ -2730,6 +2731,24 @@ export class AgentManager {
       return { status: "not_running" };
     }
 
+    // Persist the cancellation intent before the interrupt round-trip. Settling
+    // below can take seconds, and a container replacement inside that window
+    // would otherwise leave a "running" record that recovery happily resumes --
+    // reviving a run the user explicitly stopped. The marker is cleared once the
+    // cancellation resolves either way, so it only ever covers the live window.
+    await this.markCancelRequested(agent);
+    try {
+      return await this.cancelAcknowledgedRun(agent, run);
+    } finally {
+      await this.clearCancelRequested(agent);
+    }
+  }
+
+  private async cancelAcknowledgedRun(
+    agent: ActiveManagedAgent,
+    run: TrackedAgentRun,
+  ): Promise<AgentRunCancellationResult> {
+    const agentId = agent.id;
     const interruptAcknowledged = await this.interruptSession(agent.session, agentId);
     const settlement = await this.waitWithTimeout({
       operation: run.settledPromise,
@@ -2784,6 +2803,35 @@ export class AgentManager {
       this.emitState(agent);
     }
     return { status: "settled" };
+  }
+
+  private async markCancelRequested(agent: ManagedAgent): Promise<void> {
+    if (!this.registry || agent.internal) {
+      return;
+    }
+    try {
+      await this.registry.markCancelRequested(agent.id);
+    } catch (error) {
+      // Best effort: never block a cancellation on recovery bookkeeping.
+      this.logger.warn(
+        { err: error, agentId: agent.id },
+        "cancelAgentRun: could not persist cancellation intent",
+      );
+    }
+  }
+
+  private async clearCancelRequested(agent: ManagedAgent): Promise<void> {
+    if (!this.registry || agent.internal) {
+      return;
+    }
+    try {
+      await this.registry.clearCancelRequested(agent.id);
+    } catch (error) {
+      this.logger.warn(
+        { err: error, agentId: agent.id },
+        "cancelAgentRun: could not clear cancellation intent",
+      );
+    }
   }
 
   private async cancelAgentRunBefore(

--- a/packages/server/src/server/agent/agent-recovery.test.ts
+++ b/packages/server/src/server/agent/agent-recovery.test.ts
@@ -135,3 +135,95 @@ test("marks an interrupted agent without a persistence handle as unrecoverable",
       "Paseo could not resume this agent after the daemon restart: the codex conversation is not resumable on this daemon",
   });
 });
+
+test("does not resume an agent whose cancellation was interrupted by the restart", async () => {
+  const fixture = await createInterruptedAgentFixture();
+  const record = await fixture.storage.get(fixture.agentId);
+  if (!record) {
+    throw new Error("Expected persisted agent record");
+  }
+  // A cancellation acknowledged by the daemon but killed before the resulting
+  // idle transition could be written: the record still reads "running".
+  await fixture.storage.upsert({
+    ...record,
+    cancelRequestedAt: new Date().toISOString(),
+  });
+  const manager = createRecoveryManager(fixture.storage, createTestAgentClient("codex"));
+
+  await recoverInterruptedAgents({
+    agentManager: manager,
+    agentStorage: fixture.storage,
+    logger: createTestLogger(),
+  });
+
+  expect(manager.getAgent(fixture.agentId)).toBeNull();
+  expect(await fixture.storage.get(fixture.agentId)).toMatchObject({
+    lastStatus: "idle",
+    cancelRequestedAt: null,
+  });
+});
+
+test("stops retrying a candidate that never finishes its recovery attempt", async () => {
+  const fixture = await createInterruptedAgentFixture();
+  const delegate = createTestAgentClient("codex");
+  // Simulates a candidate that takes the daemon down mid-recovery: the failure
+  // path never runs, so the record keeps its "running" status every boot.
+  const crashingClient: AgentClient = {
+    provider: delegate.provider,
+    capabilities: delegate.capabilities,
+    createSession: delegate.createSession.bind(delegate),
+    resumeSession: async () => {
+      throw new Error("daemon died mid-recovery");
+    },
+    fetchCatalog: delegate.fetchCatalog.bind(delegate),
+    isAvailable: delegate.isAvailable.bind(delegate),
+  };
+
+  for (let boot = 0; boot < 5; boot += 1) {
+    const manager = createRecoveryManager(fixture.storage, crashingClient);
+    const record = await fixture.storage.get(fixture.agentId);
+    if (!record) {
+      throw new Error("Expected persisted agent record");
+    }
+    // Re-arm the interrupted status the way an unclean shutdown would.
+    await fixture.storage.upsert({ ...record, lastStatus: "running", lastError: null });
+    await recoverInterruptedAgents({
+      agentManager: manager,
+      agentStorage: fixture.storage,
+      logger: createTestLogger(),
+    });
+  }
+
+  expect(await fixture.storage.get(fixture.agentId)).toMatchObject({
+    lastStatus: "error",
+    requiresAttention: true,
+    lastError:
+      "Paseo could not resume this agent after the daemon restart: recovery was attempted 3 times without succeeding",
+  });
+});
+
+test("preserves recovery bookkeeping across a snapshot flush", async () => {
+  const fixture = await createInterruptedAgentFixture();
+  const record = await fixture.storage.get(fixture.agentId);
+  if (!record) {
+    throw new Error("Expected persisted agent record");
+  }
+  await fixture.storage.upsert({
+    ...record,
+    cancelRequestedAt: "2026-01-01T00:00:00.000Z",
+    recoveryAttempts: 2,
+  });
+
+  const manager = createRecoveryManager(fixture.storage, createTestAgentClient("codex"));
+  const agent = await manager.createAgent({ provider: "codex", cwd: fixture.workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  // The projection is built from live agent state, which knows nothing about
+  // these fields; without explicit preservation the flush would drop them.
+  await fixture.storage.applySnapshot({ ...agent, id: fixture.agentId });
+
+  expect(await fixture.storage.get(fixture.agentId)).toMatchObject({
+    cancelRequestedAt: "2026-01-01T00:00:00.000Z",
+    recoveryAttempts: 2,
+  });
+});

--- a/packages/server/src/server/agent/agent-recovery.test.ts
+++ b/packages/server/src/server/agent/agent-recovery.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, expect, test } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { AgentManager } from "./agent-manager.js";
+import { AgentStorage } from "./agent-storage.js";
+import { recoverInterruptedAgents } from "./agent-recovery.js";
+import { createTestAgentClient } from "../test-utils/fake-agent-client.js";
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import type { AgentClient } from "./agent-sdk-types.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function createInterruptedAgentFixture(): Promise<{
+  agentId: string;
+  storage: AgentStorage;
+  workdir: string;
+}> {
+  const workdir = await mkdtemp(path.join(tmpdir(), "paseo-agent-recovery-"));
+  roots.push(workdir);
+  const storage = new AgentStorage(path.join(workdir, "agents"), createTestLogger());
+  await storage.initialize();
+  const manager = new AgentManager({
+    clients: { codex: createTestAgentClient("codex") },
+    registry: storage,
+    logger: createTestLogger(),
+    idFactory: () => "11111111-1111-4111-8111-111111111111",
+  });
+  const agent = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  await storage.applySnapshot(agent);
+  await manager.closeAgent(agent.id);
+  const record = await storage.get(agent.id);
+  if (!record) {
+    throw new Error("Expected persisted agent record");
+  }
+  await storage.upsert({
+    ...record,
+    lastStatus: "running",
+    persistence: {
+      provider: "codex",
+      sessionId: "recovery-session",
+      metadata: { cwd: workdir },
+    },
+  });
+
+  return { agentId: agent.id, storage, workdir };
+}
+
+function createRecoveryManager(storage: AgentStorage, client: AgentClient): AgentManager {
+  return new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger: createTestLogger(),
+  });
+}
+
+test("resumes interrupted persisted agents before clients connect", async () => {
+  const fixture = await createInterruptedAgentFixture();
+  const manager = createRecoveryManager(fixture.storage, createTestAgentClient("codex"));
+
+  await recoverInterruptedAgents({
+    agentManager: manager,
+    agentStorage: fixture.storage,
+    logger: createTestLogger(),
+  });
+
+  expect(manager.getAgent(fixture.agentId)?.persistence).toMatchObject({
+    provider: "codex",
+  });
+});
+
+test("marks an unrecoverable interrupted agent as an attention error without retrying it", async () => {
+  const fixture = await createInterruptedAgentFixture();
+  const delegate = createTestAgentClient("codex");
+  const failingClient: AgentClient = {
+    provider: delegate.provider,
+    capabilities: delegate.capabilities,
+    createSession: delegate.createSession.bind(delegate),
+    resumeSession: async () => {
+      throw new Error("conversation no longer exists");
+    },
+    fetchCatalog: delegate.fetchCatalog.bind(delegate),
+    isAvailable: delegate.isAvailable.bind(delegate),
+  };
+  const manager = createRecoveryManager(fixture.storage, failingClient);
+
+  await recoverInterruptedAgents({
+    agentManager: manager,
+    agentStorage: fixture.storage,
+    logger: createTestLogger(),
+  });
+
+  await recoverInterruptedAgents({
+    agentManager: manager,
+    agentStorage: fixture.storage,
+    logger: createTestLogger(),
+  });
+
+  expect(await fixture.storage.get(fixture.agentId)).toMatchObject({
+    lastStatus: "error",
+    requiresAttention: true,
+    attentionReason: "error",
+    lastError:
+      "Paseo could not resume this agent after the daemon restart: conversation no longer exists",
+  });
+});
+
+test("marks an interrupted agent without a persistence handle as unrecoverable", async () => {
+  const fixture = await createInterruptedAgentFixture();
+  const record = await fixture.storage.get(fixture.agentId);
+  if (!record) {
+    throw new Error("Expected persisted agent record");
+  }
+  await fixture.storage.upsert({ ...record, persistence: null });
+  const manager = createRecoveryManager(fixture.storage, createTestAgentClient("codex"));
+
+  await recoverInterruptedAgents({
+    agentManager: manager,
+    agentStorage: fixture.storage,
+    logger: createTestLogger(),
+  });
+
+  expect(await fixture.storage.get(fixture.agentId)).toMatchObject({
+    lastStatus: "error",
+    requiresAttention: true,
+    attentionReason: "error",
+    lastError:
+      "Paseo could not resume this agent after the daemon restart: the codex conversation is not resumable on this daemon",
+  });
+});

--- a/packages/server/src/server/agent/agent-recovery.ts
+++ b/packages/server/src/server/agent/agent-recovery.ts
@@ -10,8 +10,19 @@ interface AgentRecoveryDeps {
   logger: Logger;
 }
 
+/**
+ * How many times a single record may be attempted before it is parked as an
+ * error. A record that crashes the daemon mid-recovery keeps its "running"
+ * status, so without a persisted counter it would be retried on every boot.
+ */
+const MAX_RECOVERY_ATTEMPTS = 3;
+
 function isInterrupted(record: StoredAgentRecord): boolean {
   return record.lastStatus === "initializing" || record.lastStatus === "running";
+}
+
+function wasCancelRequested(record: StoredAgentRecord): boolean {
+  return typeof record.cancelRequestedAt === "string";
 }
 
 function recoveryFailureMessage(reason: string): string {
@@ -41,6 +52,31 @@ async function recordRecoveryFailure(input: {
   });
 }
 
+/**
+ * Land an agent whose cancellation was requested but never observed to settle.
+ * It is closed rather than resumed: reviving a run the user explicitly stopped
+ * is the one outcome that creates unwanted work.
+ */
+async function settleCancelledAgent(input: {
+  agentStorage: AgentRecoveryDeps["agentStorage"];
+  agentId: string;
+}): Promise<void> {
+  const record = await input.agentStorage.get(input.agentId);
+  if (!record || record.archivedAt) {
+    return;
+  }
+
+  const now = new Date().toISOString();
+  await input.agentStorage.upsert({
+    ...record,
+    updatedAt: now,
+    lastActivityAt: now,
+    lastStatus: "idle",
+    cancelRequestedAt: null,
+    recoveryAttempts: 0,
+  });
+}
+
 async function recoverInterruptedAgent(
   record: StoredAgentRecord,
   deps: AgentRecoveryDeps,
@@ -63,6 +99,7 @@ async function recoverInterruptedAgent(
       broadcastTimeline: true,
       logger: deps.logger,
     });
+    await deps.agentStorage.clearRecoveryAttempts(record.id).catch(() => undefined);
     deps.logger.info(
       { agentId: record.id, provider: record.provider },
       "Recovered interrupted agent",
@@ -93,6 +130,33 @@ export async function recoverInterruptedAgents(deps: AgentRecoveryDeps): Promise
 
   for (const record of interrupted) {
     try {
+      // An unresolved cancellation outranks resumption: the user already said
+      // stop, and the daemon died before the idle transition could be written.
+      if (wasCancelRequested(record)) {
+        await settleCancelledAgent({ agentStorage: deps.agentStorage, agentId: record.id });
+        deps.logger.info(
+          { agentId: record.id, provider: record.provider },
+          "Skipped recovery for an agent cancelled before the daemon restart",
+        );
+        continue;
+      }
+
+      // Burn the attempt before trying, so a record that takes the daemon down
+      // with it is bounded instead of retried on every subsequent boot.
+      const attempts = await deps.agentStorage.recordRecoveryAttempt(record.id);
+      if (attempts > MAX_RECOVERY_ATTEMPTS) {
+        const message = recoveryFailureMessage(
+          `recovery was attempted ${MAX_RECOVERY_ATTEMPTS} times without succeeding`,
+        );
+        await recordRecoveryFailure({
+          agentStorage: deps.agentStorage,
+          agentId: record.id,
+          message,
+        });
+        deps.logger.warn({ agentId: record.id, provider: record.provider, attempts }, message);
+        continue;
+      }
+
       await recoverInterruptedAgent(record, deps);
     } catch (error) {
       deps.logger.error(

--- a/packages/server/src/server/agent/agent-recovery.ts
+++ b/packages/server/src/server/agent/agent-recovery.ts
@@ -1,0 +1,104 @@
+import type { Logger } from "pino";
+
+import { ensureAgentLoaded, type AgentLoaderManager } from "./agent-loading.js";
+import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
+import { toAgentPersistenceHandle } from "../persistence-hooks.js";
+
+interface AgentRecoveryDeps {
+  agentManager: AgentLoaderManager;
+  agentStorage: AgentStorage;
+  logger: Logger;
+}
+
+function isInterrupted(record: StoredAgentRecord): boolean {
+  return record.lastStatus === "initializing" || record.lastStatus === "running";
+}
+
+function recoveryFailureMessage(reason: string): string {
+  return `Paseo could not resume this agent after the daemon restart: ${reason}`;
+}
+
+async function recordRecoveryFailure(input: {
+  agentStorage: AgentRecoveryDeps["agentStorage"];
+  agentId: string;
+  message: string;
+}): Promise<void> {
+  const record = await input.agentStorage.get(input.agentId);
+  if (!record || record.archivedAt) {
+    return;
+  }
+
+  const now = new Date().toISOString();
+  await input.agentStorage.upsert({
+    ...record,
+    updatedAt: now,
+    lastActivityAt: now,
+    lastStatus: "error",
+    lastError: input.message,
+    requiresAttention: true,
+    attentionReason: "error",
+    attentionTimestamp: now,
+  });
+}
+
+async function recoverInterruptedAgent(
+  record: StoredAgentRecord,
+  deps: AgentRecoveryDeps,
+): Promise<void> {
+  const registeredProviders = deps.agentManager.getRegisteredProviderIds();
+  const handle = toAgentPersistenceHandle(registeredProviders, record.persistence);
+  if (!handle) {
+    const message = recoveryFailureMessage(
+      `the ${record.provider} conversation is not resumable on this daemon`,
+    );
+    await recordRecoveryFailure({ agentStorage: deps.agentStorage, agentId: record.id, message });
+    deps.logger.warn({ agentId: record.id, provider: record.provider }, message);
+    return;
+  }
+
+  try {
+    await ensureAgentLoaded(record.id, {
+      agentManager: deps.agentManager,
+      agentStorage: deps.agentStorage,
+      broadcastTimeline: true,
+      logger: deps.logger,
+    });
+    deps.logger.info(
+      { agentId: record.id, provider: record.provider },
+      "Recovered interrupted agent",
+    );
+  } catch (error) {
+    if (deps.agentManager.getAgent(record.id)) {
+      deps.logger.warn(
+        { err: error, agentId: record.id, provider: record.provider },
+        "Recovered agent could not hydrate its provider timeline",
+      );
+      return;
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    const message = recoveryFailureMessage(reason);
+    await recordRecoveryFailure({ agentStorage: deps.agentStorage, agentId: record.id, message });
+    deps.logger.warn({ err: error, agentId: record.id, provider: record.provider }, message);
+  }
+}
+
+/**
+ * Recover provider sessions interrupted by a daemon restart before clients can
+ * observe stale running records. Failed candidates become explicit errors and
+ * are not selected again on a later startup.
+ */
+export async function recoverInterruptedAgents(deps: AgentRecoveryDeps): Promise<void> {
+  const records = await deps.agentStorage.list();
+  const interrupted = records.filter((record) => !record.archivedAt && isInterrupted(record));
+
+  for (const record of interrupted) {
+    try {
+      await recoverInterruptedAgent(record, deps);
+    } catch (error) {
+      deps.logger.error(
+        { err: error, agentId: record.id, provider: record.provider },
+        "Failed to recover interrupted agent",
+      );
+    }
+  }
+}

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -74,6 +74,13 @@ const STORED_AGENT_SCHEMA = z.object({
   attentionTimestamp: z.string().nullable().optional(),
   internal: z.boolean().optional(),
   archivedAt: z.string().nullable().optional(),
+  // Set when a user cancellation is requested, before the provider interrupt is
+  // acknowledged. Recovery treats a record carrying this marker as cancelled
+  // even when an unclean shutdown ate the resulting idle transition.
+  cancelRequestedAt: z.string().nullable().optional(),
+  // Incremented before each recovery attempt so a record that kills the daemon
+  // mid-recovery cannot be retried forever.
+  recoveryAttempts: z.number().int().nonnegative().optional(),
   owner: AgentOwnerSchema.optional(),
 });
 
@@ -259,7 +266,72 @@ export class AgentStorage {
       if (existing && existing.archivedAt !== undefined) {
         record.archivedAt = existing.archivedAt;
       }
+      // The projection is built from live agent state, which does not carry the
+      // recovery bookkeeping below. Without this the next snapshot flush would
+      // silently drop a pending cancellation or reset the attempt counter.
+      if (existing && existing.cancelRequestedAt !== undefined) {
+        record.cancelRequestedAt = existing.cancelRequestedAt;
+      }
+      if (existing && existing.recoveryAttempts !== undefined) {
+        record.recoveryAttempts = existing.recoveryAttempts;
+      }
       return record;
+    });
+  }
+
+  /**
+   * Record that a user asked to cancel this agent's run, before the provider
+   * interrupt round-trip completes. Persisting the intent up front is what lets
+   * recovery tell "cancelled, then killed" apart from "killed mid-run".
+   */
+  async markCancelRequested(agentId: string): Promise<void> {
+    await this.load();
+    const requestedAt = new Date().toISOString();
+    await this.queueRecordMutation(agentId, (existing) => {
+      if (!existing) {
+        throw new Error(`Agent ${agentId} not found`);
+      }
+      return { ...existing, cancelRequestedAt: requestedAt };
+    });
+  }
+
+  /** Clear a cancellation marker once the run has actually settled. */
+  async clearCancelRequested(agentId: string): Promise<void> {
+    await this.load();
+    await this.queueRecordMutation(agentId, (existing) => {
+      if (!existing) {
+        throw new Error(`Agent ${agentId} not found`);
+      }
+      return { ...existing, cancelRequestedAt: null };
+    });
+  }
+
+  /**
+   * Increment and return this agent's recovery attempt counter. The write is
+   * committed before the attempt runs so a crash during recovery still burns an
+   * attempt.
+   */
+  async recordRecoveryAttempt(agentId: string): Promise<number> {
+    await this.load();
+    let attempts = 0;
+    await this.queueRecordMutation(agentId, (existing) => {
+      if (!existing) {
+        throw new Error(`Agent ${agentId} not found`);
+      }
+      attempts = (existing.recoveryAttempts ?? 0) + 1;
+      return { ...existing, recoveryAttempts: attempts };
+    });
+    return attempts;
+  }
+
+  /** Reset the recovery attempt counter after a clean resume. */
+  async clearRecoveryAttempts(agentId: string): Promise<void> {
+    await this.load();
+    await this.queueRecordMutation(agentId, (existing) => {
+      if (!existing) {
+        throw new Error(`Agent ${agentId} not found`);
+      }
+      return { ...existing, recoveryAttempts: 0 };
     });
   }
 

--- a/packages/server/src/server/bootstrap-agent-recovery.test.ts
+++ b/packages/server/src/server/bootstrap-agent-recovery.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, expect, test } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createTestPaseoDaemon, type TestPaseoDaemon } from "./test-utils/paseo-daemon.js";
+
+const roots: string[] = [];
+const staticDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all([
+    ...roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    ...staticDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  ]);
+});
+
+async function closeWithoutCleanup(daemon: TestPaseoDaemon): Promise<void> {
+  staticDirs.push(daemon.staticDir);
+  await daemon.close();
+}
+
+test("recovers interrupted agents during daemon startup", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "paseo-bootstrap-agent-recovery-"));
+  roots.push(root);
+
+  const first = await createTestPaseoDaemon({ paseoHomeRoot: root, cleanup: false });
+  const agent = await first.daemon.agentManager.createAgent(
+    { provider: "codex", cwd: root },
+    "11111111-1111-4111-8111-111111111111",
+    { workspaceId: undefined },
+  );
+  await first.daemon.agentStorage.applySnapshot(agent);
+  await closeWithoutCleanup(first);
+
+  const record = await first.daemon.agentStorage.get(agent.id);
+  if (!record) {
+    throw new Error("Expected persisted agent record");
+  }
+  await first.daemon.agentStorage.upsert({
+    ...record,
+    lastStatus: "running",
+    persistence: {
+      provider: "codex",
+      sessionId: "recovery-session",
+      metadata: { cwd: root },
+    },
+  });
+
+  const restarted = await createTestPaseoDaemon({ paseoHomeRoot: root, cleanup: false });
+  staticDirs.push(restarted.staticDir);
+  try {
+    expect(restarted.daemon.agentManager.getAgent(agent.id)?.persistence).toMatchObject({
+      provider: "codex",
+      sessionId: "recovery-session",
+    });
+  } finally {
+    await restarted.close();
+  }
+});

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -129,6 +129,7 @@ import type { LocalSpeechProviderConfig } from "./speech/providers/local/config.
 import type { RequestedSpeechProviders } from "./speech/speech-types.js";
 import { createSpeechService } from "./speech/speech-runtime.js";
 import { AgentManager } from "./agent/agent-manager.js";
+import { recoverInterruptedAgents } from "./agent/agent-recovery.js";
 import { AgentStorage } from "./agent/agent-storage.js";
 import { attachAgentStoragePersistence } from "./persistence-hooks.js";
 import { createAgentMcpServer } from "./agent/mcp-server.js";
@@ -1680,6 +1681,11 @@ export async function createPaseoDaemon(
               orchestrationSkills,
               workspaceLabelService,
             );
+            await recoverInterruptedAgents({
+              agentManager,
+              agentStorage,
+              logger,
+            });
             pluginRuntime.bindPaseoSessionHost(wsServer);
             await pluginRuntime.start();
             wsServer.beginAcceptingConnections();


### PR DESCRIPTION
Closes #3935.

Related: #3132.

## Summary

- Resume persisted `running` and `initializing` agents during daemon startup before clients connect.
- Turn failed or non-resumable recovery candidates into attention errors so they do not retry on every restart.
- Give the Docker Compose example a 30-second graceful-stop window and document the recovery boundary.

## Testing

- `npx vitest run packages/server/src/server/agent/agent-recovery.test.ts packages/server/src/server/bootstrap-agent-recovery.test.ts --bail=1` — 4 passed.
- `npm run build --workspace=@getpaseo/server` — passed.
- `npm run format:check` — passed.
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- `docker compose -f docker/docker-compose.example.yml config --quiet` — passed.

## Scope

This restores a provider session after container replacement; it does not claim an in-flight provider process or mid-tool call survives the replacement.
