### PR TITLE
feat(plugins): expose timeline source metadata

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -282,8 +282,9 @@ collapsed before the transformer replaces anything.
 `query.itemType` selects one public `AgentTimelineItem.type`. The callback owns any detailed
 recognition and returns plain plugin item objects. `undefined` keeps the source item, `items`
 replaces it, and an empty array removes it. Output `data` must be JSON-compatible. Paseo adds the
-runtime plugin ID, preserves the source timeline cursor, validates renderer data with its Zod
-schema, and mounts the component inside the normal plugin runtime and error boundary.
+runtime plugin ID, preserves the source timeline cursor, provides renderer source metadata, validates
+renderer data with its Zod schema, and mounts the component inside the normal plugin runtime and
+error boundary. The renderer contract is in [the plugin reference](../public-docs/plugins/reference.md#timeline-items).
 
 Transformers run synchronously and must be deterministic. When several transformers match, the
 first one that returns a result owns that source item. Plugin and registration ordering is stable.

--- a/docs/timeline-sync.md
+++ b/docs/timeline-sync.md
@@ -147,9 +147,9 @@ version.
 A projected page is canonical state, not a sequence of live deltas. One projected item can overlap
 rows already received live—for example, a tool call retained at its original display position while
 its completion advances `seqEnd`, followed by a merged assistant message. The app uses
-`sourceSeqRanges` to replace overlapping assistant and reasoning projections before applying the
-remaining page through the existing stream reducer. It must not append full projected text to a
-live prefix.
+`sourceSeqRanges` to replace overlapping assistant, reasoning, and plugin projections before
+applying the remaining page through the existing stream reducer. It must not append full projected
+text to a live prefix.
 
 Every path that sends a message to an agent — composer send, dictation accept-and-send, queued
 send-now, and the automatic queue drain in `HostRuntime` — goes through

--- a/packages/app/src/plugins/timeline/index.ts
+++ b/packages/app/src/plugins/timeline/index.ts
@@ -7,11 +7,12 @@ import {
 } from "./model";
 
 export type { InstalledPluginTimelineItem, TimelineItemTransform } from "./model";
+export { createPluginTimelineItemSource } from "./source";
 export { PluginTimelineItemView } from "./view";
 
 export function createInstalledTimelineTransform(serverId: string): TimelineItemTransform {
-  return (item: AgentTimelineItem): InstalledPluginTimelineItem[] | undefined => {
+  return (item: AgentTimelineItem, source): InstalledPluginTimelineItem[] | undefined => {
     const plugins = pluginRegistry.getSnapshot().filter((plugin) => plugin.serverId === serverId);
-    return transformTimelineItem(item, plugins);
+    return transformTimelineItem(item, plugins, source);
   };
 }

--- a/packages/app/src/plugins/timeline/model.test.ts
+++ b/packages/app/src/plugins/timeline/model.test.ts
@@ -2,6 +2,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 import type { InstalledPlugin } from "../types";
 import { transformTimelineItem } from "./model";
+import { createPluginTimelineItemSource } from "./source";
 
 function plugin(input: {
   id: string;
@@ -48,13 +49,13 @@ describe("plugin timeline transforms", () => {
     const transformed = transformTimelineItem(toolCall, [
       plugin({
         id: "reports",
-        transform: () => ({
+        transform: ({ item }: { item: { name: string } }) => ({
           items: [
             {
               type: "plugin" as const,
               kind: "test-report",
               version: 1,
-              data: { passed: 4 },
+              data: { passed: item.name === "shell" ? 4 : 0 },
             },
           ],
         }),
@@ -68,8 +69,59 @@ describe("plugin timeline transforms", () => {
         kind: "test-report",
         version: 1,
         data: { passed: 4 },
+        source: null,
       },
     ]);
+  });
+
+  it("attaches host source metadata instead of accepting it from plugin data", () => {
+    const source = createPluginTimelineItemSource({
+      epoch: "epoch-1",
+      seqStart: 4,
+      seqEnd: 9,
+      sourceSeqRanges: [
+        { startSeq: 4, endSeq: 5 },
+        { startSeq: 9, endSeq: 9 },
+      ],
+    });
+    const transformed = transformTimelineItem(
+      toolCall,
+      [
+        plugin({
+          id: "reports",
+          transform: () => ({
+            items: [
+              {
+                type: "plugin" as const,
+                kind: "test-report",
+                version: 1,
+                data: {
+                  source: {
+                    epoch: "spoofed",
+                    seqStart: 1,
+                    seqEnd: 1,
+                    sourceSeqRanges: [{ startSeq: 1, endSeq: 1 }],
+                  },
+                },
+              },
+            ],
+          }),
+        }),
+      ],
+      source,
+    );
+
+    expect(transformed?.[0]).toMatchObject({
+      data: {
+        source: {
+          epoch: "spoofed",
+          seqStart: 1,
+          seqEnd: 1,
+          sourceSeqRanges: [{ startSeq: 1, endSeq: 1 }],
+        },
+      },
+      source,
+    });
   });
 
   it("keeps the source item when no transformer returns a result", () => {

--- a/packages/app/src/plugins/timeline/model.ts
+++ b/packages/app/src/plugins/timeline/model.ts
@@ -1,6 +1,7 @@
 import type {
   PluginTimelineData,
   PluginTimelineItem,
+  PluginTimelineItemSource,
   PluginTimelineTransformResult,
 } from "@getpaseo/plugin";
 import type { AgentTimelineItem } from "@getpaseo/protocol/agent-types";
@@ -8,10 +9,12 @@ import type { InstalledPlugin } from "../types";
 
 export interface InstalledPluginTimelineItem extends PluginTimelineItem {
   pluginId: string;
+  source: PluginTimelineItemSource | null;
 }
 
 export type TimelineItemTransform = (
   item: AgentTimelineItem,
+  source: PluginTimelineItemSource | null,
 ) => InstalledPluginTimelineItem[] | undefined;
 
 function isTimelineData(value: unknown, ancestors: Set<object>): value is PluginTimelineData {
@@ -63,6 +66,7 @@ function parseTransformResult(value: unknown): PluginTimelineTransformResult {
 export function transformTimelineItem(
   item: AgentTimelineItem,
   plugins: readonly InstalledPlugin[],
+  source: PluginTimelineItemSource | null = null,
 ): InstalledPluginTimelineItem[] | undefined {
   for (const plugin of plugins) {
     for (const transformer of plugin.timelineTransformers) {
@@ -80,6 +84,7 @@ export function transformTimelineItem(
           version: transformedItem.version,
           data: JSON.parse(JSON.stringify(transformedItem.data)) as PluginTimelineData,
           pluginId: plugin.id,
+          source,
         }));
       } catch (error) {
         console.warn(

--- a/packages/app/src/plugins/timeline/projection.test.ts
+++ b/packages/app/src/plugins/timeline/projection.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { AgentStreamEventPayload } from "@getpaseo/protocol/messages";
-import type { TimelineItemTransform } from "./model";
+import type { StreamItem } from "@/types/stream";
 import {
   processAgentStreamEvent,
   processTimelineResponse,
+  type ProcessTimelineResponseInput,
 } from "@/timeline/session-stream-reducers";
+import type { TimelineItemTransform } from "./model";
+
+type TimelinePayload = ProcessTimelineResponseInput["payload"];
+type TimelineEntry = TimelinePayload["entries"][number];
+type TimelineEvent = Extract<AgentStreamEventPayload, { type: "timeline" }>;
 
 const transform: TimelineItemTransform = (item, source) => {
   if (item.type !== "tool_call" || item.status === "running") return;
@@ -20,7 +26,7 @@ const transform: TimelineItemTransform = (item, source) => {
   ];
 };
 
-const event: AgentStreamEventPayload = {
+const event: TimelineEvent = {
   type: "timeline",
   provider: "claude",
   item: {
@@ -33,40 +39,164 @@ const event: AgentStreamEventPayload = {
   },
 };
 
+function makeSource(
+  seqStart = 2,
+  seqEnd = seqStart,
+  sourceSeqRanges = [{ startSeq: seqStart, endSeq: seqEnd }],
+) {
+  return { epoch: "epoch-1", seqStart, seqEnd, sourceSeqRanges };
+}
+
+function makePluginItem(id = "live-plugin", source = makeSource()): StreamItem {
+  return {
+    kind: "plugin",
+    id,
+    pluginId: "reports",
+    itemKind: "test-report",
+    version: 1,
+    data: { name: "tests" },
+    timestamp: new Date("2026-01-01T00:00:00.000Z"),
+    timelineCursor: { epoch: "epoch-1", seq: source.seqEnd },
+    source,
+  };
+}
+
+function makeEntry(
+  seqStart: number,
+  seqEnd = seqStart,
+  options: {
+    sourceSeqRanges?: TimelineEntry["sourceSeqRanges"];
+    item?: TimelineEntry["item"];
+  } = {},
+): TimelineEntry {
+  return {
+    seqStart,
+    seqEnd,
+    provider: "claude",
+    item: options.item ?? event.item,
+    timestamp: "2026-01-01T00:00:01.000Z",
+    ...(options.sourceSeqRanges ? { sourceSeqRanges: options.sourceSeqRanges } : {}),
+  };
+}
+
+const basePayload: TimelinePayload = {
+  agentId: "agent-1",
+  direction: "after",
+  projection: "projected",
+  reset: false,
+  epoch: "epoch-1",
+  window: { minSeq: 1, maxSeq: 0, nextSeq: 1 },
+  startCursor: null,
+  endCursor: null,
+  entries: [],
+  error: null,
+  hasNewer: false,
+  hasOlder: false,
+};
+
+function processProjection(
+  payload: Partial<TimelinePayload>,
+  options: {
+    currentTail?: StreamItem[];
+    currentHead?: StreamItem[];
+    currentCursor?: ProcessTimelineResponseInput["currentCursor"];
+    isInitializing?: boolean;
+    hasActiveInitDeferred?: boolean;
+    initRequestDirection?: ProcessTimelineResponseInput["initRequestDirection"];
+    transformTimelineItem?: TimelineItemTransform;
+  } = {},
+) {
+  return processTimelineResponse({
+    payload: { ...basePayload, ...payload },
+    currentTail: options.currentTail ?? [],
+    currentHead: options.currentHead ?? [],
+    currentCursor: options.currentCursor,
+    isInitializing: options.isInitializing ?? false,
+    hasActiveInitDeferred: options.hasActiveInitDeferred ?? false,
+    initRequestDirection: options.initRequestDirection ?? "tail",
+    sendingClientMessageIds: [],
+    transformTimelineItem: options.transformTimelineItem,
+  });
+}
+
+function livePluginOptions() {
+  return {
+    currentTail: [makePluginItem()],
+    currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+    initRequestDirection: "after" as const,
+    transformTimelineItem: transform,
+  };
+}
+
+const pluginReconciliationCases: Array<{
+  name: string;
+  payload: Partial<TimelinePayload>;
+  currentCursor: { epoch: string; startSeq: number; endSeq: number };
+  sourceSeqEnd: number;
+}> = [
+  {
+    name: "overlapping forward history",
+    payload: {
+      window: { minSeq: 1, maxSeq: 3, nextSeq: 4 },
+      startCursor: { seq: 3 },
+      endCursor: { seq: 3 },
+      entries: [makeEntry(1, 3, { sourceSeqRanges: [{ startSeq: 1, endSeq: 3 }] })],
+    },
+    currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+    sourceSeqEnd: 3,
+  },
+  {
+    name: "inclusive merge-window boundary",
+    payload: {
+      direction: "before",
+      window: { minSeq: 1, maxSeq: 2, nextSeq: 3 },
+      startCursor: { seq: 1 },
+      endCursor: { seq: 1 },
+      mergeWindow: true,
+      hasNewer: true,
+      entries: [
+        makeEntry(1, 2, {
+          sourceSeqRanges: [
+            { startSeq: 1, endSeq: 1 },
+            { startSeq: 2, endSeq: 2 },
+          ],
+        }),
+      ],
+    },
+    currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+    sourceSeqEnd: 2,
+  },
+  {
+    name: "older-page boundary",
+    payload: {
+      direction: "before",
+      window: { minSeq: 1, maxSeq: 2, nextSeq: 3 },
+      startCursor: { seq: 1 },
+      endCursor: { seq: 1 },
+      entries: [makeEntry(1, 2, { sourceSeqRanges: [{ startSeq: 1, endSeq: 2 }] })],
+    },
+    currentCursor: { epoch: "epoch-1", startSeq: 2, endSeq: 2 },
+    sourceSeqEnd: 2,
+  },
+];
+
 describe("plugin timeline projection", () => {
   it("uses null source when projected history lacks authoritative ranges", () => {
-    const result = processTimelineResponse({
-      payload: {
-        agentId: "agent-1",
+    const result = processProjection(
+      {
         direction: "tail",
-        projection: "projected",
         reset: true,
-        epoch: "epoch-1",
         window: { minSeq: 1, maxSeq: 1, nextSeq: 2 },
         startCursor: { seq: 1 },
         endCursor: { seq: 1 },
-        entries: [
-          {
-            seqStart: 1,
-            seqEnd: 1,
-            provider: "claude",
-            item: event.item,
-            timestamp: "2026-01-01T00:00:00.000Z",
-          },
-        ],
-        error: null,
-        hasNewer: false,
-        hasOlder: false,
+        entries: [makeEntry(1)],
       },
-      currentTail: [],
-      currentHead: [],
-      currentCursor: undefined,
-      isInitializing: true,
-      hasActiveInitDeferred: true,
-      initRequestDirection: "tail",
-      sendingClientMessageIds: [],
-      transformTimelineItem: transform,
-    });
+      {
+        isInitializing: true,
+        hasActiveInitDeferred: true,
+        transformTimelineItem: transform,
+      },
+    );
 
     expect(result.tail).toMatchObject([
       {
@@ -102,64 +232,31 @@ describe("plugin timeline projection", () => {
         },
       ];
     };
-    const result = processTimelineResponse({
-      payload: {
-        agentId: "agent-1",
+    const authoritativeSource = makeSource(4, 9, [
+      { startSeq: 4, endSeq: 5 },
+      { startSeq: 9, endSeq: 9 },
+    ]);
+    const result = processProjection(
+      {
         direction: "tail",
-        projection: "projected",
         reset: true,
-        epoch: "epoch-1",
         window: { minSeq: 4, maxSeq: 9, nextSeq: 10 },
         startCursor: { seq: 4 },
         endCursor: { seq: 9 },
-        entries: [
-          {
-            seqStart: 4,
-            seqEnd: 9,
-            sourceSeqRanges: [
-              { startSeq: 4, endSeq: 5 },
-              { startSeq: 9, endSeq: 9 },
-            ],
-            provider: "claude",
-            item: event.item,
-            timestamp: "2026-01-01T00:00:00.000Z",
-          },
-        ],
-        error: null,
-        hasNewer: false,
-        hasOlder: false,
+        entries: [makeEntry(4, 9, { sourceSeqRanges: authoritativeSource.sourceSeqRanges })],
       },
-      currentTail: [],
-      currentHead: [],
-      currentCursor: undefined,
-      isInitializing: true,
-      hasActiveInitDeferred: true,
-      initRequestDirection: "tail",
-      sendingClientMessageIds: [],
-      transformTimelineItem: multipleItems,
-    });
+      {
+        isInitializing: true,
+        hasActiveInitDeferred: true,
+        transformTimelineItem: multipleItems,
+      },
+    );
 
     const pluginItems = result.tail.filter((item) => item.kind === "plugin");
     expect(pluginItems).toHaveLength(2);
     expect(pluginItems.map((item) => item.source)).toEqual([
-      {
-        epoch: "epoch-1",
-        seqStart: 4,
-        seqEnd: 9,
-        sourceSeqRanges: [
-          { startSeq: 4, endSeq: 5 },
-          { startSeq: 9, endSeq: 9 },
-        ],
-      },
-      {
-        epoch: "epoch-1",
-        seqStart: 4,
-        seqEnd: 9,
-        sourceSeqRanges: [
-          { startSeq: 4, endSeq: 5 },
-          { startSeq: 9, endSeq: 9 },
-        ],
-      },
+      authoritativeSource,
+      authoritativeSource,
     ]);
     expect(pluginItems[0]?.source).toBe(pluginItems[1]?.source);
     expect(Object.isFrozen(pluginItems[0]?.source)).toBe(true);
@@ -167,8 +264,62 @@ describe("plugin timeline projection", () => {
     expect(Object.isFrozen(pluginItems[0]?.source?.sourceSeqRanges[0])).toBe(true);
   });
 
+  it.each(pluginReconciliationCases)(
+    "reconciles $name",
+    ({ payload, currentCursor, sourceSeqEnd }) => {
+      const result = processProjection(payload, {
+        ...livePluginOptions(),
+        currentCursor,
+      });
+      expect(result.tail.filter((item) => item.kind === "plugin")).toHaveLength(1);
+      expect(result.tail[0]).toMatchObject({
+        id: "live-plugin",
+        source: { seqStart: 1, seqEnd: sourceSeqEnd },
+      });
+    },
+  );
+
+  it("continues merging an assistant boundary after plugin reconciliation", () => {
+    const result = processProjection(
+      {
+        direction: "before",
+        window: { minSeq: 1, maxSeq: 6, nextSeq: 7 },
+        startCursor: { seq: 1 },
+        endCursor: { seq: 1 },
+        entries: [
+          makeEntry(1, 5, { sourceSeqRanges: [{ startSeq: 1, endSeq: 5 }] }),
+          makeEntry(1, 1, { item: { type: "assistant_message", text: "Older" } }),
+        ],
+      },
+      {
+        currentTail: [
+          makePluginItem("live-plugin", makeSource(5)),
+          {
+            kind: "assistant_message",
+            id: "live-assistant",
+            text: "New",
+            timestamp: new Date("2026-01-01T00:00:00.000Z"),
+            timelineCursor: { epoch: "epoch-1", seq: 6 },
+          },
+        ],
+        currentCursor: { epoch: "epoch-1", startSeq: 2, endSeq: 6 },
+        initRequestDirection: "after",
+        transformTimelineItem: transform,
+      },
+    );
+
+    expect(result.tail).toMatchObject([
+      { kind: "plugin", id: "live-plugin" },
+      { kind: "assistant_message", id: "live-assistant", text: "OlderNew" },
+    ]);
+  });
+
   it("passes a single-source context to live transform checks", () => {
-    const liveTransform = vi.fn<TimelineItemTransform>(() => undefined);
+    let received: Parameters<TimelineItemTransform> | undefined;
+    const liveTransform: TimelineItemTransform = (...args) => {
+      received = args;
+      return undefined;
+    };
 
     processAgentStreamEvent({
       event,
@@ -181,12 +332,15 @@ describe("plugin timeline projection", () => {
       transformTimelineItem: liveTransform,
     });
 
-    expect(liveTransform).toHaveBeenCalledWith(event.item, {
-      epoch: "epoch-1",
-      seqStart: 7,
-      seqEnd: 7,
-      sourceSeqRanges: [{ startSeq: 7, endSeq: 7 }],
-    });
+    expect(received).toEqual([
+      event.item,
+      {
+        epoch: "epoch-1",
+        seqStart: 7,
+        seqEnd: 7,
+        sourceSeqRanges: [{ startSeq: 7, endSeq: 7 }],
+      },
+    ]);
   });
 
   it("requests authoritative projection when a live delta matches", () => {

--- a/packages/app/src/plugins/timeline/projection.test.ts
+++ b/packages/app/src/plugins/timeline/projection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentStreamEventPayload } from "@getpaseo/protocol/messages";
 import type { TimelineItemTransform } from "./model";
 import {
@@ -6,7 +6,7 @@ import {
   processTimelineResponse,
 } from "@/timeline/session-stream-reducers";
 
-const transform: TimelineItemTransform = (item) => {
+const transform: TimelineItemTransform = (item, source) => {
   if (item.type !== "tool_call" || item.status === "running") return;
   return [
     {
@@ -15,6 +15,7 @@ const transform: TimelineItemTransform = (item) => {
       kind: "test-report",
       version: 1,
       data: { name: item.name },
+      source,
     },
   ];
 };
@@ -33,7 +34,7 @@ const event: AgentStreamEventPayload = {
 };
 
 describe("plugin timeline projection", () => {
-  it("applies the same transform to fetched projected history", () => {
+  it("uses null source when projected history lacks authoritative ranges", () => {
     const result = processTimelineResponse({
       payload: {
         agentId: "agent-1",
@@ -74,8 +75,118 @@ describe("plugin timeline projection", () => {
         itemKind: "test-report",
         data: { name: "tests" },
         timelineCursor: { epoch: "epoch-1", seq: 1 },
+        source: null,
       },
     ]);
+  });
+
+  it("preserves every authoritative range on each replacement item", () => {
+    const multipleItems: TimelineItemTransform = (item, source) => {
+      if (item.type !== "tool_call") return;
+      return [
+        {
+          type: "plugin",
+          pluginId: "reports",
+          kind: "test-report",
+          version: 1,
+          data: { position: "first" },
+          source,
+        },
+        {
+          type: "plugin",
+          pluginId: "reports",
+          kind: "test-report",
+          version: 1,
+          data: { position: "second" },
+          source,
+        },
+      ];
+    };
+    const result = processTimelineResponse({
+      payload: {
+        agentId: "agent-1",
+        direction: "tail",
+        projection: "projected",
+        reset: true,
+        epoch: "epoch-1",
+        window: { minSeq: 4, maxSeq: 9, nextSeq: 10 },
+        startCursor: { seq: 4 },
+        endCursor: { seq: 9 },
+        entries: [
+          {
+            seqStart: 4,
+            seqEnd: 9,
+            sourceSeqRanges: [
+              { startSeq: 4, endSeq: 5 },
+              { startSeq: 9, endSeq: 9 },
+            ],
+            provider: "claude",
+            item: event.item,
+            timestamp: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        error: null,
+        hasNewer: false,
+        hasOlder: false,
+      },
+      currentTail: [],
+      currentHead: [],
+      currentCursor: undefined,
+      isInitializing: true,
+      hasActiveInitDeferred: true,
+      initRequestDirection: "tail",
+      sendingClientMessageIds: [],
+      transformTimelineItem: multipleItems,
+    });
+
+    const pluginItems = result.tail.filter((item) => item.kind === "plugin");
+    expect(pluginItems).toHaveLength(2);
+    expect(pluginItems.map((item) => item.source)).toEqual([
+      {
+        epoch: "epoch-1",
+        seqStart: 4,
+        seqEnd: 9,
+        sourceSeqRanges: [
+          { startSeq: 4, endSeq: 5 },
+          { startSeq: 9, endSeq: 9 },
+        ],
+      },
+      {
+        epoch: "epoch-1",
+        seqStart: 4,
+        seqEnd: 9,
+        sourceSeqRanges: [
+          { startSeq: 4, endSeq: 5 },
+          { startSeq: 9, endSeq: 9 },
+        ],
+      },
+    ]);
+    expect(pluginItems[0]?.source).toBe(pluginItems[1]?.source);
+    expect(Object.isFrozen(pluginItems[0]?.source)).toBe(true);
+    expect(Object.isFrozen(pluginItems[0]?.source?.sourceSeqRanges)).toBe(true);
+    expect(Object.isFrozen(pluginItems[0]?.source?.sourceSeqRanges[0])).toBe(true);
+  });
+
+  it("passes a single-source context to live transform checks", () => {
+    const liveTransform = vi.fn<TimelineItemTransform>(() => undefined);
+
+    processAgentStreamEvent({
+      event,
+      seq: 7,
+      epoch: "epoch-1",
+      currentTail: [],
+      currentHead: [],
+      currentCursor: undefined,
+      timestamp: new Date("2026-01-01T00:00:00.000Z"),
+      transformTimelineItem: liveTransform,
+    });
+
+    expect(liveTransform).toHaveBeenCalledWith(event.item, {
+      epoch: "epoch-1",
+      seqStart: 7,
+      seqEnd: 7,
+      sourceSeqRanges: [{ startSeq: 7, endSeq: 7 }],
+    });
   });
 
   it("requests authoritative projection when a live delta matches", () => {

--- a/packages/app/src/plugins/timeline/source.ts
+++ b/packages/app/src/plugins/timeline/source.ts
@@ -1,0 +1,15 @@
+import type { PluginTimelineItemSource } from "@getpaseo/plugin";
+
+export function createPluginTimelineItemSource(
+  input: PluginTimelineItemSource,
+): PluginTimelineItemSource {
+  const sourceSeqRanges = input.sourceSeqRanges.map((range) =>
+    Object.freeze({ startSeq: range.startSeq, endSeq: range.endSeq }),
+  );
+  return Object.freeze({
+    epoch: input.epoch,
+    seqStart: input.seqStart,
+    seqEnd: input.seqEnd,
+    sourceSeqRanges: Object.freeze(sourceSeqRanges),
+  });
+}

--- a/packages/app/src/plugins/timeline/view.test.tsx
+++ b/packages/app/src/plugins/timeline/view.test.tsx
@@ -19,7 +19,12 @@ const bundle = `(function(require) {
   const React = require("react");
   return { default: function(plugin) {
     function Card(props) {
-      return React.createElement("span", null, props.item.data.label);
+      const source = props.source;
+      return React.createElement(
+        "span",
+        null,
+        props.item.data.label + ":" + (source ? source.epoch + "/" + source.seqStart + "-" + source.seqEnd + "/" + source.sourceSeqRanges.length : "none"),
+      );
     }
     plugin.addTimelineRenderer({
       kind: "test-report",
@@ -52,6 +57,15 @@ const timelineItem = {
   version: 1,
   data: { label: "Four tests passed" },
   timestamp: new Date("2026-01-01T00:00:00.000Z"),
+  source: {
+    epoch: "epoch-1",
+    seqStart: 4,
+    seqEnd: 9,
+    sourceSeqRanges: [
+      { startSeq: 4, endSeq: 5 },
+      { startSeq: 9, endSeq: 9 },
+    ],
+  },
 };
 
 const roots: Array<ReturnType<typeof createRoot>> = [];
@@ -77,7 +91,7 @@ describe("PluginTimelineItemView", () => {
       <PluginTimelineItemView serverId="host-1" agentId="agent-1" item={timelineItem} />,
     );
 
-    expect(markup).toContain("Four tests passed");
+    expect(markup).toContain("Four tests passed:epoch-1/4-9/2");
   });
 
   it("contains renderer crashes to one timeline item", async () => {

--- a/packages/app/src/plugins/timeline/view.tsx
+++ b/packages/app/src/plugins/timeline/view.tsx
@@ -13,6 +13,7 @@ import { PluginRuntimeBoundary } from "../runtime-boundary";
 import { createPluginSurfaceRuntime } from "../surface-runtime";
 import { SurfaceErrorBoundary } from "../surface-error-boundary";
 import { toPluginTheme } from "../theme";
+import { createPluginTimelineItemSource } from "./source";
 
 const pluginThemeMapping = (theme: Theme) => ({ theme: toPluginTheme(theme) });
 
@@ -69,6 +70,10 @@ function PluginTimelineItemBody({
   const host = useMemo(() => ({ id: serverId, label: hostLabel }), [hostLabel, serverId]);
   const layout = useMemo(() => ({ compact, platform: resolvePlatform() }), [compact]);
   const stateSource = useMemo(() => createPluginClientStateSource(serverId), [serverId]);
+  const source = useMemo(
+    () => (item.source ? createPluginTimelineItemSource(item.source) : null),
+    [item.source],
+  );
 
   if (!plugin || !renderer || !parsed || !runtime) {
     return <TimelineItemUnavailable />;
@@ -87,6 +92,7 @@ function PluginTimelineItemBody({
       version: item.version,
       data: parsed.data,
     },
+    source,
   };
   return (
     <SurfaceErrorBoundary installation={plugin} Surface={Component}>

--- a/packages/app/src/runtime/replica-cache/index.test.ts
+++ b/packages/app/src/runtime/replica-cache/index.test.ts
@@ -329,6 +329,42 @@ describe("ReplicaCache", () => {
     expect((await reader.readTimeline(SERVER_ID, "agent-1"))?.items).toEqual([pluginItem]);
   });
 
+  it("restores legacy plugin timeline items without source metadata", async () => {
+    const storage = new MemoryStorage();
+    storage.rows.set(`${SERVER_ID}:timeline:agent-1`, {
+      serverId: SERVER_ID,
+      kind: "timeline",
+      id: "agent-1",
+      payload: JSON.stringify({
+        agentId: "agent-1",
+        items: [
+          {
+            id: "reports/test-report/1",
+            kind: "plugin",
+            pluginId: "reports",
+            itemKind: "test-report",
+            version: 1,
+            data: { passed: 4, failed: 0 },
+            timestamp: "2026-07-18T08:02:00.000Z",
+            timelineCursor: { epoch: "epoch-1", seq: 12 },
+          },
+        ],
+        range: { epoch: "epoch-1", startSeq: 12, endSeq: 12 },
+        hasOlder: true,
+      }),
+    });
+
+    const reader = createCache(storage);
+    const restored = await reader.readTimeline(SERVER_ID, "agent-1");
+
+    expect(restored?.items[0]).toMatchObject({
+      kind: "plugin",
+      pluginId: "reports",
+      itemKind: "test-report",
+      source: null,
+    });
+  });
+
   it("reads one requested agent and the focused timeline without scanning directory rows", async () => {
     const storage = new MemoryStorage();
     const writer = createCache(storage);

--- a/packages/app/src/runtime/replica-cache/index.test.ts
+++ b/packages/app/src/runtime/replica-cache/index.test.ts
@@ -307,6 +307,15 @@ describe("ReplicaCache", () => {
       data: { passed: 4, failed: 0 },
       timestamp: new Date("2026-07-18T08:02:00.000Z"),
       timelineCursor: { epoch: "epoch-1", seq: 12 },
+      source: {
+        epoch: "epoch-1",
+        seqStart: 10,
+        seqEnd: 12,
+        sourceSeqRanges: [
+          { startSeq: 10, endSeq: 10 },
+          { startSeq: 12, endSeq: 12 },
+        ],
+      },
     };
     writer.commitTimeline(SERVER_ID, "agent-1", {
       agentId: "agent-1",

--- a/packages/app/src/runtime/replica-cache/index.ts
+++ b/packages/app/src/runtime/replica-cache/index.ts
@@ -6,7 +6,7 @@ import {
   WorkspaceGitHubRuntimePayloadSchema,
 } from "@getpaseo/protocol/messages";
 import { AgentProviderSchema } from "@getpaseo/protocol/provider-manifest";
-import type { PluginTimelineData } from "@getpaseo/plugin";
+import type { PluginTimelineData, PluginTimelineItemSource } from "@getpaseo/plugin";
 import {
   normalizeProjectDescriptor,
   normalizeWorkspaceDescriptor,
@@ -21,6 +21,7 @@ import {
   type StreamItem,
 } from "@/types/stream";
 import { normalizeAgentSnapshot } from "@/utils/agent-snapshots";
+import { createPluginTimelineItemSource } from "@/plugins/timeline/source";
 import { clearLegacyReplicaCache } from "./legacy-cleanup";
 import {
   REPLICA_SINGLETON_ROW_ID,
@@ -39,6 +40,16 @@ const TimelinePositionSchema = z.strictObject({
   epoch: z.string(),
   seq: z.number().int().nonnegative(),
 });
+const PluginTimelineItemSourceSeqRangeSchema = z.strictObject({
+  startSeq: z.number().int().nonnegative(),
+  endSeq: z.number().int().nonnegative(),
+});
+const PluginTimelineItemSourceSchema = z.strictObject({
+  epoch: z.string(),
+  seqStart: z.number().int().nonnegative(),
+  seqEnd: z.number().int().nonnegative(),
+  sourceSeqRanges: z.array(PluginTimelineItemSourceSeqRangeSchema),
+});
 const PluginTimelineDataSchema: z.ZodType<PluginTimelineData> = z.lazy(() =>
   z.union([
     z.null(),
@@ -49,6 +60,27 @@ const PluginTimelineDataSchema: z.ZodType<PluginTimelineData> = z.lazy(() =>
     z.record(z.string(), PluginTimelineDataSchema),
   ]),
 );
+
+function serializePluginTimelineItemSource(
+  source: PluginTimelineItemSource | null,
+): z.output<typeof PluginTimelineItemSourceSchema> | null {
+  if (!source) return null;
+  return {
+    epoch: source.epoch,
+    seqStart: source.seqStart,
+    seqEnd: source.seqEnd,
+    sourceSeqRanges: source.sourceSeqRanges.map((range) => ({
+      startSeq: range.startSeq,
+      endSeq: range.endSeq,
+    })),
+  };
+}
+
+function deserializePluginTimelineItemSource(
+  source: z.output<typeof PluginTimelineItemSourceSchema> | null | undefined,
+): PluginTimelineItemSource | null {
+  return source ? createPluginTimelineItemSource(source) : null;
+}
 
 const TimelineItemBaseShape = {
   id: z.string(),
@@ -129,6 +161,8 @@ const StoredTimelineItemSchema = z.discriminatedUnion("kind", [
     itemKind: z.string(),
     version: z.number().int().positive(),
     data: PluginTimelineDataSchema,
+    // COMPAT(pluginTimelineItemSource): added in v0.6.2, remove after 2027-08-27 once cache floor >= v0.6.2.
+    source: PluginTimelineItemSourceSchema.nullable().optional(),
   }),
 ]);
 
@@ -453,6 +487,7 @@ function serializeTimelineItem(item: StreamItem): StoredTimelineItem | null {
         itemKind: item.itemKind,
         version: item.version,
         data: item.data,
+        source: serializePluginTimelineItemSource(item.source),
       };
   }
 }
@@ -537,6 +572,7 @@ function deserializeTimelineItem(item: StoredTimelineItem): StreamItem {
         itemKind: item.itemKind,
         version: item.version,
         data: item.data,
+        source: deserializePluginTimelineItemSource(item.source),
       };
   }
 }

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -1,8 +1,9 @@
 import type { AgentStreamEventPayload } from "@getpaseo/protocol/messages";
+import type { PluginTimelineItemSource } from "@getpaseo/plugin";
 import { selectAgentTimelineState, useSessionStore } from "@/stores/session-store";
 import type { AssistantMessageItem, StreamItem, TodoEntry } from "@/types/stream";
 import type { TurnLivenessTransition } from "@/timeline/turn-liveness";
-import type { TimelineItemTransform } from "@/plugins/timeline";
+import { createPluginTimelineItemSource, type TimelineItemTransform } from "@/plugins/timeline";
 import {
   applyStreamEvent,
   flushHeadToTail,
@@ -177,6 +178,7 @@ interface TimelineUnit {
   seq: number;
   seqEnd: number;
   sourceSeqRanges: TimelineSeqRange[];
+  source: PluginTimelineItemSource | null;
   event: AgentStreamEventPayload;
   timestamp: Date;
 }
@@ -390,6 +392,7 @@ function mergeTimelineWindow(args: {
     event: AgentStreamEventPayload;
     timestamp: Date;
     timelineCursor: { epoch: string; seq: number };
+    timelineSource: PluginTimelineItemSource | null;
   }>;
   transformTimelineItem?: TimelineItemTransform;
 }): TimelinePathResult {
@@ -509,9 +512,12 @@ function applyTimelineReplacePath(args: {
   currentHead: StreamItem[];
   sendingClientMessageIds: readonly string[];
   preserveContinuity: boolean;
-  toHydratedEvents: (
-    units: TimelineUnit[],
-  ) => Array<{ event: AgentStreamEventPayload; timestamp: Date }>;
+  toHydratedEvents: (units: TimelineUnit[]) => Array<{
+    event: AgentStreamEventPayload;
+    timestamp: Date;
+    timelineCursor: { epoch: string; seq: number };
+    timelineSource: PluginTimelineItemSource | null;
+  }>;
   transformTimelineItem?: TimelineItemTransform;
 }): TimelinePathResult {
   const {
@@ -957,6 +963,7 @@ function applyCanonicalForwardUnit(params: {
       timestamp,
       source: "canonical",
       timelineCursor,
+      timelineSource: params.unit.source,
       transformTimelineItem: params.transformTimelineItem,
     });
     return {
@@ -970,6 +977,7 @@ function applyCanonicalForwardUnit(params: {
       tail: reduceStreamUpdate(params.tail, event, timestamp, {
         source: "canonical",
         timelineCursor,
+        timelineSource: params.unit.source,
         transformTimelineItem: params.transformTimelineItem,
       }),
       head: params.head,
@@ -1001,6 +1009,7 @@ function applyCanonicalForwardUnit(params: {
       head: reduceStreamUpdate([], event, timestamp, {
         source: "canonical",
         timelineCursor,
+        timelineSource: params.unit.source,
         transformTimelineItem: params.transformTimelineItem,
       }),
       acknowledgedClientMessageIds: [],
@@ -1014,6 +1023,7 @@ function applyCanonicalForwardUnit(params: {
     timestamp,
     source: "canonical",
     timelineCursor,
+    timelineSource: params.unit.source,
     transformTimelineItem: params.transformTimelineItem,
   });
   return {
@@ -1155,10 +1165,11 @@ function applyAcceptedTimelinePage(input: {
     });
   }
   const olderTail = hydrateStreamState(
-    acceptedUnits.map(({ event, timestamp, seqEnd }) => ({
+    acceptedUnits.map(({ event, timestamp, seqEnd, source }) => ({
       event,
       timestamp,
       timelineCursor: { epoch: payload.epoch, seq: seqEnd },
+      timelineSource: source,
     })),
     {
       source: "canonical",
@@ -1296,6 +1307,15 @@ export function processTimelineResponse(
       entry.sourceSeqRanges && entry.sourceSeqRanges.length > 0
         ? entry.sourceSeqRanges
         : [{ startSeq: entry.seqStart, endSeq: entry.seqEnd }],
+    source:
+      entry.sourceSeqRanges && entry.sourceSeqRanges.length > 0
+        ? createPluginTimelineItemSource({
+            epoch: payload.epoch,
+            seqStart: entry.seqStart,
+            seqEnd: entry.seqEnd,
+            sourceSeqRanges: entry.sourceSeqRanges,
+          })
+        : null,
     event: {
       type: "timeline",
       provider: entry.provider,
@@ -1311,11 +1331,13 @@ export function processTimelineResponse(
     event: AgentStreamEventPayload;
     timestamp: Date;
     timelineCursor: { epoch: string; seq: number };
+    timelineSource: PluginTimelineItemSource | null;
   }> =>
-    units.map(({ event, timestamp, seqEnd }) => ({
+    units.map(({ event, timestamp, seqEnd, source }) => ({
       event,
       timestamp,
       timelineCursor: { epoch: payload.epoch, seq: seqEnd },
+      timelineSource: source,
     }));
 
   // ------------------------------------------------------------------
@@ -1476,6 +1498,20 @@ export interface ProcessAgentStreamEventOutput {
   sideEffects: AgentStreamReducerSideEffect[];
 }
 
+function createLiveTimelineSource(
+  event: AgentStreamEventPayload,
+  seq: number | undefined,
+  epoch: string | undefined,
+): PluginTimelineItemSource | null {
+  if (event.type !== "timeline" || seq === undefined || epoch === undefined) return null;
+  return createPluginTimelineItemSource({
+    epoch,
+    seqStart: seq,
+    seqEnd: seq,
+    sourceSeqRanges: [{ startSeq: seq, endSeq: seq }],
+  });
+}
+
 export interface AgentStreamReducerEvent {
   event: AgentStreamEventPayload;
   seq: number | undefined;
@@ -1622,9 +1658,10 @@ export function processAgentStreamEvent(
     event.type === "timeline" && seq !== undefined && epoch !== undefined
       ? { epoch, seq }
       : undefined;
+  const timelineSource = createLiveTimelineSource(event, seq, epoch);
   const pluginProjection =
     sequencing.shouldApplyStreamEvent && event.type === "timeline"
-      ? transformTimelineItem?.(event.item)
+      ? transformTimelineItem?.(event.item, timelineSource)
       : undefined;
 
   // ------------------------------------------------------------------
@@ -1647,6 +1684,7 @@ export function processAgentStreamEvent(
         timestamp,
         source: "live",
         timelineCursor,
+        timelineSource,
         unmatchedUserMessageInsert: "head",
       });
     } else {
@@ -1657,6 +1695,7 @@ export function processAgentStreamEvent(
         timestamp,
         source: "live",
         timelineCursor,
+        timelineSource,
       });
       streamResult = {
         tail: currentTail,
@@ -1673,6 +1712,7 @@ export function processAgentStreamEvent(
       timestamp,
       source: "live",
       timelineCursor,
+      timelineSource,
     });
   }
   const { tail, head, changedTail, changedHead } = streamResult;

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -1,5 +1,6 @@
 import type { AgentStreamEventPayload } from "@getpaseo/protocol/messages";
 import type { PluginTimelineItemSource } from "@getpaseo/plugin";
+import type { AgentTimelineItem } from "@getpaseo/protocol/agent-types";
 import { selectAgentTimelineState, useSessionStore } from "@/stores/session-store";
 import type { AssistantMessageItem, StreamItem, TodoEntry } from "@/types/stream";
 import type { TurnLivenessTransition } from "@/timeline/turn-liveness";
@@ -418,6 +419,7 @@ function mergeTimelineWindow(args: {
     units: timelineUnits,
     epoch: payload.epoch,
     currentEndSeq: currentCursor.endSeq,
+    transformTimelineItem: args.transformTimelineItem,
   });
   const retainedTail = projected.tail.filter((item) => {
     const cursor = item.timelineCursor;
@@ -700,6 +702,12 @@ function mergePrependedCanonicalTail(olderTail: StreamItem[], currentTail: Strea
   currentTail = reconciledCurrent;
   if (olderTail.length === 0) return currentTail;
 
+  const mergedPlugins = mergeOverlappingPluginItems(olderTail, currentTail);
+  if (mergedPlugins) {
+    olderTail = mergedPlugins.olderTail;
+    currentTail = mergedPlugins.currentTail;
+  }
+
   const olderLast = olderTail.at(-1);
   const currentFirst = currentTail[0];
 
@@ -782,6 +790,10 @@ function replaceLiveAssistantWithProjectedText(params: {
   return next;
 }
 
+function includesSequence(ranges: readonly TimelineSeqRange[], sequence: number): boolean {
+  return ranges.some((range) => range.startSeq <= sequence && range.endSeq >= sequence);
+}
+
 function reconcileOverlappingProjectedAssistant(params: {
   tail: StreamItem[];
   head: StreamItem[];
@@ -793,9 +805,7 @@ function reconcileOverlappingProjectedAssistant(params: {
   if (
     unit.event.type !== "timeline" ||
     unit.event.item.type !== "assistant_message" ||
-    !unit.sourceSeqRanges.some(
-      (range) => range.startSeq <= params.currentEndSeq && range.endSeq > params.currentEndSeq,
-    )
+    !includesSequence(unit.sourceSeqRanges, params.currentEndSeq)
   ) {
     return { tail: params.tail, head: params.head, reconciled: false };
   }
@@ -869,6 +879,143 @@ function reconcileOverlappingProjectedAssistant(params: {
   };
 }
 
+function sourceRangesOverlap(
+  left: readonly TimelineSeqRange[],
+  right: PluginTimelineItemSource["sourceSeqRanges"],
+): boolean {
+  return left.some((leftRange) =>
+    right.some(
+      (rightRange) =>
+        leftRange.startSeq <= rightRange.endSeq && rightRange.startSeq <= leftRange.endSeq,
+    ),
+  );
+}
+
+function pluginSourcesOverlap(
+  left: PluginTimelineItemSource | null,
+  right: PluginTimelineItemSource | null,
+): boolean {
+  return (
+    left !== null &&
+    right !== null &&
+    left.epoch === right.epoch &&
+    sourceRangesOverlap(left.sourceSeqRanges, right.sourceSeqRanges)
+  );
+}
+
+function replaceIndexedItems(
+  items: StreamItem[],
+  indexes: number[],
+  replacements: StreamItem[],
+): StreamItem[] {
+  const firstIndex = indexes[0];
+  if (firstIndex === undefined) return items;
+  const indexSet = new Set(indexes);
+  const next: StreamItem[] = [];
+  for (const [index, item] of items.entries()) {
+    if (index === firstIndex) {
+      for (const [replacementIndex, replacement] of replacements.entries()) {
+        const existing = items[indexes[replacementIndex] ?? -1];
+        next.push(existing ? { ...replacement, id: existing.id } : replacement);
+      }
+    }
+    if (!indexSet.has(index)) next.push(item);
+  }
+  return next;
+}
+
+function mergeOverlappingPluginItems(
+  olderTail: StreamItem[],
+  currentTail: StreamItem[],
+): { olderTail: StreamItem[]; currentTail: StreamItem[] } | null {
+  const matchedCurrentIndexes = new Set<number>();
+  const matches = new Map<number, number>();
+  for (const [olderIndex, older] of olderTail.entries()) {
+    if (older.kind !== "plugin") continue;
+    const currentIndex = currentTail.findIndex(
+      (current, index) =>
+        !matchedCurrentIndexes.has(index) &&
+        current.kind === "plugin" &&
+        pluginSourcesOverlap(older.source, current.source),
+    );
+    if (currentIndex < 0) continue;
+    matchedCurrentIndexes.add(currentIndex);
+    matches.set(olderIndex, currentIndex);
+  }
+  if (matches.size === 0) return null;
+
+  const mergedOlder: StreamItem[] = [];
+  for (const [index, item] of olderTail.entries()) {
+    const currentIndex = matches.get(index);
+    const current = currentIndex === undefined ? undefined : currentTail[currentIndex];
+    mergedOlder.push(
+      current?.kind === "plugin" && item.kind === "plugin" ? { ...item, id: current.id } : item,
+    );
+  }
+  return {
+    olderTail: mergedOlder,
+    currentTail: currentTail.filter((_, index) => !matchedCurrentIndexes.has(index)),
+  };
+}
+
+function reconcileOverlappingProjectedPlugin(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  unit: TimelineUnit;
+  epoch: string;
+  currentEndSeq: number;
+  transformTimelineItem?: TimelineItemTransform;
+}): { tail: StreamItem[]; head: StreamItem[]; reconciled: boolean } {
+  const { unit } = params;
+  if (
+    unit.event.type !== "timeline" ||
+    !unit.source ||
+    !includesSequence(unit.sourceSeqRanges, params.currentEndSeq) ||
+    !params.transformTimelineItem
+  ) {
+    return { tail: params.tail, head: params.head, reconciled: false };
+  }
+
+  const matches = (item: StreamItem) =>
+    item.kind === "plugin" && pluginSourcesOverlap(item.source, unit.source);
+  const matchingIndexes = (items: StreamItem[]) =>
+    items.flatMap((item, index) => (matches(item) ? [index] : []));
+  const headIndexes = matchingIndexes(params.head);
+  const tailIndexes = headIndexes.length === 0 ? matchingIndexes(params.tail) : [];
+  if (headIndexes.length === 0 && tailIndexes.length === 0) {
+    return { tail: params.tail, head: params.head, reconciled: false };
+  }
+
+  const transformed = params.transformTimelineItem(
+    unit.event.item as AgentTimelineItem,
+    unit.source,
+  );
+  if (transformed === undefined) {
+    return { tail: params.tail, head: params.head, reconciled: false };
+  }
+
+  const existingItems = [...params.tail, ...params.head];
+  const projected = reduceStreamUpdate(existingItems, unit.event, unit.timestamp, {
+    source: "canonical",
+    timelineCursor: { epoch: params.epoch, seq: unit.seqEnd },
+    timelineSource: unit.source,
+    transformedTimelineItems: transformed,
+  }).slice(existingItems.length);
+
+  if (headIndexes.length > 0) {
+    return {
+      tail: replaceIndexedItems(params.tail, matchingIndexes(params.tail), []),
+      head: replaceIndexedItems(params.head, headIndexes, projected),
+      reconciled: true,
+    };
+  }
+  return {
+    tail: replaceIndexedItems(params.tail, tailIndexes, projected),
+    head: replaceIndexedItems(params.head, matchingIndexes(params.head), []),
+    reconciled: true,
+  };
+}
+
 function reconcileOverlappingProjectedReasoning(params: {
   tail: StreamItem[];
   head: StreamItem[];
@@ -879,9 +1026,7 @@ function reconcileOverlappingProjectedReasoning(params: {
   if (
     unit.event.type !== "timeline" ||
     unit.event.item.type !== "reasoning" ||
-    !unit.sourceSeqRanges.some(
-      (range) => range.startSeq <= params.currentEndSeq && range.endSeq > params.currentEndSeq,
-    )
+    !includesSequence(unit.sourceSeqRanges, params.currentEndSeq)
   ) {
     return { tail: params.tail, head: params.head, reconciled: false };
   }
@@ -917,6 +1062,7 @@ function reconcileOverlappingProjectedStreamItems(params: {
   units: TimelineUnit[];
   epoch: string;
   currentEndSeq: number | undefined;
+  transformTimelineItem?: TimelineItemTransform;
 }): { tail: StreamItem[]; head: StreamItem[]; reconciledUnits: Set<TimelineUnit> } {
   let tail = params.tail;
   let head = params.head;
@@ -924,13 +1070,23 @@ function reconcileOverlappingProjectedStreamItems(params: {
   if (params.currentEndSeq === undefined) return { tail, head, reconciledUnits };
 
   for (const unit of params.units) {
-    let reconciled = reconcileOverlappingProjectedAssistant({
+    let reconciled = reconcileOverlappingProjectedPlugin({
       tail,
       head,
       unit,
       epoch: params.epoch,
       currentEndSeq: params.currentEndSeq,
+      transformTimelineItem: params.transformTimelineItem,
     });
+    if (!reconciled.reconciled) {
+      reconciled = reconcileOverlappingProjectedAssistant({
+        tail,
+        head,
+        unit,
+        epoch: params.epoch,
+        currentEndSeq: params.currentEndSeq,
+      });
+    }
     if (!reconciled.reconciled) {
       reconciled = reconcileOverlappingProjectedReasoning({
         tail,
@@ -1047,6 +1203,7 @@ function applyAcceptedForwardTimelineUnits(params: {
     units: params.units,
     epoch: params.epoch,
     currentEndSeq: params.currentEndSeq,
+    transformTimelineItem: params.transformTimelineItem,
   });
   let tail = reconciled.tail;
   let head = reconciled.head;

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -4,6 +4,7 @@ import type {
   ToolCallDetail,
 } from "@getpaseo/protocol/agent-types";
 import type { AgentAttachment, AgentStreamEventPayload } from "@getpaseo/protocol/messages";
+import type { PluginTimelineItemSource } from "@getpaseo/plugin";
 import type { AttachmentMetadata } from "@/attachments/types";
 import { extractTaskEntriesFromToolCall } from "../utils/tool-call-parsers";
 import { splitMarkdownBlocks } from "@/utils/split-markdown-blocks";
@@ -787,6 +788,7 @@ export interface PluginTimelineStreamItem {
   itemKind: string;
   version: number;
   data: InstalledPluginTimelineItem["data"];
+  source: PluginTimelineItemSource | null;
 }
 
 export interface TodoEntry {
@@ -818,6 +820,7 @@ interface StreamUpdateOptions {
   source?: StreamUpdateSource;
   reservedItemIds?: ReadonlySet<string>;
   timelineCursor?: TimelinePosition;
+  timelineSource?: PluginTimelineItemSource | null;
   transformTimelineItem?: TimelineItemTransform;
   transformedTimelineItems?: InstalledPluginTimelineItem[] | null;
 }
@@ -1430,13 +1433,14 @@ function reduceTimelineEvent(
   source: StreamUpdateSource,
   reservedItemIds?: ReadonlySet<string>,
   timelineCursor?: TimelinePosition,
+  timelineSource?: PluginTimelineItemSource | null,
   transformTimelineItem?: TimelineItemTransform,
   transformedTimelineItems?: InstalledPluginTimelineItem[] | null,
 ): StreamItem[] {
   const item = event.item;
   const transformed =
     transformedTimelineItems === undefined
-      ? transformTimelineItem?.(item as AgentTimelineItem)
+      ? transformTimelineItem?.(item as AgentTimelineItem, timelineSource ?? null)
       : (transformedTimelineItems ?? undefined);
   if (transformed !== undefined) {
     const projected = state.slice();
@@ -1452,6 +1456,7 @@ function reduceTimelineEvent(
         itemKind: pluginItem.kind,
         version: pluginItem.version,
         data: pluginItem.data,
+        source: pluginItem.source,
       };
       projected.push(streamItem);
     }
@@ -1541,6 +1546,7 @@ export function reduceStreamUpdate(
           source,
           options?.reservedItemIds,
           options?.timelineCursor,
+          options?.timelineSource,
           options?.transformTimelineItem,
           options?.transformedTimelineItems,
         ),
@@ -1613,12 +1619,20 @@ export function hydrateStreamState(
     event: AgentStreamEventPayload;
     timestamp: Date;
     timelineCursor?: TimelinePosition;
+    timelineSource?: PluginTimelineItemSource | null;
   }>,
   options?: Pick<StreamUpdateOptions, "source" | "reservedItemIds" | "transformTimelineItem">,
 ): StreamItem[] {
-  const hydrated = events.reduce<StreamItem[]>((state, { event, timestamp, timelineCursor }) => {
-    return reduceStreamUpdate(state, event, timestamp, { ...options, timelineCursor });
-  }, []);
+  const hydrated = events.reduce<StreamItem[]>(
+    (state, { event, timestamp, timelineCursor, timelineSource }) => {
+      return reduceStreamUpdate(state, event, timestamp, {
+        ...options,
+        timelineCursor,
+        timelineSource,
+      });
+    },
+    [],
+  );
 
   return finalizeActiveThoughts(hydrated);
 }
@@ -1971,9 +1985,10 @@ function applyCanonicalUserMessageEvent(params: {
 function transformEventTimelineItems(
   event: AgentStreamEventPayload,
   transformTimelineItem: TimelineItemTransform | undefined,
+  timelineSource: PluginTimelineItemSource | null | undefined,
 ): InstalledPluginTimelineItem[] | undefined {
   if (event.type !== "timeline") return undefined;
-  return transformTimelineItem?.(event.item);
+  return transformTimelineItem?.(event.item, timelineSource ?? null);
 }
 
 export function applyStreamEvent(params: {
@@ -1983,11 +1998,16 @@ export function applyStreamEvent(params: {
   timestamp: Date;
   source?: StreamUpdateSource;
   timelineCursor?: TimelinePosition;
+  timelineSource?: PluginTimelineItemSource | null;
   unmatchedUserMessageInsert?: "tail" | "head";
   transformTimelineItem?: TimelineItemTransform;
 }): ApplyStreamEventResult {
   const { tail, head, event, timestamp } = params;
-  const transformedTimelineItems = transformEventTimelineItems(event, params.transformTimelineItem);
+  const transformedTimelineItems = transformEventTimelineItems(
+    event,
+    params.transformTimelineItem,
+    params.timelineSource,
+  );
   const canonicalUserResult =
     transformedTimelineItems === undefined
       ? applyCanonicalUserMessageEvent({
@@ -2071,6 +2091,7 @@ export function applyStreamEvent(params: {
       source,
       reservedItemIds,
       timelineCursor: params.timelineCursor,
+      timelineSource: params.timelineSource,
       transformTimelineItem: params.transformTimelineItem,
       transformedTimelineItems: transformedTimelineItems ?? null,
     });
@@ -2095,6 +2116,7 @@ export function applyStreamEvent(params: {
   const reduced = reduceStreamUpdate(nextTail, event, timestamp, {
     source,
     timelineCursor: params.timelineCursor,
+    timelineSource: params.timelineSource,
     transformTimelineItem: params.transformTimelineItem,
     transformedTimelineItems: transformedTimelineItems ?? null,
   });

--- a/packages/plugin/src/contracts.ts
+++ b/packages/plugin/src/contracts.ts
@@ -190,6 +190,18 @@ export type PluginTimelineData =
   | PluginTimelineData[]
   | { [key: string]: PluginTimelineData };
 
+export interface PluginTimelineItemSourceSeqRange {
+  readonly startSeq: number;
+  readonly endSeq: number;
+}
+
+export interface PluginTimelineItemSource {
+  readonly epoch: string;
+  readonly seqStart: number;
+  readonly seqEnd: number;
+  readonly sourceSeqRanges: readonly PluginTimelineItemSourceSeqRange[];
+}
+
 export interface PluginTimelineItem {
   type: "plugin";
   kind: string;
@@ -223,6 +235,7 @@ export interface PluginTimelineItemProps<Data = unknown> extends PluginHostProps
     version: number;
     data: Data;
   };
+  source: PluginTimelineItemSource | null;
   timestamp: Date;
 }
 

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -42,6 +42,8 @@ export type {
   PluginTimelineData,
   PluginTimelineItem,
   PluginTimelineItemProps,
+  PluginTimelineItemSource,
+  PluginTimelineItemSourceSeqRange,
   PluginTimelineRendererContribution,
   PluginTimelineTransformerContribution,
   PluginTimelineTransformResult,

--- a/plugin-examples/timeline-items/README.md
+++ b/plugin-examples/timeline-items/README.md
@@ -12,4 +12,5 @@ calls return `undefined`, leaving Paseo's original timeline entry unchanged.
 The transformer is a pure client contribution. It receives the daemon's projected timeline item,
 returns plain plugin item objects, and runs against projected history. Matching live events refresh
 the authoritative projected tail first. The renderer validates `data` before Paseo mounts the
-component.
+component. Its props also include the host-owned source context described in the
+[plugin reference](../../public-docs/plugins/reference.md#timeline-items).

--- a/public-docs/plugins/reference.md
+++ b/public-docs/plugins/reference.md
@@ -282,8 +282,13 @@ import { z } from "zod";
 
 const schema = z.object({ label: z.string() });
 
-function Card({ item, theme }: PluginTimelineItemProps<z.output<typeof schema>>) {
-  return <Text style={{ color: theme.colors.foreground }}>{item.data.label}</Text>;
+function Card({ item, source, theme }: PluginTimelineItemProps<z.output<typeof schema>>) {
+  const latestSequence = source?.seqEnd ?? "unavailable";
+  return (
+    <Text style={{ color: theme.colors.foreground }}>
+      {item.data.label} ({latestSequence})
+    </Text>
+  );
 }
 
 export default function contribute(plugin: PluginContext) {
@@ -318,9 +323,14 @@ export default function contribute(plugin: PluginContext) {
 provider- or tool-specific recognition. Returning `undefined` keeps the original entry. Returning
 `items` replaces it; an empty array removes it. Item `data` must be JSON-compatible.
 
-Renderers receive `agentId`, `item`, `timestamp`, `theme`, `host`, and `layout`. Paseo validates
-`item.data` with the registered schema before rendering. Keep transformers synchronous and
+Renderers receive `agentId`, `item`, `timestamp`, `theme`, `host`, `layout`, and `source`. Paseo
+validates `item.data` with the registered schema before rendering. Keep transformers synchronous and
 deterministic because Paseo reruns them while reconciling projected history.
+
+`source` is an immutable host-owned value or `null`. When present, it contains the source item's
+`epoch`, `seqStart`, `seqEnd`, and every `sourceSeqRanges` entry. Compare sequence values only within
+the same epoch. The host supplies it after transformation; plugin-returned `data` cannot set it.
+`null` means the host lacks the complete authoritative source ranges, including restored legacy data.
 
 Check `navigation` before showing an action that depends on it. Older Paseo clients leave the
 capability undefined. Let Paseo own route construction so the action works without reloading on


### PR DESCRIPTION
## Summary
Expose immutable source metadata to plugin timeline renderers so timeline items can identify and reference the underlying events that provide their context. The metadata survives live updates, projected history, reconciliation, rendering, and cache restoration.

## Why / Context
A projected timeline item can represent one or more source events after lifecycle rows are collapsed or adjacent entries are merged. Without the source epoch and sequence ranges, a plugin renderer cannot correlate its item with related timeline events or recover that context across live/history reconciliation. The host owns this metadata so plugins can use it without being able to spoof or mutate it.

## Changes
- **Plugin contract**: add readonly source metadata types and expose `source` on timeline renderer props.
- **App timeline**: attach source metadata to live and projected plugin items, preserving all authoritative source ranges.
- **Reconciliation**: prevent duplicate plugin items when projected pages overlap live, merge-window, or older-page state.
- **Persistence and compatibility**: serialize source metadata while restoring older cache entries with `source: null`.
- **Tooling and docs**: update the plugin scaffold, reference documentation, and timeline example.

## Testing
- Ran 150 targeted app tests covering plugin transforms/rendering, timeline projection and reconciliation, and replica-cache compatibility.
- Covered forward overlap, inclusive merge-window boundaries, older-page boundaries, mixed plugin/assistant boundaries, and legacy cache entries.
