### PR TITLE
Start voice TTS playback sooner by synthesizing the opening clause first

### DIFF
--- a/packages/server/src/server/agent/tts-manager.test.ts
+++ b/packages/server/src/server/agent/tts-manager.test.ts
@@ -87,6 +87,73 @@ describe("TTSManager", () => {
     expect(calls.slice(1).some((text) => text.length > calls[0].length)).toBe(true);
   });
 
+  it("peels the opening clause off a long first sentence so speech starts sooner", async () => {
+    const calls: string[] = [];
+    const tts: TextToSpeechProvider = {
+      async synthesizeSpeech(text: string): Promise<{ stream: Readable; format: string }> {
+        calls.push(text);
+        return {
+          stream: Readable.from([Buffer.from("x")]),
+          format: "pcm;rate=24000",
+        };
+      },
+    };
+
+    const manager = new TTSManager("s1", pino({ level: "silent" }), tts);
+    const abort = new AbortController();
+    const firstSentence =
+      "I looked through the failing workflow logs on the release branch, and the typecheck step is the one breaking the build.";
+    const secondSentence = "The fix is already staged.";
+
+    await manager.generateAndWaitForPlayback(
+      `${firstSentence} ${secondSentence}`,
+      (msg) => {
+        if (msg.type === "audio_output") {
+          manager.confirmAudioPlayed(msg.payload.id);
+        }
+      },
+      abort.signal,
+      true,
+    );
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].length).toBeLessThanOrEqual(90);
+    expect(calls[0].endsWith(",")).toBe(true);
+    expect(`${calls[0]} ${calls[1]}`).toBe(firstSentence);
+    expect(calls[2]).toBe(secondSentence);
+  });
+
+  it("keeps a long first sentence whole when it has no clause boundary", async () => {
+    const calls: string[] = [];
+    const tts: TextToSpeechProvider = {
+      async synthesizeSpeech(text: string): Promise<{ stream: Readable; format: string }> {
+        calls.push(text);
+        return {
+          stream: Readable.from([Buffer.from("x")]),
+          format: "pcm;rate=24000",
+        };
+      },
+    };
+
+    const manager = new TTSManager("s1", pino({ level: "silent" }), tts);
+    const abort = new AbortController();
+    const sentence =
+      "The deploy finished cleanly and every smoke test on the release branch passed without a single retry.";
+
+    await manager.generateAndWaitForPlayback(
+      sentence,
+      (msg) => {
+        if (msg.type === "audio_output") {
+          manager.confirmAudioPlayed(msg.payload.id);
+        }
+      },
+      abort.signal,
+      true,
+    );
+
+    expect(calls).toEqual([sentence]);
+  });
+
   it("prefetches the next segment before current playback completes", async () => {
     const started: string[] = [];
     const gateResolvers = new Map<string, () => void>();

--- a/packages/server/src/server/agent/tts-manager.ts
+++ b/packages/server/src/server/agent/tts-manager.ts
@@ -28,6 +28,8 @@ type PreparedSegmentResult =
   | { kind: "error"; error: unknown };
 
 const MAX_TTS_SEGMENT_CHARS = 260;
+const FIRST_SEGMENT_TARGET_CHARS = 90;
+const FIRST_SEGMENT_MIN_LEAD_CHARS = 24;
 const TTS_PREFETCH_SEGMENTS = 2;
 const CLOSED_AUDIO_ID_TTL_MS = 10_000;
 
@@ -103,6 +105,38 @@ function splitOversizedFragment(fragment: string, maxChars: number): string[] {
   return parts;
 }
 
+/**
+ * Nothing plays until the first segment finishes synthesizing, and synthesis
+ * cost grows with length — a long opening sentence delays all speech. Peel off
+ * the opening clause at the last clause boundary inside the target window so
+ * the reply starts sooner; cutting anywhere else sounds broken, so a sentence
+ * without a usable boundary stays whole.
+ */
+function splitLeadClause(sentence: string): string[] {
+  if (sentence.length <= FIRST_SEGMENT_TARGET_CHARS) {
+    return [sentence];
+  }
+
+  let splitEnd = -1;
+  for (const match of sentence.matchAll(/[,;:]\s/g)) {
+    const end = match.index + 1;
+    if (end > FIRST_SEGMENT_TARGET_CHARS) {
+      break;
+    }
+    if (end >= FIRST_SEGMENT_MIN_LEAD_CHARS) {
+      splitEnd = end;
+    }
+  }
+
+  if (splitEnd === -1) {
+    return [sentence];
+  }
+
+  const lead = sentence.slice(0, splitEnd).trim();
+  const rest = sentence.slice(splitEnd).trim();
+  return rest ? [lead, rest] : [lead];
+}
+
 function splitTextForTts(text: string): TtsSegment[] {
   const normalized = text.trim().replace(/\s+/g, " ");
   if (!normalized) {
@@ -114,10 +148,13 @@ function splitTextForTts(text: string): TtsSegment[] {
   let segmentIndex = 0;
 
   for (const sentence of sentences) {
-    const fragments = splitOversizedFragment(sentence, MAX_TTS_SEGMENT_CHARS);
-    for (const fragment of fragments) {
-      parts.push({ index: segmentIndex, text: fragment });
-      segmentIndex += 1;
+    const clauses = segmentIndex === 0 ? splitLeadClause(sentence) : [sentence];
+    for (const clause of clauses) {
+      const fragments = splitOversizedFragment(clause, MAX_TTS_SEGMENT_CHARS);
+      for (const fragment of fragments) {
+        parts.push({ index: segmentIndex, text: fragment });
+        segmentIndex += 1;
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

In voice mode, nothing plays until the entire first TTS segment (the whole first sentence) is synthesized. When a reply opens with a long sentence — which agent replies usually do — all speech is delayed by that sentence's full synthesis time. Real daemon logs with the default local Kokoro model showed 5–11s of silence before the first audio:

```
"TTS segment 0 synthesized" synthMs:10161 chars:133
"TTS segment 0 synthesized" synthMs:7931  chars:177
"TTS segment 0 synthesized" synthMs:10953 chars:174
"TTS segment 0 synthesized" synthMs=9587  chars:115
```

## Change

`splitTextForTts` now peels the opening clause off a long first sentence: it splits at the **last clause boundary (`,` `;` `:`) inside a 90-char window** (minimum 24-char lead). Sentences with no usable boundary stay whole — it never cuts mid-phrase, so prosody is unaffected (the pause lands where the comma already was). Everything downstream (prefetch, playback confirmation) is unchanged.

## QA evidence

Measured with the shipped `SherpaOnnxTTS` (Kokoro en v0.19, Apple Silicon, CPU):

```
fp32 full-sentence-119ch synthMs=4131 audioSec=5.9
fp32 lead-clause-65ch    synthMs=2567 audioSec=3.4
```

First audio arrives ~1.6s sooner on this example (bigger on the 10s cases above), and the 3.4s lead plays while the remainder synthesizes behind it via the existing prefetch, so playback stays continuous.

Also measured and rejected as levers, for the record: raising ONNX intra-op threads (2 → 8: 4146ms vs 4174ms, no effect) and the upstream int8 Kokoro build (~15% faster only). The split is the effective fix.

Tests — 2 new, in `tts-manager.test.ts`:

```
npx vitest run src/server/agent/tts-manager.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

- peels the opening clause off a long first sentence so speech starts sooner
- keeps a long first sentence whole when it has no clause boundary

Mutation-checked: disabling the split (`const clauses = [sentence]`) turns the new coverage red (1 failed), restoring it goes green.

## Platforms

Server-only change (Node). Tested on a macOS daemon end-to-end over a live voice session from the iOS app. Not separately tested: Android app (no client change), Windows/Linux daemons (no platform-specific code involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
