### PR TITLE
fix(server): support downloads of files with non-ASCII names

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -811,8 +811,18 @@ export async function createPaseoDaemon(
       }
 
       const safeFileName = entry.fileName.replace(/["\r\n]/g, "_");
+      // Node rejects non-Latin-1 characters in header values (ERR_INVALID_CHAR),
+      // so a raw UTF-8 basename in Content-Disposition makes every download of a
+      // file whose name contains non-ASCII characters fail. Emit an ASCII-safe
+      // filename= fallback plus the RFC 5987 filename*=UTF-8'' form for clients
+      // that support it (browsers, Electron, WebView2).
+      const hasNonAscii = /[^\x20-\x7E]/.test(safeFileName);
+      const fallbackFileName = safeFileName.replace(/[^\x20-\x7E]/g, "_");
+      const disposition = hasNonAscii
+        ? `attachment; filename="${fallbackFileName}"; filename*=UTF-8''${encodeURIComponent(safeFileName)}`
+        : `attachment; filename="${safeFileName}"`;
       res.setHeader("Content-Type", entry.mimeType);
-      res.setHeader("Content-Disposition", `attachment; filename="${safeFileName}"`);
+      res.setHeader("Content-Disposition", disposition);
       res.setHeader("Content-Length", fileStats.size.toString());
 
       const stream = fileHandle.createReadStream();

--- a/packages/server/src/server/daemon-e2e/file-download.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/file-download.e2e.test.ts
@@ -61,6 +61,46 @@ describe("daemon E2E", () => {
       rmSync(cwd, { recursive: true, force: true });
     }, 60000);
 
+    test("downloads a file whose name contains non-ASCII characters", async () => {
+      const cwd = tmpCwd();
+      const fileName = "要求.txt";
+      const filePath = path.join(cwd, fileName);
+      const fileContents = "中文文件名下载";
+      writeFileSync(filePath, fileContents, "utf-8");
+
+      const agent = await ctx.client.createAgent({
+        provider: "codex",
+        model: CODEX_TEST_MODEL,
+        thinkingOptionId: CODEX_TEST_THINKING_OPTION_ID,
+        cwd,
+        title: "Non-ASCII Download Token Test Agent",
+      });
+
+      expect(agent.id).toBeTruthy();
+
+      const tokenResponse = await ctx.client.requestDownloadToken(cwd, fileName);
+
+      expect(tokenResponse.error).toBeNull();
+      expect(tokenResponse.token).toBeTruthy();
+      expect(tokenResponse.fileName).toBe(fileName);
+
+      const response = await fetch(
+        `http://127.0.0.1:${ctx.daemon.port}/api/files/download?token=${tokenResponse.token}`,
+      );
+
+      expect(response.status).toBe(200);
+      const disposition = response.headers.get("content-disposition") ?? "";
+      expect(disposition).toContain(`filename*=UTF-8''${encodeURIComponent(fileName)}`);
+      // Header must stay a valid ASCII value (Node throws ERR_INVALID_CHAR on
+      // non-Latin-1 header characters) and keep an ASCII-safe filename= fallback.
+      expect(disposition).toContain('filename="');
+
+      const body = await response.text();
+      expect(body).toBe(fileContents);
+
+      rmSync(cwd, { recursive: true, force: true });
+    }, 60000);
+
     test("rejects invalid token", async () => {
       const response = await fetch(
         `http://127.0.0.1:${ctx.daemon.port}/api/files/download?token=invalid-token`,


### PR DESCRIPTION
# fix(server): support downloads of files with non-ASCII names

## Problem

Downloading a file whose **filename contains non-ASCII characters** (e.g. Chinese names like `要求.txt`) through the file explorer always fails:

- The daemon writes the raw UTF-8 basename into the HTTP header:
  ```js
  res.setHeader("Content-Disposition", `attachment; filename="要求.txt"`);
  ```
- Node rejects non-Latin-1 characters in header values with `ERR_INVALID_CHAR: Invalid character in header content ["Content-Disposition"]`.
- The error is swallowed by the handler's catch block, which then returns a misleading `404 {"error": "File not found"}` for an existing file.
- Desktop clients (e.g. the Windows app) crash/black-screen while handling this failed download and must be restarted.

ASCII filenames (e.g. `1.PNG`) are unaffected, which is why only some files fail. Note the directory path is irrelevant — only the basename appears in the header.

## Fix

Emit an ASCII-safe `filename=` fallback plus the RFC 5987 `filename*=UTF-8''...` form when the name contains non-ASCII characters, so the header stays a valid ASCII value and clients (browsers, Electron, WebView2) still save the file under its original name:

```
attachment; filename="__.txt"; filename*=UTF-8''%E8%A6%81%E6%B1%82.txt
```

ASCII filenames keep the exact same header as before (no behavior change).

## QA evidence

- `cd packages/server && npm run typecheck` → passes (exit 0)
- e2e: `npx vitest run src/server/daemon-e2e/file-download.e2e.test.ts --maxWorkers=1` → **5/5 passed**:

```
✓ ... > file download tokens > issues token over WS and downloads via HTTP 373ms
✓ ... > file download tokens > downloads a file whose name contains non-ASCII characters 127ms
✓ ... > file download tokens > rejects invalid token 76ms
✓ ... > file download tokens > rejects expired token 395ms
✓ ... > file download tokens > rejects paths outside the workspace cwd 106ms
Test Files  1 passed (1)
Tests       5 passed (5)
```

- Regression proof: with the fix reverted, the new test fails exactly as the reported bug does:

```
× ... > downloads a file whose name contains non-ASCII characters 382ms
  → expected 404 to be 200 // Object.is equality
AssertionError: expected 404 to be 200 // Object.is equality
```

- Platforms tested: Linux (server side, e2e daemon). Not tested: actual Windows/macOS desktop client UI (the server-side header fix is platform-independent).

## Test added

`packages/server/src/server/daemon-e2e/file-download.e2e.test.ts` — new case "downloads a file whose name contains non-ASCII characters" that requests a token for `要求.txt`, downloads it, asserts HTTP 200, the `filename*=UTF-8''...` disposition, and the file body.
