### PR TITLE
feat(server): add durable watchdog jobs

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -54,6 +54,14 @@ $PASEO_HOME/
 │       └── {agentId}.json               # One file per agent
 ├── schedules/
 │   └── {scheduleId}.json                # One file per schedule
+├── watchdogs/
+│   ├── {jobId}.json                     # One file per durable command job
+│   ├── cancellations/{jobId}.json       # Pending cancellation requests
+│   ├── logs/{jobId}.stdout.log          # Captured stdout (bounded)
+│   ├── logs/{jobId}.stderr.log          # Captured stderr (bounded)
+│   ├── results/{jobId}.json             # Worker result payload
+│   ├── requests/{jobId}.json            # Launch request snapshot
+│   └── locks/{jobId}.lock               # Worker ownership lock
 ├── projects/
 │   ├── projects.json                    # Project registry
 │   ├── workspaces.json                  # Workspace registry
@@ -386,6 +394,35 @@ One file per schedule. ID is 8 hex characters.
 | `agentId`      | `string?` (UUID)                       | Agent used for this run |
 | `output`       | `string?`                              | Agent output text       |
 | `error`        | `string?`                              | Error message if failed |
+
+---
+
+## Watchdog Jobs
+
+**Path:** `$PASEO_HOME/watchdogs/{id}.json`
+
+One file per durable background command. Job IDs match `[a-zA-Z0-9_-]+`. Related artifacts live under sibling subdirectories (`logs/`, `results/`, `cancellations/`, `requests/`, `locks/`).
+
+| Field               | Type                                                                                             | Description                                   |
+| ------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| `id`                | `string`                                                                                         | Job ID                                        |
+| `name`              | `string`                                                                                         | Human-readable label                          |
+| `agentId`           | `string`                                                                                         | Agent to notify on completion                 |
+| `workspaceId`       | `string`                                                                                         | Owning workspace                              |
+| `cwd`               | `string`                                                                                         | Working directory for the command             |
+| `command`           | `string`                                                                                         | Executable (no shell)                         |
+| `args`              | `string[]`                                                                                       | Command arguments                             |
+| `status`            | `"queued" \| "running" \| "cancelling" \| "completed" \| "failed" \| "cancelled" \| "timed_out"` | Execution state                               |
+| `deliveryStatus`    | `"pending" \| "delivered"`                                                                       | Whether completion was delivered to the agent |
+| `workerPid`         | `number \| null`                                                                                 | Detached worker PID while running             |
+| `result`            | `WatchdogResult \| null`                                                                         | Exit metadata once terminal                   |
+| `timeoutMs`         | `number \| null`                                                                                 | Optional timeout                              |
+| `cancelRequestedAt` | `string \| null` (ISO 8601)                                                                      | When cancellation was requested               |
+| `createdAt`         | `string` (ISO 8601)                                                                              |                                               |
+| `updatedAt`         | `string` (ISO 8601)                                                                              |                                               |
+| `deliveredAt`       | `string \| null` (ISO 8601)                                                                      | When completion was delivered                 |
+
+Job records and cancellation requests are written with mode `0600`. Captured stdout/stderr are bounded (8 MiB each by default); result records may include optional `stdout`/`stderr` `{ bytes, truncated }` metadata. Only a `queued` record with no `locks/{jobId}.lock` may launch on reconcile. If that lock already exists but no result or `workerPid` was persisted (crash after the worker took the fence, before the daemon wrote running state), reconciliation reads the lock metadata: a live lock PID is adopted into the job as `running` with that `workerPid` and left to finish (no relaunch, no failure notification); a dead or corrupt lock with no result marks the job failed for operator inspection and does not start another worker or command. Invalid lock files are quarantined with a `.corrupt-{timestamp}` suffix. If a worker PID disappears without a result file, reconciliation marks the job failed rather than relaunching. Delivered jobs older than the retention window (default 30 days) are pruned together with their logs, results, requests, locks, and cancellation files. Invalid job files are quarantined with a `.corrupt-{timestamp}` suffix.
 
 ---
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,6 +12,7 @@ import { createTerminalCommand } from "./commands/terminal/index.js";
 import { createWorktreeCommand } from "./commands/worktree/index.js";
 import { createWorkspaceCommand } from "./commands/workspace/index.js";
 import { createHeartbeatCommand } from "./commands/heartbeat/index.js";
+import { createWatchdogCommand } from "./commands/watchdog/index.js";
 import { createHubCommand } from "./commands/hub/index.js";
 import { createHooksCommand } from "./commands/hooks.js";
 import { startCommand as daemonStartCommand } from "./commands/daemon/start.js";
