### PR TITLE
feat(plugin): expose scrim and tinted status tokens in PluginTheme

### DIFF
--- a/packages/app/src/plugins/composer-pills/index.tsx
+++ b/packages/app/src/plugins/composer-pills/index.tsx
@@ -16,7 +16,9 @@ import { toPluginTheme } from "../theme";
 import type { InstalledPlugin, PluginComposerPillContribution } from "../types";
 import { pluginComposerPillStore } from "./store";
 
-const pluginThemeMapping = (theme: Theme) => ({ theme: toPluginTheme(theme) });
+const pluginThemeMapping = (theme: Theme, runtime: { breakpoint?: string }) => ({
+  theme: toPluginTheme(theme, runtime.breakpoint),
+});
 
 function resolvePlatform(): PluginComposerPillProps["layout"]["platform"] {
   if (Platform.OS === "ios") return "ios";

--- a/packages/app/src/plugins/surface-screen.tsx
+++ b/packages/app/src/plugins/surface-screen.tsx
@@ -30,8 +30,8 @@ import {
 
 const EMPTY_SHORTCUT_KEYS: ShortcutKey[] = [];
 const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
-const pluginThemeMapping = (theme: Theme) => ({
-  theme: toPluginTheme(theme),
+const pluginThemeMapping = (theme: Theme, runtime: { breakpoint?: string }) => ({
+  theme: toPluginTheme(theme, runtime.breakpoint),
 });
 const ThemedX = withUnistyles(X);
 const ThemedChevronDown = withUnistyles(ChevronDown);

--- a/packages/app/src/plugins/theme.test.ts
+++ b/packages/app/src/plugins/theme.test.ts
@@ -64,7 +64,7 @@ function installed(serverId: string, themes: PluginThemeContribution[]): Install
 
 describe("toPluginTheme", () => {
   it("maps the app theme into the plugin color tokens", () => {
-    expect(toPluginTheme(lightTheme)).toEqual({
+    expect(toPluginTheme(lightTheme, "md")).toEqual({
       colors: {
         surface0: lightTheme.colors.surface0,
         surface1: lightTheme.colors.surface1,
@@ -81,6 +81,10 @@ describe("toPluginTheme", () => {
         statusDangerTint: "rgba(157, 67, 59, 0.1)",
       },
     });
+  });
+
+  it.each(["xs", "sm"])("uses the compact sheet scrim at the %s breakpoint", (breakpoint) => {
+    expect(toPluginTheme(lightTheme, breakpoint).colors.scrim).toBe("rgba(0,0,0,0.45)");
   });
 });
 

--- a/packages/app/src/plugins/theme.test.ts
+++ b/packages/app/src/plugins/theme.test.ts
@@ -70,6 +70,7 @@ describe("toPluginTheme", () => {
         surface1: lightTheme.colors.surface1,
         surface2: lightTheme.colors.surface2,
         border: lightTheme.colors.border,
+        scrim: "rgba(0,0,0,0.55)",
         foreground: lightTheme.colors.foreground,
         foregroundMuted: lightTheme.colors.foregroundMuted,
         accent: lightTheme.colors.accent,
@@ -77,6 +78,7 @@ describe("toPluginTheme", () => {
         statusSuccess: lightTheme.colors.statusSuccess,
         statusWarning: lightTheme.colors.statusWarning,
         statusDanger: lightTheme.colors.statusDanger,
+        statusDangerTint: "rgba(157, 67, 59, 0.1)",
       },
     });
   });

--- a/packages/app/src/plugins/theme.ts
+++ b/packages/app/src/plugins/theme.ts
@@ -1,5 +1,6 @@
 import type { PluginTheme } from "@getpaseo/plugin";
 import type { Theme } from "@/styles/theme";
+import { hexColorWithAlpha } from "@/utils/color";
 
 export function toPluginTheme(theme: Theme): PluginTheme {
   return {
@@ -8,6 +9,7 @@ export function toPluginTheme(theme: Theme): PluginTheme {
       surface1: theme.colors.surface1,
       surface2: theme.colors.surface2,
       border: theme.colors.border,
+      scrim: "rgba(0,0,0,0.55)",
       foreground: theme.colors.foreground,
       foregroundMuted: theme.colors.foregroundMuted,
       accent: theme.colors.accent,
@@ -15,6 +17,7 @@ export function toPluginTheme(theme: Theme): PluginTheme {
       statusSuccess: theme.colors.statusSuccess,
       statusWarning: theme.colors.statusWarning,
       statusDanger: theme.colors.statusDanger,
+      statusDangerTint: hexColorWithAlpha(theme.colors.statusDanger, 0.1),
     },
   };
 }

--- a/packages/app/src/plugins/theme.ts
+++ b/packages/app/src/plugins/theme.ts
@@ -2,14 +2,15 @@ import type { PluginTheme } from "@getpaseo/plugin";
 import type { Theme } from "@/styles/theme";
 import { hexColorWithAlpha } from "@/utils/color";
 
-export function toPluginTheme(theme: Theme): PluginTheme {
+export function toPluginTheme(theme: Theme, breakpoint: string | undefined): PluginTheme {
+  const compact = breakpoint === "xs" || breakpoint === "sm";
   return {
     colors: {
       surface0: theme.colors.surface0,
       surface1: theme.colors.surface1,
       surface2: theme.colors.surface2,
       border: theme.colors.border,
-      scrim: "rgba(0,0,0,0.55)",
+      scrim: compact ? "rgba(0,0,0,0.45)" : "rgba(0,0,0,0.55)",
       foreground: theme.colors.foreground,
       foregroundMuted: theme.colors.foregroundMuted,
       accent: theme.colors.accent,

--- a/packages/app/src/plugins/timeline/view.tsx
+++ b/packages/app/src/plugins/timeline/view.tsx
@@ -14,7 +14,9 @@ import { createPluginSurfaceRuntime } from "../surface-runtime";
 import { SurfaceErrorBoundary } from "../surface-error-boundary";
 import { toPluginTheme } from "../theme";
 
-const pluginThemeMapping = (theme: Theme) => ({ theme: toPluginTheme(theme) });
+const pluginThemeMapping = (theme: Theme, runtime: { breakpoint?: string }) => ({
+  theme: toPluginTheme(theme, runtime.breakpoint),
+});
 
 function resolvePlatform(): PluginHostProps["layout"]["platform"] {
   if (Platform.OS === "ios") return "ios";

--- a/packages/app/src/plugins/workspace-panels/panel.tsx
+++ b/packages/app/src/plugins/workspace-panels/panel.tsx
@@ -28,8 +28,8 @@ import { createPluginSurfaceRuntime } from "../surface-runtime";
 import { SurfaceErrorBoundary } from "../surface-error-boundary";
 import { resolvePluginWorkspacePanel } from "./resolution";
 
-const pluginThemeMapping = (theme: Theme) => ({
-  theme: toPluginTheme(theme),
+const pluginThemeMapping = (theme: Theme, runtime: { breakpoint?: string }) => ({
+  theme: toPluginTheme(theme, runtime.breakpoint),
 });
 
 function resolvePlatform(): PluginHostProps["layout"]["platform"] {

--- a/packages/plugin/src/contracts.ts
+++ b/packages/plugin/src/contracts.ts
@@ -10,6 +10,7 @@ export interface PluginTheme {
     readonly surface1: string;
     readonly surface2: string;
     readonly border: string;
+    readonly scrim: string;
     readonly foreground: string;
     readonly foregroundMuted: string;
     readonly accent: string;
@@ -17,6 +18,7 @@ export interface PluginTheme {
     readonly statusSuccess: string;
     readonly statusWarning: string;
     readonly statusDanger: string;
+    readonly statusDangerTint: string;
   };
 }
 

--- a/public-docs/plugins/v0.7/reference.md
+++ b/public-docs/plugins/v0.7/reference.md
@@ -379,11 +379,13 @@ Recreate styles when `theme` or `layout.compact` changes.
 | `theme.colors.surface1`         | Raised surfaces            | Cards and panels                    |
 | `theme.colors.surface2`         | Control surfaces           | Inputs and secondary controls       |
 | `theme.colors.border`           | Surface boundaries         | Borders and dividers                |
+| `theme.colors.scrim`            | Modal backdrops            | Overlays behind modal surfaces      |
 | `theme.colors.accent`           | Primary action fills       | Buttons and selected states         |
 | `theme.colors.accentForeground` | Text on an accent fill     | Button labels                       |
 | `theme.colors.statusSuccess`    | Success feedback           | Success messages and indicators     |
 | `theme.colors.statusWarning`    | Warning feedback           | Warning messages and indicators     |
 | `theme.colors.statusDanger`     | Failure copy               | Error messages and destructive text |
+| `theme.colors.statusDangerTint` | Subtle danger surfaces     | Armed destructive rows              |
 | `layout.compact`                | Padding and stacking       | `true` on mobile and narrow windows |
 | `layout.platform`               | Platform-specific behavior | `ios`, `android`, or `web`          |
 


### PR DESCRIPTION
## Problem

After the 0.7 semantic theme additions, Agent Monitor still hand-composes two colors: a modal sheet scrim from `${foreground}66` and an armed destructive-row tint from `${statusDanger}1A`. Those raw alpha composites are fragile when host surfaces change.

Fixes #3977

## Changes

- Add readonly `scrim` and `statusDangerTint` fields to `PluginTheme.colors`.
- Map `scrim` to the host adaptive modal overlay color: 45% on compact layouts and 55% otherwise.
- Derive `statusDangerTint` with the host's existing 10% danger-surface composition.
- Keep the package-based SDK contract and public plugin reference aligned.

Only the danger tint is exposed. The host has an established 10% danger surface in its diff palette, while it has no general warning tint; the existing success tint is specific to diff additions at a different 15% opacity. This keeps the contract tied to existing host semantics rather than inventing a full status-tint family.

This is additive. Existing tokens and plugin bundles are unchanged, and no protocol fields change.

## QA evidence

```text
$ cd packages/app && npx vitest run --project unit src/plugins/theme.test.ts --bail=1
Test Files  1 passed (1)
Tests       11 passed (11)

$ npm run build:server
exit 0

$ npm run typecheck
exit 0

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format
Finished successfully.

$ npm run format:check
All matched files use the correct format.
```

## Platforms

The mapping is platform-independent and affects iOS, Android, browser web, and Electron equally. Verified with focused mapping coverage for compact and regular breakpoints plus repository typecheck; no platform-specific UI changed.
