### PR TITLE
Prevent Pi from rejecting accepted prompts

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -59,7 +59,7 @@ Claude first-party model metadata lives in `packages/server/src/server/agent/pro
 
 Paseo tools are not implemented as MCP tools internally. They live in a shared tool catalog under `packages/server/src/server/agent/tools/`; MCP is only the fallback adapter. A provider that can register runtime tools directly should set `supportsNativePaseoTools: true` and consume `launchContext.paseoTools` in `createSession`/`resumeSession`. When native tools are present, `AgentManager` strips the internal Paseo MCP server from the provider launch config so the provider does not receive the same tools twice. Providers that only know MCP should keep `supportsMcpServers: true` and let the daemon inject `/mcp/agents`.
 
-Pi is a process-backed provider. Paseo requires the user to have the `pi` binary installed and talks to it through `pi --mode rpc`; the server package does not embed Pi's SDK/runtime packages.
+Pi is a process-backed provider. Paseo requires the user to have the `pi` binary installed and talks to it through `pi --mode rpc`; the server package does not embed Pi's SDK/runtime packages. Every Pi prompt RPC carries an explicit `streamingBehavior`: normal prompts and integration commands use `followUp`, while the active-turn steering path selected by the user's send behavior uses Pi's native `steer`. This avoids relying on Pi's busy-session default, which rejects prompts without an explicit behavior, and preserves the user's choice between interrupting and steering an active turn.
 
 Paseo's per-agent and daemon-wide system prompts are appended by its generated Pi integration extension. Paseo deliberately does not pass `--append-system-prompt`, because that flag replaces Pi's automatic `APPEND_SYSTEM.md` discovery instead of composing with it.
 

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -832,6 +832,185 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("correlates slash-prefixed prompts after Pi expands their submitted text", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("/review staged", { clientMessageId: "client-expanded" });
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-expanded",
+      parentId: null,
+      text: "Review the currently staged changes",
+    });
+    await events.nextTimelineEvent();
+
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "Review the currently staged changes",
+        messageId: "entry-expanded",
+        clientMessageId: "client-expanded",
+      },
+    ]);
+  });
+
+  test("does not let a terminal turn's stale correlation hide a later identical message", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("same text", { clientMessageId: "client-stale" });
+    fakeSession.finishTurn();
+    await session.startTurn("same text", { clientMessageId: "client-current" });
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-current",
+      parentId: null,
+      text: "same text",
+    });
+    await events.nextTimelineEvent();
+
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "same text",
+        messageId: "entry-current",
+        clientMessageId: "client-current",
+      },
+    ]);
+  });
+
+  test("marks an idle user prompt as a deterministic follow-up", async () => {
+    const { pi, session } = await createSession();
+
+    await session.startTurn("idle prompt", { clientMessageId: "client-idle" });
+
+    expect(pi.latestSession().prompts).toEqual([
+      {
+        message: "idle prompt",
+        imageCount: 0,
+        streamingBehavior: "followUp",
+      },
+    ]);
+  });
+
+  test("uses Pi steering only for an explicit active-turn steer and correlates its echo", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    const { turnId } = await session.startTurn("initial", { clientMessageId: "client-initial" });
+    fakeSession.emit({ type: "turn_start" });
+
+    await expect(
+      session.steerActiveTurn("change course", {
+        expectedTurnId: turnId,
+        clientMessageId: "client-steer",
+      }),
+    ).resolves.toEqual({ status: "accepted" });
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-steer",
+      parentId: null,
+      text: "change course",
+    });
+    await events.nextTimelineEvent();
+
+    expect(fakeSession.prompts).toEqual([
+      { message: "initial", imageCount: 0, streamingBehavior: "followUp" },
+      { message: "change course", imageCount: 0, streamingBehavior: "steer" },
+    ]);
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "change course",
+        messageId: "entry-steer",
+        clientMessageId: "client-steer",
+      },
+    ]);
+  });
+
+  test("clears blocking Pi UI state before sending an explicit active-turn steer", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+    const { turnId } = await session.startTurn("initial");
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "permission-before-steer",
+      method: "confirm",
+      title: "Continue?",
+      message: "Allow the current operation?",
+    });
+
+    await expect(
+      session.steerActiveTurn("user-selected steer behavior", {
+        expectedTurnId: turnId,
+        clearPendingPermissions: true,
+      }),
+    ).resolves.toEqual({ status: "accepted" });
+
+    expect(session.getPendingPermissions()).toEqual([]);
+    expect(fakeSession.canceledExtensionUiRequests).toEqual(["permission-before-steer"]);
+    expect(fakeSession.prompts.at(-1)).toEqual({
+      message: "user-selected steer behavior",
+      imageCount: 0,
+      streamingBehavior: "steer",
+    });
+  });
+
+  test("queues capture and a normal send when Pi remains busy after a turn boundary", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.rejectMissingStreamingBehaviorWhileStreaming = true;
+
+    await session.startTurn("first", { clientMessageId: "client-first" });
+    fakeSession.state = { ...fakeSession.state, isStreaming: true };
+    await Array.fromAsync(session.streamHistory());
+    fakeSession.finishTurn();
+    await session.startTurn("additional", { clientMessageId: "client-additional" });
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-additional",
+      parentId: null,
+      text: "additional",
+    });
+    await events.nextTimelineEvent();
+
+    expect(
+      fakeSession.prompts.map(({ message, streamingBehavior }) => ({
+        message: message.startsWith("/paseo_capture_entries ") ? "/paseo_capture_entries" : message,
+        streamingBehavior,
+      })),
+    ).toEqual([
+      { message: "first", streamingBehavior: "followUp" },
+      { message: "/paseo_capture_entries", streamingBehavior: "followUp" },
+      { message: "additional", streamingBehavior: "followUp" },
+    ]);
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "additional",
+        messageId: "entry-additional",
+        clientMessageId: "client-additional",
+      },
+    ]);
+    expect(events.eventTypes()).not.toContain("turn_failed");
+  });
+
+  test("uses follow-up behavior for replay entry capture without adding transcript rows", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.messages = [{ role: "user", content: "history prompt" }];
+    fakeSession.capturedUserEntries = [
+      { id: "entry-history", parentId: null, text: "history prompt" },
+    ];
+
+    const history = await Array.fromAsync(session.streamHistory());
+
+    expect(fakeSession.prompts).toEqual([
+      {
+        message: expect.stringMatching(/^\/paseo_capture_entries /),
+        imageCount: 0,
+        streamingBehavior: "followUp",
+      },
+    ]);
+    expect(history.filter((event) => event.type === "timeline")).toHaveLength(1);
+  });
+
   test("surfaces Pi extension command messages and completes when no agent turn starts", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
@@ -878,8 +1057,8 @@ describe("PiRpcAgentSession", () => {
       turnId: firstTurn.turnId,
     });
     expect(fakeSession.prompts).toEqual([
-      { message: "/silent-search", imageCount: 0 },
-      { message: "next request", imageCount: 0 },
+      { message: "/silent-search", imageCount: 0, streamingBehavior: "followUp" },
+      { message: "next request", imageCount: 0, streamingBehavior: "followUp" },
     ]);
     await expect(session.startTurn("overlapping request")).rejects.toThrow(
       "A Pi turn is already active",
@@ -1294,6 +1473,7 @@ describe("PiRpcAgentSession", () => {
       expect(fakeSession.prompts).toHaveLength(1);
       const prompt = fakeSession.prompts[0]!;
       expect(prompt.imageCount).toBe(0);
+      expect(prompt.streamingBehavior).toBe("followUp");
       expect(prompt.message).toContain("Describe this image.");
       expect(prompt.message).not.toContain(ONE_BY_ONE_PNG_BASE64);
       imagePath = prompt.message.match(/\[Image available at: (.+)\]/)?.[1];
@@ -1323,6 +1503,7 @@ describe("PiRpcAgentSession", () => {
       expect(fakeSession.prompts).toHaveLength(1);
       const prompt = fakeSession.prompts[0]!;
       expect(prompt.imageCount).toBe(0);
+      expect(prompt.streamingBehavior).toBe("followUp");
       expect(prompt.message).toContain("Describe this image.");
       imagePath = prompt.message.match(/\[Image available at: (.+)\]/)?.[1];
       expect(imagePath).toBeTypeOf("string");
@@ -1354,6 +1535,7 @@ describe("PiRpcAgentSession", () => {
       {
         message: "Describe this image.",
         imageCount: 1,
+        streamingBehavior: "followUp",
       },
     ]);
   });

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -30,6 +30,8 @@ import {
   type AgentSlashCommandKind,
   type AgentStreamEvent,
   type FetchCatalogOptions,
+  type SteerActiveTurnOptions,
+  type SteerResult,
   type ImportableProviderSession,
   type ImportProviderSessionContext,
   type ImportProviderSessionInput,
@@ -74,6 +76,7 @@ import type {
   PiRpcSlashCommand,
   PiRuntimeEvent,
   PiSessionState,
+  PiStreamingBehavior,
   PiThinkingLevel,
 } from "./rpc-types.js";
 import { PiUsagePoller, type PiUsagePollScheduler } from "./usage-poller.js";
@@ -96,6 +99,7 @@ const PASEO_PI_SUBMITTED_USER_ENTRY_MARKER = "PASEO_SUBMITTED_USER_ENTRY";
 const PASEO_PI_COMMAND_RESULT_MARKER = "PASEO_COMMAND_RESULT";
 const DEFAULT_PI_EXTENSION_RESULT_TIMEOUT_MS = 30_000;
 const DEFAULT_PI_RPC_TIMEOUT_MS = 60_000;
+const MAX_PENDING_PI_SUBMITTED_PROMPTS = 256;
 const QUESTION_RESPONSE_HEADER = "Response";
 const QUESTION_COMMENT_HEADER = "Comment";
 const PI_ASK_USER_FREEFORM_SENTINEL = "✏️ Type custom response...";
@@ -1211,6 +1215,11 @@ export class PiRpcAgentSession implements AgentSession {
   private pendingCombinedAskUserResponse: PendingCombinedAskUserResponse | null = null;
   private activeTurnId: string | null = null;
   private activeClientMessageId: string | null = null;
+  private readonly pendingSubmittedPrompts: Array<{
+    token: string;
+    text: string;
+    clientMessageId: string | null;
+  }> = [];
   private activeAssistantMessageId: string | null = null;
   private activeTurnStarted = false;
   private activeTurnStartedEmitted = false;
@@ -1300,6 +1309,7 @@ export class PiRpcAgentSession implements AgentSession {
       throw new Error("A Pi turn is already active");
     }
 
+    this.clearPendingSubmittedPrompts();
     const payload = convertPromptInput(prompt, { model: this.state.model });
     const turnId = randomUUID();
     this.activeTurnId = turnId;
@@ -1317,7 +1327,12 @@ export class PiRpcAgentSession implements AgentSession {
 
     void (async () => {
       try {
-        const ack = await this.runtimeSession.prompt(payload.text, payload.images);
+        const ack = await this.sendUserPrompt(
+          payload,
+          "followUp",
+          options?.clientMessageId ?? null,
+          true,
+        );
         this.activePromptRequestId = ack.requestId ?? null;
         const correlatedResult = ack.requestId
           ? this.pendingPromptResults.get(ack.requestId)
@@ -1345,6 +1360,7 @@ export class PiRpcAgentSession implements AgentSession {
         this.pendingSettledMessages = null;
         this.activeAssistantMessageId = null;
         this.clearNoTurnBuffers();
+        this.clearPendingSubmittedPrompts();
         if (isPiRequestAbortError(error)) {
           this.emit({
             type: "turn_canceled",
@@ -1364,6 +1380,25 @@ export class PiRpcAgentSession implements AgentSession {
     })();
 
     return { turnId };
+  }
+
+  async steerActiveTurn(
+    prompt: AgentPromptInput,
+    options: SteerActiveTurnOptions,
+  ): Promise<SteerResult> {
+    if (this.activeTurnId !== options.expectedTurnId) {
+      return { status: "unavailable" };
+    }
+    const payload = convertPromptInput(prompt, { model: this.state.model });
+    if (this.parseSlashCommandInput(payload.text)) {
+      return { status: "unavailable" };
+    }
+
+    if (options.clearPendingPermissions) {
+      this.clearPendingPermissionsForSteer();
+    }
+    await this.sendUserPrompt(payload, "steer", options.clientMessageId ?? null, true);
+    return { status: "accepted" };
   }
 
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
@@ -1461,6 +1496,7 @@ export class PiRpcAgentSession implements AgentSession {
     try {
       await this.runtimeSession.abort();
     } catch (error) {
+      this.clearPendingSubmittedPrompts();
       if (this.interruptingTurnId === turnId) {
         this.interruptingTurnId = null;
       }
@@ -1475,6 +1511,7 @@ export class PiRpcAgentSession implements AgentSession {
         this.pendingSettledMessages = null;
         this.activeAssistantMessageId = null;
         this.clearNoTurnBuffers();
+        this.clearPendingSubmittedPrompts();
         this.emit({
           type: "turn_failed",
           provider: this.provider,
@@ -1484,6 +1521,7 @@ export class PiRpcAgentSession implements AgentSession {
       }
       throw error;
     }
+    this.clearPendingSubmittedPrompts();
     if (turnId && this.activeTurnId === turnId) {
       this.usagePoller.stopTurn();
       this.activeTurnId = null;
@@ -1493,6 +1531,7 @@ export class PiRpcAgentSession implements AgentSession {
       this.pendingSettledMessages = null;
       this.activeAssistantMessageId = null;
       this.clearNoTurnBuffers();
+      this.clearPendingSubmittedPrompts();
       this.emit({
         type: "turn_canceled",
         provider: this.provider,
@@ -1532,7 +1571,11 @@ export class PiRpcAgentSession implements AgentSession {
     const requestId = randomUUID();
     const resultPromise = this.waitForExtensionResult(requestId);
     const payload = Buffer.from(JSON.stringify({ targetId, requestId })).toString("base64url");
-    await this.runtimeSession.prompt(`/${PASEO_PI_TREE_EXTENSION_COMMAND} ${payload}`);
+    await this.runtimeSession.prompt(
+      `/${PASEO_PI_TREE_EXTENSION_COMMAND} ${payload}`,
+      undefined,
+      "followUp",
+    );
     return await resultPromise;
   }
 
@@ -1545,6 +1588,7 @@ export class PiRpcAgentSession implements AgentSession {
     try {
       await this.runtimeSession.close();
     } finally {
+      this.clearPendingSubmittedPrompts();
       this.rejectAllExtensionResults(new Error("Pi session closed"));
       this.cleanup?.();
     }
@@ -1619,6 +1663,59 @@ export class PiRpcAgentSession implements AgentSession {
     for (const subscriber of this.subscribers) {
       subscriber(event);
     }
+  }
+
+  private async sendUserPrompt(
+    payload: PiPromptPayload,
+    streamingBehavior: PiStreamingBehavior,
+    clientMessageId: string | null,
+    trackSubmittedEntry: boolean,
+  ) {
+    const pending = trackSubmittedEntry
+      ? { token: randomUUID(), text: payload.text, clientMessageId }
+      : null;
+    if (pending) {
+      this.pendingSubmittedPrompts.push(pending);
+      if (this.pendingSubmittedPrompts.length > MAX_PENDING_PI_SUBMITTED_PROMPTS) {
+        this.pendingSubmittedPrompts.splice(
+          0,
+          this.pendingSubmittedPrompts.length - MAX_PENDING_PI_SUBMITTED_PROMPTS,
+        );
+      }
+    }
+    try {
+      return await this.runtimeSession.prompt(payload.text, payload.images, streamingBehavior);
+    } catch (error) {
+      if (pending) {
+        const index = this.pendingSubmittedPrompts.findIndex(
+          (candidate) => candidate.token === pending.token,
+        );
+        if (index !== -1) {
+          this.pendingSubmittedPrompts.splice(index, 1);
+        }
+      }
+      throw error;
+    }
+  }
+
+  private clearPendingPermissionsForSteer(): void {
+    this.activeAskUserDialog = null;
+    this.pendingCombinedAskUserResponse = null;
+    for (const [requestId] of this.pendingExtensionUiRequests) {
+      this.pendingExtensionUiRequests.delete(requestId);
+      this.runtimeSession.cancelExtensionUiRequest(requestId);
+      this.emit({
+        type: "permission_resolved",
+        provider: this.provider,
+        requestId,
+        resolution: { behavior: "deny", message: "Superseded by an active-turn steer" },
+        turnId: this.currentTurnIdForEvent(),
+      });
+    }
+  }
+
+  private clearPendingSubmittedPrompts(): void {
+    this.pendingSubmittedPrompts.splice(0, this.pendingSubmittedPrompts.length);
   }
 
   private currentTurnIdForEvent(): string | undefined {
@@ -1828,7 +1925,11 @@ export class PiRpcAgentSession implements AgentSession {
     const requestId = randomUUID();
     const resultPromise = this.waitForExtensionResult(requestId);
     const payload = Buffer.from(JSON.stringify({ requestId, reason })).toString("base64url");
-    await this.runtimeSession.prompt(`/${PASEO_PI_CAPTURE_EXTENSION_COMMAND} ${payload}`);
+    await this.runtimeSession.prompt(
+      `/${PASEO_PI_CAPTURE_EXTENSION_COMMAND} ${payload}`,
+      undefined,
+      "followUp",
+    );
     await resultPromise;
   }
 
@@ -1885,6 +1986,11 @@ export class PiRpcAgentSession implements AgentSession {
     if (!entry) {
       return true;
     }
+    const exactPromptIndex = this.pendingSubmittedPrompts.findIndex(
+      (pending) => pending.text === entry.text,
+    );
+    const promptIndex = exactPromptIndex === -1 ? 0 : exactPromptIndex;
+    const submittedPrompt = this.pendingSubmittedPrompts.splice(promptIndex, 1)[0];
     this.emit({
       type: "timeline",
       provider: this.provider,
@@ -1893,7 +1999,9 @@ export class PiRpcAgentSession implements AgentSession {
         type: "user_message",
         text: entry.text,
         messageId: entry.id,
-        ...(this.activeClientMessageId ? { clientMessageId: this.activeClientMessageId } : {}),
+        ...(submittedPrompt?.clientMessageId
+          ? { clientMessageId: submittedPrompt.clientMessageId }
+          : {}),
       },
     });
     return true;
@@ -2057,6 +2165,7 @@ export class PiRpcAgentSession implements AgentSession {
   }
 
   private handleProcessExit(error: string): void {
+    this.clearPendingSubmittedPrompts();
     this.rejectAllExtensionResults(new Error(error));
     if (!this.activeTurnId) {
       return;
@@ -2069,6 +2178,7 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeTurnStartedEmitted = false;
     this.pendingSettledMessages = null;
     this.clearNoTurnBuffers();
+    this.clearPendingSubmittedPrompts();
     this.emit({
       type: "turn_failed",
       provider: this.provider,
@@ -2360,6 +2470,7 @@ export class PiRpcAgentSession implements AgentSession {
       (turnId === this.lastInterruptedTurnId || (!turnId && this.lastInterruptedTurnId !== null))
     ) {
       this.lastInterruptedTurnId = null;
+      this.clearPendingSubmittedPrompts();
       return;
     }
     this.activeTurnId = null;
@@ -2369,6 +2480,7 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeTurnStartedEmitted = false;
     this.pendingSettledMessages = null;
     this.clearNoTurnBuffers();
+    this.clearPendingSubmittedPrompts();
     const errorMessage = latestPiErrorMessage(messages);
     if (typeof errorMessage === "string" && errorMessage.length > 0) {
       this.usagePoller.stopTurn();

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
@@ -151,6 +151,40 @@ describe("PiCliRuntime", () => {
     ]);
   });
 
+  test("serializes streaming behavior for racing prompt RPCs", async () => {
+    const child = createPiChild();
+    const commands: Record<string, unknown>[] = [];
+    replyToCommands(child, (command) => {
+      commands.push(command);
+      return {};
+    });
+    const session = await createRuntime(child).startSession({ cwd: "/workspace/project" });
+
+    await Promise.all([
+      session.prompt("first", undefined, "followUp"),
+      session.prompt("second", undefined, "followUp"),
+      session.prompt("explicit steer", undefined, "steer"),
+    ]);
+
+    expect(commands).toEqual([
+      expect.objectContaining({
+        type: "prompt",
+        message: "first",
+        streamingBehavior: "followUp",
+      }),
+      expect.objectContaining({
+        type: "prompt",
+        message: "second",
+        streamingBehavior: "followUp",
+      }),
+      expect.objectContaining({
+        type: "prompt",
+        message: "explicit steer",
+        streamingBehavior: "steer",
+      }),
+    ]);
+  });
+
   test("passes an MCP config path to Pi", async () => {
     const child = createPiChild();
     replyToCommands(child, () => ({}));

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.ts
@@ -23,6 +23,7 @@ import type {
   PiRuntimeEvent,
   PiSessionState,
   PiSessionStats,
+  PiStreamingBehavior,
 } from "./rpc-types.js";
 
 const DEFAULT_PI_COMMAND: [string, ...string[]] = [
@@ -104,12 +105,14 @@ class PiCliRuntimeSession implements PiRuntimeSession {
 
   async prompt(
     message: string,
-    images?: Array<{ type: "image"; data: string; mimeType: string }>,
+    images: Array<{ type: "image"; data: string; mimeType: string }> | undefined,
+    streamingBehavior: PiStreamingBehavior,
   ): Promise<PiPromptAck> {
     const { id: requestId, promise } = this.process.startRequest({
       type: "prompt",
       message,
       ...(images?.length ? { images } : {}),
+      streamingBehavior,
     });
     const data = await promise;
     if (typeof data === "object" && data !== null && !Array.isArray(data)) {

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -5,9 +5,7 @@ export interface PiImageContent {
   data: string;
   mimeType: string;
 }
-export interface PiPromptAck {
-  agentInvoked?: boolean;
-}
+export type PiStreamingBehavior = "steer" | "followUp";
 
 export interface PiPromptAck {
   requestId?: string;
@@ -127,7 +125,13 @@ export interface PiRpcSlashCommand {
 }
 
 export type PiRpcCommand =
-  | { id?: string; type: "prompt"; message: string; images?: PiImageContent[] }
+  | {
+      id?: string;
+      type: "prompt";
+      message: string;
+      images?: PiImageContent[];
+      streamingBehavior: PiStreamingBehavior;
+    }
   | { id?: string; type: "compact"; customInstructions?: string }
   | { id?: string; type: "set_auto_compaction"; enabled: boolean }
   | { id?: string; type: "abort" }

--- a/packages/server/src/server/agent/providers/pi/runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/runtime.ts
@@ -5,6 +5,7 @@ import type {
   PiRpcSlashCommand,
   PiRuntimeEvent,
   PiSessionState,
+  PiStreamingBehavior,
   PiSessionStats,
 } from "./rpc-types.js";
 import type { ProviderRuntimeSettings } from "../../provider-launch-config.js";
@@ -43,7 +44,8 @@ export interface PiRuntimeSession {
   onEvent(callback: (event: PiRuntimeEvent) => void): () => void;
   prompt(
     message: string,
-    images?: Array<{ type: "image"; data: string; mimeType: string }>,
+    images: Array<{ type: "image"; data: string; mimeType: string }> | undefined,
+    streamingBehavior: PiStreamingBehavior,
   ): Promise<PiPromptAck>;
   compact(customInstructions?: string): Promise<void>;
   setAutoCompaction(enabled: boolean): Promise<void>;

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -12,6 +12,7 @@ import type {
   PiRuntimeEvent,
   PiSessionState,
   PiSessionStats,
+  PiStreamingBehavior,
 } from "../rpc-types.js";
 import { buildPiLaunch } from "../runtime.js";
 
@@ -93,7 +94,11 @@ export class FakePi implements PiRuntime {
 }
 
 export class FakePiSession implements PiRuntimeSession {
-  readonly prompts: Array<{ message: string; imageCount: number }> = [];
+  readonly prompts: Array<{
+    message: string;
+    imageCount: number;
+    streamingBehavior: PiStreamingBehavior;
+  }> = [];
   readonly compactRequests: Array<{ customInstructions?: string }> = [];
   readonly setAutoCompactionRequests: boolean[] = [];
   readonly subagentSubscriptionRequests: FakePiSubagentSubscriptionLevel[] = [];
@@ -127,6 +132,7 @@ export class FakePiSession implements PiRuntimeSession {
   getStateError: Error | null = null;
   getSessionStatsError: Error | null = null;
   promptAck: PiPromptAck = {};
+  rejectMissingStreamingBehaviorWhileStreaming = false;
   branchResponse: { text?: string; cancelled?: boolean } = { text: "" };
   readonly branchRequests: string[] = [];
   state: PiSessionState;
@@ -160,9 +166,22 @@ export class FakePiSession implements PiRuntimeSession {
 
   async prompt(
     message: string,
-    images?: Array<{ type: "image"; data: string; mimeType: string }>,
+    images: Array<{ type: "image"; data: string; mimeType: string }> | undefined,
+    streamingBehavior?: PiStreamingBehavior,
   ): Promise<PiPromptAck> {
-    this.prompts.push({ message, imageCount: images?.length ?? 0 });
+    if (
+      this.rejectMissingStreamingBehaviorWhileStreaming &&
+      this.state.isStreaming &&
+      streamingBehavior === undefined
+    ) {
+      throw new Error(
+        "[System Error] Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.",
+      );
+    }
+    if (streamingBehavior === undefined) {
+      throw new Error("FakePi prompt requires streamingBehavior");
+    }
+    this.prompts.push({ message, imageCount: images?.length ?? 0, streamingBehavior });
     const heldPrompt = this.nextHeldPrompt;
     if (heldPrompt) {
       this.nextHeldPrompt = null;


### PR DESCRIPTION
Paseo already decides whether input should interrupt, steer, or wait in the Queue track. That behavior is unchanged.

Once Paseo sends a prompt, Pi requires an explicit streaming behavior if it still considers the session busy. Without one, an accepted prompt can fail with “Agent is already processing.”

This sends Paseo’s steering path as `steer` and ordinary accepted prompts as `followUp`, while leaving client-side queueing and interruption behavior intact.