@@ -183,6 +184,7 @@ export function createCli(): Command {
   // Schedule commands
   program.addCommand(createScheduleCommand());
   program.addCommand(createHeartbeatCommand());
+  program.addCommand(createWatchdogCommand());
 
   // Permission commands
   program.addCommand(createPermitCommand());

--- a/packages/cli/src/commands/watchdog/index.ts
+++ b/packages/cli/src/commands/watchdog/index.ts
@@ -1,0 +1,213 @@
+import type { WatchdogJob } from "@getpaseo/protocol/watchdog/types";
+import { Command } from "commander";
+
+import type {
+  CommandError,
+  CommandOptions,
+  ListResult,
+  OutputSchema,
+  SingleResult,
+} from "../../output/index.js";
+import { withOutput } from "../../output/index.js";
+import { addJsonAndDaemonHostOptions } from "../../utils/command-options.js";
+import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
+import { parseDuration } from "../../utils/duration.js";
+
+interface WatchdogOptions extends CommandOptions {
+  host?: string;
+  agent?: string;
+  workspace?: string;
+  cwd?: string;
+  name?: string;
+  timeout?: string;
+}
+
+type ConnectedClient = Awaited<ReturnType<typeof connectToDaemon>>;
+
+interface WatchdogRow {
+  id: string;
+  name: string;
+  status: string;
+  delivery: string;
+  agent: string;
+  exitCode: number | null;
+  updatedAt: string;
+}
+
+const watchdogSchema: OutputSchema<WatchdogRow> = {
+  idField: "id",
+  columns: [
+    { header: "ID", field: "id", width: 12 },
+    { header: "NAME", field: "name", width: 24 },
+    { header: "STATUS", field: "status", width: 12 },
+    { header: "DELIVERY", field: "delivery", width: 10 },
+    { header: "AGENT", field: "agent", width: 12 },
+    { header: "EXIT", field: "exitCode", width: 6 },
+    { header: "UPDATED", field: "updatedAt", width: 24 },
+  ],
+};
+
+export function createWatchdogCommand(): Command {
+  const watchdog = new Command("watchdog").description("Manage durable background commands");
+
+  addJsonAndDaemonHostOptions(
+    watchdog
+      .command("start")
+      .description("Start a durable background command")
+      .argument("<command>", "Executable to run directly (without a shell)")
+      .argument("[args...]", "Arguments passed to the executable")
+      .option("--name <name>", "Human-readable job name")
+      .option("--agent <id>", "Agent to notify (defaults to PASEO_AGENT_ID)")
+      .option("--workspace <id>", "Workspace owner (defaults to PASEO_WORKSPACE_ID)")
+      .option("--cwd <path>", "Working directory (defaults to current directory locally)")
+      .option("--timeout <duration>", "Terminate after a duration such as 30m or 2h"),
+  ).action(withOutput(runStart));
+
+  addJsonAndDaemonHostOptions(
+    watchdog
+      .command("ls")
+      .description("List durable background commands")
+      .option("--agent <id>", "Filter by agent id"),
+  ).action(withOutput(runList));
+
+  addJsonAndDaemonHostOptions(
+    watchdog.command("inspect").description("Inspect a durable command").argument("<id>", "Job ID"),
+  ).action(withOutput(runInspect));
+
+  addJsonAndDaemonHostOptions(
+    watchdog.command("cancel").description("Cancel a durable command").argument("<id>", "Job ID"),
+  ).action(withOutput(runCancel));
+
+  return watchdog;
+}
+
+async function runStart(
+  executable: string,
+  args: string[],
+  options: WatchdogOptions,
+  _command: Command,
+): Promise<SingleResult<WatchdogRow>> {
+  const { agentId, workspaceId, cwd } = resolveStartTarget(options);
+  const timeoutMs = options.timeout ? parseDuration(options.timeout) : undefined;
+  const client = await connect(options.host);
+  try {
+    const payload = await client.watchdogStart({
+      name: options.name?.trim() || executable,
+      agentId,
+      workspaceId,
+      cwd,
+      command: executable,
+      args,
+      ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    });
+    if (payload.error || !payload.job) throw new Error(payload.error ?? "Watchdog start failed");
+    return single(payload.job);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+async function runList(
+  options: WatchdogOptions,
+  _command: Command,
+): Promise<ListResult<WatchdogRow>> {
+  const client = await connect(options.host);
+  try {
+    const agentId = options.agent?.trim();
+    const payload = await client.watchdogList(agentId ? { agentId } : {});
+    if (payload.error) throw new Error(payload.error);
+    return { type: "list", data: payload.jobs.map(toRow), schema: watchdogSchema };
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+async function runInspect(
+  id: string,
+  options: WatchdogOptions,
+  _command: Command,
+): Promise<SingleResult<WatchdogRow>> {
+  const client = await connect(options.host);
+  try {
+    const payload = await client.watchdogInspect({ id });
+    if (payload.error || !payload.job)
+      throw new Error(payload.error ?? `Watchdog not found: ${id}`);
+    return single(payload.job);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+async function runCancel(
+  id: string,
+  options: WatchdogOptions,
+  _command: Command,
+): Promise<SingleResult<WatchdogRow>> {
+  const client = await connect(options.host);
+  try {
+    const payload = await client.watchdogCancel({ id });
+    if (payload.error || !payload.job)
+      throw new Error(payload.error ?? `Watchdog not found: ${id}`);
+    return single(payload.job);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+async function connect(host: string | undefined): Promise<ConnectedClient> {
+  try {
+    const client = await connectToDaemon({ host });
+    // COMPAT(durableCommands): added in v0.6.1, remove gate after 2027-02-26.
+    if (client.getLastServerInfoMessage()?.features?.durableCommands !== true) {
+      await client.close().catch(() => {});
+      throw commandError("DAEMON_UPDATE_REQUIRED", "Update the host to use durable commands.");
+    }
+    return client;
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && "message" in error) {
+      throw error;
+    }
+    throw commandError(
+      "DAEMON_NOT_RUNNING",
+      `Cannot connect to daemon at ${getDaemonHost({ host })}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function single(job: WatchdogJob): SingleResult<WatchdogRow> {
+  return { type: "single", data: toRow(job), schema: { ...watchdogSchema, serialize: () => job } };
+}
+
+function toRow(job: WatchdogJob): WatchdogRow {
+  return {
+    id: job.id,
+    name: job.name,
+    status: job.status,
+    delivery: job.deliveryStatus,
+    agent: job.agentId,
+    exitCode: job.result?.exitCode ?? null,
+    updatedAt: job.updatedAt,
+  };
+}
+
+function commandError(code: string, message: string): CommandError {
+  return { code, message };
+}
+
+function resolveStartTarget(options: WatchdogOptions): {
+  agentId: string;
+  workspaceId: string;
+  cwd: string;
+} {
+  const agentId = options.agent?.trim() || process.env.PASEO_AGENT_ID?.trim();
+  const workspaceId = options.workspace?.trim() || process.env.PASEO_WORKSPACE_ID?.trim();
+  const cwd = options.cwd?.trim();
+  if (!agentId) throw commandError("WATCHDOG_AGENT_REQUIRED", "Provide --agent or PASEO_AGENT_ID");
+  if (!workspaceId) {
+    throw commandError("WATCHDOG_WORKSPACE_REQUIRED", "Provide --workspace or PASEO_WORKSPACE_ID");
+  }
+  if (options.host !== undefined && !cwd) {
+    throw commandError("WATCHDOG_CWD_REQUIRED", "--cwd is required when --host is specified");
+  }
+  return { agentId, workspaceId, cwd: cwd || process.cwd() };
+}

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -540,6 +540,22 @@ type ScheduleUpdatePayload = Extract<
   SessionOutboundMessage,
   { type: "schedule/update/response" }
 >["payload"];
+type WatchdogStartPayload = Extract<
+  SessionOutboundMessage,
+  { type: "watchdog.start.response" }
+>["payload"];
+type WatchdogListPayload = Extract<
+  SessionOutboundMessage,
+  { type: "watchdog.list.response" }
+>["payload"];
+type WatchdogInspectPayload = Extract<
+  SessionOutboundMessage,
+  { type: "watchdog.inspect.response" }
+>["payload"];
+type WatchdogCancelPayload = Extract<
+  SessionOutboundMessage,
+  { type: "watchdog.cancel.response" }
+>["payload"];
 export type FetchAgentTimelinePayload = FetchAgentTimelineResponseMessage["payload"];
 export type AgentForkContextPayload = AgentForkContextResponseMessage["payload"];
 
@@ -772,6 +788,24 @@ export interface UpdateScheduleOptions {
   newAgentConfig?: UpdateScheduleNewAgentConfig;
   maxRuns?: number | null;
   expiresAt?: string | null;
+  requestId?: string;
+}
+export interface StartWatchdogOptions {
+  name: string;
+  agentId: string;
+  workspaceId: string;
+  cwd: string;
+  command: string;
+  args?: string[];
+  timeoutMs?: number;
+  requestId?: string;
+}
+export interface ListWatchdogsOptions {
+  agentId?: string;
+  requestId?: string;
+}
+export interface WatchdogByIdOptions {
+  id: string;
   requestId?: string;
 }
 export interface RenameBranchInput {
@@ -5480,6 +5514,54 @@ export class DaemonClient {
     });
   }
 
+  async watchdogStart(options: StartWatchdogOptions): Promise<WatchdogStartPayload> {
+    this.requireDurableCommandsSupport();
+    return this.sendCorrelatedSessionRequest({
+      requestId: options.requestId,
+      message: {
+        type: "watchdog.start.request",
+        name: options.name,
+        agentId: options.agentId,
+        workspaceId: options.workspaceId,
+        cwd: options.cwd,
+        command: options.command,
+        args: options.args ?? [],
+        ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
+      },
+      responseType: "watchdog.start.response",
+    });
+  }
+
+  async watchdogList(options: ListWatchdogsOptions = {}): Promise<WatchdogListPayload> {
+    this.requireDurableCommandsSupport();
+    return this.sendCorrelatedSessionRequest({
+      requestId: options.requestId,
+      message: {
+        type: "watchdog.list.request",
+        ...(options.agentId === undefined ? {} : { agentId: options.agentId }),
+      },
+      responseType: "watchdog.list.response",
+    });
+  }
+
+  async watchdogInspect(options: WatchdogByIdOptions): Promise<WatchdogInspectPayload> {
+    this.requireDurableCommandsSupport();
+    return this.sendCorrelatedSessionRequest({
+      requestId: options.requestId,
+      message: { type: "watchdog.inspect.request", jobId: options.id },
+      responseType: "watchdog.inspect.response",
+    });
+  }
+
+  async watchdogCancel(options: WatchdogByIdOptions): Promise<WatchdogCancelPayload> {
+    this.requireDurableCommandsSupport();
+    return this.sendCorrelatedSessionRequest({
+      requestId: options.requestId,
+      message: { type: "watchdog.cancel.request", jobId: options.id },
+      responseType: "watchdog.cancel.response",
+    });
+  }
+
   onTerminalStreamEvent(handler: (event: TerminalStreamEvent) => void): () => void {
     return this.terminalStreams.onEvent(handler);
   }
@@ -5528,6 +5610,13 @@ export class DaemonClient {
     // COMPAT(daemonConfigReload): added in v0.4.0, remove gate after 2027-02-14.
     if (this.lastServerInfoMessage?.features?.daemonConfigReload !== true) {
       throw new Error("Update the host to reload daemon configuration.");
+    }
+  }
+
+  private requireDurableCommandsSupport(): void {
+    // COMPAT(durableCommands): added in v0.6.1, remove gate after 2027-02-26.
+    if (this.lastServerInfoMessage?.features?.durableCommands !== true) {
+      throw new Error("Update the host to use durable commands.");
     }
   }
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -43,6 +43,16 @@ import {
   ScheduleUpdateResponseSchema,
 } from "./schedule/rpc-schemas.js";
 import {
+  WatchdogStartRequestSchema,
+  WatchdogListRequestSchema,
+  WatchdogInspectRequestSchema,
+  WatchdogCancelRequestSchema,
+  WatchdogStartResponseSchema,
+  WatchdogListResponseSchema,
+  WatchdogInspectResponseSchema,
+  WatchdogCancelResponseSchema,
+} from "./watchdog/rpc-schemas.js";
+import {
   LoopRunRequestSchema,
   LoopListRequestSchema,
   LoopInspectRequestSchema,
@@ -3136,6 +3146,10 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   ScheduleDeleteRequestSchema,
   ScheduleRunOnceRequestSchema,
   ScheduleUpdateRequestSchema,
+  WatchdogStartRequestSchema,
+  WatchdogListRequestSchema,
+  WatchdogInspectRequestSchema,
+  WatchdogCancelRequestSchema,
   LoopRunRequestSchema,
   LoopListRequestSchema,
   LoopInspectRequestSchema,
@@ -3338,6 +3352,8 @@ export const ServerInfoStatusPayloadSchema = z
         daemonStatusRpc: z.boolean().optional(),
         // COMPAT(daemonConfigReload): added in v0.4.0, remove gate after 2027-02-14.
         daemonConfigReload: z.boolean().optional(),
+        // COMPAT(durableCommands): added in v0.6.1, remove gate after 2027-02-26.
+        durableCommands: z.boolean().optional(),
         // COMPAT(relayConfig): added in v0.2.6, remove gate after 2027-01-31.
         relayConfig: z.boolean().optional(),
         // COMPAT(pushTokenRevocation): added in v0.3.2, remove gate after 2027-02-10.
@@ -6400,6 +6416,10 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   ScheduleDeleteResponseSchema,
   ScheduleRunOnceResponseSchema,
   ScheduleUpdateResponseSchema,
+  WatchdogStartResponseSchema,
+  WatchdogListResponseSchema,
+  WatchdogInspectResponseSchema,
+  WatchdogCancelResponseSchema,
   LoopRunResponseSchema,
   LoopListResponseSchema,
   LoopInspectResponseSchema,
@@ -6573,6 +6593,10 @@ export type ScheduleResumeResponse = z.infer<typeof ScheduleResumeResponseSchema
 export type ScheduleDeleteResponse = z.infer<typeof ScheduleDeleteResponseSchema>;
 export type ScheduleRunOnceResponse = z.infer<typeof ScheduleRunOnceResponseSchema>;
 export type ScheduleUpdateResponse = z.infer<typeof ScheduleUpdateResponseSchema>;
+export type WatchdogStartResponse = z.infer<typeof WatchdogStartResponseSchema>;
+export type WatchdogListResponse = z.infer<typeof WatchdogListResponseSchema>;
+export type WatchdogInspectResponse = z.infer<typeof WatchdogInspectResponseSchema>;
+export type WatchdogCancelResponse = z.infer<typeof WatchdogCancelResponseSchema>;
 export type LoopRunResponse = z.infer<typeof LoopRunResponseSchema>;
 export type LoopListResponse = z.infer<typeof LoopListResponseSchema>;
 export type LoopInspectResponse = z.infer<typeof LoopInspectResponseSchema>;
@@ -6641,6 +6665,10 @@ export type ScheduleResumeRequest = z.infer<typeof ScheduleResumeRequestSchema>;
 export type ScheduleDeleteRequest = z.infer<typeof ScheduleDeleteRequestSchema>;
 export type ScheduleRunOnceRequest = z.infer<typeof ScheduleRunOnceRequestSchema>;
 export type ScheduleUpdateRequest = z.infer<typeof ScheduleUpdateRequestSchema>;
+export type WatchdogStartRequest = z.infer<typeof WatchdogStartRequestSchema>;
+export type WatchdogListRequest = z.infer<typeof WatchdogListRequestSchema>;
+export type WatchdogInspectRequest = z.infer<typeof WatchdogInspectRequestSchema>;
+export type WatchdogCancelRequest = z.infer<typeof WatchdogCancelRequestSchema>;
 export type LoopRunRequest = z.infer<typeof LoopRunRequestSchema>;
 export type LoopListRequest = z.infer<typeof LoopListRequestSchema>;
 export type LoopInspectRequest = z.infer<typeof LoopInspectRequestSchema>;

--- a/packages/protocol/src/watchdog/rpc-schemas.test.ts
+++ b/packages/protocol/src/watchdog/rpc-schemas.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  WatchdogCancelRequestSchema,
+  WatchdogInspectResponseSchema,
+  WatchdogStartRequestSchema,
+} from "./rpc-schemas.js";
+
+describe("watchdog RPC schemas", () => {
+  test("accepts a durable command request with timeout", () => {
+    expect(
+      WatchdogStartRequestSchema.parse({
+        type: "watchdog.start.request",
+        requestId: "request-1",
+        name: "vision tests",
+        agentId: "agent-1",
+        workspaceId: "workspace-1",
+        cwd: "/workspace",
+        command: "npm",
+        args: ["test"],
+        timeoutMs: 60_000,
+      }),
+    ).toMatchObject({ command: "npm", timeoutMs: 60_000 });
+  });
+
+  test("leaves omitted args undefined for post-validation normalization", () => {
+    expect(
+      WatchdogStartRequestSchema.parse({
+        type: "watchdog.start.request",
+        requestId: "request-1",
+        name: "vision tests",
+        agentId: "agent-1",
+        workspaceId: "workspace-1",
+        cwd: "/workspace",
+        command: "npm",
+      }).args,
+    ).toBeUndefined();
+  });
+
+  test("rejects invalid cancellation ids", () => {
+    expect(() =>
+      WatchdogCancelRequestSchema.parse({
+        type: "watchdog.cancel.request",
+        requestId: "request-1",
+        jobId: "../outside",
+      }),
+    ).toThrow();
+  });
+
+  test("represents delivery separately from command status", () => {
+    expect(
+      WatchdogInspectResponseSchema.parse({
+        type: "watchdog.inspect.response",
+        payload: {
+          requestId: "request-1",
+          error: null,
+          job: {
+            id: "watchdog-1",
+            name: "vision tests",
+            agentId: "agent-1",
+            workspaceId: "workspace-1",
+            cwd: "/workspace",
+            command: "npm",
+            args: ["test"],
+            status: "completed",
+            deliveryStatus: "delivered",
+            workerPid: 4101,
+            result: {
+              exitCode: 0,
+              signal: null,
+              error: null,
+              finishedAt: "2026-08-19T00:05:00.000Z",
+              stdout: { bytes: 12, truncated: false },
+              stderr: { bytes: 0, truncated: false },
+            },
+            timeoutMs: null,
+            cancelRequestedAt: null,
+            createdAt: "2026-08-19T00:00:00.000Z",
+            updatedAt: "2026-08-19T00:05:00.000Z",
+            deliveredAt: "2026-08-19T00:05:00.000Z",
+          },
+        },
+      }).payload.job,
+    ).toMatchObject({ status: "completed", deliveryStatus: "delivered" });
+  });
+});

--- a/packages/protocol/src/watchdog/rpc-schemas.ts
+++ b/packages/protocol/src/watchdog/rpc-schemas.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+import { WatchdogJobIdSchema, WatchdogJobSchema } from "./types.js";
+
+export const WatchdogStartRequestSchema = z.object({
+  type: z.literal("watchdog.start.request"),
+  requestId: z.string(),
+  name: z.string().trim().min(1),
+  agentId: z.string().trim().min(1),
+  workspaceId: z.string().trim().min(1),
+  cwd: z.string().trim().min(1),
+  command: z.string().trim().min(1),
+  // Optional on the wire; normalize to [] after validation.
+  args: z.array(z.string()).optional(),
+  timeoutMs: z.number().int().positive().max(2_147_483_647).optional(),
+});
+
+export const WatchdogListRequestSchema = z.object({
+  type: z.literal("watchdog.list.request"),
+  requestId: z.string(),
+  agentId: z.string().trim().min(1).optional(),
+});
+
+export const WatchdogInspectRequestSchema = z.object({
+  type: z.literal("watchdog.inspect.request"),
+  requestId: z.string(),
+  jobId: WatchdogJobIdSchema,
+});
+
+export const WatchdogCancelRequestSchema = z.object({
+  type: z.literal("watchdog.cancel.request"),
+  requestId: z.string(),
+  jobId: WatchdogJobIdSchema,
+});
+
+export const WatchdogStartResponseSchema = z.object({
+  type: z.literal("watchdog.start.response"),
+  payload: z.object({
+    requestId: z.string(),
+    job: WatchdogJobSchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const WatchdogListResponseSchema = z.object({
+  type: z.literal("watchdog.list.response"),
+  payload: z.object({
+    requestId: z.string(),
+    jobs: z.array(WatchdogJobSchema),
+    error: z.string().nullable(),
+  }),
+});
+
+export const WatchdogInspectResponseSchema = z.object({
+  type: z.literal("watchdog.inspect.response"),
+  payload: z.object({
+    requestId: z.string(),
+    job: WatchdogJobSchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const WatchdogCancelResponseSchema = z.object({
+  type: z.literal("watchdog.cancel.response"),
+  payload: z.object({
+    requestId: z.string(),
+    job: WatchdogJobSchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});

--- a/packages/protocol/src/watchdog/types.ts
+++ b/packages/protocol/src/watchdog/types.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const WatchdogJobIdSchema = z.string().regex(/^[a-zA-Z0-9_-]+$/);
+export const WatchdogJobStatusSchema = z.enum([
+  "queued",
+  "running",
+  "cancelling",
+  "completed",
+  "failed",
+  "cancelled",
+  "timed_out",
+]);
+export const WatchdogDeliveryStatusSchema = z.enum(["pending", "delivered"]);
+export const WatchdogTerminationReasonSchema = z.enum(["cancelled", "timeout"]);
+
+export const WatchdogStreamStatsSchema = z.object({
+  bytes: z.number().int().nonnegative(),
+  truncated: z.boolean(),
+});
+
+export const WatchdogResultSchema = z.object({
+  exitCode: z.number().int().nullable(),
+  signal: z.string().nullable(),
+  error: z.string().nullable(),
+  finishedAt: z.string(),
+  terminationReason: WatchdogTerminationReasonSchema.optional(),
+  // Optional bounded-stream metadata. Older workers omit these fields.
+  stdout: WatchdogStreamStatsSchema.optional(),
+  stderr: WatchdogStreamStatsSchema.optional(),
+});
+
+export const WatchdogJobSchema = z.object({
+  id: WatchdogJobIdSchema,
+  name: z.string().min(1),
+  agentId: z.string().min(1),
+  workspaceId: z.string().min(1),
+  cwd: z.string().min(1),
+  command: z.string().min(1),
+  args: z.array(z.string()),
+  status: WatchdogJobStatusSchema,
+  deliveryStatus: WatchdogDeliveryStatusSchema,
+  workerPid: z.number().int().positive().nullable(),
+  result: WatchdogResultSchema.nullable(),
+  timeoutMs: z.number().int().positive().max(2_147_483_647).nullable(),
+  cancelRequestedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deliveredAt: z.string().nullable(),
+});
+
+export type WatchdogJob = z.infer<typeof WatchdogJobSchema>;
+export type WatchdogResult = z.infer<typeof WatchdogResultSchema>;
+export type WatchdogStreamStats = z.infer<typeof WatchdogStreamStatsSchema>;

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -198,6 +198,12 @@ export interface SendPromptToAgentParams {
    * schedule fires, notify-on-finish).
    */
   unarchive?: boolean;
+  /**
+   * Default true. Watchdog completion wakes pass false so a busy agent is not
+   * interrupted; callers that need non-interruptible delivery must also check
+   * busy/permission state before invoking this helper.
+   */
+  replaceRunning?: boolean;
   /** See {@link StartAgentRunOptions.clearPendingPermissions}. */
   clearPendingPermissions?: boolean;
   logger: Logger;
@@ -288,7 +294,7 @@ export async function sendPromptToAgent(
     : params.runOptions;
 
   return await startAgentRun(params.agentManager, params.agentId, params.prompt, params.logger, {
-    replaceRunning: true,
+    replaceRunning: params.replaceRunning ?? true,
     activeTurnBehavior: params.activeTurnBehavior,
     clearPendingPermissions: params.clearPendingPermissions,
     runOptions,

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -35,6 +35,7 @@ import type {
   UpdateScheduleInput,
 } from "@getpaseo/protocol/schedule/types";
 import type { ScheduleService } from "../schedule/service.js";
+import type { WatchdogService } from "../watchdog/service.js";
 import type { WorkspaceGitService } from "../workspace-git-service.js";
 import {
   createPaseoWorktree as createPaseoWorktreeService,
@@ -5830,5 +5831,174 @@ describe("agent snapshot MCP serialization", () => {
     expect(content).not.toContain("[User] u2");
     expect(content).not.toContain("second answer");
     expect(content).not.toContain("first answer");
+  });
+});
+
+describe("watchdog MCP tools", () => {
+  const logger = createTestLogger();
+
+  it("starts a durable job scoped to the caller's workspace", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    spies.agentManager.getAgent.mockReturnValue({
+      id: "parent-agent",
+      provider: "codex",
+      cwd: REPO_CWD,
+      workspaceId: "workspace-1",
+      lifecycle: "idle",
+      currentModeId: "build",
+      availableModes: [],
+      config: { title: "Parent agent" },
+    } as ManagedAgent);
+    const register = vi.fn(async (input) => ({
+      ...input,
+      id: "watchdog-1",
+      status: "running" as const,
+      deliveryStatus: "pending" as const,
+      workerPid: 4101,
+      result: null,
+      timeoutMs: input.timeoutMs ?? null,
+      cancelRequestedAt: null,
+      createdAt: "2026-08-19T00:00:00.000Z",
+      updatedAt: "2026-08-19T00:00:00.000Z",
+      deliveredAt: null,
+    }));
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      watchdogService: { register } as unknown as WatchdogService,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+
+    const result = await invokeToolWithParsedInput(registeredTool(server, "start_watchdog_job"), {
+      name: "vision tests",
+      command: "npm",
+      args: ["test"],
+      timeoutMs: 60_000,
+    });
+
+    expect(register).toHaveBeenCalledWith({
+      name: "vision tests",
+      command: "npm",
+      args: ["test"],
+      cwd: REPO_CWD,
+      agentId: "parent-agent",
+      workspaceId: "workspace-1",
+      timeoutMs: 60_000,
+    });
+    expect(result.structuredContent).toMatchObject({
+      id: "watchdog-1",
+      status: "running",
+      workerPid: 4101,
+    });
+  });
+
+  it("requires an agent-scoped session", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const register = vi.fn();
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      watchdogService: { register } as unknown as WatchdogService,
+      logger,
+    });
+
+    await expect(
+      registeredTool(server, "start_watchdog_job").handler({
+        name: "vision tests",
+        command: "npm",
+        args: ["test"],
+      }),
+    ).rejects.toThrow("start_watchdog_job requires an agent-scoped session");
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it("inspects only a watchdog job owned by the caller", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const inspect = vi.fn(async () => ({
+      id: "watchdog-1",
+      name: "vision tests",
+      agentId: "parent-agent",
+      workspaceId: "workspace-1",
+      cwd: REPO_CWD,
+      command: "npm",
+      args: ["test"],
+      status: "completed" as const,
+      deliveryStatus: "delivered" as const,
+      workerPid: null,
+      result: { exitCode: 0, signal: null, error: null, finishedAt: "2026-08-19T01:00:00.000Z" },
+      timeoutMs: null,
+      cancelRequestedAt: null,
+      createdAt: "2026-08-19T00:00:00.000Z",
+      updatedAt: "2026-08-19T01:00:00.000Z",
+      deliveredAt: "2026-08-19T01:00:00.000Z",
+    }));
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      watchdogService: { inspect } as unknown as WatchdogService,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+
+    const result = await invokeToolWithParsedInput(registeredTool(server, "inspect_watchdog_job"), {
+      id: "watchdog-1",
+    });
+
+    expect(inspect).toHaveBeenCalledWith("watchdog-1");
+    expect(result.structuredContent).toMatchObject({
+      id: "watchdog-1",
+      status: "completed",
+      deliveryStatus: "delivered",
+      result: { exitCode: 0 },
+    });
+  });
+
+  it("cancels only a watchdog job owned by the caller", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const inspect = vi.fn(async () => ({ id: "watchdog-1", agentId: "parent-agent" }));
+    const cancel = vi.fn(async () => ({ id: "watchdog-1", status: "cancelling" }));
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      watchdogService: { inspect, cancel } as unknown as WatchdogService,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+
+    const result = await invokeToolWithParsedInput(registeredTool(server, "cancel_watchdog_job"), {
+      id: "watchdog-1",
+    });
+
+    expect(cancel).toHaveBeenCalledWith("watchdog-1");
+    expect(result.structuredContent).toMatchObject({
+      id: "watchdog-1",
+      status: "cancelling",
+    });
+  });
+
+  it("rejects cancelling another agent's watchdog job", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const inspect = vi.fn(async () => ({ id: "watchdog-1", agentId: "other-agent" }));
+    const cancel = vi.fn();
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      watchdogService: { inspect, cancel } as unknown as WatchdogService,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+
+    await expect(
+      invokeToolWithParsedInput(registeredTool(server, "cancel_watchdog_job"), {
+        id: "watchdog-1",
+      }),
+    ).rejects.toThrow("cancel_watchdog_job can only cancel jobs started by this agent");
+    expect(cancel).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -39,6 +39,7 @@ import { expandUserPath, isSameOrDescendantPath, resolvePathFromBase } from "../
 import type { TerminalManager } from "../../../terminal/terminal-manager.js";
 import type { CreatePaseoWorktreeWorkflowFn } from "../../worktree-session.js";
 import type { ScheduleService } from "../../schedule/service.js";
+import type { WatchdogService } from "../../watchdog/service.js";
 import {
   ScheduleRunSchema,
   ScheduleSummarySchema,
@@ -99,6 +100,7 @@ export interface PaseoToolHostDependencies {
   terminalManager?: TerminalManager | null;
   getDaemonTcpPort?: () => number | null;
   scheduleService?: ScheduleService | null;
+  watchdogService?: WatchdogService | null;
   providerSnapshotManager: ProviderSnapshotManager;
   daemonConfigStore?: Pick<DaemonConfigStore, "get">;
   github?: ForgeService;
@@ -545,6 +547,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
     terminalManager,
     workspaceScripts,
     scheduleService,
+    watchdogService,
     providerSnapshotManager,
     daemonConfigStore,
     callerAgentId,
@@ -2870,6 +2873,183 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       return {
         content: [],
         structuredContent: ensureValidJson(schedule),
+      };
+    },
+  );
+
+  registerTool(
+    "start_watchdog_job",
+    {
+      title: "Start durable background job",
+      description:
+        "Start a long-running command under the Paseo daemon and return immediately. Paseo durably captures logs and resumes this agent when the command finishes. Prefer this over sleep or foreground polling for builds, tests, inference, training, deploys, and CI waits. The command is executed directly without a shell; pass each argument separately and never include secrets in arguments.",
+      inputSchema: {
+        name: z.string().trim().min(1),
+        command: z.string().trim().min(1),
+        args: z.array(z.string()).optional(),
+        cwd: z.string().optional(),
+        timeoutMs: z.number().int().positive().max(2_147_483_647).optional(),
+      },
+      outputSchema: {
+        id: z.string(),
+        name: z.string(),
+        status: z.string(),
+        workerPid: z.number().int().positive().nullable(),
+      },
+    },
+    async ({ name, command, args, cwd, timeoutMs }) => {
+      if (!watchdogService) {
+        throw new Error("Watchdog service is not configured");
+      }
+      if (!callerAgentId) {
+        throw new Error("start_watchdog_job requires an agent-scoped session");
+      }
+      const caller = resolveCallerAgent();
+      if (!caller?.workspaceId) {
+        throw new Error(`Caller agent ${callerAgentId} has no current workspace`);
+      }
+      const job = await watchdogService.register({
+        name,
+        command,
+        args: args ?? [],
+        cwd: resolveScopedCwd(cwd),
+        agentId: callerAgentId,
+        workspaceId: caller.workspaceId,
+        ...(timeoutMs === undefined ? {} : { timeoutMs }),
+      });
+      return {
+        content: [],
+        structuredContent: ensureValidJson({
+          id: job.id,
+          name: job.name,
+          status: job.status,
+          workerPid: job.workerPid,
+        }),
+      };
+    },
+  );
+
+  registerTool(
+    "list_watchdog_jobs",
+    {
+      title: "List durable background jobs",
+      description: "List durable background jobs started by this agent.",
+      inputSchema: {},
+      outputSchema: {
+        jobs: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            status: z.string(),
+            deliveryStatus: z.string(),
+            result: z.unknown().nullable(),
+          }),
+        ),
+      },
+    },
+    async () => {
+      if (!watchdogService) {
+        throw new Error("Watchdog service is not configured");
+      }
+      if (!callerAgentId) {
+        throw new Error("list_watchdog_jobs requires an agent-scoped session");
+      }
+      const jobs = await watchdogService.listForAgent(callerAgentId);
+      return {
+        content: [],
+        structuredContent: ensureValidJson({
+          jobs: jobs.map((job) => ({
+            id: job.id,
+            name: job.name,
+            status: job.status,
+            deliveryStatus: job.deliveryStatus,
+            result: job.result,
+          })),
+        }),
+      };
+    },
+  );
+
+  registerTool(
+    "inspect_watchdog_job",
+    {
+      title: "Inspect durable background job",
+      description: "Inspect a durable background job started by this agent.",
+      inputSchema: { id: z.string().trim().min(1) },
+      outputSchema: {
+        id: z.string(),
+        name: z.string(),
+        status: z.string(),
+        deliveryStatus: z.string(),
+        result: z.unknown().nullable(),
+        workerPid: z.number().int().positive().nullable(),
+        timeoutMs: z.number().int().positive().max(2_147_483_647).nullable(),
+        cancelRequestedAt: z.string().nullable(),
+        createdAt: z.string(),
+        updatedAt: z.string(),
+        deliveredAt: z.string().nullable(),
+      },
+    },
+    async ({ id }) => {
+      if (!watchdogService) {
+        throw new Error("Watchdog service is not configured");
+      }
+      if (!callerAgentId) {
+        throw new Error("inspect_watchdog_job requires an agent-scoped session");
+      }
+      const job = await watchdogService.inspect(id);
+      if (job.agentId !== callerAgentId) {
+        throw new Error("inspect_watchdog_job can only inspect jobs started by this agent");
+      }
+      return {
+        content: [],
+        structuredContent: ensureValidJson({
+          id: job.id,
+          name: job.name,
+          status: job.status,
+          deliveryStatus: job.deliveryStatus,
+          result: job.result,
+          workerPid: job.workerPid,
+          timeoutMs: job.timeoutMs,
+          cancelRequestedAt: job.cancelRequestedAt,
+          createdAt: job.createdAt,
+          updatedAt: job.updatedAt,
+          deliveredAt: job.deliveredAt,
+        }),
+      };
+    },
+  );
+
+  registerTool(
+    "cancel_watchdog_job",
+    {
+      title: "Cancel durable background job",
+      description:
+        "Durably request cancellation of a background job started by this agent. Paseo terminates the command process tree and preserves its logs and cancellation result.",
+      inputSchema: { id: z.string().trim().min(1) },
+      outputSchema: {
+        id: z.string(),
+        status: z.string(),
+      },
+    },
+    async ({ id }) => {
+      if (!watchdogService) {
+        throw new Error("Watchdog service is not configured");
+      }
+      if (!callerAgentId) {
+        throw new Error("cancel_watchdog_job requires an agent-scoped session");
+      }
+      const job = await watchdogService.inspect(id);
+      if (job.agentId !== callerAgentId) {
+        throw new Error("cancel_watchdog_job can only cancel jobs started by this agent");
+      }
+      const cancelled = await watchdogService.cancel(id);
+      return {
+        content: [],
+        structuredContent: ensureValidJson({
+          id: cancelled.id,
+          status: cancelled.status,
+        }),
       };
     },
   );

--- a/packages/server/src/server/atomic-file.ts
+++ b/packages/server/src/server/atomic-file.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 export async function writeFileAtomic(
   filePath: string,
   data: string | NodeJS.ArrayBufferView,
+  options: { mode?: number } = {},
 ): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   const tempPath = path.join(
@@ -12,7 +13,7 @@ export async function writeFileAtomic(
     `.${path.basename(filePath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
   );
   try {
-    await fs.writeFile(tempPath, data, "utf8");
+    await fs.writeFile(tempPath, data, { encoding: "utf8", mode: options.mode });
     await fs.rename(tempPath, filePath);
   } catch (error) {
     await fs.rm(tempPath, { force: true });
@@ -20,6 +21,10 @@ export async function writeFileAtomic(
   }
 }
 
-export async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
-  await writeFileAtomic(filePath, JSON.stringify(value, null, 2));
+export async function writeJsonFileAtomic(
+  filePath: string,
+  value: unknown,
+  options: { mode?: number } = {},
+): Promise<void> {
+  await writeFileAtomic(filePath, JSON.stringify(value, null, 2), options);
 }

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -147,6 +147,9 @@ import {
 } from "./workspace-registry.js";
 import { CheckoutDiffManager } from "./checkout-diff-manager.js";
 import { ScheduleService } from "./schedule/service.js";
+import { AgentWatchdogNotifier } from "./watchdog/notifier.js";
+import { WatchdogService } from "./watchdog/service.js";
+import { DetachedWatchdogLauncher, FileWatchdogResultReader } from "./watchdog/system.js";
 import { DaemonConfigStore, type MutableDaemonConfig } from "./daemon-config-store.js";
 import { createOrchestrationSkills } from "./orchestration-skills/index.js";
 import { resolveConfigFromPersisted, type CliConfigOverrides } from "./config.js";
@@ -1312,6 +1315,14 @@ export async function createPaseoDaemon(
   );
   logger.info({ elapsed: elapsed() }, "Preparing voice and MCP runtime");
 
+  const watchdogService = new WatchdogService({
+    paseoHome: config.paseoHome,
+    logger,
+    launcher: new DetachedWatchdogLauncher(config.paseoHome),
+    resultReader: new FileWatchdogResultReader(config.paseoHome),
+    notifier: new AgentWatchdogNotifier(config.paseoHome, agentManager, agentStorage, logger),
+  });
+
   const createAgentToolHostDependencies = (
     runtime: PaseoToolRuntimeContext,
   ): PaseoToolHostDependencies => ({
@@ -1320,6 +1331,7 @@ export async function createPaseoDaemon(
     terminalManager,
     getDaemonTcpPort: () => (boundListenTarget?.type === "tcp" ? boundListenTarget.port : null),
     scheduleService,
+    watchdogService,
     providerSnapshotManager,
     daemonConfigStore,
     github,
@@ -1654,9 +1666,14 @@ export async function createPaseoDaemon(
               pluginRuntime,
               orchestrationSkills,
               workspaceLabelService,
+              watchdogService,
             );
             pluginRuntime.bindPaseoSessionHost(wsServer);
             await pluginRuntime.start();
+            // Recovery may load an inactive agent to deliver a completion. Wait until
+            // the runtime MCP URL and WebSocket lifecycle are fully available so the
+            // restored agent gets the same tool configuration as a normal agent.
+            await watchdogService.start();
             wsServer.beginAcceptingConnections();
             relayRuntime = createRelayRuntime({
               config: {
@@ -1700,6 +1717,7 @@ export async function createPaseoDaemon(
       speechService.start();
       scriptHealthMonitor.start();
     } catch (error) {
+      await watchdogService.stop().catch(() => undefined);
       await pluginRuntime.stopAllPlugins().catch(() => undefined);
       await serviceProxy.stopStandalone().catch(() => undefined);
       if (mainStarted) {
@@ -1718,6 +1736,9 @@ export async function createPaseoDaemon(
     // Freeze both ingress and registration before taking the agent closure snapshot.
     wsServer?.prepareForShutdown();
     agentManager.prepareForShutdown();
+    // Stop completion reconciliation before closing agents so a shutdown cannot
+    // load or notify an agent after the closure snapshot is taken.
+    await watchdogService.stop().catch(() => undefined);
     await closeAllAgents(logger, agentManager);
     await agentManager.flushForShutdown().catch(() => undefined);
     detachAgentStoragePersistence();

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -165,6 +165,8 @@ import {
   createGitMetadataGenerator,
 } from "./session/checkout/git-metadata-generator.js";
 import { ScheduleSession } from "./session/schedule/schedule-session.js";
+import { WatchdogSession } from "./session/watchdog/watchdog-session.js";
+import type { WatchdogService } from "./watchdog/service.js";
 import { ProviderCatalogSession } from "./session/provider/provider-catalog-session.js";
 import { WorkspaceFilesSession } from "./session/files/workspace-files-session.js";
 import { AgentConfigSession } from "./session/agent-config/agent-config-session.js";
@@ -457,6 +459,7 @@ export interface SessionOptions {
   workspaceLabelService?: WorkspaceLabelService;
   filesystem?: SessionFileSystem;
   scheduleService: ScheduleService;
+  watchdogService?: WatchdogService;
   checkoutDiffManager: CheckoutDiffManager;
   github?: ForgeService;
   createAgentMcpTransport?: AgentMcpTransportFactory;
@@ -609,6 +612,14 @@ function resolveDirectorySync(service: DirectorySyncService | undefined): Direct
   return service ?? new DirectorySyncService();
 }
 
+function createOptionalWatchdogSession(
+  service: WatchdogService | undefined,
+  emit: (message: SessionOutboundMessage) => void,
+  logger: pino.Logger,
+): WatchdogSession | null {
+  return service ? new WatchdogSession({ emit }, service, logger) : null;
+}
+
 function describeRegistryTransition(record: ArchivedRecordSnapshot | null): RegistryTransition {
   if (!record) {
     return "created";
@@ -729,6 +740,7 @@ export class Session {
   private readonly voiceSession: VoiceSession;
   private readonly checkoutSession: CheckoutSession;
   private readonly scheduleSession: ScheduleSession;
+  private readonly watchdogSession: WatchdogSession | null;
   private readonly providerCatalogSession: ProviderCatalogSession;
   private readonly workspaceFilesSession: WorkspaceFilesSession;
   private readonly agentConfigSession: AgentConfigSession;
@@ -764,6 +776,7 @@ export class Session {
       workspaceLabelService,
       filesystem,
       scheduleService,
+      watchdogService,
       checkoutDiffManager,
       github,
       renameCurrentBranch,
@@ -902,6 +915,11 @@ export class Session {
       scheduleService,
       logger: this.sessionLogger,
     });
+    this.watchdogSession = createOptionalWatchdogSession(
+      watchdogService,
+      (msg) => this.emit(msg),
+      this.sessionLogger,
+    );
     this.providerCatalogSession = new ProviderCatalogSession({
       host: {
         emit: (msg) => this.emit(msg),
@@ -1929,7 +1947,7 @@ export class Session {
       this.dispatchPluginDirectoryMessage(msg) ??
       this.dispatchPluginMessage(msg) ??
       this.dispatchTerminalMessage(msg) ??
-      this.dispatchScheduleMessage(msg) ??
+      this.dispatchDurableAutomationMessage(msg) ??
       this.dispatchMiscMessage(msg);
     if (promise) await promise;
   }
@@ -2562,6 +2580,26 @@ export class Session {
         return this.scheduleSession.handleScheduleRunOnceRequest(msg);
       case "schedule/update":
         return this.scheduleSession.handleScheduleUpdateRequest(msg);
+      default:
+        return undefined;
+    }
+  }
+
+  private dispatchDurableAutomationMessage(msg: SessionInboundMessage): Promise<void> | undefined {
+    return this.dispatchScheduleMessage(msg) ?? this.dispatchWatchdogMessage(msg);
+  }
+
+  private dispatchWatchdogMessage(msg: SessionInboundMessage): Promise<void> | undefined {
+    if (!this.watchdogSession) return undefined;
+    switch (msg.type) {
+      case "watchdog.start.request":
+        return this.watchdogSession.handleStart(msg);
+      case "watchdog.list.request":
+        return this.watchdogSession.handleList(msg);
+      case "watchdog.inspect.request":
+        return this.watchdogSession.handleInspect(msg);
+      case "watchdog.cancel.request":
+        return this.watchdogSession.handleCancel(msg);
       default:
         return undefined;
     }

--- a/packages/server/src/server/session/watchdog/watchdog-session.ts
+++ b/packages/server/src/server/session/watchdog/watchdog-session.ts
@@ -1,0 +1,100 @@
+import type {
+  SessionOutboundMessage,
+  WatchdogCancelRequest,
+  WatchdogInspectRequest,
+  WatchdogListRequest,
+  WatchdogStartRequest,
+} from "@getpaseo/protocol/messages";
+import type { Logger } from "pino";
+
+import type { WatchdogService } from "../../watchdog/service.js";
+
+interface WatchdogSessionHost {
+  emit(message: SessionOutboundMessage): void;
+}
+
+export class WatchdogSession {
+  constructor(
+    private readonly host: WatchdogSessionHost,
+    private readonly service: WatchdogService,
+    private readonly logger: Logger,
+  ) {}
+
+  async handleStart(message: WatchdogStartRequest): Promise<void> {
+    try {
+      const job = await this.service.register({
+        name: message.name,
+        agentId: message.agentId,
+        workspaceId: message.workspaceId,
+        cwd: message.cwd,
+        command: message.command,
+        args: message.args ?? [],
+        ...(message.timeoutMs === undefined ? {} : { timeoutMs: message.timeoutMs }),
+      });
+      this.host.emit({
+        type: "watchdog.start.response",
+        payload: { requestId: message.requestId, job, error: null },
+      });
+    } catch (error) {
+      this.emitError("watchdog.start.response", message.requestId, error);
+    }
+  }
+
+  async handleList(message: WatchdogListRequest): Promise<void> {
+    try {
+      const jobs = message.agentId
+        ? await this.service.listForAgent(message.agentId)
+        : await this.service.list();
+      this.host.emit({
+        type: "watchdog.list.response",
+        payload: { requestId: message.requestId, jobs, error: null },
+      });
+    } catch (error) {
+      this.logger.warn({ err: error }, "Failed to list watchdog jobs");
+      this.host.emit({
+        type: "watchdog.list.response",
+        payload: { requestId: message.requestId, jobs: [], error: toErrorMessage(error) },
+      });
+    }
+  }
+
+  async handleInspect(message: WatchdogInspectRequest): Promise<void> {
+    try {
+      const job = await this.service.inspect(message.jobId);
+      this.host.emit({
+        type: "watchdog.inspect.response",
+        payload: { requestId: message.requestId, job, error: null },
+      });
+    } catch (error) {
+      this.emitError("watchdog.inspect.response", message.requestId, error);
+    }
+  }
+
+  async handleCancel(message: WatchdogCancelRequest): Promise<void> {
+    try {
+      const job = await this.service.cancel(message.jobId);
+      this.host.emit({
+        type: "watchdog.cancel.response",
+        payload: { requestId: message.requestId, job, error: null },
+      });
+    } catch (error) {
+      this.emitError("watchdog.cancel.response", message.requestId, error);
+    }
+  }
+
+  private emitError(
+    type: "watchdog.start.response" | "watchdog.inspect.response" | "watchdog.cancel.response",
+    requestId: string,
+    error: unknown,
+  ): void {
+    this.logger.warn({ err: error, type }, "Watchdog request failed");
+    this.host.emit({
+      type,
+      payload: { requestId, job: null, error: toErrorMessage(error) },
+    });
+  }
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/server/src/server/watchdog/notifier.test.ts
+++ b/packages/server/src/server/watchdog/notifier.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import type { AgentManager, ManagedAgent } from "../agent/agent-manager.js";
+import type { AgentStorage } from "../agent/agent-storage.js";
+import { AgentWatchdogNotifier, watchdogWakeClientMessageId } from "./notifier.js";
+import type { StoredWatchdogJob } from "./service.js";
+
+const agent = {
+  id: "agent-1",
+  provider: "codex",
+  cwd: "/workspace",
+  workspaceId: "workspace-1",
+  lifecycle: "idle",
+  currentModeId: "build",
+  availableModes: [],
+  config: { title: "Agent" },
+} as unknown as ManagedAgent;
+
+const job = {
+  id: "watchdog-1",
+  name: "vision tests",
+  agentId: agent.id,
+  workspaceId: "workspace-1",
+  cwd: "/workspace",
+  command: "npm",
+  args: ["test"],
+  status: "completed",
+  deliveryStatus: "pending",
+  workerPid: 4101,
+  result: {
+    exitCode: 0,
+    signal: null,
+    error: null,
+    finishedAt: "2026-08-19T00:05:00.000Z",
+    stdout: { bytes: 4, truncated: false },
+    stderr: { bytes: 0, truncated: false },
+  },
+  timeoutMs: null,
+  cancelRequestedAt: null,
+  createdAt: "2026-08-19T00:00:00.000Z",
+  updatedAt: "2026-08-19T00:05:00.000Z",
+  deliveredAt: null,
+} satisfies StoredWatchdogJob;
+
+describe("AgentWatchdogNotifier", () => {
+  test("delivers through the canonical submitted-prompt path with a deterministic message id", async () => {
+    const streamAgent = vi.fn(async function* () {
+      yield { type: "message", message: "accepted" } as never;
+    });
+    const waitForAgentRunStart = vi.fn(async () => undefined);
+    const notifier = createNotifier({ streamAgent, waitForAgentRunStart });
+
+    await expect(notifier.notify(job)).resolves.toBe("delivered");
+    expect(streamAgent).toHaveBeenCalledWith(
+      agent.id,
+      expect.stringContaining(`[PASEO_WATCHDOG job=${job.id}]`),
+      expect.objectContaining({ clientMessageId: watchdogWakeClientMessageId(job.id) }),
+    );
+    expect(waitForAgentRunStart).toHaveBeenCalledWith(agent.id, expect.anything());
+  });
+
+  test("a second notification attempt does not call streamAgent when the wake is already on the timeline", async () => {
+    const wakeId = watchdogWakeClientMessageId(job.id);
+    const streamAgent = vi.fn(async function* () {
+      yield { type: "message", message: "accepted" } as never;
+    });
+    let timeline: Array<{ type: "user_message"; text: string; clientMessageId: string }> = [];
+    let timelineRows: Array<{
+      seq: number;
+      timestamp: string;
+      item: { type: "user_message"; text: string; clientMessageId: string };
+    }> = [];
+    const notifier = createNotifier({
+      streamAgent,
+      getTimeline: () => timeline,
+      getTimelineRows: async () => timelineRows,
+    });
+
+    await expect(notifier.notify(job)).resolves.toBe("delivered");
+    expect(streamAgent).toHaveBeenCalledTimes(1);
+
+    timeline = [{ type: "user_message", text: "wake", clientMessageId: wakeId }];
+    timelineRows = [
+      {
+        seq: 1,
+        timestamp: "2026-08-19T00:05:00.000Z",
+        item: { type: "user_message", text: "wake", clientMessageId: wakeId },
+      },
+    ];
+    await expect(notifier.notify(job)).resolves.toBe("delivered");
+    expect(streamAgent).toHaveBeenCalledTimes(1);
+  });
+
+  test("leaves delivery pending when the agent is busy", async () => {
+    const streamAgent = vi.fn(async function* () {
+      yield { type: "message", message: "accepted" } as never;
+    });
+    const notifier = createNotifier({
+      streamAgent,
+      hasInFlightRun: () => true,
+    });
+
+    await expect(notifier.notify(job)).resolves.toBe("busy");
+    expect(streamAgent).not.toHaveBeenCalled();
+  });
+
+  test("leaves delivery pending when the agent has pending permissions", async () => {
+    const streamAgent = vi.fn(async function* () {
+      yield { type: "message", message: "accepted" } as never;
+    });
+    const notifier = createNotifier({
+      streamAgent,
+      getPendingPermissions: () => [{ id: "perm-1" } as never],
+    });
+
+    await expect(notifier.notify(job)).resolves.toBe("busy");
+    expect(streamAgent).not.toHaveBeenCalled();
+  });
+
+  test("does not acknowledge when run start fails", async () => {
+    const notifier = createNotifier({
+      streamAgent: async function* () {
+        yield { type: "message", message: "accepted" } as never;
+      },
+      waitForAgentRunStart: async () => {
+        throw new Error("authentication failed");
+      },
+    });
+
+    await expect(notifier.notify(job)).rejects.toThrow("authentication failed");
+  });
+});
+
+function createNotifier(options: {
+  streamAgent: AgentManager["streamAgent"];
+  waitForAgentRunStart?: AgentManager["waitForAgentRunStart"];
+  hasInFlightRun?: () => boolean;
+  getPendingPermissions?: () => unknown[];
+  getTimeline?: AgentManager["getTimeline"];
+  getTimelineRows?: AgentManager["getTimelineRows"];
+}): AgentWatchdogNotifier {
+  const agentManager = {
+    getAgent: vi.fn(() => agent),
+    waitForAgentClose: vi.fn(),
+    waitForAgentRunStart: options.waitForAgentRunStart ?? vi.fn(async () => undefined),
+    hasInFlightRun: vi.fn(options.hasInFlightRun ?? (() => false)),
+    getPendingPermissions: vi.fn(options.getPendingPermissions ?? (() => [])),
+    getTimeline: vi.fn(options.getTimeline ?? (() => [])),
+    getTimelineRows: vi.fn(options.getTimelineRows ?? (async () => [])),
+    tryRunOutOfBand: vi.fn(() => false),
+    steerOrReplaceActiveTurn: vi.fn(async () => ({ status: "inactive" as const })),
+    streamAgent: vi.fn(options.streamAgent),
+    setAgentMode: vi.fn(),
+    unarchiveSnapshot: vi.fn(),
+    notifyAgentState: vi.fn(),
+  } as unknown as AgentManager;
+  const agentStorage = {
+    get: vi.fn(async () => ({ id: agent.id, archivedAt: null })),
+  } as unknown as AgentStorage;
+  return new AgentWatchdogNotifier("/tmp/paseo", agentManager, agentStorage, createTestLogger());
+}

--- a/packages/server/src/server/watchdog/notifier.ts
+++ b/packages/server/src/server/watchdog/notifier.ts
@@ -1,0 +1,111 @@
+import path from "node:path";
+import type { Logger } from "pino";
+
+import type { AgentManager } from "../agent/agent-manager.js";
+import type { AgentStorage } from "../agent/agent-storage.js";
+import { ensureAgentLoaded } from "../agent/agent-loading.js";
+import {
+  formatSystemNotificationPrompt,
+  sendPromptToAgent,
+  waitForAgentRunStartWithTimeout,
+} from "../agent/agent-prompt.js";
+import type { StoredWatchdogJob, WatchdogNotifier } from "./service.js";
+
+export function watchdogWakeClientMessageId(jobId: string): string {
+  return `paseo-watchdog-wake:${jobId}`;
+}
+
+export class AgentWatchdogNotifier implements WatchdogNotifier {
+  constructor(
+    private readonly paseoHome: string,
+    private readonly agentManager: AgentManager,
+    private readonly agentStorage: AgentStorage,
+    private readonly logger: Logger,
+  ) {}
+
+  async notify(job: StoredWatchdogJob): Promise<"delivered" | "busy"> {
+    const record = await this.agentStorage.get(job.agentId);
+    if (!record) {
+      throw new Error(`Watchdog target agent ${job.agentId} no longer exists`);
+    }
+    if (record.archivedAt) {
+      throw new Error(`Watchdog target agent ${job.agentId} is archived`);
+    }
+
+    const agent = await ensureAgentLoaded(job.agentId, {
+      agentManager: this.agentManager,
+      agentStorage: this.agentStorage,
+      logger: this.logger,
+    });
+
+    const wakeMessageId = watchdogWakeClientMessageId(job.id);
+    // Idempotent wake: if the canonical timeline already has this clientMessageId,
+    // treat delivery as done without starting or steering another turn.
+    // Check the live timeline first (covers same-process retries before durable commit),
+    // then durable/canonical rows (covers daemon restart after the wake was recorded).
+    const wakeAlreadyPresent = (item: { type: string; clientMessageId?: string }): boolean =>
+      item.type === "user_message" && item.clientMessageId === wakeMessageId;
+    if (this.agentManager.getTimeline(agent.id).some(wakeAlreadyPresent)) {
+      return "delivered";
+    }
+    const timelineRows = await this.agentManager.getTimelineRows(agent.id);
+    if (timelineRows.some((row) => wakeAlreadyPresent(row.item))) {
+      return "delivered";
+    }
+
+    // Leave delivery pending while the agent is mid-turn or blocked on a permission.
+    // Never interrupt an active run or clear pending permissions for a wake.
+    if (this.agentManager.hasInFlightRun(agent.id)) {
+      return "busy";
+    }
+    if (this.agentManager.getPendingPermissions(agent.id).length > 0) {
+      return "busy";
+    }
+
+    const result = job.result;
+    let outcome = `exit code ${result?.exitCode ?? "unknown"}`;
+    if (result?.error) {
+      outcome = `worker error: ${result.error}`;
+    } else if (result?.signal) {
+      outcome = `terminated by ${result.signal}`;
+    }
+    const logsDirectory = path.join(this.paseoHome, "watchdogs", "logs");
+    const streamSummary = [
+      result?.stdout
+        ? `stdout bytes=${result.stdout.bytes} truncated=${result.stdout.truncated}`
+        : null,
+      result?.stderr
+        ? `stderr bytes=${result.stderr.bytes} truncated=${result.stderr.truncated}`
+        : null,
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n");
+    const body = [
+      `[PASEO_WATCHDOG job=${job.id}]`,
+      `Durable background job "${job.name}" finished with ${outcome}.`,
+      `stdout: ${path.join(logsDirectory, `${job.id}.stdout.log`)}`,
+      `stderr: ${path.join(logsDirectory, `${job.id}.stderr.log`)}`,
+      ...(streamSummary ? [streamSummary] : []),
+      "Inspect the artifacts, report the real result, and continue the interrupted task. Do not rerun the job unless the artifacts show it is necessary.",
+    ].join("\n");
+
+    const disposition = await sendPromptToAgent({
+      agentManager: this.agentManager,
+      agentStorage: this.agentStorage,
+      agentId: agent.id,
+      prompt: formatSystemNotificationPrompt(body),
+      // Deterministic id makes repeated wake attempts idempotent in the submitted-prompt timeline.
+      messageId: wakeMessageId,
+      activeTurnBehavior: "steer",
+      replaceRunning: false,
+      clearPendingPermissions: false,
+      unarchive: false,
+      logger: this.logger,
+    });
+
+    if (disposition.disposition === "turn_started") {
+      await waitForAgentRunStartWithTimeout(this.agentManager, agent.id);
+    }
+    return "delivered";
+  }
+}

--- a/packages/server/src/server/watchdog/service.test.ts
+++ b/packages/server/src/server/watchdog/service.test.ts
@@ -1,0 +1,577 @@
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import {
+  WatchdogService,
+  type WatchdogLauncher,
+  type WatchdogNotifier,
+  type WatchdogResult,
+  type WatchdogResultReader,
+} from "./service.js";
+
+let tempHome: string | null = null;
+
+afterEach(async () => {
+  if (tempHome) {
+    await rm(tempHome, { recursive: true, force: true });
+    tempHome = null;
+  }
+});
+
+describe("WatchdogService", () => {
+  test("registers a durable job and returns while the external command is still running", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const launcher = new FakeLauncher();
+    const service = createService({ paseoHome: tempHome, launcher });
+
+    const job = await service.register({
+      name: "vision tests",
+      agentId: "11111111-1111-4111-8111-111111111111",
+      workspaceId: "workspace-1",
+      cwd: "/workspace",
+      command: "npm",
+      args: ["test", "--", "vision"],
+      timeoutMs: 60_000,
+    });
+
+    expect(job).toMatchObject({
+      name: "vision tests",
+      status: "running",
+      workerPid: 4101,
+      command: "npm",
+      args: ["test", "--", "vision"],
+    });
+    expect(launcher.launched).toEqual([
+      {
+        jobId: job.id,
+        cwd: "/workspace",
+        command: "npm",
+        args: ["test", "--", "vision"],
+        timeoutMs: 60_000,
+      },
+    ]);
+    expect(await service.listForAgent(job.agentId)).toEqual([job]);
+  });
+
+  test("a restarted service delivers a completed job exactly once", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const resultReader = new FakeResultReader();
+    const firstService = createService({ paseoHome: tempHome, resultReader });
+    const job = await firstService.register({
+      name: "remote inference",
+      agentId: "11111111-1111-4111-8111-111111111111",
+      workspaceId: "workspace-1",
+      cwd: "/workspace",
+      command: "uv",
+      args: ["run", "infer.py"],
+    });
+    resultReader.results.set(job.id, {
+      exitCode: 0,
+      signal: null,
+      error: null,
+      finishedAt: "2026-08-19T00:05:00.000Z",
+    });
+    const notifier = new FakeNotifier();
+    const restartedService = createService({
+      paseoHome: tempHome,
+      resultReader,
+      notifier,
+    });
+
+    await restartedService.reconcile();
+    await restartedService.reconcile();
+
+    expect(notifier.notified).toEqual([
+      {
+        id: job.id,
+        agentId: job.agentId,
+        status: "completed",
+        result: {
+          exitCode: 0,
+          signal: null,
+          error: null,
+          finishedAt: "2026-08-19T00:05:00.000Z",
+        },
+      },
+    ]);
+    expect(await restartedService.listForAgent(job.agentId)).toEqual([
+      expect.objectContaining({
+        id: job.id,
+        status: "completed",
+        deliveryStatus: "delivered",
+        deliveredAt: "2026-08-19T00:00:00.000Z",
+      }),
+    ]);
+  });
+
+  test("a notification failure does not block other completed jobs", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const launcher = new FakeLauncher();
+    const results = new FakeResultReader();
+    let blockedJobId = "";
+    const delivered: string[] = [];
+    const notifier: WatchdogNotifier = {
+      async notify(job) {
+        if (job.id === blockedJobId) {
+          throw new Error("agent is archived");
+        }
+        delivered.push(job.id);
+        return "delivered";
+      },
+    };
+    let nextId = 0;
+    const service = createService({
+      paseoHome: tempHome,
+      launcher,
+      resultReader: results,
+      notifier,
+      idGenerator: () => `watchdog-${++nextId}`,
+    });
+    const blocked = await service.register({
+      name: "blocked",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      cwd: "/tmp/workspace-1",
+      command: "npm",
+      args: ["test"],
+    });
+    blockedJobId = blocked.id;
+    const deliverable = await service.register({
+      name: "deliverable",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      cwd: "/tmp/workspace-1",
+      command: "npm",
+      args: ["run", "build"],
+    });
+    const result: WatchdogResult = {
+      exitCode: 0,
+      signal: null,
+      error: null,
+      finishedAt: "2026-08-19T00:05:00.000Z",
+    };
+    results.results.set(blocked.id, result);
+    results.results.set(deliverable.id, result);
+
+    await service.reconcile();
+
+    expect(delivered).toEqual([deliverable.id]);
+    expect(
+      (await service.listForAgent("agent-1")).find((job) => job.id === blocked.id)?.status,
+    ).toBe("completed");
+  });
+
+  test("quarantines a corrupt record without blocking startup", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const watchdogDirectory = path.join(tempHome, "watchdogs");
+    await mkdir(watchdogDirectory, { recursive: true });
+    await writeFile(path.join(watchdogDirectory, "broken.json"), "not-json", "utf8");
+    const service = createService({ paseoHome: tempHome });
+
+    await expect(service.start()).resolves.toBeUndefined();
+    await service.stop();
+
+    expect(await readdir(watchdogDirectory)).toEqual([
+      expect.stringMatching(/^broken\.json\.corrupt-/),
+    ]);
+  });
+
+  test("quarantines records whose id is invalid or does not match the filename", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const watchdogDirectory = path.join(tempHome, "watchdogs");
+    await mkdir(watchdogDirectory, { recursive: true });
+    const base = {
+      name: "tampered",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      cwd: "/workspace",
+      command: "npm",
+      args: ["test"],
+      status: "queued",
+      deliveryStatus: "pending",
+      workerPid: null,
+      result: null,
+      timeoutMs: null,
+      cancelRequestedAt: null,
+      createdAt: "2026-08-19T00:00:00.000Z",
+      updatedAt: "2026-08-19T00:00:00.000Z",
+      deliveredAt: null,
+    };
+    await writeFile(
+      path.join(watchdogDirectory, "safe.json"),
+      JSON.stringify({ ...base, id: "../../escape" }),
+    );
+    await writeFile(
+      path.join(watchdogDirectory, "expected.json"),
+      JSON.stringify({ ...base, id: "different" }),
+    );
+    const service = createService({ paseoHome: tempHome });
+
+    await service.reconcile();
+
+    expect(await service.list()).toEqual([]);
+    const files = await readdir(watchdogDirectory);
+    expect(files.some((entry) => entry.startsWith("safe.json.corrupt-"))).toBe(true);
+    expect(files.some((entry) => entry.startsWith("expected.json.corrupt-"))).toBe(true);
+  });
+
+  test("durably cancels a running job and delivers the cancelled result", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const results = new FakeResultReader();
+    const notifier = new FakeNotifier();
+    const service = createService({ paseoHome: tempHome, resultReader: results, notifier });
+    const job = await service.register({
+      name: "cancel me",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      cwd: "/workspace",
+      command: "npm",
+      args: ["test"],
+    });
+
+    const cancelling = await service.cancel(job.id);
+
+    expect(cancelling).toMatchObject({
+      status: "cancelling",
+      cancelRequestedAt: expect.any(String),
+    });
+    expect(
+      JSON.parse(
+        await readFile(path.join(tempHome, "watchdogs", "cancellations", `${job.id}.json`), "utf8"),
+      ),
+    ).toMatchObject({ jobId: job.id, requestedAt: expect.any(String) });
+
+    results.results.set(job.id, {
+      exitCode: null,
+      signal: "SIGTERM",
+      error: null,
+      finishedAt: "2026-08-19T00:05:00.000Z",
+      terminationReason: "cancelled",
+    });
+    await service.reconcile();
+
+    expect(notifier.notified).toEqual([
+      expect.objectContaining({ id: job.id, status: "cancelled" }),
+    ]);
+    expect(await service.inspect(job.id)).toMatchObject({
+      status: "cancelled",
+      deliveryStatus: "delivered",
+    });
+  });
+
+  test("prunes delivered terminal jobs and artifacts after retention", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const results = new FakeResultReader();
+    const first = createService({ paseoHome: tempHome, resultReader: results });
+    const job = await first.register({
+      name: "old job",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      cwd: "/workspace",
+      command: "npm",
+      args: ["test"],
+    });
+    results.results.set(job.id, {
+      exitCode: 0,
+      signal: null,
+      error: null,
+      finishedAt: "2026-08-19T00:05:00.000Z",
+    });
+    await first.reconcile();
+    const artifact = path.join(tempHome, "watchdogs", "logs", `${job.id}.stdout.log`);
+    await mkdir(path.dirname(artifact), { recursive: true });
+    await writeFile(artifact, "done", "utf8");
+
+    const retained = new WatchdogService({
+      paseoHome: tempHome,
+      launcher: new FakeLauncher(),
+      resultReader: results,
+      notifier: new FakeNotifier(),
+      logger: createTestLogger(),
+      now: () => new Date("2026-09-19T00:00:01.000Z"),
+      idGenerator: () => "unused",
+      retentionMs: 30 * 24 * 60 * 60 * 1000,
+    });
+    await retained.reconcile();
+
+    expect(await retained.list()).toEqual([]);
+    await expect(access(artifact)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("does not arm reconciliation after stop races an in-flight start", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    let releaseRead: (() => void) | undefined;
+    let signalReadStarted: (() => void) | undefined;
+    const readStarted = new Promise<void>((resolve) => {
+      signalReadStarted = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    let reads = 0;
+    const resultReader: WatchdogResultReader = {
+      read: async () => {
+        reads += 1;
+        signalReadStarted?.();
+        await release;
+        return null;
+      },
+    };
+    const service = createService({ paseoHome: tempHome, resultReader, reconcileIntervalMs: 5 });
+    await service.register({
+      name: "startup race",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      cwd: "/workspace",
+      command: "npm",
+      args: ["test"],
+    });
+
+    const starting = service.start();
+    await readStarted;
+    const stopping = service.stop();
+    releaseRead?.();
+    await Promise.all([starting, stopping]);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(reads).toBe(1);
+  });
+
+  test("marks a job failed when the worker pid is gone without a result", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const service = new WatchdogService({
+      paseoHome: tempHome,
+      launcher: new FakeLauncher(),
+      resultReader: new FakeResultReader(),
+      notifier: new FakeNotifier(),
+      logger: createTestLogger(),
+      now: () => new Date("2026-08-19T00:00:00.000Z"),
+      idGenerator: () => "watchdog-dead",
+      isProcessAlive: () => false,
+    });
+    const job = await service.register({
+      name: "missing receipt",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      cwd: "/workspace",
+      command: "npm",
+      args: ["test"],
+    });
+
+    await service.reconcile();
+
+    expect(await service.inspect(job.id)).toMatchObject({
+      status: "failed",
+      result: {
+        error: expect.stringContaining("exited without writing a result"),
+      },
+    });
+  });
+
+  test("queued job with a live worker lock adopts the pid and does not relaunch", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const jobId = "watchdog-live-lock";
+    const lockPid = 4242;
+    const lockPath = await seedQueuedJobWithLock({
+      paseoHome: tempHome,
+      jobId,
+      name: "live lock adoption",
+      lockPid,
+    });
+    const launcher = new FakeLauncher();
+    const notifier = new FakeNotifier();
+    const service = new WatchdogService({
+      paseoHome: tempHome,
+      launcher,
+      resultReader: new FakeResultReader(),
+      notifier,
+      logger: createTestLogger(),
+      now: () => new Date("2026-08-19T00:00:00.000Z"),
+      idGenerator: () => "unused",
+      isProcessAlive: (pid) => pid === lockPid,
+    });
+
+    await service.reconcile();
+
+    expect(launcher.launched).toEqual([]);
+    expect(notifier.notified).toEqual([]);
+    expect(await service.inspect(jobId)).toMatchObject({
+      status: "running",
+      workerPid: lockPid,
+      result: null,
+      deliveryStatus: "pending",
+    });
+    await expect(access(lockPath)).resolves.toBeUndefined();
+  });
+
+  test("queued job with a dead worker lock fails without relaunching", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const jobId = "watchdog-dead-lock";
+    const lockPath = await seedQueuedJobWithLock({
+      paseoHome: tempHome,
+      jobId,
+      name: "dead lock failure",
+      lockPid: 4242,
+    });
+    const launcher = new FakeLauncher();
+    const notifier = new FakeNotifier();
+    const service = new WatchdogService({
+      paseoHome: tempHome,
+      launcher,
+      resultReader: new FakeResultReader(),
+      notifier,
+      logger: createTestLogger(),
+      now: () => new Date("2026-08-19T00:00:00.000Z"),
+      idGenerator: () => "unused",
+      isProcessAlive: () => false,
+    });
+
+    await service.reconcile();
+
+    expect(launcher.launched).toEqual([]);
+    expect(await service.inspect(jobId)).toMatchObject({
+      status: "failed",
+      workerPid: null,
+      result: {
+        error: expect.stringContaining("refusing to relaunch for operator inspection"),
+      },
+    });
+    await expect(access(lockPath)).resolves.toBeUndefined();
+  });
+
+  test("classifies non-zero exits as failed", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-"));
+    const results = new FakeResultReader();
+    const notifier = new FakeNotifier();
+    const service = createService({ paseoHome: tempHome, resultReader: results, notifier });
+    const job = await service.register({
+      name: "failing tests",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      cwd: "/workspace",
+      command: "npm",
+      args: ["test"],
+    });
+    results.results.set(job.id, {
+      exitCode: 1,
+      signal: null,
+      error: null,
+      finishedAt: "2026-08-19T00:05:00.000Z",
+    });
+
+    await service.reconcile();
+
+    expect(notifier.notified).toEqual([expect.objectContaining({ id: job.id, status: "failed" })]);
+  });
+});
+
+function createService(options: {
+  paseoHome: string;
+  launcher?: WatchdogLauncher;
+  resultReader?: WatchdogResultReader;
+  notifier?: WatchdogNotifier;
+  idGenerator?: () => string;
+  reconcileIntervalMs?: number;
+}): WatchdogService {
+  return new WatchdogService({
+    paseoHome: options.paseoHome,
+    launcher: options.launcher ?? new FakeLauncher(),
+    resultReader: options.resultReader ?? new FakeResultReader(),
+    notifier: options.notifier ?? new FakeNotifier(),
+    logger: createTestLogger(),
+    now: () => new Date("2026-08-19T00:00:00.000Z"),
+    idGenerator: options.idGenerator ?? (() => "watchdog-1"),
+    reconcileIntervalMs: options.reconcileIntervalMs,
+  });
+}
+
+async function seedQueuedJobWithLock(input: {
+  paseoHome: string;
+  jobId: string;
+  name: string;
+  lockPid: number;
+}): Promise<string> {
+  const watchdogDirectory = path.join(input.paseoHome, "watchdogs");
+  const locksDirectory = path.join(watchdogDirectory, "locks");
+  await mkdir(locksDirectory, { recursive: true });
+  await writeFile(
+    path.join(watchdogDirectory, `${input.jobId}.json`),
+    JSON.stringify({
+      id: input.jobId,
+      name: input.name,
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      cwd: "/workspace",
+      command: "npm",
+      args: ["test"],
+      status: "queued",
+      deliveryStatus: "pending",
+      workerPid: null,
+      result: null,
+      timeoutMs: null,
+      cancelRequestedAt: null,
+      createdAt: "2026-08-19T00:00:00.000Z",
+      updatedAt: "2026-08-19T00:00:00.000Z",
+      deliveredAt: null,
+    }),
+    "utf8",
+  );
+  const lockPath = path.join(locksDirectory, `${input.jobId}.lock`);
+  await writeFile(
+    lockPath,
+    JSON.stringify({ pid: input.lockPid, startedAt: "2026-08-19T00:00:00.000Z" }),
+    "utf8",
+  );
+  return lockPath;
+}
+
+class FakeLauncher implements WatchdogLauncher {
+  readonly launched: Array<{
+    jobId: string;
+    cwd: string;
+    command: string;
+    args: string[];
+    timeoutMs?: number;
+  }> = [];
+
+  async launch(input: {
+    jobId: string;
+    cwd: string;
+    command: string;
+    args: string[];
+    timeoutMs?: number;
+  }): Promise<{ pid: number }> {
+    this.launched.push(input);
+    return { pid: 4101 };
+  }
+}
+
+class FakeResultReader implements WatchdogResultReader {
+  readonly results = new Map<string, WatchdogResult>();
+
+  async read(jobId: string): Promise<WatchdogResult | null> {
+    return this.results.get(jobId) ?? null;
+  }
+}
+
+class FakeNotifier implements WatchdogNotifier {
+  readonly notified: Array<{
+    id: string;
+    agentId: string;
+    status: string;
+    result: WatchdogResult | null;
+  }> = [];
+
+  async notify(job: Parameters<WatchdogNotifier["notify"]>[0]): Promise<"delivered" | "busy"> {
+    this.notified.push({
+      id: job.id,
+      agentId: job.agentId,
+      status: job.status,
+      result: job.result,
+    });
+    return "delivered";
+  }
+}

--- a/packages/server/src/server/watchdog/service.ts
+++ b/packages/server/src/server/watchdog/service.ts
@@ -1,0 +1,632 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readdir, readFile, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import type { Logger } from "pino";
+import { z } from "zod";
+
+import { writeJsonFileAtomic } from "../atomic-file.js";
+
+export const WATCHDOG_MAX_STREAM_BYTES = 8 * 1024 * 1024;
+
+const WATCHDOG_JOB_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+const WatchdogStreamStatsSchema = z.object({
+  bytes: z.number().int().nonnegative(),
+  truncated: z.boolean(),
+});
+
+const WatchdogWorkerLockSchema = z.object({
+  pid: z.number().int().positive(),
+  startedAt: z.string().min(1),
+});
+
+const WatchdogResultSchema = z.object({
+  exitCode: z.number().int().nullable(),
+  signal: z.string().nullable(),
+  error: z.string().nullable(),
+  finishedAt: z.string(),
+  terminationReason: z.enum(["cancelled", "timeout"]).optional(),
+  stdout: WatchdogStreamStatsSchema.optional(),
+  stderr: WatchdogStreamStatsSchema.optional(),
+});
+
+type WatchdogWorkerLock = z.infer<typeof WatchdogWorkerLockSchema>;
+type WatchdogWorkerLockRead =
+  | { status: "missing" }
+  | { status: "valid"; lock: WatchdogWorkerLock }
+  | { status: "corrupt" };
+
+const StoredWatchdogJobRawSchema = z.object({
+  id: z.string().regex(WATCHDOG_JOB_ID_PATTERN),
+  name: z.string().min(1),
+  agentId: z.string().min(1),
+  workspaceId: z.string().min(1),
+  cwd: z.string().min(1),
+  command: z.string().min(1),
+  args: z.array(z.string()).optional(),
+  status: z.enum([
+    "queued",
+    "running",
+    "cancelling",
+    "completed",
+    "failed",
+    "cancelled",
+    "timed_out",
+  ]),
+  deliveryStatus: z.enum(["pending", "delivered"]).optional(),
+  workerPid: z.number().int().positive().nullable().optional(),
+  result: WatchdogResultSchema.nullable().optional(),
+  timeoutMs: z.number().int().positive().max(2_147_483_647).nullable().optional(),
+  cancelRequestedAt: z.string().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deliveredAt: z.string().nullable().optional(),
+});
+
+export type WatchdogResult = z.infer<typeof WatchdogResultSchema>;
+export interface StoredWatchdogJob {
+  id: string;
+  name: string;
+  agentId: string;
+  workspaceId: string;
+  cwd: string;
+  command: string;
+  args: string[];
+  status: "queued" | "running" | "cancelling" | "completed" | "failed" | "cancelled" | "timed_out";
+  deliveryStatus: "pending" | "delivered";
+  workerPid: number | null;
+  result: WatchdogResult | null;
+  timeoutMs: number | null;
+  cancelRequestedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deliveredAt: string | null;
+}
+
+export interface WatchdogLauncher {
+  launch(input: {
+    jobId: string;
+    cwd: string;
+    command: string;
+    args: string[];
+    timeoutMs?: number;
+  }): Promise<{ pid: number }>;
+}
+
+export interface WatchdogResultReader {
+  read(jobId: string): Promise<WatchdogResult | null>;
+}
+
+export interface WatchdogNotifier {
+  notify(job: StoredWatchdogJob): Promise<"delivered" | "busy">;
+}
+
+export interface RegisterWatchdogInput {
+  name: string;
+  agentId: string;
+  workspaceId: string;
+  cwd: string;
+  command: string;
+  args?: string[];
+  timeoutMs?: number;
+}
+
+interface WatchdogServiceOptions {
+  paseoHome: string;
+  launcher: WatchdogLauncher;
+  resultReader: WatchdogResultReader;
+  notifier: WatchdogNotifier;
+  logger: Logger;
+  now?: () => Date;
+  idGenerator?: () => string;
+  reconcileIntervalMs?: number;
+  retentionMs?: number;
+  isProcessAlive?: (pid: number) => boolean;
+}
+
+export class WatchdogService {
+  private readonly store: WatchdogStore;
+  private readonly launcher: WatchdogLauncher;
+  private readonly resultReader: WatchdogResultReader;
+  private readonly notifier: WatchdogNotifier;
+  private readonly logger: Logger;
+  private readonly now: () => Date;
+  private readonly idGenerator: () => string;
+  private readonly reconcileIntervalMs: number;
+  private readonly retentionMs: number;
+  private readonly isProcessAlive: (pid: number) => boolean;
+  private reconciliation: Promise<void> | null = null;
+  private timer: NodeJS.Timeout | null = null;
+  private lifecycleVersion = 0;
+
+  constructor(options: WatchdogServiceOptions) {
+    this.logger = options.logger.child({ module: "watchdog-service" });
+    this.store = new WatchdogStore(path.join(options.paseoHome, "watchdogs"), this.logger);
+    this.launcher = options.launcher;
+    this.resultReader = options.resultReader;
+    this.notifier = options.notifier;
+    this.now = options.now ?? (() => new Date());
+    this.idGenerator = options.idGenerator ?? randomUUID;
+    this.reconcileIntervalMs = options.reconcileIntervalMs ?? 2_000;
+    this.retentionMs = options.retentionMs ?? 30 * 24 * 60 * 60 * 1_000;
+    this.isProcessAlive = options.isProcessAlive ?? isProcessAlive;
+  }
+
+  async start(): Promise<void> {
+    if (this.timer) {
+      return;
+    }
+    const lifecycleVersion = ++this.lifecycleVersion;
+    await this.reconcile();
+    if (lifecycleVersion !== this.lifecycleVersion) {
+      return;
+    }
+    this.timer = setInterval(() => {
+      void this.reconcile().catch((error) => {
+        this.logger.error({ err: error }, "Watchdog reconciliation failed");
+      });
+    }, this.reconcileIntervalMs);
+    this.timer.unref();
+  }
+
+  async stop(): Promise<void> {
+    this.lifecycleVersion += 1;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.reconciliation;
+  }
+
+  async register(input: RegisterWatchdogInput): Promise<StoredWatchdogJob> {
+    const now = this.now().toISOString();
+    const queued = normalizeStoredWatchdogJob({
+      id: this.idGenerator(),
+      name: requireNonEmpty(input.name, "name"),
+      agentId: requireNonEmpty(input.agentId, "agentId"),
+      workspaceId: requireNonEmpty(input.workspaceId, "workspaceId"),
+      cwd: requireNonEmpty(input.cwd, "cwd"),
+      command: requireNonEmpty(input.command, "command"),
+      args: input.args ?? [],
+      status: "queued",
+      deliveryStatus: "pending",
+      workerPid: null,
+      result: null,
+      timeoutMs: input.timeoutMs ?? null,
+      cancelRequestedAt: null,
+      createdAt: now,
+      updatedAt: now,
+      deliveredAt: null,
+    });
+    await this.store.write(queued);
+
+    let launched: { pid: number };
+    try {
+      launched = await this.launcher.launch({
+        jobId: queued.id,
+        cwd: queued.cwd,
+        command: queued.command,
+        args: queued.args,
+        ...(queued.timeoutMs === null ? {} : { timeoutMs: queued.timeoutMs }),
+      });
+    } catch (error) {
+      const failed = normalizeStoredWatchdogJob({
+        ...queued,
+        status: "failed",
+        result: {
+          exitCode: null,
+          signal: null,
+          error: error instanceof Error ? error.message : String(error),
+          finishedAt: this.now().toISOString(),
+        },
+        updatedAt: this.now().toISOString(),
+      });
+      await this.store.write(failed);
+      this.logger.error({ err: error, watchdogId: failed.id }, "Failed to launch watchdog job");
+      throw error;
+    }
+
+    const running = normalizeStoredWatchdogJob({
+      ...queued,
+      status: "running",
+      workerPid: launched.pid,
+      updatedAt: this.now().toISOString(),
+    });
+    try {
+      await this.store.write(running);
+    } catch (error) {
+      this.logger.warn(
+        { err: error, watchdogId: running.id, workerPid: running.workerPid },
+        "Watchdog worker started but running state could not be persisted",
+      );
+    }
+    return running;
+  }
+
+  async listForAgent(agentId: string): Promise<StoredWatchdogJob[]> {
+    return (await this.store.list()).filter((job) => job.agentId === agentId);
+  }
+
+  async list(): Promise<StoredWatchdogJob[]> {
+    return this.store.list();
+  }
+
+  async inspect(id: string): Promise<StoredWatchdogJob> {
+    const job = await this.store.get(id);
+    if (!job) throw new Error(`Watchdog job not found: ${id}`);
+    return job;
+  }
+
+  async cancel(id: string): Promise<StoredWatchdogJob> {
+    const job = await this.inspect(id);
+    if (isTerminalStatus(job.status)) return job;
+    const requestedAt = this.now().toISOString();
+    await this.store.requestCancellation(job.id, requestedAt);
+    const cancelling = normalizeStoredWatchdogJob({
+      ...job,
+      status: "cancelling",
+      cancelRequestedAt: requestedAt,
+      updatedAt: requestedAt,
+    });
+    await this.store.write(cancelling);
+    return cancelling;
+  }
+
+  async reconcile(): Promise<void> {
+    if (this.reconciliation) {
+      return this.reconciliation;
+    }
+    this.reconciliation = this.reconcileJobs().finally(() => {
+      this.reconciliation = null;
+    });
+    return this.reconciliation;
+  }
+
+  private async reconcileJobs(): Promise<void> {
+    for (const stored of await this.store.list()) {
+      try {
+        const job = await this.reconcileActiveJob(stored);
+        if (!job) {
+          continue;
+        }
+        await this.deliverIfPending(job);
+      } catch (error) {
+        this.logger.warn({ err: error, jobId: stored.id }, "Watchdog job reconciliation failed");
+      }
+    }
+    await this.store.pruneDeliveredBefore(this.now().getTime() - this.retentionMs);
+  }
+
+  private async reconcileActiveJob(stored: StoredWatchdogJob): Promise<StoredWatchdogJob | null> {
+    if (
+      stored.status !== "queued" &&
+      stored.status !== "running" &&
+      stored.status !== "cancelling"
+    ) {
+      return stored;
+    }
+
+    const result = await this.resultReader.read(stored.id);
+    if (!result) {
+      return this.reconcileActiveJobWithoutResult(stored);
+    }
+
+    const job = normalizeStoredWatchdogJob({
+      ...stored,
+      status: statusForResult(result),
+      result,
+      updatedAt: this.now().toISOString(),
+    });
+    await this.store.write(job);
+    return job;
+  }
+
+  private async reconcileActiveJobWithoutResult(
+    job: StoredWatchdogJob,
+  ): Promise<StoredWatchdogJob | null> {
+    if (job.status === "queued" && job.workerPid === null) {
+      return this.reconcileQueuedWithoutPid(job);
+    }
+    if (job.workerPid !== null && !this.isProcessAlive(job.workerPid)) {
+      return this.failDeadWorker(job);
+    }
+    return null;
+  }
+
+  private async reconcileQueuedWithoutPid(
+    job: StoredWatchdogJob,
+  ): Promise<StoredWatchdogJob | null> {
+    // Crash window: worker acquired the durable lock before the daemon
+    // persisted workerPid/running. Prefer adopting a live lock owner;
+    // only fail for operator inspection when the lock PID is gone.
+    const lockRead = await this.store.readWorkerLock(job.id);
+    if (lockRead.status === "missing") {
+      await this.launchQueuedJob(job);
+      return null;
+    }
+    if (lockRead.status === "valid" && this.isProcessAlive(lockRead.lock.pid)) {
+      await this.adoptQueuedWithLiveLock(job, lockRead.lock.pid);
+      return null;
+    }
+    return this.failQueuedWithExistingLock(job);
+  }
+
+  private async adoptQueuedWithLiveLock(
+    job: StoredWatchdogJob,
+    workerPid: number,
+  ): Promise<StoredWatchdogJob> {
+    const running = normalizeStoredWatchdogJob({
+      ...job,
+      status: "running",
+      workerPid,
+      updatedAt: this.now().toISOString(),
+    });
+    await this.store.write(running);
+    return running;
+  }
+
+  private async failQueuedWithExistingLock(job: StoredWatchdogJob): Promise<StoredWatchdogJob> {
+    const failed = normalizeStoredWatchdogJob({
+      ...job,
+      status: "failed",
+      result: {
+        exitCode: null,
+        signal: null,
+        error:
+          "Watchdog worker lock exists without a persisted result or workerPid; refusing to relaunch for operator inspection",
+        finishedAt: this.now().toISOString(),
+      },
+      updatedAt: this.now().toISOString(),
+    });
+    await this.store.write(failed);
+    return failed;
+  }
+
+  private async launchQueuedJob(job: StoredWatchdogJob): Promise<StoredWatchdogJob> {
+    const launched = await this.launcher.launch({
+      jobId: job.id,
+      cwd: job.cwd,
+      command: job.command,
+      args: job.args,
+      ...(job.timeoutMs === null ? {} : { timeoutMs: job.timeoutMs }),
+    });
+    const running = normalizeStoredWatchdogJob({
+      ...job,
+      status: "running",
+      workerPid: launched.pid,
+      updatedAt: this.now().toISOString(),
+    });
+    await this.store.write(running);
+    return running;
+  }
+
+  private async failDeadWorker(job: StoredWatchdogJob): Promise<StoredWatchdogJob> {
+    const failed = normalizeStoredWatchdogJob({
+      ...job,
+      status: "failed",
+      result: {
+        exitCode: null,
+        signal: null,
+        error: `Watchdog worker pid ${job.workerPid} exited without writing a result`,
+        finishedAt: this.now().toISOString(),
+      },
+      updatedAt: this.now().toISOString(),
+    });
+    await this.store.write(failed);
+    return failed;
+  }
+
+  private async deliverIfPending(job: StoredWatchdogJob): Promise<void> {
+    if (!isTerminalStatus(job.status) || job.deliveryStatus === "delivered") {
+      return;
+    }
+    const notification = await this.notifier.notify(job);
+    if (notification === "busy") {
+      return;
+    }
+    const deliveredAt = this.now().toISOString();
+    await this.store.write(
+      normalizeStoredWatchdogJob({
+        ...job,
+        deliveryStatus: "delivered",
+        deliveredAt,
+        updatedAt: deliveredAt,
+      }),
+    );
+  }
+}
+
+class WatchdogStore {
+  constructor(
+    private readonly directory: string,
+    private readonly logger: Logger,
+  ) {}
+
+  async write(job: StoredWatchdogJob): Promise<void> {
+    await mkdir(this.directory, { recursive: true });
+    await writeJsonFileAtomic(this.filePath(job.id), normalizeStoredWatchdogJob(job), {
+      mode: 0o600,
+    });
+  }
+
+  async get(id: string): Promise<StoredWatchdogJob | null> {
+    try {
+      return normalizeStoredWatchdogJob(
+        StoredWatchdogJobRawSchema.parse(JSON.parse(await readFile(this.filePath(id), "utf8"))),
+      );
+    } catch (error) {
+      if (isNodeErrorWithCode(error, "ENOENT")) return null;
+      throw error;
+    }
+  }
+
+  async requestCancellation(id: string, requestedAt: string): Promise<void> {
+    const validId = requireValidJobId(id);
+    await writeJsonFileAtomic(
+      path.join(this.directory, "cancellations", `${validId}.json`),
+      { jobId: validId, requestedAt },
+      { mode: 0o600 },
+    );
+  }
+
+  async list(): Promise<StoredWatchdogJob[]> {
+    await mkdir(this.directory, { recursive: true });
+    const entries = await readdir(this.directory, { withFileTypes: true });
+    const jobs: StoredWatchdogJob[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) {
+        continue;
+      }
+      const filePath = path.join(this.directory, entry.name);
+      try {
+        const parsed = JSON.parse(await readFile(filePath, "utf8"));
+        const job = normalizeStoredWatchdogJob(StoredWatchdogJobRawSchema.parse(parsed));
+        const expectedId = entry.name.slice(0, -".json".length);
+        if (job.id !== expectedId) {
+          throw new Error(`Watchdog record id ${job.id} does not match filename ${entry.name}`);
+        }
+        jobs.push(job);
+      } catch (error) {
+        const quarantinePath = `${filePath}.corrupt-${Date.now()}`;
+        try {
+          await rename(filePath, quarantinePath);
+        } catch (quarantineError) {
+          this.logger.warn(
+            { err: quarantineError, filePath },
+            "Failed to quarantine invalid watchdog job",
+          );
+        }
+        this.logger.warn(
+          { err: error, filePath, quarantinePath },
+          "Quarantined invalid watchdog job",
+        );
+      }
+    }
+    return jobs.sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+  }
+
+  async pruneDeliveredBefore(cutoffMs: number): Promise<void> {
+    for (const job of await this.list()) {
+      if (
+        job.deliveryStatus !== "delivered" ||
+        !isTerminalStatus(job.status) ||
+        Date.parse(job.updatedAt) >= cutoffMs
+      ) {
+        continue;
+      }
+      const id = requireValidJobId(job.id);
+      await Promise.all([
+        rm(this.filePath(id), { force: true }),
+        rm(path.join(this.directory, "requests", `${id}.json`), { force: true }),
+        rm(path.join(this.directory, "results", `${id}.json`), { force: true }),
+        rm(path.join(this.directory, "logs", `${id}.stdout.log`), { force: true }),
+        rm(path.join(this.directory, "logs", `${id}.stderr.log`), { force: true }),
+        rm(this.lockPath(id), { force: true }),
+        rm(path.join(this.directory, "cancellations", `${id}.json`), { force: true }),
+      ]);
+    }
+  }
+
+  async readWorkerLock(id: string): Promise<WatchdogWorkerLockRead> {
+    const lockPath = this.lockPath(id);
+    let raw: string;
+    try {
+      raw = await readFile(lockPath, "utf8");
+    } catch (error) {
+      if (isNodeErrorWithCode(error, "ENOENT")) return { status: "missing" };
+      throw error;
+    }
+    try {
+      return {
+        status: "valid",
+        lock: WatchdogWorkerLockSchema.parse(JSON.parse(raw)),
+      };
+    } catch (error) {
+      const quarantinePath = `${lockPath}.corrupt-${Date.now()}`;
+      try {
+        await rename(lockPath, quarantinePath);
+      } catch (quarantineError) {
+        this.logger.warn(
+          { err: quarantineError, lockPath },
+          "Failed to quarantine invalid watchdog worker lock",
+        );
+      }
+      this.logger.warn(
+        { err: error, lockPath, quarantinePath },
+        "Quarantined invalid watchdog worker lock",
+      );
+      return { status: "corrupt" };
+    }
+  }
+
+  private lockPath(id: string): string {
+    return path.join(this.directory, "locks", `${requireValidJobId(id)}.lock`);
+  }
+
+  private filePath(id: string): string {
+    return path.join(this.directory, `${requireValidJobId(id)}.json`);
+  }
+}
+
+export function normalizeStoredWatchdogJob(
+  value: z.infer<typeof StoredWatchdogJobRawSchema> | StoredWatchdogJob,
+): StoredWatchdogJob {
+  const parsed = StoredWatchdogJobRawSchema.parse(value);
+  return {
+    id: parsed.id,
+    name: parsed.name,
+    agentId: parsed.agentId,
+    workspaceId: parsed.workspaceId,
+    cwd: parsed.cwd,
+    command: parsed.command,
+    args: parsed.args ?? [],
+    status: parsed.status,
+    deliveryStatus: parsed.deliveryStatus ?? "pending",
+    workerPid: parsed.workerPid ?? null,
+    result: parsed.result ?? null,
+    timeoutMs: parsed.timeoutMs ?? null,
+    cancelRequestedAt: parsed.cancelRequestedAt ?? null,
+    createdAt: parsed.createdAt,
+    updatedAt: parsed.updatedAt,
+    deliveredAt: parsed.deliveredAt ?? null,
+  };
+}
+
+function isTerminalStatus(status: StoredWatchdogJob["status"]): boolean {
+  return ["completed", "failed", "cancelled", "timed_out"].includes(status);
+}
+
+function statusForResult(result: WatchdogResult): StoredWatchdogJob["status"] {
+  if (result.terminationReason === "cancelled") return "cancelled";
+  if (result.terminationReason === "timeout") return "timed_out";
+  if (result.error || result.exitCode === null || result.exitCode !== 0) return "failed";
+  return "completed";
+}
+
+function requireValidJobId(id: string): string {
+  if (!WATCHDOG_JOB_ID_PATTERN.test(id)) {
+    throw new Error(`Invalid watchdog job id: ${id}`);
+  }
+  return id;
+}
+
+function isNodeErrorWithCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+function requireNonEmpty(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${field} is required`);
+  }
+  return trimmed;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return isNodeErrorWithCode(error, "EPERM");
+  }
+}

--- a/packages/server/src/server/watchdog/system.test.ts
+++ b/packages/server/src/server/watchdog/system.test.ts
@@ -1,0 +1,146 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { DetachedWatchdogLauncher, FileWatchdogResultReader } from "./system.js";
+import { runWatchdogWorker } from "./worker.js";
+
+let tempHome: string | null = null;
+
+afterEach(async () => {
+  if (tempHome) {
+    await rm(tempHome, { recursive: true, force: true });
+    tempHome = null;
+  }
+});
+
+describe("watchdog worker", () => {
+  test("runs an argv command without a shell and writes durable output and result files", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-worker-"));
+    const paths = {
+      result: path.join(tempHome, "watchdogs", "results", "job-1.json"),
+      stdout: path.join(tempHome, "watchdogs", "logs", "job-1.stdout.log"),
+      stderr: path.join(tempHome, "watchdogs", "logs", "job-1.stderr.log"),
+    };
+
+    await runWatchdogWorker({
+      cwd: tempHome,
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('done\\n'); process.stderr.write('warning\\n')"],
+      ...paths,
+    });
+
+    const reader = new FileWatchdogResultReader(tempHome);
+    expect(await reader.read("job-1")).toEqual({
+      exitCode: 0,
+      signal: null,
+      error: null,
+      finishedAt: expect.any(String),
+      stdout: { bytes: 5, truncated: false },
+      stderr: { bytes: 8, truncated: false },
+    });
+    expect(await readFile(paths.stdout, "utf8")).toBe("done\n");
+    expect(await readFile(paths.stderr, "utf8")).toBe("warning\n");
+    if (process.platform !== "win32") {
+      expect((await stat(paths.result)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  test("the detached launcher executes the TypeScript worker in development", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-system-"));
+    const launcher = new DetachedWatchdogLauncher(tempHome);
+    const reader = new FileWatchdogResultReader(tempHome);
+
+    const launched = await launcher.launch({
+      jobId: "dev-worker",
+      cwd: tempHome,
+      command: process.execPath,
+      args: ["-e", "console.log('detached-dev-ok')"],
+    });
+
+    expect(launched.pid).toBeGreaterThan(0);
+    let result = null;
+    for (let attempt = 0; attempt < 100 && result === null; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      result = await reader.read("dev-worker");
+    }
+    expect(result).toMatchObject({ exitCode: 0, error: null });
+    expect(
+      await readFile(path.join(tempHome, "watchdogs", "logs", "dev-worker.stdout.log"), "utf8"),
+    ).toBe("detached-dev-ok\n");
+  });
+
+  test("terminates a command when its timeout expires", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-timeout-"));
+    const paths = {
+      result: path.join(tempHome, "result.json"),
+      stdout: path.join(tempHome, "stdout.log"),
+      stderr: path.join(tempHome, "stderr.log"),
+    };
+    const startedAt = Date.now();
+
+    await runWatchdogWorker({
+      cwd: tempHome,
+      command: process.execPath,
+      args: ["-e", "setTimeout(() => process.exit(0), 500)"],
+      timeoutMs: 50,
+      ...paths,
+    });
+
+    expect(Date.now() - startedAt).toBeLessThan(450);
+    expect(JSON.parse(await readFile(paths.result, "utf8"))).toMatchObject({
+      exitCode: null,
+      terminationReason: "timeout",
+    });
+  });
+
+  test("terminates a command after a durable cancellation request", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-cancel-"));
+    const cancel = path.join(tempHome, "cancel.json");
+    const paths = {
+      result: path.join(tempHome, "result.json"),
+      stdout: path.join(tempHome, "stdout.log"),
+      stderr: path.join(tempHome, "stderr.log"),
+    };
+    const running = runWatchdogWorker({
+      cwd: tempHome,
+      command: process.execPath,
+      args: ["-e", "setTimeout(() => process.exit(0), 500)"],
+      cancel,
+      ...paths,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await writeFile(cancel, "{}", "utf8");
+
+    await running;
+
+    expect(JSON.parse(await readFile(paths.result, "utf8"))).toMatchObject({
+      exitCode: null,
+      terminationReason: "cancelled",
+    });
+  });
+
+  test("bounds captured stdout and records truncation metadata", async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "paseo-watchdog-bound-"));
+    const paths = {
+      result: path.join(tempHome, "result.json"),
+      stdout: path.join(tempHome, "stdout.log"),
+      stderr: path.join(tempHome, "stderr.log"),
+    };
+
+    await runWatchdogWorker({
+      cwd: tempHome,
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('abcdefghij')"],
+      maxStreamBytes: 4,
+      ...paths,
+    });
+
+    expect(JSON.parse(await readFile(paths.result, "utf8"))).toMatchObject({
+      exitCode: 0,
+      stdout: { bytes: 4, truncated: true },
+    });
+    expect(await readFile(paths.stdout, "utf8")).toBe("abcd");
+  });
+});

--- a/packages/server/src/server/watchdog/system.ts
+++ b/packages/server/src/server/watchdog/system.ts
@@ -1,0 +1,107 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { z } from "zod";
+
+import { writeJsonFileAtomic } from "../atomic-file.js";
+import type { WatchdogLauncher, WatchdogResult, WatchdogResultReader } from "./service.js";
+
+const WatchdogResultFileSchema = z.object({
+  exitCode: z.number().int().nullable(),
+  signal: z.string().nullable(),
+  error: z.string().nullable(),
+  finishedAt: z.string(),
+  terminationReason: z.enum(["cancelled", "timeout"]).optional(),
+  stdout: z
+    .object({
+      bytes: z.number().int().nonnegative(),
+      truncated: z.boolean(),
+    })
+    .optional(),
+  stderr: z
+    .object({
+      bytes: z.number().int().nonnegative(),
+      truncated: z.boolean(),
+    })
+    .optional(),
+});
+
+export class DetachedWatchdogLauncher implements WatchdogLauncher {
+  private readonly workerModulePath: string;
+
+  constructor(
+    private readonly paseoHome: string,
+    workerModulePath?: string,
+  ) {
+    if (workerModulePath) {
+      this.workerModulePath = workerModulePath;
+      return;
+    }
+    const builtWorkerPath = fileURLToPath(new URL("./worker-entrypoint.js", import.meta.url));
+    this.workerModulePath = existsSync(builtWorkerPath)
+      ? builtWorkerPath
+      : fileURLToPath(new URL("./worker-entrypoint.ts", import.meta.url));
+  }
+
+  async launch(input: {
+    jobId: string;
+    cwd: string;
+    command: string;
+    args: string[];
+    timeoutMs?: number;
+  }): Promise<{ pid: number }> {
+    const requestPath = path.join(this.paseoHome, "watchdogs", "requests", `${input.jobId}.json`);
+    await writeJsonFileAtomic(
+      requestPath,
+      {
+        ...input,
+        result: path.join(this.paseoHome, "watchdogs", "results", `${input.jobId}.json`),
+        stdout: path.join(this.paseoHome, "watchdogs", "logs", `${input.jobId}.stdout.log`),
+        stderr: path.join(this.paseoHome, "watchdogs", "logs", `${input.jobId}.stderr.log`),
+        lock: path.join(this.paseoHome, "watchdogs", "locks", `${input.jobId}.lock`),
+        cancel: path.join(this.paseoHome, "watchdogs", "cancellations", `${input.jobId}.json`),
+      },
+      { mode: 0o600 },
+    );
+    const runtimeArgs = this.workerModulePath.endsWith(".ts") ? ["--import", "tsx"] : [];
+    const worker = spawn(process.execPath, [...runtimeArgs, this.workerModulePath, requestPath], {
+      detached: true,
+      stdio: "ignore",
+      shell: false,
+    });
+    if (!worker.pid) {
+      throw new Error("Failed to start watchdog worker");
+    }
+    worker.unref();
+    return { pid: worker.pid };
+  }
+}
+
+export class FileWatchdogResultReader implements WatchdogResultReader {
+  constructor(private readonly paseoHome: string) {}
+
+  async read(jobId: string): Promise<WatchdogResult | null> {
+    try {
+      const content = await readFile(this.resultPath(jobId), "utf8");
+      return WatchdogResultFileSchema.parse(JSON.parse(content));
+    } catch (error) {
+      if (isNodeErrorWithCode(error, "ENOENT")) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private resultPath(jobId: string): string {
+    if (!/^[a-zA-Z0-9_-]+$/.test(jobId)) {
+      throw new Error(`Invalid watchdog job id: ${jobId}`);
+    }
+    return path.join(this.paseoHome, "watchdogs", "results", `${jobId}.json`);
+  }
+}
+
+function isNodeErrorWithCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === code;
+}

--- a/packages/server/src/server/watchdog/worker-entrypoint.ts
+++ b/packages/server/src/server/watchdog/worker-entrypoint.ts
@@ -1,0 +1,61 @@
+import { mkdir, open, readFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+
+import { writeJsonFileAtomic } from "../atomic-file.js";
+import { runWatchdogWorker } from "./worker.js";
+
+const WorkerRequestSchema = z.object({
+  jobId: z.string().min(1),
+  cwd: z.string().min(1),
+  command: z.string().min(1),
+  args: z.array(z.string()),
+  result: z.string().min(1),
+  stdout: z.string().min(1),
+  stderr: z.string().min(1),
+  lock: z.string().min(1),
+  cancel: z.string().min(1),
+  timeoutMs: z.number().int().positive().max(2_147_483_647).optional(),
+});
+
+async function main(): Promise<void> {
+  const requestPath = process.argv[2];
+  if (!requestPath) {
+    throw new Error("Watchdog worker requires a request path");
+  }
+  const request = WorkerRequestSchema.parse(JSON.parse(await readFile(requestPath, "utf8")));
+  try {
+    await mkdir(path.dirname(request.lock), { recursive: true });
+    const lock = await open(request.lock, "wx", 0o600);
+    await lock.writeFile(JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }));
+    await lock.close();
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "EEXIST") {
+      return;
+    }
+    throw error;
+  }
+  await runWatchdogWorker(request);
+}
+
+void main().catch(async (error: unknown) => {
+  const requestPath = process.argv[2];
+  if (requestPath) {
+    try {
+      const request = WorkerRequestSchema.parse(JSON.parse(await readFile(requestPath, "utf8")));
+      await writeJsonFileAtomic(
+        request.result,
+        {
+          exitCode: null,
+          signal: null,
+          error: error instanceof Error ? error.message : String(error),
+          finishedAt: new Date().toISOString(),
+        },
+        { mode: 0o600 },
+      );
+    } catch {
+      // The daemon will retain the queued job for operator inspection when even the request is unreadable.
+    }
+  }
+  process.exitCode = 1;
+});

--- a/packages/server/src/server/watchdog/worker.ts
+++ b/packages/server/src/server/watchdog/worker.ts
@@ -1,0 +1,155 @@
+import { createWriteStream } from "node:fs";
+import { access, mkdir, open } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { finished } from "node:stream/promises";
+import type { Readable } from "node:stream";
+
+import { terminateWithTreeKill } from "../../utils/tree-kill.js";
+import { writeJsonFileAtomic } from "../atomic-file.js";
+import { WATCHDOG_MAX_STREAM_BYTES, type WatchdogResult } from "./service.js";
+
+export interface WatchdogWorkerInput {
+  cwd: string;
+  command: string;
+  args: string[];
+  result: string;
+  stdout: string;
+  stderr: string;
+  cancel?: string;
+  timeoutMs?: number;
+  maxStreamBytes?: number;
+}
+
+export interface WatchdogStreamStats {
+  bytes: number;
+  truncated: boolean;
+}
+
+export async function runWatchdogWorker(input: WatchdogWorkerInput): Promise<void> {
+  await Promise.all([
+    mkdir(path.dirname(input.result), { recursive: true }),
+    mkdir(path.dirname(input.stdout), { recursive: true }),
+    mkdir(path.dirname(input.stderr), { recursive: true }),
+  ]);
+  // Truncate previous logs for a relaunch of the same job id.
+  await Promise.all([
+    (await open(input.stdout, "w", 0o600)).close(),
+    (await open(input.stderr, "w", 0o600)).close(),
+  ]);
+
+  const maxStreamBytes = input.maxStreamBytes ?? WATCHDOG_MAX_STREAM_BYTES;
+  let terminationReason: "cancelled" | "timeout" | null = null;
+  const child = spawn(input.command, input.args, {
+    cwd: input.cwd,
+    env: process.env,
+    shell: false,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (!child.stdout || !child.stderr) {
+    throw new Error("Watchdog worker failed to open child stdio pipes");
+  }
+
+  const stdoutCapture = captureBoundedStream(child.stdout, input.stdout, maxStreamBytes);
+  const stderrCapture = captureBoundedStream(child.stderr, input.stderr, maxStreamBytes);
+
+  const terminate = (reason: "cancelled" | "timeout") => {
+    if (child.exitCode !== null || child.signalCode !== null || terminationReason) return;
+    terminationReason = reason;
+    void terminateWithTreeKill(child, {
+      gracefulTimeoutMs: 200,
+      forceTimeoutMs: 200,
+    });
+  };
+  const timeout =
+    input.timeoutMs === undefined ? null : setTimeout(() => terminate("timeout"), input.timeoutMs);
+  timeout?.unref();
+  const checkCancellation = () => {
+    if (!input.cancel) return;
+    void access(input.cancel)
+      .then(() => terminate("cancelled"))
+      .catch(() => undefined);
+  };
+  checkCancellation();
+  const cancellationPoll = input.cancel ? setInterval(checkCancellation, 50) : null;
+  cancellationPoll?.unref();
+
+  const result = await Promise.race([
+    new Promise<WatchdogResult>((resolve) => {
+      child.once("error", (error) =>
+        resolve({
+          exitCode: null,
+          signal: null,
+          error: error.message,
+          finishedAt: new Date().toISOString(),
+        }),
+      );
+    }),
+    new Promise<WatchdogResult>((resolve) => {
+      child.once("close", (exitCode, signal) =>
+        resolve({
+          exitCode: terminationReason ? null : exitCode,
+          signal,
+          error: null,
+          finishedAt: new Date().toISOString(),
+          ...(terminationReason ? { terminationReason } : {}),
+        }),
+      );
+    }),
+  ]);
+  if (timeout) clearTimeout(timeout);
+  if (cancellationPoll) clearInterval(cancellationPoll);
+
+  const [stdout, stderr] = await Promise.all([stdoutCapture, stderrCapture]);
+  await writeJsonFileAtomic(
+    input.result,
+    {
+      ...result,
+      stdout,
+      stderr,
+    },
+    { mode: 0o600 },
+  );
+}
+
+function captureBoundedStream(
+  stream: Readable,
+  filePath: string,
+  maxBytes: number,
+): Promise<WatchdogStreamStats> {
+  return new Promise((resolve, reject) => {
+    let bytes = 0;
+    let truncated = false;
+    const output = createWriteStream(filePath, { flags: "w", mode: 0o600 });
+    stream.on("data", (chunk: Buffer | string) => {
+      const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+      if (truncated) {
+        return;
+      }
+      const remaining = maxBytes - bytes;
+      if (buffer.length <= remaining) {
+        bytes += buffer.length;
+        if (!output.write(buffer)) {
+          stream.pause();
+          output.once("drain", () => stream.resume());
+        }
+        return;
+      }
+      if (remaining > 0) {
+        bytes += remaining;
+        output.write(buffer.subarray(0, remaining));
+      }
+      truncated = true;
+      stream.resume();
+    });
+    stream.on("error", reject);
+    output.on("error", reject);
+    void finished(stream)
+      .then(() => {
+        output.end();
+        return finished(output);
+      })
+      .then(() => resolve({ bytes, truncated }))
+      .catch(reject);
+  });
+}

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -12,6 +12,7 @@ import type pino from "pino";
 import type { ProjectRegistry, WorkspaceRegistry } from "./workspace-registry.js";
 import type { ProjectUpdate } from "./workspace-reconciliation-service.js";
 import type { ScheduleService } from "./schedule/service.js";
+import type { WatchdogService } from "./watchdog/service.js";
 import type { CheckoutDiffManager, CheckoutDiffMetrics } from "./checkout-diff-manager.js";
 import type { DaemonConfigStore, MutableDaemonConfig } from "./daemon-config-store.js";
 import {
@@ -554,6 +555,7 @@ export class VoiceAssistantWebSocketServer {
   private readonly workspaceRegistry: WorkspaceRegistry;
   private readonly workspaceLabelService: WorkspaceLabelService | null;
   private readonly scheduleService: ScheduleService;
+  private readonly watchdogService: WatchdogService | null;
   private readonly checkoutDiffManager: CheckoutDiffManager;
   private readonly github: ForgeService;
   private readonly workspaceGitService: WorkspaceGitService;
@@ -652,6 +654,7 @@ export class VoiceAssistantWebSocketServer {
     pluginRuntime?: SessionOptions["pluginRuntime"],
     orchestrationSkills?: SessionOptions["orchestrationSkills"],
     workspaceLabelService?: WorkspaceLabelService,
+    watchdogService?: WatchdogService,
   ) {
     this.logger = logger.child({ module: "websocket-server" });
     this.workspaceSetupRuntime = workspaceSetupRuntime;
@@ -678,6 +681,7 @@ export class VoiceAssistantWebSocketServer {
       checkoutDiffManager,
     });
     this.scheduleService = requiredServices.scheduleService;
+    this.watchdogService = watchdogService ?? null;
     this.checkoutDiffManager = requiredServices.checkoutDiffManager;
     this.github = github ?? createGitHubService();
     this.workspaceGitService = workspaceGitService ?? createFallbackWorkspaceGitService();
@@ -1435,6 +1439,7 @@ export class VoiceAssistantWebSocketServer {
       workspaceLabelService: this.workspaceLabelService ?? undefined,
       directorySync: this.directorySync,
       scheduleService: this.scheduleService,
+      watchdogService: this.watchdogService ?? undefined,
       checkoutDiffManager: this.checkoutDiffManager,
       github: this.github,
       workspaceGitService: this.workspaceGitService,
@@ -1678,6 +1683,8 @@ export class VoiceAssistantWebSocketServer {
         ...(this.advertiseDaemonStatusRpc ? { daemonStatusRpc: true } : {}),
         // COMPAT(daemonConfigReload): added in v0.4.0, remove gate after 2027-02-14.
         daemonConfigReload: true,
+        // COMPAT(durableCommands): added in v0.6.1, remove gate after 2027-02-26.
+        ...(this.watchdogService ? { durableCommands: true } : {}),
         // COMPAT(relayConfig): added in v0.2.6, remove gate after 2027-01-31.
         ...(this.advertiseRelayConfig ? { relayConfig: true } : {}),
         // COMPAT(pushTokenRevocation): added in v0.3.2, remove gate after 2027-02-10.


### PR DESCRIPTION
### Linked issue

Discussion: https://github.com/getpaseo/paseo/discussions/3836

Related bugs: #2495, #2625, #3061

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

I use Paseo to run bounded commands such as builds, tests, exports, and remote job monitors. These commands can outlive the provider turn that started them, but I still need the exit status and output before the agent can finish its workflow.

Today I either keep a turn open, poll a terminal, or delegate the wait to another agent. I wanted Paseo to accept the command once, persist its receipt, and wake the same Agent when it is safe to continue. I have been running this implementation on my Linux Paseo host and used its completion wake to resume the original Agent after a daemon restart.

This PR is based on Paseo **0.6.1**, commit `5c9a04d33388ae8ee3a91f1feadc52b4281ffe5c`. It intentionally does not include the current `0.7.0-beta.1` main changes. If the direction is accepted, I can merge the requested upstream commit into this long-lived feature branch and resolve the drift.

### Goals

- Persist a bounded command request before launch and return a stable job ID immediately.
- Run the command outside the initiating provider turn with `shell: false`.
- Preserve terminal result, exit code, bounded stdout/stderr metadata, timeout, and cancellation state.
- Reconcile results after daemon restart without blindly rerunning an uncertain command.
- Keep execution state separate from completion-delivery state.
- Defer completion while the originating Agent is busy or blocked on permission.
- Expose start/list/inspect/cancel through protocol, client, CLI, and Agent MCP tools.
- Gate new clients on `server_info.features.durableCommands`.

### Non-goals

- Interactive terminals or intentionally long-lived workspace services.
- Schedules, recurring automation, or agent-to-agent delegation.
- App UI.
- Automatic rerun after a host reboot or uncertain mutation.
- Updating this initial implementation beyond the tested Paseo 0.6.1 base.

### QA

Root repository gates:

```text
$ npm run format
Finished in 2524ms on 4097 files using 16 threads.

$ npm run lint
Found 0 warnings and 0 errors.
Finished in 1.9s on 3847 files with 177 rules using 16 threads.

$ npm run typecheck
@.../expo-two-way-audio, highlight, plugin, protocol, client,
server, app, relay, website, desktop, and cli all passed.
```

Focused tests:

```bash
npx vitest run \
  packages/protocol/src/watchdog/rpc-schemas.test.ts \
  packages/server/src/server/watchdog/service.test.ts \
  packages/server/src/server/watchdog/system.test.ts \
  packages/server/src/server/watchdog/notifier.test.ts \
  packages/server/src/server/agent/mcp-server.test.ts \
  --bail=1
```

```text
PASS (147) FAIL (0)
```

Crash-window service tests after live-lock recovery hardening:

```text
PASS (12) FAIL (0)
```

Existing POSIX process-tree fixture:

```text
$ npx vitest run packages/server/src/utils/tree-kill.test.ts --bail=1
PASS (1) FAIL (0) skipped (1)
```

The skipped leg is the Windows-specific fixture.

I also ran `npm run build:server`, `npm run typecheck:server`, and npm package dry-runs. The packed server contains the compiled `worker-entrypoint.js`; the packed CLI contains the Watchdog command.

Runtime observations on Linux:

| Scenario | Observed result |
| --- | --- |
| success | `completed`, exit code `0`, stdout/stderr receipt preserved |
| timeout | `timed_out`, `SIGTERM`, `terminationReason=timeout` |
| cancellation | `cancelled`, `SIGTERM`, `terminationReason=cancelled` |
| daemon restart | detached worker completed; restarted daemon consumed the existing receipt |
| Agent wake | completion resumed the original Agent and marked delivery `delivered` |

Installed live smoke:

```text
jobId: 3b0a0b0c-1990-4175-83e1-df3acea3a208
status: completed
deliveryStatus: delivered
exitCode: 0
stdout: live-watchdog-0.6.1-ok
stdoutBytes: 23
stdoutTruncated: false
stderrBytes: 0
```

Platform coverage:

- Linux: automated tests, package build, isolated restart, and installed live smoke.
- macOS: not tested.
- Windows: not tested for detached execution or process-tree runtime.
- Docker: not tested.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
