### PR TITLE
docs: document Linear Hub triggers

### DIFF
--- a/public-docs/hub/activity.md
+++ b/public-docs/hub/activity.md
@@ -2,7 +2,7 @@
 title: Hub activity
 description: Read what Hub did with an event, tell a filtered event from an unrouted one, and debug a trigger that did nothing.
 nav: Activity
-order: 72
+order: 73
 category: Hub
 ---
 
@@ -23,14 +23,14 @@ Every event Hub accepts is recorded, whether or not it ran anything. That record
 | `trigger_filters_rejected`  | A trigger handles the source, but its filters rejected it    |
 | `configuration_unavailable` | A relevant configuration or connection could not be resolved |
 
-## Nothing happened when I mentioned the bot
+## Nothing happened when I triggered a workflow
 
 Work down this list.
 
 1. **Is the event in the project's Activity?** If not, check **Connections → Known unrouted events** and use its reason to distinguish routing, source, filter, and configuration failures.
-2. **Is the event anywhere at all?** If not, the event never reached Hub. Check the provider's own delivery log: GitHub's App → Advanced → Recent Deliveries, or Slack's Event Subscriptions page. Then check that the app is subscribed to that event type.
-3. **Is your user in `from_users`?** This is the most common cause. GitHub uses your login; Slack and Discord use the user ID, not the display name. See [find your Slack IDs](/docs/hub/triggers/slack#find-your-slack-ids) and [find your Discord IDs](/docs/hub/triggers/discord#find-your-discord-ids).
-4. **Did the invocation match?** On GitHub, `contains` must appear in the comment body. On Slack and Discord the bot must be mentioned, and `pattern` or its legacy `contains` alias must prefix the text after the mention.
+2. **Is the event anywhere at all?** If not, the event never reached Hub. Check the provider's own delivery log: GitHub's App → Advanced → Recent Deliveries, Linear's application webhook, or Slack's Event Subscriptions page. Then check that the app is subscribed to that event type.
+3. **Is your user in `from_users`?** This is the most common cause for reactive triggers. GitHub uses your login; Linear, Slack, and Discord use the user ID, not the display name. The autonomous Linear project-scope trigger uses project scope instead. See [Linear filters](/docs/hub/triggers/linear#filter-linear-events), [find your Slack IDs](/docs/hub/triggers/slack#find-your-slack-ids), and [find your Discord IDs](/docs/hub/triggers/discord#find-your-discord-ids).
+4. **Did the invocation match?** On GitHub and Linear comments, `contains` must occur in the original comment and `pattern` must match its start. On Slack and Discord the bot must be mentioned, and `pattern` or its legacy `contains` alias must prefix the text after the mention.
 5. **Is the configuration you think is active actually active?** The Configuration tab shows the active revision and the last sync attempt. A failed push leaves the old revision serving.
 6. **Is the daemon connected?** An offline daemon fails dispatch with `daemon_not_connected`.
 7. **Did it run and stop early?** Compare the execution with the step's authored `idle_timeout` and `max_runtime`, and the workflow's `max_runtime`. All three limits are explicit in the workflow.

--- a/public-docs/hub/api.md
+++ b/public-docs/hub/api.md
@@ -2,7 +2,7 @@
 title: Hub public API
 description: Use organization credentials to list projects, validate or install configuration, dispatch runs, and enroll daemons.
 nav: Public API
-order: 79
+order: 81
 category: Hub
 ---
 

--- a/public-docs/hub/concepts.md
+++ b/public-docs/hub/concepts.md
@@ -11,21 +11,21 @@ category: Hub
 Hub connects the places where requests arrive to the machines where your agents run.
 
 ```text
-GitHub / Slack / Discord / manual request
-                    ↓
-                  Hub
-        matches a project trigger
-                    ↓
-                workflow
-          runs ordered agent steps
-                    ↓
-             Paseo daemon
-             starts the agent
+GitHub / Linear / Slack / Discord / manual request
+                       ↓
+                     Hub
+           matches a project trigger
+                       ↓
+                   workflow
+             runs ordered agent steps
+                       ↓
+                Paseo daemon
+                starts the agent
 ```
 
 ## The pieces
 
-- A **connection** lets Hub receive events from GitHub, Slack, or Discord.
+- A **connection** lets Hub receive events from GitHub, Linear, Slack, or Discord.
 - A **daemon** is a registered machine running the Paseo daemon.
 - A **project** groups one configuration with the connections and daemons it uses.
 - An **environment** names where a workflow step runs: a daemon, its working directory, and an optional worktree.
@@ -37,9 +37,9 @@ The configuration lives in `.paseo/hub.yml` plus convention-discovered `.paseo/w
 
 ## From event to agent
 
-1. A provider sends an event to Hub. GitHub and Slack use webhooks; Discord uses its gateway connection; manual runs use the Hub API.
-2. Hub verifies the provider event and identifies its project resource, such as a repository, workspace, or guild.
-3. Hub evaluates triggers and their filters, including the required `from_users` allowlist.
+1. A provider sends an event to Hub. GitHub, Linear, and Slack Webhooks use HTTPS callbacks; Discord uses its gateway connection; Slack Socket Mode connects out from Hub; manual runs use the Hub API.
+2. Hub verifies the provider event and identifies its project resource, such as a repository, Linear project, workspace, or guild.
+3. Hub evaluates triggers and their filters. Reactive external events require `from_users`; the autonomous `linear.issue_entered_scope` event instead requires a project scope.
 4. A matching trigger creates a workflow run from the active configuration revision.
 5. The workflow evaluates its next step. A false `if` condition skips that step; a true condition starts it on the configured daemon.
 6. The daemon starts the agent and Hub records its replies, structured output, status, and completion.
@@ -51,7 +51,7 @@ Complete configurations are in [Workflows](/docs/hub/workflows).
 
 When Hub syncs the bundle, it validates every source file and resolves its references:
 
-- `filters.repo`, `filters.workspace`, and `filters.guild` must name resources available through the organization's connections.
+- `filters.repo`, `filters.project`, `filters.workspace`, and `filters.guild` must name resources available through the organization's connections.
 - `environment.daemon` must match a registered daemon's friendly slug.
 - Step ids, expressions, input filters, output schemas, and durations must be valid.
 - Every finite environment or named-agent result must exist and validate.
@@ -61,7 +61,10 @@ If activation fails, Hub keeps the previous active revision. The Configuration t
 
 ## Security boundaries
 
-Triggers require a non-empty `from_users` allowlist for externally sourced events. Protect the configuration repository because anyone who can change the active configuration can choose which connections, daemons, and agent capabilities a project uses.
+Reactive external triggers require a non-empty `from_users` allowlist. The autonomous Linear
+project-scope trigger has no actor allowlist, so its project, state, label, and assignee scope is the
+policy boundary. Protect the configuration repository because anyone who can change the active
+configuration can choose which connections, daemons, and agent capabilities a project uses.
 
 These controls do not sandbox the agent or make input safe. See [Hub security](/docs/hub/security) for the host boundary, provider-native policy, and defense-in-depth guidance.
 

--- a/public-docs/hub/concepts.md
+++ b/public-docs/hub/concepts.md
@@ -39,7 +39,7 @@ The configuration lives in `.paseo/hub.yml` plus convention-discovered `.paseo/w
 
 1. A provider sends an event to Hub. GitHub, Linear, and Slack Webhooks use HTTPS callbacks; Discord uses its gateway connection; Slack Socket Mode connects out from Hub; manual runs use the Hub API.
 2. Hub verifies the provider event and identifies its project resource, such as a repository, Linear project, workspace, or guild.
-3. Hub evaluates triggers and their filters. Reactive external events require `from_users`; the autonomous `linear.issue_entered_scope` event instead requires a project scope.
+3. Hub evaluates triggers and their filters. Reactive external events require `from_users`; the autonomous `linear.issue_entered_scope` event instead requires a project or team scope.
 4. A matching trigger creates a workflow run from the active configuration revision.
 5. The workflow evaluates its next step. A false `if` condition skips that step; a true condition starts it on the configured daemon.
 6. The daemon starts the agent and Hub records its replies, structured output, status, and completion.

--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -179,23 +179,25 @@ See [GitHub triggers](/docs/hub/triggers/github) for complete triage, pull-reque
 | `linear.comment_created`     | A newly created issue comment.                                             |
 | `linear.agent_session`       | A native agent session is created or receives another prompt.              |
 
-`linear.issue_entered_scope` requires `project` and does not require `from_users`. It is an
-intentionally autonomous, edge-triggered policy: an issue already in scope does not run again for
-an unrelated edit. The other three events require a non-empty `from_users` allowlist.
+`linear.issue_entered_scope` requires `project` or `team` and does not require `from_users`. It is
+an intentionally autonomous, edge-triggered policy: an issue already in scope does not run again
+for an unrelated edit. The other three events require a non-empty `from_users` allowlist.
 
 All supplied Linear filters compose with AND.
 
-| Field            | Type                                | Applies to                 | Meaning                                                |
-| ---------------- | ----------------------------------- | -------------------------- | ------------------------------------------------------ |
-| `connection`     | string                              | all Linear events          | Linear connection slug.                                |
-| `project`        | non-empty string                    | all Linear events          | Linear project id; required for `issue_entered_scope`. |
-| `states`         | non-empty list of non-empty strings | all Linear events          | Allowed current workflow-state ids.                    |
-| `labels`         | non-empty list of non-empty strings | all Linear events          | Every listed label id must be currently present.       |
-| `exclude_labels` | non-empty list of non-empty strings | all Linear events          | No listed label id may be currently present.           |
-| `assignees`      | non-empty list of non-empty strings | all Linear events          | Allowed resulting assignee ids.                        |
-| `from_users`     | non-empty list of strings           | reactive Linear events     | Linear actor ids allowed to start the workflow.        |
-| `pattern`        | string                              | comment and session events | Prefix of the direct user message.                     |
-| `contains`       | string                              | comment and session events | Substring of the direct user message.                  |
+| Field            | Type                                | Applies to                 | Meaning                                                                         |
+| ---------------- | ----------------------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `connection`     | string                              | all Linear events          | Linear connection slug.                                                         |
+| `project`        | non-empty string                    | all Linear events          | Linear project id; either this or `team` is required for `issue_entered_scope`. |
+| `team`           | non-empty string                    | all Linear events          | Linear team id; supports projectless issue routing.                             |
+| `states`         | non-empty list of non-empty strings | all Linear events          | Allowed current workflow-state ids.                                             |
+| `labels`         | non-empty list of non-empty strings | all Linear events          | Every listed label id must be currently present.                                |
+| `exclude_labels` | non-empty list of non-empty strings | all Linear events          | No listed label id may be currently present.                                    |
+| `assignees`      | non-empty list of non-empty strings | all Linear events          | Allowed resulting assignee ids.                                                 |
+| `from_users`     | non-empty list of strings           | reactive Linear events     | Linear actor ids allowed to start the workflow.                                 |
+| `pattern`        | string                              | comment and session events | Prefix of the direct user message.                                              |
+| `contains`       | string                              | comment and session events | Substring of the direct user message.                                           |
+| `replies_only`   | boolean                             | comment events             | When true, match replies but not root comments.                                 |
 
 Use Linear ids, not display names. `from_users` is the actor who assigned, commented, or prompted;
 `assignees` is the issue's resulting assignee. See [Linear triggers](/docs/hub/triggers/linear)

--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -177,28 +177,31 @@ See [GitHub triggers](/docs/hub/triggers/github) for complete triage, pull-reque
 | `linear.issue_entered_scope` | An issue created in, or transitioning into, the complete configured scope. |
 | `linear.issue_assigned`      | An issue update that changes its assignee to a user.                       |
 | `linear.comment_created`     | A newly created issue comment.                                             |
+| `linear.agent_session`       | A native agent session is created or receives another prompt.              |
 
 `linear.issue_entered_scope` requires `project` and does not require `from_users`. It is an
 intentionally autonomous, edge-triggered policy: an issue already in scope does not run again for
-an unrelated edit. The other two events require a non-empty `from_users` allowlist.
+an unrelated edit. The other three events require a non-empty `from_users` allowlist.
 
 All supplied Linear filters compose with AND.
 
-| Field            | Type                                | Applies to                    | Meaning                                                |
-| ---------------- | ----------------------------------- | ----------------------------- | ------------------------------------------------------ |
-| `connection`     | string                              | all Linear events             | Linear connection slug.                                |
-| `project`        | non-empty string                    | all Linear events             | Linear project id; required for `issue_entered_scope`. |
-| `states`         | non-empty list of non-empty strings | all Linear events             | Allowed current workflow-state ids.                    |
-| `labels`         | non-empty list of non-empty strings | all Linear events             | Every listed label id must be currently present.       |
-| `exclude_labels` | non-empty list of non-empty strings | all Linear events             | No listed label id may be currently present.           |
-| `assignees`      | non-empty list of non-empty strings | all Linear events             | Allowed resulting assignee ids.                        |
-| `from_users`     | non-empty list of strings           | assignment and comment events | Linear actor ids allowed to start the workflow.        |
-| `pattern`        | string                              | `linear.comment_created`      | Prefix of the original comment.                        |
-| `contains`       | string                              | `linear.comment_created`      | Substring of the original comment.                     |
+| Field            | Type                                | Applies to                 | Meaning                                                |
+| ---------------- | ----------------------------------- | -------------------------- | ------------------------------------------------------ |
+| `connection`     | string                              | all Linear events          | Linear connection slug.                                |
+| `project`        | non-empty string                    | all Linear events          | Linear project id; required for `issue_entered_scope`. |
+| `states`         | non-empty list of non-empty strings | all Linear events          | Allowed current workflow-state ids.                    |
+| `labels`         | non-empty list of non-empty strings | all Linear events          | Every listed label id must be currently present.       |
+| `exclude_labels` | non-empty list of non-empty strings | all Linear events          | No listed label id may be currently present.           |
+| `assignees`      | non-empty list of non-empty strings | all Linear events          | Allowed resulting assignee ids.                        |
+| `from_users`     | non-empty list of strings           | reactive Linear events     | Linear actor ids allowed to start the workflow.        |
+| `pattern`        | string                              | comment and session events | Prefix of the direct user message.                     |
+| `contains`       | string                              | comment and session events | Substring of the direct user message.                  |
 
-Use Linear ids, not display names. `from_users` is the actor who assigned or commented;
+Use Linear ids, not display names. `from_users` is the actor who assigned, commented, or prompted;
 `assignees` is the issue's resulting assignee. See [Linear triggers](/docs/hub/triggers/linear)
-for a reactive comment workflow and a guarded first-draft PR scout.
+for a native agent-session workflow, a reactive comment workflow, and a guarded first-draft PR
+scout. Mark `linear.reply` as required when a successful agent-session workflow must complete the
+session with a response.
 
 ### Inputs and values
 

--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -2,7 +2,7 @@
 title: Hub configuration reference
 description: Canonical Hub resource, workflow, agent, expression, and prompt fields.
 nav: Configuration reference
-order: 71
+order: 72
 category: Hub
 ---
 
@@ -170,6 +170,36 @@ Use `label` only with a label-added event. It has no match on other events. Use 
 
 See [GitHub triggers](/docs/hub/triggers/github) for complete triage, pull-request review, and ready-for-agent workflows.
 
+### Linear events and filters
+
+| `on`                         | Matches                                                                    |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| `linear.issue_entered_scope` | An issue created in, or transitioning into, the complete configured scope. |
+| `linear.issue_assigned`      | An issue update that changes its assignee to a user.                       |
+| `linear.comment_created`     | A newly created issue comment.                                             |
+
+`linear.issue_entered_scope` requires `project` and does not require `from_users`. It is an
+intentionally autonomous, edge-triggered policy: an issue already in scope does not run again for
+an unrelated edit. The other two events require a non-empty `from_users` allowlist.
+
+All supplied Linear filters compose with AND.
+
+| Field            | Type                                | Applies to                    | Meaning                                                |
+| ---------------- | ----------------------------------- | ----------------------------- | ------------------------------------------------------ |
+| `connection`     | string                              | all Linear events             | Linear connection slug.                                |
+| `project`        | non-empty string                    | all Linear events             | Linear project id; required for `issue_entered_scope`. |
+| `states`         | non-empty list of non-empty strings | all Linear events             | Allowed current workflow-state ids.                    |
+| `labels`         | non-empty list of non-empty strings | all Linear events             | Every listed label id must be currently present.       |
+| `exclude_labels` | non-empty list of non-empty strings | all Linear events             | No listed label id may be currently present.           |
+| `assignees`      | non-empty list of non-empty strings | all Linear events             | Allowed resulting assignee ids.                        |
+| `from_users`     | non-empty list of strings           | assignment and comment events | Linear actor ids allowed to start the workflow.        |
+| `pattern`        | string                              | `linear.comment_created`      | Prefix of the original comment.                        |
+| `contains`       | string                              | `linear.comment_created`      | Substring of the original comment.                     |
+
+Use Linear ids, not display names. `from_users` is the actor who assigned or commented;
+`assignees` is the issue's resulting assignee. See [Linear triggers](/docs/hub/triggers/linear)
+for a reactive comment workflow and a guarded first-draft PR scout.
+
 ### Inputs and values
 
 Inputs have `type: string | number | boolean`, plus optional `required`, `default`, and `choices`. `required` and `default` cannot be combined. Finite `choices` are required when an input can choose authority such as an environment or named agent.
@@ -244,7 +274,9 @@ allow_outputs:
     required: true
 ```
 
-Slack workflows use `slack.reply`; Discord workflows use `discord.reply`. The declaration grants `hub.reply`, and the prompt must tell the agent to call it. GitHub has no reply output; use an explicit [`github` block](/docs/hub/github).
+Linear workflows use `linear.reply`; Slack workflows use `slack.reply`; Discord workflows use
+`discord.reply`. The declaration grants `hub.reply`, and the prompt must tell the agent to call it.
+GitHub has no reply output; use an explicit [`github` block](/docs/hub/github).
 
 Every step receives `hub.finish_execution`. The prompt must tell the agent when to call it; Hub does not append completion or reply instructions. If `output.schema` is present, `hub.finish_execution` requires an `output` value that matches the schema. If an `allow_outputs` entry is `required: true`, the agent must emit that output before finishing. `max` defaults to `1`.
 

--- a/public-docs/hub/configuration/index.md
+++ b/public-docs/hub/configuration/index.md
@@ -2,7 +2,7 @@
 title: Hub configuration
 description: Configuration bundles, GitHub sync, CLI deployment, and revisions.
 nav: Configuration
-order: 70
+order: 71
 category: Hub
 ---
 

--- a/public-docs/hub/faq.md
+++ b/public-docs/hub/faq.md
@@ -2,7 +2,7 @@
 title: Hub FAQ
 description: Common questions about projects, connections, configuration, and daemons in Paseo Hub.
 nav: FAQ
-order: 78
+order: 80
 category: Hub
 ---
 
@@ -40,7 +40,9 @@ Yes, with a manual source. A project using a GitHub source is read-only in the d
 
 ## Who can trigger an agent?
 
-Only the users listed in a trigger's `from_users`. It is required and cannot be empty.
+Reactive external triggers start only for users listed in `from_users`; it is required and cannot
+be empty. `linear.issue_entered_scope` is the explicit autonomous exception. It requires a Linear
+project and runs only when an issue enters the complete configured scope.
 
 ## What happens if the daemon is offline?
 
@@ -50,12 +52,14 @@ Dispatch fails and the event is recorded as failed. Nothing is queued, so trigge
 
 No. The stored CLI login is a human organization credential; the enrolled daemon has its own relationship credential. Interactive `paseo hub logout` offers to disconnect a daemon related to the same Hub. Declining is normal, and JSON or noninteractive logout never disconnects unless you pass `--disconnect-daemon`.
 
-## Can an agent reply back to Slack or Discord?
+## Can an agent reply back to Linear, Slack, or Discord?
 
 Yes. Put `allow_outputs` on the step and tell the agent to call `hub.reply` in the prompt. [Tell the agent which tool to call](/docs/hub/workflows#tell-the-agent-which-tool-to-call) shows the prompting; reply limits and `required` are in the [output capability reference](/docs/hub/configuration/hub-yml#output-capabilities).
+
+Use `linear.reply`, `slack.reply`, or `discord.reply` for the matching provider context.
 
 GitHub has no reply capability; give the step a [`github` block](/docs/hub/github) and the agent acts through the `gh` CLI.
 
 ## Can I use it without GitHub?
 
-Yes. A project with a manual configuration and a Discord or Slack connection works fine. GitHub is only needed if you want configuration synced from a repository.
+Yes. A project with a manual configuration and a Linear, Discord, or Slack connection works fine. GitHub is only needed if you want configuration synced from a repository or a workflow step to use explicit GitHub authority.

--- a/public-docs/hub/faq.md
+++ b/public-docs/hub/faq.md
@@ -42,7 +42,7 @@ Yes, with a manual source. A project using a GitHub source is read-only in the d
 
 Reactive external triggers start only for users listed in `from_users`; it is required and cannot
 be empty. `linear.issue_entered_scope` is the explicit autonomous exception. It requires a Linear
-project and runs only when an issue enters the complete configured scope.
+project or team and runs only when an issue enters the complete configured scope.
 
 ## What happens if the daemon is offline?
 

--- a/public-docs/hub/hosted.md
+++ b/public-docs/hub/hosted.md
@@ -2,7 +2,7 @@
 title: Hosted Hub
 description: Sign in to the managed Paseo Hub or self-host the same service.
 nav: Hosted
-order: 73
+order: 74
 category: Hub
 ---
 

--- a/public-docs/hub/index.md
+++ b/public-docs/hub/index.md
@@ -19,7 +19,7 @@ A daemon runs agents on one machine, for you. Paseo Hub is the layer above your 
 
 What that gives you today:
 
-- Agents that start on their own, from activity in GitHub, Slack, and Discord.
+- Agents that start on their own, from activity in GitHub, Linear, Slack, and Discord.
 - Configuration that lives in a repository and deploys when you push.
 - A record of everything that arrived, what it matched, and what ran.
 - One place for your team to see all of it.
@@ -50,7 +50,7 @@ Guided setup deploys the bundle, and mentioning the bot starts an agent on your 
 7. [Configuration](/docs/hub/configuration)
 8. [Security](/docs/hub/security)
 
-If a workflow accepts requests from GitHub, Slack, Discord, or the API, read [Hub security](/docs/hub/security) before giving an agent access to a working directory or output capability.
+If a workflow accepts requests from GitHub, Linear, Slack, Discord, or the API, read [Hub security](/docs/hub/security) before giving an agent access to a working directory or output capability.
 
 ## Run Hub yourself
 

--- a/public-docs/hub/security.md
+++ b/public-docs/hub/security.md
@@ -2,7 +2,7 @@
 title: Hub security
 description: Security boundaries, untrusted input, provider controls, and explicit workflow authority.
 nav: Security
-order: 80
+order: 82
 category: Hub
 ---
 
@@ -27,7 +27,11 @@ filters:
   from_users: [U01234567]
 ```
 
-Use `from_users` on external triggers. Pin GitHub to `repo`, Slack to `workspace` and `channels`, and Discord to `guild` and `channels`. Allowlists reduce exposure but do not make a permitted account or its text trustworthy.
+Use `from_users` on reactive external triggers. Pin GitHub to `repo`, Linear to `project`, Slack to
+`workspace` and `channels`, and Discord to `guild` and `channels`. The autonomous
+`linear.issue_entered_scope` event has no actor allowlist; narrow its project scope with states,
+labels, excluded labels, and assignees. Allowlists and resource scopes reduce exposure but do not
+make a permitted account, issue, or comment trustworthy.
 
 Keep the triggering text explicit and delimited:
 
@@ -54,6 +58,7 @@ Keep secrets and unrelated repositories outside the selected `cwd`. Use a dedica
 
 - Put `slack.reply` only in a Slack workflow step that replies.
 - Put `discord.reply` only in a Discord workflow step that replies.
+- Put `linear.reply` only in a Linear workflow step that replies to the issue.
 - Put a [`github` block](/docs/hub/github) only on a step that needs GitHub.
 - Give classifiers no reply or repository authority.
 
@@ -177,7 +182,7 @@ Provider policy does not replace OS filesystem or network isolation. Test the ex
 ## Review checklist
 
 - The configuration repository is protected.
-- Every external trigger has narrow resource and sender filters.
+- Every reactive external trigger has narrow resource and sender filters; every autonomous Linear trigger has a narrow project scope.
 - Each environment points at the smallest useful working directory.
 - Dynamic environment and agent authority has finite choices.
 - Named agent options match the selected provider and remain complete.

--- a/public-docs/hub/self-hosting/discord-app.md
+++ b/public-docs/hub/self-hosting/discord-app.md
@@ -2,7 +2,7 @@
 title: Discord for Hub
 description: Create the Discord application your Hub uses and connect a server.
 nav: Discord app
-order: 77
+order: 78
 category: Hub
 ---
 

--- a/public-docs/hub/self-hosting/github-app.md
+++ b/public-docs/hub/self-hosting/github-app.md
@@ -2,7 +2,7 @@
 title: GitHub for Hub
 description: Create the GitHub App your Hub uses for repository access and event triggers.
 nav: GitHub App
-order: 75
+order: 76
 category: Hub
 ---
 

--- a/public-docs/hub/self-hosting/index.md
+++ b/public-docs/hub/self-hosting/index.md
@@ -2,7 +2,7 @@
 title: Self-hosting Hub
 description: Run Hub locally with its embedded database, or deploy it with PostgreSQL.
 nav: Self-hosting
-order: 74
+order: 75
 category: Hub
 ---
 
@@ -14,7 +14,7 @@ The shortest path is one command:
 npx @getpaseo/hub
 ```
 
-Open <http://localhost:3000>. A fresh Hub creates its embedded database and authentication secret, then guides you through creating the operator account and the GitHub, Slack, or Discord apps you want.
+Open <http://localhost:3000>. A fresh Hub creates its embedded database and authentication secret, then guides you through creating the operator account and the GitHub, Linear, Slack, or Discord apps you want.
 
 Follow the [quickstart](/docs/hub/quickstart) to connect Slack over Socket Mode and run the first workflow without a public server.
 
@@ -34,7 +34,7 @@ Embedded mode supports one Hub process per data directory. It is intended for a 
 
 Hub defaults to `http://localhost:3000`. That is enough for its dashboard, daemons, Slack Socket Mode, and providers that connect out from Hub.
 
-GitHub event triggers use webhooks and need a public HTTPS address. Repository access can still work without the webhook. Slack's optional Webhooks transport also needs public HTTPS; Socket Mode does not.
+GitHub and Linear event triggers use webhooks and need a public HTTPS address. GitHub repository access can still work without its webhook. Linear setup requires HTTPS for both OAuth and event delivery. Slack's optional Webhooks transport also needs public HTTPS; Socket Mode does not.
 
 When Hub is available at a stable public origin, set it before starting:
 
@@ -59,7 +59,7 @@ The database also stores Hub's generated authentication secret. Set `PASEO_HUB_A
 
 ## App configuration
 
-The operator configures GitHub, Slack, and Discord under **Apps**. Hub verifies the credentials before saving them in its database and starts the same provider runtime used by environment-configured deployments.
+The operator configures GitHub, Linear, Slack, and Discord under **Apps**. Hub verifies the credentials before saving them in its database and starts the same provider runtime used by environment-configured deployments.
 
 Environment variables remain available for deployments that manage secrets outside Hub. A complete environment configuration takes precedence over a saved application and appears as **Managed by environment** in the dashboard.
 
@@ -88,9 +88,14 @@ SLACK_SIGNING_SECRET=
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
 DISCORD_BOT_TOKEN=
+
+# Linear
+LINEAR_CLIENT_ID=
+LINEAR_CLIENT_SECRET=
+LINEAR_WEBHOOK_SECRET=
 ```
 
-See [GitHub](/docs/hub/self-hosting/github-app), [Slack](/docs/hub/self-hosting/slack-app), and [Discord](/docs/hub/self-hosting/discord-app) for provider behavior and connection steps.
+See [GitHub](/docs/hub/self-hosting/github-app), [Linear](/docs/hub/self-hosting/linear-app), [Slack](/docs/hub/self-hosting/slack-app), and [Discord](/docs/hub/self-hosting/discord-app) for provider behavior and connection steps.
 
 ## Bootstrap from environment
 

--- a/public-docs/hub/self-hosting/linear-app.md
+++ b/public-docs/hub/self-hosting/linear-app.md
@@ -1,0 +1,66 @@
+---
+title: Linear for Hub
+description: Create the Linear application your Hub uses for project triggers and issue replies.
+nav: Linear app
+order: 79
+category: Hub
+---
+
+# Linear for Hub
+
+Hub connects to Linear through an OAuth application you create and own. One application serves
+the Hub; each Linear workspace an administrator authorizes becomes a separate connection.
+
+Linear setup requires a stable public HTTPS origin. Set `PASEO_HUB_APP_URL` and open Hub at that
+address before starting the Apps guide. Hub does not persist an application setup attempted from
+plain HTTP.
+
+## Create the application
+
+Open **Apps → Linear**. Hub links to Linear's API application settings and gives you the exact URLs
+for the current origin:
+
+| Linear setting | Hub URL                                                |
+| -------------- | ------------------------------------------------------ |
+| Redirect URL   | `<PASEO_HUB_APP_URL>/api/integrations/linear/callback` |
+| Webhook URL    | `<PASEO_HUB_APP_URL>/api/integrations/linear/events`   |
+
+In Linear:
+
+1. Create an OAuth application and add the redirect URL.
+2. Add application webhooks for **Issue** and **Comment** events at the webhook URL.
+3. Choose a webhook signing secret.
+4. Copy the Client ID, Client Secret, and signing secret into Hub.
+
+Choose **Save and continue to Linear**. A workspace administrator authorizes the application with
+the narrow `read` and `comments:create` scopes. Hub saves the application and workspace connection
+only after that authorization succeeds. Replaying a completed or expired authorization link is
+rejected.
+
+The OAuth request uses Linear's app actor, so comments emitted through `linear.reply` are visibly
+authored by the application rather than by the administrator who connected it.
+
+Choose **Connect another workspace** to authorize more workspaces. Each connection gets its own
+Hub slug for `filters.connection`.
+
+## Configure from environment
+
+Deployments that keep application secrets outside Hub can set all three values:
+
+```dotenv
+LINEAR_CLIENT_ID=
+LINEAR_CLIENT_SECRET=
+LINEAR_WEBHOOK_SECRET=
+```
+
+Environment configuration takes precedence over a saved Linear application and appears as
+**Managed by environment** under **Apps**. A workspace administrator must still complete OAuth for
+each workspace connection; those workspace tokens are stored by Hub.
+
+## Webhook verification
+
+Keep Linear's webhook signing secret and Hub's `LINEAR_WEBHOOK_SECRET` identical. Hub verifies the
+HMAC against the raw request body and rejects a signed timestamp more than one minute in the past
+or future. Invalid, missing, malformed, and stale signatures do not reach trigger matching.
+
+Continue with [Linear triggers](/docs/hub/triggers/linear).

--- a/public-docs/hub/self-hosting/linear-app.md
+++ b/public-docs/hub/self-hosting/linear-app.md
@@ -1,6 +1,6 @@
 ---
 title: Linear for Hub
-description: Create the Linear application your Hub uses for project triggers and issue replies.
+description: Create the Linear application your Hub uses for project triggers, agent sessions, and replies.
 nav: Linear app
 order: 79
 category: Hub
@@ -28,17 +28,25 @@ for the current origin:
 In Linear:
 
 1. Create an OAuth application and add the redirect URL.
-2. Add application webhooks for **Issue** and **Comment** events at the webhook URL.
+2. Add application webhooks for **Issue**, **Comment**, and **Agent session events** at the webhook
+   URL. Agent session events let people mention the app or delegate an issue to it.
 3. Choose a webhook signing secret.
 4. Copy the Client ID, Client Secret, and signing secret into Hub.
 
 Choose **Save and continue to Linear**. A workspace administrator authorizes the application with
-the narrow `read` and `comments:create` scopes. Hub saves the application and workspace connection
-only after that authorization succeeds. Replaying a completed or expired authorization link is
-rejected.
+`read`, `write`, `app:assignable`, and `app:mentionable`. The two app scopes make the application
+available as an issue delegate and an @mention target; `write` lets it emit native Agent
+Activities. Hub saves the application and workspace connection only after that authorization
+succeeds. Replaying a completed or expired authorization link is rejected.
 
-The OAuth request uses Linear's app actor, so comments emitted through `linear.reply` are visibly
-authored by the application rather than by the administrator who connected it.
+An existing Linear connection that predates these scopes appears as requiring reauthorization.
+Reconnect it once to enable native agent sessions.
+
+The OAuth request uses Linear's app actor. Ordinary issue-trigger replies are visibly authored by
+the application; an agent-session reply is emitted as a native `response` activity on that
+session.
+
+Linear currently labels its Agent APIs as Developer Preview, so its upstream contract may change.
 
 Choose **Connect another workspace** to authorize more workspaces. Each connection gets its own
 Hub slug for `filters.connection`.

--- a/public-docs/hub/self-hosting/slack-app.md
+++ b/public-docs/hub/self-hosting/slack-app.md
@@ -2,7 +2,7 @@
 title: Slack for Hub
 description: Connect Slack over Socket Mode, or use webhooks from a public Hub.
 nav: Slack app
-order: 76
+order: 77
 category: Hub
 ---
 

--- a/public-docs/hub/triggers/index.md
+++ b/public-docs/hub/triggers/index.md
@@ -45,6 +45,7 @@ Field-by-field detail is in the [configuration reference](/docs/hub/configuratio
 | `linear.issue_entered_scope`          | An issue is created in, or enters, a project scope.  |
 | `linear.issue_assigned`               | An issue is assigned to a user.                      |
 | `linear.comment_created`              | A comment is created on an issue.                    |
+| `linear.agent_session`                | A native agent session starts or is prompted.        |
 | `slack.mention`                       | The bot is mentioned in a channel.                   |
 | `discord.mention`                     | The bot is mentioned in a guild.                     |
 | `manual.run`                          | A run started from the API.                          |
@@ -113,6 +114,10 @@ Put `allow_outputs` on the step that should reply. The reply capabilities are `l
 - Set `max` when a step needs more than one update.
 - Set `required: true` when the step must emit at least one reply before it can finish. A required type must be registered and available for the execution context.
 
-`linear.reply` posts to the triggering issue. GitHub has no reply capability; a step with a [`github` block](/docs/hub/github) comments through `gh` instead. The [output capability reference](/docs/hub/configuration/hub-yml#output-capabilities) has the contract.
+`linear.reply` posts to the triggering issue for issue/comment events and emits a native response
+activity for an agent-session event. GitHub has no reply capability; a step with a
+[`github` block](/docs/hub/github) comments through `gh` instead. The
+[output capability reference](/docs/hub/configuration/hub-yml#output-capabilities) has the
+contract.
 
 The declaration grants the `hub.reply` tool; the prompt has to tell the agent to call it. See [Tell the agent which tool to call](/docs/hub/workflows#tell-the-agent-which-tool-to-call).

--- a/public-docs/hub/triggers/index.md
+++ b/public-docs/hub/triggers/index.md
@@ -60,7 +60,8 @@ Each provider page documents its events and the data they expose:
 
 ## Filters
 
-`filters` is required. Reactive external triggers require a non-empty `from_users` allowlist.
+`filters` is required. `manual.run` and reactive external triggers require a non-empty `from_users`
+allowlist. For `manual.run`, it matches the `actor` supplied by the dispatch request.
 `linear.issue_entered_scope` is the deliberate exception: it is an autonomous policy, requires a
 Linear project, and fires only when an issue enters the complete configured scope.
 
@@ -70,7 +71,7 @@ An allowlist is one layer of defense. It does not make a permitted account trust
 
 | Filter           | Applies to                     | Matches                                                                         |
 | ---------------- | ------------------------------ | ------------------------------------------------------------------------------- |
-| `from_users`     | reactive external events       | GitHub login; Linear, Slack, and Discord **user id**, not display name          |
+| `from_users`     | manual and reactive events     | Manual actor; GitHub login; Linear, Slack, and Discord **user id**              |
 | `repo`           | GitHub                         | `owner/name`                                                                    |
 | `project`        | Linear                         | Project id                                                                      |
 | `states`         | Linear                         | Current workflow-state ids                                                      |

--- a/public-docs/hub/triggers/index.md
+++ b/public-docs/hub/triggers/index.md
@@ -42,6 +42,9 @@ Field-by-field detail is in the [configuration reference](/docs/hub/configuratio
 | `github.pull_request_comment_created` | A conversation comment is created on a pull request. |
 | `github.issue_label_added`            | A label is added to an issue.                        |
 | `github.pull_request_label_added`     | A label is added to a pull request.                  |
+| `linear.issue_entered_scope`          | An issue is created in, or enters, a project scope.  |
+| `linear.issue_assigned`               | An issue is assigned to a user.                      |
+| `linear.comment_created`              | A comment is created on an issue.                    |
 | `slack.mention`                       | The bot is mentioned in a channel.                   |
 | `discord.mention`                     | The bot is mentioned in a guild.                     |
 | `manual.run`                          | A run started from the API.                          |
@@ -51,35 +54,42 @@ New GitHub workflows should use a semantic event. The five legacy events remain 
 Each provider page documents its events and the data they expose:
 
 - [GitHub triggers](/docs/hub/triggers/github)
+- [Linear triggers](/docs/hub/triggers/linear)
 - [Slack triggers](/docs/hub/triggers/slack)
 - [Discord triggers](/docs/hub/triggers/discord)
 
 ## Filters
 
-`filters` is required, and `from_users` must be present and non-empty. A trigger without it is rejected at validation.
+`filters` is required. Reactive external triggers require a non-empty `from_users` allowlist.
+`linear.issue_entered_scope` is the deliberate exception: it is an autonomous policy, requires a
+Linear project, and fires only when an issue enters the complete configured scope.
 
 The allowlist is what keeps a stranger's comment on a public issue from starting an agent on your machine. There is no default, because a safe default differs per repository.
 
 An allowlist is one layer of defense. It does not make a permitted account trustworthy after compromise or make prompt injection harmless. See [Hub security](/docs/hub/security) before choosing the daemon, working directory, provider policy, and outputs for an external trigger.
 
-| Filter       | Applies to                | Matches                                                              |
-| ------------ | ------------------------- | -------------------------------------------------------------------- |
-| `from_users` | all                       | GitHub: login. Slack and Discord: **user id**, not display name      |
-| `repo`       | GitHub                    | `owner/name`                                                         |
-| `workspace`  | Slack                     | Team id, `T01234567`                                                 |
-| `guild`      | Discord                   | Guild id                                                             |
-| `channels`   | Slack, Discord            | Channel ids                                                          |
-| `contains`   | all                       | GitHub substring; Slack and Discord invocation prefix                |
-| `pattern`    | all                       | Invocation prefix                                                    |
-| `connection` | all                       | A connection slug, when the organization has several                 |
-| `label`      | GitHub label-added events | The label added by this delivery, case-insensitively                 |
-| `labels`     | GitHub                    | Every listed current issue or pull-request label, case-insensitively |
+| Filter           | Applies to                     | Matches                                                                         |
+| ---------------- | ------------------------------ | ------------------------------------------------------------------------------- |
+| `from_users`     | reactive external events       | GitHub login; Linear, Slack, and Discord **user id**, not display name          |
+| `repo`           | GitHub                         | `owner/name`                                                                    |
+| `project`        | Linear                         | Project id                                                                      |
+| `states`         | Linear                         | Current workflow-state ids                                                      |
+| `assignees`      | Linear                         | Current assignee ids                                                            |
+| `exclude_labels` | Linear                         | Any listed label id makes the issue ineligible                                  |
+| `workspace`      | Slack                          | Team id, `T01234567`                                                            |
+| `guild`          | Discord                        | Guild id                                                                        |
+| `channels`       | Slack, Discord                 | Channel ids                                                                     |
+| `contains`       | GitHub, Linear, Slack, Discord | GitHub and Linear substring; Slack and Discord invocation prefix                |
+| `pattern`        | GitHub, Linear, Slack, Discord | Start of the provider's invocation text                                         |
+| `connection`     | all                            | A connection slug, when the organization has several                            |
+| `label`          | GitHub label-added events      | The label added by this delivery, case-insensitively                            |
+| `labels`         | GitHub, Linear                 | Every listed current label; GitHub names case-insensitively, Linear ids exactly |
 
 All conditions must pass. There is no `any` mode.
 
 ## Which connection an event comes from
 
-`repo`, `workspace`, and `guild` are resolved to immutable ids when the configuration activates, along with the connection that owns them. Naming a resource the organization has no connection for fails activation, so you find out on push rather than when someone comments.
+`repo`, `project`, `workspace`, and `guild` are resolved to immutable ids when the configuration activates, along with the connection that owns them. Naming a resource the organization has no connection for fails activation, so you find out on push rather than when someone comments.
 
 Omit the resource filter and the trigger listens to every connection of that provider in the organization. To pin it to one:
 
@@ -97,11 +107,11 @@ Both run. Triggers are not ordered and do not shadow each other, in one configur
 
 ## Replying
 
-Put `allow_outputs` on the step that should reply. The reply capabilities are `slack.reply` and `discord.reply`.
+Put `allow_outputs` on the step that should reply. The reply capabilities are `linear.reply`, `slack.reply`, and `discord.reply`.
 
 - Set `max` when a step needs more than one update.
 - Set `required: true` when the step must emit at least one reply before it can finish. A required type must be registered and available for the execution context.
 
-GitHub has no reply capability; a step with a [`github` block](/docs/hub/github) comments through `gh` instead. The [output capability reference](/docs/hub/configuration/hub-yml#output-capabilities) has the contract.
+`linear.reply` posts to the triggering issue. GitHub has no reply capability; a step with a [`github` block](/docs/hub/github) comments through `gh` instead. The [output capability reference](/docs/hub/configuration/hub-yml#output-capabilities) has the contract.
 
 The declaration grants the `hub.reply` tool; the prompt has to tell the agent to call it. See [Tell the agent which tool to call](/docs/hub/workflows#tell-the-agent-which-tool-to-call).

--- a/public-docs/hub/triggers/index.md
+++ b/public-docs/hub/triggers/index.md
@@ -34,21 +34,21 @@ Field-by-field detail is in the [configuration reference](/docs/hub/configuratio
 
 ## Events
 
-| `on`                                  | Fires when                                           |
-| ------------------------------------- | ---------------------------------------------------- |
-| `github.issue_created`                | An issue is opened.                                  |
-| `github.pull_request_created`         | A pull request is opened.                            |
-| `github.issue_comment_created`        | A comment is created on an issue.                    |
-| `github.pull_request_comment_created` | A conversation comment is created on a pull request. |
-| `github.issue_label_added`            | A label is added to an issue.                        |
-| `github.pull_request_label_added`     | A label is added to a pull request.                  |
-| `linear.issue_entered_scope`          | An issue is created in, or enters, a project scope.  |
-| `linear.issue_assigned`               | An issue is assigned to a user.                      |
-| `linear.comment_created`              | A comment is created on an issue.                    |
-| `linear.agent_session`                | A native agent session starts or is prompted.        |
-| `slack.mention`                       | The bot is mentioned in a channel.                   |
-| `discord.mention`                     | The bot is mentioned in a guild.                     |
-| `manual.run`                          | A run started from the API.                          |
+| `on`                                  | Fires when                                                               |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `github.issue_created`                | An issue is opened.                                                      |
+| `github.pull_request_created`         | A pull request is opened.                                                |
+| `github.issue_comment_created`        | A comment is created on an issue.                                        |
+| `github.pull_request_comment_created` | A conversation comment is created on a pull request.                     |
+| `github.issue_label_added`            | A label is added to an issue.                                            |
+| `github.pull_request_label_added`     | A label is added to a pull request.                                      |
+| `linear.issue_entered_scope`          | An issue is created in, or enters, the complete configured filter scope. |
+| `linear.issue_assigned`               | An issue is assigned to a user.                                          |
+| `linear.comment_created`              | A comment is created on an issue.                                        |
+| `linear.agent_session`                | A native agent session starts or is prompted.                            |
+| `slack.mention`                       | The bot is mentioned in a channel.                                       |
+| `discord.mention`                     | The bot is mentioned in a guild.                                         |
+| `manual.run`                          | A run started from the API.                                              |
 
 New GitHub workflows should use a semantic event. The five legacy events remain compatible: `github.issues`, `github.issue_comment`, `github.pull_request_review`, `github.pull_request_review_comment`, and `github.push`. See [GitHub triggers](/docs/hub/triggers/github) for complete workflows and when to use each event.
 
@@ -64,7 +64,7 @@ Each provider page documents its events and the data they expose:
 `filters` is required. `manual.run` and reactive external triggers require a non-empty `from_users`
 allowlist. For `manual.run`, it matches the `actor` supplied by the dispatch request.
 `linear.issue_entered_scope` is the deliberate exception: it is an autonomous policy, requires a
-Linear project, and fires only when an issue enters the complete configured scope.
+Linear project or team, and fires only when an issue enters the complete configured scope.
 
 The allowlist is what keeps a stranger's comment on a public issue from starting an agent on your machine. There is no default, because a safe default differs per repository.
 

--- a/public-docs/hub/triggers/linear.md
+++ b/public-docs/hub/triggers/linear.md
@@ -57,6 +57,9 @@ Enable **Agent session events** when you [create the Linear app](/docs/hub/self-
 Mentioning the app or delegating an issue creates a session; another message on that session sends
 a `prompted` event and starts another workflow run.
 
+The examples below assume `.paseo/hub.yml` defines an environment named `dev` and an agent named
+`codex`.
+
 `.paseo/workflows/linear-agent.yml`:
 
 ```yaml
@@ -101,8 +104,6 @@ activity. The example marks `linear.reply` as required so a successful run canno
 completing the session.
 
 ## Respond to a command comment
-
-Assume `.paseo/hub.yml` defines an environment named `dev` and an agent named `codex`.
 
 `.paseo/workflows/linear-comment.yml`:
 
@@ -231,5 +232,6 @@ steps:
 The project filter is the autonomous trust boundary in this example. Use `team` instead when a
 team maps to the repository and issues may have no Linear project. Narrow either route further with
 states, labels, excluded labels, and assignees. The trigger grants no repository credential. Only
-the `github` block on `implement` authorizes GitHub access, and only that step can emit
-`linear.reply`.
+the `github` block on `implement` grants Hub-issued GitHub authority; ambient daemon credentials
+remain subject to the daemon and provider's environment and permission policy. Only `implement`
+can emit `linear.reply`.

--- a/public-docs/hub/triggers/linear.md
+++ b/public-docs/hub/triggers/linear.md
@@ -1,0 +1,174 @@
+---
+title: Linear triggers
+description: Start reactive or autonomous Hub workflows from Linear issues and comments.
+nav: Linear
+order: 70
+category: Hub
+---
+
+# Linear triggers
+
+Connect a workspace through [Linear for Hub](/docs/hub/self-hosting/linear-app), then use its
+stable Linear IDs to scope each workflow. Display names are not accepted for projects, states,
+labels, assignees, or users.
+
+## Choose the event
+
+| `on`                         | Fires when                                                                 |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| `linear.issue_entered_scope` | An issue is created in, or transitions into, the configured project scope. |
+| `linear.issue_assigned`      | An issue's assignee changes to a user.                                     |
+| `linear.comment_created`     | A comment is created on an issue.                                          |
+
+`linear.issue_entered_scope` is the intentionally autonomous event. It requires `filters.project`
+and fires only on the edge into the complete configured scope. Editing the title or description of
+an issue already in scope does not start another run.
+
+`linear.issue_assigned` and `linear.comment_created` are reactive. Both require a non-empty
+`filters.from_users` list containing the Linear IDs of actors allowed to start the workflow.
+
+## Filter Linear events
+
+All supplied filters compose with AND.
+
+| Filter           | Meaning                                                                       |
+| ---------------- | ----------------------------------------------------------------------------- |
+| `connection`     | Linear connection slug.                                                       |
+| `project`        | Linear project ID; required for `linear.issue_entered_scope`.                 |
+| `states`         | The issue's current workflow-state ID must be in the list.                    |
+| `labels`         | The issue must currently have every listed Linear label ID.                   |
+| `exclude_labels` | The issue must have none of the listed Linear label IDs.                      |
+| `assignees`      | The issue's resulting assignee ID must be in the list.                        |
+| `from_users`     | Actor IDs allowed to assign or comment; required for the two reactive events. |
+| `pattern`        | For comments, text that must occur at the start of the original comment.      |
+| `contains`       | For comments, text that must occur somewhere in the original comment.         |
+
+`from_users` identifies the person who performed the assignment or wrote the comment.
+`assignees` identifies the issue's resulting assignee. They are different checks.
+
+## Respond to a command comment
+
+Assume `.paseo/hub.yml` defines an environment named `dev` and an agent named `codex`.
+
+`.paseo/workflows/linear-comment.yml`:
+
+```yaml
+name: linear-comment
+on: linear.comment_created
+max_runtime: 1h
+filters:
+  connection: acme-linear
+  project: 00000000-0000-0000-0000-000000000000
+  from_users: [11111111-1111-1111-1111-111111111111]
+  contains: /paseo
+steps:
+  - id: answer
+    environment: dev
+    max_runtime: 30m
+    idle_timeout: 5m
+    agent: codex
+    prompt:
+      - text: |
+          Answer the Linear request with hub.reply, then call hub.finish_execution.
+
+          <user-prompt>
+          ${{ paseo.prompt }}
+          </user-prompt>
+
+          <linear-context>
+          ${{ paseo.context }}
+          </linear-context>
+    allow_outputs:
+      - { type: linear.reply, max: 1, required: true }
+```
+
+For a Linear comment, `${{ paseo.prompt }}` preserves the complete original comment. `pattern` and
+`contains` choose where declared leading `key=value` inputs are parsed; they do not rewrite the
+prompt. `linear.reply` posts to the triggering issue through the connected Linear application.
+
+Authoring `${{ paseo.context }}` opts the step into Linear context. It includes the organization,
+actor, issue, triggering comment, and a bounded chronological thread: the issue title and
+description followed by up to 49 comments strictly before the trigger. If optional history cannot
+be loaded, the context marks the thread unavailable and still includes the issue root.
+
+## Start a first-draft PR when an issue enters scope
+
+The project scout below first classifies an issue without Hub-issued GitHub authority. Only an
+eligible issue reaches the implementation step, which has explicit repository permissions and one
+Linear reply.
+
+`.paseo/hub.yml`:
+
+```yaml
+environments:
+  project:
+    kind: daemon
+    daemon: workstation
+    cwd: /work/acme/repo
+    worktree:
+      mode: branch-off
+      newBranch: paseo/linear-${{ paseo.execution.id }}
+      base: origin/main
+agents:
+  codex:
+    provider: codex
+```
+
+`.paseo/workflows/linear-project-scout.yml`:
+
+```yaml
+name: linear-project-scout
+on: linear.issue_entered_scope
+max_runtime: 2h
+filters:
+  connection: acme-linear
+  project: 00000000-0000-0000-0000-000000000000
+  states: [22222222-2222-2222-2222-222222222222]
+  exclude_labels: [33333333-3333-3333-3333-333333333333]
+steps:
+  - id: assess
+    environment: project
+    max_runtime: 20m
+    idle_timeout: 5m
+    agent: codex
+    prompt:
+      - text: |
+          Assess this Linear issue for a safe, self-contained first-draft PR. Set eligible
+          to true only when the change is clear, bounded, testable, and requires no product
+          or security decision.
+
+          ${{ paseo.context }}
+    output:
+      schema:
+        type: object
+        required: [eligible]
+        properties:
+          eligible: { type: boolean }
+        additionalProperties: false
+
+  - id: implement
+    if: ${{ steps.assess.outputs.eligible == true }}
+    environment: project
+    max_runtime: 90m
+    idle_timeout: 10m
+    agent: codex
+    github:
+      connection: acme-github
+      repositories: [acme/repo]
+      permissions:
+        contents: write
+        pull_requests: write
+    prompt:
+      - text: |
+          Implement the issue, run focused checks, and open a draft pull request. Then call
+          hub.reply with the pull-request URL and a short summary, and call
+          hub.finish_execution. Do not open a pull request if the issue proves ambiguous.
+
+          ${{ paseo.context }}
+    allow_outputs:
+      - { type: linear.reply, max: 1, required: true }
+```
+
+The project filter is the autonomous trust boundary; narrow it further with states, labels,
+excluded labels, and assignees. The trigger grants no repository credential. Only the `github`
+block on `implement` authorizes GitHub access, and only that step can emit `linear.reply`.

--- a/public-docs/hub/triggers/linear.md
+++ b/public-docs/hub/triggers/linear.md
@@ -10,20 +10,20 @@ category: Hub
 
 Connect a workspace through [Linear for Hub](/docs/hub/self-hosting/linear-app), then use its
 stable Linear IDs to scope each workflow. Display names are not accepted for projects, states,
-labels, assignees, or users.
+teams, labels, assignees, or users.
 
 ## Choose the event
 
-| `on`                         | Fires when                                                                 |
-| ---------------------------- | -------------------------------------------------------------------------- |
-| `linear.issue_entered_scope` | An issue is created in, or transitions into, the configured project scope. |
-| `linear.issue_assigned`      | An issue's assignee changes to a user.                                     |
-| `linear.comment_created`     | A comment is created on an issue.                                          |
-| `linear.agent_session`       | A native agent session is created or receives another prompt.              |
+| `on`                         | Fires when                                                                         |
+| ---------------------------- | ---------------------------------------------------------------------------------- |
+| `linear.issue_entered_scope` | An issue is created in, or transitions into, the configured project or team scope. |
+| `linear.issue_assigned`      | An issue's assignee changes to a user.                                             |
+| `linear.comment_created`     | A comment is created on an issue.                                                  |
+| `linear.agent_session`       | A native agent session is created or receives another prompt.                      |
 
 `linear.issue_entered_scope` is the intentionally autonomous event. It requires `filters.project`
-and fires only on the edge into the complete configured scope. Editing the title or description of
-an issue already in scope does not start another run.
+or `filters.team` and fires only on the edge into the complete configured scope. Editing the title
+or description of an issue already in scope does not start another run.
 
 `linear.issue_assigned`, `linear.comment_created`, and `linear.agent_session` are reactive. They
 require a non-empty `filters.from_users` list containing the Linear IDs of actors allowed to start
@@ -33,17 +33,19 @@ the workflow.
 
 All supplied filters compose with AND.
 
-| Filter           | Meaning                                                                    |
-| ---------------- | -------------------------------------------------------------------------- |
-| `connection`     | Linear connection slug.                                                    |
-| `project`        | Linear project ID; required for `linear.issue_entered_scope`.              |
-| `states`         | The issue's current workflow-state ID must be in the list.                 |
-| `labels`         | The issue must currently have every listed Linear label ID.                |
-| `exclude_labels` | The issue must have none of the listed Linear label IDs.                   |
-| `assignees`      | The issue's resulting assignee ID must be in the list.                     |
-| `from_users`     | Actor IDs allowed to assign, comment, or prompt a session.                 |
-| `pattern`        | For comments or sessions, text that must start the direct user message.    |
-| `contains`       | For comments or sessions, text that must occur in the direct user message. |
+| Filter           | Meaning                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| `connection`     | Linear connection slug.                                                                |
+| `project`        | Linear project ID; either this or `team` is required for `linear.issue_entered_scope`. |
+| `team`           | Linear team ID; useful when issues are not assigned to Linear projects.                |
+| `states`         | The issue's current workflow-state ID must be in the list.                             |
+| `labels`         | The issue must currently have every listed Linear label ID.                            |
+| `exclude_labels` | The issue must have none of the listed Linear label IDs.                               |
+| `assignees`      | The issue's resulting assignee ID must be in the list.                                 |
+| `from_users`     | Actor IDs allowed to assign, comment, or prompt a session.                             |
+| `pattern`        | For comments or sessions, text that must start the direct user message.                |
+| `contains`       | For comments or sessions, text that must occur in the direct user message.             |
+| `replies_only`   | For comments, `true` restricts the trigger to replies.                                 |
 
 `from_users` identifies the person who performed the assignment, wrote the comment, or prompted
 the agent session.
@@ -139,9 +141,13 @@ For a Linear comment, `${{ paseo.prompt }}` preserves the complete original comm
 prompt. `linear.reply` posts to the triggering issue through the connected Linear application.
 
 Authoring `${{ paseo.context }}` opts the step into Linear context. It includes the organization,
-actor, issue, triggering comment, and a bounded chronological thread: the issue title and
-description followed by up to 49 comments strictly before the trigger. If optional history cannot
-be loaded, the context marks the thread unavailable and still includes the issue root.
+actor, structured issue project and team, triggering comment, and a bounded chronological thread:
+the issue title and description followed by up to 49 comments strictly before the trigger. A reply
+also exposes its parent as `linear.comment.parent_id`. If optional history cannot be loaded, the
+context marks the thread unavailable and still includes the issue root.
+
+Use a second `linear.comment_created` trigger with `replies_only: true` and no text marker when an
+allowlisted user should be able to continue by replying without mentioning the app again.
 
 ## Start a first-draft PR when an issue enters scope
 
@@ -222,6 +228,8 @@ steps:
       - { type: linear.reply, max: 1, required: true }
 ```
 
-The project filter is the autonomous trust boundary; narrow it further with states, labels,
-excluded labels, and assignees. The trigger grants no repository credential. Only the `github`
-block on `implement` authorizes GitHub access, and only that step can emit `linear.reply`.
+The project filter is the autonomous trust boundary in this example. Use `team` instead when a
+team maps to the repository and issues may have no Linear project. Narrow either route further with
+states, labels, excluded labels, and assignees. The trigger grants no repository credential. Only
+the `github` block on `implement` authorizes GitHub access, and only that step can emit
+`linear.reply`.

--- a/public-docs/hub/triggers/linear.md
+++ b/public-docs/hub/triggers/linear.md
@@ -1,6 +1,6 @@
 ---
 title: Linear triggers
-description: Start reactive or autonomous Hub workflows from Linear issues and comments.
+description: Start reactive, autonomous, or native agent-session Hub workflows from Linear.
 nav: Linear
 order: 70
 category: Hub
@@ -19,32 +19,84 @@ labels, assignees, or users.
 | `linear.issue_entered_scope` | An issue is created in, or transitions into, the configured project scope. |
 | `linear.issue_assigned`      | An issue's assignee changes to a user.                                     |
 | `linear.comment_created`     | A comment is created on an issue.                                          |
+| `linear.agent_session`       | A native agent session is created or receives another prompt.              |
 
 `linear.issue_entered_scope` is the intentionally autonomous event. It requires `filters.project`
 and fires only on the edge into the complete configured scope. Editing the title or description of
 an issue already in scope does not start another run.
 
-`linear.issue_assigned` and `linear.comment_created` are reactive. Both require a non-empty
-`filters.from_users` list containing the Linear IDs of actors allowed to start the workflow.
+`linear.issue_assigned`, `linear.comment_created`, and `linear.agent_session` are reactive. They
+require a non-empty `filters.from_users` list containing the Linear IDs of actors allowed to start
+the workflow.
 
 ## Filter Linear events
 
 All supplied filters compose with AND.
 
-| Filter           | Meaning                                                                       |
-| ---------------- | ----------------------------------------------------------------------------- |
-| `connection`     | Linear connection slug.                                                       |
-| `project`        | Linear project ID; required for `linear.issue_entered_scope`.                 |
-| `states`         | The issue's current workflow-state ID must be in the list.                    |
-| `labels`         | The issue must currently have every listed Linear label ID.                   |
-| `exclude_labels` | The issue must have none of the listed Linear label IDs.                      |
-| `assignees`      | The issue's resulting assignee ID must be in the list.                        |
-| `from_users`     | Actor IDs allowed to assign or comment; required for the two reactive events. |
-| `pattern`        | For comments, text that must occur at the start of the original comment.      |
-| `contains`       | For comments, text that must occur somewhere in the original comment.         |
+| Filter           | Meaning                                                                    |
+| ---------------- | -------------------------------------------------------------------------- |
+| `connection`     | Linear connection slug.                                                    |
+| `project`        | Linear project ID; required for `linear.issue_entered_scope`.              |
+| `states`         | The issue's current workflow-state ID must be in the list.                 |
+| `labels`         | The issue must currently have every listed Linear label ID.                |
+| `exclude_labels` | The issue must have none of the listed Linear label IDs.                   |
+| `assignees`      | The issue's resulting assignee ID must be in the list.                     |
+| `from_users`     | Actor IDs allowed to assign, comment, or prompt a session.                 |
+| `pattern`        | For comments or sessions, text that must start the direct user message.    |
+| `contains`       | For comments or sessions, text that must occur in the direct user message. |
 
-`from_users` identifies the person who performed the assignment or wrote the comment.
+`from_users` identifies the person who performed the assignment, wrote the comment, or prompted
+the agent session.
 `assignees` identifies the issue's resulting assignee. They are different checks.
+
+## Act as a native Linear agent
+
+Enable **Agent session events** when you [create the Linear app](/docs/hub/self-hosting/linear-app).
+Mentioning the app or delegating an issue creates a session; another message on that session sends
+a `prompted` event and starts another workflow run.
+
+`.paseo/workflows/linear-agent.yml`:
+
+```yaml
+name: linear-agent
+on: linear.agent_session
+max_runtime: 1h
+filters:
+  connection: acme-linear
+  project: 00000000-0000-0000-0000-000000000000
+  from_users: [11111111-1111-1111-1111-111111111111]
+steps:
+  - id: respond
+    environment: dev
+    max_runtime: 45m
+    idle_timeout: 5m
+    agent: codex
+    prompt:
+      - text: |
+          Act on this Linear agent-session request. Reply with hub.reply, then call
+          hub.finish_execution.
+
+          <current-turn>
+          ${{ paseo.prompt }}
+          </current-turn>
+
+          <linear-context>
+          ${{ paseo.context }}
+          </linear-context>
+    allow_outputs:
+      - { type: linear.reply, max: 1, required: true }
+```
+
+For a new session, `${{ paseo.prompt }}` is Linear's canonical `promptContext`, including its
+issue, relevant comments, and guidance. For a follow-up it is the new prompt activity's original
+body. `${{ paseo.context }}` exposes the session and issue; on follow-ups its chronological thread
+contains the issue root and up to 49 activities strictly before the triggering prompt. Optional
+history failure does not fail the run.
+
+Hub emits an ephemeral `thought` when it accepts the session. `linear.reply` becomes a native
+`response` activity, which completes the session, while a failed workflow emits an `error`
+activity. The example marks `linear.reply` as required so a successful run cannot finish without
+completing the session.
 
 ## Respond to a command comment
 

--- a/public-docs/hub/triggers/linear.md
+++ b/public-docs/hub/triggers/linear.md
@@ -135,7 +135,8 @@ steps:
       - text: |
           Assess this Linear issue for a safe, self-contained first-draft PR. Set eligible
           to true only when the change is clear, bounded, testable, and requires no product
-          or security decision.
+          or security decision. Then call hub.finish_execution with an output object containing
+          that eligible decision; do not return it only as prose.
 
           ${{ paseo.context }}
     output:

--- a/public-docs/hub/workflows.md
+++ b/public-docs/hub/workflows.md
@@ -39,7 +39,7 @@ steps:
       - { type: slack.reply, max: 1, required: true }
 ```
 
-Hub removes the mention and declared input headers before exposing the remaining text as `${{ paseo.prompt }}`. The reply capability is explicit beside the Slack trigger. Discord uses `discord.reply`; GitHub uses a step-scoped [`github` block](/docs/hub/github), not `hub.reply`.
+Hub removes the mention and declared input headers before exposing the remaining text as `${{ paseo.prompt }}`. The reply capability is explicit beside the Slack trigger. Discord uses `discord.reply`; Linear uses `linear.reply`; GitHub uses a step-scoped [`github` block](/docs/hub/github), not `hub.reply`.
 
 ## Choose where a step runs
 
@@ -240,7 +240,7 @@ allow_outputs:
     required: true
 ```
 
-`max` defaults to `1`. `required: true` prevents successful completion until the capability has been emitted. Keep Slack and Discord reply types in their own provider workflow files.
+`max` defaults to `1`. `required: true` prevents successful completion until the capability has been emitted. Keep Linear, Slack, and Discord reply types in their own provider workflow files.
 
 ## Deadlines
 


### PR DESCRIPTION
## Summary

- add a Linear application setup guide for OAuth, signed webhooks, required scopes, and workspace connections
- document comment, assignment, project-scope, team-scope, and native Agent Session triggers
- provide complete command-comment, Agent Session, and guarded first-draft PR workflows
- document bounded causal context, native Agent Session activities, security boundaries, activity reporting, and self-hosting requirements

## Why

Hub PR #84 merged the proven core Linear trigger integration. This companion documentation covers the follow-up Linear capabilities: Agent Sessions, team routing, and reply behavior.

## User impact

Operators can connect a Linear app, route allowlisted reactive events or an explicitly project- or team-scoped autonomous workflow, participate in Linear native Agent Sessions, preserve bounded causal context, and grant GitHub authority only to the workflow step that needs it. The guide identifies Agent Sessions as a Linear Developer Preview capability and calls out the reauthorization required by the agent scopes.

## Validation

- git diff --check
- oxfmt --check public-docs/hub (23 files)
- Hub public-docs contract: all 42 YAML examples parsed; removed-authoring guards passed