### PR TITLE
feat(speech): add Gemini transcription and TTS

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -241,8 +241,8 @@ snapshot so a mixed edit can apply its live subset and still name the paths that
   pluginsEnabled: boolean,
   plugins: Record<pluginId, { source: "directory", path: string, enabled?: boolean }>,
   features: {
-    dictation: { enabled, stt: { provider, model, language, confidenceThreshold } },
-    voiceMode: { enabled, llm, stt: { provider, model, language }, turnDetection, tts: { provider, model, voice, speakerId, speed } }
+    dictation: { enabled, stt: { provider, model, language, confidenceThreshold, mode } },
+    voiceMode: { enabled, llm, stt: { provider, model, language, mode }, turnDetection, tts: { provider, model, voice, speakerId, speed } }
   },
   log: {
     level, format,
@@ -313,7 +313,7 @@ remains authoritative during reload.
 
 Local speech model ids are intentionally narrow: STT uses `parakeet-tdt-0.6b-v2-int8`, TTS uses `kokoro-en-v0_19`, and turn detection uses the bundled Silero VAD model.
 
-Set these to select OpenAI instead of local speech:
+Set these to select a cloud provider instead of local speech. STT and TTS accept `openai` or `gemini`:
 
 | Env var                        | Applies to                      |
 | ------------------------------ | ------------------------------- |
@@ -347,6 +347,8 @@ Paseo uses these paths under the configured OpenAI base URL:
 - dictation STT: `/v1/audio/transcriptions`
 - voice mode STT: `/v1/audio/transcriptions`
 - voice mode TTS: `/v1/audio/speech`
+
+Gemini speech uses `providers.gemini.apiKey` or `GEMINI_API_KEY`. Set `features.dictation.stt.provider`, `features.voiceMode.stt.provider`, or `features.voiceMode.tts.provider` to `gemini`. STT defaults to `gemini-3.5-transcribe-live`; `mode` accepts `smart` or `verbatim`, and an omitted language enables automatic detection. TTS defaults to `gemini-3.1-flash-tts-preview` with the `Kore` voice. Model and voice fields accept provider identifiers without a Paseo allowlist. Gemini CLI authentication is unrelated to this speech provider.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6395,6 +6395,30 @@
       "resolved": "packages/website",
       "link": true
     },
