### PR TITLE
Restore rewound prompts immediately on iOS

### DIFF
--- a/packages/app/src/components/workspace-setup-dialog.tsx
+++ b/packages/app/src/components/workspace-setup-dialog.tsx
@@ -439,7 +439,7 @@ export function WorkspaceSetupDialog() {
           blurOnSubmit={true}
           value={chatDraft.text}
           onChangeText={chatDraft.editText}
-          textReplacementKey={chatDraft.textReplacementKey}
+          textReplacement={chatDraft.textReplacement}
           attachments={chatDraft.attachments}
           onChangeAttachments={chatDraft.setAttachments}
           cwd={sourceDirectory}

--- a/packages/app/src/composer/draft/input-draft.live.test.tsx
+++ b/packages/app/src/composer/draft/input-draft.live.test.tsx
@@ -224,20 +224,21 @@ describe("useAgentInputDraft live contract", () => {
       thinkingOptionId: "high",
     });
 
-    const hydratedReplacementKey = getLatest().textReplacementKey;
+    const hydratedTextReplacement = getLatest().textReplacement;
 
     await act(async () => {
       getLatest().editText("hello world");
       getLatest().setAttachments([{ kind: "image", metadata: image }]);
     });
 
-    expect(getLatest().textReplacementKey).toBe(hydratedReplacementKey);
+    expect(getLatest().textReplacement).toBe(hydratedTextReplacement);
 
     await act(async () => {
       getLatest().replaceText("replacement text");
     });
 
-    expect(getLatest().textReplacementKey).not.toBe(hydratedReplacementKey);
+    expect(getLatest().textReplacement).not.toBe(hydratedTextReplacement);
+    expect(getLatest().textReplacement.text).toBe("replacement text");
 
     await act(async () => {
       getLatest().editText("hello world");

--- a/packages/app/src/composer/draft/input-draft.ts
+++ b/packages/app/src/composer/draft/input-draft.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { UserComposerAttachment } from "@/attachments/types";
+import type { TextReplacement } from "@/composer/types";
 import type { DraftAgentControlsProps } from "@/composer/agent-controls";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
 import {
@@ -56,7 +57,7 @@ export interface AgentInputDraft {
   text: string;
   editText: (text: string) => void;
   replaceText: (text: string) => void;
-  textReplacementKey: string;
+  textReplacement: TextReplacement;
   attachments: UserComposerAttachment[];
   setAttachments: (updater: AttachmentUpdater) => void;
   clear: (lifecycle: "sent" | "abandoned") => void;
@@ -88,10 +89,25 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     (state) => state.attachmentFocusRequestByDraftKey[draftKey] ?? 0,
   );
   const [hydratedDraftKey, setHydratedDraftKey] = useState<string | null>(null);
-  const [textReplacementRevision, setTextReplacementRevision] = useState(0);
   const text = draft?.text ?? "";
   const attachments = draft?.attachments ?? [];
   const isHydrated = hydratedDraftKey === draftKey;
+  const textReplacementRevisionRef = useRef(0);
+  const [textReplacement, setTextReplacement] = useState<TextReplacement>(() => ({
+    key: `${draftKey}:0`,
+    text,
+  }));
+
+  const publishTextReplacement = useCallback(
+    (nextText: string) => {
+      textReplacementRevisionRef.current += 1;
+      setTextReplacement({
+        key: `${draftKey}:${textReplacementRevisionRef.current}`,
+        text: nextText,
+      });
+    },
+    [draftKey],
+  );
 
   const saveDraft = useCallback(
     (
@@ -135,9 +151,9 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     (nextText: string) => {
       textPublication.cancel();
       saveDraft((current) => ({ ...current, text: nextText }));
-      setTextReplacementRevision((revision) => revision + 1);
+      publishTextReplacement(nextText);
     },
-    [saveDraft, textPublication],
+    [publishTextReplacement, saveDraft, textPublication],
   );
 
   const setAttachments = useCallback(
@@ -187,7 +203,8 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     void (async () => {
       await useDraftStore.getState().hydrateDraftInput({ draftKey });
       if (!cancelled) {
-        setTextReplacementRevision((revision) => revision + 1);
+        const hydratedText = useDraftStore.getState().getDraftInput(draftKey)?.text ?? "";
+        publishTextReplacement(hydratedText);
         setHydratedDraftKey(draftKey);
       }
     })();
@@ -195,7 +212,7 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     return () => {
       cancelled = true;
     };
-  }, [draftKey]);
+  }, [draftKey, publishTextReplacement]);
 
   const lockedWorkingDir = composerOptions?.lockedWorkingDir?.trim() ?? "";
   useEffect(() => {
@@ -318,7 +335,7 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     text,
     editText,
     replaceText,
-    textReplacementKey: `${draftKey}:${textReplacementRevision}`,
+    textReplacement,
     attachments,
     setAttachments,
     clear,

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -697,7 +697,7 @@ export function WorkspaceDraftAgentTab({
           blurOnSubmit={true}
           value={draftInput.text}
           onChangeText={draftInput.editText}
-          textReplacementKey={draftInput.textReplacementKey}
+          textReplacement={draftInput.textReplacement}
           attachments={draftInput.attachments}
           attachmentScopeKeys={attachmentScopeKeys}
           onOpenWorkspaceAttachment={handleOpenWorkspaceAttachment}

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -53,7 +53,7 @@ import {
   type ComposerKeyPressEvent,
   type MessageInputRef,
 } from "./input/input";
-import type { ImageAttachment, MessagePayload } from "./types";
+import type { ImageAttachment, MessagePayload, TextReplacement } from "./types";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
 import { encodeImages } from "@/utils/encode-images";
@@ -931,7 +931,7 @@ interface ComposerProps {
   blurOnSubmit?: boolean;
   value: string;
   onChangeText: (text: string) => void;
-  textReplacementKey: string;
+  textReplacement: TextReplacement;
   attachments: UserComposerAttachment[];
   attachmentScopeKeys?: readonly string[];
   onOpenWorkspaceAttachment?: (attachment: WorkspaceComposerAttachment) => void;
@@ -1153,7 +1153,7 @@ function ComposerContentImpl({
   blurOnSubmit = false,
   value,
   onChangeText,
-  textReplacementKey,
+  textReplacement,
   attachments,
   attachmentScopeKeys = EMPTY_ATTACHMENT_SCOPE_KEYS,
   onOpenWorkspaceAttachment,
@@ -2328,7 +2328,7 @@ function ComposerContentImpl({
                   attachmentSlot={attachmentTray}
                   inputMode={inputMode}
                   readOnly={readOnly}
-                  textReplacementKey={textReplacementKey}
+                  textReplacement={textReplacement}
                   submitLabel={submitLabel}
                 />
               </RenderProfile>

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -35,7 +35,7 @@ import {
   filesToImageAttachments,
 } from "@/utils/image-attachments-from-files";
 import type { ComposerAttachment } from "@/attachments/types";
-import type { ImageAttachment, MessagePayload } from "@/composer/types";
+import type { ImageAttachment, MessagePayload, TextReplacement } from "@/composer/types";
 import { focusWithRetries } from "@/utils/web-focus";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Shortcut } from "@/components/ui/shortcut";
@@ -169,8 +169,8 @@ export interface MessageInputProps {
   inputMode?: ComposerInputMode;
   /** Renders `value` as static text on the same surface, for content there is nothing to type into. */
   readOnly?: boolean;
-  /** Changes only when application state must replace native-owned text. */
-  textReplacementKey: string;
+  /** Command issued when application state must replace native-owned text. */
+  textReplacement: TextReplacement;
   /** Replaces the submit icon with this label, still inside the composer's own toolbar row. */
   submitLabel?: string;
 }
@@ -1081,7 +1081,7 @@ interface ResolvedMessageInputProps {
   attachmentSlot: React.ReactNode;
   inputMode: ComposerInputMode;
   readOnly: boolean;
-  textReplacementKey: string;
+  textReplacement: TextReplacement;
   submitLabel: string | undefined;
 }
 
@@ -1128,7 +1128,7 @@ function resolveMessageInputProps(props: MessageInputProps): ResolvedMessageInpu
     attachmentSlot: props.attachmentSlot,
     inputMode: props.inputMode ?? "chat",
     readOnly: props.readOnly ?? false,
-    textReplacementKey: props.textReplacementKey,
+    textReplacement: props.textReplacement,
     submitLabel: props.submitLabel,
   };
 }
@@ -1183,7 +1183,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       attachmentSlot,
       inputMode,
       readOnly,
-      textReplacementKey,
+      textReplacement,
       submitLabel,
     } = resolveMessageInputProps(props);
     const mode = resolveComposerInputMode(inputMode);
@@ -1209,7 +1209,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const isInputFocusedRef = useRef(false);
     const valueRef = useRef(value);
     const selectionRef = useRef({ start: value.length, end: value.length });
-    const appliedTextReplacementKeyRef = useRef(textReplacementKey);
+    const appliedTextReplacementKeyRef = useRef(textReplacement.key);
     const webTextareaRef = useRef<HTMLElement | null>(null);
     const composerHeight = useComposerHeight({
       value,
@@ -1287,13 +1287,13 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     );
 
     useEffect(() => {
-      if (appliedTextReplacementKeyRef.current === textReplacementKey) return;
-      appliedTextReplacementKeyRef.current = textReplacementKey;
-      updateComposerHeightForText?.(valueRef.current, value);
-      valueRef.current = value;
-      updateLiveTextPresence(value);
-      textInputRef.current?.replaceText(value);
-    }, [textReplacementKey, updateComposerHeightForText, updateLiveTextPresence, value]);
+      if (appliedTextReplacementKeyRef.current === textReplacement.key) return;
+      appliedTextReplacementKeyRef.current = textReplacement.key;
+      updateComposerHeightForText?.(valueRef.current, textReplacement.text);
+      valueRef.current = textReplacement.text;
+      updateLiveTextPresence(textReplacement.text);
+      textInputRef.current?.replaceText(textReplacement.text);
+    }, [textReplacement, updateComposerHeightForText, updateLiveTextPresence]);
 
     useEffect(() => {
       return () => {

--- a/packages/app/src/composer/types.ts
+++ b/packages/app/src/composer/types.ts
@@ -8,3 +8,8 @@ export interface MessagePayload {
   cwd: string;
   forceSend?: boolean;
 }
+
+export interface TextReplacement {
+  key: string;
+  text: string;
+}

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -1306,7 +1306,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
     text,
     editText,
     replaceText,
-    textReplacementKey,
+    textReplacement,
     attachments,
     setAttachments,
     clear,
@@ -1319,7 +1319,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
       text,
       editText,
       replaceText,
-      textReplacementKey,
+      textReplacement,
       attachments,
       setAttachments,
       clear,
@@ -1331,7 +1331,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
       text,
       editText,
       replaceText,
-      textReplacementKey,
+      textReplacement,
       attachments,
       setAttachments,
       clear,
@@ -1720,7 +1720,7 @@ function ActiveAgentComposer({
         isPaneFocused={isPaneFocused}
         value={agentInputDraft.text}
         onChangeText={agentInputDraft.editText}
-        textReplacementKey={agentInputDraft.textReplacementKey}
+        textReplacement={agentInputDraft.textReplacement}
         attachments={agentInputDraft.attachments}
         attachmentScopeKeys={attachmentScopeKeys}
         onOpenWorkspaceAttachment={handleOpenWorkspaceAttachment}

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -2279,6 +2279,7 @@ export function NewWorkspaceScreen({
           {formStack}
           {isTerminalLaunch ? (
             <Composer
+              key="terminal"
               externalKeyboardShift
               inputMode="terminal"
               readOnly={!terminalTakesPrompt}
@@ -2306,6 +2307,7 @@ export function NewWorkspaceScreen({
             />
           ) : (
             <Composer
+              key="chat"
               externalKeyboardShift
               agentId={draftKey}
               serverId={selectedServerId}

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -1620,6 +1620,10 @@ export function NewWorkspaceScreen({
     terminalSubmitLabel,
     launchFocusKey,
   } = useTerminalComposerState({ launchTarget, terminalProfiles, terminalPromptText });
+  const terminalTextReplacement = useMemo(
+    () => ({ key: launchFocusKey, text: terminalComposerValue }),
+    [launchFocusKey, terminalComposerValue],
+  );
 
   useEffect(() => {
     const trimmed = pickerSearchQuery.trim();
@@ -2292,7 +2296,7 @@ export function NewWorkspaceScreen({
               blurOnSubmit={true}
               value={terminalComposerValue}
               onChangeText={setTerminalPromptText}
-              textReplacementKey={launchFocusKey}
+              textReplacement={terminalTextReplacement}
               attachments={NO_TERMINAL_ATTACHMENTS}
               onChangeAttachments={noopChangeAttachments}
               cwd={selectedSourceDirectory ?? ""}
@@ -2317,7 +2321,7 @@ export function NewWorkspaceScreen({
               blurOnSubmit={true}
               value={chatDraft.text}
               onChangeText={chatDraft.editText}
-              textReplacementKey={chatDraft.textReplacementKey}
+              textReplacement={chatDraft.textReplacement}
               attachments={chatDraft.attachments}
               attachmentScopeKeys={visibleDraftContextScopeKeys}
               onChangeAttachments={chatDraft.setAttachments}


### PR DESCRIPTION
### Linked issue

Reported in [Discord](https://discord.com/channels/1481169421832814616/1542230122495479838/1542230122495479838).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Rewinding a conversation could persist the restored prompt while leaving the mounted iOS composer blank until the view remounted. The replacement revision and replacement text arrived through independently scheduled React and draft-store updates, so the editor could consume the new revision with the old empty value.

A text replacement now carries its revision and text as one command. The uncontrolled native editor keeps its typing-performance ownership while replacement identity and contents can no longer disagree.

### Goals

- Restore the rewound prompt immediately in the mounted iOS composer.
- Keep native-owned text editing uncontrolled during ordinary typing.
- Make programmatic text replacements atomic across React and draft-store scheduling.
- Cover the replacement command contract with an automated regression.

### Non-goals

- Change rewind history or daemon behavior.
- Make the composer controlled.
- Change ordinary draft editing or persistence semantics.

### QA

Before the fix, an exact v0.5.2 bundle on the iPhone 17 Pro simulator reproduced the report:

1. Send `REWIND-IOS-REPRO-20260827. Reply only: done`.
2. Rewind that conversation.
3. Observe the timeline clear while the mounted editable input remains blank.
4. Relaunch the app and observe the persisted prompt appear.

After the fix, the same flow on the current development bundle showed the prompt immediately after rewind without navigation or remount:

```
@e14 [scroll-area] "Start chatting with this agent..."
@e16 [text-view] "REWIND-ATOMIC-20260827. Reply only: done" [editable]
```

Automated and static verification:

```
npm run test --workspace=@getpaseo/app -- src/composer/draft/input-draft.live.test.tsx --bail=1
# 1 file passed, 7 tests passed

npm run typecheck
# passed

npm run lint
# 0 warnings, 0 errors

npm run format
# passed
```

Platforms tested: iOS simulator. Android, browser, and Electron were not manually exercised. The shared composer API is typechecked across every call site.

Risk surface: programmatic composer replacement and hydration across agent, workspace setup, draft workspace, and terminal creation composers.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
