### PR TITLE
fix(app): stop the model browser from using sheet scrollables outside a sheet

### DIFF
--- a/packages/app/src/components/model-browser-view.test.ts
+++ b/packages/app/src/components/model-browser-view.test.ts
@@ -4,10 +4,11 @@ import type {
   ProviderSelectorProvider,
 } from "@/provider-selection/provider-selection";
 import {
+  clampModelBrowserScrolling,
   resolveInitialModelBrowserView,
   resolveModelBrowserAllView,
-  groupProfilesByProviderModel,
   resolveModelBrowserScrolling,
+  groupProfilesByProviderModel,
 } from "./model-browser-view";
 
 function provider(
@@ -232,5 +233,19 @@ describe("model browser all view", () => {
         isSearchFocused: true,
       }),
     ).toEqual({ kind: "noSearchMatches" });
+  });
+});
+
+describe("clampModelBrowserScrolling", () => {
+  it("keeps sheet scrolling inside a bottom sheet", () => {
+    expect(clampModelBrowserScrolling("sheet", true)).toBe("sheet");
+  });
+
+  it("falls back to independent scrolling outside a bottom sheet", () => {
+    expect(clampModelBrowserScrolling("sheet", false)).toBe("independent");
+  });
+
+  it("never promotes an independent list to a sheet scrollable", () => {
+    expect(clampModelBrowserScrolling("independent", true)).toBe("independent");
   });
 });

--- a/packages/app/src/components/model-browser-view.ts
+++ b/packages/app/src/components/model-browser-view.ts
@@ -109,3 +109,17 @@ export function resolveInitialModelBrowserView({
 
   return { kind: "all" };
 }
+
+export type ModelBrowserScrolling = "sheet" | "independent";
+
+/**
+ * Sheet scrolling only holds where a sheet actually is: gorhom's scrollables read the sheet's
+ * context and throw without it. Callers pick `scrolling` from platform or form factor, which is a
+ * different question from whether this particular render sits inside a sheet.
+ */
+export function clampModelBrowserScrolling(
+  requested: ModelBrowserScrolling,
+  insideBottomSheet: boolean,
+): ModelBrowserScrolling {
+  return requested === "sheet" && !insideBottomSheet ? "independent" : requested;
+}

--- a/packages/app/src/components/model-browser.tsx
+++ b/packages/app/src/components/model-browser.tsx
@@ -56,8 +56,10 @@ import {
   groupProfilesByProviderModel,
   resolveInitialModelBrowserView,
   resolveModelBrowserAllView,
+  clampModelBrowserScrolling,
   type ModelBrowserView,
 } from "@/components/model-browser-view";
+import { useIsInsideBottomSheet } from "@/components/ui/text-input/bottom-sheet-scope";
 
 const DESKTOP_PROVIDER_VIEW_MIN_HEIGHT = 220;
 const DESKTOP_PROVIDER_VIEW_MAX_HEIGHT = 400;
@@ -1485,6 +1487,7 @@ export function ModelBrowser({
   rootBrowseContent,
   showProfilesSection,
 }: ModelBrowserProps) {
+  const insideBottomSheet = useIsInsideBottomSheet();
   return (
     <ModelBrowserContent
       view={state.view}
@@ -1502,7 +1505,7 @@ export function ModelBrowser({
       onDrillDown={state.drillDown}
       onRetryProvider={onRetryProvider}
       isRetryingProvider={isRetryingProvider}
-      scrolling={scrolling}
+      scrolling={clampModelBrowserScrolling(scrolling, insideBottomSheet)}
       searchAllOnFocus={searchAllOnFocus}
       rootBrowseContent={rootBrowseContent}
       showProfilesSection={showProfilesSection}

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -34,6 +34,7 @@ import {
   BottomSheetBackgroundProps,
 } from "@gorhom/bottom-sheet";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { Check, File, Folder, Search } from "lucide-react-native";
 import {
   flip,
@@ -1266,7 +1267,12 @@ function DesktopComboboxBody(props: DesktopBodyProps): ReactElement {
       visible={props.isOpen}
       onRequestClose={props.handleClose}
     >
-      {overlay}
+      {/*
+       * Modal children mount into a separate native view hierarchy, outside the
+       * app's root GestureHandlerRootView. Gesture handlers inside need their own
+       * root or they never receive touches.
+       */}
+      <GestureHandlerRootView style={styles.modalGestureRoot}>{overlay}</GestureHandlerRootView>
     </Modal>
   );
 }
@@ -1647,6 +1653,9 @@ export function Combobox({
 }
 
 const styles = StyleSheet.create((theme) => ({
+  modalGestureRoot: {
+    flex: 1,
+  },
   mobileSheetFrame: {
     flex: 1,
     minHeight: 0,


### PR DESCRIPTION
## Problem

Opening the model picker on a non-compact native screen — a tablet, an unfolded foldable, or a phone in landscape — crashes the app to the error boundary with:

```
'useBottomSheetInternal' cannot be used out of the BottomSheet!
```

`CombinedModelSelector` picks the browser's scroll mode from the platform (`isWeb ? "independent" : "sheet"`), but `Combobox` only presents as a bottom sheet when the breakpoint is compact. Anywhere else it is a popover, so `ModelBrowser`'s `BottomSheetScrollView` renders with no sheet context to read and gorhom throws. (`BottomSheetScrollView` reaches `useBottomSheetInternal()` before its own friendlier `'Scrollable' cannot be used out of the BottomSheet!` check, which is why the message names the hook.)

Fixing only that leaves the picker rendering but inert on Android: the popover lives inside a plain RN `Modal`, whose children mount into a separate native view hierarchy outside the app's root `GestureHandlerRootView`. Gesture handlers there never receive touches, and `ModelBrowser`'s independent-scrolling rows are `GestureDetector` taps with no `Pressable` fallback — so every press in the picker silently does nothing.

## Fix

Two commits:

1. Resolve the scrolling mode from the render scope, the way #3942 made text inputs do it: a `"sheet"` request holds only where a sheet actually is, and degrades to `"independent"` — exactly what web already uses for the popover — anywhere else. The mapping is one-directional, so a caller asking for `"independent"` inside a sheet is left alone. `resolveModelBrowserScrolling` is pure and unit tested; `ModelBrowser` reads the existing `useIsInsideBottomSheet()` scope.
2. Wrap the `Combobox` popover modal's content in its own `GestureHandlerRootView`, the same repair `AdaptiveModalSheet` already carries for its own modal path, so those rows are pressable.

## Test plan

- `npx vitest run src/components/model-browser-view.test.ts` (17 passed)
- `npm run typecheck` (all workspaces)
- `oxlint` / `oxfmt --check` on the touched files
- Android phone: model picker opens as a popover, rows scroll and respond to taps