+    "node_modules/@google/genai": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.19.0.tgz",
+      "integrity": "sha512-IM3u1FjpOLyOPsPh0smGA6Ntj2olUWCPbTs/WQj7cA/2AKCGw/652W7IaySx0XtwuscFnMYBoraebQusSZ0zSQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@gorhom/bottom-sheet": {
       "version": "5.2.14",
       "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.14.tgz",
@@ -9788,6 +9812,63 @@
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "license": "MIT"
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -13081,6 +13162,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -15596,6 +15683,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -15827,7 +15923,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
@@ -17601,6 +17696,15 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -18646,7 +18750,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -22109,6 +22212,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fetch-retry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-4.1.1.tgz",
@@ -22415,6 +22541,18 @@
         "node": ">=18.3.0"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -22574,6 +22712,74 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/generator-function": {
@@ -22912,6 +23118,53 @@
       "resolved": "https://registry.npmjs.org/golden-fleece/-/golden-fleece-1.0.9.tgz",
       "integrity": "sha512-YSwLaGMOgSBx9roJlNLL12c+FRiw7VECphinc6mGucphc/ZxTHgdEz6gmJqH6NOzYEd/yr64hwjom5pZ+tJVpg==",
       "dev": true
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -25210,6 +25463,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -26133,6 +26395,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -28453,6 +28721,26 @@
         "semver": "^7.3.5"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -29337,6 +29625,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/p-throttle": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-8.1.0.tgz",
@@ -30177,6 +30487,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -35577,6 +35910,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -39062,6 +39404,7 @@
         "@getpaseo/plugin": "0.7.0-beta.1",
         "@getpaseo/protocol": "0.7.0-beta.1",
         "@getpaseo/relay": "0.7.0-beta.1",
+        "@google/genai": "^2.19.0",
         "@isaacs/ttlcache": "^2.1.4",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opencode-ai/sdk": "1.14.46",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -77,6 +77,7 @@
     "@getpaseo/plugin": "0.7.0-beta.1",
     "@getpaseo/protocol": "0.7.0-beta.1",
     "@getpaseo/relay": "0.7.0-beta.1",
+    "@google/genai": "^2.19.0",
     "@isaacs/ttlcache": "^2.1.4",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opencode-ai/sdk": "1.14.46",

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -126,6 +126,7 @@ import { createPaseoWorktreeWorkflow } from "./worktree-session.js";
 import { DownloadTokenStore } from "./file-download/token-store.js";
 import type { OpenAiSpeechProviderConfig } from "./speech/providers/openai/config.js";
 import type { LocalSpeechProviderConfig } from "./speech/providers/local/config.js";
+import type { GeminiSpeechProviderConfig } from "./speech/providers/gemini/config.js";
 import type { RequestedSpeechProviders } from "./speech/speech-types.js";
 import { createSpeechService } from "./speech/speech-runtime.js";
 import { AgentManager } from "./agent/agent-manager.js";
@@ -427,6 +428,7 @@ export interface PaseoDaemonConfig {
   appBaseUrl?: string;
   auth?: DaemonAuthConfig;
   openai?: PaseoOpenAIConfig;
+  gemini?: GeminiSpeechProviderConfig;
   speech?: PaseoSpeechConfig;
   voiceLlmProvider?: AgentProvider | null;
   voiceLlmProviderExplicit?: boolean;
@@ -1498,6 +1500,7 @@ export async function createPaseoDaemon(
 
   const speechService = createSpeechService({
     logger,
+    geminiConfig: config.gemini,
     openaiConfig: config.openai,
     speechConfig: config.speech,
   });

--- a/packages/server/src/server/config.test.ts
+++ b/packages/server/src/server/config.test.ts
@@ -112,6 +112,11 @@ describe("server config", () => {
       ],
     },
     {
+      name: "Gemini speech providers",
+      providers: { dictation: "gemini", voiceStt: "gemini", voiceTts: "gemini" },
+      expected: ["providers.gemini.apiKey"],
+    },
+    {
       name: "mixed local and OpenAI speech providers",
       providers: { dictation: "local", voiceStt: "openai", voiceTts: "local" },
       expected: [
@@ -137,6 +142,7 @@ describe("server config", () => {
       },
       {
         env: {
+          GEMINI_API_KEY: "test-gemini-api-key",
           OPENAI_API_KEY: "test-api-key",
           PASEO_DICTATION_LOCAL_STT_MODEL: "parakeet-tdt-0.6b-v2-int8",
           PASEO_VOICE_LOCAL_STT_MODEL: "parakeet-tdt-0.6b-v2-int8",

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -21,7 +21,7 @@ import { ProviderOverrideSchema } from "./agent/provider-launch-config.js";
 import { AgentProviderSchema } from "@getpaseo/protocol/provider-manifest";
 import { hashDaemonPassword } from "./auth.js";
 import { resolveSpeechConfig } from "./speech/speech-config-resolver.js";
-import type { RequestedSpeechProviders } from "./speech/speech-types.js";
+import type { RequestedSpeechProviders, SpeechProviderId } from "./speech/speech-types.js";
 import { mergeHostnames, parseHostnamesEnv, type HostnamesConfig } from "./hostnames.js";
 import { resolveGitProcessPolicy } from "../utils/git-process-scheduler.js";
 
@@ -786,7 +786,7 @@ function resolveLogOverrideControlledPaths(env: NodeJS.ProcessEnv): string[] {
 
 function isEnabledSpeechProvider(
   provider: RequestedSpeechProviders[keyof RequestedSpeechProviders],
-  expected: "local" | "openai" | "gemini",
+  expected: SpeechProviderId,
 ): boolean {
   return provider.enabled !== false && provider.provider === expected;
 }

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -583,7 +583,7 @@ export function resolveConfigFromPersisted(
   const serviceProxy = resolveServiceProxyConfig(env, persisted);
   const webUi = resolveWebUiConfig(paseoHome, env, cli, persisted);
 
-  const { openai, speech } = resolveSpeechConfig({
+  const { gemini, openai, speech } = resolveSpeechConfig({
     paseoHome,
     env,
     persisted,
@@ -632,6 +632,7 @@ export function resolveConfigFromPersisted(
     appBaseUrl,
     auth: resolveAuthConfig(env, persisted),
     openai,
+    gemini,
     speech,
     voiceLlmProvider: voiceLlm.provider,
     voiceLlmProviderExplicit: voiceLlm.providerExplicit,
@@ -785,7 +786,7 @@ function resolveLogOverrideControlledPaths(env: NodeJS.ProcessEnv): string[] {
 
 function isEnabledSpeechProvider(
   provider: RequestedSpeechProviders[keyof RequestedSpeechProviders],
-  expected: "local" | "openai",
+  expected: "local" | "openai" | "gemini",
 ): boolean {
   return provider.enabled !== false && provider.provider === expected;
 }
@@ -829,6 +830,15 @@ function resolveSpeechOverrideControlledPaths(
   add("PASEO_VOICE_LOCAL_TTS_SPEAKER_ID", "features.voiceMode.tts.speakerId");
   add("PASEO_VOICE_LOCAL_TTS_SPEED", "features.voiceMode.tts.speed");
   add("PASEO_LOCAL_MODELS_DIR", "providers.local.modelsDir");
+  const geminiDictationStt = isEnabledSpeechProvider(providers.dictationStt, "gemini");
+  const geminiVoiceStt = isEnabledSpeechProvider(providers.voiceStt, "gemini");
+  const geminiVoiceTts = isEnabledSpeechProvider(providers.voiceTts, "gemini");
+  if (
+    env.GEMINI_API_KEY !== undefined &&
+    (geminiDictationStt || geminiVoiceStt || geminiVoiceTts)
+  ) {
+    paths.push("providers.gemini.apiKey");
+  }
   const openAiDictationStt = isEnabledSpeechProvider(providers.dictationStt, "openai");
   const openAiVoiceStt = isEnabledSpeechProvider(providers.voiceStt, "openai");
   if (env.STT_CONFIDENCE_THRESHOLD !== undefined && (openAiDictationStt || openAiVoiceStt)) {

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -3,6 +3,12 @@ import path from "node:path";
 import { z } from "zod";
 
 import {
+  SttProviderIdSchema,
+  TtsProviderIdSchema,
+  TurnDetectionProviderIdSchema,
+} from "./speech/speech-types.js";
+
+import {
   AgentProviderRuntimeSettingsMapSchema,
   migrateProviderSettings,
   ProviderOverridesSchema,
@@ -74,10 +80,17 @@ const LocalSpeechProviderSchema = z
   })
   .strict();
 
+const GeminiSpeechProviderSchema = z
+  .object({
+    apiKey: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
 const ProvidersSchema = z
   .object({
     openai: OpenAiProviderSchema.optional(),
     local: LocalSpeechProviderSchema.optional(),
+    gemini: GeminiSpeechProviderSchema.optional(),
   })
   .strict();
 
@@ -98,21 +111,17 @@ const DaemonAuthSchema = z
   })
   .strict();
 
-const SpeechProviderIdSchema = z
-  .string()
-  .trim()
-  .toLowerCase()
-  .pipe(z.enum(["openai", "local"]));
-
+const TranscriptionModeSchema = z.enum(["smart", "verbatim"]);
 const FeatureDictationSchema = z
   .object({
     enabled: z.boolean().optional(),
     stt: z
       .object({
-        provider: SpeechProviderIdSchema.optional(),
+        provider: SttProviderIdSchema.optional(),
         model: z.string().min(1).optional(),
         language: z.string().trim().min(1).optional(),
         confidenceThreshold: z.number().optional(),
+        mode: TranscriptionModeSchema.optional(),
       })
       .strict()
       .optional(),
@@ -131,23 +140,24 @@ const FeatureVoiceModeSchema = z
       .optional(),
     stt: z
       .object({
-        provider: SpeechProviderIdSchema.optional(),
+        provider: SttProviderIdSchema.optional(),
         model: z.string().min(1).optional(),
         language: z.string().trim().min(1).optional(),
+        mode: TranscriptionModeSchema.optional(),
       })
       .strict()
       .optional(),
     turnDetection: z
       .object({
-        provider: SpeechProviderIdSchema.optional(),
+        provider: TurnDetectionProviderIdSchema.optional(),
       })
       .strict()
       .optional(),
     tts: z
       .object({
-        provider: SpeechProviderIdSchema.optional(),
+        provider: TtsProviderIdSchema.optional(),
         model: z.string().min(1).optional(),
-        voice: z.enum(["alloy", "echo", "fable", "onyx", "nova", "shimmer"]).optional(),
+        voice: z.string().trim().min(1).optional(),
         speakerId: z.number().int().optional(),
         speed: z.number().optional(),
       })

--- a/packages/server/src/server/speech/providers/gemini/config.ts
+++ b/packages/server/src/server/speech/providers/gemini/config.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+
+import type { PersistedConfig } from "../../../persisted-config.js";
+import type { RequestedSpeechProvider, RequestedSpeechProviders } from "../../speech-types.js";
+
+export const DEFAULT_GEMINI_TRANSCRIPTION_MODEL = "gemini-3.5-transcribe-live";
+export const DEFAULT_GEMINI_TTS_MODEL = "gemini-3.1-flash-tts-preview";
+export const DEFAULT_GEMINI_TTS_VOICE = "Kore";
+
+const NonEmptyStringSchema = z.string().trim().min(1);
+
+const GeminiSttConfigSchema = z.object({
+  model: NonEmptyStringSchema.default(DEFAULT_GEMINI_TRANSCRIPTION_MODEL),
+  language: NonEmptyStringSchema.optional(),
+  mode: z.enum(["smart", "verbatim"]).default("smart"),
+});
+
+const GeminiTtsConfigSchema = z.object({
+  model: NonEmptyStringSchema.default(DEFAULT_GEMINI_TTS_MODEL),
+  voice: NonEmptyStringSchema.default(DEFAULT_GEMINI_TTS_VOICE),
+});
+
+export type GeminiSttConfig = z.infer<typeof GeminiSttConfigSchema>;
+export type GeminiTtsConfig = z.infer<typeof GeminiTtsConfigSchema>;
+
+export interface GeminiSpeechProviderConfig {
+  apiKey: string;
+  dictationStt: GeminiSttConfig;
+  voiceStt: GeminiSttConfig;
+  tts: GeminiTtsConfig;
+}
+
+function pickIfGemini<T>(provider: RequestedSpeechProvider, value: T | undefined): T | undefined {
+  const isActive = provider.enabled !== false && provider.provider === "gemini";
+  return isActive ? value : undefined;
+}
+
+function firstNonEmpty(values: Array<string | null | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+export function resolveGeminiSpeechConfig(params: {
+  env: NodeJS.ProcessEnv;
+  persisted: PersistedConfig;
+  providers: RequestedSpeechProviders;
+}): GeminiSpeechProviderConfig | undefined {
+  const { env, persisted, providers } = params;
+  const dictationSettings = persisted.features?.dictation?.stt;
+  const voiceModeSettings = persisted.features?.voiceMode;
+  const voiceSttSettings = voiceModeSettings?.stt;
+  const voiceTtsSettings = voiceModeSettings?.tts;
+  const dictationLanguage = firstNonEmpty([
+    env.PASEO_DICTATION_LANGUAGE,
+    dictationSettings?.language,
+  ]);
+  const dictationStt = GeminiSttConfigSchema.parse({
+    model: pickIfGemini(providers.dictationStt, dictationSettings?.model),
+    language: dictationLanguage,
+    mode: pickIfGemini(providers.dictationStt, dictationSettings?.mode),
+  });
+  const voiceStt = GeminiSttConfigSchema.parse({
+    model: pickIfGemini(providers.voiceStt, voiceSttSettings?.model),
+    language: firstNonEmpty([
+      env.PASEO_VOICE_LANGUAGE,
+      pickIfGemini(providers.voiceStt, voiceSttSettings?.language),
+      dictationLanguage,
+    ]),
+    mode: pickIfGemini(providers.voiceStt, voiceSttSettings?.mode),
+  });
+  const tts = GeminiTtsConfigSchema.parse({
+    model: pickIfGemini(providers.voiceTts, voiceTtsSettings?.model),
+    voice: pickIfGemini(providers.voiceTts, voiceTtsSettings?.voice),
+  });
+  const apiKey = firstNonEmpty([persisted.providers?.gemini?.apiKey, env.GEMINI_API_KEY]);
+
+  return apiKey ? { apiKey, dictationStt, voiceStt, tts } : undefined;
+}

--- a/packages/server/src/server/speech/providers/gemini/config.ts
+++ b/packages/server/src/server/speech/providers/gemini/config.ts
@@ -3,14 +3,14 @@ import { z } from "zod";
 import type { PersistedConfig } from "../../../persisted-config.js";
 import type { RequestedSpeechProvider, RequestedSpeechProviders } from "../../speech-types.js";
 
-export const DEFAULT_GEMINI_TRANSCRIPTION_MODEL = "gemini-3.5-transcribe-live";
+export const DEFAULT_GEMINI_STT_MODEL = "gemini-3.5-transcribe-live";
 export const DEFAULT_GEMINI_TTS_MODEL = "gemini-3.1-flash-tts-preview";
 export const DEFAULT_GEMINI_TTS_VOICE = "Kore";
 
 const NonEmptyStringSchema = z.string().trim().min(1);
 
 const GeminiSttConfigSchema = z.object({
-  model: NonEmptyStringSchema.default(DEFAULT_GEMINI_TRANSCRIPTION_MODEL),
+  model: NonEmptyStringSchema.default(DEFAULT_GEMINI_STT_MODEL),
   language: NonEmptyStringSchema.optional(),
   mode: z.enum(["smart", "verbatim"]).default("smart"),
 });

--- a/packages/server/src/server/speech/providers/gemini/runtime.test.ts
+++ b/packages/server/src/server/speech/providers/gemini/runtime.test.ts
@@ -1,0 +1,37 @@
+import pino from "pino";
+import { describe, expect, test } from "vitest";
+
+import { initializeGeminiSpeechServices } from "./runtime.js";
+import { GeminiSTT } from "./stt.js";
+import { GeminiTTS } from "./tts.js";
+
+describe("initializeGeminiSpeechServices", () => {
+  test("initializes Gemini STT independently for voice and dictation", () => {
+    const services = initializeGeminiSpeechServices({
+      providers: {
+        dictationStt: { provider: "gemini", explicit: true },
+        voiceTurnDetection: { provider: "local", explicit: false },
+        voiceStt: { provider: "gemini", explicit: true },
+        voiceTts: { provider: "gemini", explicit: true },
+      },
+      config: {
+        apiKey: "gemini-test-key",
+        dictationStt: { model: "gemini-3.5-transcribe-live", mode: "smart" },
+        voiceStt: { model: "gemini-3.5-transcribe-live", mode: "verbatim" },
+        tts: { model: "gemini-3.1-flash-tts-preview", voice: "Kore" },
+      },
+      existing: {
+        turnDetectionService: null,
+        sttService: null,
+        ttsService: null,
+        dictationSttService: null,
+      },
+      logger: pino({ level: "silent" }),
+    });
+
+    expect(services.sttService).toBeInstanceOf(GeminiSTT);
+    expect(services.dictationSttService).toBeInstanceOf(GeminiSTT);
+    expect(services.sttService).not.toBe(services.dictationSttService);
+    expect(services.ttsService).toBeInstanceOf(GeminiTTS);
+  });
+});

--- a/packages/server/src/server/speech/providers/gemini/runtime.ts
+++ b/packages/server/src/server/speech/providers/gemini/runtime.ts
@@ -1,0 +1,68 @@
+import type { Logger } from "pino";
+
+import type { SpeechServices } from "../../speech-provider.js";
+import type { RequestedSpeechProvider, RequestedSpeechProviders } from "../../speech-types.js";
+import type { GeminiSpeechProviderConfig } from "./config.js";
+import { GeminiSTT } from "./stt.js";
+import { GeminiTTS } from "./tts.js";
+
+function isGeminiEnabled(provider: RequestedSpeechProvider): boolean {
+  return provider.enabled !== false && provider.provider === "gemini";
+}
+
+export function validateGeminiCredentialRequirements(params: {
+  providers: RequestedSpeechProviders;
+  config: GeminiSpeechProviderConfig | undefined;
+  logger: Logger;
+}): void {
+  if (params.config) {
+    return;
+  }
+
+  const requirements = [
+    { feature: "voice.stt", provider: params.providers.voiceStt },
+    { feature: "dictation.stt", provider: params.providers.dictationStt },
+    { feature: "voice.tts", provider: params.providers.voiceTts },
+  ];
+  const missingCredentialsFor = requirements
+    .filter(({ provider }) => isGeminiEnabled(provider))
+    .map(({ feature }) => feature);
+
+  if (missingCredentialsFor.length > 0) {
+    params.logger.warn(
+      { missingCredentialsFor },
+      "Invalid speech configuration: Gemini provider selected but credentials are missing",
+    );
+  }
+}
+
+export function initializeGeminiSpeechServices(params: {
+  providers: RequestedSpeechProviders;
+  config: GeminiSpeechProviderConfig | undefined;
+  existing: SpeechServices;
+  logger: Logger;
+}): SpeechServices {
+  const { providers, config, existing, logger } = params;
+  if (!config) {
+    return existing;
+  }
+
+  return {
+    ...existing,
+    sttService:
+      existing.sttService ??
+      (isGeminiEnabled(providers.voiceStt)
+        ? new GeminiSTT({ apiKey: config.apiKey, config: config.voiceStt, logger })
+        : null),
+    ttsService:
+      existing.ttsService ??
+      (isGeminiEnabled(providers.voiceTts)
+        ? new GeminiTTS({ apiKey: config.apiKey, config: config.tts, logger })
+        : null),
+    dictationSttService:
+      existing.dictationSttService ??
+      (isGeminiEnabled(providers.dictationStt)
+        ? new GeminiSTT({ apiKey: config.apiKey, config: config.dictationStt, logger })
+        : null),
+  };
+}

--- a/packages/server/src/server/speech/providers/gemini/stt.test.ts
+++ b/packages/server/src/server/speech/providers/gemini/stt.test.ts
@@ -1,0 +1,204 @@
+import pino from "pino";
+import { describe, expect, test, vi } from "vitest";
+
+import type { GeminiSttConfig } from "./config.js";
+import type { GeminiLiveTranscriptionApi, GeminiLiveTranscriptionConnection } from "./stt.js";
+import { GeminiSTT } from "./stt.js";
+
+interface FakeLiveApi {
+  api: GeminiLiveTranscriptionApi;
+  activities: string[];
+  audio: Buffer[];
+  configs: GeminiSttConfig[];
+  emitPartial(text: string, language?: string): void;
+  emitFinal(text: string, language?: string): void;
+  emitError(error: Error): void;
+}
+
+function createLiveApi(): FakeLiveApi {
+  const activities: string[] = [];
+  const audio: Buffer[] = [];
+  const configs: GeminiSttConfig[] = [];
+  let emitPartial: FakeLiveApi["emitPartial"] = () => {};
+  let emitFinal: FakeLiveApi["emitFinal"] = () => {};
+  let emitError: FakeLiveApi["emitError"] = () => {};
+
+  const connection: GeminiLiveTranscriptionConnection = {
+    startActivity() {
+      activities.push("start");
+    },
+    sendAudio(pcm16) {
+      audio.push(pcm16);
+    },
+    endActivity() {
+      activities.push("end");
+    },
+    close() {
+      activities.push("close");
+    },
+  };
+  const api: GeminiLiveTranscriptionApi = {
+    async connect(config, callbacks) {
+      configs.push(config);
+      emitPartial = callbacks.onPartial;
+      emitFinal = callbacks.onFinal;
+      emitError = callbacks.onError;
+      return connection;
+    },
+  };
+
+  return {
+    api,
+    activities,
+    audio,
+    configs,
+    emitPartial: (text, language) => emitPartial(text, language),
+    emitFinal: (text, language) => emitFinal(text, language),
+    emitError: (error) => emitError(error),
+  };
+}
+
+function createProvider(live: FakeLiveApi): GeminiSTT {
+  return new GeminiSTT({
+    apiKey: "gemini-test-key",
+    config: { model: "gemini-3.5-transcribe-live", language: "zh-CN", mode: "smart" },
+    logger: pino({ level: "silent" }),
+    api: live.api,
+  });
+}
+
+describe("GeminiSTT", () => {
+  test("streams PCM and maps partial and final transcripts to the committed segment", async () => {
+    const live = createLiveApi();
+    const session = createProvider(live).createSession({ logger: pino({ level: "silent" }) });
+    const committed: Array<{ segmentId: string; previousSegmentId: string | null }> = [];
+    const transcripts: Array<{
+      segmentId: string;
+      transcript: string;
+      isFinal: boolean;
+      language?: string;
+    }> = [];
+    session.on("committed", (event) => committed.push(event));
+    session.on("transcript", (event) => transcripts.push(event));
+
+    await session.connect();
+    session.appendPcm16(Buffer.from([1, 0]));
+    session.appendPcm16(Buffer.from([2, 0]));
+    live.emitPartial("你好", "zh-CN");
+    session.commit();
+    live.emitFinal("你好世界", "zh-CN");
+
+    expect(live.configs).toEqual([
+      {
+        model: "gemini-3.5-transcribe-live",
+        language: "zh-CN",
+        mode: "smart",
+      },
+    ]);
+    expect(live.activities).toEqual(["start", "end"]);
+    expect(live.audio).toEqual([Buffer.from([1, 0]), Buffer.from([2, 0])]);
+    expect(committed).toHaveLength(1);
+    expect(committed[0]?.previousSegmentId).toBeNull();
+    expect(transcripts).toEqual([
+      {
+        segmentId: committed[0]?.segmentId,
+        transcript: "你好",
+        isFinal: false,
+        language: "zh-CN",
+      },
+      {
+        segmentId: committed[0]?.segmentId,
+        transcript: "你好世界",
+        isFinal: true,
+        language: "zh-CN",
+      },
+    ]);
+  });
+
+  test("preserves segment order across consecutive live activities", async () => {
+    const live = createLiveApi();
+    const session = createProvider(live).createSession({ logger: pino({ level: "silent" }) });
+    const committed: Array<{ segmentId: string; previousSegmentId: string | null }> = [];
+    const finals: Array<{ segmentId: string; transcript: string }> = [];
+    session.on("committed", (event) => committed.push(event));
+    session.on("transcript", (event) => {
+      if (event.isFinal) {
+        finals.push({ segmentId: event.segmentId, transcript: event.transcript });
+      }
+    });
+
+    await session.connect();
+    session.appendPcm16(Buffer.from([1, 0]));
+    session.commit();
+    session.appendPcm16(Buffer.from([2, 0]));
+    session.commit();
+    live.emitFinal("first");
+    live.emitFinal("second");
+
+    expect(committed).toHaveLength(2);
+    expect(committed[1]?.previousSegmentId).toBe(committed[0]?.segmentId);
+    expect(finals).toEqual([
+      { segmentId: committed[0]?.segmentId, transcript: "first" },
+      { segmentId: committed[1]?.segmentId, transcript: "second" },
+    ]);
+    expect(live.activities).toEqual(["start", "end", "start", "end"]);
+  });
+
+  test("clears a segment without requiring a silence transcript from Gemini", async () => {
+    const live = createLiveApi();
+    const session = createProvider(live).createSession({ logger: pino({ level: "silent" }) });
+    const committed: string[] = [];
+    const transcripts = vi.fn();
+    session.on("committed", ({ segmentId }) => committed.push(segmentId));
+    session.on("transcript", transcripts);
+
+    await session.connect();
+    session.appendPcm16(Buffer.from([0, 0]));
+    session.clear();
+    session.appendPcm16(Buffer.from([1, 0]));
+    session.commit();
+    live.emitFinal("kept");
+
+    expect(live.activities).toEqual(["start", "end"]);
+    expect(committed).toHaveLength(1);
+    expect(transcripts).toHaveBeenCalledOnce();
+    expect(transcripts.mock.calls[0]?.[0]).toEqual({
+      segmentId: committed[0],
+      transcript: "kept",
+      isFinal: true,
+    });
+  });
+
+  test("hides live provider errors", async () => {
+    const live = createLiveApi();
+    const session = createProvider(live).createSession({ logger: pino({ level: "silent" }) });
+    const error = vi.fn();
+    session.on("error", error);
+
+    await session.connect();
+    live.emitError(new Error("internal websocket response"));
+
+    expect(error).toHaveBeenCalledOnce();
+    expect(error.mock.calls[0]?.[0]).toEqual(new Error("Gemini live transcription failed"));
+  });
+
+  test("hides live connection errors", async () => {
+    const api: GeminiLiveTranscriptionApi = {
+      async connect() {
+        throw new Error("internal handshake response");
+      },
+    };
+    const provider = new GeminiSTT({
+      apiKey: "gemini-test-key",
+      config: { model: "gemini-3.5-transcribe-live", mode: "smart" },
+      logger: pino({ level: "silent" }),
+      api,
+    });
+    const session = provider.createSession({ logger: pino({ level: "silent" }) });
+
+    await expect(session.connect()).rejects.toHaveProperty(
+      "message",
+      "Gemini live transcription connection failed",
+    );
+  });
+});

--- a/packages/server/src/server/speech/providers/gemini/stt.ts
+++ b/packages/server/src/server/speech/providers/gemini/stt.ts
@@ -1,0 +1,282 @@
+import { EventEmitter } from "node:events";
+
+import {
+  AudioTranscriptionConfigMode,
+  GoogleGenAI,
+  Modality,
+  type LiveServerMessage,
+} from "@google/genai";
+import type { Logger } from "pino";
+import { v4 } from "uuid";
+
+import type { SpeechToTextProvider, StreamingTranscriptionSession } from "../../speech-provider.js";
+import type { GeminiSttConfig } from "./config.js";
+
+const PCM_SAMPLE_RATE = 16000;
+const PCM_MIME_TYPE = `audio/pcm;rate=${PCM_SAMPLE_RATE}`;
+
+interface GeminiLiveTranscriptionCallbacks {
+  onPartial(text: string, language?: string): void;
+  onFinal(text: string, language?: string): void;
+  onError(error: unknown): void;
+  onClose(reason: string): void;
+}
+
+export interface GeminiLiveTranscriptionConnection {
+  startActivity(): void;
+  sendAudio(pcm16: Buffer): void;
+  endActivity(): void;
+  close(): void;
+}
+
+export interface GeminiLiveTranscriptionApi {
+  connect(
+    config: GeminiSttConfig,
+    callbacks: GeminiLiveTranscriptionCallbacks,
+  ): Promise<GeminiLiveTranscriptionConnection>;
+}
+
+function transcriptionText(
+  message: LiveServerMessage,
+  kind: "partial" | "final",
+): { text: string; language?: string } | undefined {
+  const transcription =
+    kind === "partial"
+      ? message.serverContent?.interimInputTranscription
+      : message.serverContent?.inputTranscription;
+  if (typeof transcription?.text !== "string") {
+    return undefined;
+  }
+  return {
+    text: transcription.text,
+    ...(transcription.languageCode ? { language: transcription.languageCode } : {}),
+  };
+}
+
+function createGoogleLiveTranscriptionApi(apiKey: string): GeminiLiveTranscriptionApi {
+  const client = new GoogleGenAI({ apiKey });
+
+  return {
+    async connect(config, callbacks) {
+      const session = await client.live.connect({
+        model: config.model,
+        config: {
+          responseModalities: [Modality.TEXT],
+          inputAudioTranscription: {
+            mode:
+              config.mode === "smart"
+                ? AudioTranscriptionConfigMode.SMART
+                : AudioTranscriptionConfigMode.VERBATIM,
+            ...(config.language ? { languageCodes: [config.language] } : {}),
+          },
+          realtimeInputConfig: {
+            automaticActivityDetection: { disabled: true },
+          },
+        },
+        callbacks: {
+          onmessage(message) {
+            const partial = transcriptionText(message, "partial");
+            if (partial) {
+              callbacks.onPartial(partial.text, partial.language);
+            }
+            const final = transcriptionText(message, "final");
+            if (final) {
+              callbacks.onFinal(final.text, final.language);
+            }
+          },
+          onerror(event) {
+            callbacks.onError(event.error ?? new Error(event.message));
+          },
+          onclose(event) {
+            callbacks.onClose(event.reason);
+          },
+        },
+      });
+
+      return {
+        startActivity() {
+          session.sendRealtimeInput({ activityStart: {} });
+        },
+        sendAudio(pcm16) {
+          session.sendRealtimeInput({
+            audio: { data: pcm16.toString("base64"), mimeType: PCM_MIME_TYPE },
+          });
+        },
+        endActivity() {
+          session.sendRealtimeInput({ activityEnd: {} });
+        },
+        close() {
+          session.close();
+        },
+      };
+    },
+  };
+}
+
+export class GeminiSTT implements SpeechToTextProvider {
+  public readonly id = "gemini" as const;
+  private readonly config: GeminiSttConfig;
+  private readonly api: GeminiLiveTranscriptionApi;
+
+  constructor(params: {
+    apiKey: string;
+    config: GeminiSttConfig;
+    logger: Logger;
+    api?: GeminiLiveTranscriptionApi;
+  }) {
+    this.config = params.config;
+    this.api = params.api ?? createGoogleLiveTranscriptionApi(params.apiKey);
+    params.logger
+      .child({ provider: "gemini", component: "stt" })
+      .info(
+        { model: params.config.model, mode: params.config.mode },
+        "Gemini Live STT initialized",
+      );
+  }
+
+  public createSession(params: {
+    logger: Logger;
+    language?: string;
+    prompt?: string;
+  }): StreamingTranscriptionSession {
+    const emitter = new EventEmitter();
+    const logger = params.logger.child({ provider: "gemini", component: "stt-session" });
+    const api = this.api;
+    const config = this.config;
+    const pendingSegmentIds: string[] = [];
+    let connection: GeminiLiveTranscriptionConnection | null = null;
+    let connected = false;
+    let closing = false;
+    let terminalErrorEmitted = false;
+    let hasAudio = false;
+    let currentSegmentId = v4();
+    let previousSegmentId: string | null = null;
+
+    function fail(error: unknown, message: string): void {
+      if (closing || terminalErrorEmitted) {
+        return;
+      }
+      terminalErrorEmitted = true;
+      logger.error({ err: error }, message);
+      emitter.emit("error", new Error("Gemini live transcription failed"));
+    }
+
+    function activeSegmentId(): string | undefined {
+      return pendingSegmentIds[0] ?? (hasAudio ? currentSegmentId : undefined);
+    }
+
+    function finishCurrentSegment(): void {
+      const segmentId = currentSegmentId;
+      const committedAfter = previousSegmentId;
+      currentSegmentId = v4();
+      previousSegmentId = segmentId;
+      emitter.emit("committed", { segmentId, previousSegmentId: committedAfter });
+
+      if (!hasAudio) {
+        emitter.emit("transcript", { segmentId, transcript: "", isFinal: true });
+        return;
+      }
+
+      pendingSegmentIds.push(segmentId);
+      hasAudio = false;
+      connection?.endActivity();
+    }
+
+    return {
+      requiredSampleRate: PCM_SAMPLE_RATE,
+      async connect() {
+        if (connected) {
+          return;
+        }
+        closing = false;
+        terminalErrorEmitted = false;
+        try {
+          connection = await api.connect(config, {
+            onPartial(text, language) {
+              const segmentId = activeSegmentId();
+              if (segmentId) {
+                emitter.emit("transcript", {
+                  segmentId,
+                  transcript: text,
+                  isFinal: false,
+                  ...(language ? { language } : {}),
+                });
+              }
+            },
+            onFinal(text, language) {
+              const segmentId = pendingSegmentIds.shift();
+              if (segmentId) {
+                emitter.emit("transcript", {
+                  segmentId,
+                  transcript: text,
+                  isFinal: true,
+                  ...(language ? { language } : {}),
+                });
+              }
+            },
+            onError(error) {
+              fail(error, "Gemini Live transcription connection failed");
+            },
+            onClose(reason) {
+              connected = false;
+              connection = null;
+              if (!closing) {
+                fail(new Error(reason || "Connection closed"), "Gemini Live transcription closed");
+              }
+            },
+          });
+          connected = true;
+        } catch (error) {
+          logger.error({ err: error }, "Failed to connect Gemini Live transcription");
+          throw new Error("Gemini live transcription connection failed", { cause: error });
+        }
+      },
+      appendPcm16(pcm16) {
+        if (!connected || !connection) {
+          emitter.emit("error", new Error("Gemini STT session not connected"));
+          return;
+        }
+        try {
+          if (!hasAudio) {
+            connection.startActivity();
+            hasAudio = true;
+          }
+          connection.sendAudio(pcm16);
+        } catch (error) {
+          fail(error, "Failed to send audio to Gemini Live transcription");
+        }
+      },
+      commit() {
+        if (!connected || !connection) {
+          emitter.emit("error", new Error("Gemini STT session not connected"));
+          return;
+        }
+        try {
+          finishCurrentSegment();
+        } catch (error) {
+          fail(error, "Failed to commit Gemini Live transcription segment");
+        }
+      },
+      clear() {
+        if (!connected) {
+          return;
+        }
+        // Streamed audio cannot be retracted. Keep the activity open so a silence tail
+        // that produces no final transcript cannot desynchronize later segments.
+        currentSegmentId = v4();
+      },
+      close() {
+        closing = true;
+        connected = false;
+        hasAudio = false;
+        pendingSegmentIds.length = 0;
+        connection?.close();
+        connection = null;
+      },
+      on(event: string, handler: (...args: never[]) => void) {
+        emitter.on(event, handler as (...args: unknown[]) => void);
+        return undefined;
+      },
+    };
+  }
+}

--- a/packages/server/src/server/speech/providers/gemini/tts.test.ts
+++ b/packages/server/src/server/speech/providers/gemini/tts.test.ts
@@ -1,0 +1,64 @@
+import type { Readable } from "node:stream";
+
+import pino from "pino";
+import { describe, expect, test } from "vitest";
+
+import type { GeminiSpeechSynthesisApi, GeminiTtsRequest } from "./tts.js";
+import { GeminiTTS } from "./tts.js";
+
+async function readStream(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+describe("GeminiTTS", () => {
+  test("returns 24 kHz PCM speech with the configured model and voice", async () => {
+    const requests: GeminiTtsRequest[] = [];
+    const api: GeminiSpeechSynthesisApi = {
+      async synthesize(request) {
+        requests.push(request);
+        return { pcm16: Buffer.from([1, 0, 2, 0]), sampleRate: 24000 };
+      },
+    };
+    const provider = new GeminiTTS({
+      apiKey: "gemini-test-key",
+      config: { model: "gemini-3.1-flash-tts-preview", voice: "Kore" },
+      logger: pino({ level: "silent" }),
+      api,
+    });
+
+    const speech = await provider.synthesizeSpeech("  Hello from Paseo.  ");
+
+    expect(requests).toEqual([
+      {
+        model: "gemini-3.1-flash-tts-preview",
+        voice: "Kore",
+        text: "Hello from Paseo.",
+      },
+    ]);
+    expect(speech.format).toBe("pcm;rate=24000");
+    await expect(readStream(speech.stream)).resolves.toEqual(Buffer.from([1, 0, 2, 0]));
+  });
+
+  test("hides provider errors", async () => {
+    const api: GeminiSpeechSynthesisApi = {
+      async synthesize() {
+        throw new Error("internal API response");
+      },
+    };
+    const provider = new GeminiTTS({
+      apiKey: "gemini-test-key",
+      config: { model: "gemini-3.1-flash-tts-preview", voice: "Kore" },
+      logger: pino({ level: "silent" }),
+      api,
+    });
+
+    await expect(provider.synthesizeSpeech("Hello")).rejects.toHaveProperty(
+      "message",
+      "Gemini TTS synthesis failed",
+    );
+  });
+});

--- a/packages/server/src/server/speech/providers/gemini/tts.ts
+++ b/packages/server/src/server/speech/providers/gemini/tts.ts
@@ -1,0 +1,106 @@
+import { Readable } from "node:stream";
+
+import { GoogleGenAI } from "@google/genai";
+import type { Logger } from "pino";
+import { z } from "zod";
+
+import type { SpeechStreamResult, TextToSpeechProvider } from "../../speech-provider.js";
+import type { GeminiTtsConfig } from "./config.js";
+
+const PCM_MIME_TYPE = "audio/l16";
+const PCM_SAMPLE_RATE = 24000;
+
+const AudioInteractionSchema = z.object({
+  output_audio: z.object({
+    type: z.literal("audio"),
+    data: z.base64(),
+    mime_type: z.string().optional(),
+    sample_rate: z.number().int().positive().optional(),
+    channels: z.number().int().positive().optional(),
+  }),
+});
+
+export interface GeminiTtsRequest extends GeminiTtsConfig {
+  text: string;
+}
+
+export interface GeminiSpeechSynthesisApi {
+  synthesize(request: GeminiTtsRequest): Promise<{ pcm16: Buffer; sampleRate: number }>;
+}
+
+function createGoogleSpeechSynthesisApi(apiKey: string): GeminiSpeechSynthesisApi {
+  const client = new GoogleGenAI({ apiKey });
+
+  return {
+    async synthesize(request) {
+      const interaction = await client.interactions.create({
+        model: request.model,
+        input: `Synthesize speech from the transcript below. Read only the transcript.\n\nTranscript:\n${request.text}`,
+        store: false,
+        response_format: {
+          type: "audio",
+        },
+        generation_config: {
+          speech_config: [{ voice: request.voice }],
+        },
+      });
+      const audio = AudioInteractionSchema.parse(interaction).output_audio;
+      const mimeType = audio.mime_type?.split(";", 1)[0]?.trim().toLowerCase();
+      if (mimeType && mimeType !== PCM_MIME_TYPE) {
+        throw new Error(`Unexpected Gemini TTS audio format: ${audio.mime_type}`);
+      }
+      if (audio.channels !== undefined && audio.channels !== 1) {
+        throw new Error(`Unexpected Gemini TTS channel count: ${audio.channels}`);
+      }
+
+      const pcm16 = Buffer.from(audio.data, "base64");
+      if (pcm16.length === 0 || pcm16.length % 2 !== 0) {
+        throw new Error(`Unexpected Gemini TTS PCM byte length: ${pcm16.length}`);
+      }
+      return {
+        pcm16,
+        sampleRate: audio.sample_rate ?? PCM_SAMPLE_RATE,
+      };
+    },
+  };
+}
+
+export class GeminiTTS implements TextToSpeechProvider {
+  private readonly config: GeminiTtsConfig;
+  private readonly api: GeminiSpeechSynthesisApi;
+  private readonly logger: Logger;
+
+  constructor(params: {
+    apiKey: string;
+    config: GeminiTtsConfig;
+    logger: Logger;
+    api?: GeminiSpeechSynthesisApi;
+  }) {
+    this.config = params.config;
+    this.api = params.api ?? createGoogleSpeechSynthesisApi(params.apiKey);
+    this.logger = params.logger.child({ provider: "gemini", component: "tts" });
+    this.logger.info(params.config, "Gemini TTS initialized");
+  }
+
+  public async synthesizeSpeech(text: string): Promise<SpeechStreamResult> {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      throw new Error("Cannot synthesize empty text");
+    }
+
+    try {
+      const speech = await this.api.synthesize({
+        model: this.config.model,
+        voice: this.config.voice,
+        text: trimmed,
+      });
+      return {
+        stream: Readable.from([speech.pcm16]),
+        format: `pcm;rate=${speech.sampleRate}`,
+      };
+    } catch (error) {
+      this.logger.error({ err: error }, "Gemini TTS synthesis failed");
+      throw new Error("Gemini TTS synthesis failed", { cause: error });
+    }
+  }
+}

--- a/packages/server/src/server/speech/providers/local/runtime.ts
+++ b/packages/server/src/server/speech/providers/local/runtime.ts
@@ -36,7 +36,6 @@ export interface InitializedLocalSpeech {
   sttService: SpeechToTextProvider | null;
   ttsService: TextToSpeechProvider | null;
   dictationSttService: SpeechToTextProvider | null;
-  localVoiceTtsProvider: TextToSpeechProvider | null;
   localModelConfig: {
     modelsDir: string;
     defaultModelIds: LocalSpeechModelId[];
@@ -147,7 +146,6 @@ export async function initializeLocalSpeechServices(params: {
   let ttsService: TextToSpeechProvider | null = null;
   let dictationSttService: SpeechToTextProvider | null = null;
   let turnDetectionService: TurnDetectionProvider | null = null;
-  let localVoiceTtsProvider: TextToSpeechProvider | null = null;
 
   const requiredLocalModelIds = computeRequiredLocalModelIds({
     providers,
@@ -194,12 +192,9 @@ export async function initializeLocalSpeechServices(params: {
 
   if (isLocalProviderEnabled(providers.voiceTts)) {
     if (workerClient) {
-      localVoiceTtsProvider = initializeLocalVoiceTts({ client: workerClient });
+      ttsService = initializeLocalVoiceTts({ client: workerClient });
     } else {
       warnLocalConfigMissing(logger, "voice TTS");
-    }
-    if (localVoiceTtsProvider) {
-      ttsService = localVoiceTtsProvider;
     }
   }
 
@@ -212,7 +207,6 @@ export async function initializeLocalSpeechServices(params: {
     sttService,
     ttsService,
     dictationSttService,
-    localVoiceTtsProvider,
     localModelConfig: localConfig
       ? {
           modelsDir: localConfig.modelsDir,

--- a/packages/server/src/server/speech/providers/openai/runtime.ts
+++ b/packages/server/src/server/speech/providers/openai/runtime.ts
@@ -1,8 +1,11 @@
 import type { Logger } from "pino";
 
-import type { SpeechToTextProvider, TextToSpeechProvider } from "../../speech-provider.js";
+import type {
+  SpeechServices,
+  SpeechToTextProvider,
+  TextToSpeechProvider,
+} from "../../speech-provider.js";
 import type { RequestedSpeechProviders } from "../../speech-types.js";
-import type { TurnDetectionProvider } from "../../turn-detection-provider.js";
 import { DEFAULT_OPENAI_TTS_MODEL, type OpenAiSpeechProviderConfig } from "./config.js";
 import { OpenAISTT } from "./stt.js";
 import { OpenAITTS } from "./tts.js";
@@ -17,13 +20,6 @@ export interface OpenAiSpeechAvailability {
   stt: boolean;
   tts: boolean;
   dictationStt: boolean;
-}
-
-export interface SpeechServices {
-  turnDetectionService: TurnDetectionProvider | null;
-  sttService: SpeechToTextProvider | null;
-  ttsService: TextToSpeechProvider | null;
-  dictationSttService: SpeechToTextProvider | null;
 }
 
 function resolveOpenAiCredentials(

--- a/packages/server/src/server/speech/speech-config-resolver.test.ts
+++ b/packages/server/src/server/speech/speech-config-resolver.test.ts
@@ -18,6 +18,7 @@ describe("resolveSpeechConfig", () => {
     });
 
     expect(result.openai).toBeUndefined();
+    expect(result.gemini).toBeUndefined();
     expect(result.speech.providers.dictationStt).toEqual({
       provider: "local",
       explicit: false,
@@ -55,6 +56,136 @@ describe("resolveSpeechConfig", () => {
       dictation: "en",
       voice: "en",
     });
+  });
+
+  test("resolves Gemini transcription settings without forcing a default language", () => {
+    const persisted = PersistedConfigSchema.parse({
+      providers: {
+        gemini: { apiKey: "persisted-gemini-key" },
+      },
+      features: {
+        dictation: {
+          stt: {
+            provider: "gemini",
+            model: "gemini-3.5-transcribe-live",
+            language: "zh-CN",
+            mode: "smart",
+          },
+        },
+        voiceMode: {
+          stt: {
+            provider: "gemini",
+            mode: "verbatim",
+          },
+          tts: {
+            provider: "gemini",
+            model: "gemini-2.5-flash-preview-tts",
+            voice: "Aoede",
+          },
+        },
+      },
+    });
+
+    const result = resolveSpeechConfig({
+      paseoHome: "/tmp/paseo-home",
+      env: {} as NodeJS.ProcessEnv,
+      persisted,
+    });
+
+    expect(result.gemini).toEqual({
+      apiKey: "persisted-gemini-key",
+      dictationStt: {
+        model: "gemini-3.5-transcribe-live",
+        language: "zh-CN",
+        mode: "smart",
+      },
+      voiceStt: {
+        model: "gemini-3.5-transcribe-live",
+        language: "zh-CN",
+        mode: "verbatim",
+      },
+      tts: {
+        model: "gemini-2.5-flash-preview-tts",
+        voice: "Aoede",
+      },
+    });
+    expect(result.speech.providers.dictationStt.provider).toBe("gemini");
+    expect(result.speech.providers.voiceStt.provider).toBe("gemini");
+    expect(result.speech.providers.voiceTts.provider).toBe("gemini");
+  });
+
+  test("uses Gemini automatic language detection when no language is configured", () => {
+    const persisted = PersistedConfigSchema.parse({
+      features: {
+        dictation: { stt: { provider: "gemini" } },
+      },
+    });
+
+    const result = resolveSpeechConfig({
+      paseoHome: "/tmp/paseo-home",
+      env: { GEMINI_API_KEY: "env-gemini-key" } as NodeJS.ProcessEnv,
+      persisted,
+    });
+
+    expect(result.gemini?.dictationStt).toEqual({
+      model: "gemini-3.5-transcribe-live",
+      mode: "smart",
+    });
+  });
+
+  test("inherits the dictation language when only voice STT uses Gemini", () => {
+    const persisted = PersistedConfigSchema.parse({
+      providers: {
+        gemini: { apiKey: "persisted-gemini-key" },
+      },
+      features: {
+        dictation: {
+          stt: { provider: "openai", language: "zh-CN" },
+        },
+        voiceMode: {
+          stt: { provider: "gemini" },
+        },
+      },
+    });
+
+    const result = resolveSpeechConfig({
+      paseoHome: "/tmp/paseo-home",
+      env: {},
+      persisted,
+    });
+
+    expect(result.gemini?.voiceStt.language).toBe("zh-CN");
+  });
+
+  test("rejects Gemini turn detection", () => {
+    expect(() =>
+      resolveSpeechConfig({
+        paseoHome: "/tmp/paseo-home",
+        env: { PASEO_VOICE_TURN_DETECTION_PROVIDER: "gemini" },
+        persisted: PersistedConfigSchema.parse({}),
+      }),
+    ).toThrow();
+  });
+
+  test("passes configured Gemini model IDs and voices through", () => {
+    const persisted = PersistedConfigSchema.parse({
+      providers: { gemini: { apiKey: "persisted-gemini-key" } },
+      features: {
+        dictation: { stt: { provider: "gemini", model: "future-transcribe-model" } },
+        voiceMode: {
+          tts: {
+            provider: "gemini",
+            model: "future-tts-model",
+            voice: "FutureVoice",
+          },
+        },
+      },
+    });
+
+    const result = resolveSpeechConfig({ paseoHome: "/tmp/paseo-home", env: {}, persisted });
+
+    expect(result.gemini?.dictationStt.model).toBe("future-transcribe-model");
+    expect(result.gemini?.tts).toEqual({ model: "future-tts-model", voice: "FutureVoice" });
   });
 
   test("resolves feature-scoped local speech settings", () => {

--- a/packages/server/src/server/speech/speech-config-resolver.ts
+++ b/packages/server/src/server/speech/speech-config-resolver.ts
@@ -2,20 +2,20 @@ import { z } from "zod";
 
 import type { PersistedConfig } from "../persisted-config.js";
 import type { PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
+import {
+  type GeminiSpeechProviderConfig,
+  resolveGeminiSpeechConfig,
+} from "./providers/gemini/config.js";
 import { resolveLocalSpeechConfig } from "./providers/local/config.js";
 import { resolveOpenAiSpeechConfig } from "./providers/openai/config.js";
 import {
-  SpeechProviderIdSchema,
+  SttProviderIdSchema,
+  TtsProviderIdSchema,
+  TurnDetectionProviderIdSchema,
+  type SpeechProviderId,
   type RequestedSpeechProvider,
   type RequestedSpeechProviders,
 } from "./speech-types.js";
-
-const OptionalSpeechProviderSchema = z
-  .string()
-  .trim()
-  .toLowerCase()
-  .pipe(SpeechProviderIdSchema)
-  .optional();
 
 const OptionalBooleanFlagSchema = z
   .union([z.boolean(), z.string().trim().toLowerCase()])
@@ -37,10 +37,10 @@ const OptionalBooleanFlagSchema = z
   });
 
 const RequestedSpeechProvidersSchema = z.object({
-  dictationStt: OptionalSpeechProviderSchema.default("local"),
-  voiceTurnDetection: OptionalSpeechProviderSchema.default("local"),
-  voiceStt: OptionalSpeechProviderSchema.default("local"),
-  voiceTts: OptionalSpeechProviderSchema.default("local"),
+  dictationStt: SttProviderIdSchema.optional().default("local"),
+  voiceTurnDetection: TurnDetectionProviderIdSchema.optional().default("local"),
+  voiceStt: SttProviderIdSchema.optional().default("local"),
+  voiceTts: TtsProviderIdSchema.optional().default("local"),
 });
 
 function resolveOptionalBooleanFlag(value: unknown): boolean {
@@ -108,10 +108,10 @@ function buildFeatureProviderInputs(params: {
   };
 }
 
-function buildRequestedFeatureProvider(
+function buildRequestedFeatureProvider<TProvider extends SpeechProviderId>(
   inputs: FeatureProviderInputs,
-  parsedValue: z.infer<typeof SpeechProviderIdSchema>,
-): RequestedSpeechProvider {
+  parsedValue: TProvider,
+): RequestedSpeechProvider<TProvider> {
   return {
     provider: parsedValue,
     explicit: inputs.configuredValue !== undefined,
@@ -148,6 +148,7 @@ export function resolveSpeechConfig(params: {
   env: NodeJS.ProcessEnv;
   persisted: PersistedConfig;
 }): {
+  gemini: GeminiSpeechProviderConfig | undefined;
   openai: PaseoOpenAIConfig | undefined;
   speech: PaseoSpeechConfig;
 } {
@@ -169,7 +170,14 @@ export function resolveSpeechConfig(params: {
     providers,
   });
 
+  const gemini = resolveGeminiSpeechConfig({
+    env: params.env,
+    persisted: params.persisted,
+    providers,
+  });
+
   return {
+    gemini,
     openai,
     speech: {
       providers,

--- a/packages/server/src/server/speech/speech-provider.ts
+++ b/packages/server/src/server/speech/speech-provider.ts
@@ -1,5 +1,6 @@
 import type pino from "pino";
 import type { Readable } from "node:stream";
+import type { TurnDetectionProvider } from "./turn-detection-provider.js";
 
 export interface LogprobToken {
   token: string;
@@ -65,4 +66,11 @@ export interface SpeechStreamResult {
 
 export interface TextToSpeechProvider {
   synthesizeSpeech(text: string): Promise<SpeechStreamResult>;
+}
+
+export interface SpeechServices {
+  turnDetectionService: TurnDetectionProvider | null;
+  sttService: SpeechToTextProvider | null;
+  ttsService: TextToSpeechProvider | null;
+  dictationSttService: SpeechToTextProvider | null;
 }

--- a/packages/server/src/server/speech/speech-runtime.test.ts
+++ b/packages/server/src/server/speech/speech-runtime.test.ts
@@ -98,7 +98,6 @@ describe("createSpeechService readiness", () => {
       sttService: null,
       ttsService: null,
       dictationSttService: dictationStt,
-      localVoiceTtsProvider: null,
       localModelConfig: null,
       availability: {
         configured: false,
@@ -138,7 +137,6 @@ describe("createSpeechService readiness", () => {
       sttService: voiceStt,
       ttsService: voiceTts,
       dictationSttService: null,
-      localVoiceTtsProvider: voiceTts,
       localModelConfig: null,
       availability: {
         configured: false,
@@ -179,7 +177,6 @@ describe("createSpeechService readiness", () => {
       sttService: null,
       ttsService: null,
       dictationSttService: null,
-      localVoiceTtsProvider: null,
       localModelConfig: {
         modelsDir: "/tmp/missing-local-speech-models",
         defaultModelIds: ["parakeet-tdt-0.6b-v2-int8"],

--- a/packages/server/src/server/speech/speech-runtime.ts
+++ b/packages/server/src/server/speech/speech-runtime.ts
@@ -3,6 +3,11 @@ import { join } from "node:path";
 import type { Logger } from "pino";
 
 import type { PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
+import type { GeminiSpeechProviderConfig } from "./providers/gemini/config.js";
+import {
+  initializeGeminiSpeechServices,
+  validateGeminiCredentialRequirements,
+} from "./providers/gemini/runtime.js";
 import type { LocalSpeechModelId } from "./providers/local/config.js";
 import {
   ensureLocalSpeechModels,
@@ -311,21 +316,12 @@ function describeRequestedProviders(providers: RequestedSpeechProviders): {
   };
 }
 
-function resolveVoiceTtsLabel(
-  ttsService: TextToSpeechProvider | null,
-  localVoiceTtsProvider: TextToSpeechProvider | null,
-): "unavailable" | "local" | "openai" {
-  if (!ttsService) return "unavailable";
-  if (ttsService === localVoiceTtsProvider) return "local";
-  return "openai";
-}
-
 function resolveEffectiveProviderIds(params: {
+  providers: RequestedSpeechProviders;
   turnDetectionService: TurnDetectionProvider | null;
   sttService: SpeechToTextProvider | null;
   ttsService: TextToSpeechProvider | null;
   dictationSttService: SpeechToTextProvider | null;
-  localVoiceTtsProvider: TextToSpeechProvider | null;
 }): {
   dictationStt: string;
   voiceTurnDetection: string;
@@ -336,7 +332,7 @@ function resolveEffectiveProviderIds(params: {
     dictationStt: params.dictationSttService?.id ?? "unavailable",
     voiceTurnDetection: params.turnDetectionService?.id ?? "unavailable",
     voiceStt: params.sttService?.id ?? "unavailable",
-    voiceTts: resolveVoiceTtsLabel(params.ttsService, params.localVoiceTtsProvider),
+    voiceTts: params.ttsService ? params.providers.voiceTts.provider : "unavailable",
   };
 }
 
@@ -356,11 +352,13 @@ export interface SpeechService {
 
 export function createSpeechService(params: {
   logger: Logger;
+  geminiConfig?: GeminiSpeechProviderConfig;
   openaiConfig?: PaseoOpenAIConfig;
   speechConfig?: PaseoSpeechConfig;
 }): SpeechService {
   const logger = params.logger.child({ module: "speech-runtime" });
   const speechConfig = params.speechConfig ?? null;
+  const geminiConfig = params.geminiConfig;
   const openaiConfig = params.openaiConfig;
   const providers = resolveRequestedSpeechProviders(speechConfig);
   const requestedProviders = describeRequestedProviders(providers);
@@ -370,11 +368,17 @@ export function createSpeechService(params: {
     openaiConfig,
     logger,
   });
+  validateGeminiCredentialRequirements({
+    providers,
+    config: geminiConfig,
+    logger,
+  });
 
   logger.info(
     {
       requestedProviders,
       availability: {
+        gemini: { configured: geminiConfig !== undefined },
         openai: getOpenAiSpeechAvailability(openaiConfig),
       },
     },
@@ -390,7 +394,6 @@ export function createSpeechService(params: {
     defaultModelIds: LocalSpeechModelId[];
   } | null = null;
   let localCleanup = () => {};
-  let localVoiceTtsProvider: TextToSpeechProvider | null = null;
 
   let missingLocalModelIds: LocalSpeechModelId[] = [];
   let backgroundDownloadInProgress = false;
@@ -516,25 +519,30 @@ export function createSpeechService(params: {
       },
       logger,
     });
+    const nextGeminiSpeech = initializeGeminiSpeechServices({
+      providers,
+      config: geminiConfig,
+      existing: nextOpenAiSpeech,
+      logger,
+    });
 
     const previousLocalCleanup = localCleanup;
-    turnDetectionService = nextOpenAiSpeech.turnDetectionService;
-    sttService = nextOpenAiSpeech.sttService;
-    ttsService = nextOpenAiSpeech.ttsService;
-    dictationSttService = nextOpenAiSpeech.dictationSttService;
+    turnDetectionService = nextGeminiSpeech.turnDetectionService;
+    sttService = nextGeminiSpeech.sttService;
+    ttsService = nextGeminiSpeech.ttsService;
+    dictationSttService = nextGeminiSpeech.dictationSttService;
     localModelConfig = nextLocalSpeech.localModelConfig;
-    localVoiceTtsProvider = nextLocalSpeech.localVoiceTtsProvider;
     localCleanup = nextLocalSpeech.cleanup;
     previousLocalCleanup();
 
     await refreshMissingLocalModels();
 
     const effectiveProviders = resolveEffectiveProviderIds({
+      providers,
       turnDetectionService,
       sttService,
       ttsService,
       dictationSttService,
-      localVoiceTtsProvider,
     });
     const unavailableFeatures = [
       providers.dictationStt.enabled !== false && !dictationSttService ? "dictation.stt" : null,

--- a/packages/server/src/server/speech/speech-types.ts
+++ b/packages/server/src/server/speech/speech-types.ts
@@ -1,18 +1,33 @@
 import { z } from "zod";
 
-export const SpeechProviderIdSchema = z.enum(["openai", "local"]);
-export type SpeechProviderId = z.infer<typeof SpeechProviderIdSchema>;
+const NormalizedProviderIdSchema = z.string().trim().toLowerCase();
 
-export const RequestedSpeechProviderSchema = z.object({
-  provider: SpeechProviderIdSchema,
-  explicit: z.boolean(),
-  enabled: z.boolean().optional(),
-});
-export type RequestedSpeechProvider = z.infer<typeof RequestedSpeechProviderSchema>;
+export const SttProviderIdSchema = NormalizedProviderIdSchema.pipe(
+  z.enum(["openai", "local", "gemini"]),
+);
+export type SttProviderId = z.infer<typeof SttProviderIdSchema>;
+
+export const TurnDetectionProviderIdSchema = NormalizedProviderIdSchema.pipe(
+  z.enum(["openai", "local"]),
+);
+export type TurnDetectionProviderId = z.infer<typeof TurnDetectionProviderIdSchema>;
+
+export const TtsProviderIdSchema = NormalizedProviderIdSchema.pipe(
+  z.enum(["openai", "local", "gemini"]),
+);
+export type TtsProviderId = z.infer<typeof TtsProviderIdSchema>;
+
+export type SpeechProviderId = SttProviderId | TurnDetectionProviderId | TtsProviderId;
+
+export interface RequestedSpeechProvider<TProvider extends SpeechProviderId = SpeechProviderId> {
+  provider: TProvider;
+  explicit: boolean;
+  enabled?: boolean;
+}
 
 export interface RequestedSpeechProviders {
-  dictationStt: RequestedSpeechProvider;
-  voiceTurnDetection: RequestedSpeechProvider;
-  voiceStt: RequestedSpeechProvider;
-  voiceTts: RequestedSpeechProvider;
+  dictationStt: RequestedSpeechProvider<SttProviderId>;
+  voiceTurnDetection: RequestedSpeechProvider<TurnDetectionProviderId>;
+  voiceStt: RequestedSpeechProvider<SttProviderId>;
+  voiceTts: RequestedSpeechProvider<TtsProviderId>;
 }

--- a/packages/website/public/schemas/paseo.config.v1.json
+++ b/packages/website/public/schemas/paseo.config.v1.json
@@ -233,6 +233,16 @@
                 }
               },
               "additionalProperties": false
+            },
+            "gemini": {
+              "type": "object",
+              "properties": {
+                "apiKey": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -363,7 +373,7 @@
                         },
                         {
                           "type": "string",
-                          "enum": ["openai", "local"]
+                          "enum": ["openai", "local", "gemini"]
                         }
                       ]
                     },
@@ -377,6 +387,10 @@
                     },
                     "confidenceThreshold": {
                       "type": "number"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "enum": ["smart", "verbatim"]
                     }
                   },
                   "additionalProperties": false
@@ -416,6 +430,9 @@
                     "language": {
                       "type": "string",
                       "minLength": 1
+                    },
+                    "mode": {
+                      "$ref": "#/definitions/PaseoConfigV1/properties/features/properties/dictation/properties/stt/properties/mode"
                     }
                   },
                   "additionalProperties": false
@@ -424,7 +441,15 @@
                   "type": "object",
                   "properties": {
                     "provider": {
-                      "$ref": "#/definitions/PaseoConfigV1/properties/features/properties/dictation/properties/stt/properties/provider"
+                      "allOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["openai", "local"]
+                        }
+                      ]
                     }
                   },
                   "additionalProperties": false
@@ -433,7 +458,15 @@
                   "type": "object",
                   "properties": {
                     "provider": {
-                      "$ref": "#/definitions/PaseoConfigV1/properties/features/properties/dictation/properties/stt/properties/provider"
+                      "allOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["openai", "local", "gemini"]
+                        }
+                      ]
                     },
                     "model": {
                       "type": "string",
@@ -441,7 +474,7 @@
                     },
                     "voice": {
                       "type": "string",
-                      "enum": ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
+                      "minLength": 1
                     },
                     "speakerId": {
                       "type": "integer"

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -247,8 +247,9 @@ Set the persisted value in `config.json`:
 - `OPENAI_API_KEY`, override OpenAI provider key
 - `OPENAI_STT_API_KEY`, `OPENAI_STT_BASE_URL`, OpenAI speech-to-text endpoint (dictation + voice mode STT)
 - `OPENAI_TTS_API_KEY`, `OPENAI_TTS_BASE_URL`, OpenAI text-to-speech endpoint (voice mode TTS)
+- `GEMINI_API_KEY`, Gemini speech-to-text and text-to-speech credential
 - `PASEO_VOICE_LLM_PROVIDER`, override voice LLM provider (`claude`, `codex`, `opencode`)
-- `PASEO_DICTATION_STT_PROVIDER`, `PASEO_VOICE_STT_PROVIDER`, `PASEO_VOICE_TTS_PROVIDER`, override voice provider selection (`local` or `openai`)
+- `PASEO_DICTATION_STT_PROVIDER`, `PASEO_VOICE_STT_PROVIDER`, `PASEO_VOICE_TTS_PROVIDER`, override voice provider selection (`local`, `openai`, or `gemini`)
 - `PASEO_LOCAL_MODELS_DIR`, control local model directory
 - `PASEO_DICTATION_LOCAL_STT_MODEL`, override local dictation STT model
 - `PASEO_VOICE_LOCAL_STT_MODEL`, `PASEO_VOICE_LOCAL_TTS_MODEL`, override local voice STT/TTS models

--- a/public-docs/voice.md
+++ b/public-docs/voice.md
@@ -12,13 +12,13 @@ Paseo has first-class voice support for dictation and voice mode conversations w
 
 ## Philosophy
 
-Voice is local-first. You can run speech fully on-device, or choose OpenAI for speech features. For voice reasoning/orchestration, Paseo reuses agent providers already installed and authenticated on your machine.
+Voice is local-first. You can run speech fully on-device, or choose OpenAI or Gemini for cloud speech. For voice reasoning/orchestration, Paseo reuses agent providers already installed and authenticated on your machine.
 
 This keeps credentials and execution in your environment and avoids introducing a separate cloud-only voice stack.
 
 ## Architecture
 
-- Speech I/O: STT and TTS providers per feature (`local` or `openai`)
+- Speech I/O: STT providers per feature and voice TTS providers (`local`, `openai`, or `gemini`)
 - Local speech runtime: ONNX models executed on CPU by default
 - Voice LLM orchestration: hidden agent session using your configured provider (`claude`, `codex`, or `opencode`)
 - Tooling path: MCP stdio bridge for voice tools and agent control
@@ -36,7 +36,7 @@ Missing models are downloaded at daemon startup into `$PASEO_HOME/models/local-s
 | `parakeet-tdt-0.6b-v2-int8` | English only (default). Includes punctuation and capitalization.                                                                                                                                                                                                             |
 | `parakeet-tdt-0.6b-v3-int8` | 25 European languages, auto-detected: Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Spanish, Swedish, Ukrainian. |
 
-**To use a non-English language, switch the local STT model to `parakeet-tdt-0.6b-v3-int8`.** v3 detects the spoken language automatically — there is no per-language setting for it. The `language` field below does **not** steer the local Parakeet model (v2 is English-only, v3 auto-detects); it only applies to the OpenAI STT provider.
+**To use a non-English language, switch the local STT model to `parakeet-tdt-0.6b-v3-int8`.** v3 detects the spoken language automatically — there is no per-language setting for it. The `language` field below does **not** steer the local Parakeet model (v2 is English-only, v3 auto-detects); it applies to cloud STT providers.
 
 ```json
 {
@@ -72,7 +72,38 @@ For multilingual local dictation, set the model to v3 — it auto-detects the la
 }
 ```
 
-The `language` field applies only to the OpenAI STT provider: set `features.dictation.stt.language` for dictation and `features.voiceMode.stt.language` for voice mode. If voice language is omitted, Paseo uses the dictation language before falling back to `en`. It has no effect on the local Parakeet models.
+The `language` field applies to OpenAI and Gemini STT: set `features.dictation.stt.language` for dictation and `features.voiceMode.stt.language` for voice mode. Gemini detects the language automatically when neither field is set. OpenAI falls back to `en`. The field has no effect on local Parakeet models.
+
+## Gemini Speech
+
+Gemini 3.5 Live Transcribe supports automatic language detection across 85+ languages, incremental transcription, and Smart transcription, which removes filler words, resolves self-corrections, and formats dictated text. Gemini 3.1 Flash TTS provides controllable multilingual speech generation. Select `gemini` independently for dictation STT, voice mode STT, and voice mode TTS. Turn detection remains local.
+
+```json
+{
+  "version": 1,
+  "features": {
+    "dictation": {
+      "stt": { "provider": "gemini", "mode": "smart" }
+    },
+    "voiceMode": {
+      "stt": { "provider": "gemini", "mode": "smart" },
+      "turnDetection": { "provider": "local" },
+      "tts": { "provider": "gemini", "voice": "Kore" }
+    }
+  },
+  "providers": {
+    "gemini": { "apiKey": "..." }
+  }
+}
+```
+
+Gemini STT defaults to `gemini-3.5-transcribe-live`. Set `features.dictation.stt.model` and `features.voiceMode.stt.model` to use another Live Transcribe model. Set `mode` to `verbatim` to preserve filler words, repetitions, and false starts. Set a BCP-47 `language` such as `zh-CN` only when you want to steer recognition; omit it for automatic detection.
+
+The default TTS model is `gemini-3.1-flash-tts-preview`, with the `Kore` voice. `gemini-2.5-flash-preview-tts` and `gemini-2.5-pro-preview-tts` are also supported; Google offers the Pro model only on its paid tier. Set `features.voiceMode.tts.model` and `features.voiceMode.tts.voice` to select another speech-capable model or [prebuilt voice](https://ai.google.dev/gemini-api/docs/speech-generation#voices). Gemini detects the input text language automatically; STT language hints do not control TTS. Paseo passes configured model and voice names through without maintaining its own allowlist.
+
+Paseo streams mono 16 kHz PCM to Gemini Live Transcribe. Paseo's local turn detector supplies activity boundaries, while Gemini returns partial and final transcripts over the live connection. TTS uses the Interactions API and returns mono 24 kHz PCM audio. Both features use `providers.gemini.apiKey` or `GEMINI_API_KEY`, not the Gemini CLI login configured as an agent provider.
+
+Gemini Live Transcribe connections have a 10-minute maximum duration. Finish a dictation stream within that limit; voice mode reconnects when Google closes a Live session.
 
 ## OpenAI Voice Option
 
@@ -114,14 +145,16 @@ Paseo uses these paths under the configured OpenAI base URL:
 ## Environment Variables
 
 - `PASEO_VOICE_LLM_PROVIDER`, voice agent provider override
-- `PASEO_DICTATION_STT_PROVIDER`, `PASEO_VOICE_STT_PROVIDER`, `PASEO_VOICE_TTS_PROVIDER`, speech provider selection (`local` or `openai`)
+- `PASEO_DICTATION_STT_PROVIDER`, `PASEO_VOICE_STT_PROVIDER`, STT provider selection (`local`, `openai`, or `gemini`)
+- `PASEO_VOICE_TTS_PROVIDER`, TTS provider selection (`local`, `openai`, or `gemini`)
+- `GEMINI_API_KEY`, Gemini API credential for dictation, voice mode STT, and voice mode TTS
 - `OPENAI_STT_API_KEY`, `OPENAI_STT_BASE_URL`, OpenAI speech-to-text endpoint (dictation + voice mode STT)
 - `OPENAI_TTS_API_KEY`, `OPENAI_TTS_BASE_URL`, OpenAI text-to-speech endpoint (voice mode TTS)
 - `PASEO_LOCAL_MODELS_DIR`, local model storage directory
 - `PASEO_DICTATION_LOCAL_STT_MODEL`, local dictation STT model ID
 - `PASEO_VOICE_LOCAL_STT_MODEL`, `PASEO_VOICE_LOCAL_TTS_MODEL`, local voice STT/TTS model IDs
-- `PASEO_DICTATION_LANGUAGE`, dictation STT language (OpenAI STT only; ignored by local Parakeet)
-- `PASEO_VOICE_LANGUAGE`, voice mode STT language; falls back to `PASEO_DICTATION_LANGUAGE` when unset (OpenAI STT only; ignored by local Parakeet)
+- `PASEO_DICTATION_LANGUAGE`, dictation STT language hint (OpenAI and Gemini; ignored by local Parakeet)
+- `PASEO_VOICE_LANGUAGE`, voice mode STT language hint; falls back to `PASEO_DICTATION_LANGUAGE` when unset (OpenAI and Gemini; ignored by local Parakeet)
 - `PASEO_VOICE_LOCAL_TTS_SPEAKER_ID`, `PASEO_VOICE_LOCAL_TTS_SPEED`, optional local voice TTS tuning
 
 ## Operational Notes


### PR DESCRIPTION
### Linked issue

Related discussion: https://github.com/getpaseo/paseo/discussions/3687

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Paseo's local speech path is the right default, but its multilingual model covers European languages and does not cover the Chinese/English code-switching workflow described in the linked discussion. The existing OpenAI speech provider also defaults to an explicit language instead of automatic multilingual recognition.

This adds Gemini as an independent cloud speech provider for dictation STT, voice-mode STT, and voice-mode TTS. Gemini 3.5 Live Transcribe provides incremental transcripts, automatic language detection across 85+ languages, and smart or verbatim transcription. Gemini TTS uses the same API key and provider boundary. Users opt into each speech feature separately; local speech remains the default.

Why Gemini for this workflow: Gemini 3.5 Transcribe combines Live partial/final transcription, automatic code-switching across 85+ languages, smart cleanup, and TTS under one provider credential. [Artificial Analysis](https://artificialanalysis.ai/speech-to-text/streaming) independently measures 4.0% streaming WER, placing it in the current top tier; this PR does not claim that Gemini is universally the best STT model. It is an alternative provider implementation for the workflow in #3687, which proposed Qwen.

### Goals

- Add Gemini Live STT for dictation and voice mode using Paseo's existing streaming session contract.
- Preserve Paseo's local VAD and segment lifecycle while forwarding 16 kHz mono PCM to Gemini.
- Support automatic language detection, optional BCP-47 language hints, and `smart` / `verbatim` modes.
- Add Gemini TTS with validated mono PCM output and the existing speech resampling pipeline.
- Keep model and voice identifiers configurable without a Paseo-owned allowlist.
- Keep provider credentials in persisted config or `GEMINI_API_KEY`, separate from Gemini CLI agent authentication.
- Preserve local and OpenAI behavior and configuration.

### Non-goals

- Gemini turn detection. Voice mode continues to use the local or OpenAI turn detector.
- UI settings for speech providers; this follows the existing config-file and environment-variable surface.
- A model or voice allowlist that would drift behind Google's API.
- Other STT providers or a change to Paseo's local-first defaults.
- Regenerating the full published config schema. The generator already differs substantially from the committed artifact; this PR updates only the Gemini-owned schema fields in the committed shape.

### QA

#### Automated coverage

```text
$ npx vitest run packages/server/src/server/config.test.ts packages/server/src/server/speech/speech-config-resolver.test.ts packages/server/src/server/speech/speech-runtime.test.ts packages/server/src/server/speech/providers/gemini/runtime.test.ts packages/server/src/server/speech/providers/gemini/stt.test.ts packages/server/src/server/speech/providers/gemini/tts.test.ts --bail=1

Test Files  6 passed (6)
Tests       31 passed (31)
```

The focused tests cover configuration precedence and passthrough, provider composition, STT activity/segment ordering, silent clear behavior, partial/final transcripts, terminal errors, TTS request passthrough, PCM validation, and sanitized provider failures. Production network calls are behind typed adapters; the real API checks below exercise the Google service.

```text
$ npm run typecheck
All 10 workspace typechecks passed.

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format:check
All matched files use the correct format.

$ git diff --check
Passed with no output.
```

The published draft-07 JSON schema was compiled with Ajv and checked with two configurations:

```text
Schema accepts multilingual Gemini STT/TTS config and rejects Gemini turn detection.
```

#### Real Gemini API

Tested from Linux x64 with Node.js, a real Gemini API key, and the production `@google/genai@2.19.0` SDK contract.

English round trip:

- Synthesized with `gemini-3.1-flash-tts-preview` at 24 kHz PCM.
- Passed through Paseo's production resampler to 16 kHz PCM.
- Transcribed with `gemini-3.5-transcribe-live`, `en-US`, and `verbatim` mode.
- Received 6 partial transcripts and one final transcript.
- Expected and final: `Paseo can transcribe this English sentence clearly.`

Chinese/English code-switch round trip:

- Synthesized with `gemini-2.5-flash-preview-tts` and passed through the same resampler.
- Transcribed with automatic language detection and `smart` mode.
- Received 5 partial transcripts and one final transcript.
- Input: `请在 Paseo 里运行 typecheck，然后检查 Gemini API。`
- Final: `请在 bash 里运行 typecheck，然后检查 Gemini API。`
- The language switch and technical terms were preserved, but the product name `Paseo` was misrecognized as `bash`. This is an upstream recognition-quality limitation, not treated as a passing exact-match claim.

TTS models exercised:

- `gemini-3.1-flash-tts-preview`: returned valid mono 24 kHz PCM.
- `gemini-2.5-flash-preview-tts`: returned valid mono 24 kHz PCM.
- `gemini-2.5-pro-preview-tts`: the test key reported zero free-tier quota, matching Google's paid-tier availability.

The API key used for QA lives in ignored `packages/server/.env.test`; no key-shaped value is present in the commit.

#### Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| Daemon on Linux x64 | Yes | Unit, config-schema, and real Google API verification |
| Daemon on macOS | No | No platform-specific implementation |
| Daemon on Windows | No | No platform-specific implementation |
| Docker | No | Uses the same Node daemon path; `GEMINI_API_KEY` must be supplied to the container |
| iOS / Android / Web / Electron UI | Not affected | No app or UI changes |

Known service constraint: Gemini Live Transcribe sessions have a 10-minute maximum duration. Voice mode recreates a closed STT session through its existing recovery path; a single dictation stream must finish within that limit.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
