### PR TITLE
fix(quota): show Grok unified-billing usage as a weekly window

### DIFF
--- a/packages/server/src/services/quota-fetcher/providers/grok.ts
+++ b/packages/server/src/services/quota-fetcher/providers/grok.ts
@@ -3,14 +3,20 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Logger } from "pino";
 import { z } from "zod";
-import type { ProviderUsage, ProviderUsageBalance } from "../../../server/messages.js";
+import type {
+  ProviderUsage,
+  ProviderUsageBalance,
+  ProviderUsageWindow,
+} from "../../../server/messages.js";
 import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
 import {
   ApiNumberSchema,
+  ApiOptionalStringSchema,
   toneFromUsedPct,
   usedPctOf,
   fetchProviderApi,
   unavailableUsage,
+  windowFromUsedPct,
 } from "../usage.js";
 
 const GrokUsageResponseSchema = z.object({
@@ -24,6 +30,13 @@ const GrokUsageResponseSchema = z.object({
       used: z
         .object({
           val: ApiNumberSchema.optional(),
+        })
+        .nullish(),
+      creditUsagePercent: ApiNumberSchema.optional(),
+      currentPeriod: z
+        .object({
+          type: ApiOptionalStringSchema,
+          end: ApiOptionalStringSchema,
         })
         .nullish(),
     })
@@ -84,6 +97,22 @@ function grokMonthlyCreditBalance(
   };
 }
 
+function grokUsageWindow(
+  response: z.infer<typeof GrokUsageResponseSchema>,
+): ProviderUsageWindow | null {
+  const percent = response.config?.creditUsagePercent;
+  if (typeof percent !== "number") return null;
+  const period = response.config?.currentPeriod;
+  const weekly = (period?.type ?? "").toUpperCase().includes("WEEKLY");
+  return windowFromUsedPct({
+    id: weekly ? "weekly" : "monthly",
+    label: weekly ? "Weekly" : "Monthly",
+    utilizationPct: percent,
+    resetsAt: period?.end ?? null,
+    tone: toneFromUsedPct(percent),
+  });
+}
+
 export class GrokQuotaProvider implements ProviderUsageFetcher {
   readonly providerId = "grok";
   readonly displayName = "Grok";
@@ -104,9 +133,11 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
 
     if (!token) return unavailableUsage(this);
 
+    // The Grok CLI's /usage uses ?format=credits; without it, unified-billing accounts
+    // get a zeroed legacy monthly shape (monthlyLimit.val 0) instead of real usage.
     const res = await fetchProviderApi(
       this.fetchApi,
-      "https://cli-chat-proxy.grok.com/v1/billing",
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
       {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -123,13 +154,14 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
 
     const resp = GrokUsageResponseSchema.parse(await res.json());
     const balance = grokMonthlyCreditBalance(resp);
+    const window = grokUsageWindow(resp);
 
     return {
       providerId: this.providerId,
       displayName: this.displayName,
       status: "available",
       planLabel: null,
-      windows: [],
+      windows: window ? [window] : [],
       balances: balance ? [balance] : [],
       details: [],
       error: null,

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -871,7 +871,7 @@ describe("real provider usage fetchers", () => {
     fetchApi = mockFetch(
       new Map([
         [
-          "https://cli-chat-proxy.grok.com/v1/billing",
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
           () =>
             jsonResponse({
               config: { monthlyLimit: { val: 0 }, used: { val: 0 } },
@@ -900,7 +900,7 @@ describe("real provider usage fetchers", () => {
     fetchApi = mockFetch(
       new Map([
         [
-          "https://cli-chat-proxy.grok.com/v1/billing",
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
           () =>
             jsonResponse({
               config: {
@@ -973,7 +973,7 @@ describe("real provider usage fetchers", () => {
     fetchApi = mockFetch(
       new Map([
         [
-          "https://cli-chat-proxy.grok.com/v1/billing",
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
           () =>
             jsonResponse({
               config: { monthlyLimit: { val: 50 } },
@@ -995,6 +995,48 @@ describe("real provider usage fetchers", () => {
           limit: 50,
         }),
       ],
+    });
+  });
+
+  it("fetches Grok unified-billing usage as a weekly window", async () => {
+    process.env["GROK_API_KEY"] = "grok_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+          () =>
+            jsonResponse({
+              config: {
+                currentPeriod: {
+                  type: "USAGE_PERIOD_TYPE_WEEKLY",
+                  start: "2026-08-24T09:41:40.001370+00:00",
+                  end: "2026-08-31T09:41:40.001370+00:00",
+                },
+                creditUsagePercent: 76.0,
+                isUnifiedBillingUser: true,
+                billingPeriodStart: "2026-08-24T09:41:40.001370+00:00",
+                billingPeriodEnd: "2026-08-31T09:41:40.001370+00:00",
+              },
+            }),
+        ],
+      ]),
+    );
+
+    const grok = findProvider(await service().listUsage(), "grok");
+
+    expect(grok).toMatchObject({
+      status: "available",
+      windows: [
+        {
+          id: "weekly",
+          label: "Weekly",
+          usedPct: 76,
+          remainingPct: 24,
+          resetsAt: "2026-08-31T09:41:40.001370+00:00",
+          tone: "warning",
+        },
+      ],
+      balances: [],
     });
   });
 


### PR DESCRIPTION
### Linked issue

No dedicated issue. Related context: #2352 fixed the previous Grok billing schema drift (July); #3306 is an open PR covering the same billing endpoint change as part of a much larger Grok usage overhaul (composer meter, ACP adapter, plan label). This PR is the minimal daemon-side fix for the Settings → Usage card only.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Settings → Usage stopped showing anything useful for Grok. xAI has been migrating accounts to **unified billing**: for these accounts, the plain `GET /v1/billing` endpoint the daemon calls now returns a zeroed legacy monthly shape:

```json
{"config":{"monthlyLimit":{"val":0},"used":{"val":67}, ...}}
```

`GrokQuotaProvider` turns that into a `{used: 67, limit: 0, remaining: 0}` balance, which the app renders as a misleading **"0 credits left"** with no bar. The real usage moved to `GET /v1/billing?format=credits` — the same query the Grok CLI's own `/usage` command sends — which returns a weekly percentage instead:

```json
{"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","end":"2026-08-31T09:41:40+00:00"},"creditUsagePercent":76.0,"isUnifiedBillingUser":true, ...}}
```

The fix: request `?format=credits` and map `creditUsagePercent` + `currentPeriod` onto a usage window via the existing `windowFromUsedPct`/`toneFromUsedPct` helpers, matching the Claude/Codex weekly window convention. The legacy monthly-credits balance path is untouched — unified-billing responses omit `monthlyLimit`/`used` entirely, so it naturally yields no balance; legacy accounts keep their monthly credits display.

### Goals

- Grok Settings usage works again for unified-billing accounts: a Weekly window with percent, tone, and reset time.
- Legacy (monthly credits) accounts keep the exact same output as before.
- No changes outside `providers/grok.ts` and its tests: no protocol change, no app change, no shared-helper change.

### Non-goals

- Plan label from `/v1/settings`, `prepaidBalance`, `productUsage` breakdown, weekly/monthly counted-window merging — #3306 territory.
- Composer context-window meter for Grok agents (#1390 / #3306).

### QA

Daemon on Linux, real Grok CLI login (unified-billing account).

**Repro before:** the daemon's `GrokQuotaProvider.fetchUsage()` against the live account returned

```json
{"status":"available","windows":[],"balances":[{"id":"monthly_credits","used":67,"remaining":0,"limit":0,"unit":"credits","tone":"default"}]}
```

→ Settings → Usage showed "0 credits left", no bar.

**After (same account, this branch):**

```json
{"status":"available","windows":[{"id":"weekly","label":"Weekly","usedPct":76,"remainingPct":24,"resetsAt":"2026-08-31T09:41:40.001370+00:00","tone":"warning"}],"balances":[]}
```

**UI:** verified in the web app (Android mobile browser) served by the patched daemon — Grok card shows a Weekly 76% amber bar with "resets 2d", alongside correctly rendering Claude/Codex/Cursor/Copilot cards (shared window renderer, no app change). Screenshot in the first comment.

Platforms tested: web (Android browser) against a Linux daemon. Not tested: iOS/Android native, desktop — the rendering path is the same generic `windows` renderer already used by Claude/Codex.

**Automated tests:**

```
npx vitest run packages/server/src/services/quota-fetcher/service.test.ts --bail=1
Test Files  1 passed (1)
     Tests  68 passed (68)
```

New test covers the unified-billing shape (captured from the live API) → weekly window, warning tone, empty balances. Existing legacy-shape Grok tests (monthly limit, zero preservation, `usage.creditUsage` fallback, nested auth.json token) unchanged and passing.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Overlap

Supersedes the Settings → Usage quota-fetcher portion of #3306. It does not supersede #3306's Grok composer context-window, ACP adapter, or plan-label work.
