### PR TITLE
fix(server): recover unresponsive agent stops

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -42,9 +42,10 @@ into that contract; lifecycle callers do not interpret provider-specific errors.
 
 After an acknowledged interrupt, the manager settles the captured run even when no terminal event
 arrives or the run was still waiting for its provider turn id. The captured run token prevents an
-older cancellation from settling a newer turn. If interruption is rejected or times out, the agent
-keeps its active foreground turn and replacement, reload, rewind, and Stop report the failure.
-Accepting new work after an ambiguous interruption would create a split-brain session.
+older cancellation from settling a newer turn. If the normal interrupt rejects or times out, Paseo
+escalates the provider runtime when it supports direct process interruption, then closes and reloads
+the session. A successful recovery leaves the agent idle and ready for the next prompt. If the
+session cannot be restored, the agent becomes an attention error instead of remaining `running`.
 
 ## Relationships
 

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -1194,6 +1194,8 @@ class McpCapableTestAgentClient extends TestAgentClient {
 
 class ControlledInterruptSession extends TestAgentSession {
   interruptCalled = false;
+  forceInterruptCalled = false;
+  closeCalled = false;
 
   constructor(
     config: AgentSessionConfig,
@@ -1214,6 +1216,14 @@ class ControlledInterruptSession extends TestAgentSession {
     this.interruptCalled = true;
     await this.interruptBehavior(this);
   }
+
+  override async forceInterrupt(): Promise<void> {
+    this.forceInterruptCalled = true;
+  }
+
+  override async close(): Promise<void> {
+    this.closeCalled = true;
+  }
 }
 
 interface ControlledInterruptFixture {
@@ -1229,6 +1239,7 @@ async function createControlledInterruptFixture(options: {
   agentId: string;
   turnId: string;
   interrupt: (session: ControlledInterruptSession) => Promise<void>;
+  resumeSession?: () => Promise<AgentSession>;
 }): Promise<ControlledInterruptFixture> {
   const workdir = mkdtempSync(join(tmpdir(), `agent-manager-${options.name}-`));
   const session = new ControlledInterruptSession(
@@ -1239,6 +1250,17 @@ async function createControlledInterruptFixture(options: {
   const client = new (class extends TestAgentClient {
     override async createSession(): Promise<AgentSession> {
       return session;
+    }
+
+    override async resumeSession(
+      handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+      launchContext?: AgentLaunchContext,
+    ): Promise<AgentSession> {
+      if (options.resumeSession) {
+        return options.resumeSession();
+      }
+      return super.resumeSession(handle, config, launchContext);
     }
   })();
   const manager = new AgentManager({
@@ -2312,7 +2334,7 @@ test("reloadAgentSession completes when the previous session close hangs", async
   }
 });
 
-test("cancelAgentRun preserves running state when the provider interrupt hangs", async () => {
+test("cancelAgentRun force-recovers an unresponsive provider session", async () => {
   const fixture = await createControlledInterruptFixture({
     name: "interrupt-timeout",
     agentId: "00000000-0000-4000-8000-000000000303",
@@ -2330,16 +2352,31 @@ test("cancelAgentRun preserves running state when the provider interrupt hangs",
     await running;
 
     await expect(fixture.manager.cancelAgentRun(fixture.agentId)).resolves.toEqual({
-      status: "refused",
+      status: "settled",
     });
     expect(fixture.session.interruptCalled).toBe(true);
-    expect(fixture.manager.getAgent(fixture.agentId)?.lifecycle).toBe("running");
+    expect(fixture.session.forceInterruptCalled).toBe(true);
+    expect(fixture.session.closeCalled).toBe(true);
+    expect(fixture.manager.getAgent(fixture.agentId)).toMatchObject({
+      lifecycle: "idle",
+      activeForegroundTurnId: null,
+    });
+    expect(fixture.manager.getAgent(fixture.agentId)?.session).not.toBe(fixture.session);
+
+    const followUp = fixture.manager.streamAgent(fixture.agentId, "follow-up after forced stop");
+    const events: AgentStreamEvent[] = [];
+    for await (const event of followUp) {
+      events.push(event);
+    }
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "turn_completed", provider: "codex" }),
+    );
   } finally {
     await fixture.cleanup();
   }
 });
 
-test("cancelAgentRun preserves the active turn when the provider rejects the interrupt", async () => {
+test("cancelAgentRun force-recovers when the provider rejects the interrupt", async () => {
   const fixture = await createControlledInterruptFixture({
     name: "interrupt-rejected",
     agentId: "00000000-0000-4000-8000-000000000304",
@@ -2353,17 +2390,46 @@ test("cancelAgentRun preserves the active turn when the provider rejects the int
     await fixture.startForegroundRun();
 
     await expect(fixture.manager.cancelAgentRun(fixture.agentId)).resolves.toEqual({
-      status: "refused",
+      status: "settled",
     });
     expect(fixture.manager.getAgent(fixture.agentId)).toMatchObject({
-      lifecycle: "running",
-      activeForegroundTurnId: "provider-still-active-turn",
+      lifecycle: "idle",
+      activeForegroundTurnId: null,
     });
+    expect(fixture.session.forceInterruptCalled).toBe(true);
+    expect(fixture.session.closeCalled).toBe(true);
+  } finally {
+    await fixture.cleanup();
+  }
+});
 
-    fixture.session.pushEvent({
-      type: "turn_completed",
-      provider: "codex",
-      turnId: "provider-still-active-turn",
+test("cancelAgentRun exposes recovery failure instead of a permanent running state", async () => {
+  const fixture = await createControlledInterruptFixture({
+    name: "interrupt-recovery-failure",
+    agentId: "00000000-0000-4000-8000-000000000307",
+    turnId: "unrecoverable-turn",
+    interrupt: async () => await new Promise(() => {}),
+    resumeSession: async () => {
+      throw new Error("provider session cannot be resumed");
+    },
+  });
+
+  try {
+    await fixture.startForegroundRun();
+
+    await expect(fixture.manager.cancelAgentRun(fixture.agentId)).resolves.toEqual({
+      status: "settled",
+    });
+    expect(fixture.manager.getAgent(fixture.agentId)).toMatchObject({
+      lifecycle: "error",
+      activeForegroundTurnId: null,
+      pendingReplacement: false,
+      attention: expect.objectContaining({
+        requiresAttention: true,
+        attentionReason: "error",
+      }),
+      lastError:
+        "Paseo stopped the unresponsive runtime but could not restore its session: provider session cannot be resumed",
     });
   } finally {
     await fixture.cleanup();
@@ -6169,7 +6235,7 @@ test("cancelAgentRun waits for an acknowledged autonomous interrupt to settle", 
   expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
 });
 
-test("failed replacement cancellation preserves an autonomous running state", async () => {
+test("failed replacement cancellation force-recovers an autonomous running state", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-live-replace-rejected-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);
 
@@ -6212,11 +6278,17 @@ test("failed replacement cancellation preserves an autonomous running state", as
     });
     await running;
 
-    await expect(manager.replaceAgentRun(agent.id, "replacement prompt")).rejects.toThrow(
-      `Cannot replace agent ${agent.id} because its active run cancellation was not acknowledged`,
+    const replacement = await manager.replaceAgentRun(agent.id, "replacement prompt");
+    const events: AgentStreamEvent[] = [];
+    for await (const event of replacement) {
+      events.push(event);
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "turn_completed", provider: "codex" }),
     );
     expect(manager.getAgent(agent.id)).toMatchObject({
-      lifecycle: "running",
+      lifecycle: "idle",
       activeForegroundTurnId: null,
     });
   } finally {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -70,6 +70,7 @@ import {
   AgentRunState,
   type ForegroundTurnWaiter,
   type PendingForegroundRun,
+  type TrackedAgentRun,
 } from "./agent-run-state.js";
 import { invokeRewindCapability, type RewindMode } from "./rewind/rewind.js";
 import { isSystemInjectedEnvelope } from "./agent-prompt.js";
@@ -97,6 +98,11 @@ const STORED_AGENT_CAPABILITIES: AgentCapabilityFlags = {
 };
 
 type TimeoutResult = "completed" | "timed_out";
+
+interface ReloadAgentSessionOptions {
+  rehydrateFromDisk?: boolean;
+  skipCancellation?: boolean;
+}
 
 function submittedPromptText(prompt: AgentPromptInput): string {
   if (typeof prompt === "string") {
@@ -1347,11 +1353,11 @@ export class AgentManager {
   private async reloadAgentSessionInternal(
     agentId: string,
     overrides?: Partial<AgentSessionConfig>,
-    options?: { rehydrateFromDisk?: boolean },
+    options?: ReloadAgentSessionOptions,
   ): Promise<ManagedAgent> {
     this.assertAcceptingAgentRegistrations();
     let existing = this.requireSessionAgent(agentId);
-    if (this.hasInFlightRun(agentId)) {
+    if (this.hasInFlightRun(agentId) && !options?.skipCancellation) {
       await this.cancelAgentRunBefore(agentId, "reload");
       existing = this.requireSessionAgent(agentId);
     }
@@ -2731,42 +2737,15 @@ export class AgentManager {
     });
 
     if (!interruptAcknowledged) {
-      return { status: settlement === "completed" ? "settled" : "refused" };
+      if (settlement === "completed") {
+        return { status: "settled" };
+      }
+      await this.recoverAfterInterruptedCancel(agent, run);
+      return { status: "settled" };
     }
 
-    if (settlement === "timed_out" && run.turnId) {
-      this.logger.warn(
-        { agentId, turnId: run.turnId, kind: run.kind },
-        "cancelAgentRun: acknowledged turn still active after timeout, force-canceling",
-      );
-      await this.dispatchSessionEvent(agent, {
-        type: "turn_canceled",
-        provider: agent.provider,
-        reason: "interrupted",
-        turnId: run.turnId,
-      });
-      await run.settledPromise;
-    } else if (settlement === "timed_out" && run.kind === "foreground") {
-      this.logger.warn(
-        { agentId, kind: run.kind },
-        "cancelAgentRun: acknowledged pending turn still active after timeout, clearing it",
-      );
-      this.runs.settleForegroundRun(agentId, run.token);
-      if (!agent.pendingReplacement) {
-        agent.lifecycle = "idle";
-        this.touchUpdatedAt(agent);
-        this.emitState(agent);
-      }
-    } else if (settlement === "timed_out" && run.kind === "autonomous") {
-      this.logger.warn(
-        { agentId, kind: run.kind },
-        "cancelAgentRun: acknowledged turn still active after timeout, force-canceling",
-      );
-      await this.dispatchSessionEvent(agent, {
-        type: "turn_canceled",
-        provider: agent.provider,
-        reason: "interrupted",
-      });
+    if (settlement === "timed_out") {
+      await this.forceCancelTrackedRun(agent, run);
     }
 
     if (agent.pendingPermissions.size > 0) {
@@ -2775,6 +2754,81 @@ export class AgentManager {
       this.emitState(agent);
     }
     return { status: "settled" };
+  }
+
+  private async forceCancelTrackedRun(
+    agent: ActiveManagedAgent,
+    run: TrackedAgentRun,
+  ): Promise<void> {
+    if (run.turnId) {
+      this.logger.warn(
+        { agentId: agent.id, turnId: run.turnId, kind: run.kind },
+        "cancelAgentRun: turn still active after interrupt timeout, force-canceling",
+      );
+      await this.dispatchSessionEvent(agent, {
+        type: "turn_canceled",
+        provider: agent.provider,
+        reason: "interrupted",
+        turnId: run.turnId,
+      });
+      this.runs.clearAgentRun(agent.id);
+      await run.settledPromise;
+    } else if (run.kind === "foreground") {
+      this.logger.warn(
+        { agentId: agent.id, kind: run.kind },
+        "cancelAgentRun: pending turn still active after interrupt timeout, clearing it",
+      );
+      this.runs.settleForegroundRun(agent.id, run.token);
+      if (!agent.pendingReplacement) {
+        agent.lifecycle = "idle";
+        this.touchUpdatedAt(agent);
+        this.emitState(agent);
+      }
+    } else if (run.kind === "autonomous") {
+      this.logger.warn(
+        { agentId: agent.id, kind: run.kind },
+        "cancelAgentRun: turn still active after interrupt timeout, force-canceling",
+      );
+      await this.dispatchSessionEvent(agent, {
+        type: "turn_canceled",
+        provider: agent.provider,
+        reason: "interrupted",
+      });
+      this.runs.clearAgentRun(agent.id);
+      await run.settledPromise;
+    }
+  }
+
+  private async recoverAfterInterruptedCancel(
+    agent: ActiveManagedAgent,
+    run: TrackedAgentRun,
+  ): Promise<void> {
+    await this.forceInterruptSession(agent.session, agent.id);
+    await this.forceCancelTrackedRun(agent, run);
+    await this.closeReloadedSession(agent.session, agent.id);
+    try {
+      await this.reloadAgentSessionInternal(agent.id, undefined, { skipCancellation: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const current = this.agents.get(agent.id);
+      if (!current || current.session === null) {
+        this.logger.error(
+          { err: error, agentId: agent.id },
+          "Forced session recovery failed after the existing agent closed",
+        );
+        return;
+      }
+      current.pendingReplacement = false;
+      current.lifecycle = "error";
+      current.lastError = `Paseo stopped the unresponsive runtime but could not restore its session: ${message}`;
+      current.attention = {
+        requiresAttention: true,
+        attentionReason: "error",
+        attentionTimestamp: new Date(),
+      };
+      this.touchUpdatedAt(current);
+      this.emitState(current);
+    }
   }
 
   private async cancelAgentRunBefore(
@@ -2811,6 +2865,33 @@ export class AgentManager {
     } catch (error) {
       this.logger.error({ err: error, agentId }, "Failed to interrupt session");
       return false;
+    }
+  }
+
+  private async forceInterruptSession(session: AgentSession, agentId: string): Promise<void> {
+    if (!session.forceInterrupt) {
+      return;
+    }
+
+    try {
+      const result = await this.waitWithTimeout({
+        operation: session.forceInterrupt(),
+        timeoutMs: this.rescueTimeouts.reloadSessionCloseMs,
+        onLateError: (error) => {
+          this.logger.warn(
+            { err: error, agentId },
+            "Forced session interrupt failed after timeout during cancel",
+          );
+        },
+      });
+      if (result === "timed_out") {
+        this.logger.warn(
+          { agentId, timeoutMs: this.rescueTimeouts.reloadSessionCloseMs },
+          "Timed out force-interrupting session during cancel",
+        );
+      }
+    } catch (error) {
+      this.logger.warn({ err: error, agentId }, "Failed to force-interrupt session during cancel");
     }
   }
 

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -659,6 +659,11 @@ export interface AgentSession {
    * still uncertain.
    */
   interrupt(): Promise<void>;
+  /**
+   * Best-effort process escalation after the normal provider interrupt stops
+   * responding. Implementations must leave the durable provider session intact.
+   */
+  forceInterrupt?(): Promise<void>;
   /** Release live runtime resources without archiving or deleting the durable native session. */
   close(): Promise<void>;
   listCommands?(): Promise<AgentSlashCommand[]>;

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -29,7 +29,11 @@ import {
   resolveACPModelSelection,
   summarizeACPRequestError,
 } from "./acp-agent.js";
-import type { ProcessTerminator, TreeKillTarget } from "../../../utils/tree-kill.js";
+import type {
+  ProcessTerminator,
+  TerminateWithTreeKillOptions,
+  TreeKillTarget,
+} from "../../../utils/tree-kill.js";
 import {
   COPILOT_AGENT_FEATURE_OPTION,
   COPILOT_ALLOW_ALL_MODE_ID,
@@ -91,6 +95,10 @@ interface ACPSessionInternals {
   configOptions: SessionConfigOption[];
   translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
   acpMcpServers(): unknown[];
+}
+
+interface ACPForceInterruptInternals {
+  child: ChildProcessWithoutNullStreams | null;
 }
 
 interface ACPModelSelectionInternals {
@@ -262,6 +270,34 @@ function createProbeChildStub(): ChildProcessWithoutNullStreams {
   child.kill = vi.fn(() => true) as ChildProcessWithoutNullStreams["kill"];
   return child;
 }
+
+describe("ACPAgentSession forced interruption", () => {
+  test("escalates an unresponsive process from SIGINT to SIGTERM and SIGKILL", async () => {
+    const calls: TerminateWithTreeKillOptions[] = [];
+    const terminate: ProcessTerminator = async (_child, options) => {
+      calls.push(options);
+      return calls.length === 1 ? "kill-timeout" : "terminated";
+    };
+    const session = createSession(terminate);
+    asInternals<ACPForceInterruptInternals>(session).child = createProbeChildStub();
+
+    await session.forceInterrupt();
+
+    expect(calls).toEqual([
+      {
+        gracefulSignal: "SIGINT",
+        forceSignal: "SIGTERM",
+        gracefulTimeoutMs: 2_000,
+        forceTimeoutMs: 2_000,
+      },
+      {
+        gracefulSignal: "SIGKILL",
+        forceSignal: "SIGKILL",
+        gracefulTimeoutMs: 0,
+      },
+    ]);
+  });
+});
 
 function selectConfigOption(
   category: "mode" | "model" | "thought_level",

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2181,6 +2181,28 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
+  async forceInterrupt(): Promise<void> {
+    if (!this.child) {
+      return;
+    }
+
+    const firstPass = await this.terminateProcess(this.child, {
+      gracefulSignal: "SIGINT",
+      forceSignal: "SIGTERM",
+      gracefulTimeoutMs: 2_000,
+      forceTimeoutMs: 2_000,
+    });
+    if (firstPass !== "kill-timeout") {
+      return;
+    }
+
+    await this.terminateProcess(this.child, {
+      gracefulSignal: "SIGKILL",
+      forceSignal: "SIGKILL",
+      gracefulTimeoutMs: 0,
+    });
+  }
+
   async close(): Promise<void> {
     if (this.closed) {
       return;


### PR DESCRIPTION
Fixes #3540.

Related: #3256 and #2679.

## Summary

- Escalate an unresponsive ACP provider process through `SIGINT → SIGTERM → SIGKILL` after its normal interrupt fails.
- Settle the stale manager run, close the compromised provider session, and reload the durable session before accepting the next prompt.
- Surface recovery failures as attention errors instead of leaving an agent permanently `running`.

## Testing

- `npx vitest run packages/server/src/server/agent/lifecycle-command.test.ts packages/server/src/server/agent/agent-manager.test.ts packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1` — 275 passed.
- `npm run build --workspace=@getpaseo/server` — passed.
- `npm run format:check` — passed.
- `npm run lint` — passed.
- `npm run typecheck` — passed.

## Risk

Force recovery deliberately terminates an unresponsive provider process only after the normal provider interrupt rejects or times out. It retains the provider persistence handle and resumes the same Paseo agent session; if resumption fails, the agent visibly enters an error state.
