### PR TITLE
fix(claude): state why a permission prompt appeared

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -709,6 +709,42 @@ describe("ClaudeAgentSession features", () => {
     }
   });
 
+  test("carries the SDK decision reason onto the permission request description", async () => {
+    const { queryFactory } = createQueryMock();
+    const session = await new ClaudeAgentClient({
+      logger,
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    }).createSession({ provider: "claude", cwd: process.cwd(), modeId: "bypassPermissions" });
+    const events: AgentStreamEvent[] = [];
+    const unsubscribe = session.subscribe((event) => events.push(event));
+
+    try {
+      await session.startTurn("run the tool");
+      const canUseTool = queryFactory.mock.calls[0]?.[0].options.canUseTool;
+      if (!canUseTool) throw new Error("Expected canUseTool callback");
+      canUseTool(
+        "Bash",
+        { command: "printf test" },
+        {
+          toolUseID: "tool-hook-ask",
+          decisionReason: "Heredoc input to python3 -- cannot statically verify safety",
+        },
+      ).catch(() => undefined);
+
+      expect(events.find((event) => event.type === "permission_requested")).toMatchObject({
+        type: "permission_requested",
+        request: {
+          name: "Bash",
+          description: "Heredoc input to python3 -- cannot statically verify safety",
+        },
+      });
+    } finally {
+      unsubscribe();
+      await session.close();
+    }
+  });
+
   test("passes exact configured Fable 5 IDs through to Claude Code", async () => {
     const { queryFactory, queryMock } = createQueryMock();
     const client = new ClaudeAgentClient({

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -4596,6 +4596,7 @@ class ClaudeAgentSession implements AgentSession {
       provider: "claude",
       name: toolName,
       kind,
+      description: readNonEmptyString(options.decisionReason)?.trim(),
       ...buildClaudeQuestionPermissionSummary(toolName, input),
       input: requestInput,
       detail: toolDetail,


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A user selects Bypass and expects no prompts. A `permissions.ask` rule or a `PreToolUse` hook outranks the mode, so the agent asks anyway, and the card gives no cause. The user reads this as a broken mode.

Claude explains each prompt in `canUseTool`'s `decisionReason`. Paseo dropped it. The card now shows that sentence, so a user can find the hook that owns the rule instead of guessing.

Codex already puts its approval reason in `description`. Claude now matches, so no new field and no protocol change are needed. `description` was unset on every Claude permission request except `AskUserQuestion`, which keeps its own summary because that spread still runs after this line.

### Goals

- The card shows the provider's reason when the provider sends one. Acceptance: a hook-forced prompt in Bypass shows the hook's `permissionDecisionReason`.
- A card without a reason looks exactly as it does today. Acceptance: no new row, no layout shift.
- Claude and Codex carry an approval reason the same way. Acceptance: one field, no provider-specific rendering.

### Non-goals

- Changing the CLI's precedence. A hook that asks still asks. Paseo shows the cause; it does not overrule the hook.
- Auto-approving hook-forced tools in Bypass. `f998ee169` did that and was reverted the same day. A blanket allow defeats a real safety hook.

### QA

Real Claude, web (browser), one live session in `bypassPermissions`, driven through the app by Playwright.

```
npx playwright test --project=real-provider e2e/browser/permission-reason-card.real.spec.ts
1 passed (52.7s)
```

The run forces two prompts in the same session and captures both.

Forced by a `permissions.ask` rule, which sends no reason. This is the card before this change:

![before-rule-forced-no-reason.png](https://github.com/user-attachments/assets/75d30b5f-b26c-48bb-a3dd-82074ae30d6c)

Forced by a `PreToolUse` hook that returns a reason, same session:

![after-hook-forced-with-reason.png](https://github.com/user-attachments/assets/78b8c01b-6adb-4107-92a7-7e45cd4357e8)

The spec asserts both states, so the screenshots are not the only proof: the hook's sentence is absent from the first card and visible on the second.

Both cards come from one session on this branch. The pair shows the two render paths, with a reason and without. It is not an old build beside a new one. A card without a reason renders exactly as it did before this change, which is why the first shot stands in for the old card.

The spec lives at
`packages/app/e2e/browser/permission-reason-card.real.spec.ts`. It is not part of this commit.

Unit:

```
npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts
Test Files  1 passed (1)      Tests  75 passed (75)
```

Platforms: the daemon fills a field the card already rendered, so every platform gets it through the existing path. Web verified above with real Claude.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
