### PR TITLE
feat(client): expose agent permission responses through the public SDK

### DIFF
--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -237,19 +237,24 @@ test("createPaseoApi borrows daemon capabilities without exposing connection own
   expect("skills" in paseo.agents).toBe(false);
 });
 
-test("agent handles delegate permission responses to the daemon client", async () => {
-  const daemonClient = new DaemonClient({
-    url: "ws://daemon.test",
-    clientId: "borrowed-api",
-    reconnect: { enabled: false },
-  });
-  const respondToPermission = vi
-    .spyOn(daemonClient, "respondToPermission")
-    .mockResolvedValue(undefined);
+test("agent handles send permission responses for their agent", async () => {
+  const { client, ws } = await connectClient();
 
-  await createPaseoApi(daemonClient)
-    .agents.ref("agent_sdk")
-    .respondToPermission({
+  await client.agents.ref("agent_sdk").respondToPermission({
+    requestId: "permission-request",
+    response: {
+      behavior: "deny",
+      selectedActionId: "deny-once",
+      message: "Not approved",
+      interrupt: true,
+    },
+  });
+
+  expect(parseSentFrame(ws.sent.at(-1))).toEqual({
+    type: "session",
+    message: {
+      type: "agent_permission_response",
+      agentId: "agent_sdk",
       requestId: "permission-request",
       response: {
         behavior: "deny",
@@ -257,14 +262,10 @@ test("agent handles delegate permission responses to the daemon client", async (
         message: "Not approved",
         interrupt: true,
       },
-    });
-
-  expect(respondToPermission).toHaveBeenCalledWith("agent_sdk", "permission-request", {
-    behavior: "deny",
-    selectedActionId: "deny-once",
-    message: "Not approved",
-    interrupt: true,
+    },
   });
+
+  await client.close();
 });
 
 test("project actions list registered projects through the existing RPC", async () => {

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -237,6 +237,36 @@ test("createPaseoApi borrows daemon capabilities without exposing connection own
   expect("skills" in paseo.agents).toBe(false);
 });
 
+test("agent handles delegate permission responses to the daemon client", async () => {
+  const daemonClient = new DaemonClient({
+    url: "ws://daemon.test",
+    clientId: "borrowed-api",
+    reconnect: { enabled: false },
+  });
+  const respondToPermission = vi
+    .spyOn(daemonClient, "respondToPermission")
+    .mockResolvedValue(undefined);
+
+  await createPaseoApi(daemonClient)
+    .agents.ref("agent_sdk")
+    .respondToPermission({
+      requestId: "permission-request",
+      response: {
+        behavior: "deny",
+        selectedActionId: "deny-once",
+        message: "Not approved",
+        interrupt: true,
+      },
+    });
+
+  expect(respondToPermission).toHaveBeenCalledWith("agent_sdk", "permission-request", {
+    behavior: "deny",
+    selectedActionId: "deny-once",
+    message: "Not approved",
+    interrupt: true,
+  });
+});
+
 test("project actions list registered projects through the existing RPC", async () => {
   const { client, ws } = await connectClient();
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,3 +1,4 @@
+import type { AgentPermissionResponse } from "@getpaseo/protocol/agent-types";
 import type {
   AgentSnapshotPayload,
   CreateAgentRequestMessage,
@@ -237,6 +238,12 @@ export interface PaseoAgentRunOptions extends PaseoAgentSendOptions {
 }
 
 export type PaseoAgentRunResult = WaitForFinishResult;
+export type PaseoAgentPermissionResponse = AgentPermissionResponse;
+
+export interface PaseoAgentRespondToPermissionOptions {
+  requestId: string;
+  response: PaseoAgentPermissionResponse;
+}
 
 export interface PaseoAgentCommandsOptions {
   requestId?: string;
@@ -289,6 +296,7 @@ export interface PaseoAgentHandle {
   current(): PaseoAgent | null;
   refresh(requestId?: string): Promise<PaseoAgentRefetchResult | null>;
   send(text: string, options?: PaseoAgentSendOptions): Promise<void>;
+  respondToPermission(options: PaseoAgentRespondToPermissionOptions): Promise<void>;
   /** Sends a prompt and resolves when that turn finishes or needs attention. */
   run(text: string, options?: PaseoAgentRunOptions): Promise<PaseoAgentRunResult>;
   /** Waits for the current turn, including one started with `prompt`. */
@@ -664,6 +672,9 @@ function createAgentHandleFactory(daemonClient: DaemonClient): AgentHandleFactor
       },
       send: async (text, options) => {
         await daemonClient.sendAgentMessage(id, text, options);
+      },
+      respondToPermission: async ({ requestId, response }) => {
+        await daemonClient.respondToPermission(id, requestId, response);
       },
       run: async (text, options) => {
         const { timeoutMs, ...sendOptions } = options ?? {};

--- a/public-docs/sdk/reference.md
+++ b/public-docs/sdk/reference.md
@@ -72,30 +72,31 @@ Creation options include `config`, `cwd`, `parent`, `title`, `prompt`, `env`, `o
 
 ### Agent handle
 
-| Member                      | Result                            | Behavior                                                                                                |
-| --------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `id`                        | `string`                          | Stable daemon agent ID.                                                                                 |
-| `workspaceId`               | `string \| null`                  | Current workspace placement.                                                                            |
-| `cwd`                       | `string \| null`                  | Current working directory.                                                                              |
-| `status`                    | Agent status or `null`            | Current lifecycle status.                                                                               |
-| `capabilities`              | Capability flags or `null`        | What the provider session supports.                                                                     |
-| `availableModes`            | Agent modes or `null`             | Modes the session can switch to.                                                                        |
-| `pendingPermissions`        | Permission requests or `null`     | Requests waiting on an answer.                                                                          |
-| `activeTurn`                | Active turn or `null`             | The turn in flight, with `turnId` and `startedAt`.                                                      |
-| `lastUsage`                 | Usage or `null`                   | Token counts, cost, and context-window use from the last turn.                                          |
-| `lastError`                 | `string \| null`                  | Last error the daemon recorded for the agent.                                                           |
-| `features`                  | Agent features or `null`          | Provider feature toggles and selects with their current values.                                         |
-| `runtimeInfo`               | Runtime info or `null`            | Live provider, session ID, model, thinking option, and mode.                                            |
-| `archivedAt`                | `string \| null`                  | Archive timestamp; `null` while the agent is active.                                                    |
-| `current()`                 | `PaseoAgent \| null`              | Current detailed value observed by this handle; never fetches.                                          |
-| `refresh(requestId?)`       | `PaseoAgentRefetchResult \| null` | Fetches the current agent and project placement.                                                        |
-| `send(text, options?)`      | `Promise<void>`                   | Resolves when the daemon accepts the prompt.                                                            |
-| `run(text, options?)`       | `PaseoAgentRunResult`             | Sends a prompt and waits for that turn. `timeoutMs` controls the wait; it defaults to 10 minutes.       |
-| `waitForFinish(timeoutMs?)` | `PaseoAgentRunResult`             | Waits for the active turn, including an initial prompt. Default timeout: 10 minutes.                    |
-| `commands(options?)`        | `PaseoAgentCommandsResult`        | Asks the live session for its slash commands and skills, including built-in ones. Options: `requestId`. |
-| `subscribe(handler)`        | Unsubscribe function              | Filters agent-directory updates to this ID and refreshes the handle properties.                         |
-| `archive()`                 | `{ archivedAt }`                  | Soft-deletes the agent and closes its runtime.                                                          |
-| `detach()`                  | `Promise<void>`                   | Removes the parent relationship without stopping the agent.                                             |
+| Member                         | Result                            | Behavior                                                                                                |
+| ------------------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `id`                           | `string`                          | Stable daemon agent ID.                                                                                 |
+| `workspaceId`                  | `string \| null`                  | Current workspace placement.                                                                            |
+| `cwd`                          | `string \| null`                  | Current working directory.                                                                              |
+| `status`                       | Agent status or `null`            | Current lifecycle status.                                                                               |
+| `capabilities`                 | Capability flags or `null`        | What the provider session supports.                                                                     |
+| `availableModes`               | Agent modes or `null`             | Modes the session can switch to.                                                                        |
+| `pendingPermissions`           | Permission requests or `null`     | Requests waiting on an answer.                                                                          |
+| `activeTurn`                   | Active turn or `null`             | The turn in flight, with `turnId` and `startedAt`.                                                      |
+| `lastUsage`                    | Usage or `null`                   | Token counts, cost, and context-window use from the last turn.                                          |
+| `lastError`                    | `string \| null`                  | Last error the daemon recorded for the agent.                                                           |
+| `features`                     | Agent features or `null`          | Provider feature toggles and selects with their current values.                                         |
+| `runtimeInfo`                  | Runtime info or `null`            | Live provider, session ID, model, thinking option, and mode.                                            |
+| `archivedAt`                   | `string \| null`                  | Archive timestamp; `null` while the agent is active.                                                    |
+| `current()`                    | `PaseoAgent \| null`              | Current detailed value observed by this handle; never fetches.                                          |
+| `refresh(requestId?)`          | `PaseoAgentRefetchResult \| null` | Fetches the current agent and project placement.                                                        |
+| `send(text, options?)`         | `Promise<void>`                   | Resolves when the daemon accepts the prompt.                                                            |
+| `respondToPermission(options)` | `Promise<void>`                   | Answers a pending permission by `requestId` with an allow or deny `response`.                           |
+| `run(text, options?)`          | `PaseoAgentRunResult`             | Sends a prompt and waits for that turn. `timeoutMs` controls the wait; it defaults to 10 minutes.       |
+| `waitForFinish(timeoutMs?)`    | `PaseoAgentRunResult`             | Waits for the active turn, including an initial prompt. Default timeout: 10 minutes.                    |
+| `commands(options?)`           | `PaseoAgentCommandsResult`        | Asks the live session for its slash commands and skills, including built-in ones. Options: `requestId`. |
+| `subscribe(handler)`           | Unsubscribe function              | Filters agent-directory updates to this ID and refreshes the handle properties.                         |
+| `archive()`                    | `{ archivedAt }`                  | Soft-deletes the agent and closes its runtime.                                                          |
+| `detach()`                     | `Promise<void>`                   | Removes the parent relationship without stopping the agent.                                             |
 
 `workspaceId` through `archivedAt` mirror the last snapshot the handle observed. A handle from `ref()` reads `null` for all of them until `refresh()`, `run()`, `waitForFinish()`, a timeline refetch, or `subscribe()` delivers a snapshot. Optional values in an observed snapshot also read as `null`. Call `current()` when you need the whole snapshot or need to distinguish those states.
 


### PR DESCRIPTION
## Problem

Agent snapshots expose `pendingPermissions`, but `PaseoAgentHandle` cannot answer them. Agent Monitor can display a blocked agent, yet its user must manually find the agent tab to approve or deny the request.

Fixes #3980

## Change

- Add `agent.respondToPermission({ requestId, response })` to the public `PaseoApi` agent handle.
- Reuse the existing exported `AgentPermissionResponse` allow/deny union and delegate to `DaemonClient.respondToPermission`.
- Document the method and cover its exact argument mapping.

## Trust model

This grants plugins the ability to approve agent permissions. Plugins are trusted local code installed per daemon: backend code runs unsandboxed on the daemon machine, and client contributions run inside the Paseo app. This adds no permission-granting pathway beyond the existing `DaemonClient.respondToPermission` operation.

## QA evidence

```text
$ npx vitest run packages/client/src/index.test.ts --bail=1
Test Files  1 passed (1)
Tests       15 passed (15)
Duration    3.81s

$ npm run typecheck
@getpaseo/expo-two-way-audio typecheck: passed
@getpaseo/highlight typecheck: passed
@getpaseo/plugin typecheck: passed
@getpaseo/protocol typecheck: passed
@getpaseo/client typecheck: passed
@getpaseo/server typecheck: passed
@getpaseo/app typecheck: passed
@getpaseo/relay typecheck: passed
@getpaseo/website typecheck: passed
@getpaseo/desktop typecheck: passed
@getpaseo/cli typecheck: passed

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format:check
All matched files use the correct format.
```

## Platforms

SDK-only and platform-independent. No platform-specific UI or runtime behavior changed.