### PR TITLE
Keep restored workspaces out of reconciliation loops

### DIFF
--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -3391,6 +3391,89 @@ describe("workspace-layout-store actions", () => {
     expect(findPaneById(layout.root, "main")?.focusedTabId).toBe(mainTab?.tabId);
   });
 
+  it("reconcileTabs stays stable when startup removes a duplicate agent kept in Explorer", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    workspaceLayoutStore.setState((state) => ({
+      layoutByWorkspace: {
+        ...state.layoutByWorkspace,
+        [workspaceKey]: {
+          root: {
+            kind: "group",
+            group: {
+              id: "root",
+              direction: "horizontal",
+              sizes: [0.78, 0.22],
+              children: [
+                createPane({
+                  id: "main",
+                  tabIds: ["new", "draft-origin-agent"],
+                  focusedTabId: "draft-origin-agent",
+                  targetsByTabId: {
+                    new: { kind: "new_tab" },
+                    "draft-origin-agent": { kind: "agent", agentId: "agent-1" },
+                  },
+                }),
+                createPane({
+                  id: "explorer",
+                  tabIds: ["files", "changes_tree", "agent_agent-1"],
+                  focusedTabId: "agent_agent-1",
+                  targetsByTabId: {
+                    files: { kind: "files" },
+                    changes_tree: { kind: "changes_tree" },
+                    "agent_agent-1": { kind: "agent", agentId: "agent-1" },
+                  },
+                }),
+              ],
+            },
+          },
+          focusedPaneId: "main",
+        },
+      },
+      explorerSidebarPaneIdByWorkspace: {
+        ...state.explorerSidebarPaneIdByWorkspace,
+        [workspaceKey]: "explorer",
+      },
+    }));
+
+    store.reconcileTabs(workspaceKey, {
+      agentsHydrated: false,
+      terminalsHydrated: false,
+      activeAgentIds: [],
+      autoOpenAgentIds: [],
+      knownAgentIds: [],
+      knownTerminalIds: [],
+      standaloneTerminalIds: [],
+    });
+    expect(workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey].focusedPaneId).toBe(
+      "main",
+    );
+
+    const emptySnapshot = {
+      agentsHydrated: true,
+      terminalsHydrated: true,
+      activeAgentIds: [],
+      autoOpenAgentIds: [],
+      knownAgentIds: [],
+      knownTerminalIds: [],
+      standaloneTerminalIds: [],
+      hasActivePendingDraftCreate: false,
+    };
+    store.reconcileTabs(workspaceKey, emptySnapshot);
+    store.reconcileTabs(workspaceKey, emptySnapshot);
+    const afterSecondReconcile = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    store.reconcileTabs(workspaceKey, emptySnapshot);
+    const afterThirdReconcile = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+
+    expect(afterThirdReconcile).toBe(afterSecondReconcile);
+    const mainTabs = collectAllTabs(afterThirdReconcile.root).filter(
+      (tab) => findPaneContainingTab(afterThirdReconcile.root, tab.tabId)?.id === "main",
+    );
+    expect(mainTabs).toEqual([
+      expect.objectContaining({ target: expect.objectContaining({ kind: "draft" }) }),
+    ]);
+  });
+
   it("reconcileTabs does not auto-open subagents omitted from autoOpenAgentIds", () => {
     const workspaceKey = createWorkspaceKey();
 

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -3449,6 +3449,16 @@ describe("workspace-layout-store actions", () => {
       "main",
     );
 
+    workspaceLayoutStore.setState((state) => ({
+      layoutByWorkspace: {
+        ...state.layoutByWorkspace,
+        [workspaceKey]: {
+          ...state.layoutByWorkspace[workspaceKey],
+          focusedPaneId: "explorer",
+        },
+      },
+    }));
+
     const emptySnapshot = {
       agentsHydrated: true,
       terminalsHydrated: true,

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -1186,27 +1186,33 @@ export function createWorkspaceLayoutStore(
               state.layoutByWorkspace,
               normalizedWorkspaceKey,
             );
+            const explorerSidebarPaneId = resolveExplorerSidebarPaneId(
+              currentLayout,
+              state.explorerSidebarPaneIdByWorkspace[normalizedWorkspaceKey],
+            );
             const nextState = reconcileWorkspaceTabs(
               {
                 layout: currentLayout,
                 pinnedAgentIds: state.pinnedAgentIdsByWorkspace[normalizedWorkspaceKey] ?? null,
                 pendingAgentIds: state.pendingAgentIdsByWorkspace[normalizedWorkspaceKey] ?? null,
                 hiddenAgentIds: state.hiddenAgentIdsByWorkspace[normalizedWorkspaceKey] ?? null,
-                explorerSidebarPaneId: resolveExplorerSidebarPaneId(
-                  currentLayout,
-                  state.explorerSidebarPaneIdByWorkspace[normalizedWorkspaceKey],
-                ),
+                explorerSidebarPaneId,
               },
               snapshot,
             );
-            if (nextState.layout === currentLayout) {
+            const nextLayout = keepWorkspaceFocusOutOfExplorerSidebar(
+              nextState.layout,
+              explorerSidebarPaneId,
+              currentLayout.focusedPaneId,
+            );
+            if (nextLayout === currentLayout) {
               return state;
             }
 
             return {
               layoutByWorkspace: {
                 ...state.layoutByWorkspace,
-                [normalizedWorkspaceKey]: nextState.layout,
+                [normalizedWorkspaceKey]: nextLayout,
               },
             };
           });

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -1182,13 +1182,15 @@ export function createWorkspaceLayoutStore(
           }
 
           set((state) => {
-            const currentLayout = getWorkspaceLayout(
-              state.layoutByWorkspace,
-              normalizedWorkspaceKey,
-            );
+            const rawLayout = getWorkspaceLayout(state.layoutByWorkspace, normalizedWorkspaceKey);
             const explorerSidebarPaneId = resolveExplorerSidebarPaneId(
-              currentLayout,
+              rawLayout,
               state.explorerSidebarPaneIdByWorkspace[normalizedWorkspaceKey],
+            );
+            const currentLayout = keepWorkspaceFocusOutOfExplorerSidebar(
+              rawLayout,
+              explorerSidebarPaneId,
+              rawLayout.focusedPaneId,
             );
             const nextState = reconcileWorkspaceTabs(
               {
@@ -1205,7 +1207,7 @@ export function createWorkspaceLayoutStore(
               explorerSidebarPaneId,
               currentLayout.focusedPaneId,
             );
-            if (nextLayout === currentLayout) {
+            if (nextLayout === rawLayout) {
               return state;
             }
 


### PR DESCRIPTION
### Linked issue

Closes #3925

Refs #3806

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A restored workspace could contain duplicate tabs for one agent, with the canonical tab in Explorer and the focused duplicate in Main. Startup reconciliation kept the canonical tab and incorrectly transferred workspace focus into Explorer. If hydration then removed that stale agent from an otherwise empty workspace, every reconciliation seeded another draft into Explorer and retriggered the layout effect until React stopped the update loop with error #185.

Normalize reconciler output at the layout-store boundary using the existing Explorer focus invariant. Explorer keeps its selected tab, while workspace focus stays in an ordinary pane and empty-workspace draft seeding settles in Main.

### Goals

- Keep startup tab reconciliation from making Explorer the workspace-focused pane.
- Let stale duplicate removal and empty-workspace draft seeding converge to stable state.
- Preserve Explorer tab selection and existing duplicate canonicalization behavior.

### Non-goals

- Change Explorer placement or tab-selection behavior.
- Add a React-side update-loop guard.
- Reset or migrate persisted workspace layouts.

### QA

Red-before/green-after regression:

```text
npm test -- --run src/stores/workspace-layout-store.test.ts --bail=1
Before: failed because each reconciliation appended another draft_msg_* tab to Explorer.
After: 122 tests passed.
```

Affected store coverage:

```text
npm test -- --run src/stores/workspace-layout-store.test.ts src/stores/workspace-subagents-integration.test.ts --bail=1
Test Files  2 passed (2)
Tests       127 passed (127)
```

Repository checks:

```text
npm run typecheck
All workspace typechecks passed.

npm run lint -- packages/app/src/stores/workspace-layout-store.ts packages/app/src/stores/workspace-layout-store.test.ts
Found 0 warnings and 0 errors.

npm run format
Finished successfully on 4131 files.

npm run format:check
All matched files use the correct format.
```

No visual UI changed. The affected behavior is shared workspace-layout state; the automated reproduction covers the startup hydration sequence and stable final layout.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
