### PR TITLE
Hide Pi subagent control reports from chat

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -69,6 +69,14 @@ Pi MCP support depends on the open-source `pi-mcp-adapter` extension being loade
 
 Pi import discovery reads Pi's persisted JSONL session files because Pi RPC does not expose a recent-session listing command. Resume and full history hydration still go through `pi --mode rpc` using the session file as `nativeHandle`.
 
+Pi extension custom messages remain in Pi's native session and model context, but not every custom
+message belongs in Paseo's transcript. The Pi provider suppresses pi-subagents completion, failure,
+progress, attention, and supervisor-decision control reports from both live projection and history
+replay. Prefer the `subagent-notify`, `subagent_control_notice`, `subagent_steering_notice`,
+`subagent_supervisor_request`, and `subagent_watchdog_warning` custom types; use the exact report
+opener only when Pi RPC omits that metadata. Other extension custom messages and user messages
+remain visible.
+
 OMP is a first-class built-in provider, disabled by default. Its launch contract, typed runtime, agent/session behavior, history, permissions, imports, and test fake live under `providers/omp/`; only the provider-neutral JSONL child-process transport is shared with Pi. It launches `omp --mode rpc-ui`, uses OMP's `get_available_commands` RPC for slash-command discovery, bridges OMP `rpc-ui` approval dialogs into Paseo permissions, and imports terminal-started sessions from `~/.omp/agent/sessions` when enabled.
 
 OMP supports native Paseo host tools. The adapter registers the full caller-scoped Paseo tool catalog directly with OMP, matching providers such as Claude that expose the full catalog through MCP. Serialize every OMP host definition with `loadMode: "essential"` so `create_agent`, `send_agent_prompt`, `wait_for_agent`, and related tools remain direct calls; omitting the field makes OMP mount non-built-in names under `xd://` instead. OMP's provider-managed task subagents are surfaced as Paseo subagents through `child_session` imports; the parent keeps the subagents track while the child runtime stays owned by OMP. Custom OMP profiles should extend `omp`; other Pi-compatible forks can still extend `pi`, override `command`, and set `params.sessionDir` to their JSONL session directory.

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -169,6 +169,124 @@ test("keeps normal Pi agent sessions persisted", async () => {
   await session.close();
 });
 
