### PR TITLE
feat: add Prime Agent (PrimeIntellect) as a harness provider

### DIFF
--- a/packages/protocol/src/provider-manifest.ts
+++ b/packages/protocol/src/provider-manifest.ts
@@ -255,6 +255,15 @@ export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
     defaultModeId: "full",
     modes: OMP_MODES,
   },
+  {
+    id: "prime",
+    label: "Prime Agent",
+    description:
+      "Self-improving RLM agent for coding workflows and long-running autonomous tasks with background sessions",
+    enabledByDefault: false,
+    defaultModeId: null,
+    modes: [],
+  },
 ];
 
 export const DEV_AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -219,6 +219,16 @@ const PROVIDER_CLIENT_FACTORIES: Record<string, ProviderClientFactory> = {
       runtimeSettings,
       providerParams: options?.providerParams,
     }),
+  prime: (logger, runtimeSettings, options) =>
+    new PiRpcAgentClient({
+      logger,
+      runtimeSettings,
+      providerParams: options?.providerParams,
+      provider: "prime",
+      binaryCommand: process.env.PRIME_AGENT_COMMAND ?? "prime-agent",
+      agentDirName: ".prime",
+      displayName: "Prime Agent",
+    }),
   omp: (logger, runtimeSettings, options) =>
     new OmpAgentClient({
       logger,

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -89,6 +89,8 @@ import {
 const PI_PROVIDER = "pi";
 const DEFAULT_PI_THINKING_LEVEL: PiThinkingLevel = "medium";
 const PI_BINARY_COMMAND = process.env.PI_COMMAND ?? process.env.PI_ACP_PI_COMMAND ?? "pi";
+const PI_AGENT_DIR_NAME = ".pi";
+const PI_DISPLAY_NAME = "Pi";
 const PASEO_PI_TREE_EXTENSION_COMMAND = "paseo_tree";
 const PASEO_PI_CAPTURE_EXTENSION_COMMAND = "paseo_capture_entries";
 const PASEO_PI_ENTRY_CAPTURE_MARKER = "PASEO_ENTRY_CAPTURE";
@@ -184,6 +186,14 @@ export interface PiRpcAgentClientOptions {
   providerParams?: unknown;
   runtime?: PiRuntime;
   usagePollScheduler?: PiUsagePollScheduler;
+  /** Provider id override (defaults to "pi"). Used by forks like Prime Agent. */
+  provider?: string;
+  /** Binary command override (defaults to PI_BINARY_COMMAND / PI_COMMAND env). */
+  binaryCommand?: string;
+  /** Agent directory name under home (defaults to ".pi"). Prime Agent uses ".prime". */
+  agentDirName?: string;
+  /** Display name for diagnostics and permission prompts (defaults to "Pi"). */
+  displayName?: string;
 }
 
 interface PiPromptPayload {
@@ -226,6 +236,8 @@ interface PiRpcAgentSessionOptions {
   extensionTimeoutMs?: number;
   logger: Logger;
   usagePollScheduler?: PiUsagePollScheduler;
+  provider?: string;
+  displayName?: string;
 }
 
 interface PiResumeConfig {
@@ -526,10 +538,11 @@ function toPiMcpConfig(config: McpServerConfig): PiMcpServerConfig {
   };
 }
 
-function resolvePiAgentDir(env: Record<string, string> | undefined): string {
+function resolvePiAgentDir(env: Record<string, string> | undefined, agentDirName?: string): string {
+  const dirName = agentDirName ?? PI_AGENT_DIR_NAME;
   const configured = env?.PI_CODING_AGENT_DIR?.trim() || process.env.PI_CODING_AGENT_DIR?.trim();
   if (!configured) {
-    return join(homedir(), ".pi", "agent");
+    return join(homedir(), dirName, "agent");
   }
   if (configured === "~") {
     return homedir();
@@ -540,8 +553,11 @@ function resolvePiAgentDir(env: Record<string, string> | undefined): string {
   return resolvePath(configured);
 }
 
-function readPiGlobalMcpConfig(env: Record<string, string> | undefined): Record<string, unknown> {
-  const globalConfigPath = join(resolvePiAgentDir(env), "mcp.json");
+function readPiGlobalMcpConfig(
+  env: Record<string, string> | undefined,
+  agentDirName?: string,
+): Record<string, unknown> {
+  const globalConfigPath = join(resolvePiAgentDir(env, agentDirName), "mcp.json");
   if (!existsSync(globalConfigPath)) {
     return {};
   }
@@ -565,10 +581,11 @@ function createPiMcpConfigFile(
   servers: Record<string, McpServerConfig>,
   options?: {
     piGlobalConfigEnv?: Record<string, string>;
+    agentDirName?: string;
   },
 ): PiMcpConfigFile {
   const globalConfig = options?.piGlobalConfigEnv
-    ? readPiGlobalMcpConfig(options.piGlobalConfigEnv)
+    ? readPiGlobalMcpConfig(options.piGlobalConfigEnv, options.agentDirName)
     : {};
   let configuredServers: Record<string, unknown> = {};
   if (isRecord(globalConfig.mcpServers)) {
@@ -1184,17 +1201,22 @@ function mapPiModel(model: PiModel, provider: AgentProvider): AgentModelDefiniti
   };
 }
 
-function createRuntime(logger: Logger, runtimeSettings?: ProviderRuntimeSettings): PiRuntime {
+function createRuntime(
+  logger: Logger,
+  runtimeSettings?: ProviderRuntimeSettings,
+  binaryCommand?: string,
+): PiRuntime {
   return new PiCliRuntime({
     logger,
     runtimeSettings,
-    command: [PI_BINARY_COMMAND],
+    command: [binaryCommand ?? PI_BINARY_COMMAND],
     commandsRpcName: "get_commands",
   });
 }
 
 export class PiRpcAgentSession implements AgentSession {
   readonly provider: AgentProvider;
+  readonly displayName: string;
   readonly capabilities: AgentCapabilityFlags;
 
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
@@ -1237,7 +1259,8 @@ export class PiRpcAgentSession implements AgentSession {
     this.config = options.config;
     this.state = options.initialState;
     this.capabilities = options.capabilities;
-    this.provider = PI_PROVIDER;
+    this.provider = options.provider ?? PI_PROVIDER;
+    this.displayName = options.displayName ?? PI_DISPLAY_NAME;
     this.currentModeId = options.currentModeId ?? null;
     this.cleanup = options.cleanup;
     this.lastKnownThinkingOptionId =
@@ -1947,7 +1970,7 @@ export class PiRpcAgentSession implements AgentSession {
       this.activeAskUserDialog.allowMultiple === false;
     const request = mapExtensionUiRequestToPermission(event, {
       provider: this.provider,
-      label: "Pi",
+      label: this.displayName,
       combineOptionalComment: shouldCombineOptionalComment,
       allowFreeform: this.activeAskUserDialog?.allowFreeform,
     });
@@ -2400,14 +2423,21 @@ export class PiRpcAgentClient implements AgentClient {
   private readonly providerParams: PiProviderParams;
   private readonly runtime: PiRuntime;
   private readonly usagePollScheduler?: PiUsagePollScheduler;
+  private readonly binaryCommand: string;
+  private readonly agentDirName: string;
+  private readonly displayName: string;
 
   constructor(options: PiRpcAgentClientOptions) {
-    this.provider = PI_PROVIDER;
+    this.provider = options.provider ?? PI_PROVIDER;
     this.capabilities = capabilitiesForClient();
     this.logger = options.logger;
     this.runtimeSettings = options.runtimeSettings;
     this.providerParams = PiProviderParamsSchema.parse(options.providerParams ?? {});
-    this.runtime = options.runtime ?? createRuntime(options.logger, options.runtimeSettings);
+    this.binaryCommand = options.binaryCommand ?? PI_BINARY_COMMAND;
+    this.agentDirName = options.agentDirName ?? PI_AGENT_DIR_NAME;
+    this.displayName = options.displayName ?? PI_DISPLAY_NAME;
+    this.runtime =
+      options.runtime ?? createRuntime(options.logger, options.runtimeSettings, this.binaryCommand);
     this.usagePollScheduler = options.usagePollScheduler;
   }
 
@@ -2450,6 +2480,8 @@ export class PiRpcAgentClient implements AgentClient {
         extensionTimeoutMs: this.providerParams.extensionTimeoutMs,
         logger: this.logger,
         usagePollScheduler: this.usagePollScheduler,
+        provider: this.provider,
+        displayName: this.displayName,
       });
     } catch (error) {
       await runtimeSession.close().catch(() => undefined);
@@ -2513,6 +2545,8 @@ export class PiRpcAgentClient implements AgentClient {
         extensionTimeoutMs: this.providerParams.extensionTimeoutMs,
         logger: this.logger,
         usagePollScheduler: this.usagePollScheduler,
+        provider: this.provider,
+        displayName: this.displayName,
       });
     } catch (error) {
       await runtimeSession.close().catch(() => undefined);
@@ -2550,7 +2584,7 @@ export class PiRpcAgentClient implements AgentClient {
           await runProviderRefreshActivity(context, "get_available_models", () =>
             catalogSession.getAvailableModels(null),
           )
-        ).map((model) => mapPiModel(model, PI_PROVIDER)),
+        ).map((model) => mapPiModel(model, this.provider)),
       );
       return { models, modes: [] };
     } finally {
@@ -2570,6 +2604,7 @@ export class PiRpcAgentClient implements AgentClient {
       ...options,
       sessionDir: this.providerParams.sessionDir,
       runtimeSettings: this.runtimeSettings,
+      agentDirName: this.agentDirName,
     });
   }
 
@@ -2598,24 +2633,25 @@ export class PiRpcAgentClient implements AgentClient {
     try {
       const launch = await this.resolvePiLaunch();
       const availability = await checkProviderLaunchAvailable(launch);
-      const authConfigPath = join(homedir(), ".pi", "agent", "auth.json");
+      const authConfigPath = join(homedir(), this.agentDirName, "agent", "auth.json");
+      const authConfigLabel = `Auth config (~/${this.agentDirName}/agent/auth.json)`;
 
       return {
-        diagnostic: formatProviderDiagnostic("Pi", [
+        diagnostic: formatProviderDiagnostic(this.displayName, [
           ...(await buildCommandResolutionDiagnosticRows(launch, {
             knownBinaryNames: [launch.command],
           })),
           ...(await buildBinaryDiagnosticRows(launch, availability)),
           {
-            label: "Auth config (~/.pi/agent/auth.json)",
+            label: authConfigLabel,
             value: existsSync(authConfigPath) ? "found" : "not found",
           },
         ]),
       };
     } catch (error) {
-      this.logger.debug({ err: error }, "Pi diagnostic lookup failed");
+      this.logger.debug({ err: error }, `${this.displayName} diagnostic lookup failed`);
       return {
-        diagnostic: formatProviderDiagnosticError("Pi", error),
+        diagnostic: formatProviderDiagnosticError(this.displayName, error),
       };
     }
   }
@@ -2631,7 +2667,10 @@ export class PiRpcAgentClient implements AgentClient {
     if (!(await this.detectMcpAdapter(cwd, env))) {
       return null;
     }
-    return createPiMcpConfigFile(servers, { piGlobalConfigEnv: env });
+    return createPiMcpConfigFile(servers, {
+      piGlobalConfigEnv: env,
+      agentDirName: this.agentDirName,
+    });
   }
 
   private async detectMcpAdapter(cwd: string, env?: Record<string, string>): Promise<boolean> {
@@ -2655,7 +2694,7 @@ export class PiRpcAgentClient implements AgentClient {
   private async resolvePiLaunch(): Promise<ResolvedProviderLaunch> {
     return resolveProviderLaunch({
       commandConfig: this.runtimeSettings?.command,
-      defaultBinary: PI_BINARY_COMMAND,
+      defaultBinary: this.binaryCommand,
     });
   }
 }

--- a/packages/server/src/server/agent/providers/pi/session-descriptor.ts
+++ b/packages/server/src/server/agent/providers/pi/session-descriptor.ts
@@ -27,6 +27,7 @@ interface PiSessionDescriptorOptions extends ListImportableSessionsOptions {
   runtimeSettings?: ProviderRuntimeSettings;
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
+  agentDirName?: string;
 }
 
 interface PiSessionHeader {
@@ -111,7 +112,12 @@ async function resolvePiSessionsDir(options: PiSessionDescriptorOptions): Promis
     return resolveConfigPath(options.sessionDir, { baseDir, homeDir });
   }
 
-  const agentDir = resolvePiAgentDir({ runtimeSettings: options.runtimeSettings, env, homeDir });
+  const agentDir = resolvePiAgentDir({
+    runtimeSettings: options.runtimeSettings,
+    env,
+    homeDir,
+    agentDirName: options.agentDirName,
+  });
 
   const envSessionDir =
     options.runtimeSettings?.env?.[PI_SESSION_DIR_ENV] ?? env[PI_SESSION_DIR_ENV];
@@ -122,6 +128,7 @@ async function resolvePiSessionsDir(options: PiSessionDescriptorOptions): Promis
   const settingsSessionDir = await readConfiguredSessionDir({
     agentDir,
     cwd: options.cwd,
+    agentDirName: options.agentDirName,
   });
   if (settingsSessionDir?.trim()) {
     return resolveConfigPath(settingsSessionDir, { baseDir, homeDir });
@@ -134,23 +141,25 @@ function resolvePiAgentDir(input: {
   runtimeSettings?: ProviderRuntimeSettings;
   env: NodeJS.ProcessEnv;
   homeDir: string;
+  agentDirName?: string;
 }): string {
   const configured = input.runtimeSettings?.env?.[PI_AGENT_DIR_ENV] ?? input.env[PI_AGENT_DIR_ENV];
   if (configured?.trim()) {
     return resolveConfigPath(configured, { baseDir: process.cwd(), homeDir: input.homeDir });
   }
-  return path.join(input.homeDir, PI_CONFIG_DIR_NAME, "agent");
+  const dirName = input.agentDirName ?? PI_CONFIG_DIR_NAME;
+  return path.join(input.homeDir, dirName, "agent");
 }
 
 async function readConfiguredSessionDir(input: {
   agentDir: string;
   cwd: string | undefined;
+  agentDirName?: string;
 }): Promise<string | null> {
+  const dirName = input.agentDirName ?? PI_CONFIG_DIR_NAME;
   const values = await Promise.all([
     readSessionDirFromSettings(path.join(input.agentDir, "settings.json")),
-    input.cwd
-      ? readSessionDirFromSettings(path.join(input.cwd, PI_CONFIG_DIR_NAME, "settings.json"))
-      : null,
+    input.cwd ? readSessionDirFromSettings(path.join(input.cwd, dirName, "settings.json")) : null,
   ]);
   return values[1] ?? values[0] ?? null;
 }


### PR DESCRIPTION
## Summary

Adds [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) (PrimeIntellect) as a 6th built-in harness provider, reusing the existing `PiRpcAgentClient` with parameterized overrides.

Closes #4002.

## Background

Prime Agent is a self-improving RLM (recursive language model) agent for coding workflows and long-running autonomous tasks. It is built **on top of the Pi agent toolkit** and shares:
- The same RPC protocol (`--mode rpc`, framed JSONL transport)
- The same CLI interface (`--version`, `--resume`, `agents`, `attach`, `shutdown`, etc.)
- The same session format (JSONL under `~/.prime/agent/sessions`)
- The same extension system (`pi.on("session_start", ...)`, `pi.registerCommand(...)`)

The only differences that matter for Paseo integration are:
- Binary name: `prime-agent` (not `pi`)
- Config directory: `~/.prime/agent` (not `~/.pi/agent`)
- Auth config: `~/.prime/agent/auth.json`
- Display name: "Prime Agent" (not "Pi")

## Approach

Since Prime Agent is protocol-compatible with Pi, I **parameterized** the existing `PiRpcAgentClient` rather than duplicating 2600+ lines of code. The client now accepts optional `provider`, `binaryCommand`, `agentDirName`, and `displayName` overrides. All default to Pi's existing values, so there is **zero behavior change** for the `pi` provider.

### Changes (4 files, +91 / -24)

| File | Change |
|---|---|
| `protocol/src/provider-manifest.ts` | Register `prime` in `AGENT_PROVIDER_DEFINITIONS` with `enabledByDefault: false` |
| `server/.../provider-registry.ts` | Add `prime` factory: creates `PiRpcAgentClient` with `prime-agent` binary, `.prime` dir, `"Prime Agent"` display name |
| `server/.../providers/pi/agent.ts` | Parameterize `PiRpcAgentClient` + `PiRpcAgentSession` with `provider`, `binaryCommand`, `agentDirName`, `displayName` fields; update `createRuntime()`, `resolvePiAgentDir()`, `getDiagnostic()`, `fetchCatalog()`, `prepareMcpConfig()`, and session construction to use instance fields instead of hardcoded `PI_*` constants |
| `server/.../providers/pi/session-descriptor.ts` | Pass `agentDirName` through session import resolution so Prime sessions under `~/.prime/agent/sessions` are discovered |

### Env var override

Following the existing `PI_COMMAND` pattern, `PRIME_AGENT_COMMAND` overrides the binary name. This is useful for:
- Windows users who install Prime Agent via the [mutsuki14/prime-agent-win](https://github.com/mutsuki14/prime-agent-win) fork (which installs to `%LOCALAPPDATA%\Programs\prime-agent-win`)
- Users who build Prime Agent from source and want to point to a custom binary path

## Windows note

Prime Agent's official installer targets macOS/Linux. On Windows, the community fork `mutsuki14/prime-agent-win` provides a PowerShell-native launcher. I filed a related issue on GooeyPi (a Pi/OMP/Prime desktop workspace) for Windows `.cmd` shim detection: https://github.com/am-will/gooey-pi/issues/189

## Verification

- `oxlint` — 0 warnings, 0 errors on all 4 files
- `tsc` — no compilation errors in any modified file
- `oxfmt` — formatting passes

## What's next

After this PR merges, Prime Agent will appear in Paseo's provider list (disabled by default, matching `omp`'s pattern). Users can enable it in Settings and it will auto-detect `prime-agent` on PATH (or `PRIME_AGENT_COMMAND` if set).
