### PR TITLE
feat(app): add fleet live activity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2497,6 +2497,59 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bacons/apple-targets": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@bacons/apple-targets/-/apple-targets-4.0.7.tgz",
+      "integrity": "sha512-DwD8gbz2vjbmLatR5qlWjrTocG/Ku4d2Kz/rIF4yzREPZtVBHMepVPCH7gEEgZw4PBTtWQe3XMGrPkomNp7QUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bacons/xcode": "1.0.0-alpha.32",
+        "@react-native/normalize-colors": "^0.79.2",
+        "debug": "^4.3.4",
+        "glob": "^10.4.2"
+      },
+      "peerDependencies": {
+        "expo": ">=52"
+      }
+    },
+    "node_modules/@bacons/apple-targets/node_modules/@react-native/normalize-colors": {
+      "version": "0.79.7",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.7.tgz",
+      "integrity": "sha512-RrvewhdanEWhlyrHNWGXGZCc6MY0JGpNgRzA8y6OomDz0JmlnlIsbBHbNpPnIrt9Jh2KaV10KTscD1Ry8xU9gQ==",
+      "license": "MIT"
+    },
+    "node_modules/@bacons/xcode": {
+      "version": "1.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@bacons/xcode/-/xcode-1.0.0-alpha.32.tgz",
+      "integrity": "sha512-OGpH7+yMbWC2cgYZon5B+VVadH9HsB2V/abtEiplA65XnSuV4GAYAVixOCDc5k182WkfoakfdM0zW6U9cbcsbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/plist": "^0.0.18",
+        "debug": "^4.3.4",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/@expo/plist": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.18.tgz",
+      "integrity": "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.0",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@blazediff/core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
@@ -7051,7 +7104,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -7069,7 +7121,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7082,7 +7133,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7095,14 +7145,12 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -7120,7 +7168,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -7136,7 +7183,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -9698,7 +9744,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11309,8 +11354,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -11323,8 +11367,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -11337,8 +11380,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -11351,8 +11393,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -11365,8 +11406,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -11379,8 +11419,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -11393,8 +11432,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -11407,8 +11445,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -11421,8 +11458,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -11435,8 +11471,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -11449,8 +11484,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -11463,8 +11497,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -11477,8 +11510,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -11491,8 +11523,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -11505,8 +11536,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -11519,8 +11549,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -11533,8 +11562,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -11547,8 +11575,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -11561,8 +11588,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -11575,8 +11601,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -11589,8 +11614,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -11603,8 +11627,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -11617,8 +11640,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -11631,8 +11653,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -11645,8 +11666,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -14267,7 +14287,6 @@
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
       "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
       "deprecated": "this version is no longer supported, please update to at least 0.8.*",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -18639,7 +18658,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -19246,7 +19264,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22369,7 +22386,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -22743,7 +22759,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -22777,7 +22792,6 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -24516,7 +24530,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -29362,7 +29375,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
@@ -29495,6 +29507,10 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/paseo-live-activity": {
+      "resolved": "packages/app/modules/paseo-live-activity",
+      "link": true
+    },
     "node_modules/password-prompt": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
@@ -29579,7 +29595,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -29596,7 +29611,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
@@ -32709,7 +32723,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -33299,7 +33312,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -33439,7 +33451,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -35896,7 +35907,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -36035,7 +36045,6 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
       "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
@@ -36300,6 +36309,7 @@
       "name": "@getpaseo/app",
       "version": "0.7.0-beta.1",
       "dependencies": {
+        "@bacons/apple-targets": "4.0.7",
         "@codemirror/commands": "6.10.4",
         "@codemirror/language": "6.12.4",
         "@codemirror/search": "6.7.1",
@@ -36367,6 +36377,7 @@
         "markdown-it": "^10.0.0",
         "mermaid": "^11.16.0",
         "mnemonic-id": "^3.2.7",
+        "paseo-live-activity": "file:modules/paseo-live-activity",
         "qrcode": "^1.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -36423,6 +36434,13 @@
         "vitest": "^4.1.6",
         "wrangler": "^4.105.0",
         "ws": "^8.20.0"
+      }
+    },
+    "packages/app/modules/paseo-live-activity": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@bacons/xcode": "1.0.0-alpha.32"
       }
     },
     "packages/app/node_modules/@cloudflare/workerd-darwin-64": {
@@ -37389,92 +37407,6 @@
         "zx": "^8.8.5"
       }
     },
-    "packages/cli/node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/cli/node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/cli/node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.6",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/cli/node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/cli/node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/cli/node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "packages/cli/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -37494,123 +37426,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "packages/cli/node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "packages/cli/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.6",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
       }
     },
     "packages/client": {
@@ -37660,215 +37475,12 @@
         "undici-types": "~7.13.0"
       }
     },
