### PR TITLE
feat(plugin): add accessibility props to host-rendered PluginIcon

### DIFF
--- a/packages/app/src/plugins/icons.test.ts
+++ b/packages/app/src/plugins/icons.test.ts
@@ -3,10 +3,23 @@ import { describe, expect, it } from "vitest";
 import { Icon } from "./icons";
 
 describe("Icon", () => {
-  it("renders a host Lucide icon with the requested presentation", () => {
-    expect(Icon({ name: "Settings", size: 18, color: "#123456" })).toMatchObject({
+  it("renders a host Lucide icon with the requested presentation and accessibility props", () => {
+    expect(
+      Icon({
+        name: "Settings",
+        size: 18,
+        color: "#123456",
+        accessible: true,
+        accessibilityLabel: "Agent settings",
+      }),
+    ).toMatchObject({
       type: Settings,
-      props: { size: 18, color: "#123456" },
+      props: {
+        size: 18,
+        color: "#123456",
+        accessible: true,
+        accessibilityLabel: "Agent settings",
+      },
     });
   });
 

--- a/packages/app/src/plugins/icons.ts
+++ b/packages/app/src/plugins/icons.ts
@@ -18,7 +18,13 @@ export function resolvePluginIcon(name: string): LucideIcon {
   return icon;
 }
 
-export function Icon({ name, size, color }: PluginIconProps): ReactElement | null {
+export function Icon({
+  name,
+  size,
+  color,
+  accessible,
+  accessibilityLabel,
+}: PluginIconProps): ReactElement | null {
   const icon = findPluginIcon(name);
-  return icon ? createElement(icon, { size, color }) : null;
+  return icon ? createElement(icon, { size, color, accessible, accessibilityLabel }) : null;
 }

--- a/packages/plugin/src/contracts.ts
+++ b/packages/plugin/src/contracts.ts
@@ -17,6 +17,35 @@ export interface PluginTheme {
   };
 }
 
+export interface PluginHostProps {
+  theme: PluginTheme;
+  host: {
+    id: string;
+    label: string;
+  };
+  layout: {
+    compact: boolean;
+    platform: "ios" | "android" | "web";
+  };
+}
+
+interface PluginNavigableHostProps extends PluginHostProps {
+  /** Client-owned navigation. Undefined on older hosts; hide dependent affordances when absent. */
+  readonly navigation?: {
+    readonly openAgent: (input: { readonly agentId: string }) => void;
+    readonly openWorkspace: (input: { readonly workspaceId: string }) => void;
+  };
+}
+
+export interface PluginSurfaceProps extends PluginNavigableHostProps {}
+
+export interface PluginIconProps {
+  name: string;
+  size?: number;
+  color?: string;
+  accessible?: boolean;
+  accessibilityLabel?: string;
+}
 export interface PluginWorkspaceSnapshot {
   readonly id: string;
   readonly projectId: string;

--- a/public-docs/plugins/v0.7/reference.md
+++ b/public-docs/plugins/v0.7/reference.md
@@ -269,11 +269,13 @@ Showing another toast replaces the currently visible toast. An empty message is 
 `Icon` renders a [Lucide icon](https://lucide.dev/icons/) from Paseo's installed icon set. Plugin bundles do not import
 `lucide-react-native` or `react-native-svg`.
 
-| Prop    | Type     | Required | Behavior                                        |
-| ------- | -------- | -------- | ----------------------------------------------- |
-| `name`  | `string` | Yes      | Lucide icon name. Unknown names render nothing. |
-| `size`  | `number` | No       | Icon width and height.                          |
-| `color` | `string` | No       | Icon color. Use a plugin theme token.           |
+| Prop                 | Type      | Required | Behavior                                        |
+| -------------------- | --------- | -------- | ----------------------------------------------- |
+| `name`               | `string`  | Yes      | Lucide icon name. Unknown names render nothing. |
+| `size`               | `number`  | No       | Icon width and height.                          |
+| `color`              | `string`  | No       | Icon color. Use a plugin theme token.           |
+| `accessible`         | `boolean` | No       | Includes the icon in the accessibility tree.    |
+| `accessibilityLabel` | `string`  | No       | Provides the icon's accessible label.           |
 
 ## Timeline items
 


### PR DESCRIPTION
## Problem

Host-rendered `PluginIcon` only accepts presentation props, so Agent Monitor and other plugins must wrap labelled icon controls in an extra `View`. This weakens the host component contract and prevents direct React Native accessibility semantics.

Fixes #3978

## Change

- add optional `accessible` and `accessibilityLabel` fields to `PluginIconProps`
- pass both fields through to the host-rendered Lucide component
- update plugin reference docs for the 0.7 package-based SDK contract
- assert accessibility prop forwarding in the existing icon unit test

This is purely additive. It does not change the wire protocol or existing plugin behavior.

## QA evidence

```text
$ npx vitest run src/plugins/icons.test.ts --bail=1
Test Files  1 passed (1)
Tests       2 passed (2)

$ npm run build:server
exit 0

$ npm run typecheck
exit 0

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format
Finished successfully.

$ npm run format:check
All matched files use the correct format.
```

## Platforms tested

Automated unit coverage and TypeScript validation cover the shared React Native host component contract. No visual output changes; only accessibility semantics are added. No device or browser visual testing was performed.
