### PR TITLE
docs(cli): fix remote host option placement

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -101,8 +101,8 @@ paseo ls                           # 実行中のエージェントを一覧表�
 paseo attach abc123                # ライブ出力をストリーミング
 paseo send abc123 "also add tests" # 追加タスクを送信
 
-# リモートデーモンで実行
-paseo --host workstation.local:6767 run "run the full test suite"
+# リモートデーモンで実行（パスはリモートマシン上で解決されます）
+paseo run --host workstation.local:6767 --cwd /path/to/project "run the full test suite"
 ```
 
 詳細は[完全な CLI リファレンス](https://paseo.sh/docs/cli)を参照してください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -111,8 +111,8 @@ paseo ls                           # 실행 중인 에이전트 목록
 paseo attach abc123                # 실시간 출력 스트리밍
 paseo send abc123 "also add tests" # 후속 작업 전송
 
-# 원격 데몬에서 실행
-paseo --host workstation.local:6767 run "run the full test suite"
+# 원격 데몬에서 실행(경로는 원격 머신에서 해석됨)
+paseo run --host workstation.local:6767 --cwd /path/to/project "run the full test suite"
 ```
 
 자세한 내용은 [전체 CLI 레퍼런스](https://paseo.sh/docs/cli)를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ paseo ls                           # list running agents
 paseo attach abc123                # stream live output
 paseo send abc123 "also add tests" # follow-up task
 
-# run on a remote daemon
-paseo --host workstation.local:6767 run "run the full test suite"
+# run on a remote daemon (the path is resolved on that machine)
+paseo run --host workstation.local:6767 --cwd /path/to/project "run the full test suite"
 ```
 
 See the [full CLI reference](https://paseo.sh/docs/cli) for more.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,8 +101,8 @@ paseo ls                           # 列出正在运行的 agents
 paseo attach abc123                # 实时流式查看输出
 paseo send abc123 "also add tests" # 发送后续任务
 
-# 在远程 daemon 上运行
-paseo --host workstation.local:6767 run "run the full test suite"
+# 在远程 daemon 上运行（路径由远程机器解析）
+paseo run --host workstation.local:6767 --cwd /path/to/project "run the full test suite"
 ```
 
 更多内容见[完整 CLI 参考](https://paseo.sh/docs/cli)。

--- a/public-docs/cli.md
+++ b/public-docs/cli.md
@@ -360,7 +360,9 @@ paseo ls --format yaml         # YAML output
 paseo ls -q                    # IDs only (quiet)
 ```
 
-## Global options
+## Common command options
+
+These options are registered on individual subcommands, so place them after the command name (for example, `paseo ls --host workstation.local:6767`, not `paseo --host workstation.local:6767 ls`). Not every command supports every option; for example, `paseo status` only reports the local daemon and does not accept `--host`.
 
 - `--host <target>`, connect to a different daemon (`host:port`, unix socket, or `https://app.paseo.sh/#offer=...` for relay). See [Connecting to a remote daemon](#connecting-to-a-remote-daemon).
 - `--json`, JSON output

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -195,14 +195,14 @@ The CLI picks up a password from, in order:
 1. The `password` query parameter on a `tcp://` host URI:
 
    ```bash
-   paseo --host "tcp://192.168.1.10:6767?password=my-secret" ls
+   paseo ls --host "tcp://192.168.1.10:6767?password=my-secret"
    ```
 
 2. The `PASEO_PASSWORD` environment variable, used as a fallback when the host carries no embedded password (works for `localhost:6767`, bare `host:port`, or `tcp://` hosts without a `password=` query):
 
    ```bash
    PASEO_PASSWORD=my-secret paseo ls
-   PASEO_PASSWORD=my-secret paseo --host 192.168.1.10:6767 ls
+   PASEO_PASSWORD=my-secret paseo ls --host 192.168.1.10:6767
    ```
 
 A `password=` in the URI always wins over the env var, so you can keep `PASEO_PASSWORD` set globally and still target a different daemon by spelling its password into the URI.


### PR DESCRIPTION
## Summary

- place `--host` after each CLI subcommand in README and configuration examples
- clarify that remote `run` paths are resolved on the daemon host and include `--cwd` in the example
- document that these are per-command options and that `status` does not support `--host`
- keep the translated README examples in sync

## Validation

- `npm run format:check:files -- README.md README.zh-CN.md README.ja.md README.ko.md public-docs/configuration.md public-docs/cli.md`
- `npm run typecheck`
- `git diff --check`

Closes #3949