-    "packages/desktop/node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/desktop/node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/desktop/node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.6",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/desktop/node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/desktop/node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/desktop/node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "packages/desktop/node_modules/undici-types": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
       "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/desktop/node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "packages/desktop/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.6",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
     },
     "packages/expo-two-way-audio": {
       "name": "@getpaseo/expo-two-way-audio",
@@ -38844,209 +38456,6 @@
         "@types/ws": "^8.5.8",
         "typescript": "^5.2.2",
         "vitest": "^4.1.6"
-      }
-    },
-    "packages/relay/node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/relay/node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/relay/node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.6",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/relay/node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/relay/node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/relay/node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/relay/node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "packages/relay/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.6",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
       }
     },
     "packages/server": {

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -109,6 +109,7 @@ export default {
       infoPlist: {
         NSMicrophoneUsageDescription: "This app needs access to the microphone for voice commands.",
         ITSAppUsesNonExemptEncryption: false,
+        NSSupportsLiveActivities: true,
       },
       bundleIdentifier: variant.packageId,
       ...(variant.googleServiceInfoPlist
@@ -176,6 +177,10 @@ export default {
         },
       ],
       ...buildProfile.fdroidPlugins,
+      // Links targets/* (the Live Activity widget extension) into the CNG-generated
+      // Xcode project. Must stay after the plugins that create the main app target.
+      // Local wrapper works around @bacons/apple-targets 4.0.7 incremental-prebuild crash.
+      "./modules/paseo-live-activity/app.plugin.js",
       ...(isProfileBuild ? [withAndroidProfileable] : []),
     ],
     experiments: {

--- a/packages/app/modules/paseo-live-activity/app.plugin.js
+++ b/packages/app/modules/paseo-live-activity/app.plugin.js
@@ -1,0 +1,143 @@
+/**
+ * Wrapper around @bacons/apple-targets that makes incremental iOS prebuild idempotent.
+ *
+ * Upstream @bacons/apple-targets@4.0.7 crashes on the second `expo prebuild` when a
+ * widget target already exists: its update path calls
+ * `buildConfigurationList.getReferrers().forEach(ref => ref.removeReference(...))`,
+ * which clears the target's configuration-list reference, then invokes
+ * `removeFromProject()` on the now-undefined list (GitHub EvanBacon/expo-apple-targets#201).
+ *
+ * v5.0.0 targets Expo SDK 55, so SDK 54 needs this narrow workaround: register a
+ * pre-sync mod immediately before the xcodeProjectBeta2 base provider and remove the
+ * Live Activity extension target so upstream always takes the working create path.
+ */
+const fs = require("fs");
+const path = require("path");
+const { PBXNativeTarget } = require("@bacons/xcode");
+const withWidget = require("@bacons/apple-targets/build/with-widget").default;
+const { withPodTargetExtension } = require("@bacons/apple-targets/build/with-pod-target-extension");
+const {
+  withXcodeProjectBeta,
+  withXcodeProjectBetaBaseMod,
+} = require("@bacons/apple-targets/build/with-bacons-xcode");
+const { warnOnce } = require("@bacons/apple-targets/build/util");
+
+/** Must match `name` in targets/paseo-live-activity/expo-target.config.js. */
+const LIVE_ACTIVITY_TARGET_NAME = "PaseoLiveActivity";
+
+/**
+ * @param {string} projectRoot
+ * @param {string} root
+ * @param {string} match
+ * @returns {string[]}
+ */
+function findTargetConfigPaths(projectRoot, root, match) {
+  const targetsRoot = path.join(projectRoot, root);
+  if (!fs.existsSync(targetsRoot)) {
+    return [];
+  }
+
+  const configs = [];
+  for (const entry of fs.readdirSync(targetsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (match !== "*" && entry.name !== match) {
+      continue;
+    }
+    for (const fileName of ["expo-target.config.js", "expo-target.config.json"]) {
+      const configPath = path.join(targetsRoot, entry.name, fileName);
+      if (fs.existsSync(configPath)) {
+        configs.push(configPath);
+      }
+    }
+  }
+  return configs;
+}
+
+/**
+ * @param {import('@bacons/xcode').XcodeProject} project
+ */
+function removeExistingLiveActivityTarget(project) {
+  const existingTarget = project.rootObject.props.targets.find(
+    (target) =>
+      PBXNativeTarget.is(target) && target.props.productName === LIVE_ACTIVITY_TARGET_NAME,
+  );
+
+  if (existingTarget) {
+    existingTarget.removeFromProject();
+  }
+}
+
+/**
+ * Same as @bacons/apple-targets/build/config-plugin, plus the incremental-prebuild fix.
+ *
+ * @type {import('expo/config-plugins').ConfigPlugin<{ root?: string; match?: string; appleTeamId?: string } | void>}
+ */
+function withPaseoAppleTargets(config, props) {
+  let { appleTeamId = config.ios?.appleTeamId } = props ?? {};
+  const { root = "./targets", match = "*" } = props ?? {};
+  const projectRoot = config._internal.projectRoot;
+
+  if (!config.ios?.bundleIdentifier) {
+    const fallbackBundleId = `com.example.${config.slug}`;
+    warnOnce(
+      `[bacons/apple-targets] Expo config is missing ios.bundleIdentifier property. Using fallback: ${fallbackBundleId}. Add it to your app.json or app.config.js for production builds.`,
+    );
+    config.ios = config.ios ?? {};
+    config.ios.bundleIdentifier = fallbackBundleId;
+  }
+
+  if (!appleTeamId) {
+    warnOnce(
+      "[bacons/apple-targets] Expo config is missing required ios.appleTeamId property. Find this in Xcode and add to the Expo Config to correct. iOS builds may fail until this is corrected.",
+    );
+  }
+
+  const targets = findTargetConfigPaths(projectRoot, root, match);
+
+  for (const configPath of targets) {
+    const targetConfig = require(configPath);
+    let evaluatedTargetConfigObject = targetConfig;
+
+    if (typeof targetConfig === "function") {
+      evaluatedTargetConfigObject = targetConfig(config);
+      if (typeof evaluatedTargetConfigObject !== "object") {
+        throw new Error(
+          `Expected target config function to return an object, but got ${typeof evaluatedTargetConfigObject}`,
+        );
+      }
+    } else if (typeof targetConfig !== "object") {
+      throw new Error(
+        `Expected target config to be an object or function that returns an object, but got ${typeof targetConfig}`,
+      );
+    }
+
+    if (!evaluatedTargetConfigObject.type) {
+      throw new Error(
+        "Expected target config to have a 'type' property denoting the type of target it is, e.g. 'widget'",
+      );
+    }
+
+    config = withWidget(config, {
+      appleTeamId,
+      ...evaluatedTargetConfigObject,
+      directory: path.relative(projectRoot, path.dirname(configPath)),
+      configPath,
+    });
+  }
+
+  withPodTargetExtension(config);
+
+  // Runs after upstream widget mods register but before the base provider is sealed.
+  // Mod chain executes in reverse registration order, so this runs before applyXcodeChanges.
+  config = withXcodeProjectBeta(config, (pluginConfig) => {
+    removeExistingLiveActivityTarget(pluginConfig.modResults);
+    return pluginConfig;
+  });
+
+  withXcodeProjectBetaBaseMod(config);
+  return config;
+}
+
+module.exports = withPaseoAppleTargets;

--- a/packages/app/modules/paseo-live-activity/expo-module.config.json
+++ b/packages/app/modules/paseo-live-activity/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["PaseoLiveActivityModule"]
+  }
+}

--- a/packages/app/modules/paseo-live-activity/index.android.ts
+++ b/packages/app/modules/paseo-live-activity/index.android.ts
@@ -1,0 +1,2 @@
+export { default } from "./index.stub";
+export * from "./index.stub";

--- a/packages/app/modules/paseo-live-activity/index.ios.ts
+++ b/packages/app/modules/paseo-live-activity/index.ios.ts
@@ -1,0 +1,33 @@
+import { requireOptionalNativeModule } from "expo";
+import type { PaseoLiveActivityModule } from "./types";
+
+export type {
+  LiveActivityContentState,
+  LiveActivityHeroState,
+  PaseoLiveActivityModule,
+} from "./types";
+
+const unavailableModule: PaseoLiveActivityModule = {
+  isSupported() {
+    return false;
+  },
+  start() {
+    return Promise.resolve();
+  },
+  update() {
+    return Promise.resolve();
+  },
+  end() {
+    return Promise.resolve();
+  },
+};
+
+/**
+ * Missing in Expo Go and in dev clients built before this local module landed.
+ * Treat those binaries as unsupported rather than failing module evaluation.
+ */
+const PaseoLiveActivity: PaseoLiveActivityModule =
+  requireOptionalNativeModule<PaseoLiveActivityModule>("PaseoLiveActivity") ?? unavailableModule;
+
+export { PaseoLiveActivity };
+export default PaseoLiveActivity;

--- a/packages/app/modules/paseo-live-activity/index.stub.ts
+++ b/packages/app/modules/paseo-live-activity/index.stub.ts
@@ -1,0 +1,26 @@
+import type { PaseoLiveActivityModule } from "./types";
+
+export type {
+  LiveActivityContentState,
+  LiveActivityHeroState,
+  PaseoLiveActivityModule,
+} from "./types";
+
+/** Android and web intentionally ship no native implementation in v1. */
+const PaseoLiveActivity: PaseoLiveActivityModule = {
+  isSupported() {
+    return false;
+  },
+  start() {
+    return Promise.resolve();
+  },
+  update() {
+    return Promise.resolve();
+  },
+  end() {
+    return Promise.resolve();
+  },
+};
+
+export { PaseoLiveActivity };
+export default PaseoLiveActivity;

--- a/packages/app/modules/paseo-live-activity/index.ts
+++ b/packages/app/modules/paseo-live-activity/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./index.stub";
+export * from "./index.stub";

--- a/packages/app/modules/paseo-live-activity/index.web.ts
+++ b/packages/app/modules/paseo-live-activity/index.web.ts
@@ -1,0 +1,2 @@
+export { default } from "./index.stub";
+export * from "./index.stub";

--- a/packages/app/modules/paseo-live-activity/ios/PaseoFleetAttributes.swift
+++ b/packages/app/modules/paseo-live-activity/ios/PaseoFleetAttributes.swift
@@ -1,0 +1,1 @@
+../../../targets/paseo-live-activity/PaseoFleetAttributes.swift

--- a/packages/app/modules/paseo-live-activity/ios/PaseoLiveActivity.podspec
+++ b/packages/app/modules/paseo-live-activity/ios/PaseoLiveActivity.podspec
@@ -1,0 +1,37 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'PaseoLiveActivity'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = 'Paseo'
+  s.homepage       = 'https://paseo.sh'
+  s.platforms      = {
+    :ios => '15.1'
+  }
+  s.swift_version  = '5.9'
+  s.source         = { :path => '.' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  # The app target remains 15.1; weak-link ActivityKit because call sites use
+  # iOS 16.2 APIs and are fenced with @available(iOS 16.2, *).
+  s.weak_frameworks = 'ActivityKit'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  # PaseoFleetAttributes.swift is a symlink into ../../../targets/paseo-live-activity
+  # so the ActivityKit contract has one definition shared with the widget
+  # extension. CocoaPods globs symlinked files, Xcode compiles through them; a
+  # `../` source_files pattern would silently match nothing because CocoaPods
+  # matches patterns against a cached listing of the pod root.
+  s.source_files = '**/*.{h,m,mm,swift}'
+end

--- a/packages/app/modules/paseo-live-activity/ios/PaseoLiveActivityModule.swift
+++ b/packages/app/modules/paseo-live-activity/ios/PaseoLiveActivityModule.swift
@@ -11,7 +11,6 @@ internal struct PaseoFleetStateRecord: Record {
   @Field var todoDone: Int?
   @Field var todoTotal: Int?
   @Field var permissionToolName: String?
-  @Field var permissionDetail: String?
   @Field var needsYouCount: Int = 0
   @Field var runningCount: Int = 0
   @Field var heroDeepLink: String = ""
@@ -36,7 +35,6 @@ extension PaseoFleetStateRecord {
       todoDone: todoDone,
       todoTotal: todoTotal,
       permissionToolName: permissionToolName,
-      permissionDetail: permissionDetail,
       needsYouCount: needsYouCount,
       runningCount: runningCount,
       heroDeepLink: heroDeepLink,
@@ -60,42 +58,60 @@ internal final class LiveActivityRequestFailedException: GenericException<String
   }
 }
 
-/// Owns the single fleet-mode activity.
+/// Owns one fleet activity per connected daemon.
+///
+/// Several controllers can be live at once (one per daemon the app is connected
+/// to), so every operation is keyed by `serverId` and never touches another
+/// server's activity. `PaseoFleetAttributes.serverId` is the durable key: the
+/// dictionary is only a cache, and after a relaunch or JS reload the store
+/// re-adopts activities by matching their attributes.
+///
+/// An actor because `AsyncFunction` calls from two controllers can overlap and
+/// each one suspends mid-operation (`Activity.end` is async). A plain class
+/// would let a second `start` interleave between the end and the request and
+/// leave the dictionary pointing at an activity it does not own.
 ///
 /// Isolated in its own `@available` type so the module class itself stays
 /// buildable against the app's iOS 15.1 deployment target.
 @available(iOS 16.2, *)
-internal final class PaseoFleetActivityStore {
+internal actor PaseoFleetActivityStore {
   static let shared = PaseoFleetActivityStore()
 
-  private var activity: Activity<PaseoFleetAttributes>?
+  private var activities: [String: Activity<PaseoFleetAttributes>] = [:]
+
+  /// Every live activity this app owns for `serverId`. More than one only
+  /// happens if a previous launch left one behind.
+  private func systemActivities(serverId: String) -> [Activity<PaseoFleetAttributes>] {
+    Activity<PaseoFleetAttributes>.activities.filter { $0.attributes.serverId == serverId }
+  }
 
   /// Adopts an activity that outlived the JS handle (app relaunch, JS reload).
   /// Without this, `update` after a reload would silently do nothing while a
   /// stale banner stayed on the lock screen.
-  private func liveActivity() -> Activity<PaseoFleetAttributes>? {
-    if let activity, activity.activityState == .active {
-      return activity
+  private func liveActivity(serverId: String) -> Activity<PaseoFleetAttributes>? {
+    if let cached = activities[serverId], cached.activityState == .active {
+      return cached
     }
-    let adopted = Activity<PaseoFleetAttributes>.activities.first { $0.activityState == .active }
-    activity = adopted
+    let adopted = systemActivities(serverId: serverId).first { $0.activityState == .active }
+    activities[serverId] = adopted
     return adopted
   }
 
-  private func endAll(dismissalPolicy: ActivityUIDismissalPolicy) async {
-    activity = nil
-    for existing in Activity<PaseoFleetAttributes>.activities {
+  private func endOwn(serverId: String, dismissalPolicy: ActivityUIDismissalPolicy) async {
+    activities[serverId] = nil
+    for existing in systemActivities(serverId: serverId) {
       await existing.end(nil, dismissalPolicy: dismissalPolicy)
     }
   }
 
-  func start(state: PaseoFleetAttributes.ContentState) async throws {
-    // Idempotent: one Paseo activity at a time, including leftovers from a
-    // previous launch that ActivityKit still considers live.
-    await endAll(dismissalPolicy: .immediate)
+  func start(serverId: String, state: PaseoFleetAttributes.ContentState) async throws {
+    // Idempotent per daemon: replaces this server's activity, including a
+    // leftover from a previous launch that ActivityKit still considers live.
+    // Activities belonging to other daemons are left alone.
+    await endOwn(serverId: serverId, dismissalPolicy: .immediate)
     do {
-      activity = try Activity.request(
-        attributes: PaseoFleetAttributes(),
+      activities[serverId] = try Activity.request(
+        attributes: PaseoFleetAttributes(serverId: serverId),
         content: ActivityContent(state: state, staleDate: nil),
         pushType: nil
       )
@@ -104,13 +120,17 @@ internal final class PaseoFleetActivityStore {
     }
   }
 
-  func update(state: PaseoFleetAttributes.ContentState) async {
-    guard let activity = liveActivity() else { return }
+  func update(serverId: String, state: PaseoFleetAttributes.ContentState) async {
+    guard let activity = liveActivity(serverId: serverId) else { return }
     await activity.update(ActivityContent(state: state, staleDate: nil))
   }
 
-  func end(state: PaseoFleetAttributes.ContentState, dismissAfterSeconds: Double) async {
-    guard let activity = liveActivity() else { return }
+  func end(
+    serverId: String,
+    state: PaseoFleetAttributes.ContentState,
+    dismissAfterSeconds: Double
+  ) async {
+    guard let activity = liveActivity(serverId: serverId) else { return }
     let policy: ActivityUIDismissalPolicy =
       dismissAfterSeconds > 0
       ? .after(Date().addingTimeInterval(dismissAfterSeconds))
@@ -119,7 +139,7 @@ internal final class PaseoFleetActivityStore {
       ActivityContent(state: state, staleDate: nil),
       dismissalPolicy: policy
     )
-    self.activity = nil
+    activities[serverId] = nil
   }
 }
 
@@ -132,19 +152,27 @@ public final class PaseoLiveActivityModule: Module {
       return ActivityAuthorizationInfo().areActivitiesEnabled
     }
 
-    AsyncFunction("start") { (state: PaseoFleetStateRecord) in
+    AsyncFunction("start") { (serverId: String, state: PaseoFleetStateRecord) in
       guard #available(iOS 16.2, *) else { throw LiveActivityUnsupportedException() }
-      try await PaseoFleetActivityStore.shared.start(state: state.contentState)
+      try await PaseoFleetActivityStore.shared.start(
+        serverId: serverId,
+        state: state.contentState
+      )
     }
 
-    AsyncFunction("update") { (state: PaseoFleetStateRecord) in
+    AsyncFunction("update") { (serverId: String, state: PaseoFleetStateRecord) in
       guard #available(iOS 16.2, *) else { return }
-      await PaseoFleetActivityStore.shared.update(state: state.contentState)
+      await PaseoFleetActivityStore.shared.update(
+        serverId: serverId,
+        state: state.contentState
+      )
     }
 
-    AsyncFunction("end") { (state: PaseoFleetStateRecord, dismissAfterSeconds: Double) in
+    AsyncFunction("end") {
+      (serverId: String, state: PaseoFleetStateRecord, dismissAfterSeconds: Double) in
       guard #available(iOS 16.2, *) else { return }
       await PaseoFleetActivityStore.shared.end(
+        serverId: serverId,
         state: state.contentState,
         dismissAfterSeconds: dismissAfterSeconds
       )

--- a/packages/app/modules/paseo-live-activity/ios/PaseoLiveActivityModule.swift
+++ b/packages/app/modules/paseo-live-activity/ios/PaseoLiveActivityModule.swift
@@ -14,6 +14,11 @@ internal struct PaseoFleetStateRecord: Record {
   @Field var permissionDetail: String?
   @Field var needsYouCount: Int = 0
   @Field var runningCount: Int = 0
+  @Field var heroDeepLink: String = ""
+  @Field var primaryActionLabel: String?
+  @Field var primaryActionDeepLink: String?
+  @Field var secondaryActionLabel: String?
+  @Field var secondaryActionDeepLink: String?
 }
 
 /// Lets Expo convert the JS string union into the shared enum, and reject
@@ -33,7 +38,12 @@ extension PaseoFleetStateRecord {
       permissionToolName: permissionToolName,
       permissionDetail: permissionDetail,
       needsYouCount: needsYouCount,
-      runningCount: runningCount
+      runningCount: runningCount,
+      heroDeepLink: heroDeepLink,
+      primaryActionLabel: primaryActionLabel,
+      primaryActionDeepLink: primaryActionDeepLink,
+      secondaryActionLabel: secondaryActionLabel,
+      secondaryActionDeepLink: secondaryActionDeepLink
     )
   }
 }

--- a/packages/app/modules/paseo-live-activity/ios/PaseoLiveActivityModule.swift
+++ b/packages/app/modules/paseo-live-activity/ios/PaseoLiveActivityModule.swift
@@ -1,0 +1,143 @@
+import ActivityKit
+import ExpoModulesCore
+
+/// Argument record for the JS `LiveActivityContentState`. Names must match
+/// `types.ts` exactly; Expo maps JS object keys to `@Field` names.
+internal struct PaseoFleetStateRecord: Record {
+  @Field var heroTitle: String = ""
+  @Field var heroState: PaseoFleetHeroState = .running
+  @Field var sinceMs: Double = 0
+  @Field var phase: String?
+  @Field var todoDone: Int?
+  @Field var todoTotal: Int?
+  @Field var permissionToolName: String?
+  @Field var permissionDetail: String?
+  @Field var needsYouCount: Int = 0
+  @Field var runningCount: Int = 0
+}
+
+/// Lets Expo convert the JS string union into the shared enum, and reject
+/// anything outside it with a descriptive error.
+extension PaseoFleetHeroState: Enumerable {}
+
+@available(iOS 16.2, *)
+extension PaseoFleetStateRecord {
+  fileprivate var contentState: PaseoFleetAttributes.ContentState {
+    PaseoFleetAttributes.ContentState(
+      heroTitle: heroTitle,
+      heroState: heroState,
+      sinceMs: sinceMs,
+      phase: phase,
+      todoDone: todoDone,
+      todoTotal: todoTotal,
+      permissionToolName: permissionToolName,
+      permissionDetail: permissionDetail,
+      needsYouCount: needsYouCount,
+      runningCount: runningCount
+    )
+  }
+}
+
+internal final class LiveActivityUnsupportedException: Exception {
+  override var reason: String {
+    "Live Activities require iOS 16.2 or newer"
+  }
+}
+
+internal final class LiveActivityRequestFailedException: GenericException<String> {
+  override var reason: String {
+    "Could not start the Paseo Live Activity: \(param)"
+  }
+}
+
+/// Owns the single fleet-mode activity.
+///
+/// Isolated in its own `@available` type so the module class itself stays
+/// buildable against the app's iOS 15.1 deployment target.
+@available(iOS 16.2, *)
+internal final class PaseoFleetActivityStore {
+  static let shared = PaseoFleetActivityStore()
+
+  private var activity: Activity<PaseoFleetAttributes>?
+
+  /// Adopts an activity that outlived the JS handle (app relaunch, JS reload).
+  /// Without this, `update` after a reload would silently do nothing while a
+  /// stale banner stayed on the lock screen.
+  private func liveActivity() -> Activity<PaseoFleetAttributes>? {
+    if let activity, activity.activityState == .active {
+      return activity
+    }
+    let adopted = Activity<PaseoFleetAttributes>.activities.first { $0.activityState == .active }
+    activity = adopted
+    return adopted
+  }
+
+  private func endAll(dismissalPolicy: ActivityUIDismissalPolicy) async {
+    activity = nil
+    for existing in Activity<PaseoFleetAttributes>.activities {
+      await existing.end(nil, dismissalPolicy: dismissalPolicy)
+    }
+  }
+
+  func start(state: PaseoFleetAttributes.ContentState) async throws {
+    // Idempotent: one Paseo activity at a time, including leftovers from a
+    // previous launch that ActivityKit still considers live.
+    await endAll(dismissalPolicy: .immediate)
+    do {
+      activity = try Activity.request(
+        attributes: PaseoFleetAttributes(),
+        content: ActivityContent(state: state, staleDate: nil),
+        pushType: nil
+      )
+    } catch {
+      throw LiveActivityRequestFailedException(error.localizedDescription)
+    }
+  }
+
+  func update(state: PaseoFleetAttributes.ContentState) async {
+    guard let activity = liveActivity() else { return }
+    await activity.update(ActivityContent(state: state, staleDate: nil))
+  }
+
+  func end(state: PaseoFleetAttributes.ContentState, dismissAfterSeconds: Double) async {
+    guard let activity = liveActivity() else { return }
+    let policy: ActivityUIDismissalPolicy =
+      dismissAfterSeconds > 0
+      ? .after(Date().addingTimeInterval(dismissAfterSeconds))
+      : .immediate
+    await activity.end(
+      ActivityContent(state: state, staleDate: nil),
+      dismissalPolicy: policy
+    )
+    self.activity = nil
+  }
+}
+
+public final class PaseoLiveActivityModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("PaseoLiveActivity")
+
+    Function("isSupported") { () -> Bool in
+      guard #available(iOS 16.2, *) else { return false }
+      return ActivityAuthorizationInfo().areActivitiesEnabled
+    }
+
+    AsyncFunction("start") { (state: PaseoFleetStateRecord) in
+      guard #available(iOS 16.2, *) else { throw LiveActivityUnsupportedException() }
+      try await PaseoFleetActivityStore.shared.start(state: state.contentState)
+    }
+
+    AsyncFunction("update") { (state: PaseoFleetStateRecord) in
+      guard #available(iOS 16.2, *) else { return }
+      await PaseoFleetActivityStore.shared.update(state: state.contentState)
+    }
+
+    AsyncFunction("end") { (state: PaseoFleetStateRecord, dismissAfterSeconds: Double) in
+      guard #available(iOS 16.2, *) else { return }
+      await PaseoFleetActivityStore.shared.end(
+        state: state.contentState,
+        dismissAfterSeconds: dismissAfterSeconds
+      )
+    }
+  }
+}

--- a/packages/app/modules/paseo-live-activity/package.json
+++ b/packages/app/modules/paseo-live-activity/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "paseo-live-activity",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Local Expo module driving the Paseo fleet-mode iOS Live Activity",
+  "license": "MIT",
+  "main": "index",
+  "dependencies": {
+    "@bacons/xcode": "1.0.0-alpha.32"
+  }
+}

--- a/packages/app/modules/paseo-live-activity/types.ts
+++ b/packages/app/modules/paseo-live-activity/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Wire contract between the JS controller and ActivityKit.
+ *
+ * Field names are the Codable keys of `PaseoFleetAttributes.ContentState` in
+ * `targets/paseo-live-activity/PaseoFleetAttributes.swift`. Renaming a field
+ * here without renaming it there breaks the bridge silently.
+ */
+
+export type LiveActivityHeroState = "running" | "needs_you" | "error" | "finished";
+
+export interface LiveActivityContentState {
+  heroTitle: string;
+  heroState: LiveActivityHeroState;
+  /** epoch ms; drives Text(timerInterval:) client-side */
+  sinceMs: number;
+  phase?: string;
+  todoDone?: number;
+  todoTotal?: number;
+  permissionToolName?: string;
+  permissionDetail?: string;
+  needsYouCount: number;
+  runningCount: number;
+}
+
+export interface PaseoLiveActivityModule {
+  /** false on Android, web, iOS < 16.2, or Activities disabled in Settings */
+  isSupported(): boolean;
+  /** idempotent: replaces any existing Paseo activity */
+  start(state: LiveActivityContentState): Promise<void>;
+  /** no-op when no activity is live */
+  update(state: LiveActivityContentState): Promise<void>;
+  /** pushes final frame, dismisses after dismissAfterSeconds */
+  end(state: LiveActivityContentState, dismissAfterSeconds: number): Promise<void>;
+}

--- a/packages/app/modules/paseo-live-activity/types.ts
+++ b/packages/app/modules/paseo-live-activity/types.ts
@@ -20,6 +20,12 @@ export interface LiveActivityContentState {
   permissionDetail?: string;
   needsYouCount: number;
   runningCount: number;
+  /** opens the exact hero agent; used for widgetURL on Lock Screen/banner/compact/minimal */
+  heroDeepLink: string;
+  primaryActionLabel?: string;
+  primaryActionDeepLink?: string;
+  secondaryActionLabel?: string;
+  secondaryActionDeepLink?: string;
 }
 
 export interface PaseoLiveActivityModule {

--- a/packages/app/modules/paseo-live-activity/types.ts
+++ b/packages/app/modules/paseo-live-activity/types.ts
@@ -17,7 +17,6 @@ export interface LiveActivityContentState {
   todoDone?: number;
   todoTotal?: number;
   permissionToolName?: string;
-  permissionDetail?: string;
   needsYouCount: number;
   runningCount: number;
   /** opens the exact hero agent; used for widgetURL on Lock Screen/banner/compact/minimal */
@@ -31,10 +30,19 @@ export interface LiveActivityContentState {
 export interface PaseoLiveActivityModule {
   /** false on Android, web, iOS < 16.2, or Activities disabled in Settings */
   isSupported(): boolean;
-  /** idempotent: replaces any existing Paseo activity */
-  start(state: LiveActivityContentState): Promise<void>;
-  /** no-op when no activity is live */
-  update(state: LiveActivityContentState): Promise<void>;
-  /** pushes final frame, dismisses after dismissAfterSeconds */
-  end(state: LiveActivityContentState, dismissAfterSeconds: number): Promise<void>;
+  /**
+   * Idempotent per daemon: replaces this server's activity and leaves activities
+   * belonging to other daemons alone. `serverId` becomes the activity's static
+   * `PaseoFleetAttributes.serverId`, which is how the native side finds this
+   * server's activity again after an app relaunch.
+   */
+  start(serverId: string, state: LiveActivityContentState): Promise<void>;
+  /** no-op when this server has no live activity */
+  update(serverId: string, state: LiveActivityContentState): Promise<void>;
+  /** pushes this server's final frame, dismisses after dismissAfterSeconds */
+  end(
+    serverId: string,
+    state: LiveActivityContentState,
+    dismissAfterSeconds: number,
+  ): Promise<void>;
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -39,6 +39,7 @@
     "build:mermaid-runtime": "node ./src/components/markdown/fence/mermaid/build-runtime.mjs"
   },
   "dependencies": {
+    "@bacons/apple-targets": "4.0.7",
     "@codemirror/commands": "6.10.4",
     "@codemirror/language": "6.12.4",
     "@codemirror/search": "6.7.1",
@@ -106,6 +107,7 @@
     "markdown-it": "^10.0.0",
     "mermaid": "^11.16.0",
     "mnemonic-id": "^3.2.7",
+    "paseo-live-activity": "file:modules/paseo-live-activity",
     "qrcode": "^1.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -40,6 +40,10 @@ import {
   type InlinePathTarget,
 } from "@/components/message";
 import { PlanCard } from "@/components/plan-card";
+import {
+  useLiveActivityFocusStore,
+  useLiveActivityPermissionFocus,
+} from "@/live-activity/live-activity-focus";
 import type { StreamItem } from "@/types/stream";
 import type { PendingMessageSubmission } from "@/composer/submission/model";
 import type { TurnPresentation } from "@/timeline/turn-liveness";
@@ -1312,6 +1316,7 @@ interface PermissionActionButtonProps {
   isRespondingAction: boolean;
   isResponding: boolean;
   isPrimary: boolean;
+  isFocused: boolean;
   Icon: typeof ThemedCheckIcon;
   testID: string;
   onPress: (action: AgentPermissionAction) => void;
@@ -1322,6 +1327,7 @@ function PermissionActionButton({
   isRespondingAction,
   isResponding,
   isPrimary,
+  isFocused,
   Icon,
   testID,
   onPress,
@@ -1331,11 +1337,18 @@ function PermissionActionButton({
     ? [permissionStyles.optionText, permissionStyles.optionTextPrimary]
     : permissionStyles.optionText;
   const colorMapping = isPrimary ? primaryColorMapping : mutedColorMapping;
+  const buttonStyle = useCallback(
+    (state: PressableStateCallbackType & { hovered?: boolean }) => [
+      ...pressableStyle(state),
+      isFocused ? permissionStyles.optionButtonFocused : null,
+    ],
+    [isFocused],
+  );
   return (
     <Pressable
       accessibilityRole="button"
       testID={testID}
-      style={pressableStyle}
+      style={buttonStyle}
       onPress={handlePress}
       disabled={isResponding}
     >
@@ -1351,6 +1364,13 @@ function PermissionActionButton({
   );
 }
 
+function withLiveActivityFocusAccent(node: ReactNode, isFocused: boolean): ReactNode {
+  if (!isFocused) {
+    return node;
+  }
+  return <View style={permissionStyles.focusedCard}>{node}</View>;
+}
+
 function PermissionRequestCard({
   permission,
   client,
@@ -1360,6 +1380,11 @@ function PermissionRequestCard({
 }) {
   const { t } = useTranslation();
   const isMobile = useIsCompactFormFactor();
+  const { isFocused, focusedActionId } = useLiveActivityPermissionFocus(
+    permission.agentId,
+    permission.request.id,
+  );
+  const clearLiveActivityFocus = useLiveActivityFocusStore((state) => state.clearFocus);
 
   const { request } = permission;
   const isPlanRequest = request.kind === "plan";
@@ -1447,8 +1472,16 @@ function PermissionRequestCard({
     resetPermissionMutation();
     setRespondingActionId(null);
   }, [permission.request.id, resetPermissionMutation]);
+  useEffect(() => {
+    const agentId = permission.agentId;
+    const requestId = permission.request.id;
+    return () => {
+      clearLiveActivityFocus({ agentId, requestId });
+    };
+  }, [clearLiveActivityFocus, permission.agentId, permission.request.id]);
   const handleResponse = useCallback(
     (response: AgentPermissionResponse) => {
+      clearLiveActivityFocus({ agentId: permission.agentId, requestId: permission.request.id });
       respondToPermission({
         agentId: permission.agentId,
         requestId: permission.request.id,
@@ -1457,7 +1490,7 @@ function PermissionRequestCard({
         console.error("[PermissionRequestCard] Failed to respond to permission:", error);
       });
     },
-    [permission.agentId, permission.request.id, respondToPermission],
+    [clearLiveActivityFocus, permission.agentId, permission.request.id, respondToPermission],
   );
   const handleActionPress = useCallback(
     (action: AgentPermissionAction) => {
@@ -1487,12 +1520,13 @@ function PermissionRequestCard({
   );
 
   if (request.kind === "question") {
-    return (
+    return withLiveActivityFocusAccent(
       <QuestionFormCard
         permission={permission}
         onRespond={handleResponse}
         isResponding={isResponding}
-      />
+      />,
+      isFocused,
     );
   }
 
@@ -1520,6 +1554,7 @@ function PermissionRequestCard({
               isRespondingAction={isRespondingAction}
               isResponding={isResponding}
               isPrimary={isPrimary}
+              isFocused={focusedActionId === action.id}
               Icon={Icon}
               testID={testID}
               onPress={handleActionPress}
@@ -1531,7 +1566,7 @@ function PermissionRequestCard({
   );
 
   if (isPlanRequest && planMarkdown) {
-    return (
+    return withLiveActivityFocusAccent(
       <PlanCard
         title={title}
         description={description}
@@ -1539,11 +1574,12 @@ function PermissionRequestCard({
         footer={footer}
         testID="permission-plan-card"
         disableOuterSpacing
-      />
+      />,
+      isFocused,
     );
   }
 
-  return (
+  return withLiveActivityFocusAccent(
     <View style={permissionStyles.container}>
       <Text style={permissionStyles.title}>{title}</Text>
 
@@ -1563,7 +1599,8 @@ function PermissionRequestCard({
       ) : null}
 
       {footer}
-    </View>
+    </View>,
+    isFocused,
   );
 }
 
@@ -1652,6 +1689,11 @@ const stylesheet = StyleSheet.create((theme) => ({
 }));
 
 const permissionStyles = StyleSheet.create((theme) => ({
+  focusedCard: {
+    borderRadius: theme.spacing[2] + theme.borderWidth[2],
+    borderWidth: theme.borderWidth[2],
+    borderColor: theme.colors.accent,
+  },
   container: {
     marginVertical: theme.spacing[3],
     padding: theme.spacing[3],
@@ -1701,6 +1743,10 @@ const permissionStyles = StyleSheet.create((theme) => ({
     borderWidth: theme.borderWidth[1],
     backgroundColor: theme.colors.surface1,
     borderColor: theme.colors.borderAccent,
+  },
+  optionButtonFocused: {
+    borderColor: theme.colors.accent,
+    borderWidth: theme.borderWidth[2],
   },
   optionButtonHovered: {
     backgroundColor: theme.colors.surface2,

--- a/packages/app/src/app/h/[serverId]/agent/[agentId].tsx
+++ b/packages/app/src/app/h/[serverId]/agent/[agentId].tsx
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useLocalSearchParams, useRouter, type Href } from "expo-router";
 import { HostRouteBootstrapBoundary } from "@/components/host-route-bootstrap-boundary";
 import { useFetchQuery } from "@/data/query";
+import {
+  resolveLiveActivityFocusTarget,
+  useLiveActivityFocusStore,
+} from "@/live-activity/live-activity-focus";
 import { resolveAgentRoute, type AgentRouteLookup } from "@/navigation/agent-route-resolution";
 import { AgentRouteResolutionView } from "@/navigation/agent-route-resolution-view";
 import { useSessionStore } from "@/stores/session-store";
@@ -18,15 +22,39 @@ export default function HostAgentReadyRoute() {
   );
 }
 
+interface AgentRouteSearchParams {
+  serverId?: string;
+  agentId?: string;
+  source?: string;
+  permissionRequestId?: string;
+  permissionActionId?: string;
+}
+
+function normalizeAgentRouteParams(params: AgentRouteSearchParams) {
+  return {
+    serverId: typeof params.serverId === "string" ? params.serverId : "",
+    agentId: typeof params.agentId === "string" ? params.agentId : "",
+    source: typeof params.source === "string" ? params.source : "",
+    permissionRequestId:
+      typeof params.permissionRequestId === "string" ? params.permissionRequestId : "",
+    permissionActionId:
+      typeof params.permissionActionId === "string" ? params.permissionActionId : undefined,
+  };
+}
+
 function HostAgentReadyRouteContent() {
   const router = useRouter();
   const params = useLocalSearchParams<{
     serverId?: string;
     agentId?: string;
+    source?: string;
+    permissionRequestId?: string;
+    permissionActionId?: string;
   }>();
   const handledNavigationRef = useRef<string | null>(null);
-  const serverId = typeof params.serverId === "string" ? params.serverId : "";
-  const agentId = typeof params.agentId === "string" ? params.agentId : "";
+  const { serverId, agentId, source, permissionRequestId, permissionActionId } =
+    normalizeAgentRouteParams(params);
+  const setLiveActivityFocus = useLiveActivityFocusStore((state) => state.setFocus);
   const hosts = useHosts();
   const runtimeSnapshot = useHostRuntimeSnapshot(serverId);
   const client = runtimeSnapshot?.client ?? null;
@@ -106,11 +134,30 @@ function HostAgentReadyRouteContent() {
     handledNavigationRef.current = navigationKey;
 
     if (resolution.kind === "resolved") {
+      const focusTarget = resolveLiveActivityFocusTarget({
+        source,
+        serverId,
+        agentId,
+        permissionRequestId,
+        permissionActionId,
+      });
+      if (focusTarget) {
+        setLiveActivityFocus(focusTarget);
+      }
       navigateToAgent({ serverId, agentId, workspaceId: resolution.workspaceId });
       return;
     }
     router.replace(resolution.kind === "invalid" ? ("/" as Href) : buildHostRootRoute(serverId));
-  }, [agentId, resolution, router, serverId]);
+  }, [
+    agentId,
+    permissionActionId,
+    permissionRequestId,
+    resolution,
+    router,
+    serverId,
+    setLiveActivityFocus,
+    source,
+  ]);
 
   const handleRetry = useCallback(() => {
     if (resolution.kind === "lookupError") {

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useClientActivity } from "@/hooks/use-client-activity";
 import { useAppVisible } from "@/hooks/use-app-visible";
+import { useLiveActivity } from "@/live-activity/use-live-activity";
 import { startPushNotifications } from "@/push-notifications";
 import {
   createSetAgentInitializing,
@@ -300,6 +301,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
     onAppResumed: handleAppResumed,
   });
   useEffect(() => startPushNotifications({ client, serverId }), [client, serverId]);
+  useLiveActivity({ serverId });
 
   const notifyAgentAttention = useCallback(
     (params: {

--- a/packages/app/src/live-activity/deep-link.test.ts
+++ b/packages/app/src/live-activity/deep-link.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLiveActivityHeroDeepLink,
+  buildLiveActivityPermissionPrimaryDeepLink,
+  buildLiveActivityPermissionReviewDeepLink,
+  parseLiveActivityDeepLink,
+} from "./deep-link";
+
+const TARGET = { serverId: "server-1", agentId: "agent-1" };
+
+describe("buildLiveActivityHeroDeepLink", () => {
+  it("targets the hero agent with only the source query param", () => {
+    const link = buildLiveActivityHeroDeepLink(TARGET);
+    expect(link).toBe("paseo://h/server-1/agent/agent-1?source=live-activity");
+  });
+
+  it("percent-encodes serverId and agentId segments", () => {
+    const link = buildLiveActivityHeroDeepLink({ serverId: "server/main", agentId: "agent 123" });
+    expect(link).toBe("paseo://h/server%2Fmain/agent/agent%20123?source=live-activity");
+  });
+});
+
+describe("buildLiveActivityPermissionReviewDeepLink", () => {
+  it("adds permissionRequestId to the base link", () => {
+    const link = buildLiveActivityPermissionReviewDeepLink({
+      ...TARGET,
+      permissionRequestId: "req-1",
+    });
+    expect(link).toBe(
+      "paseo://h/server-1/agent/agent-1?source=live-activity&permissionRequestId=req-1",
+    );
+  });
+});
+
+describe("buildLiveActivityPermissionPrimaryDeepLink", () => {
+  it("adds permissionRequestId and permissionActionId to the base link", () => {
+    const link = buildLiveActivityPermissionPrimaryDeepLink({
+      ...TARGET,
+      permissionRequestId: "req-1",
+      permissionActionId: "accept",
+    });
+    expect(link).toBe(
+      "paseo://h/server-1/agent/agent-1?source=live-activity&permissionRequestId=req-1&permissionActionId=accept",
+    );
+  });
+});
+
+describe("parseLiveActivityDeepLink", () => {
+  it("round-trips a hero link built by buildLiveActivityHeroDeepLink", () => {
+    const link = buildLiveActivityHeroDeepLink(TARGET);
+    expect(parseLiveActivityDeepLink(link)).toEqual({
+      serverId: "server-1",
+      agentId: "agent-1",
+      source: "live-activity",
+      permissionRequestId: null,
+      permissionActionId: null,
+    });
+  });
+
+  it("round-trips a permission primary link, decoding percent-encoded segments", () => {
+    const link = buildLiveActivityPermissionPrimaryDeepLink({
+      serverId: "server/main",
+      agentId: "agent 123",
+      permissionRequestId: "req-1",
+      permissionActionId: "accept",
+    });
+    expect(parseLiveActivityDeepLink(link)).toEqual({
+      serverId: "server/main",
+      agentId: "agent 123",
+      source: "live-activity",
+      permissionRequestId: "req-1",
+      permissionActionId: "accept",
+    });
+  });
+
+  it("returns null for a non-paseo URL", () => {
+    expect(parseLiveActivityDeepLink("https://h/server-1/agent/agent-1")).toBeNull();
+  });
+
+  it("returns null for a malformed input", () => {
+    expect(parseLiveActivityDeepLink("not a url")).toBeNull();
+  });
+
+  it("returns null when the path is missing the agent segment", () => {
+    expect(parseLiveActivityDeepLink("paseo://h/server-1/workspace/w1")).toBeNull();
+  });
+});

--- a/packages/app/src/live-activity/deep-link.ts
+++ b/packages/app/src/live-activity/deep-link.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure Live Activity deep-link helpers. Wraps `buildAgentDeepLink` with the query parameters
+ * from the fixed fleet-mode contract. Every link targets the current hero agent; tapping one
+ * never submits a permission response by itself.
+ */
+
+import { buildAgentDeepLink, type AgentDeepLinkTarget } from "@getpaseo/protocol/agent-deep-link";
+
+export interface LiveActivityPermissionReviewTarget extends AgentDeepLinkTarget {
+  permissionRequestId: string;
+}
+
+export interface LiveActivityPermissionActionTarget extends LiveActivityPermissionReviewTarget {
+  permissionActionId: string;
+}
+
+export interface LiveActivityDeepLinkParams {
+  serverId: string;
+  agentId: string;
+  source: string | null;
+  permissionRequestId: string | null;
+  permissionActionId: string | null;
+}
+
+function appendLiveActivityQuery(
+  base: string,
+  extra: { permissionRequestId?: string; permissionActionId?: string },
+): string {
+  const query = new URLSearchParams();
+  query.set("source", "live-activity");
+  if (extra.permissionRequestId !== undefined) {
+    query.set("permissionRequestId", extra.permissionRequestId);
+  }
+  if (extra.permissionActionId !== undefined) {
+    query.set("permissionActionId", extra.permissionActionId);
+  }
+  return `${base}?${query.toString()}`;
+}
+
+/** The base hero link: opens the exact hero agent, no permission review attached. */
+export function buildLiveActivityHeroDeepLink(target: AgentDeepLinkTarget): string {
+  return appendLiveActivityQuery(buildAgentDeepLink(target), {});
+}
+
+/** Review link: opens the hero agent at the exact pending permission request. */
+export function buildLiveActivityPermissionReviewDeepLink(
+  target: LiveActivityPermissionReviewTarget,
+): string {
+  return appendLiveActivityQuery(buildAgentDeepLink(target), {
+    permissionRequestId: target.permissionRequestId,
+  });
+}
+
+/** Primary-action link: review params plus the provider action id to focus. */
+export function buildLiveActivityPermissionPrimaryDeepLink(
+  target: LiveActivityPermissionActionTarget,
+): string {
+  return appendLiveActivityQuery(buildAgentDeepLink(target), {
+    permissionRequestId: target.permissionRequestId,
+    permissionActionId: target.permissionActionId,
+  });
+}
+
+/**
+ * Parses a link built by the helpers above. Independent of `parseAgentDeepLink`, which rejects
+ * any URL carrying a query string; this is the query-aware counterpart used for round-trip
+ * verification and for reading the params off `paseo://` links directly.
+ */
+export function parseLiveActivityDeepLink(input: string): LiveActivityDeepLinkParams | null {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "paseo:" || url.hostname !== "h" || url.username || url.password) {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments.length !== 3 || segments[1] !== "agent") {
+    return null;
+  }
+
+  let serverId: string;
+  let agentId: string;
+  try {
+    serverId = decodeURIComponent(segments[0] ?? "").trim();
+    agentId = decodeURIComponent(segments[2] ?? "").trim();
+  } catch {
+    return null;
+  }
+  if (!serverId || !agentId) {
+    return null;
+  }
+
+  return {
+    serverId,
+    agentId,
+    source: url.searchParams.get("source"),
+    permissionRequestId: url.searchParams.get("permissionRequestId"),
+    permissionActionId: url.searchParams.get("permissionActionId"),
+  };
+}

--- a/packages/app/src/live-activity/fleet-agent-input.test.ts
+++ b/packages/app/src/live-activity/fleet-agent-input.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import type { Agent } from "@/stores/session-store";
+import type { TodoEntry } from "@/types/stream";
+import { deriveFleetAgentInputs } from "./fleet-agent-input";
+
+const NOW = new Date("2026-04-01T03:00:00.000Z");
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    serverId: "server-a",
+    id: "agent-12345678",
+    provider: "codex",
+    status: "idle",
+    createdAt: NOW,
+    updatedAt: NOW,
+    lastUserMessageAt: null,
+    lastActivityAt: NOW,
+    capabilities: {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    },
+    currentModeId: null,
+    availableModes: [],
+    pendingPermissions: [],
+    persistence: null,
+    title: "My Agent",
+    cwd: "/repo",
+    model: null,
+    parentAgentId: null,
+    labels: {},
+    archivedAt: null,
+    ...overrides,
+    activeTurn: overrides.activeTurn ?? null,
+  };
+}
+
+function derive(agents: Agent[], agentTasks: ReadonlyMap<string, TodoEntry[]> = new Map()) {
+  return deriveFleetAgentInputs(new Map(agents.map((agent) => [agent.id, agent])), agentTasks);
+}
+
+describe("deriveFleetAgentInputs", () => {
+  it("excludes archived agents", () => {
+    const agent = makeAgent({ archivedAt: NOW });
+    expect(derive([agent])).toEqual([]);
+  });
+
+  it("excludes closed agents", () => {
+    const agent = makeAgent({ status: "closed" });
+    expect(derive([agent])).toEqual([]);
+  });
+
+  it("excludes initializing agents", () => {
+    const agent = makeAgent({ status: "initializing" });
+    expect(derive([agent])).toEqual([]);
+  });
+
+  it("marks running agents and reads runningSinceMs from activeTurn.startedAt", () => {
+    const startedAt = new Date("2026-04-01T02:00:00.000Z");
+    const agent = makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt } });
+    const [input] = derive([agent]);
+    expect(input?.running).toBe(true);
+    expect(input?.runningSinceMs).toBe(startedAt.getTime());
+  });
+
+  it("falls back to lastUserMessageAt when activeTurn.startedAt is unavailable", () => {
+    const lastUserMessageAt = new Date("2026-04-01T01:00:00.000Z");
+    const agent = makeAgent({ status: "running", activeTurn: null, lastUserMessageAt });
+    const [input] = derive([agent]);
+    expect(input?.runningSinceMs).toBe(lastUserMessageAt.getTime());
+  });
+
+  it("falls back to updatedAt when activeTurn and lastUserMessageAt are unavailable", () => {
+    const updatedAt = new Date("2026-04-01T00:30:00.000Z");
+    const agent = makeAgent({
+      status: "running",
+      activeTurn: null,
+      lastUserMessageAt: null,
+      updatedAt,
+    });
+    const [input] = derive([agent]);
+    expect(input?.runningSinceMs).toBe(updatedAt.getTime());
+  });
+
+  it("omits runningSinceMs and marks running false for non-running agents", () => {
+    const agent = makeAgent({ status: "idle", activeTurn: { turnId: "t1", startedAt: NOW } });
+    const [input] = derive([agent]);
+    expect(input?.running).toBe(false);
+    expect(input?.runningSinceMs).toBeUndefined();
+  });
+
+  it("marks error agents from status", () => {
+    const agent = makeAgent({ status: "error" });
+    const [input] = derive([agent]);
+    expect(input?.error).toBe(true);
+  });
+
+  it("maps a pending permission, preferring title over name for toolName", () => {
+    const attentionTimestamp = new Date("2026-04-01T02:45:00.000Z");
+    const agent = makeAgent({
+      status: "idle",
+      attentionTimestamp,
+      pendingPermissions: [
+        {
+          id: "p1",
+          provider: "codex",
+          name: "bash",
+          kind: "tool",
+          title: "Run bash",
+          description: "ls -la\nmore",
+        },
+      ],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission).toEqual({
+      toolName: "Run bash",
+      detail: "ls -la",
+      sinceMs: attentionTimestamp.getTime(),
+    });
+  });
+
+  it("falls back to name when a pending permission has no title", () => {
+    const agent = makeAgent({
+      pendingPermissions: [{ id: "p1", provider: "codex", name: "bash", kind: "tool" }],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.toolName).toBe("bash");
+  });
+
+  it("falls back to the input's first line when a pending permission has no description", () => {
+    const agent = makeAgent({
+      pendingPermissions: [
+        {
+          id: "p1",
+          provider: "codex",
+          name: "bash",
+          kind: "tool",
+          input: { command: "rm -rf /tmp\nnext" },
+        },
+      ],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.detail).toBe(JSON.stringify({ command: "rm -rf /tmp\nnext" }));
+  });
+
+  it("falls back to lastActivityAt for a pending permission's sinceMs when attentionTimestamp is unset", () => {
+    const lastActivityAt = new Date("2026-04-01T02:10:00.000Z");
+    const agent = makeAgent({
+      lastActivityAt,
+      attentionTimestamp: null,
+      pendingPermissions: [{ id: "p1", provider: "codex", name: "bash", kind: "tool" }],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.sinceMs).toBe(lastActivityAt.getTime());
+  });
+
+  it("sets needsAttentionSinceMs when requiresAttention is true and the reason is not finished", () => {
+    const attentionTimestamp = new Date("2026-04-01T02:50:00.000Z");
+    const agent = makeAgent({
+      requiresAttention: true,
+      attentionReason: "error",
+      attentionTimestamp,
+    });
+    const [input] = derive([agent]);
+    expect(input?.needsAttentionSinceMs).toBe(attentionTimestamp.getTime());
+  });
+
+  it("omits needsAttentionSinceMs when the attention reason is finished", () => {
+    const agent = makeAgent({
+      requiresAttention: true,
+      attentionReason: "finished",
+      attentionTimestamp: NOW,
+    });
+    const [input] = derive([agent]);
+    expect(input?.needsAttentionSinceMs).toBeUndefined();
+  });
+
+  it("omits needsAttentionSinceMs when requiresAttention is not set", () => {
+    const agent = makeAgent({ requiresAttention: undefined, attentionTimestamp: NOW });
+    const [input] = derive([agent]);
+    expect(input?.needsAttentionSinceMs).toBeUndefined();
+  });
+
+  it("reads phase and todo progress from agentTasks when present", () => {
+    const agent = makeAgent({ id: "agent-1" });
+    const tasks: TodoEntry[] = [
+      { text: "Read file", completed: true, status: "completed" },
+      { text: "Edit file", activeForm: "Editing file", completed: false, status: "in_progress" },
+      { text: "Run tests", completed: false, status: "pending" },
+    ];
+    const [input] = derive([agent], new Map([["agent-1", tasks]]));
+    expect(input?.phase).toBe("Editing file");
+    expect(input?.todoDone).toBe(1);
+    expect(input?.todoTotal).toBe(3);
+  });
+
+  it("omits phase and todo progress when the agent has no entry in agentTasks", () => {
+    const agent = makeAgent({ id: "agent-1" });
+    const [input] = derive([agent], new Map());
+    expect(input?.phase).toBeUndefined();
+    expect(input?.todoDone).toBeUndefined();
+    expect(input?.todoTotal).toBeUndefined();
+  });
+
+  it("sets errorSinceMs from attentionTimestamp, falling back to lastActivityAt and updatedAt", () => {
+    const attentionTimestamp = new Date("2026-04-01T02:55:00.000Z");
+    const lastActivityAt = new Date("2026-04-01T02:10:00.000Z");
+    const updatedAt = new Date("2026-04-01T01:00:00.000Z");
+
+    const withAttention = makeAgent({ status: "error", attentionTimestamp });
+    const withLastActivity = makeAgent({
+      status: "error",
+      attentionTimestamp: null,
+      lastActivityAt,
+    });
+    const withUpdatedAt = makeAgent({
+      status: "error",
+      attentionTimestamp: null,
+      lastActivityAt: updatedAt,
+      updatedAt,
+    });
+
+    expect(derive([withAttention])[0]?.errorSinceMs).toBe(attentionTimestamp.getTime());
+    expect(derive([withLastActivity])[0]?.errorSinceMs).toBe(lastActivityAt.getTime());
+    expect(derive([withUpdatedAt])[0]?.errorSinceMs).toBe(updatedAt.getTime());
+  });
+
+  it("falls back to the agent's title, or 'Agent <shortId>' when title is null", () => {
+    const titled = makeAgent({ id: "agent-1", title: "Named agent" });
+    const untitled = makeAgent({ id: "agent-abcdefgh12345", title: null });
+    const [titledInput, untitledInput] = derive([titled, untitled]);
+    expect(titledInput?.title).toBe("Named agent");
+    expect(untitledInput?.title).toBe("Agent agent-ab");
+  });
+});

--- a/packages/app/src/live-activity/fleet-agent-input.test.ts
+++ b/packages/app/src/live-activity/fleet-agent-input.test.ts
@@ -118,7 +118,6 @@ describe("deriveFleetAgentInputs", () => {
     expect(input?.pendingPermission).toEqual({
       requestId: "p1",
       toolName: "Run bash",
-      detail: "ls -la",
       sinceMs: attentionTimestamp.getTime(),
       primaryAction: { id: "accept", label: "Accept" },
     });
@@ -132,20 +131,33 @@ describe("deriveFleetAgentInputs", () => {
     expect(input?.pendingPermission?.toolName).toBe("bash");
   });
 
-  it("falls back to the input's first line when a pending permission has no description", () => {
+  it("never copies request.description or request.input into the Live Activity permission state", () => {
+    const attentionTimestamp = new Date("2026-04-01T02:45:00.000Z");
     const agent = makeAgent({
+      attentionTimestamp,
       pendingPermissions: [
         {
           id: "p1",
           provider: "codex",
           name: "bash",
           kind: "tool",
-          input: { command: "rm -rf /tmp\nnext" },
+          description: "Export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+          input: {
+            command: "curl -H 'Authorization: Bearer sk-live-topsecret' https://api.example.com",
+          },
         },
       ],
     });
     const [input] = derive([agent]);
-    expect(input?.pendingPermission?.detail).toBe(JSON.stringify({ command: "rm -rf /tmp\nnext" }));
+    expect(input?.pendingPermission).toEqual({
+      requestId: "p1",
+      toolName: "bash",
+      sinceMs: attentionTimestamp.getTime(),
+      primaryAction: { id: "accept", label: "Accept" },
+    });
+    const serialized = JSON.stringify(input?.pendingPermission);
+    expect(serialized).not.toContain("AWS_SECRET_ACCESS_KEY");
+    expect(serialized).not.toContain("sk-live-topsecret");
   });
 
   it("falls back to lastActivityAt for a pending permission's sinceMs when attentionTimestamp is unset", () => {

--- a/packages/app/src/live-activity/fleet-agent-input.test.ts
+++ b/packages/app/src/live-activity/fleet-agent-input.test.ts
@@ -116,9 +116,11 @@ describe("deriveFleetAgentInputs", () => {
     });
     const [input] = derive([agent]);
     expect(input?.pendingPermission).toEqual({
+      requestId: "p1",
       toolName: "Run bash",
       detail: "ls -la",
       sinceMs: attentionTimestamp.getTime(),
+      primaryAction: { id: "accept", label: "Accept" },
     });
   });
 
@@ -234,5 +236,111 @@ describe("deriveFleetAgentInputs", () => {
     const [titledInput, untitledInput] = derive([titled, untitled]);
     expect(titledInput?.title).toBe("Named agent");
     expect(untitledInput?.title).toBe("Agent agent-ab");
+  });
+
+  it("includes the agent's serverId on the derived input", () => {
+    const agent = makeAgent({ serverId: "server-xyz" });
+    const [input] = derive([agent]);
+    expect(input?.serverId).toBe("server-xyz");
+  });
+
+  it("uses the latest pending permission request", () => {
+    const agent = makeAgent({
+      pendingPermissions: [
+        { id: "p1", provider: "codex", name: "old", kind: "tool" },
+        { id: "p2", provider: "codex", name: "new", kind: "tool" },
+      ],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.requestId).toBe("p2");
+    expect(input?.pendingPermission?.toolName).toBe("new");
+  });
+
+  it("selects the first primary+allow provider action for a permission's primaryAction", () => {
+    const agent = makeAgent({
+      pendingPermissions: [
+        {
+          id: "p1",
+          provider: "codex",
+          name: "bash",
+          kind: "tool",
+          actions: [
+            { id: "reject", label: "Reject", behavior: "deny", variant: "danger" },
+            { id: "allow-secondary", label: "Allow once", behavior: "allow" },
+            { id: "implement", label: "Implement", behavior: "allow", variant: "primary" },
+          ],
+        },
+      ],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.primaryAction).toEqual({
+      id: "implement",
+      label: "Implement",
+    });
+  });
+
+  it("falls back to the first allow action when no action is variant primary", () => {
+    const agent = makeAgent({
+      pendingPermissions: [
+        {
+          id: "p1",
+          provider: "codex",
+          name: "bash",
+          kind: "tool",
+          actions: [
+            { id: "reject", label: "Reject", behavior: "deny" },
+            { id: "allow-first", label: "Allow once", behavior: "allow" },
+            { id: "allow-second", label: "Allow always", behavior: "allow" },
+          ],
+        },
+      ],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.primaryAction).toEqual({
+      id: "allow-first",
+      label: "Allow once",
+    });
+  });
+
+  it("never selects a deny action as the primary shortcut", () => {
+    const agent = makeAgent({
+      pendingPermissions: [
+        {
+          id: "p1",
+          provider: "codex",
+          name: "bash",
+          kind: "tool",
+          actions: [{ id: "reject", label: "Reject", behavior: "deny", variant: "primary" }],
+        },
+      ],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.primaryAction).toBeUndefined();
+  });
+
+  it("omits a primary action for a question request with no provider actions", () => {
+    const agent = makeAgent({
+      pendingPermissions: [
+        { id: "p1", provider: "codex", name: "AskUserQuestion", kind: "question" },
+      ],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.primaryAction).toBeUndefined();
+  });
+
+  it("defaults to Implement for a plan request with no provider actions", () => {
+    const agent = makeAgent({
+      pendingPermissions: [{ id: "p1", provider: "codex", name: "ExitPlanMode", kind: "plan" }],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.primaryAction).toEqual({ id: "accept", label: "Implement" });
+  });
+
+  it("defaults to Accept for a tool request with no provider actions", () => {
+    const agent = makeAgent({
+      pendingPermissions: [{ id: "p1", provider: "codex", name: "bash", kind: "tool" }],
+    });
+    const [input] = derive([agent]);
+    expect(input?.pendingPermission?.primaryAction).toEqual({ id: "accept", label: "Accept" });
   });
 });

--- a/packages/app/src/live-activity/fleet-agent-input.ts
+++ b/packages/app/src/live-activity/fleet-agent-input.ts
@@ -4,14 +4,39 @@
  * Pure and synchronous: no React, no native imports, no wall-clock reads.
  */
 
+import type { AgentPermissionAction, AgentPermissionRequest } from "@getpaseo/protocol/agent-types";
 import type { Agent } from "@/stores/session-store";
 import type { TodoEntry } from "@/types/stream";
 import type { FleetAgentInput, FleetPendingPermission } from "./fleet-snapshot";
 
 const SHORT_AGENT_ID_LENGTH = 8;
 
+/**
+ * Primary permission shortcut, per the fixed fleet-mode contract: first primary+allow provider
+ * action, else first allow action, else a kind-based fallback when the provider defines none.
+ * Never a deny action.
+ */
+function selectPrimaryPermissionAction(
+  request: AgentPermissionRequest,
+): { id: string; label: string } | undefined {
+  const actions = request.actions;
+  if (actions !== undefined && actions.length > 0) {
+    const allowActions = actions.filter(
+      (action): action is AgentPermissionAction => action.behavior === "allow",
+    );
+    const primary = allowActions.find((action) => action.variant === "primary") ?? allowActions[0];
+    return primary !== undefined ? { id: primary.id, label: primary.label } : undefined;
+  }
+  if (request.kind === "question") {
+    return undefined;
+  }
+  return request.kind === "plan"
+    ? { id: "accept", label: "Implement" }
+    : { id: "accept", label: "Accept" };
+}
+
 function pendingPermissionInput(agent: Agent): FleetPendingPermission | undefined {
-  const request = agent.pendingPermissions[0];
+  const request = agent.pendingPermissions.at(-1);
   if (request === undefined) {
     return undefined;
   }
@@ -19,9 +44,11 @@ function pendingPermissionInput(agent: Agent): FleetPendingPermission | undefine
     request.description ??
     (request.input !== undefined ? JSON.stringify(request.input) : undefined);
   return {
+    requestId: request.id,
     toolName: request.title ?? request.name,
     detail: detailSource !== undefined ? (detailSource.split("\n")[0] ?? "") : undefined,
     sinceMs: (agent.attentionTimestamp ?? agent.lastActivityAt).getTime(),
+    primaryAction: selectPrimaryPermissionAction(request),
   };
 }
 
@@ -67,6 +94,7 @@ function toFleetAgentInput(agent: Agent, tasks: readonly TodoEntry[] | undefined
   const progress = tasks !== undefined ? taskProgress(tasks) : undefined;
   return {
     agentId: agent.id,
+    serverId: agent.serverId,
     title: agent.title ?? `Agent ${agent.id.slice(0, SHORT_AGENT_ID_LENGTH)}`,
     running: agent.status === "running",
     error: agent.status === "error",

--- a/packages/app/src/live-activity/fleet-agent-input.ts
+++ b/packages/app/src/live-activity/fleet-agent-input.ts
@@ -35,18 +35,19 @@ function selectPrimaryPermissionAction(
     : { id: "accept", label: "Accept" };
 }
 
+/**
+ * Never carries `request.description` or `request.input`: both can hold credentials, file
+ * paths, or arbitrary user text, and Live Activity state is rendered on the Lock Screen and
+ * expanded Dynamic Island outside the app's own access control.
+ */
 function pendingPermissionInput(agent: Agent): FleetPendingPermission | undefined {
   const request = agent.pendingPermissions.at(-1);
   if (request === undefined) {
     return undefined;
   }
-  const detailSource =
-    request.description ??
-    (request.input !== undefined ? JSON.stringify(request.input) : undefined);
   return {
     requestId: request.id,
     toolName: request.title ?? request.name,
-    detail: detailSource !== undefined ? (detailSource.split("\n")[0] ?? "") : undefined,
     sinceMs: (agent.attentionTimestamp ?? agent.lastActivityAt).getTime(),
     primaryAction: selectPrimaryPermissionAction(request),
   };

--- a/packages/app/src/live-activity/fleet-agent-input.ts
+++ b/packages/app/src/live-activity/fleet-agent-input.ts
@@ -1,0 +1,99 @@
+/**
+ * Adapts one daemon connection's live agent state (`SessionState.agents` /
+ * `SessionState.agentTasks`) into the `FleetAgentInput[]` shape `selectFleetSnapshot` consumes.
+ * Pure and synchronous: no React, no native imports, no wall-clock reads.
+ */
+
+import type { Agent } from "@/stores/session-store";
+import type { TodoEntry } from "@/types/stream";
+import type { FleetAgentInput, FleetPendingPermission } from "./fleet-snapshot";
+
+const SHORT_AGENT_ID_LENGTH = 8;
+
+function pendingPermissionInput(agent: Agent): FleetPendingPermission | undefined {
+  const request = agent.pendingPermissions[0];
+  if (request === undefined) {
+    return undefined;
+  }
+  const detailSource =
+    request.description ??
+    (request.input !== undefined ? JSON.stringify(request.input) : undefined);
+  return {
+    toolName: request.title ?? request.name,
+    detail: detailSource !== undefined ? (detailSource.split("\n")[0] ?? "") : undefined,
+    sinceMs: (agent.attentionTimestamp ?? agent.lastActivityAt).getTime(),
+  };
+}
+
+function needsAttentionSinceMs(agent: Agent): number | undefined {
+  if (agent.requiresAttention !== true || agent.attentionReason === "finished") {
+    return undefined;
+  }
+  return (agent.attentionTimestamp ?? agent.lastActivityAt).getTime();
+}
+
+function runningSinceMs(agent: Agent): number | undefined {
+  if (agent.status !== "running") {
+    return undefined;
+  }
+  const startedAt = agent.activeTurn?.startedAt ?? agent.lastUserMessageAt ?? agent.updatedAt;
+  return startedAt.getTime();
+}
+
+function errorSinceMs(agent: Agent): number | undefined {
+  if (agent.status !== "error") {
+    return undefined;
+  }
+  return (agent.attentionTimestamp ?? agent.lastActivityAt ?? agent.updatedAt).getTime();
+}
+
+interface TaskProgress {
+  phase: string | undefined;
+  todoDone: number;
+  todoTotal: number;
+}
+
+function taskProgress(tasks: readonly TodoEntry[]): TaskProgress {
+  const todoDone = tasks.filter((task) => task.completed || task.status === "completed").length;
+  const inProgress = tasks.find((task) => task.status === "in_progress");
+  return {
+    phase: inProgress?.activeForm ?? inProgress?.text,
+    todoDone,
+    todoTotal: tasks.length,
+  };
+}
+
+function toFleetAgentInput(agent: Agent, tasks: readonly TodoEntry[] | undefined): FleetAgentInput {
+  const progress = tasks !== undefined ? taskProgress(tasks) : undefined;
+  return {
+    agentId: agent.id,
+    title: agent.title ?? `Agent ${agent.id.slice(0, SHORT_AGENT_ID_LENGTH)}`,
+    running: agent.status === "running",
+    error: agent.status === "error",
+    pendingPermission: pendingPermissionInput(agent),
+    needsAttentionSinceMs: needsAttentionSinceMs(agent),
+    runningSinceMs: runningSinceMs(agent),
+    errorSinceMs: errorSinceMs(agent),
+    phase: progress?.phase,
+    todoDone: progress?.todoDone,
+    todoTotal: progress?.todoTotal,
+  };
+}
+
+/**
+ * Excludes archived agents and agents outside the fleet's active lifecycle (`closed`,
+ * `initializing`). Order follows `agents` map iteration order.
+ */
+export function deriveFleetAgentInputs(
+  agents: ReadonlyMap<string, Agent>,
+  agentTasks: ReadonlyMap<string, TodoEntry[]>,
+): readonly FleetAgentInput[] {
+  const inputs: FleetAgentInput[] = [];
+  for (const agent of agents.values()) {
+    if (agent.archivedAt != null || agent.status === "closed" || agent.status === "initializing") {
+      continue;
+    }
+    inputs.push(toFleetAgentInput(agent, agentTasks.get(agent.id)));
+  }
+  return inputs;
+}

--- a/packages/app/src/live-activity/fleet-snapshot.test.ts
+++ b/packages/app/src/live-activity/fleet-snapshot.test.ts
@@ -39,7 +39,6 @@ describe("selectFleetSnapshot", () => {
         title: "a1",
         state: "running",
         permissionToolName: undefined,
-        permissionDetail: undefined,
         phase: "editing",
         todoDone: undefined,
         todoTotal: undefined,
@@ -192,24 +191,6 @@ describe("selectFleetSnapshot", () => {
     const snapshot = selectFleetSnapshot(agents, null);
     expect(snapshot.needsYouCount).toBe(3);
     expect(snapshot.runningCount).toBe(1);
-  });
-
-  it("truncates permission detail to its first line and 80 characters", () => {
-    const longLine = "x".repeat(120);
-    const agents = [
-      agent({
-        agentId: "blocked",
-        pendingPermission: {
-          requestId: "req-blocked",
-          toolName: "bash",
-          detail: `${longLine}\nsecond line`,
-          sinceMs: 100,
-        },
-      }),
-    ];
-    const snapshot = selectFleetSnapshot(agents, null);
-    expect(snapshot.hero?.permissionDetail).toBe(longLine.slice(0, 80));
-    expect(snapshot.hero?.permissionDetail).toHaveLength(80);
   });
 
   it("computes longestRunningSinceMs from plain running agents only", () => {

--- a/packages/app/src/live-activity/fleet-snapshot.test.ts
+++ b/packages/app/src/live-activity/fleet-snapshot.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { deriveFleetAgentInputs } from "./fleet-agent-input";
+import { selectFleetSnapshot, type FleetAgentInput } from "./fleet-snapshot";
+
+function agent(
+  overrides: Partial<FleetAgentInput> & Pick<FleetAgentInput, "agentId">,
+): FleetAgentInput {
+  return {
+    title: overrides.agentId,
+    running: false,
+    error: false,
+    ...overrides,
+  };
+}
+
+describe("selectFleetSnapshot", () => {
+  it("returns an inactive snapshot for an empty fleet", () => {
+    expect(selectFleetSnapshot([], null)).toEqual({
+      active: false,
+      hero: null,
+      needsYouCount: 0,
+      runningCount: 0,
+    });
+  });
+
+  it("promotes the sole running agent to hero in a degenerate fleet", () => {
+    const snapshot = selectFleetSnapshot(
+      [agent({ agentId: "a1", running: true, runningSinceMs: 1000, phase: "editing" })],
+      null,
+    );
+    expect(snapshot).toEqual({
+      active: true,
+      hero: {
+        agentId: "a1",
+        title: "a1",
+        state: "running",
+        permissionToolName: undefined,
+        permissionDetail: undefined,
+        phase: "editing",
+        todoDone: undefined,
+        todoTotal: undefined,
+        sinceMs: 1000,
+      },
+      needsYouCount: 0,
+      runningCount: 1,
+      longestRunningSinceMs: 1000,
+    });
+  });
+
+  it("prioritizes pending permission over error, waiting, and running", () => {
+    const agents = [
+      agent({ agentId: "runner", running: true, runningSinceMs: 500 }),
+      agent({ agentId: "waiter", needsAttentionSinceMs: 400 }),
+      agent({ agentId: "erroring", error: true }),
+      agent({ agentId: "blocked", pendingPermission: { toolName: "bash", sinceMs: 900 } }),
+    ];
+    expect(selectFleetSnapshot(agents, null).hero?.agentId).toBe("blocked");
+  });
+
+  it("prioritizes error over waiting and running when no permission is pending", () => {
+    const agents = [
+      agent({ agentId: "runner", running: true, runningSinceMs: 500 }),
+      agent({ agentId: "waiter", needsAttentionSinceMs: 400 }),
+      agent({ agentId: "erroring", error: true }),
+    ];
+    const snapshot = selectFleetSnapshot(agents, null);
+    expect(snapshot.hero?.agentId).toBe("erroring");
+    expect(snapshot.hero?.state).toBe("error");
+  });
+
+  it("maps error status to heroState error even when needsAttentionSinceMs is also set", () => {
+    const agents = [
+      agent({
+        agentId: "erroring",
+        error: true,
+        needsAttentionSinceMs: 400,
+        errorSinceMs: 900,
+      }),
+    ];
+    const snapshot = selectFleetSnapshot(agents, null);
+    expect(snapshot.hero?.state).toBe("error");
+    expect(snapshot.hero?.sinceMs).toBe(900);
+  });
+
+  it("uses errorSinceMs for an error hero and never falls back to epoch 0 in production shape", () => {
+    const attentionTimestamp = new Date("2026-04-01T02:30:00.000Z");
+    const agentRecord = {
+      serverId: "server-a",
+      id: "agent-error01",
+      provider: "codex" as const,
+      status: "error" as const,
+      createdAt: new Date("2026-04-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T01:00:00.000Z"),
+      lastUserMessageAt: null,
+      lastActivityAt: new Date("2026-04-01T02:00:00.000Z"),
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      currentModeId: null,
+      availableModes: [],
+      pendingPermissions: [],
+      persistence: null,
+      title: "Broken agent",
+      cwd: "/repo",
+      model: null,
+      parentAgentId: null,
+      labels: {},
+      archivedAt: null,
+      activeTurn: null,
+      requiresAttention: true,
+      attentionReason: "error" as const,
+      attentionTimestamp,
+    };
+    const inputs = deriveFleetAgentInputs(new Map([[agentRecord.id, agentRecord]]), new Map());
+    const snapshot = selectFleetSnapshot(inputs, null);
+    expect(snapshot.hero?.state).toBe("error");
+    expect(snapshot.hero?.sinceMs).toBe(attentionTimestamp.getTime());
+    expect(snapshot.hero?.sinceMs).toBeGreaterThan(0);
+  });
+
+  it("prioritizes the longest-waiting needs_you agent over running", () => {
+    const agents = [
+      agent({ agentId: "runner", running: true, runningSinceMs: 500 }),
+      agent({ agentId: "shortWait", needsAttentionSinceMs: 900 }),
+      agent({ agentId: "longWait", needsAttentionSinceMs: 100 }),
+    ];
+    expect(selectFleetSnapshot(agents, null).hero?.agentId).toBe("longWait");
+  });
+
+  it("prioritizes the longest-running agent among plain running agents", () => {
+    const agents = [
+      agent({ agentId: "shortRun", running: true, runningSinceMs: 900 }),
+      agent({ agentId: "longRun", running: true, runningSinceMs: 100 }),
+    ];
+    expect(selectFleetSnapshot(agents, null).hero?.agentId).toBe("longRun");
+  });
+
+  it("keeps the current hero when no candidate reaches a strictly higher priority class", () => {
+    const agents = [
+      agent({ agentId: "hero", running: true, runningSinceMs: 900 }),
+      agent({ agentId: "fresherRunner", running: true, runningSinceMs: 100 }),
+    ];
+    expect(selectFleetSnapshot(agents, "hero").hero?.agentId).toBe("hero");
+  });
+
+  it("keeps the current hero over a same-class needs_you agent with a longer wait", () => {
+    const agents = [
+      agent({ agentId: "hero", needsAttentionSinceMs: 900 }),
+      agent({ agentId: "longerWait", needsAttentionSinceMs: 100 }),
+    ];
+    expect(selectFleetSnapshot(agents, "hero").hero?.agentId).toBe("hero");
+  });
+
+  it("swaps the hero when a candidate reaches a strictly higher priority class", () => {
+    const agents = [
+      agent({ agentId: "hero", running: true, runningSinceMs: 900 }),
+      agent({ agentId: "blocked", pendingPermission: { toolName: "bash", sinceMs: 100 } }),
+    ];
+    expect(selectFleetSnapshot(agents, "hero").hero?.agentId).toBe("blocked");
+  });
+
+  it("swaps the hero once it leaves the active set", () => {
+    const agents = [agent({ agentId: "next", running: true, runningSinceMs: 500 })];
+    expect(selectFleetSnapshot(agents, "gone").hero?.agentId).toBe("next");
+  });
+
+  it("counts needs-you and running agents without double-counting a running error", () => {
+    const agents = [
+      agent({ agentId: "runner", running: true, runningSinceMs: 500 }),
+      agent({ agentId: "runningError", running: true, error: true }),
+      agent({ agentId: "waiter", needsAttentionSinceMs: 400 }),
+      agent({ agentId: "blocked", pendingPermission: { toolName: "bash", sinceMs: 900 } }),
+    ];
+    const snapshot = selectFleetSnapshot(agents, null);
+    expect(snapshot.needsYouCount).toBe(3);
+    expect(snapshot.runningCount).toBe(1);
+  });
+
+  it("truncates permission detail to its first line and 80 characters", () => {
+    const longLine = "x".repeat(120);
+    const agents = [
+      agent({
+        agentId: "blocked",
+        pendingPermission: { toolName: "bash", detail: `${longLine}\nsecond line`, sinceMs: 100 },
+      }),
+    ];
+    const snapshot = selectFleetSnapshot(agents, null);
+    expect(snapshot.hero?.permissionDetail).toBe(longLine.slice(0, 80));
+    expect(snapshot.hero?.permissionDetail).toHaveLength(80);
+  });
+
+  it("computes longestRunningSinceMs from plain running agents only", () => {
+    const agents = [
+      agent({ agentId: "slow", running: true, runningSinceMs: 900 }),
+      agent({ agentId: "fast", running: true, runningSinceMs: 100 }),
+      agent({
+        agentId: "runningNeedsAttention",
+        running: true,
+        runningSinceMs: 1,
+        needsAttentionSinceMs: 50,
+      }),
+    ];
+    expect(selectFleetSnapshot(agents, null).longestRunningSinceMs).toBe(100);
+  });
+
+  it("omits longestRunningSinceMs when no plain running agent exists", () => {
+    const agents = [agent({ agentId: "waiter", needsAttentionSinceMs: 400 })];
+    expect(selectFleetSnapshot(agents, null).longestRunningSinceMs).toBeUndefined();
+  });
+});

--- a/packages/app/src/live-activity/fleet-snapshot.test.ts
+++ b/packages/app/src/live-activity/fleet-snapshot.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from "vitest";
 import { deriveFleetAgentInputs } from "./fleet-agent-input";
 import { selectFleetSnapshot, type FleetAgentInput } from "./fleet-snapshot";
 
+const SERVER_ID = "server-1";
+
 function agent(
   overrides: Partial<FleetAgentInput> & Pick<FleetAgentInput, "agentId">,
 ): FleetAgentInput {
   return {
+    serverId: SERVER_ID,
     title: overrides.agentId,
     running: false,
     error: false,
@@ -32,6 +35,7 @@ describe("selectFleetSnapshot", () => {
       active: true,
       hero: {
         agentId: "a1",
+        serverId: SERVER_ID,
         title: "a1",
         state: "running",
         permissionToolName: undefined,
@@ -52,7 +56,10 @@ describe("selectFleetSnapshot", () => {
       agent({ agentId: "runner", running: true, runningSinceMs: 500 }),
       agent({ agentId: "waiter", needsAttentionSinceMs: 400 }),
       agent({ agentId: "erroring", error: true }),
-      agent({ agentId: "blocked", pendingPermission: { toolName: "bash", sinceMs: 900 } }),
+      agent({
+        agentId: "blocked",
+        pendingPermission: { requestId: "req-blocked", toolName: "bash", sinceMs: 900 },
+      }),
     ];
     expect(selectFleetSnapshot(agents, null).hero?.agentId).toBe("blocked");
   });
@@ -159,7 +166,10 @@ describe("selectFleetSnapshot", () => {
   it("swaps the hero when a candidate reaches a strictly higher priority class", () => {
     const agents = [
       agent({ agentId: "hero", running: true, runningSinceMs: 900 }),
-      agent({ agentId: "blocked", pendingPermission: { toolName: "bash", sinceMs: 100 } }),
+      agent({
+        agentId: "blocked",
+        pendingPermission: { requestId: "req-blocked", toolName: "bash", sinceMs: 100 },
+      }),
     ];
     expect(selectFleetSnapshot(agents, "hero").hero?.agentId).toBe("blocked");
   });
@@ -174,7 +184,10 @@ describe("selectFleetSnapshot", () => {
       agent({ agentId: "runner", running: true, runningSinceMs: 500 }),
       agent({ agentId: "runningError", running: true, error: true }),
       agent({ agentId: "waiter", needsAttentionSinceMs: 400 }),
-      agent({ agentId: "blocked", pendingPermission: { toolName: "bash", sinceMs: 900 } }),
+      agent({
+        agentId: "blocked",
+        pendingPermission: { requestId: "req-blocked", toolName: "bash", sinceMs: 900 },
+      }),
     ];
     const snapshot = selectFleetSnapshot(agents, null);
     expect(snapshot.needsYouCount).toBe(3);
@@ -186,7 +199,12 @@ describe("selectFleetSnapshot", () => {
     const agents = [
       agent({
         agentId: "blocked",
-        pendingPermission: { toolName: "bash", detail: `${longLine}\nsecond line`, sinceMs: 100 },
+        pendingPermission: {
+          requestId: "req-blocked",
+          toolName: "bash",
+          detail: `${longLine}\nsecond line`,
+          sinceMs: 100,
+        },
       }),
     ];
     const snapshot = selectFleetSnapshot(agents, null);

--- a/packages/app/src/live-activity/fleet-snapshot.ts
+++ b/packages/app/src/live-activity/fleet-snapshot.ts
@@ -1,0 +1,199 @@
+/**
+ * Pure fleet-mode selector for the iOS Live Activity feature. Types and priority/hysteresis
+ * rules follow the fixed fleet-mode contract; this module has no React and no native imports.
+ */
+
+export type FleetAgentState = "running" | "needs_you" | "error";
+
+export interface FleetHero {
+  agentId: string;
+  title: string;
+  state: FleetAgentState;
+  /** set when needs_you is due to a pending permission request */
+  permissionToolName?: string;
+  /** first line of the permission command/input, truncated to 80 chars */
+  permissionDetail?: string;
+  /** one-line current phase, e.g. tool name; omit rather than fabricate */
+  phase?: string;
+  todoDone?: number;
+  todoTotal?: number;
+  /** epoch ms when the hero entered its current state; drives client-side timers */
+  sinceMs: number;
+}
+
+export interface FleetSnapshot {
+  /** true iff any agent is running, needs_you, or error */
+  active: boolean;
+  hero: FleetHero | null;
+  needsYouCount: number; // includes error agents
+  runningCount: number;
+  /** epoch ms start of the longest-running agent, when runningCount > 0 */
+  longestRunningSinceMs?: number;
+}
+
+export interface FleetPendingPermission {
+  toolName: string;
+  detail?: string;
+  sinceMs: number;
+}
+
+export interface FleetAgentInput {
+  agentId: string;
+  title: string;
+  running: boolean;
+  error: boolean;
+  pendingPermission?: FleetPendingPermission;
+  /** set when agent requires attention (non-permission) */
+  needsAttentionSinceMs?: number;
+  /** set when running */
+  runningSinceMs?: number;
+  /** set when status is error; from attentionTimestamp, lastActivityAt, or updatedAt */
+  errorSinceMs?: number;
+  phase?: string;
+  todoDone?: number;
+  todoTotal?: number;
+}
+
+type FleetPriorityClass = 1 | 2 | 3 | 4;
+
+interface ActiveFleetAgent {
+  input: FleetAgentInput;
+  index: number;
+  priorityClass: FleetPriorityClass;
+  tiebreakMs: number;
+}
+
+function needsYou(input: FleetAgentInput): boolean {
+  return (
+    input.pendingPermission !== undefined ||
+    input.needsAttentionSinceMs !== undefined ||
+    input.error
+  );
+}
+
+/**
+ * Classifies one agent into its hero-selection priority class, or `null` when the agent is
+ * not part of the active set. Class 2 (error) has no timestamp on the input, so its tiebreak
+ * falls back to input order for determinism.
+ */
+function classifyActiveAgent(input: FleetAgentInput, index: number): ActiveFleetAgent | null {
+  if (input.pendingPermission !== undefined) {
+    return { input, index, priorityClass: 1, tiebreakMs: input.pendingPermission.sinceMs };
+  }
+  if (input.error) {
+    return { input, index, priorityClass: 2, tiebreakMs: index };
+  }
+  if (input.needsAttentionSinceMs !== undefined) {
+    return { input, index, priorityClass: 3, tiebreakMs: input.needsAttentionSinceMs };
+  }
+  if (input.running) {
+    return { input, index, priorityClass: 4, tiebreakMs: input.runningSinceMs ?? index };
+  }
+  return null;
+}
+
+function compareActiveFleetAgents(a: ActiveFleetAgent, b: ActiveFleetAgent): number {
+  if (a.priorityClass !== b.priorityClass) {
+    return a.priorityClass - b.priorityClass;
+  }
+  if (a.tiebreakMs !== b.tiebreakMs) {
+    return a.tiebreakMs - b.tiebreakMs;
+  }
+  return a.index - b.index;
+}
+
+function truncatePermissionDetail(detail: string | undefined): string | undefined {
+  if (detail === undefined) {
+    return undefined;
+  }
+  const firstLine = detail.split("\n")[0] ?? "";
+  return firstLine.slice(0, 80);
+}
+
+function heroState(input: FleetAgentInput): FleetAgentState {
+  if (input.pendingPermission !== undefined) {
+    return "needs_you";
+  }
+  if (input.error) {
+    return "error";
+  }
+  if (input.needsAttentionSinceMs !== undefined) {
+    return "needs_you";
+  }
+  return "running";
+}
+
+function heroSinceMs(input: FleetAgentInput): number {
+  if (input.pendingPermission !== undefined) {
+    return input.pendingPermission.sinceMs;
+  }
+  if (input.error) {
+    return input.errorSinceMs ?? input.needsAttentionSinceMs ?? input.runningSinceMs ?? 0;
+  }
+  if (input.needsAttentionSinceMs !== undefined) {
+    return input.needsAttentionSinceMs;
+  }
+  return input.runningSinceMs ?? 0;
+}
+
+function buildHero(input: FleetAgentInput): FleetHero {
+  return {
+    agentId: input.agentId,
+    title: input.title,
+    state: heroState(input),
+    permissionToolName: input.pendingPermission?.toolName,
+    permissionDetail: truncatePermissionDetail(input.pendingPermission?.detail),
+    phase: input.phase,
+    todoDone: input.todoDone,
+    todoTotal: input.todoTotal,
+    sinceMs: heroSinceMs(input),
+  };
+}
+
+/** Longest-running start time among agents counted in `runningCount`, i.e. plain running agents. */
+function longestRunningSinceMs(agents: readonly FleetAgentInput[]): number | undefined {
+  return agents.reduce<number | undefined>((longest, input) => {
+    if (!input.running || needsYou(input) || input.runningSinceMs === undefined) {
+      return longest;
+    }
+    return longest === undefined || input.runningSinceMs < longest ? input.runningSinceMs : longest;
+  }, undefined);
+}
+
+/**
+ * Selects the fleet hero and headline counts from raw agent state. Pure and deterministic:
+ * every timestamp comes from `agents`, none from the wall clock.
+ *
+ * Hysteresis: `prevHeroAgentId` keeps its hero unless it left the active set, or a candidate
+ * reaches a strictly higher priority class. Same-class ties or better same-class timestamps
+ * never swap the hero.
+ */
+export function selectFleetSnapshot(
+  agents: readonly FleetAgentInput[],
+  prevHeroAgentId: string | null,
+): FleetSnapshot {
+  const activeAgents = agents
+    .map((input, index) => classifyActiveAgent(input, index))
+    .filter((entry): entry is ActiveFleetAgent => entry !== null);
+
+  if (activeAgents.length === 0) {
+    return { active: false, hero: null, needsYouCount: 0, runningCount: 0 };
+  }
+
+  const bestCandidate = activeAgents.reduce((best, candidate) =>
+    compareActiveFleetAgents(candidate, best) < 0 ? candidate : best,
+  );
+  const currentHero = activeAgents.find((candidate) => candidate.input.agentId === prevHeroAgentId);
+  const hero =
+    currentHero !== undefined && bestCandidate.priorityClass >= currentHero.priorityClass
+      ? currentHero
+      : bestCandidate;
+
+  return {
+    active: true,
+    hero: buildHero(hero.input),
+    needsYouCount: agents.filter(needsYou).length,
+    runningCount: agents.filter((input) => input.running && !needsYou(input)).length,
+    longestRunningSinceMs: longestRunningSinceMs(agents),
+  };
+}

--- a/packages/app/src/live-activity/fleet-snapshot.ts
+++ b/packages/app/src/live-activity/fleet-snapshot.ts
@@ -12,8 +12,6 @@ export interface FleetHero {
   state: FleetAgentState;
   /** set when needs_you is due to a pending permission request */
   permissionToolName?: string;
-  /** first line of the permission command/input, truncated to 80 chars */
-  permissionDetail?: string;
   /** id of the pending permission request driving needs_you, when applicable */
   permissionRequestId?: string;
   /** provider action link-worthy as the primary Live Activity action, per selection rules */
@@ -39,7 +37,6 @@ export interface FleetSnapshot {
 export interface FleetPendingPermission {
   requestId: string;
   toolName: string;
-  detail?: string;
   sinceMs: number;
   /** provider-selected primary action, per selection rules; absent means no primary shortcut */
   primaryAction?: { id: string; label: string };
@@ -111,14 +108,6 @@ function compareActiveFleetAgents(a: ActiveFleetAgent, b: ActiveFleetAgent): num
   return a.index - b.index;
 }
 
-function truncatePermissionDetail(detail: string | undefined): string | undefined {
-  if (detail === undefined) {
-    return undefined;
-  }
-  const firstLine = detail.split("\n")[0] ?? "";
-  return firstLine.slice(0, 80);
-}
-
 function heroState(input: FleetAgentInput): FleetAgentState {
   if (input.pendingPermission !== undefined) {
     return "needs_you";
@@ -152,7 +141,6 @@ function buildHero(input: FleetAgentInput): FleetHero {
     title: input.title,
     state: heroState(input),
     permissionToolName: input.pendingPermission?.toolName,
-    permissionDetail: truncatePermissionDetail(input.pendingPermission?.detail),
     permissionRequestId: input.pendingPermission?.requestId,
     permissionPrimaryAction: input.pendingPermission?.primaryAction,
     phase: input.phase,

--- a/packages/app/src/live-activity/fleet-snapshot.ts
+++ b/packages/app/src/live-activity/fleet-snapshot.ts
@@ -7,12 +7,17 @@ export type FleetAgentState = "running" | "needs_you" | "error";
 
 export interface FleetHero {
   agentId: string;
+  serverId: string;
   title: string;
   state: FleetAgentState;
   /** set when needs_you is due to a pending permission request */
   permissionToolName?: string;
   /** first line of the permission command/input, truncated to 80 chars */
   permissionDetail?: string;
+  /** id of the pending permission request driving needs_you, when applicable */
+  permissionRequestId?: string;
+  /** provider action link-worthy as the primary Live Activity action, per selection rules */
+  permissionPrimaryAction?: { id: string; label: string };
   /** one-line current phase, e.g. tool name; omit rather than fabricate */
   phase?: string;
   todoDone?: number;
@@ -32,13 +37,17 @@ export interface FleetSnapshot {
 }
 
 export interface FleetPendingPermission {
+  requestId: string;
   toolName: string;
   detail?: string;
   sinceMs: number;
+  /** provider-selected primary action, per selection rules; absent means no primary shortcut */
+  primaryAction?: { id: string; label: string };
 }
 
 export interface FleetAgentInput {
   agentId: string;
+  serverId: string;
   title: string;
   running: boolean;
   error: boolean;
@@ -139,10 +148,13 @@ function heroSinceMs(input: FleetAgentInput): number {
 function buildHero(input: FleetAgentInput): FleetHero {
   return {
     agentId: input.agentId,
+    serverId: input.serverId,
     title: input.title,
     state: heroState(input),
     permissionToolName: input.pendingPermission?.toolName,
     permissionDetail: truncatePermissionDetail(input.pendingPermission?.detail),
+    permissionRequestId: input.pendingPermission?.requestId,
+    permissionPrimaryAction: input.pendingPermission?.primaryAction,
     phase: input.phase,
     todoDone: input.todoDone,
     todoTotal: input.todoTotal,

--- a/packages/app/src/live-activity/live-activity-focus.test.ts
+++ b/packages/app/src/live-activity/live-activity-focus.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resolveLiveActivityFocusTarget,
+  useLiveActivityFocusStore,
+  useLiveActivityPermissionFocus,
+} from "./live-activity-focus";
+
+afterEach(() => {
+  useLiveActivityFocusStore.setState({ focus: null });
+});
+
+describe("resolveLiveActivityFocusTarget", () => {
+  it("returns the exact request and action for a Live Activity route", () => {
+    expect(
+      resolveLiveActivityFocusTarget({
+        source: "live-activity",
+        serverId: "server-1",
+        agentId: "agent-1",
+        permissionRequestId: "req-1",
+        permissionActionId: "accept",
+      }),
+    ).toEqual({
+      serverId: "server-1",
+      agentId: "agent-1",
+      requestId: "req-1",
+      actionId: "accept",
+    });
+  });
+
+  it("ignores ordinary agent routes and Live Activity routes without a request", () => {
+    const base = {
+      serverId: "server-1",
+      agentId: "agent-1",
+      permissionActionId: undefined,
+    };
+    expect(
+      resolveLiveActivityFocusTarget({
+        ...base,
+        source: "notification",
+        permissionRequestId: "req-1",
+      }),
+    ).toBeNull();
+    expect(
+      resolveLiveActivityFocusTarget({
+        ...base,
+        source: "live-activity",
+        permissionRequestId: "",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("useLiveActivityPermissionFocus", () => {
+  it("is unfocused before any target is recorded", () => {
+    const { result } = renderHook(() => useLiveActivityPermissionFocus("agent-1", "req-1"));
+    expect(result.current).toEqual({ isFocused: false, focusedActionId: undefined });
+  });
+
+  it("matches by agentId and requestId, exposing the recorded actionId", () => {
+    useLiveActivityFocusStore.getState().setFocus({
+      serverId: "server-1",
+      agentId: "agent-1",
+      requestId: "req-1",
+      actionId: "accept",
+    });
+    const { result } = renderHook(() => useLiveActivityPermissionFocus("agent-1", "req-1"));
+    expect(result.current).toEqual({ isFocused: true, focusedActionId: "accept" });
+  });
+
+  it("does not match a different agentId even with the same requestId", () => {
+    useLiveActivityFocusStore.getState().setFocus({
+      serverId: "server-1",
+      agentId: "agent-1",
+      requestId: "req-1",
+    });
+    const { result } = renderHook(() => useLiveActivityPermissionFocus("agent-2", "req-1"));
+    expect(result.current).toEqual({ isFocused: false, focusedActionId: undefined });
+  });
+
+  it("does not match a different requestId even with the same agentId", () => {
+    useLiveActivityFocusStore.getState().setFocus({
+      serverId: "server-1",
+      agentId: "agent-1",
+      requestId: "req-1",
+    });
+    const { result } = renderHook(() => useLiveActivityPermissionFocus("agent-1", "req-2"));
+    expect(result.current).toEqual({ isFocused: false, focusedActionId: undefined });
+  });
+
+  it("exposes no focusedActionId when the recorded target has no actionId", () => {
+    useLiveActivityFocusStore.getState().setFocus({
+      serverId: "server-1",
+      agentId: "agent-1",
+      requestId: "req-1",
+    });
+    const { result } = renderHook(() => useLiveActivityPermissionFocus("agent-1", "req-1"));
+    expect(result.current).toEqual({ isFocused: true, focusedActionId: undefined });
+  });
+});
+
+describe("useLiveActivityFocusStore clearFocus", () => {
+  it("clears the focus when the match agrees with the recorded target", () => {
+    useLiveActivityFocusStore.getState().setFocus({
+      serverId: "server-1",
+      agentId: "agent-1",
+      requestId: "req-1",
+    });
+    useLiveActivityFocusStore.getState().clearFocus({ agentId: "agent-1", requestId: "req-1" });
+    expect(useLiveActivityFocusStore.getState().focus).toBeNull();
+  });
+
+  it("leaves an unrelated focus target untouched", () => {
+    useLiveActivityFocusStore.getState().setFocus({
+      serverId: "server-1",
+      agentId: "agent-1",
+      requestId: "req-1",
+    });
+    useLiveActivityFocusStore.getState().clearFocus({ agentId: "agent-2", requestId: "req-1" });
+    expect(useLiveActivityFocusStore.getState().focus).toEqual({
+      serverId: "server-1",
+      agentId: "agent-1",
+      requestId: "req-1",
+    });
+  });
+
+  it("is a no-op when nothing is focused", () => {
+    useLiveActivityFocusStore.getState().clearFocus({ agentId: "agent-1", requestId: "req-1" });
+    expect(useLiveActivityFocusStore.getState().focus).toBeNull();
+  });
+});

--- a/packages/app/src/live-activity/live-activity-focus.ts
+++ b/packages/app/src/live-activity/live-activity-focus.ts
@@ -1,0 +1,89 @@
+/**
+ * Transient focus target recorded by a Live Activity deep link before `navigateToAgent`.
+ * `agent-stream/view.tsx` reads it to highlight the matching `PermissionRequestCard` and
+ * action button. It never submits a permission response by itself; a card clears its own
+ * focus when it unmounts (the request resolved) or the user presses any action.
+ */
+
+import { create } from "zustand";
+import { useShallow } from "zustand/shallow";
+
+export interface LiveActivityFocusTarget {
+  serverId: string;
+  agentId: string;
+  requestId: string;
+  actionId?: string;
+}
+
+export interface LiveActivityFocusRouteParams {
+  source: string;
+  serverId: string;
+  agentId: string;
+  permissionRequestId: string;
+  permissionActionId?: string;
+}
+
+/**
+ * A Live Activity tap carries `source=live-activity` and `permissionRequestId`; other entries
+ * to the agent route (in-app navigation, notifications, plain agent links) do not.
+ */
+export function resolveLiveActivityFocusTarget(
+  params: LiveActivityFocusRouteParams,
+): LiveActivityFocusTarget | null {
+  if (params.source !== "live-activity" || !params.permissionRequestId) {
+    return null;
+  }
+  return {
+    serverId: params.serverId,
+    agentId: params.agentId,
+    requestId: params.permissionRequestId,
+    actionId: params.permissionActionId,
+  };
+}
+
+interface LiveActivityFocusMatch {
+  agentId: string;
+  requestId: string;
+}
+
+interface LiveActivityFocusStoreState {
+  focus: LiveActivityFocusTarget | null;
+  setFocus: (target: LiveActivityFocusTarget) => void;
+  clearFocus: (match: LiveActivityFocusMatch) => void;
+}
+
+export const useLiveActivityFocusStore = create<LiveActivityFocusStoreState>((set) => ({
+  focus: null,
+  setFocus: (target) => set({ focus: target }),
+  clearFocus: (match) =>
+    set((state) =>
+      state.focus !== null &&
+      state.focus.agentId === match.agentId &&
+      state.focus.requestId === match.requestId
+        ? { focus: null }
+        : state,
+    ),
+}));
+
+export interface LiveActivityPermissionFocus {
+  isFocused: boolean;
+  focusedActionId: string | undefined;
+}
+
+const UNFOCUSED: LiveActivityPermissionFocus = { isFocused: false, focusedActionId: undefined };
+
+/** Matches `PermissionRequestCard` by agentId + requestId, per the fixed fleet-mode contract. */
+export function useLiveActivityPermissionFocus(
+  agentId: string,
+  requestId: string,
+): LiveActivityPermissionFocus {
+  return useLiveActivityFocusStore(
+    useShallow((state) => {
+      const { focus } = state;
+      if (focus === null || focus.agentId !== agentId || focus.requestId !== requestId) {
+        return UNFOCUSED;
+      }
+      return { isFocused: true, focusedActionId: focus.actionId };
+    }),
+  );
+}

--- a/packages/app/src/live-activity/presenter.native.ts
+++ b/packages/app/src/live-activity/presenter.native.ts
@@ -84,7 +84,6 @@ function contentStateFromHero(hero: FleetHero, snapshot: FleetSnapshot): LiveAct
     todoDone: hero.todoDone,
     todoTotal: hero.todoTotal,
     permissionToolName: hero.permissionToolName,
-    permissionDetail: hero.permissionDetail,
     needsYouCount: snapshot.needsYouCount,
     runningCount: snapshot.runningCount,
     heroDeepLink: heroDeepLinkFor(hero),
@@ -100,14 +99,20 @@ export async function start(snapshot: FleetSnapshot): Promise<void> {
   if (!supported() || snapshot.hero === null) {
     return;
   }
-  await PaseoLiveActivityModule.start(contentStateFromHero(snapshot.hero, snapshot));
+  await PaseoLiveActivityModule.start(
+    snapshot.hero.serverId,
+    contentStateFromHero(snapshot.hero, snapshot),
+  );
 }
 
 export async function update(snapshot: FleetSnapshot): Promise<void> {
   if (!supported() || snapshot.hero === null) {
     return;
   }
-  await PaseoLiveActivityModule.update(contentStateFromHero(snapshot.hero, snapshot));
+  await PaseoLiveActivityModule.update(
+    snapshot.hero.serverId,
+    contentStateFromHero(snapshot.hero, snapshot),
+  );
 }
 
 export async function end(receipt: FleetReceipt): Promise<void> {
@@ -119,6 +124,7 @@ export async function end(receipt: FleetReceipt): Promise<void> {
     agentId: receipt.agentId,
   });
   await PaseoLiveActivityModule.end(
+    receipt.serverId,
     {
       heroTitle: receipt.finishedTitle,
       heroState: "finished",

--- a/packages/app/src/live-activity/presenter.native.ts
+++ b/packages/app/src/live-activity/presenter.native.ts
@@ -1,0 +1,62 @@
+/**
+ * Fleet presenter seam, native implementation. Wraps the local `paseo-live-activity` Expo module
+ * (ActivityKit) per the fixed fleet-mode contract. Android has no Live Activities and gets the
+ * same no-op behavior as web via the `isSupported()`/`Platform.OS` gate below.
+ */
+
+import { Platform } from "react-native";
+import PaseoLiveActivityModule, { type LiveActivityContentState } from "paseo-live-activity";
+import type { FleetHero, FleetSnapshot } from "./fleet-snapshot";
+import type { FleetReceipt } from "./presenter";
+
+/** Grace window after the final "finished" frame before ActivityKit dismisses the activity. */
+const FINISHED_DISMISS_AFTER_SECONDS = 5;
+
+function contentStateFromHero(hero: FleetHero, snapshot: FleetSnapshot): LiveActivityContentState {
+  return {
+    heroTitle: hero.title,
+    heroState: hero.state,
+    sinceMs: hero.sinceMs,
+    phase: hero.phase,
+    todoDone: hero.todoDone,
+    todoTotal: hero.todoTotal,
+    permissionToolName: hero.permissionToolName,
+    permissionDetail: hero.permissionDetail,
+    needsYouCount: snapshot.needsYouCount,
+    runningCount: snapshot.runningCount,
+  };
+}
+
+export function supported(): boolean {
+  return Platform.OS === "ios" && PaseoLiveActivityModule.isSupported();
+}
+
+export async function start(snapshot: FleetSnapshot): Promise<void> {
+  if (!supported() || snapshot.hero === null) {
+    return;
+  }
+  await PaseoLiveActivityModule.start(contentStateFromHero(snapshot.hero, snapshot));
+}
+
+export async function update(snapshot: FleetSnapshot): Promise<void> {
+  if (!supported() || snapshot.hero === null) {
+    return;
+  }
+  await PaseoLiveActivityModule.update(contentStateFromHero(snapshot.hero, snapshot));
+}
+
+export async function end(receipt: FleetReceipt): Promise<void> {
+  if (!supported()) {
+    return;
+  }
+  await PaseoLiveActivityModule.end(
+    {
+      heroTitle: receipt.finishedTitle,
+      heroState: "finished",
+      sinceMs: Date.now(),
+      needsYouCount: 0,
+      runningCount: 0,
+    },
+    FINISHED_DISMISS_AFTER_SECONDS,
+  );
+}

--- a/packages/app/src/live-activity/presenter.native.ts
+++ b/packages/app/src/live-activity/presenter.native.ts
@@ -6,11 +6,74 @@
 
 import { Platform } from "react-native";
 import PaseoLiveActivityModule, { type LiveActivityContentState } from "paseo-live-activity";
+import {
+  buildLiveActivityHeroDeepLink,
+  buildLiveActivityPermissionPrimaryDeepLink,
+  buildLiveActivityPermissionReviewDeepLink,
+} from "./deep-link";
 import type { FleetHero, FleetSnapshot } from "./fleet-snapshot";
 import type { FleetReceipt } from "./presenter";
 
 /** Grace window after the final "finished" frame before ActivityKit dismisses the activity. */
 const FINISHED_DISMISS_AFTER_SECONDS = 5;
+
+interface HeroActionLinks {
+  primaryActionLabel?: string;
+  primaryActionDeepLink?: string;
+  secondaryActionLabel?: string;
+  secondaryActionDeepLink?: string;
+}
+
+/** Opens the exact hero/request: the permission review URL when one is pending, else the hero. */
+function heroDeepLinkFor(hero: FleetHero): string {
+  const target = { serverId: hero.serverId, agentId: hero.agentId };
+  if (hero.permissionRequestId !== undefined) {
+    return buildLiveActivityPermissionReviewDeepLink({
+      ...target,
+      permissionRequestId: hero.permissionRequestId,
+    });
+  }
+  return buildLiveActivityHeroDeepLink(target);
+}
+
+/** Presenter action mapping from the fixed fleet-mode contract. */
+function heroActionLinks(hero: FleetHero): HeroActionLinks {
+  const target = { serverId: hero.serverId, agentId: hero.agentId };
+  if (hero.state === "running") {
+    return {
+      primaryActionLabel: "Open agent",
+      primaryActionDeepLink: buildLiveActivityHeroDeepLink(target),
+    };
+  }
+  if (hero.state === "error") {
+    return {
+      primaryActionLabel: "View error",
+      primaryActionDeepLink: buildLiveActivityHeroDeepLink(target),
+    };
+  }
+  if (hero.permissionRequestId === undefined) {
+    return {
+      primaryActionLabel: "Review",
+      primaryActionDeepLink: buildLiveActivityHeroDeepLink(target),
+    };
+  }
+  const reviewTarget = { ...target, permissionRequestId: hero.permissionRequestId };
+  if (hero.permissionPrimaryAction === undefined) {
+    return {
+      primaryActionLabel: "Review",
+      primaryActionDeepLink: buildLiveActivityPermissionReviewDeepLink(reviewTarget),
+    };
+  }
+  return {
+    primaryActionLabel: hero.permissionPrimaryAction.label,
+    primaryActionDeepLink: buildLiveActivityPermissionPrimaryDeepLink({
+      ...reviewTarget,
+      permissionActionId: hero.permissionPrimaryAction.id,
+    }),
+    secondaryActionLabel: "Review",
+    secondaryActionDeepLink: buildLiveActivityPermissionReviewDeepLink(reviewTarget),
+  };
+}
 
 function contentStateFromHero(hero: FleetHero, snapshot: FleetSnapshot): LiveActivityContentState {
   return {
@@ -24,6 +87,8 @@ function contentStateFromHero(hero: FleetHero, snapshot: FleetSnapshot): LiveAct
     permissionDetail: hero.permissionDetail,
     needsYouCount: snapshot.needsYouCount,
     runningCount: snapshot.runningCount,
+    heroDeepLink: heroDeepLinkFor(hero),
+    ...heroActionLinks(hero),
   };
 }
 
@@ -49,6 +114,10 @@ export async function end(receipt: FleetReceipt): Promise<void> {
   if (!supported()) {
     return;
   }
+  const heroDeepLink = buildLiveActivityHeroDeepLink({
+    serverId: receipt.serverId,
+    agentId: receipt.agentId,
+  });
   await PaseoLiveActivityModule.end(
     {
       heroTitle: receipt.finishedTitle,
@@ -56,6 +125,9 @@ export async function end(receipt: FleetReceipt): Promise<void> {
       sinceMs: Date.now(),
       needsYouCount: 0,
       runningCount: 0,
+      heroDeepLink,
+      primaryActionLabel: "View result",
+      primaryActionDeepLink: heroDeepLink,
     },
     FINISHED_DISMISS_AFTER_SECONDS,
   );

--- a/packages/app/src/live-activity/presenter.ts
+++ b/packages/app/src/live-activity/presenter.ts
@@ -7,6 +7,8 @@
 import type { FleetSnapshot } from "./fleet-snapshot";
 
 export interface FleetReceipt {
+  serverId: string;
+  agentId: string;
   durationMs: number;
   finishedTitle: string;
 }

--- a/packages/app/src/live-activity/presenter.ts
+++ b/packages/app/src/live-activity/presenter.ts
@@ -1,0 +1,22 @@
+/**
+ * Fleet presenter seam: `useLiveActivity` targets this surface and never imports a native module
+ * directly. Metro picks `presenter.native.ts` on iOS/Android and this no-op base everywhere else
+ * (web resolves `presenter.web.ts`, an identical stub, first).
+ */
+
+import type { FleetSnapshot } from "./fleet-snapshot";
+
+export interface FleetReceipt {
+  durationMs: number;
+  finishedTitle: string;
+}
+
+export function supported(): boolean {
+  return false;
+}
+
+export async function start(_snapshot: FleetSnapshot): Promise<void> {}
+
+export async function update(_snapshot: FleetSnapshot): Promise<void> {}
+
+export async function end(_receipt: FleetReceipt): Promise<void> {}

--- a/packages/app/src/live-activity/presenter.web.ts
+++ b/packages/app/src/live-activity/presenter.web.ts
@@ -6,6 +6,8 @@
 import type { FleetSnapshot } from "./fleet-snapshot";
 
 export interface FleetReceipt {
+  serverId: string;
+  agentId: string;
   durationMs: number;
   finishedTitle: string;
 }

--- a/packages/app/src/live-activity/presenter.web.ts
+++ b/packages/app/src/live-activity/presenter.web.ts
@@ -1,0 +1,21 @@
+/**
+ * Fleet presenter seam: `useLiveActivity` targets this surface and never imports a native module
+ * directly. Live Activities are iOS-only; the web bundle always gets this no-op stub.
+ */
+
+import type { FleetSnapshot } from "./fleet-snapshot";
+
+export interface FleetReceipt {
+  durationMs: number;
+  finishedTitle: string;
+}
+
+export function supported(): boolean {
+  return false;
+}
+
+export async function start(_snapshot: FleetSnapshot): Promise<void> {}
+
+export async function update(_snapshot: FleetSnapshot): Promise<void> {}
+
+export async function end(_receipt: FleetReceipt): Promise<void> {}

--- a/packages/app/src/live-activity/use-live-activity-controller.ts
+++ b/packages/app/src/live-activity/use-live-activity-controller.ts
@@ -1,0 +1,246 @@
+/**
+ * iOS fleet Live Activity controller implementation. Imported by `use-live-activity.ios.ts`
+ * and unit tests; non-iOS builds use the no-op `use-live-activity.ts` stub instead.
+ */
+
+import { useEffect, useMemo, useRef } from "react";
+import { useShallow } from "zustand/shallow";
+import { useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import { useSessionStore, type Agent } from "@/stores/session-store";
+import type { TodoEntry } from "@/types/stream";
+import { deriveFleetAgentInputs } from "./fleet-agent-input";
+import { selectFleetSnapshot, type FleetAgentState, type FleetSnapshot } from "./fleet-snapshot";
+import * as presenter from "./presenter";
+
+export interface UseLiveActivityOptions {
+  serverId: string;
+}
+
+const UPDATE_DEBOUNCE_MS = 1000;
+const GRACE_PERIOD_MS = 120_000;
+
+const EMPTY_AGENTS: ReadonlyMap<string, Agent> = new Map();
+const EMPTY_TASKS: ReadonlyMap<string, TodoEntry[]> = new Map();
+
+interface MaterialFleetState {
+  heroId: string | null;
+  heroState: FleetAgentState | null;
+  needsYouCount: number;
+  runningCount: number;
+  phase: string | undefined;
+  todoDone: number | undefined;
+  todoTotal: number | undefined;
+}
+
+function materialState(snapshot: FleetSnapshot): MaterialFleetState {
+  return {
+    heroId: snapshot.hero?.agentId ?? null,
+    heroState: snapshot.hero?.state ?? null,
+    needsYouCount: snapshot.needsYouCount,
+    runningCount: snapshot.runningCount,
+    phase: snapshot.hero?.phase,
+    todoDone: snapshot.hero?.todoDone,
+    todoTotal: snapshot.hero?.todoTotal,
+  };
+}
+
+function materialStateChanged(a: MaterialFleetState, b: MaterialFleetState): boolean {
+  return (
+    a.heroId !== b.heroId ||
+    a.heroState !== b.heroState ||
+    a.needsYouCount !== b.needsYouCount ||
+    a.runningCount !== b.runningCount ||
+    a.phase !== b.phase ||
+    a.todoDone !== b.todoDone ||
+    a.todoTotal !== b.todoTotal
+  );
+}
+
+interface ActivityLifecycle {
+  activityStartMs: number | null;
+  lastHeroTitle: string;
+  lastMaterial: MaterialFleetState | null;
+  debounceTimer: ReturnType<typeof setTimeout> | null;
+  graceTimer: ReturnType<typeof setTimeout> | null;
+  pendingSnapshot: FleetSnapshot | null;
+  presenterEpoch: number;
+  inFlightUpdate: Promise<void> | null;
+}
+
+function createActivityLifecycle(): ActivityLifecycle {
+  return {
+    activityStartMs: null,
+    lastHeroTitle: "",
+    lastMaterial: null,
+    debounceTimer: null,
+    graceTimer: null,
+    pendingSnapshot: null,
+    presenterEpoch: 0,
+    inFlightUpdate: null,
+  };
+}
+
+function clearPendingUpdate(lifecycle: ActivityLifecycle): void {
+  if (lifecycle.debounceTimer !== null) {
+    clearTimeout(lifecycle.debounceTimer);
+    lifecycle.debounceTimer = null;
+  }
+  lifecycle.pendingSnapshot = null;
+}
+
+function clearGraceTimer(lifecycle: ActivityLifecycle): void {
+  if (lifecycle.graceTimer === null) {
+    return;
+  }
+  clearTimeout(lifecycle.graceTimer);
+  lifecycle.graceTimer = null;
+}
+
+async function runPresenterUpdate(
+  lifecycle: ActivityLifecycle,
+  snapshot: FleetSnapshot,
+): Promise<void> {
+  const epoch = lifecycle.presenterEpoch;
+  if (lifecycle.activityStartMs === null) {
+    return;
+  }
+  const updatePromise = (async () => {
+    try {
+      await presenter.update(snapshot);
+    } catch {
+      return;
+    }
+    if (lifecycle.presenterEpoch !== epoch || lifecycle.activityStartMs === null) {
+      return;
+    }
+    lifecycle.lastMaterial = materialState(snapshot);
+  })();
+  lifecycle.inFlightUpdate = updatePromise;
+  try {
+    await updatePromise;
+  } finally {
+    if (lifecycle.inFlightUpdate === updatePromise) {
+      lifecycle.inFlightUpdate = null;
+    }
+  }
+}
+
+function scheduleDebouncedUpdate(lifecycle: ActivityLifecycle, snapshot: FleetSnapshot): void {
+  clearPendingUpdate(lifecycle);
+  lifecycle.pendingSnapshot = snapshot;
+  lifecycle.debounceTimer = setTimeout(() => {
+    lifecycle.debounceTimer = null;
+    const pending = lifecycle.pendingSnapshot;
+    lifecycle.pendingSnapshot = null;
+    if (lifecycle.activityStartMs === null || pending === null) {
+      return;
+    }
+    void runPresenterUpdate(lifecycle, pending);
+  }, UPDATE_DEBOUNCE_MS);
+}
+
+function endActivity(lifecycle: ActivityLifecycle): void {
+  lifecycle.presenterEpoch += 1;
+  clearPendingUpdate(lifecycle);
+  clearGraceTimer(lifecycle);
+  if (lifecycle.activityStartMs === null) {
+    return;
+  }
+  const receipt = {
+    durationMs: Date.now() - lifecycle.activityStartMs,
+    finishedTitle: lifecycle.lastHeroTitle,
+  };
+  lifecycle.activityStartMs = null;
+  lifecycle.lastMaterial = null;
+  const inFlight = lifecycle.inFlightUpdate;
+  if (inFlight === null) {
+    void presenter.end(receipt).catch(() => undefined);
+    return;
+  }
+  void (async () => {
+    await inFlight.catch(() => undefined);
+    try {
+      await presenter.end(receipt);
+    } catch {
+      return;
+    }
+  })();
+}
+
+function reconcileActivity(lifecycle: ActivityLifecycle, snapshot: FleetSnapshot): void {
+  if (snapshot.hero !== null) {
+    lifecycle.lastHeroTitle = snapshot.hero.title;
+  }
+
+  if (!snapshot.active) {
+    if (lifecycle.activityStartMs !== null && lifecycle.graceTimer === null) {
+      clearPendingUpdate(lifecycle);
+      lifecycle.graceTimer = setTimeout(() => {
+        lifecycle.graceTimer = null;
+        endActivity(lifecycle);
+      }, GRACE_PERIOD_MS);
+    }
+    return;
+  }
+
+  clearGraceTimer(lifecycle);
+
+  if (lifecycle.activityStartMs === null) {
+    lifecycle.presenterEpoch += 1;
+    lifecycle.activityStartMs = Date.now();
+    lifecycle.lastMaterial = materialState(snapshot);
+    clearPendingUpdate(lifecycle);
+    void presenter.start(snapshot).catch(() => undefined);
+    return;
+  }
+
+  const nextMaterial = materialState(snapshot);
+  if (
+    lifecycle.lastMaterial !== null &&
+    !materialStateChanged(lifecycle.lastMaterial, nextMaterial)
+  ) {
+    return;
+  }
+
+  scheduleDebouncedUpdate(lifecycle, snapshot);
+}
+
+export function useLiveActivityController({ serverId }: UseLiveActivityOptions): void {
+  const isConnected = useHostRuntimeIsConnected(serverId);
+  const { agents, agentTasks } = useSessionStore(
+    useShallow((state) => ({
+      agents: state.sessions[serverId]?.agents,
+      agentTasks: state.sessions[serverId]?.agentTasks,
+    })),
+  );
+
+  const prevHeroAgentIdRef = useRef<string | null>(null);
+  const lifecycleRef = useRef<ActivityLifecycle>(createActivityLifecycle());
+
+  const snapshot = useMemo(() => {
+    const inputs = deriveFleetAgentInputs(agents ?? EMPTY_AGENTS, agentTasks ?? EMPTY_TASKS);
+    const result = selectFleetSnapshot(inputs, prevHeroAgentIdRef.current);
+    prevHeroAgentIdRef.current = result.hero?.agentId ?? null;
+    return result;
+  }, [agents, agentTasks]);
+
+  useEffect(() => {
+    if (!presenter.supported()) {
+      return;
+    }
+    if (!isConnected) {
+      endActivity(lifecycleRef.current);
+      prevHeroAgentIdRef.current = null;
+      return;
+    }
+    reconcileActivity(lifecycleRef.current, snapshot);
+  }, [isConnected, snapshot]);
+
+  useEffect(() => {
+    const lifecycle = lifecycleRef.current;
+    return () => {
+      endActivity(lifecycle);
+      prevHeroAgentIdRef.current = null;
+    };
+  }, []);
+}

--- a/packages/app/src/live-activity/use-live-activity-controller.ts
+++ b/packages/app/src/live-activity/use-live-activity-controller.ts
@@ -74,7 +74,8 @@ interface ActivityLifecycle {
   graceTimer: ReturnType<typeof setTimeout> | null;
   pendingSnapshot: FleetSnapshot | null;
   presenterEpoch: number;
-  inFlightUpdate: Promise<void> | null;
+  /** The currently running (or most recently chained) native start/update/end call, if any. */
+  presenterInFlight: Promise<void> | null;
 }
 
 function createActivityLifecycle(): ActivityLifecycle {
@@ -87,7 +88,7 @@ function createActivityLifecycle(): ActivityLifecycle {
     graceTimer: null,
     pendingSnapshot: null,
     presenterEpoch: 0,
-    inFlightUpdate: null,
+    presenterInFlight: null,
   };
 }
 
@@ -107,33 +108,43 @@ function clearGraceTimer(lifecycle: ActivityLifecycle): void {
   lifecycle.graceTimer = null;
 }
 
-async function runPresenterUpdate(
+/**
+ * Runs one native call. When nothing is in flight, `task` runs immediately (synchronously up to
+ * its first `await`), matching the pre-serialization dispatch latency. When a previous call is
+ * still in flight, `task` is chained after it instead of racing it. Either way, a later call
+ * always settles after an earlier one: a deferred `end` can't outrun an unresolved `start`, and a
+ * stale `end` can't terminate a replacement activity that started after it was scheduled.
+ */
+function enqueuePresenterTask(
   lifecycle: ActivityLifecycle,
-  snapshot: FleetSnapshot,
+  task: () => Promise<void>,
 ): Promise<void> {
+  const previous = lifecycle.presenterInFlight;
+  const run =
+    previous === null
+      ? task().catch(() => undefined)
+      : previous.then(() => task().catch(() => undefined));
+  lifecycle.presenterInFlight = run;
+  void run.finally(() => {
+    if (lifecycle.presenterInFlight === run) {
+      lifecycle.presenterInFlight = null;
+    }
+  });
+  return run;
+}
+
+function runPresenterUpdate(lifecycle: ActivityLifecycle, snapshot: FleetSnapshot): Promise<void> {
   const epoch = lifecycle.presenterEpoch;
-  if (lifecycle.activityStartMs === null) {
-    return;
-  }
-  const updatePromise = (async () => {
-    try {
-      await presenter.update(snapshot);
-    } catch {
+  return enqueuePresenterTask(lifecycle, async () => {
+    if (lifecycle.presenterEpoch !== epoch || lifecycle.activityStartMs === null) {
       return;
     }
+    await presenter.update(snapshot);
     if (lifecycle.presenterEpoch !== epoch || lifecycle.activityStartMs === null) {
       return;
     }
     lifecycle.lastMaterial = materialState(snapshot);
-  })();
-  lifecycle.inFlightUpdate = updatePromise;
-  try {
-    await updatePromise;
-  } finally {
-    if (lifecycle.inFlightUpdate === updatePromise) {
-      lifecycle.inFlightUpdate = null;
-    }
-  }
+  });
 }
 
 function scheduleDebouncedUpdate(lifecycle: ActivityLifecycle, snapshot: FleetSnapshot): void {
@@ -165,19 +176,7 @@ function endActivity(lifecycle: ActivityLifecycle, serverId: string): void {
   };
   lifecycle.activityStartMs = null;
   lifecycle.lastMaterial = null;
-  const inFlight = lifecycle.inFlightUpdate;
-  if (inFlight === null) {
-    void presenter.end(receipt).catch(() => undefined);
-    return;
-  }
-  void (async () => {
-    await inFlight.catch(() => undefined);
-    try {
-      await presenter.end(receipt);
-    } catch {
-      return;
-    }
-  })();
+  void enqueuePresenterTask(lifecycle, () => presenter.end(receipt));
 }
 
 function reconcileActivity(
@@ -208,7 +207,13 @@ function reconcileActivity(
     lifecycle.activityStartMs = Date.now();
     lifecycle.lastMaterial = materialState(snapshot);
     clearPendingUpdate(lifecycle);
-    void presenter.start(snapshot).catch(() => undefined);
+    const epoch = lifecycle.presenterEpoch;
+    void enqueuePresenterTask(lifecycle, async () => {
+      if (lifecycle.presenterEpoch !== epoch || lifecycle.activityStartMs === null) {
+        return;
+      }
+      await presenter.start(snapshot);
+    });
     return;
   }
 

--- a/packages/app/src/live-activity/use-live-activity-controller.ts
+++ b/packages/app/src/live-activity/use-live-activity-controller.ts
@@ -30,6 +30,9 @@ interface MaterialFleetState {
   phase: string | undefined;
   todoDone: number | undefined;
   todoTotal: number | undefined;
+  permissionRequestId: string | undefined;
+  permissionPrimaryActionId: string | undefined;
+  permissionPrimaryActionLabel: string | undefined;
 }
 
 function materialState(snapshot: FleetSnapshot): MaterialFleetState {
@@ -41,6 +44,9 @@ function materialState(snapshot: FleetSnapshot): MaterialFleetState {
     phase: snapshot.hero?.phase,
     todoDone: snapshot.hero?.todoDone,
     todoTotal: snapshot.hero?.todoTotal,
+    permissionRequestId: snapshot.hero?.permissionRequestId,
+    permissionPrimaryActionId: snapshot.hero?.permissionPrimaryAction?.id,
+    permissionPrimaryActionLabel: snapshot.hero?.permissionPrimaryAction?.label,
   };
 }
 
@@ -52,13 +58,17 @@ function materialStateChanged(a: MaterialFleetState, b: MaterialFleetState): boo
     a.runningCount !== b.runningCount ||
     a.phase !== b.phase ||
     a.todoDone !== b.todoDone ||
-    a.todoTotal !== b.todoTotal
+    a.todoTotal !== b.todoTotal ||
+    a.permissionRequestId !== b.permissionRequestId ||
+    a.permissionPrimaryActionId !== b.permissionPrimaryActionId ||
+    a.permissionPrimaryActionLabel !== b.permissionPrimaryActionLabel
   );
 }
 
 interface ActivityLifecycle {
   activityStartMs: number | null;
   lastHeroTitle: string;
+  lastHeroAgentId: string;
   lastMaterial: MaterialFleetState | null;
   debounceTimer: ReturnType<typeof setTimeout> | null;
   graceTimer: ReturnType<typeof setTimeout> | null;
@@ -71,6 +81,7 @@ function createActivityLifecycle(): ActivityLifecycle {
   return {
     activityStartMs: null,
     lastHeroTitle: "",
+    lastHeroAgentId: "",
     lastMaterial: null,
     debounceTimer: null,
     graceTimer: null,
@@ -139,7 +150,7 @@ function scheduleDebouncedUpdate(lifecycle: ActivityLifecycle, snapshot: FleetSn
   }, UPDATE_DEBOUNCE_MS);
 }
 
-function endActivity(lifecycle: ActivityLifecycle): void {
+function endActivity(lifecycle: ActivityLifecycle, serverId: string): void {
   lifecycle.presenterEpoch += 1;
   clearPendingUpdate(lifecycle);
   clearGraceTimer(lifecycle);
@@ -147,6 +158,8 @@ function endActivity(lifecycle: ActivityLifecycle): void {
     return;
   }
   const receipt = {
+    serverId,
+    agentId: lifecycle.lastHeroAgentId,
     durationMs: Date.now() - lifecycle.activityStartMs,
     finishedTitle: lifecycle.lastHeroTitle,
   };
@@ -167,9 +180,14 @@ function endActivity(lifecycle: ActivityLifecycle): void {
   })();
 }
 
-function reconcileActivity(lifecycle: ActivityLifecycle, snapshot: FleetSnapshot): void {
+function reconcileActivity(
+  lifecycle: ActivityLifecycle,
+  snapshot: FleetSnapshot,
+  serverId: string,
+): void {
   if (snapshot.hero !== null) {
     lifecycle.lastHeroTitle = snapshot.hero.title;
+    lifecycle.lastHeroAgentId = snapshot.hero.agentId;
   }
 
   if (!snapshot.active) {
@@ -177,7 +195,7 @@ function reconcileActivity(lifecycle: ActivityLifecycle, snapshot: FleetSnapshot
       clearPendingUpdate(lifecycle);
       lifecycle.graceTimer = setTimeout(() => {
         lifecycle.graceTimer = null;
-        endActivity(lifecycle);
+        endActivity(lifecycle, serverId);
       }, GRACE_PERIOD_MS);
     }
     return;
@@ -229,18 +247,18 @@ export function useLiveActivityController({ serverId }: UseLiveActivityOptions):
       return;
     }
     if (!isConnected) {
-      endActivity(lifecycleRef.current);
+      endActivity(lifecycleRef.current, serverId);
       prevHeroAgentIdRef.current = null;
       return;
     }
-    reconcileActivity(lifecycleRef.current, snapshot);
-  }, [isConnected, snapshot]);
+    reconcileActivity(lifecycleRef.current, snapshot, serverId);
+  }, [isConnected, serverId, snapshot]);
 
   useEffect(() => {
     const lifecycle = lifecycleRef.current;
     return () => {
-      endActivity(lifecycle);
+      endActivity(lifecycle, serverId);
       prevHeroAgentIdRef.current = null;
     };
-  }, []);
+  }, [serverId]);
 }

--- a/packages/app/src/live-activity/use-live-activity.ios.ts
+++ b/packages/app/src/live-activity/use-live-activity.ios.ts
@@ -1,0 +1,8 @@
+/**
+ * iOS Live Activity mount: delegates to the controller when ActivityKit is available.
+ */
+
+export {
+  useLiveActivityController as useLiveActivity,
+  type UseLiveActivityOptions,
+} from "./use-live-activity-controller";

--- a/packages/app/src/live-activity/use-live-activity.test.ts
+++ b/packages/app/src/live-activity/use-live-activity.test.ts
@@ -1,0 +1,494 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionStore, type Agent } from "@/stores/session-store";
+import type { FleetSnapshot } from "./fleet-snapshot";
+import type { FleetReceipt } from "./presenter";
+import { useLiveActivityController as useLiveActivity } from "./use-live-activity-controller";
+
+const presenterMock = vi.hoisted(() => ({
+  supported: vi.fn<() => boolean>(() => true),
+  start: vi.fn<(snapshot: FleetSnapshot) => Promise<void>>(async (_snapshot) => {}),
+  update: vi.fn<(snapshot: FleetSnapshot) => Promise<void>>(async (_snapshot) => {}),
+  end: vi.fn<(receipt: FleetReceipt) => Promise<void>>(async (_receipt) => {}),
+}));
+
+vi.mock("./presenter", () => presenterMock);
+
+const hostRuntimeMock = vi.hoisted(() => ({
+  useHostRuntimeIsConnected: vi.fn(() => true),
+}));
+
+vi.mock("@/runtime/host-runtime", () => hostRuntimeMock);
+
+const SERVER_ID = "live-activity-server";
+const NOW = new Date("2026-04-01T03:00:00.000Z");
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    serverId: SERVER_ID,
+    id: "agent-1",
+    provider: "codex",
+    status: "idle",
+    createdAt: NOW,
+    updatedAt: NOW,
+    lastUserMessageAt: null,
+    lastActivityAt: NOW,
+    capabilities: {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    },
+    currentModeId: null,
+    availableModes: [],
+    pendingPermissions: [],
+    persistence: null,
+    title: "Agent under test",
+    cwd: "/repo",
+    model: null,
+    parentAgentId: null,
+    labels: {},
+    archivedAt: null,
+    ...overrides,
+    activeTurn: overrides.activeTurn ?? null,
+  };
+}
+
+function setAgents(agents: Agent[]): void {
+  useSessionStore
+    .getState()
+    .setAgents(SERVER_ID, new Map(agents.map((agent) => [agent.id, agent])));
+}
+
+describe("useLiveActivity", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    presenterMock.supported.mockReturnValue(true);
+    presenterMock.start.mockClear();
+    presenterMock.update.mockClear();
+    presenterMock.end.mockClear();
+    hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(true);
+    useSessionStore.getState().initializeSession(SERVER_ID, null as unknown as DaemonClient);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useSessionStore.getState().clearSession(SERVER_ID);
+    vi.useRealTimers();
+  });
+
+  it("does nothing when the presenter is unsupported", () => {
+    presenterMock.supported.mockReturnValue(false);
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+
+    expect(presenterMock.start).not.toHaveBeenCalled();
+  });
+
+  it("starts the activity immediately when the fleet goes active", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+    expect(presenterMock.start.mock.calls[0]?.[0]?.active).toBe(true);
+    expect(presenterMock.start.mock.calls[0]?.[0]?.hero?.agentId).toBe("agent-1");
+  });
+
+  it("debounces an update 1000ms after a material change, keeping the hero via hysteresis", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([
+        makeAgent({
+          id: "agent-1",
+          status: "running",
+          activeTurn: { turnId: "t1", startedAt: NOW },
+        }),
+      ]);
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setAgents([
+        makeAgent({
+          id: "agent-1",
+          status: "running",
+          activeTurn: { turnId: "t1", startedAt: NOW },
+        }),
+        makeAgent({
+          id: "agent-2",
+          status: "running",
+          activeTurn: { turnId: "t2", startedAt: NOW },
+        }),
+      ]);
+    });
+    expect(presenterMock.update).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(presenterMock.update).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(presenterMock.update).toHaveBeenCalledTimes(1);
+    expect(presenterMock.update.mock.calls[0]?.[0]?.hero?.agentId).toBe("agent-1");
+    expect(presenterMock.update.mock.calls[0]?.[0]?.runningCount).toBe(2);
+  });
+
+  it("does not schedule an update when nothing material changed", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(presenterMock.update).not.toHaveBeenCalled();
+  });
+
+  it("ends the activity with a receipt after a 120s grace period once the fleet goes inactive", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setAgents([makeAgent({ status: "idle" })]);
+    });
+    expect(presenterMock.end).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(119_999);
+    });
+    expect(presenterMock.end).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(presenterMock.end).toHaveBeenCalledTimes(1);
+    expect(presenterMock.end.mock.calls[0]?.[0]?.finishedTitle).toBe("Agent under test");
+    expect(presenterMock.end.mock.calls[0]?.[0]?.durationMs).toBeGreaterThanOrEqual(120_000);
+  });
+
+  it("cancels the grace timer when the fleet becomes active again before it fires", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+    act(() => {
+      setAgents([makeAgent({ status: "idle" })]);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(presenterMock.end).not.toHaveBeenCalled();
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("ends immediately on unmount, bypassing the grace period", () => {
+    const { unmount } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      unmount();
+    });
+
+    expect(presenterMock.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("ends immediately when the daemon disconnects", () => {
+    const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(false);
+      rerender();
+    });
+
+    expect(presenterMock.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply a debounced update after the activity has ended", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+    act(() => {
+      useSessionStore.getState().setAgentStreamState(SERVER_ID, "agent-1", {
+        taskSnapshot: [
+          { text: "Step", activeForm: "Running step", completed: false, status: "in_progress" },
+        ],
+      });
+    });
+
+    act(() => {
+      setAgents([makeAgent({ status: "idle" })]);
+    });
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(presenterMock.end).toHaveBeenCalledTimes(1);
+    expect(presenterMock.update).not.toHaveBeenCalled();
+  });
+
+  it("clears a pending debounced update when the fleet goes idle", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([
+        makeAgent({
+          id: "agent-1",
+          status: "running",
+          activeTurn: { turnId: "t1", startedAt: NOW },
+        }),
+      ]);
+    });
+    act(() => {
+      setAgents([
+        makeAgent({
+          id: "agent-1",
+          status: "running",
+          activeTurn: { turnId: "t1", startedAt: NOW },
+        }),
+        makeAgent({
+          id: "agent-2",
+          status: "running",
+          activeTurn: { turnId: "t2", startedAt: NOW },
+        }),
+      ]);
+    });
+
+    act(() => {
+      setAgents([makeAgent({ status: "idle" })]);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(presenterMock.update).not.toHaveBeenCalled();
+  });
+
+  it("delivers a pending material update after the fleet resumes within the grace period", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([
+        makeAgent({
+          id: "agent-1",
+          status: "running",
+          activeTurn: { turnId: "t1", startedAt: NOW },
+        }),
+      ]);
+    });
+    act(() => {
+      setAgents([
+        makeAgent({
+          id: "agent-1",
+          status: "running",
+          activeTurn: { turnId: "t1", startedAt: NOW },
+        }),
+        makeAgent({
+          id: "agent-2",
+          status: "running",
+          activeTurn: { turnId: "t2", startedAt: NOW },
+        }),
+      ]);
+    });
+
+    act(() => {
+      setAgents([makeAgent({ status: "idle" })]);
+    });
+
+    act(() => {
+      setAgents([
+        makeAgent({
+          id: "agent-1",
+          status: "running",
+          activeTurn: { turnId: "t1", startedAt: NOW },
+        }),
+        makeAgent({
+          id: "agent-2",
+          status: "running",
+          activeTurn: { turnId: "t2", startedAt: NOW },
+        }),
+      ]);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(presenterMock.update).toHaveBeenCalledTimes(1);
+    expect(presenterMock.update.mock.calls[0]?.[0]?.runningCount).toBe(2);
+  });
+
+  it("starts again and resets hysteresis after reconnecting to an active fleet", () => {
+    const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([
+        makeAgent({
+          id: "agent-hero",
+          status: "running",
+          activeTurn: { turnId: "t1", startedAt: NOW },
+        }),
+        makeAgent({
+          id: "agent-fresher",
+          status: "running",
+          activeTurn: { turnId: "t2", startedAt: new Date(NOW.getTime() - 60_000) },
+        }),
+      ]);
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+    expect(presenterMock.start.mock.calls[0]?.[0]?.hero?.agentId).toBe("agent-fresher");
+
+    act(() => {
+      hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(false);
+      rerender();
+    });
+    expect(presenterMock.end).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(true);
+      rerender();
+    });
+
+    expect(presenterMock.start).toHaveBeenCalledTimes(2);
+    expect(presenterMock.start.mock.calls[1]?.[0]?.hero?.agentId).toBe("agent-fresher");
+  });
+
+  it("suppresses a pending debounced update when the daemon disconnects", () => {
+    const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+    act(() => {
+      setAgents([
+        makeAgent({
+          id: "agent-1",
+          status: "running",
+          activeTurn: { turnId: "t1", startedAt: NOW },
+        }),
+        makeAgent({
+          id: "agent-2",
+          status: "running",
+          activeTurn: { turnId: "t2", startedAt: NOW },
+        }),
+      ]);
+    });
+
+    act(() => {
+      hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(false);
+      rerender();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(presenterMock.end).toHaveBeenCalledTimes(1);
+    expect(presenterMock.update).not.toHaveBeenCalled();
+  });
+
+  it("does not let an in-flight update land after end", async () => {
+    let resolveUpdate: (() => void) | undefined;
+    presenterMock.update.mockImplementation((_snapshot: FleetSnapshot) => {
+      return new Promise<void>((resolve) => {
+        resolveUpdate = resolve;
+      });
+    });
+
+    const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+    act(() => {
+      useSessionStore.getState().setAgentStreamState(SERVER_ID, "agent-1", {
+        taskSnapshot: [
+          { text: "Step", activeForm: "Running step", completed: false, status: "in_progress" },
+        ],
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(presenterMock.update).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(false);
+      rerender();
+    });
+    expect(presenterMock.end).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveUpdate?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(presenterMock.update).toHaveBeenCalledTimes(1);
+    expect(presenterMock.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start an activity for finished-attention-only agents", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([
+        makeAgent({
+          status: "idle",
+          requiresAttention: true,
+          attentionReason: "finished",
+          attentionTimestamp: NOW,
+        }),
+      ]);
+    });
+
+    expect(presenterMock.start).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/live-activity/use-live-activity.test.ts
+++ b/packages/app/src/live-activity/use-live-activity.test.ts
@@ -106,10 +106,10 @@ describe("useLiveActivity", () => {
     expect(presenterMock.start.mock.calls[0]?.[0]?.hero?.agentId).toBe("agent-1");
   });
 
-  it("debounces an update 1000ms after a material change, keeping the hero via hysteresis", () => {
+  it("debounces an update 1000ms after a material change, keeping the hero via hysteresis", async () => {
     renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([
         makeAgent({
           id: "agent-1",
@@ -164,10 +164,10 @@ describe("useLiveActivity", () => {
     expect(presenterMock.update).not.toHaveBeenCalled();
   });
 
-  it("ends the activity with a receipt after a 120s grace period once the fleet goes inactive", () => {
+  it("ends the activity with a receipt after a 120s grace period once the fleet goes inactive", async () => {
     renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
     });
     expect(presenterMock.start).toHaveBeenCalledTimes(1);
@@ -192,10 +192,10 @@ describe("useLiveActivity", () => {
     expect(presenterMock.end.mock.calls[0]?.[0]?.agentId).toBe("agent-1");
   });
 
-  it("debounces an update when the pending permission's requestId changes while the hero stays needs_you", () => {
+  it("debounces an update when the pending permission's requestId changes while the hero stays needs_you", async () => {
     renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([
         makeAgent({
           status: "idle",
@@ -250,10 +250,10 @@ describe("useLiveActivity", () => {
     expect(presenterMock.start).toHaveBeenCalledTimes(1);
   });
 
-  it("ends immediately on unmount, bypassing the grace period", () => {
+  it("ends immediately on unmount, bypassing the grace period", async () => {
     const { unmount } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
     });
     expect(presenterMock.start).toHaveBeenCalledTimes(1);
@@ -265,10 +265,10 @@ describe("useLiveActivity", () => {
     expect(presenterMock.end).toHaveBeenCalledTimes(1);
   });
 
-  it("ends immediately when the daemon disconnects", () => {
+  it("ends immediately when the daemon disconnects", async () => {
     const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
     });
     expect(presenterMock.start).toHaveBeenCalledTimes(1);
@@ -281,10 +281,10 @@ describe("useLiveActivity", () => {
     expect(presenterMock.end).toHaveBeenCalledTimes(1);
   });
 
-  it("does not apply a debounced update after the activity has ended", () => {
+  it("does not apply a debounced update after the activity has ended", async () => {
     renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
     });
     act(() => {
@@ -344,10 +344,10 @@ describe("useLiveActivity", () => {
     expect(presenterMock.update).not.toHaveBeenCalled();
   });
 
-  it("delivers a pending material update after the fleet resumes within the grace period", () => {
+  it("delivers a pending material update after the fleet resumes within the grace period", async () => {
     renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([
         makeAgent({
           id: "agent-1",
@@ -398,10 +398,10 @@ describe("useLiveActivity", () => {
     expect(presenterMock.update.mock.calls[0]?.[0]?.runningCount).toBe(2);
   });
 
-  it("starts again and resets hysteresis after reconnecting to an active fleet", () => {
+  it("starts again and resets hysteresis after reconnecting to an active fleet", async () => {
     const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([
         makeAgent({
           id: "agent-hero",
@@ -418,13 +418,13 @@ describe("useLiveActivity", () => {
     expect(presenterMock.start).toHaveBeenCalledTimes(1);
     expect(presenterMock.start.mock.calls[0]?.[0]?.hero?.agentId).toBe("agent-fresher");
 
-    act(() => {
+    await act(async () => {
       hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(false);
       rerender();
     });
     expect(presenterMock.end).toHaveBeenCalledTimes(1);
 
-    act(() => {
+    await act(async () => {
       hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(true);
       rerender();
     });
@@ -433,10 +433,10 @@ describe("useLiveActivity", () => {
     expect(presenterMock.start.mock.calls[1]?.[0]?.hero?.agentId).toBe("agent-fresher");
   });
 
-  it("suppresses a pending debounced update when the daemon disconnects", () => {
+  it("suppresses a pending debounced update when the daemon disconnects", async () => {
     const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
     });
     act(() => {
@@ -477,7 +477,7 @@ describe("useLiveActivity", () => {
 
     const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
 
-    act(() => {
+    await act(async () => {
       setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
     });
     act(() => {
@@ -507,6 +507,70 @@ describe("useLiveActivity", () => {
 
     expect(presenterMock.update).toHaveBeenCalledTimes(1);
     expect(presenterMock.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for an unresolved start before ending the activity", async () => {
+    let resolveStart: (() => void) | undefined;
+    presenterMock.start.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+    const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(false);
+      rerender();
+    });
+    expect(presenterMock.end).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveStart?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(presenterMock.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for an unresolved end before starting a replacement activity", async () => {
+    let resolveEnd: (() => void) | undefined;
+    presenterMock.end.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveEnd = resolve;
+        }),
+    );
+    const { rerender } = renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    await act(async () => {
+      setAgents([makeAgent({ status: "running", activeTurn: { turnId: "t1", startedAt: NOW } })]);
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(false);
+      rerender();
+    });
+    expect(presenterMock.end).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      hostRuntimeMock.useHostRuntimeIsConnected.mockReturnValue(true);
+      rerender();
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveEnd?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(2);
   });
 
   it("does not start an activity for finished-attention-only agents", () => {

--- a/packages/app/src/live-activity/use-live-activity.test.ts
+++ b/packages/app/src/live-activity/use-live-activity.test.ts
@@ -188,6 +188,40 @@ describe("useLiveActivity", () => {
     expect(presenterMock.end).toHaveBeenCalledTimes(1);
     expect(presenterMock.end.mock.calls[0]?.[0]?.finishedTitle).toBe("Agent under test");
     expect(presenterMock.end.mock.calls[0]?.[0]?.durationMs).toBeGreaterThanOrEqual(120_000);
+    expect(presenterMock.end.mock.calls[0]?.[0]?.serverId).toBe(SERVER_ID);
+    expect(presenterMock.end.mock.calls[0]?.[0]?.agentId).toBe("agent-1");
+  });
+
+  it("debounces an update when the pending permission's requestId changes while the hero stays needs_you", () => {
+    renderHook(() => useLiveActivity({ serverId: SERVER_ID }));
+
+    act(() => {
+      setAgents([
+        makeAgent({
+          status: "idle",
+          pendingPermissions: [{ id: "perm-1", provider: "codex", name: "bash", kind: "tool" }],
+        }),
+      ]);
+    });
+    expect(presenterMock.start).toHaveBeenCalledTimes(1);
+    expect(presenterMock.start.mock.calls[0]?.[0]?.hero?.permissionRequestId).toBe("perm-1");
+
+    act(() => {
+      setAgents([
+        makeAgent({
+          status: "idle",
+          pendingPermissions: [{ id: "perm-2", provider: "codex", name: "bash", kind: "tool" }],
+        }),
+      ]);
+    });
+    expect(presenterMock.update).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(presenterMock.update).toHaveBeenCalledTimes(1);
+    expect(presenterMock.update.mock.calls[0]?.[0]?.hero?.permissionRequestId).toBe("perm-2");
   });
 
   it("cancels the grace timer when the fleet becomes active again before it fires", () => {

--- a/packages/app/src/live-activity/use-live-activity.ts
+++ b/packages/app/src/live-activity/use-live-activity.ts
@@ -1,0 +1,11 @@
+/**
+ * Per-daemon-connection Live Activity mount point. Non-iOS builds resolve to this no-op stub so
+ * `SessionProvider` can call `useLiveActivity` without subscribing to session store state.
+ * iOS resolves `use-live-activity.ios.ts`, which delegates to the controller implementation.
+ */
+
+import type { UseLiveActivityOptions } from "./use-live-activity-controller";
+
+export type { UseLiveActivityOptions };
+
+export function useLiveActivity(_options: UseLiveActivityOptions): void {}

--- a/packages/app/targets/paseo-live-activity/Info.plist
+++ b/packages/app/targets/paseo-live-activity/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/packages/app/targets/paseo-live-activity/PaseoFleetAttributes.swift
+++ b/packages/app/targets/paseo-live-activity/PaseoFleetAttributes.swift
@@ -44,6 +44,18 @@ public struct PaseoFleetAttributes: ActivityAttributes {
     public var permissionDetail: String?
     public var needsYouCount: Int
     public var runningCount: Int
+    /// Whole-surface tap destination: the exact hero agent, plus the pending
+    /// request when there is one. Empty or unparseable means the surface has no
+    /// destination, and the widget renders no tap target rather than guessing.
+    public var heroDeepLink: String
+    /// Label/URL pairs for the expanded Dynamic Island controls. Flat fields
+    /// because the Expo bridge carries no nested records. A pair is only
+    /// rendered when both halves are present and the URL is a valid `paseo://`
+    /// link.
+    public var primaryActionLabel: String?
+    public var primaryActionDeepLink: String?
+    public var secondaryActionLabel: String?
+    public var secondaryActionDeepLink: String?
 
     public init(
       heroTitle: String,
@@ -55,7 +67,12 @@ public struct PaseoFleetAttributes: ActivityAttributes {
       permissionToolName: String? = nil,
       permissionDetail: String? = nil,
       needsYouCount: Int,
-      runningCount: Int
+      runningCount: Int,
+      heroDeepLink: String,
+      primaryActionLabel: String? = nil,
+      primaryActionDeepLink: String? = nil,
+      secondaryActionLabel: String? = nil,
+      secondaryActionDeepLink: String? = nil
     ) {
       self.heroTitle = heroTitle
       self.heroState = heroState
@@ -67,6 +84,11 @@ public struct PaseoFleetAttributes: ActivityAttributes {
       self.permissionDetail = permissionDetail
       self.needsYouCount = needsYouCount
       self.runningCount = runningCount
+      self.heroDeepLink = heroDeepLink
+      self.primaryActionLabel = primaryActionLabel
+      self.primaryActionDeepLink = primaryActionDeepLink
+      self.secondaryActionLabel = secondaryActionLabel
+      self.secondaryActionDeepLink = secondaryActionDeepLink
     }
 
     /// `sinceMs` as a `Date`, for timer ranges.

--- a/packages/app/targets/paseo-live-activity/PaseoFleetAttributes.swift
+++ b/packages/app/targets/paseo-live-activity/PaseoFleetAttributes.swift
@@ -1,0 +1,79 @@
+// The ActivityKit contract shared by the app and the widget extension.
+//
+// This file is the single source of truth for the Live Activity payload. It is
+// compiled into two Swift modules:
+//
+//   1. the `PaseoLiveActivity` pod (the local Expo module), via a symlink at
+//      `modules/paseo-live-activity/ios/PaseoFleetAttributes.swift`;
+//   2. this widget extension, because @bacons/apple-targets makes every file in
+//      the target directory a member of the extension target.
+//
+// ActivityKit matches an `Activity<Attributes>` to its `ActivityConfiguration`
+// by the unqualified attributes type name, so the two module copies pair up.
+//
+// Keep `ContentState` field-for-field identical to `LiveActivityContentState` in
+// `modules/paseo-live-activity/types.ts`. Codable uses the property names
+// verbatim, so renaming a field here silently breaks the JS bridge.
+//
+// Do not import ExpoModulesCore, WidgetKit, or SwiftUI here: the pod links none
+// of them.
+
+import ActivityKit
+import Foundation
+
+/// Hero state reported by the JS controller. Raw values are the wire strings.
+public enum PaseoFleetHeroState: String, Codable, Hashable, CaseIterable, Sendable {
+  case running
+  case needsYou = "needs_you"
+  case error
+  case finished
+}
+
+@available(iOS 16.2, *)
+public struct PaseoFleetAttributes: ActivityAttributes {
+  public struct ContentState: Codable, Hashable, Sendable {
+    public var heroTitle: String
+    public var heroState: PaseoFleetHeroState
+    /// Epoch milliseconds. Drives `Text(timerInterval:)` on the widget side, so
+    /// the timer keeps ticking without an update from the app.
+    public var sinceMs: Double
+    public var phase: String?
+    public var todoDone: Int?
+    public var todoTotal: Int?
+    public var permissionToolName: String?
+    public var permissionDetail: String?
+    public var needsYouCount: Int
+    public var runningCount: Int
+
+    public init(
+      heroTitle: String,
+      heroState: PaseoFleetHeroState,
+      sinceMs: Double,
+      phase: String? = nil,
+      todoDone: Int? = nil,
+      todoTotal: Int? = nil,
+      permissionToolName: String? = nil,
+      permissionDetail: String? = nil,
+      needsYouCount: Int,
+      runningCount: Int
+    ) {
+      self.heroTitle = heroTitle
+      self.heroState = heroState
+      self.sinceMs = sinceMs
+      self.phase = phase
+      self.todoDone = todoDone
+      self.todoTotal = todoTotal
+      self.permissionToolName = permissionToolName
+      self.permissionDetail = permissionDetail
+      self.needsYouCount = needsYouCount
+      self.runningCount = runningCount
+    }
+
+    /// `sinceMs` as a `Date`, for timer ranges.
+    public var since: Date {
+      Date(timeIntervalSince1970: sinceMs / 1000)
+    }
+  }
+
+  public init() {}
+}

--- a/packages/app/targets/paseo-live-activity/PaseoFleetAttributes.swift
+++ b/packages/app/targets/paseo-live-activity/PaseoFleetAttributes.swift
@@ -41,7 +41,6 @@ public struct PaseoFleetAttributes: ActivityAttributes {
     public var todoDone: Int?
     public var todoTotal: Int?
     public var permissionToolName: String?
-    public var permissionDetail: String?
     public var needsYouCount: Int
     public var runningCount: Int
     /// Whole-surface tap destination: the exact hero agent, plus the pending
@@ -65,7 +64,6 @@ public struct PaseoFleetAttributes: ActivityAttributes {
       todoDone: Int? = nil,
       todoTotal: Int? = nil,
       permissionToolName: String? = nil,
-      permissionDetail: String? = nil,
       needsYouCount: Int,
       runningCount: Int,
       heroDeepLink: String,
@@ -81,7 +79,6 @@ public struct PaseoFleetAttributes: ActivityAttributes {
       self.todoDone = todoDone
       self.todoTotal = todoTotal
       self.permissionToolName = permissionToolName
-      self.permissionDetail = permissionDetail
       self.needsYouCount = needsYouCount
       self.runningCount = runningCount
       self.heroDeepLink = heroDeepLink
@@ -97,5 +94,12 @@ public struct PaseoFleetAttributes: ActivityAttributes {
     }
   }
 
-  public init() {}
+  /// Daemon that owns this activity. Static for the activity's lifetime, which
+  /// is what lets the app find its own activity again after a relaunch and keep
+  /// one activity per connected daemon instead of one per device.
+  public var serverId: String
+
+  public init(serverId: String) {
+    self.serverId = serverId
+  }
 }

--- a/packages/app/targets/paseo-live-activity/PaseoFleetLiveActivity.swift
+++ b/packages/app/targets/paseo-live-activity/PaseoFleetLiveActivity.swift
@@ -14,8 +14,34 @@ private enum PaseoColor {
   static let error = Color(red: 255 / 255, green: 69 / 255, blue: 58 / 255)
 }
 
-/// Tapping anywhere in the activity opens the app. Per-agent routing is v2.
-private let paseoDeepLink = URL(string: "paseo://")
+/// The app's registered URL scheme. Anything else in a content-state link is a
+/// bug upstream, and honoring it would send the tap to Safari or another app.
+private let paseoURLScheme = "paseo"
+
+/// Parses a content-state link, rejecting empty strings, unparseable URLs, and
+/// foreign schemes. Callers omit the control instead of substituting a target.
+private func paseoLink(_ raw: String?) -> URL? {
+  guard let raw, !raw.isEmpty, let url = URL(string: raw) else { return nil }
+  guard url.scheme?.lowercased() == paseoURLScheme else { return nil }
+  return url
+}
+
+/// A label plus a destination that is known to be openable. Failing the
+/// initializer is how an incomplete or invalid action disappears.
+private struct PaseoFleetAction {
+  let label: String
+  let url: URL
+
+  init?(label: String?, deepLink: String?) {
+    guard
+      let trimmed = label?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !trimmed.isEmpty,
+      let url = paseoLink(deepLink)
+    else { return nil }
+    self.label = trimmed
+    self.url = url
+  }
+}
 
 extension PaseoFleetHeroState {
   fileprivate var tint: Color {
@@ -81,6 +107,24 @@ extension PaseoFleetAttributes.ContentState {
   /// The strip is noise when there is only one agent to talk about.
   fileprivate var showsFleetStrip: Bool {
     needsYouCount + runningCount > 1
+  }
+
+  /// Destination for the whole-surface tap on the Lock Screen, compact, and
+  /// minimal presentations.
+  fileprivate var heroURL: URL? {
+    paseoLink(heroDeepLink)
+  }
+
+  fileprivate var primaryAction: PaseoFleetAction? {
+    PaseoFleetAction(label: primaryActionLabel, deepLink: primaryActionDeepLink)
+  }
+
+  fileprivate var secondaryAction: PaseoFleetAction? {
+    PaseoFleetAction(label: secondaryActionLabel, deepLink: secondaryActionDeepLink)
+  }
+
+  fileprivate var hasActions: Bool {
+    primaryAction != nil || secondaryAction != nil
   }
 }
 
@@ -154,6 +198,59 @@ private struct FleetStrip: View {
   }
 }
 
+/// Capsule shell for an expanded-Dynamic-Island action.
+///
+/// The expanded presentation is always drawn on the black island, so the
+/// contrast pair is fixed: black text on the state tint for the primary, white
+/// text on a translucent white fill for the secondary.
+private struct ActionCapsule: View {
+  let label: String
+  let fill: Color
+  let foreground: Color
+
+  var body: some View {
+    Text(label)
+      .font(.caption2.weight(.semibold))
+      .lineLimit(1)
+      .minimumScaleFactor(0.85)
+      .foregroundStyle(foreground)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 5)
+      .background(fill, in: Capsule())
+  }
+}
+
+/// Up to two real `Link`s. Apple allows `Link` in the expanded presentation
+/// only, which is why nothing here is reused by the Lock Screen or the compact
+/// presentations: those get a whole-surface `widgetURL` instead.
+@available(iOS 16.2, *)
+private struct ActionRow: View {
+  let state: PaseoFleetAttributes.ContentState
+
+  var body: some View {
+    HStack(spacing: 8) {
+      if let primary = state.primaryAction {
+        Link(destination: primary.url) {
+          ActionCapsule(
+            label: primary.label,
+            fill: state.heroState.tint,
+            foreground: .black
+          )
+        }
+      }
+      if let secondary = state.secondaryAction {
+        Link(destination: secondary.url) {
+          ActionCapsule(
+            label: secondary.label,
+            fill: Color.white.opacity(0.18),
+            foreground: .white
+          )
+        }
+      }
+    }
+  }
+}
+
 @available(iOS 16.2, *)
 private struct LockScreenBanner: View {
   let state: PaseoFleetAttributes.ContentState
@@ -221,7 +318,7 @@ struct PaseoFleetLiveActivity: Widget {
       LockScreenBanner(state: context.state)
         .activityBackgroundTint(Color.black.opacity(0.4))
         .activitySystemActionForegroundColor(.white)
-        .widgetURL(paseoDeepLink)
+        .widgetURL(context.state.heroURL)
     } dynamicIsland: { context in
       let state = context.state
 
@@ -270,6 +367,10 @@ struct PaseoFleetLiveActivity: Widget {
             if let progress = state.todoProgress {
               TodoBar(state: state, progress: progress)
             }
+            if state.hasActions {
+              ActionRow(state: state)
+                .padding(.top, 2)
+            }
           }
           .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -294,7 +395,7 @@ struct PaseoFleetLiveActivity: Widget {
           .fill(state.heroState.tint)
           .frame(width: 8, height: 8)
       }
-      .widgetURL(paseoDeepLink)
+      .widgetURL(state.heroURL)
       .keylineTint(state.heroState.tint)
     }
   }

--- a/packages/app/targets/paseo-live-activity/PaseoFleetLiveActivity.swift
+++ b/packages/app/targets/paseo-live-activity/PaseoFleetLiveActivity.swift
@@ -92,13 +92,6 @@ extension PaseoFleetAttributes.ContentState {
     return "Approve: \(tool)"
   }
 
-  fileprivate var monospacedDetail: String? {
-    guard heroState == .needsYou, let detail = permissionDetail, !detail.isEmpty else {
-      return nil
-    }
-    return detail
-  }
-
   fileprivate var phaseLine: String? {
     guard let phase, !phase.isEmpty else { return nil }
     return phase
@@ -282,12 +275,6 @@ private struct LockScreenBanner: View {
           .font(.caption.weight(.semibold))
           .foregroundStyle(PaseoColor.needsYou)
           .lineLimit(1)
-        if let detail = state.monospacedDetail {
-          Text(detail)
-            .font(.caption2.monospaced())
-            .foregroundStyle(.secondary)
-            .lineLimit(2)
-        }
       }
 
       if let phase = state.phaseLine {
@@ -350,12 +337,6 @@ struct PaseoFleetLiveActivity: Widget {
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(PaseoColor.needsYou)
                 .lineLimit(1)
-              if let detail = state.monospacedDetail {
-                Text(detail)
-                  .font(.caption2.monospaced())
-                  .foregroundStyle(.secondary)
-                  .lineLimit(1)
-              }
             }
 
             if let phase = state.phaseLine {

--- a/packages/app/targets/paseo-live-activity/PaseoFleetLiveActivity.swift
+++ b/packages/app/targets/paseo-live-activity/PaseoFleetLiveActivity.swift
@@ -1,0 +1,301 @@
+import ActivityKit
+import Foundation
+import SwiftUI
+import WidgetKit
+
+/// Fleet-mode colors from the design contract. Kept as literals rather than
+/// asset colors so the extension has no asset-catalog dependency.
+private enum PaseoColor {
+  /// #30d158
+  static let running = Color(red: 48 / 255, green: 209 / 255, blue: 88 / 255)
+  /// #ff9f0a
+  static let needsYou = Color(red: 255 / 255, green: 159 / 255, blue: 10 / 255)
+  /// #ff453a
+  static let error = Color(red: 255 / 255, green: 69 / 255, blue: 58 / 255)
+}
+
+/// Tapping anywhere in the activity opens the app. Per-agent routing is v2.
+private let paseoDeepLink = URL(string: "paseo://")
+
+extension PaseoFleetHeroState {
+  fileprivate var tint: Color {
+    switch self {
+    case .running, .finished: return PaseoColor.running
+    case .needsYou: return PaseoColor.needsYou
+    case .error: return PaseoColor.error
+    }
+  }
+
+  fileprivate var word: String {
+    switch self {
+    case .running: return "Running"
+    case .needsYou: return "Needs you"
+    case .error: return "Error"
+    case .finished: return "Finished"
+    }
+  }
+
+  fileprivate var glyph: String {
+    switch self {
+    case .running: return "bolt.fill"
+    case .needsYou: return "exclamationmark.triangle.fill"
+    case .error: return "exclamationmark.octagon.fill"
+    case .finished: return "checkmark.circle.fill"
+    }
+  }
+
+  /// A finished activity has nothing left to time.
+  fileprivate var showsTimer: Bool {
+    self != .finished
+  }
+}
+
+@available(iOS 16.2, *)
+extension PaseoFleetAttributes.ContentState {
+  /// `(done, total)` only when the hero actually reported a todo list.
+  fileprivate var todoProgress: (done: Int, total: Int)? {
+    guard let total = todoTotal, total > 0 else { return nil }
+    return (min(max(todoDone ?? 0, 0), total), total)
+  }
+
+  /// "Approve: <tool>" headline, only for a pending permission request.
+  fileprivate var approvalHeadline: String? {
+    guard heroState == .needsYou, let tool = permissionToolName, !tool.isEmpty else {
+      return nil
+    }
+    return "Approve: \(tool)"
+  }
+
+  fileprivate var monospacedDetail: String? {
+    guard heroState == .needsYou, let detail = permissionDetail, !detail.isEmpty else {
+      return nil
+    }
+    return detail
+  }
+
+  fileprivate var phaseLine: String? {
+    guard let phase, !phase.isEmpty else { return nil }
+    return phase
+  }
+
+  /// The strip is noise when there is only one agent to talk about.
+  fileprivate var showsFleetStrip: Bool {
+    needsYouCount + runningCount > 1
+  }
+}
+
+/// Elapsed-time text that ticks on the widget's own clock.
+private struct ElapsedTimer: View {
+  let since: Date
+
+  var body: some View {
+    // 12h covers the longest an activity can stay alive; past the range the
+    // system freezes the label instead of rolling over.
+    Text(timerInterval: since...since.addingTimeInterval(43_200), countsDown: false)
+      .monospacedDigit()
+  }
+}
+
+private struct StateDot: View {
+  let state: PaseoFleetHeroState
+
+  var body: some View {
+    if state == .finished {
+      Image(systemName: "checkmark.circle.fill")
+        .font(.system(size: 11, weight: .bold))
+        .foregroundStyle(PaseoColor.running)
+    } else {
+      Circle()
+        .fill(state.tint)
+        .frame(width: 8, height: 8)
+    }
+  }
+}
+
+@available(iOS 16.2, *)
+private struct TodoBar: View {
+  let state: PaseoFleetAttributes.ContentState
+  let progress: (done: Int, total: Int)
+
+  var body: some View {
+    HStack(spacing: 6) {
+      ProgressView(value: Double(progress.done), total: Double(progress.total))
+        .progressViewStyle(.linear)
+        .tint(state.heroState.tint)
+      Text("\(progress.done)/\(progress.total)")
+        .font(.caption2.monospacedDigit())
+        .foregroundStyle(.secondary)
+    }
+  }
+}
+
+@available(iOS 16.2, *)
+private struct FleetStrip: View {
+  let state: PaseoFleetAttributes.ContentState
+
+  var body: some View {
+    HStack(spacing: 6) {
+      if state.needsYouCount > 0 {
+        Label("\(state.needsYouCount) need you", systemImage: "exclamationmark.triangle.fill")
+          .foregroundStyle(PaseoColor.needsYou)
+      }
+      if state.needsYouCount > 0 && state.runningCount > 0 {
+        Text("·").foregroundStyle(.secondary)
+      }
+      if state.runningCount > 0 {
+        Label("\(state.runningCount) running", systemImage: "circle.fill")
+          .foregroundStyle(PaseoColor.running)
+      }
+    }
+    .font(.caption2)
+    .labelStyle(.titleAndIcon)
+    .imageScale(.small)
+    .lineLimit(1)
+  }
+}
+
+@available(iOS 16.2, *)
+private struct LockScreenBanner: View {
+  let state: PaseoFleetAttributes.ContentState
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 6) {
+        StateDot(state: state.heroState)
+        Text("Paseo")
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(.secondary)
+        Text(state.heroState.word)
+          .font(.caption2)
+          .foregroundStyle(state.heroState.tint)
+        Spacer(minLength: 8)
+        if state.heroState.showsTimer {
+          ElapsedTimer(since: state.since)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+
+      Text(state.heroTitle)
+        .font(.headline)
+        .lineLimit(1)
+
+      if let approval = state.approvalHeadline {
+        Text(approval)
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(PaseoColor.needsYou)
+          .lineLimit(1)
+        if let detail = state.monospacedDetail {
+          Text(detail)
+            .font(.caption2.monospaced())
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+        }
+      }
+
+      if let phase = state.phaseLine {
+        Text(phase)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+
+      if let progress = state.todoProgress {
+        TodoBar(state: state, progress: progress)
+      }
+
+      if state.showsFleetStrip {
+        FleetStrip(state: state)
+      }
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+@available(iOS 16.2, *)
+struct PaseoFleetLiveActivity: Widget {
+  var body: some WidgetConfiguration {
+    ActivityConfiguration(for: PaseoFleetAttributes.self) { context in
+      LockScreenBanner(state: context.state)
+        .activityBackgroundTint(Color.black.opacity(0.4))
+        .activitySystemActionForegroundColor(.white)
+        .widgetURL(paseoDeepLink)
+    } dynamicIsland: { context in
+      let state = context.state
+
+      return DynamicIsland {
+        DynamicIslandExpandedRegion(.leading) {
+          HStack(spacing: 6) {
+            StateDot(state: state.heroState)
+            Text("Paseo")
+              .font(.caption2.weight(.semibold))
+              .foregroundStyle(.secondary)
+          }
+        }
+        DynamicIslandExpandedRegion(.trailing) {
+          if state.heroState.showsTimer {
+            ElapsedTimer(since: state.since)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+        DynamicIslandExpandedRegion(.center) {
+          Text(state.heroTitle)
+            .font(.caption.weight(.semibold))
+            .lineLimit(1)
+        }
+        DynamicIslandExpandedRegion(.bottom) {
+          VStack(alignment: .leading, spacing: 4) {
+            if let approval = state.approvalHeadline {
+              Text(approval)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(PaseoColor.needsYou)
+                .lineLimit(1)
+              if let detail = state.monospacedDetail {
+                Text(detail)
+                  .font(.caption2.monospaced())
+                  .foregroundStyle(.secondary)
+                  .lineLimit(1)
+              }
+            }
+
+            if let phase = state.phaseLine {
+              Text(phase)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+            if let progress = state.todoProgress {
+              TodoBar(state: state, progress: progress)
+            }
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      } compactLeading: {
+        Image(systemName: state.heroState.glyph)
+          .foregroundStyle(state.heroState.tint)
+      } compactTrailing: {
+        if state.needsYouCount > 0 {
+          HStack(spacing: 2) {
+            Image(systemName: "exclamationmark.triangle.fill")
+            Text("\(state.needsYouCount)").monospacedDigit()
+          }
+          .font(.caption2)
+          .foregroundStyle(PaseoColor.needsYou)
+        } else if state.heroState.showsTimer {
+          ElapsedTimer(since: state.since)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+      } minimal: {
+        Circle()
+          .fill(state.heroState.tint)
+          .frame(width: 8, height: 8)
+      }
+      .widgetURL(paseoDeepLink)
+      .keylineTint(state.heroState.tint)
+    }
+  }
+}

--- a/packages/app/targets/paseo-live-activity/PaseoLiveActivityBundle.swift
+++ b/packages/app/targets/paseo-live-activity/PaseoLiveActivityBundle.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct PaseoLiveActivityBundle: WidgetBundle {
+  var body: some Widget {
+    // The extension ships no home-screen widget; the Live Activity is the only
+    // member. Deployment target is 16.2, so no availability fence is needed.
+    PaseoFleetLiveActivity()
+  }
+}

--- a/packages/app/targets/paseo-live-activity/expo-target.config.js
+++ b/packages/app/targets/paseo-live-activity/expo-target.config.js
@@ -1,0 +1,22 @@
+/**
+ * Widget extension that hosts the Paseo fleet-mode Live Activity.
+ *
+ * `ios/` is CNG output, so this directory is the repo-owned source for the
+ * extension: @bacons/apple-targets links every file here into the generated
+ * Xcode project on each `expo prebuild`.
+ *
+ * No `entitlements` block on purpose. Live Activities need no App Group, and
+ * declaring one would add a provisioning requirement for nothing.
+ *
+ * @type {import('@bacons/apple-targets/app.plugin').Config}
+ */
+module.exports = {
+  type: "widget",
+  name: "PaseoLiveActivity",
+  displayName: "Paseo Live Activity",
+  // Appended to the main app's bundle identifier, so it tracks the app variant.
+  bundleIdentifier: ".liveactivity",
+  // ActivityKit's `ActivityContent` / `ActivityUIDismissalPolicy` API is 16.2.
+  deploymentTarget: "16.2",
+  frameworks: ["ActivityKit", "WidgetKit", "SwiftUI"],
+};


### PR DESCRIPTION
## In a Nutshell
- Add one fleet-level iOS Live Activity per connected daemon
- Prioritize agents needing attention and show fleet counts
- Deep-link to the exact hero agent or pending permission
- Add expanded Dynamic Island actions without auto-submitting permissions
- Preserve Expo SDK 54 compatibility

## Description
Adds one Live Activity per connected Paseo daemon. The activity selects a stable highest-priority agent, summarizes running and attention counts, and updates the Lock Screen and Dynamic Island through a local ActivityKit Expo module.

Lock Screen, compact, and minimal presentations open the exact hero agent. Pending-permission links also focus the exact request and optional provider action in Paseo. Expanded Dynamic Island actions open Paseo for review; they never submit a permission response from ActivityKit.

The implementation stays on Expo SDK 54 by using a CNG-managed SwiftUI widget extension instead of the SDK 55-only expo-widgets package. Android remains a no-op behind the presenter seam; Android 16 Live Updates can be added independently.

## Screenshots

### Lock Screen states

![Paseo Live Activity on three iPhone Lock Screens: working, needs approval, and fleet view](https://github.com/user-attachments/assets/5f2c4a6c-bfa2-457f-bfdf-ef6e0eee757d)

### Needs approval

![Paseo needs-approval Live Activity on the iPhone Lock Screen](https://github.com/user-attachments/assets/3854d0b9-26fa-4f79-97e3-1ee345578e1e)

### Fleet view

![Paseo fleet Live Activity summarizing fifteen active agents](https://github.com/user-attachments/assets/942fb853-35ec-42d4-b1ef-4e6db3cdce52)

## Verification
- 78 focused Live Activity tests
- app typecheck
- full repository lint and format
- clean and incremental iOS prebuild
- npm clean install

## QA Notes
- Swift compilation and on-device Lock Screen / Dynamic Island interaction require macOS with Xcode and a physical supported iPhone.
- Extension signing needs the existing build environment's Apple team configuration.

## Must
- [x] Tests
- [x] Documentation not required: behavior is represented by code-level contracts and tests