+test("keeps pi-subagents live control reports in Pi context without projecting chat bubbles", async () => {
+  const { pi, session, events } = await createSession();
+  const runtime = pi.latestSession();
+  const controlMessages = [
+    {
+      role: "custom" as const,
+      customType: "subagent-notify",
+      content: "Background task completed: **worker**\n\nDone",
+    },
+    {
+      role: "custom" as const,
+      customType: "subagent-notify",
+      content: "Background task failed: **worker**\n\nFailed",
+    },
+    {
+      role: "custom" as const,
+      customType: "subagent_supervisor_request",
+      content: "Subagent progress update.\nRun: run-1",
+    },
+    {
+      role: "custom" as const,
+      customType: "subagent_control_notice",
+      content: "Subagent needs attention: worker\nRun: run-1",
+    },
+    {
+      role: "custom" as const,
+      customType: "subagent_supervisor_request",
+      content: "Subagent needs a supervisor decision.\nRun: run-1",
+    },
+    {
+      role: "custom" as const,
+      customType: "subagent_steering_notice",
+      content: "Subagent steering failed: run-1",
+    },
+    {
+      role: "custom" as const,
+      customType: "subagent_watchdog_warning",
+      content: "<subagent_watchdog><summary>warning</summary></subagent_watchdog>",
+    },
+  ];
+  runtime.messages = [...controlMessages];
+  const userSpoof = "Background task completed: **worker**\n\nThis is a real user prompt";
+
+  await session.startTurn(userSpoof);
+  expect(runtime.prompts).toContainEqual({ message: userSpoof, imageCount: 0 });
+  for (const message of controlMessages) {
+    runtime.emit({ type: "message_end", message });
+  }
+  runtime.emit({
+    type: "message_end",
+    message: {
+      role: "custom",
+      customType: "extension-result",
+      content: "Ordinary extension notification",
+    },
+  });
+  runtime.emit({
+    type: "message_end",
+    message: {
+      role: "custom",
+      customType: "extension-result",
+      content: "Background task completed: ordinary prose without a bold agent",
+    },
+  });
+
+  expect(events.timelineItems()).toEqual([
+    { type: "assistant_message", text: "Ordinary extension notification" },
+    {
+      type: "assistant_message",
+      text: "Background task completed: ordinary prose without a bold agent",
+    },
+  ]);
+  expect(runtime.messages).toEqual(controlMessages);
+
+  await session.close();
+});
+
+test("filters pi-subagents reports during resumed history replay without removing native context", async () => {
+  const pi = new FakePi();
+  const nativeMessages = [
+    {
+      role: "custom" as const,
+      customType: "subagent_supervisor_request",
+      content: "Subagent progress update.\nRun: run-1",
+    },
+    {
+      role: "custom" as const,
+      customType: "extension-result",
+      content: "Ordinary extension notification",
+    },
+  ];
+  pi.queueSessionSetup((runtime) => {
+    runtime.messages = [...nativeMessages];
+  });
+  const session = (await createClient(pi).resumeSession({
+    provider: "pi",
+    sessionId: "pi-session-1",
+    nativeHandle: "/tmp/native-pi-session",
+    metadata: { cwd: "/workspace/project" },
+  })) as PiRpcAgentSession;
+  const replayed: AgentStreamEvent[] = [];
+
+  for await (const event of session.streamHistory()) {
+    replayed.push(event);
+  }
+
+  expect(replayed).toEqual([
+    {
+      type: "timeline",
+      provider: "pi",
+      item: { type: "assistant_message", text: "Ordinary extension notification" },
+    },
+  ]);
+  expect(pi.latestSession().messages).toEqual(nativeMessages);
+
+  await session.close();
+});
+
 class SessionEvents {
   private readonly events: AgentStreamEvent[] = [];
   private readonly waiters: Array<{

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -61,6 +61,7 @@ import {
   streamPiHistory,
   type PiCapturedUserMessageEntry,
 } from "./history-mapper.js";
+import { shouldProjectPiCustomMessage } from "./message-projection.js";
 import { materializeProviderImage } from "../provider-image-output.js";
 import { PiCliRuntime } from "./cli-runtime.js";
 import { revertPiConversation } from "./rewind.js";
@@ -2290,7 +2291,7 @@ export class PiRpcAgentSession implements AgentSession {
     }
     if (event.message.role === "custom") {
       const text = getUserMessageText(event.message.content);
-      if (text) {
+      if (text && shouldProjectPiCustomMessage(event.message, text)) {
         this.emit({
           type: "timeline",
           provider: this.provider,

--- a/packages/server/src/server/agent/providers/pi/history-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.test.ts
@@ -128,16 +128,51 @@ describe("Pi history mapper", () => {
     ]);
   });
 
-  test("replays non-notice custom messages as assistant text, matching the live path", async () => {
-    await expect(
-      collectHistory([{ role: "custom", content: "Extension command output" }]),
-    ).resolves.toEqual([
+  test("replays ordinary user and extension messages while omitting pi-subagents control reports", async () => {
+    const messages: PiAgentMessage[] = [
+      { role: "user", content: "Background task completed: this is my real prompt" },
+      {
+        role: "custom",
+        customType: "subagent-notify",
+        content: "Background task completed: **worker**\n\nDone",
+      },
+      {
+        role: "custom",
+        customType: "subagent-notify",
+        content: "Background task failed: **worker**\n\nFailed",
+      },
+      {
+        role: "custom",
+        customType: "subagent_supervisor_request",
+        content: "Subagent progress update.\nRun: run-1",
+      },
+      {
+        role: "custom",
+        customType: "subagent_control_notice",
+        content: "Subagent needs attention: worker\nRun: run-1",
+      },
+      {
+        role: "custom",
+        customType: "subagent_supervisor_request",
+        content: "Subagent needs a supervisor decision.\nRun: run-1",
+      },
+      { role: "custom", customType: "extension-result", content: "Extension command output" },
+    ];
+    const originalMessages = structuredClone(messages);
+
+    await expect(collectHistory(messages)).resolves.toEqual([
+      {
+        type: "timeline",
+        provider: "pi",
+        item: { type: "user_message", text: "Background task completed: this is my real prompt" },
+      },
       {
         type: "timeline",
         provider: "pi",
         item: { type: "assistant_message", text: "Extension command output" },
       },
     ]);
+    expect(messages).toEqual(originalMessages);
   });
 
   test("uses Pi tree entry ids for replayed user messages", async () => {

--- a/packages/server/src/server/agent/providers/pi/history-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.ts
@@ -1,5 +1,6 @@
 import type { AgentStreamEvent, AgentTimelineItem, ToolCallDetail } from "../../agent-sdk-types.js";
 import type { PiAgentMessage, PiImageContent, PiTextContent } from "./rpc-types.js";
+import { shouldProjectPiCustomMessage } from "./message-projection.js";
 import {
   extractTextFromToolResult,
   mapToolDetail,
@@ -117,19 +118,20 @@ export class PiHistoryMapper {
     message: Extract<PiAgentMessage, { role: "custom" }>,
   ): AgentStreamEvent[] {
     const text = getUserMessageText(message.content);
-    const mappedEvent = text ? this.hooks.mapCustomMessage?.(text, this.provider) : null;
+    if (!text || !shouldProjectPiCustomMessage(message, text)) {
+      return [];
+    }
+    const mappedEvent = this.hooks.mapCustomMessage?.(text, this.provider) ?? null;
     if (mappedEvent) {
       return [mappedEvent];
     }
-    return text
-      ? [
-          {
-            type: "timeline",
-            provider: this.provider,
-            item: { type: "assistant_message", text },
-          },
-        ]
-      : [];
+    return [
+      {
+        type: "timeline",
+        provider: this.provider,
+        item: { type: "assistant_message", text },
+      },
+    ];
   }
 
   private mapAssistantMessage(

--- a/packages/server/src/server/agent/providers/pi/message-projection.test.ts
+++ b/packages/server/src/server/agent/providers/pi/message-projection.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+
+import type { PiAgentMessage } from "./rpc-types.js";
+import { shouldProjectPiCustomMessage } from "./message-projection.js";
+
+function customMessage(
+  content: string,
+  customType?: string,
+): Extract<PiAgentMessage, { role: "custom" }> {
+  return {
+    role: "custom",
+    content,
+    ...(customType ? { customType } : {}),
+  };
+}
+
+const COMPLETION_STATUSES = ["completed", "failed", "paused", "stopped"];
+
+describe("Pi custom message projection", () => {
+  test.each([
+    ...COMPLETION_STATUSES.flatMap((status) => [
+      [`Background task ${status}`, `Background task ${status}: **worker**\n\nResult`],
+      [
+        `Detached foreground task ${status}`,
+        `Detached foreground task ${status}: **worker** (task 1)\n\nResult`,
+      ],
+      [
+        `Background tasks ${status}`,
+        `Background tasks ${status} (2): **worker**, **reviewer**\n\nResults`,
+      ],
+      [
+        `Detached foreground tasks ${status}`,
+        `Detached foreground tasks ${status} (2): **worker**, **reviewer**\n\nResults`,
+      ],
+    ]),
+    ["progress report", "Subagent progress update.\nRun: run-1"],
+    ["attention report", "Subagent needs attention: worker\nRun: run-1"],
+    ["failed control report", "Subagent failed: worker\nRun: run-1"],
+    ["long-running report", "Subagent active but long-running: worker\nRun: run-1"],
+    ["supervisor decision report", "Subagent needs a supervisor decision.\nRun: run-1"],
+    [
+      "structured supervisor interview",
+      "Subagent requests a structured supervisor interview.\nRun: run-1",
+    ],
+  ])("suppresses a %s when Pi RPC omits customType", (_name, content) => {
+    expect(shouldProjectPiCustomMessage(customMessage(content), content)).toBe(false);
+  });
+
+  test.each([
+    "subagent-notify",
+    "subagent_control_notice",
+    "subagent_steering_notice",
+    "subagent_supervisor_request",
+    "subagent_watchdog_warning",
+  ])("prefers the structured %s customType over message prose", (customType) => {
+    const content = "Control report wording from a future pi-subagents version";
+    expect(shouldProjectPiCustomMessage(customMessage(content, customType), content)).toBe(false);
+  });
+
+  test.each([
+    "Extension command output",
+    "Background task completed: ordinary prose without a bold agent",
+    "Background task completed this is ordinary prose",
+    "Background tasks completed: ordinary prose without a count",
+    "Subagent progress update. This is ordinary prose on the same line",
+    "Subagent needs attention from the extension user",
+    "A Subagent failed: worker message that does not begin with the signature",
+    "Subagent requests a structured supervisor interview from this extension.",
+  ])("projects ordinary extension custom prose: %s", (content) => {
+    expect(shouldProjectPiCustomMessage(customMessage(content, "extension-result"), content)).toBe(
+      true,
+    );
+  });
+});

--- a/packages/server/src/server/agent/providers/pi/message-projection.ts
+++ b/packages/server/src/server/agent/providers/pi/message-projection.ts
@@ -1,0 +1,35 @@
+import type { PiAgentMessage } from "./rpc-types.js";
+
+const PI_SUBAGENT_CONTROL_CUSTOM_TYPES = new Set([
+  "subagent-notify",
+  "subagent_control_notice",
+  "subagent_steering_notice",
+  "subagent_supervisor_request",
+  "subagent_watchdog_warning",
+]);
+
+const PI_SUBAGENT_CONTROL_TEXT_SIGNATURES = [
+  /^(?:Background task|Detached foreground task) (?:completed|failed|paused|stopped): \*\*[^\n]+?\*\*(?: \([^\n)]*\))?(?:\n|$)/,
+  /^(?:Background tasks|Detached foreground tasks) (?:completed|failed|paused|stopped) \(\d+\): \*\*[^\n]+\*\*(?:\n|$)/,
+  /^Subagent progress update\.(?:\n|$)/,
+  /^Subagent needs attention: [^\n]+(?:\n|$)/,
+  /^Subagent failed: [^\n]+(?:\n|$)/,
+  /^Subagent active but long-running: [^\n]+(?:\n|$)/,
+  /^Subagent needs a supervisor decision\.(?:\n|$)/,
+  /^Subagent requests a structured supervisor interview\.(?:\n|$)/,
+];
+
+/**
+ * Pi keeps custom messages in its native session and model context. Paseo only
+ * decides here whether the same message should become a visible transcript row.
+ */
+export function shouldProjectPiCustomMessage(
+  message: Extract<PiAgentMessage, { role: "custom" }>,
+  text: string,
+): boolean {
+  if (message.customType && PI_SUBAGENT_CONTROL_CUSTOM_TYPES.has(message.customType)) {
+    return false;
+  }
+
+  return !PI_SUBAGENT_CONTROL_TEXT_SIGNATURES.some((signature) => signature.test(text));
+}

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -41,6 +41,7 @@ export type PiAgentMessage =
   | {
       role: "custom";
       content: string | Array<PiTextContent | PiImageContent>;
+      customType?: string;
     }
   | {
       role: "assistant";


### PR DESCRIPTION
Pi subagent control reports need to remain in the native session and model context, but Paseo currently displays them as ordinary assistant messages. This clutters the conversation and makes internal orchestration look like an agent response.

This keeps those reports in Pi’s context while omitting them from the visible transcript. Ordinary extension messages and subagent lifecycle updates are unchanged.