### PR TITLE
feat(app): animate sidebar workspace list items on add and archive

### DIFF
--- a/packages/app/e2e/browser/empty-project-persists.spec.ts
+++ b/packages/app/e2e/browser/empty-project-persists.spec.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { existsSync } from "node:fs";
+import type { Locator } from "@playwright/test";
 import { test, expect, type Page } from "../support/fixtures";
 import { gotoAppShell } from "../support/helpers/app";
 import {
@@ -77,6 +78,24 @@ async function waitForSidebarProjectListReady(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 60_000 });
 }
 
+async function expectSidebarRowIsInMotion(row: Locator) {
+  await expect
+    .poll(
+      () =>
+        row.evaluate((element) => {
+          let current: Element | null = element;
+          let lowestOpacity = 1;
+          for (let depth = 0; current && depth < 6; depth += 1) {
+            lowestOpacity = Math.min(lowestOpacity, Number(getComputedStyle(current).opacity));
+            current = current.parentElement;
+          }
+          return lowestOpacity;
+        }),
+      { timeout: 150 },
+    )
+    .toBeLessThan(1);
+}
+
 test.describe("Project picker search", () => {
   test("opens a project from a fuzzy directory-name search", async ({
     page,
@@ -129,6 +148,7 @@ test.describe("Project with no workspaces persists", () => {
       projectId = await addProjectFromPicker(page, repo.path);
       const projectRow = page.getByTestId(`sidebar-project-row-${projectId}`);
       await expect(projectRow).toBeVisible({ timeout: 30_000 });
+      await expectSidebarRowIsInMotion(projectRow);
       await expect(projectRow).toContainText(path.basename(repo.path));
       await expect(page.getByTestId(`sidebar-workspace-list-${projectId}`)).toHaveCount(0);
 
@@ -144,6 +164,34 @@ test.describe("Project with no workspaces persists", () => {
       }
       await client.close().catch(() => undefined);
       await repo.cleanup().catch(() => undefined);
+    }
+  });
+
+  test("adding a workspace falls into its project list", async ({ page }) => {
+    const workspace = await seedWorkspace({ repoPrefix: "workspace-fall-in-" });
+
+    try {
+      await gotoAppShell(page);
+      await waitForSidebarHydration(page);
+
+      const created = await workspace.client.createWorkspace({
+        source: {
+          kind: "directory",
+          path: workspace.repoPath,
+          projectId: workspace.projectId,
+        },
+        title: "Falling workspace",
+      });
+      if (!created.workspace) {
+        throw new Error(created.error ?? "Failed to create workspace");
+      }
+
+      const row = page.getByTestId(workspaceRowTestId(created.workspace.id));
+      await expect(row).toBeAttached({ timeout: 30_000 });
+      await expectSidebarRowIsInMotion(row);
+      await expect(row).toBeVisible();
+    } finally {
+      await workspace.cleanup();
     }
   });
 
@@ -171,6 +219,7 @@ test.describe("Project with no workspaces persists", () => {
       await expect(page.getByTestId("changes-primary-cta")).toHaveCount(0);
 
       await archiveWorkspaceFromSidebar(page, workspace.workspaceId);
+      await expectSidebarRowIsInMotion(workspaceRow);
 
       // The workspace row goes away, but its project parent stays and exposes a
       // child row for creating the next workspace.
@@ -211,6 +260,7 @@ test.describe("Project remove", () => {
       });
 
       await removeProjectFromSidebar(page, projectViewKey);
+      await expectSidebarRowIsInMotion(projectRow);
 
       await expect(page.getByTestId(workspaceRowTestId(workspace.workspaceId))).toHaveCount(0, {
         timeout: 30_000,

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -5,7 +5,9 @@ import {
   Pressable,
   ScrollView,
   type GestureResponderEvent,
+  type LayoutChangeEvent,
   type PressableStateCallbackType,
+  type Role,
   type StyleProp,
   type ViewStyle,
 } from "react-native";
@@ -15,7 +17,10 @@ import {
   useMemo,
   useState,
   useEffect,
+  useLayoutEffect,
   useRef,
+  createContext,
+  useContext,
   type ReactElement,
   type MutableRefObject,
   type Ref,
@@ -151,6 +156,25 @@ import type { HostBadgeModel } from "@/hosts/appearance";
 import { useHostBadges } from "@/hosts/use-host-badges";
 import { useSidebarRowItems } from "@/components/sidebar/display-preferences/model";
 import { PullRequestStateIcon } from "@/git/pull-request-state-icon";
+import Animated, {
+  Easing,
+  ReduceMotion,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import {
+  SIDEBAR_ITEM_MOTION_AUTO_HEIGHT,
+  SIDEBAR_ITEM_MOTION_DURATION_MS,
+  SIDEBAR_ITEM_MOTION_OFFSET,
+  isNewSidebarMotionItem,
+  rememberSidebarMotionItem,
+  seedSidebarItemMotionKeys,
+  shouldMeasureSidebarItemEnterOffscreen,
+  sidebarProjectMotionKey,
+  sidebarWorkspaceMotionKey,
+} from "@/components/sidebar/item-motion";
 
 const workspaceKeyExtractor = (workspace: SidebarWorkspacePlacement) => workspace.workspaceKey;
 
@@ -163,6 +187,211 @@ const ThemedPlus = withUnistyles(Plus);
 const ThemedMoreVertical = withUnistyles(MoreVertical);
 const ThemedTrash2 = withUnistyles(Trash2);
 const ThemedSettings = withUnistyles(Settings);
+
+interface SidebarItemMotionRegistry {
+  didHydrate: MutableRefObject<boolean>;
+  seenKeys: MutableRefObject<Set<string>>;
+}
+
+const SidebarItemMotionContext = createContext<SidebarItemMotionRegistry | null>(null);
+const EMPTY_SIDEBAR_ITEM_MOTION_KEYS: ReadonlySet<string> = new Set();
+
+function collectSidebarItemMotionKeys(input: {
+  projects: readonly SidebarProjectEntry[];
+  pinnedChats: readonly SidebarWorkspacePlacement[];
+  workspaceGroups: readonly SidebarWorkspaceGroup[];
+}): string[] {
+  const keys: string[] = [];
+  for (const project of input.projects) {
+    keys.push(sidebarProjectMotionKey(project.viewKey));
+    for (const workspace of project.workspaces) {
+      keys.push(sidebarWorkspaceMotionKey(workspace.workspaceKey));
+    }
+  }
+  for (const workspace of input.pinnedChats) {
+    keys.push(sidebarWorkspaceMotionKey(workspace.workspaceKey));
+  }
+  for (const group of input.workspaceGroups) {
+    for (const workspace of group.rows) {
+      keys.push(sidebarWorkspaceMotionKey(workspace.workspaceKey));
+    }
+  }
+  return keys;
+}
+
+function SidebarItemMotionProvider({
+  children,
+  itemKeys,
+}: PropsWithChildren<{ itemKeys: readonly string[] }>) {
+  const didHydrate = useRef(false);
+  const seenKeys = useRef(new Set<string>());
+  const registry = useMemo(() => ({ didHydrate, seenKeys }), []);
+
+  seedSidebarItemMotionKeys({
+    seenKeys: seenKeys.current,
+    didHydrate: didHydrate.current,
+    keys: itemKeys,
+  });
+
+  useEffect(() => {
+    didHydrate.current = true;
+  }, []);
+
+  return (
+    <SidebarItemMotionContext.Provider value={registry}>
+      {children}
+    </SidebarItemMotionContext.Provider>
+  );
+}
+
+function useIsNewSidebarItem(key: string): boolean {
+  const registry = useContext(SidebarItemMotionContext);
+  const isNew = isNewSidebarMotionItem({
+    key,
+    didHydrate: registry?.didHydrate.current === true,
+    seenKeys: registry?.seenKeys.current ?? EMPTY_SIDEBAR_ITEM_MOTION_KEYS,
+  });
+
+  useEffect(() => {
+    if (!registry) {
+      return undefined;
+    }
+    return rememberSidebarMotionItem({
+      seenKeys: registry.seenKeys.current,
+      key,
+    });
+  }, [key, registry]);
+
+  return isNew;
+}
+
+function useSidebarItemMotion(input: { entering: boolean; exiting: boolean }) {
+  const offset = useSharedValue(input.entering ? -SIDEBAR_ITEM_MOTION_OFFSET : 0);
+  const opacity = useSharedValue(input.entering ? 0 : 1);
+  const height = useSharedValue(input.entering ? 0 : SIDEBAR_ITEM_MOTION_AUTO_HEIGHT);
+  const measuredHeight = useRef(0);
+  const didArmEnter = useRef(false);
+  const [hasMeasuredEnter, setHasMeasuredEnter] = useState(!input.entering);
+  const measureOffscreen = shouldMeasureSidebarItemEnterOffscreen({
+    entering: input.entering,
+    hasMeasuredEnter,
+  });
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const nextHeight = event.nativeEvent.layout.height;
+      if (nextHeight <= 0) {
+        return;
+      }
+      if (nextHeight >= measuredHeight.current) {
+        measuredHeight.current = nextHeight;
+      }
+      if (measureOffscreen) {
+        setHasMeasuredEnter(true);
+      }
+    },
+    [measureOffscreen],
+  );
+
+  useLayoutEffect(() => {
+    const timing = {
+      duration: SIDEBAR_ITEM_MOTION_DURATION_MS,
+      easing: Easing.out(Easing.cubic),
+      reduceMotion: ReduceMotion.System,
+    };
+
+    if (input.exiting) {
+      if (height.value < 0 && measuredHeight.current > 0) {
+        height.value = measuredHeight.current;
+      }
+      height.value = withTiming(0, timing);
+      offset.value = withTiming(SIDEBAR_ITEM_MOTION_OFFSET, timing);
+      opacity.value = withTiming(0, timing);
+      return;
+    }
+
+    if (input.entering && hasMeasuredEnter && !didArmEnter.current) {
+      didArmEnter.current = true;
+      height.value = 0;
+      offset.value = -SIDEBAR_ITEM_MOTION_OFFSET;
+      opacity.value = 0;
+      height.value = withTiming(measuredHeight.current, timing, (finished) => {
+        if (finished) {
+          height.value = SIDEBAR_ITEM_MOTION_AUTO_HEIGHT;
+        }
+      });
+      offset.value = withTiming(0, timing);
+      opacity.value = withTiming(1, timing);
+      return;
+    }
+
+    if (!input.entering) {
+      didArmEnter.current = false;
+      offset.value = withTiming(0, timing);
+      opacity.value = withTiming(1, timing);
+    }
+  }, [hasMeasuredEnter, height, input.entering, input.exiting, offset, opacity]);
+
+  const style = useAnimatedStyle(() => {
+    const nextHeight = height.value;
+    if (nextHeight >= 0) {
+      return {
+        height: nextHeight,
+        opacity: opacity.value,
+        overflow: "hidden",
+        transform: [{ translateY: offset.value }],
+      };
+    }
+    return {
+      opacity: opacity.value,
+      overflow: "visible",
+      transform: [{ translateY: offset.value }],
+    };
+  });
+
+  const measureStyle = measureOffscreen ? styles.itemMotionMeasureOffscreen : undefined;
+
+  return { style, measureStyle, onLayout: handleLayout };
+}
+
+function SidebarItemMotionView({
+  entering,
+  exiting,
+  innerStyle,
+  role,
+  accessibilityLabel,
+  children,
+}: PropsWithChildren<{
+  entering: boolean;
+  exiting: boolean;
+  innerStyle?: StyleProp<ViewStyle>;
+  role?: Role;
+  accessibilityLabel?: string;
+}>) {
+  const motion = useSidebarItemMotion({ entering, exiting });
+  return (
+    <Animated.View
+      role={role}
+      accessibilityLabel={accessibilityLabel}
+      style={[styles.itemMotionFrame, motion.style]}
+    >
+      <View
+        onLayout={motion.onLayout}
+        style={[innerStyle, motion.measureStyle]}
+        collapsable={false}
+      >
+        {children}
+      </View>
+    </Animated.View>
+  );
+}
+
+function waitForSidebarItemMotion(reducedMotion: boolean): Promise<void> {
+  if (reducedMotion) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => setTimeout(resolve, SIDEBAR_ITEM_MOTION_DURATION_MS));
+}
 
 const foregroundColorMapping = (theme: Theme) => ({
   color: theme.colors.foreground,
@@ -1237,6 +1466,8 @@ function WorkspaceRowWithMenu({
   const [isHidingWorkspace, setIsHidingWorkspace] = useState(false);
   const [isRenameOpen, setIsRenameOpen] = useState(false);
   const isArchiving = workspace.archivingAt !== null || isHidingWorkspace;
+  const reducedMotion = useReducedMotion();
+  const isNew = useIsNewSidebarItem(sidebarWorkspaceMotionKey(workspace.workspaceKey));
   const redirectAfterArchive = useCallback(() => {
     redirectIfArchivingActiveWorkspace({
       serverId: workspace.serverId,
@@ -1244,6 +1475,10 @@ function WorkspaceRowWithMenu({
       activeWorkspaceSelection: selectionForSelectedWorkspace(selected, workspace),
     });
   }, [selected, workspace]);
+  const animateBeforeArchive = useCallback(
+    () => waitForSidebarItemMotion(reducedMotion),
+    [reducedMotion],
+  );
 
   const archiveController = useWorkspaceArchive({
     serverId: workspace.serverId,
@@ -1251,6 +1486,7 @@ function WorkspaceRowWithMenu({
     workspaceKind: workspace.workspaceKind,
     name: workspace.name,
     ...toWorktreeArchiveRisk(workspace),
+    onBeforeArchive: animateBeforeArchive,
     onArchiveStarted: redirectAfterArchive,
     onSetHiding: setIsHidingWorkspace,
   });
@@ -1309,34 +1545,36 @@ function WorkspaceRowWithMenu({
 
   return (
     <>
-      <WorkspaceRowInner
-        workspace={workspace}
-        hostBadge={hostBadge}
-        leadingProjectName={leadingProjectName}
-        leadingProjectIconDataUri={leadingProjectIconDataUri}
-        selected={selected}
-        shortcutNumber={shortcutNumber}
-        showShortcutBadge={showShortcutBadge}
-        onPress={onPress}
-        drag={drag}
-        isDragging={isDragging}
-        isArchiving={isArchiving}
-        isCreating={isCreating}
-        dragHandleProps={dragHandleProps}
-        menuController={null}
-        archiveLabel={t("sidebar.workspace.actions.archive")}
-        archiveStatus={isArchiving ? "pending" : "idle"}
-        archivePendingLabel={t("sidebar.workspace.actions.archiving")}
-        onArchive={handleArchive}
-        onCopyBranchName={canCopyBranchName ? handleCopyBranchName : undefined}
-        onCopyPath={handleCopyPath}
-        onRename={handleOpenRename}
-        onMarkAsRead={hasClearableAttention ? handleMarkAsRead : undefined}
-        archiveShortcutKeys={selected ? archiveShortcutKeys : null}
-        isPinned={isPinned}
-        onTogglePin={onTogglePin}
-        reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
-      />
+      <SidebarItemMotionView entering={isNew} exiting={isArchiving}>
+        <WorkspaceRowInner
+          workspace={workspace}
+          hostBadge={hostBadge}
+          leadingProjectName={leadingProjectName}
+          leadingProjectIconDataUri={leadingProjectIconDataUri}
+          selected={selected}
+          shortcutNumber={shortcutNumber}
+          showShortcutBadge={showShortcutBadge}
+          onPress={onPress}
+          drag={drag}
+          isDragging={isDragging}
+          isArchiving={isArchiving}
+          isCreating={isCreating}
+          dragHandleProps={dragHandleProps}
+          menuController={null}
+          archiveLabel={t("sidebar.workspace.actions.archive")}
+          archiveStatus={isArchiving ? "pending" : "idle"}
+          archivePendingLabel={t("sidebar.workspace.actions.archiving")}
+          onArchive={handleArchive}
+          onCopyBranchName={canCopyBranchName ? handleCopyBranchName : undefined}
+          onCopyPath={handleCopyPath}
+          onRename={handleOpenRename}
+          onMarkAsRead={hasClearableAttention ? handleMarkAsRead : undefined}
+          archiveShortcutKeys={selected ? archiveShortcutKeys : null}
+          isPinned={isPinned}
+          onTogglePin={onTogglePin}
+          reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
+        />
+      </SidebarItemMotionView>
       <WorkspaceRenameModal
         visible={isRenameOpen}
         workspace={workspace}
@@ -1673,6 +1911,8 @@ function ProjectBlock({
   const toast = useToast();
   const { t } = useTranslation();
   const [isRemovingProject, setIsRemovingProject] = useState(false);
+  const reducedMotion = useReducedMotion();
+  const isNew = useIsNewSidebarItem(sidebarProjectMotionKey(project.viewKey));
 
   const handleRemoveProject = useCallback(() => {
     if (isRemovingProject) {
@@ -1692,6 +1932,7 @@ function ProjectBlock({
       }
 
       setIsRemovingProject(true);
+      await waitForSidebarItemMotion(reducedMotion);
       const readiness = getCurrentProjectRemoveReadiness({
         hosts: project.hosts,
       });
@@ -1724,7 +1965,7 @@ function ProjectBlock({
           setIsRemovingProject(false);
         });
     })();
-  }, [isRemovingProject, displayName, t, toast, project.hosts]);
+  }, [isRemovingProject, displayName, t, toast, project.hosts, reducedMotion]);
 
   const handleToggleCollapsed = useCallback(() => {
     onToggleCollapsed(project.viewKey);
@@ -1770,11 +2011,15 @@ function ProjectBlock({
     }
   }
 
+  // Collapse/expand stays instant so the project name does not interpolate.
+  // Add/archive grow or shrink the inserted item's height instead.
   return (
-    <View
+    <SidebarItemMotionView
+      entering={isNew}
+      exiting={isRemovingProject}
       role="group"
       accessibilityLabel={displayName}
-      style={projectChildren ? styles.projectBlockExpanded : undefined}
+      innerStyle={projectChildren ? styles.projectBlockExpanded : undefined}
     >
       <ProjectHeaderRow
         project={project}
@@ -1800,7 +2045,7 @@ function ProjectBlock({
       />
 
       {projectChildren}
-    </View>
+    </SidebarItemMotionView>
   );
 }
 
@@ -1941,6 +2186,15 @@ export function SidebarWorkspaceList({
   // project or is not applied at all — it can narrow this list but never empty it.
   const sidebarFilterEmpty =
     hasActiveLabelFilter && hasProjectsBeforeFilter && projects.length === 0;
+  const itemMotionKeys = useMemo(
+    () =>
+      collectSidebarItemMotionKeys({
+        projects,
+        pinnedChats: pinnedGroups.pinnedChats,
+        workspaceGroups,
+      }),
+    [pinnedGroups.pinnedChats, projects, workspaceGroups],
+  );
 
   // Project mode is the one that keeps its project headers; every other grouping mode is a flat
   // list of grouped rows, so a new mode lands in the grouped branch rather than silently in this
@@ -1990,7 +2244,7 @@ export function SidebarWorkspaceList({
       />
     );
 
-  return content;
+  return <SidebarItemMotionProvider itemKeys={itemMotionKeys}>{content}</SidebarItemMotionProvider>;
 }
 
 /**
@@ -2475,6 +2729,17 @@ function ProjectModeList({
 const styles = StyleSheet.create((theme) => ({
   container: {
     flex: 1,
+  },
+  itemMotionMeasureOffscreen: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    opacity: 0,
+    pointerEvents: "none",
+  },
+  itemMotionFrame: {
+    width: "100%",
+    position: "relative",
   },
   list: {
     flex: 1,

--- a/packages/app/src/components/sidebar/item-motion.test.ts
+++ b/packages/app/src/components/sidebar/item-motion.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  isNewSidebarMotionItem,
+  rememberSidebarMotionItem,
+  seedSidebarItemMotionKeys,
+  shouldMeasureSidebarItemEnterOffscreen,
+  sidebarProjectMotionKey,
+  sidebarWorkspaceMotionKey,
+} from "./item-motion";
+
+describe("sidebar item motion keys", () => {
+  it("does not treat workspaces present at hydrate as new, even if they were collapsed", () => {
+    const seenKeys = new Set<string>();
+    const collapsedWorkspaceKey = sidebarWorkspaceMotionKey("hidden-workspace");
+    const projectKey = sidebarProjectMotionKey("hidden-project");
+
+    seedSidebarItemMotionKeys({
+      seenKeys,
+      didHydrate: false,
+      keys: [projectKey, collapsedWorkspaceKey],
+    });
+
+    expect(
+      isNewSidebarMotionItem({
+        key: collapsedWorkspaceKey,
+        didHydrate: true,
+        seenKeys,
+      }),
+    ).toBe(false);
+    expect(
+      isNewSidebarMotionItem({
+        key: projectKey,
+        didHydrate: true,
+        seenKeys,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats keys that appear after hydrate as new", () => {
+    const seenKeys = new Set<string>();
+    seedSidebarItemMotionKeys({
+      seenKeys,
+      didHydrate: false,
+      keys: [sidebarWorkspaceMotionKey("existing")],
+    });
+
+    const addedKey = sidebarWorkspaceMotionKey("added");
+    seedSidebarItemMotionKeys({
+      seenKeys,
+      didHydrate: true,
+      keys: [sidebarWorkspaceMotionKey("existing"), addedKey],
+    });
+
+    expect(
+      isNewSidebarMotionItem({
+        key: addedKey,
+        didHydrate: true,
+        seenKeys,
+      }),
+    ).toBe(true);
+    expect(
+      isNewSidebarMotionItem({
+        key: sidebarWorkspaceMotionKey("existing"),
+        didHydrate: true,
+        seenKeys,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a newly added workspace as new again after its first mount is rolled back", () => {
+    const seenKeys = new Set<string>();
+    const existingKey = sidebarWorkspaceMotionKey("existing");
+    const addedKey = sidebarWorkspaceMotionKey("added");
+    seedSidebarItemMotionKeys({
+      seenKeys,
+      didHydrate: false,
+      keys: [existingKey],
+    });
+
+    const forgetAdded = rememberSidebarMotionItem({ seenKeys, key: addedKey });
+    expect(
+      isNewSidebarMotionItem({
+        key: addedKey,
+        didHydrate: true,
+        seenKeys,
+      }),
+    ).toBe(false);
+
+    forgetAdded();
+    expect(
+      isNewSidebarMotionItem({
+        key: addedKey,
+        didHydrate: true,
+        seenKeys,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not forget hydrated keys when a collapsed row unmounts", () => {
+    const seenKeys = new Set<string>();
+    const hydratedKey = sidebarWorkspaceMotionKey("hidden-workspace");
+    seedSidebarItemMotionKeys({
+      seenKeys,
+      didHydrate: false,
+      keys: [hydratedKey],
+    });
+
+    const forgetHydrated = rememberSidebarMotionItem({ seenKeys, key: hydratedKey });
+    forgetHydrated();
+    expect(
+      isNewSidebarMotionItem({
+        key: hydratedKey,
+        didHydrate: true,
+        seenKeys,
+      }),
+    ).toBe(false);
+  });
+
+  it("measures a newly added item offscreen so its first layout does not push project names", () => {
+    expect(
+      shouldMeasureSidebarItemEnterOffscreen({
+        entering: true,
+        hasMeasuredEnter: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldMeasureSidebarItemEnterOffscreen({
+        entering: true,
+        hasMeasuredEnter: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldMeasureSidebarItemEnterOffscreen({
+        entering: false,
+        hasMeasuredEnter: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/components/sidebar/item-motion.ts
+++ b/packages/app/src/components/sidebar/item-motion.ts
@@ -1,0 +1,53 @@
+export const SIDEBAR_ITEM_MOTION_DURATION_MS = 180;
+export const SIDEBAR_ITEM_MOTION_OFFSET = 8;
+/** Shared-value sentinel: do not constrain height so collapse/expand can reflow. */
+export const SIDEBAR_ITEM_MOTION_AUTO_HEIGHT = -1;
+
+export function sidebarProjectMotionKey(viewKey: string): string {
+  return `project:${viewKey}`;
+}
+
+export function sidebarWorkspaceMotionKey(workspaceKey: string): string {
+  return `workspace:${workspaceKey}`;
+}
+
+export function seedSidebarItemMotionKeys(input: {
+  seenKeys: Set<string>;
+  didHydrate: boolean;
+  keys: readonly string[];
+}): void {
+  if (input.didHydrate) {
+    return;
+  }
+  for (const key of input.keys) {
+    input.seenKeys.add(key);
+  }
+}
+
+export function isNewSidebarMotionItem(input: {
+  key: string;
+  didHydrate: boolean;
+  seenKeys: ReadonlySet<string>;
+}): boolean {
+  return input.didHydrate && !input.seenKeys.has(input.key);
+}
+
+export function rememberSidebarMotionItem(input: {
+  seenKeys: Set<string>;
+  key: string;
+}): () => void {
+  const alreadySeen = input.seenKeys.has(input.key);
+  input.seenKeys.add(input.key);
+  return () => {
+    if (!alreadySeen) {
+      input.seenKeys.delete(input.key);
+    }
+  };
+}
+
+export function shouldMeasureSidebarItemEnterOffscreen(input: {
+  entering: boolean;
+  hasMeasuredEnter: boolean;
+}): boolean {
+  return input.entering && !input.hasMeasuredEnter;
+}

--- a/packages/app/src/workspace/use-workspace-archive.ts
+++ b/packages/app/src/workspace/use-workspace-archive.ts
@@ -28,6 +28,7 @@ export interface ArchiveWorkspaceInput {
   aheadOfOrigin?: number | null;
   diffStat?: { additions: number; deletions: number } | null;
   warningLabels?: WorktreeArchiveWarningLabels;
+  onBeforeArchive?: () => Promise<void>;
   onArchiveStarted: () => void;
   onSetHiding?: (hiding: boolean) => void;
 }
@@ -46,6 +47,7 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
     aheadOfOrigin,
     diffStat,
     warningLabels = DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS,
+    onBeforeArchive,
     onArchiveStarted,
     onSetHiding,
   } = input;
@@ -60,6 +62,7 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
     }
     onSetHiding?.(true);
     try {
+      await onBeforeArchive?.();
       onArchiveStarted();
       await archiveWorkspaceOptimistically({
         client,
@@ -76,7 +79,7 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
     } finally {
       onSetHiding?.(false);
     }
-  }, [onArchiveStarted, onSetHiding, serverId, t, toast, workspaceId]);
+  }, [onArchiveStarted, onBeforeArchive, onSetHiding, serverId, t, toast, workspaceId]);
 
   const archive = useCallback(() => {
     void (async () => {


### PR DESCRIPTION
Add enter/leave and reorder motion to the sidebar project/workspace list, backed by a small item-motion key registry, plus the workspace archive tie-in and project-picker persistence coverage.

<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

You MUST read CONTRIBUTING.md before sending a PR.
-->

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

<!-- A short description of the reasoning of this change in your own words. What was wrong, and how do you hope this PR fixes it. If you can't explain this briefly, the PR is probably too big. This description must be grounded in real user flows and framed as value provided to Paseo users. -->

Using Paseo should feel good.  Currently archiving and adding workspaces feels abrupt instead of feeling succinct, this helps to polish that experience and make archiving and adding of workspaces match the feel of reordering them by making them ease away on archive and ease in on add.

### Goals
1. In project grouping, adding a workspace eases the new row in.  The project name above it stays put. 
2. Project names below ease down with the opening row; they do not jump.
3. Adding a project eases the whole block in the same way, including the project name.
4. Archiving a workspace eases the row out
5. Workspaces and projects already in the list at hydrate do not play enter motion, including ones that were collapsed and later expanded.


<!-- A bullet list of what this PR wants to accomplish, include requirements and acceptance criteria. This helps lock down the scope of the PR and prevent expanding scope over the intended goal. -->

### Non-goals

<!-- A bullet list of what this PR does not want to accomplish. Add any intentional trade offs taken. This helps lock down the scope of the PR and prevent expanding scope over the intended goal. -->


- Status, label, or other non-project grouping lists.
- Pinned-section motion beyond what the same workspace row already does.
- Layout-animating collapse/expand, or any motion that slides the project name when its children open or close.
- Mobile implementations; this is the shared sidebar list.

### QA
Web:

https://github.com/user-attachments/assets/d89223f0-588d-43aa-a0e2-1d472df86f1e

Desktop:

https://github.com/user-attachments/assets/c872484d-c1d9-43b3-bbe3-b8b0bd5b7ce0

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.
-->

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
