### PR TITLE
Voice: record spoken replies in the chat and let the agent work while audio plays

### DIFF
--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -1162,7 +1162,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       {
         title: "Speak",
         description:
-          "Speak text to the user via daemon-managed voice output. Blocks until playback completes.",
+          "Speak text to the user via daemon-managed voice output. The text is also recorded in the chat, and the call returns once the utterance is queued — continue working while it plays.",
         inputSchema: {
           text: z
             .string()

--- a/packages/server/src/server/session/voice/voice-session.test.ts
+++ b/packages/server/src/server/session/voice/voice-session.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
 import pino from "pino";
 import { describe, expect, test, vi } from "vitest";
 
@@ -10,11 +11,13 @@ import type {
   StreamingTranscriptionCommittedEvent,
   StreamingTranscriptionEvent,
   StreamingTranscriptionSession,
+  TextToSpeechProvider,
 } from "../../speech/speech-provider.js";
 import type {
   TurnDetectionProvider,
   TurnDetectionSession,
 } from "../../speech/turn-detection-provider.js";
+import type { VoiceSpeakHandler } from "../../voice-types.js";
 
 const VOICE_AGENT_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -231,6 +234,173 @@ describe("VoiceSession streaming transcription", () => {
         }),
       }),
     );
+
+    await voiceSession.cleanup();
+  });
+});
+
+class FakeVoiceTts implements TextToSpeechProvider {
+  public readonly synthesized: string[] = [];
+  public failWith: Error | null = null;
+
+  async synthesizeSpeech(text: string): Promise<{ stream: Readable; format: string }> {
+    if (this.failWith) {
+      throw this.failWith;
+    }
+    this.synthesized.push(text);
+    return {
+      stream: Readable.from([Buffer.from(text)]),
+      format: "pcm;rate=24000",
+    };
+  }
+}
+
+function createSpeakingVoiceSession() {
+  const detector = new FakeVoiceTurnDetectionSession();
+  const sttSession = new FakeVoiceSttSession();
+  const stt: SpeechToTextProvider = {
+    id: "local",
+    createSession: vi.fn(() => sttSession),
+  };
+  const turnDetection: TurnDetectionProvider = {
+    id: "local",
+    createSession: vi.fn(() => detector),
+  };
+  const host = createFakeHost();
+  const tts = new FakeVoiceTts();
+  const speakHandlers = new Map<string, VoiceSpeakHandler>();
+  const voiceSession = new VoiceSession({
+    host,
+    logger: pino({ level: "silent" }),
+    sessionId: "voice-session-speak-test",
+    sttLanguage: "en",
+    tts,
+    stt,
+    voice: { turnDetection },
+    voiceBridge: {
+      registerVoiceSpeakHandler: (agentId, handler) => {
+        speakHandlers.set(agentId, handler);
+      },
+      unregisterVoiceSpeakHandler: (agentId) => {
+        speakHandlers.delete(agentId);
+      },
+    },
+  });
+  return { voiceSession, host, tts, speakHandlers };
+}
+
+function audioOutputs(host: { emitted: SessionOutboundMessage[] }) {
+  return host.emitted.filter(
+    (msg): msg is Extract<SessionOutboundMessage, { type: "audio_output" }> =>
+      msg.type === "audio_output",
+  );
+}
+
+function assistantEntries(host: { emitted: SessionOutboundMessage[] }) {
+  return host.emitted.filter(
+    (msg) => msg.type === "activity_log" && msg.payload.type === "assistant",
+  );
+}
+
+describe("VoiceSession speak handler", () => {
+  test("records the spoken text in the chat before audio and returns without awaiting playback", async () => {
+    const { voiceSession, host, speakHandlers } = createSpeakingVoiceSession();
+    await voiceSession.handleSetVoiceMode(true, VOICE_AGENT_ID);
+    const handler = speakHandlers.get(VOICE_AGENT_ID);
+    expect(handler).toBeDefined();
+
+    // Playback is never confirmed; a handler that awaited playback would hang here.
+    await handler!({ text: "Checking the config now.", callerAgentId: VOICE_AGENT_ID });
+
+    expect(assistantEntries(host)).toHaveLength(1);
+    expect(host.emitted).toContainEqual(
+      expect.objectContaining({
+        type: "activity_log",
+        payload: expect.objectContaining({
+          type: "assistant",
+          content: "Checking the config now.",
+        }),
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(audioOutputs(host).length).toBeGreaterThan(0);
+    });
+    const assistantIndex = host.emitted.findIndex(
+      (msg) => msg.type === "activity_log" && msg.payload.type === "assistant",
+    );
+    const audioIndex = host.emitted.findIndex((msg) => msg.type === "audio_output");
+    expect(assistantIndex).toBeLessThan(audioIndex);
+
+    await voiceSession.cleanup();
+  });
+
+  test("plays overlapping speak calls in order, starting the next only after playback confirms", async () => {
+    const { voiceSession, host, tts, speakHandlers } = createSpeakingVoiceSession();
+    await voiceSession.handleSetVoiceMode(true, VOICE_AGENT_ID);
+    const handler = speakHandlers.get(VOICE_AGENT_ID)!;
+
+    await handler({ text: "First update.", callerAgentId: VOICE_AGENT_ID });
+    await handler({ text: "Second update.", callerAgentId: VOICE_AGENT_ID });
+
+    await vi.waitFor(() => {
+      expect(tts.synthesized).toEqual(["First update."]);
+      expect(audioOutputs(host)).toHaveLength(1);
+    });
+    expect(assistantEntries(host)).toHaveLength(2);
+
+    voiceSession.handleAudioPlayed(audioOutputs(host)[0].payload.id);
+
+    await vi.waitFor(() => {
+      expect(tts.synthesized).toEqual(["First update.", "Second update."]);
+      expect(audioOutputs(host)).toHaveLength(2);
+    });
+
+    voiceSession.handleAudioPlayed(audioOutputs(host)[1].payload.id);
+    await voiceSession.cleanup();
+  });
+
+  test("drops queued speech after an abort but keeps the text record", async () => {
+    const { voiceSession, host, tts, speakHandlers } = createSpeakingVoiceSession();
+    await voiceSession.handleSetVoiceMode(true, VOICE_AGENT_ID);
+    const handler = speakHandlers.get(VOICE_AGENT_ID)!;
+
+    await handler({ text: "First update.", callerAgentId: VOICE_AGENT_ID });
+    await handler({ text: "Queued update.", callerAgentId: VOICE_AGENT_ID });
+    await vi.waitFor(() => {
+      expect(audioOutputs(host)).toHaveLength(1);
+    });
+
+    await voiceSession.handleAbort();
+    await settle();
+
+    expect(tts.synthesized).toEqual(["First update."]);
+    expect(audioOutputs(host)).toHaveLength(1);
+    expect(assistantEntries(host)).toHaveLength(2);
+
+    await voiceSession.cleanup();
+  });
+
+  test("surfaces synthesis failure as an error entry while keeping the text record", async () => {
+    const { voiceSession, host, tts, speakHandlers } = createSpeakingVoiceSession();
+    await voiceSession.handleSetVoiceMode(true, VOICE_AGENT_ID);
+    const handler = speakHandlers.get(VOICE_AGENT_ID)!;
+    tts.failWith = new Error("synthesis exploded");
+
+    await handler({ text: "Doomed reply.", callerAgentId: VOICE_AGENT_ID });
+
+    expect(assistantEntries(host)).toHaveLength(1);
+    await vi.waitFor(() => {
+      expect(host.emitted).toContainEqual(
+        expect.objectContaining({
+          type: "activity_log",
+          payload: expect.objectContaining({
+            type: "error",
+            content: expect.stringContaining("Voice playback failed: synthesis exploded"),
+          }),
+        }),
+      );
+    });
 
     await voiceSession.cleanup();
   });

--- a/packages/server/src/server/session/voice/voice-session.ts
+++ b/packages/server/src/server/session/voice/voice-session.ts
@@ -206,6 +206,7 @@ export class VoiceSession {
 
   private voiceModeAgentId: string | null = null;
   private voiceModeBaseConfig: VoiceModeBaseConfig | null = null;
+  private speechQueue: Promise<void> = Promise.resolve();
 
   constructor(options: VoiceSessionOptions) {
     const { host, logger, sessionId, sttLanguage, tts, stt, voice, voiceBridge, dictation } =
@@ -1029,7 +1030,7 @@ export class VoiceSession {
   }
 
   private registerVoiceBridgeForAgent(agentId: string): void {
-    this.registerVoiceSpeakHandler?.(agentId, async ({ text, signal }) => {
+    this.registerVoiceSpeakHandler?.(agentId, async ({ text }) => {
       this.sessionLogger.info(
         {
           agentId,
@@ -1038,17 +1039,10 @@ export class VoiceSession {
         },
         "Voice speak tool call received by session handler",
       );
-      const abortSignal = signal ?? this.abortController.signal;
-      await this.ttsManager.generateAndWaitForPlayback(
-        text,
-        (msg) => this.emit(msg),
-        abortSignal,
-        true,
-      );
-      this.sessionLogger.info(
-        { agentId, textLength: text.length },
-        "Voice speak tool call finished playback",
-      );
+
+      // The spoken text is the durable transcript record: emit it before any
+      // audio work so the chat carries the reply even when synthesis or
+      // playback fails, and the user can fall back to reading it.
       this.emit({
         type: "activity_log",
         payload: {
@@ -1058,6 +1052,27 @@ export class VoiceSession {
           content: text,
         },
       });
+
+      // Queue playback and return without awaiting it, so the agent keeps
+      // working while audio plays. The chain keeps overlapping speak calls in
+      // spoken order. Capture the abort signal at enqueue time: a barge-in
+      // aborts the current controller, which drains queued utterances, while
+      // speaks after the next user turn ride the fresh controller.
+      const abortSignal = this.abortController.signal;
+      this.speechQueue = this.speechQueue
+        .then(() => this.playSpeechUtterance(text, agentId, abortSignal))
+        .catch((error) => {
+          this.sessionLogger.error({ err: error, agentId }, "Voice speak playback failed");
+          this.emit({
+            type: "activity_log",
+            payload: {
+              id: uuidv4(),
+              timestamp: new Date(),
+              type: "error",
+              content: `Voice playback failed: ${getErrorMessage(error)}. The reply is shown as text above.`,
+            },
+          });
+        });
     });
 
     this.registerVoiceCallerContext?.(agentId, {
@@ -1065,6 +1080,23 @@ export class VoiceSession {
       allowCustomCwd: false,
       enableVoiceTools: true,
     });
+  }
+
+  private async playSpeechUtterance(
+    text: string,
+    agentId: string,
+    abortSignal: AbortSignal,
+  ): Promise<void> {
+    if (abortSignal.aborted) {
+      return;
+    }
+    await this.ttsManager.generateAndWaitForPlayback(
+      text,
+      (msg) => this.emit(msg),
+      abortSignal,
+      true,
+    );
+    this.sessionLogger.info({ agentId, textLength: text.length }, "Voice speak playback finished");
   }
 
   /**

--- a/packages/server/src/server/voice-config.ts
+++ b/packages/server/src/server/voice-config.ts
@@ -4,8 +4,10 @@ const VOICE_PROMPT_BLOCK_END = "</paseo_voice_mode>";
 const VOICE_AGENT_SYSTEM_INSTRUCTION = [
   "Paseo voice mode is now on.",
   "You are the Paseo voice assistant.",
-  "The user cannot see your chat messages or tool calls.",
+  "The user may not be looking at the chat, so anything important must be spoken.",
   "Always use the speak tool for all user-facing communication.",
+  "Do not also write normal assistant messages: the text you pass to speak is recorded in the chat automatically, so speaking is sufficient.",
+  "speak returns as soon as the utterance is queued and audio plays while you keep working, so call speak first and continue immediately.",
   "Before calling any non-speak tool, first call speak with a short acknowledgement of what you heard and what you will do next.",
   "For long-running work, use speak to provide progress updates before and during execution.",
   "Treat the user input as transcribed speech.",


### PR DESCRIPTION
## Problem

Two voice-mode failure modes, both hit in real use:

1. **The agent freezes while it talks.** The `speak` handler awaited playback confirmation from the client, so the agent could not start any work until the audio finished playing on the phone. The observed flow was: think → speak → silence while the audio plays → *then* the first tool call. For a multi-sentence acknowledgment that's many seconds of dead time before work begins.
2. **Voice fails silently.** The transcript entry for a spoken reply was only emitted *after* playback completed. When synthesis or playback failed (TTS provider error, client never confirming), the reply vanished entirely — the user heard nothing and had nothing to read either.

## Change

`speak` is now "a chat message that also plays as audio":

- The assistant transcript entry is emitted **immediately, before any audio work** — the chat always carries the reply as a durable record and readable fallback.
- Playback is queued on a per-session promise chain: overlapping `speak` calls play in spoken order, and a barge-in drains the queue through the existing abort path.
- The tool **returns once the utterance is queued**, so the agent keeps working while audio plays.
- Synthesis/playback failure surfaces as an error activity entry pointing at the text ("The reply is shown as text above.").
- The voice-mode prompt now tells the model the spoken text is recorded automatically (so it stops duplicating replies as normal messages) and to continue working while audio plays. The tool description is updated to match.

## QA evidence

Live on a daemon running this branch, driven from the iOS app: the acknowledgment audio plays **while** the agent's shell commands are already streaming — previously work only started after the audio ended. Text for every utterance appears in the chat at speak time.

Tests — 4 new, in `voice-session.test.ts`:

```
npx vitest run src/server/session/voice/voice-session.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

- records the spoken text in the chat before audio and returns without awaiting playback
- plays overlapping speak calls in order, starting the next only after playback confirms
- drops queued speech after an abort but keeps the text record
- surfaces synthesis failure as an error entry while keeping the text record

Mutation-checked: restoring the old blocking behavior (`await this.speechQueue` in the handler) turns 3 of them red (timeouts, exactly the old freeze); reverting goes green. Typecheck and lint clean.

## Platforms

Server-only change. Tested on a macOS daemon end-to-end from the iOS app. Not separately tested: Android app (no client change), Windows/Linux daemons (no platform-specific code involved).

Happy to adjust semantics (e.g., a queue-depth cap on pending utterances) if you'd rather different behavior here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
