### PR TITLE
fix(app): use popout scrolling on iPad desktop

### DIFF
--- a/packages/app/src/components/combined-model-selector.tsx
+++ b/packages/app/src/components/combined-model-selector.tsx
@@ -8,6 +8,7 @@ import { ComboboxTrigger } from "@/components/ui/combobox-trigger";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Combobox, type ComboboxOption, type ComboboxProps } from "@/components/ui/combobox";
 import { ModelBrowser, ModelProviderGlyph, useModelBrowser } from "@/components/model-browser";
+import { resolveModelBrowserScrolling } from "@/components/model-browser-view";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { isNative, isWeb } from "@/constants/platform";
 import type { ProviderSelectorProvider } from "@/provider-selection/provider-selection";
@@ -21,10 +22,6 @@ const foregroundMutedMapping = (theme: Theme) => ({
 });
 
 function noop() {}
-
-function resolveModelBrowserScrolling(isCompact: boolean): "sheet" | "independent" {
-  return isWeb || !isCompact ? "independent" : "sheet";
-}
 
 interface CombinedModelSelectorProps {
   providers: ProviderSelectorProvider[];
@@ -93,6 +90,7 @@ export function CombinedModelSelector({
 }: CombinedModelSelectorProps) {
   const { t } = useTranslation();
   const isCompact = useIsCompactFormFactor();
+  const modelBrowserScrolling = resolveModelBrowserScrolling({ isNative, isCompact });
   const anchorRef = useRef<View>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [isContentReady, setIsContentReady] = useState(isWeb);
@@ -204,7 +202,7 @@ export function CombinedModelSelector({
       onEditProfile={onEditProfile ? handleEditProfile : undefined}
       onRetryProvider={onRetryProvider}
       isRetryingProvider={isRetryingProvider}
-      scrolling={resolveModelBrowserScrolling(isCompact)}
+      scrolling={modelBrowserScrolling}
     />
   ) : (
     <View style={styles.sheetLoadingState}>

--- a/packages/app/src/components/combined-model-selector.tsx
+++ b/packages/app/src/components/combined-model-selector.tsx
@@ -8,6 +8,7 @@ import { ComboboxTrigger } from "@/components/ui/combobox-trigger";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Combobox, type ComboboxOption, type ComboboxProps } from "@/components/ui/combobox";
 import { ModelBrowser, ModelProviderGlyph, useModelBrowser } from "@/components/model-browser";
+import { useIsCompactFormFactor } from "@/constants/layout";
 import { isNative, isWeb } from "@/constants/platform";
 import type { ProviderSelectorProvider } from "@/provider-selection/provider-selection";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
@@ -20,6 +21,10 @@ const foregroundMutedMapping = (theme: Theme) => ({
 });
 
 function noop() {}
+
+function resolveModelBrowserScrolling(isCompact: boolean): "sheet" | "independent" {
+  return isWeb || !isCompact ? "independent" : "sheet";
+}
 
 interface CombinedModelSelectorProps {
   providers: ProviderSelectorProvider[];
@@ -87,6 +92,7 @@ export function CombinedModelSelector({
   toolbar,
 }: CombinedModelSelectorProps) {
   const { t } = useTranslation();
+  const isCompact = useIsCompactFormFactor();
   const anchorRef = useRef<View>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [isContentReady, setIsContentReady] = useState(isWeb);
@@ -198,7 +204,7 @@ export function CombinedModelSelector({
       onEditProfile={onEditProfile ? handleEditProfile : undefined}
       onRetryProvider={onRetryProvider}
       isRetryingProvider={isRetryingProvider}
-      scrolling={isWeb ? "independent" : "sheet"}
+      scrolling={resolveModelBrowserScrolling(isCompact)}
     />
   ) : (
     <View style={styles.sheetLoadingState}>

--- a/packages/app/src/components/model-browser-view.test.ts
+++ b/packages/app/src/components/model-browser-view.test.ts
@@ -7,6 +7,7 @@ import {
   resolveInitialModelBrowserView,
   resolveModelBrowserAllView,
   groupProfilesByProviderModel,
+  resolveModelBrowserScrolling,
 } from "./model-browser-view";
 
 function provider(
@@ -36,6 +37,20 @@ function modelRow(
     description: modelId,
   };
 }
+
+describe("model browser scrolling", () => {
+  it("participates in native compact bottom-sheet scrolling", () => {
+    expect(resolveModelBrowserScrolling({ isNative: true, isCompact: true })).toBe("sheet");
+  });
+
+  it.each([
+    { platform: "native wide", isNative: true, isCompact: false },
+    { platform: "compact web", isNative: false, isCompact: true },
+    { platform: "wide web", isNative: false, isCompact: false },
+  ])("owns scrolling on $platform surfaces", ({ isNative, isCompact }) => {
+    expect(resolveModelBrowserScrolling({ isNative, isCompact })).toBe("independent");
+  });
+});
 
 describe("model browser initial view", () => {
   const codex = provider("codex", "Codex");

--- a/packages/app/src/components/model-browser-view.ts
+++ b/packages/app/src/components/model-browser-view.ts
@@ -9,6 +9,16 @@ export type ModelBrowserView =
   | { kind: "all" }
   | { kind: "provider"; providerId: string; providerLabel: string };
 
+export function resolveModelBrowserScrolling({
+  isNative,
+  isCompact,
+}: {
+  isNative: boolean;
+  isCompact: boolean;
+}): "sheet" | "independent" {
+  return isNative && isCompact ? "sheet" : "independent";
+}
+
 /** A profile's model reference; used to match profiles back to model rows. */
 export interface ModelProfileRef {
   provider: string;

--- a/packages/app/src/composer/agent-controls/model-sheet-flow.test.ts
+++ b/packages/app/src/composer/agent-controls/model-sheet-flow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ProviderSelectorProvider } from "@/provider-selection/provider-selection";
-import { resolveModelBrowserScrolling, resolveModelSheetOpening } from "./model-sheet-flow";
+import { resolveModelSheetOpening } from "./model-sheet-flow";
 
 function provider(id: string, label: string): ProviderSelectorProvider {
   return { id, label, modelSelection: { kind: "models", rows: [] } };
@@ -38,15 +38,5 @@ describe("model sheet opening", () => {
         selectedProvider: "",
       }),
     ).toEqual({ kind: "provider", providerId: "codex", providerLabel: "Codex" });
-  });
-});
-
-describe("model sheet gesture ownership", () => {
-  it("uses the sheet-aware model browser inside compact bottom sheets", () => {
-    expect(resolveModelBrowserScrolling(true)).toBe("sheet");
-  });
-
-  it("keeps independent scrolling in the desktop split viewport", () => {
-    expect(resolveModelBrowserScrolling(false)).toBe("independent");
   });
 });

--- a/packages/app/src/composer/agent-controls/model-sheet-flow.ts
+++ b/packages/app/src/composer/agent-controls/model-sheet-flow.ts
@@ -1,10 +1,6 @@
 import type { ModelBrowserView } from "@/components/model-browser-view";
 import type { ProviderSelectorProvider } from "@/provider-selection/provider-selection";
 
-export function resolveModelBrowserScrolling(usesBottomSheet: boolean): "sheet" | "independent" {
-  return usesBottomSheet ? "sheet" : "independent";
-}
-
 export function resolveModelSheetOpening({
   canSwitchProvider,
   providers,

--- a/packages/app/src/composer/agent-controls/model-sheet.tsx
+++ b/packages/app/src/composer/agent-controls/model-sheet.tsx
@@ -9,15 +9,13 @@ import { AdaptiveModalSheet } from "@/components/adaptive-modal-sheet";
 import { ComboboxTrigger } from "@/components/ui/combobox-trigger";
 import { getProviderIcon } from "@/components/provider-icons";
 import { ModelBrowser, useModelBrowser } from "@/components/model-browser";
+import { resolveModelBrowserScrolling } from "@/components/model-browser-view";
 import { AgentControlTrigger } from "@/composer/agent-controls/control";
 import { ComposerToolbarGlyph } from "@/composer/agent-controls/glyph";
-import {
-  resolveModelBrowserScrolling,
-  resolveModelSheetOpening,
-} from "@/composer/agent-controls/model-sheet-flow";
+import { resolveModelSheetOpening } from "@/composer/agent-controls/model-sheet-flow";
 import type { ProviderSelectorProvider } from "@/provider-selection/provider-selection";
 import { useIsCompactFormFactor } from "@/constants/layout";
-import { isWeb } from "@/constants/platform";
+import { isNative, isWeb } from "@/constants/platform";
 
 const SNAP_POINTS = ["80%", "90%"];
 const MODEL_LIST_TOP_INSET = 4;
@@ -102,7 +100,10 @@ export function CompactModelSheet({
 }: CompactModelSheetProps) {
   const { t } = useTranslation();
   const usesBottomSheet = useIsCompactFormFactor();
-  const modelBrowserScrolling = resolveModelBrowserScrolling(usesBottomSheet);
+  const modelBrowserScrolling = resolveModelBrowserScrolling({
+    isNative,
+    isCompact: usesBottomSheet,
+  });
   const [isOpen, setIsOpen] = useState(false);
   const [isModelBrowserOpen, setIsModelBrowserOpen] = useState(false);
   const availableProviders = useMemo(() => {


### PR DESCRIPTION
### Linked issue

Closes #3993

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Regression introduced by [4a5a8d469](https://github.com/getpaseo/paseo/commit/4a5a8d469c8ef91ef63c8f84150e79e357dcc2ee) (`fix(app): keep compact model options scrollable`). It made `ModelBrowser` use `BottomSheetScrollView` for its existing `"sheet"` mode, which is required for native compact sheets.

`CombinedModelSelector` chose that mode from the runtime platform alone:

```tsx
scrolling={isWeb ? "independent" : "sheet"}
```

That incorrectly treated native non-compact layout (iPad desktop) as a bottom sheet. Its selector is a desktop popout, so after the regression it mounted `BottomSheetScrollView` without a BottomSheet provider and crashed.

The fix selects the mode from the existing compact-layout breakpoint:

```tsx
function resolveModelBrowserScrolling(isCompact: boolean) {
  return isWeb || !isCompact ? "independent" : "sheet";
}
```

| Layout | Mode |
| --- | --- |
| Web, compact or non-compact | `independent` |
| Native compact | `sheet` |
| Native non-compact / iPad desktop | `independent` |

`independent` renders `ModelBrowser` own scroll container, which is appropriate for the desktop popout. `sheet` remains limited to the native compact Gorhom BottomSheet.

The pure resolver is colocated in `combined-model-selector.tsx`: the inline condition raised that component from the configured complexity limit of 20 to 21. Keeping the resolver private restores lint compliance while avoiding an extra production module. No unit test is added because importing this UI component solely to test the resolver requires a disproportionate React Native/UI mock harness.

### Goals

- Keep compact native provider browsing inside the BottomSheet scroll owner.
- Use independent scrolling for desktop popouts.
- Keep the desktop popout selector usable on iPad.

### Non-goals

- Change `ModelBrowser` or the compact model-selector sheet.
- Change web scrolling behavior.

### QA

- Reproduced the crash on an iPad Pro 13-inch (M5) simulator, iOS 26.5, before applying the layout gate.
- Confirmed the desktop model popout opens with the fix applied; screenshot attached below.
- Targeted lint for `packages/app/src/components/combined-model-selector.tsx` passes.
- `npm run format` and `npm run format:check` pass.

### Checklist

- [x] One focused change
- [x] Checks run only on modified files
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] Manual iPad desktop QA
- [ ] Tests added or updated (not added; a direct unit test would require UI mocks disproportionate to this one-line pure decision)

<img width="2064" height="2652" alt="paseo-v070-beta1-ipad-fixed-popout" src="https://github.com/user-attachments/assets/e90d18fc-f3eb-4bcd-9c76-20b14f310590" />