### PR TITLE
Publish Paseo terms and privacy policies

### DIFF
--- a/packages/website/src/components/legal-page.tsx
+++ b/packages/website/src/components/legal-page.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { SiteShell } from "~/components/site-shell";
+
+interface LegalPageProps {
+  title: string;
+  lastUpdated: string;
+  children: ReactNode;
+}
+
+export function LegalPage({ title, lastUpdated, children }: LegalPageProps) {
+  return (
+    <SiteShell width="prose">
+      <article className="space-y-8 text-white/70 leading-relaxed [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-white [&_h2]:text-xl [&_h2]:font-medium [&_h2]:text-white [&_li]:pl-1 [&_section]:space-y-3 [&_ul]:ml-5 [&_ul]:list-disc [&_ul]:space-y-1">
+        <header className="space-y-3">
+          <h1 className="text-3xl font-medium text-white">{title}</h1>
+          <p className="text-sm text-white/50">Last updated: {lastUpdated}</p>
+        </header>
+        {children}
+      </article>
+    </SiteShell>
+  );
+}
+
+export function PaseoLegalIdentity() {
+  return (
+    <address className="not-italic">
+      <strong className="font-medium text-white">Mohamed Boudra Ziani</strong>, operating as Paseo
+      <br />
+      NIF/VAT ID: ES26617095T
+      <br />
+      Roc Boronat 48, Bajos 2
+      <br />
+      08005 Barcelona, Spain
+      <br />
+      Email: <a href="mailto:hello@moboudra.com">hello@moboudra.com</a>
+    </address>
+  );
+}

--- a/packages/website/src/components/site-footer.tsx
+++ b/packages/website/src/components/site-footer.tsx
@@ -52,6 +52,12 @@ export function SiteFooter({ width = "default" }: SiteFooterProps) {
               Privacy
             </a>
             <a
+              href="/terms"
+              className="block text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Terms
+            </a>
+            <a
               href="/sponsor"
               className="block text-muted-foreground hover:text-foreground transition-colors"
             >

--- a/packages/website/src/llms.ts
+++ b/packages/website/src/llms.ts
@@ -60,9 +60,10 @@ ${agents}
 
 - [Changelog](${SITE_URL}/changelog): Release notes for the Paseo daemon, CLI, desktop, and mobile apps.
 - [Download](${SITE_URL}/download): Install Paseo on Mac, Windows, Linux, iOS, Android, or run the web app.
-- [Paseo Hub](${SITE_URL}/hub): Self-hosted service above your daemons that adds GitHub, Slack, and Discord triggers. A hosted version is planned.
+- [Paseo Hub](${SITE_URL}/hub): Connect daemons and run GitHub, Slack, Discord, and Linear workflows through the hosted service or your own deployment.
 - [Blog](${SITE_URL}/blog): Updates and technical posts from the Paseo team.
 - [Privacy](${SITE_URL}/privacy): Privacy policy.
+- [Terms](${SITE_URL}/terms): Terms for the official relay and hosted Hub.
 - [GitHub](https://github.com/getpaseo/paseo): Source code, issues, and releases.
 `;
 }

--- a/packages/website/src/routeTree.gen.ts
+++ b/packages/website/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from "./routes/__root";
 import { Route as VtcodeRouteImport } from "./routes/vtcode";
+import { Route as TermsRouteImport } from "./routes/terms";
 import { Route as StakpakRouteImport } from "./routes/stakpak";
 import { Route as SponsorRouteImport } from "./routes/sponsor";
 import { Route as SigitRouteImport } from "./routes/sigit";
@@ -72,6 +73,11 @@ import { Route as AlternativesClaudeDesktopRouteImport } from "./routes/alternat
 const VtcodeRoute = VtcodeRouteImport.update({
   id: "/vtcode",
   path: "/vtcode",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const TermsRoute = TermsRouteImport.update({
+  id: "/terms",
+  path: "/terms",
   getParentRoute: () => rootRouteImport,
 } as any);
 const StakpakRoute = StakpakRouteImport.update({
@@ -415,6 +421,7 @@ export interface FileRoutesByFullPath {
   "/sigit": typeof SigitRoute;
   "/sponsor": typeof SponsorRoute;
   "/stakpak": typeof StakpakRoute;
+  "/terms": typeof TermsRoute;
   "/vtcode": typeof VtcodeRoute;
   "/alternatives/claude-desktop": typeof AlternativesClaudeDesktopRoute;
   "/alternatives/codex-app": typeof AlternativesCodexAppRoute;
@@ -474,6 +481,7 @@ export interface FileRoutesByTo {
   "/sigit": typeof SigitRoute;
   "/sponsor": typeof SponsorRoute;
   "/stakpak": typeof StakpakRoute;
+  "/terms": typeof TermsRoute;
   "/vtcode": typeof VtcodeRoute;
   "/alternatives/claude-desktop": typeof AlternativesClaudeDesktopRoute;
   "/alternatives/codex-app": typeof AlternativesCodexAppRoute;
@@ -536,6 +544,7 @@ export interface FileRoutesById {
   "/sigit": typeof SigitRoute;
   "/sponsor": typeof SponsorRoute;
   "/stakpak": typeof StakpakRoute;
+  "/terms": typeof TermsRoute;
   "/vtcode": typeof VtcodeRoute;
   "/alternatives/claude-desktop": typeof AlternativesClaudeDesktopRoute;
   "/alternatives/codex-app": typeof AlternativesCodexAppRoute;
@@ -599,6 +608,7 @@ export interface FileRouteTypes {
     | "/sigit"
     | "/sponsor"
     | "/stakpak"
+    | "/terms"
     | "/vtcode"
     | "/alternatives/claude-desktop"
     | "/alternatives/codex-app"
@@ -658,6 +668,7 @@ export interface FileRouteTypes {
     | "/sigit"
     | "/sponsor"
     | "/stakpak"
+    | "/terms"
     | "/vtcode"
     | "/alternatives/claude-desktop"
     | "/alternatives/codex-app"
@@ -719,6 +730,7 @@ export interface FileRouteTypes {
     | "/sigit"
     | "/sponsor"
     | "/stakpak"
+    | "/terms"
     | "/vtcode"
     | "/alternatives/claude-desktop"
     | "/alternatives/codex-app"
@@ -781,6 +793,7 @@ export interface RootRouteChildren {
   SigitRoute: typeof SigitRoute;
   SponsorRoute: typeof SponsorRoute;
   StakpakRoute: typeof StakpakRoute;
+  TermsRoute: typeof TermsRoute;
   VtcodeRoute: typeof VtcodeRoute;
   AlternativesClaudeDesktopRoute: typeof AlternativesClaudeDesktopRoute;
   AlternativesCodexAppRoute: typeof AlternativesCodexAppRoute;
@@ -798,6 +811,13 @@ declare module "@tanstack/react-router" {
       path: "/vtcode";
       fullPath: "/vtcode";
       preLoaderRoute: typeof VtcodeRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/terms": {
+      id: "/terms";
+      path: "/terms";
+      fullPath: "/terms";
+      preLoaderRoute: typeof TermsRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/stakpak": {
@@ -1281,6 +1301,7 @@ const rootRouteChildren: RootRouteChildren = {
   SigitRoute: SigitRoute,
   SponsorRoute: SponsorRoute,
   StakpakRoute: StakpakRoute,
+  TermsRoute: TermsRoute,
   VtcodeRoute: VtcodeRoute,
   AlternativesClaudeDesktopRoute: AlternativesClaudeDesktopRoute,
   AlternativesCodexAppRoute: AlternativesCodexAppRoute,

--- a/packages/website/src/routes/privacy.tsx
+++ b/packages/website/src/routes/privacy.tsx
@@ -1,12 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { SiteShell } from "~/components/site-shell";
+import { LegalPage, PaseoLegalIdentity } from "~/components/legal-page";
 import { pageMeta } from "~/meta";
 
 export const Route = createFileRoute("/privacy")({
   head: () =>
     pageMeta(
       "Privacy Policy - Paseo",
-      "Privacy policy for Paseo, the self-hosted coding agent manager. No tracking, no analytics, no data collection. Your code stays on your machine.",
+      "What stays on your machines, what the encrypted relay can see, and what Paseo Hub stores.",
       "/privacy",
     ),
   component: Privacy,
@@ -14,81 +14,191 @@ export const Route = createFileRoute("/privacy")({
 
 function Privacy() {
   return (
-    <SiteShell width="default">
-      <h1 className="text-3xl font-medium mb-8">Privacy Policy</h1>
+    <LegalPage title="Privacy Policy" lastUpdated="August 29, 2026">
+      <p>
+        Paseo is local-first. Installing or using the open-source software does not send us your
+        code, prompts, files, terminal output, or agent conversations. This policy explains the
+        separate data boundaries for local Paseo, the optional official relay, the hosted Paseo Hub,
+        and paseo.sh.
+      </p>
 
-      <div className="space-y-6 text-white/70 leading-relaxed">
+      <section>
+        <h2>Who is responsible</h2>
+        <PaseoLegalIdentity />
         <p>
-          Paseo is a self-hosted tool for managing coding agents. Your code and data stay on your
-          machine.
+          Mohamed Boudra Ziani is the data controller for personal data processed through the
+          official Paseo website, relay, and hosted Hub. Independently self-hosted daemons, Hubs,
+          and relays are controlled by their operators and are not covered by this policy.
         </p>
+      </section>
 
-        <section className="space-y-3">
-          <h2 className="text-xl font-medium text-white">What we collect</h2>
-          <p>Nothing. Paseo runs on your machine and doesn&apos;t send us any data.</p>
-        </section>
+      <section>
+        <h2>Local Paseo apps and daemons</h2>
+        <p>
+          Paseo runs on your machines. It does not send us analytics, telemetry, advertising
+          identifiers, or crash reports.
+        </p>
+        <p>
+          Packaged desktop apps check GitHub Releases for updates. GitHub receives the ordinary
+          network information needed to answer that request under its own privacy policy.
+        </p>
+        <p>
+          Agents such as Claude Code, Codex, and OpenCode communicate with their providers using
+          credentials on your machine. Paseo does not manage or intercept those provider API calls.
+        </p>
+      </section>
 
-        <section className="space-y-3">
-          <h2 className="text-xl font-medium text-white">The relay server</h2>
-          <p>
-            If you use the optional encrypted relay to connect your phone to your daemon, the relay
-            sees:
-          </p>
-          <ul className="list-disc list-inside space-y-1 ml-4">
-            <li>IP addresses and connection timing</li>
-            <li>Message sizes</li>
-            <li>Session IDs</li>
-          </ul>
-          <p>
-            Your phone and daemon encrypt relay payloads end-to-end with NaCl box encryption
-            (Curve25519 plus XSalsa20-Poly1305). The relay only carries the ciphertext.
-          </p>
-        </section>
+      <section>
+        <h2>The official relay</h2>
+        <p>The relay is optional. To connect your client and daemon, it processes:</p>
+        <ul>
+          <li>IP addresses and connection timing</li>
+          <li>Session identifiers and public handshake keys</li>
+          <li>Message sizes and aggregate bandwidth</li>
+          <li>Temporary connection and routing state</li>
+        </ul>
+        <p>
+          Your client and daemon encrypt application traffic end-to-end with NaCl box encryption.
+          The relay carries ciphertext and cannot read your code, prompts, terminal output, or agent
+          conversations. Payloads exist in relay memory only while being forwarded. We do not store
+          message contents. Infrastructure may retain limited operational logs and aggregate metrics
+          for security, capacity planning, and troubleshooting.
+        </p>
+      </section>
 
-        <section className="space-y-3">
-          <h2 className="text-xl font-medium text-white">Analytics and tracking</h2>
-          <p>
-            We don&apos;t use analytics, tracking pixels, cookies, or ads. The app doesn&apos;t
-            phone home.
-          </p>
-        </section>
+      <section>
+        <h2>Paseo Hub</h2>
+        <p>When you create or use a hosted Hub account, we process:</p>
+        <ul>
+          <li>Your name, email, account credentials, sessions, IP address, and user agent</li>
+          <li>Your organization, members, roles, invitations, and daemon registrations</li>
+          <li>Identifiers and credentials for services you connect</li>
+          <li>
+            Webhook events, messages, comments, attachment metadata, and related context received
+            from those services
+          </li>
+          <li>
+            Workflow configurations, trigger inputs, outputs, execution state, activity, and audit
+            records
+          </li>
+          <li>Stripe customer identifiers and subscription information needed to provide access</li>
+        </ul>
+        <p>
+          Your repositories, local files, and agent-provider credentials remain on your
+          infrastructure unless a workflow explicitly sends information to Hub or a connected
+          service. Hub does not provide AI inference.
+        </p>
+      </section>
 
-        <section className="space-y-3">
-          <h2 className="text-xl font-medium text-white">Third-party services</h2>
-          <p>
-            Paseo wraps agent providers like Claude Code, Codex, and OpenCode. Those tools
-            communicate with their own APIs (Anthropic, OpenAI, etc.) using your credentials. Paseo
-            doesn&apos;t manage or intercept those API calls.
-          </p>
-          <p>
-            If you use voice features with cloud providers (OpenAI speech), your voice data is sent
-            to those services according to their privacy policies.
-          </p>
-        </section>
+      <section>
+        <h2>Who controls workflow data</h2>
+        <p>
+          Paseo controls account, billing, security, and service-operation data. When an
+          organization uses Hub to process personal data in its workflows, that organization decides
+          why the data is processed and Paseo processes it on the organization&apos;s behalf.
+        </p>
+      </section>
 
-        <section className="space-y-3">
-          <h2 className="text-xl font-medium text-white">We don&apos;t sell your data</h2>
-          <p>We don&apos;t have your data to sell. Paseo is self-hosted and local-first.</p>
-        </section>
+      <section>
+        <h2>Why we process data</h2>
+        <p>We process data to:</p>
+        <ul>
+          <li>Provide accounts, Hub workflows, relay connectivity, billing, and support</li>
+          <li>Authenticate users, daemons, and connected services</li>
+          <li>Prevent abuse and protect the services</li>
+          <li>Maintain operational and audit records</li>
+          <li>Meet accounting, tax, and other legal obligations</li>
+        </ul>
+        <p>
+          The legal bases are performance of our contract with you, our legitimate interests in
+          operating and protecting the services, and compliance with legal obligations.
+        </p>
+      </section>
 
-        <section className="space-y-3">
-          <h2 className="text-xl font-medium text-white">Questions</h2>
-          <p>
-            If you have questions about privacy, open an issue on{" "}
-            <a
-              href="https://github.com/getpaseo/paseo"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-white/90"
-            >
-              GitHub
-            </a>
-            .
-          </p>
-        </section>
+      <section>
+        <h2>Service providers</h2>
+        <p>
+          We use Fly.io for hosted infrastructure, Stripe for subscriptions and payments, and GitHub
+          for software releases and connected GitHub features. Slack, Discord, Linear, and other
+          services receive data only when you choose to connect or use them.
+        </p>
+        <p>
+          Some providers may process data outside the European Economic Area. Where required, we use
+          appropriate contractual safeguards for those transfers.
+        </p>
+        <p>
+          We do not sell personal data, share it with advertisers, or use it to train AI models.
+        </p>
+      </section>
 
-        <p className="text-sm text-white/50 pt-6">Last updated: February 2025</p>
-      </div>
-    </SiteShell>
+      <section>
+        <h2>Retention and deletion</h2>
+        <p>
+          We keep account and organization data while your account remains active. We retain
+          operational, workflow, and audit records while needed to provide and protect the service.
+          Billing records may be kept for legally required accounting and tax periods. Short-lived
+          authorization codes and sessions expire automatically.
+        </p>
+        <p>
+          You can request account deletion by emailing us. Some records may remain where the law
+          requires it or where they form part of another organization&apos;s legitimate audit
+          history.
+        </p>
+      </section>
+
+      <section>
+        <h2>Cookies</h2>
+        <p>
+          The marketing website does not use analytics or advertising cookies. Hub uses only the
+          session and security cookies needed to sign you in and operate your account.
+        </p>
+      </section>
+
+      <section>
+        <h2>Your rights</h2>
+        <p>
+          Depending on applicable law, you may request access, correction, deletion, restriction,
+          objection, or portability of your personal data. Email{" "}
+          <a href="mailto:hello@moboudra.com">hello@moboudra.com</a>. You may also complain to the{" "}
+          <a href="https://www.aepd.es/" target="_blank" rel="noopener noreferrer">
+            Spanish Data Protection Agency
+          </a>
+          .
+        </p>
+      </section>
+
+      <section>
+        <h2>Security</h2>
+        <p>
+          We use access controls, encrypted transport, and limited service permissions. No online
+          service can guarantee absolute security. Read Paseo&apos;s{" "}
+          <a
+            href="https://github.com/getpaseo/paseo/blob/main/SECURITY.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            security model
+          </a>{" "}
+          or report a vulnerability privately to{" "}
+          <a href="mailto:hello@moboudra.com">hello@moboudra.com</a>.
+        </p>
+      </section>
+
+      <section>
+        <h2>Children</h2>
+        <p>
+          The official services are for professional developers and are not directed at children
+          under 16.
+        </p>
+      </section>
+
+      <section>
+        <h2>Changes</h2>
+        <p>
+          We will update this page and its date when our services or data practices materially
+          change.
+        </p>
+      </section>
+    </LegalPage>
   );
 }

--- a/packages/website/src/routes/terms.tsx
+++ b/packages/website/src/routes/terms.tsx
@@ -1,0 +1,189 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { LegalPage, PaseoLegalIdentity } from "~/components/legal-page";
+import { pageMeta } from "~/meta";
+
+export const Route = createFileRoute("/terms")({
+  head: () =>
+    pageMeta(
+      "Terms of Service - Paseo",
+      "Terms for the official Paseo Relay and hosted Paseo Hub services.",
+      "/terms",
+    ),
+  component: Terms,
+});
+
+function Terms() {
+  return (
+    <LegalPage title="Terms of Service" lastUpdated="August 29, 2026">
+      <p>
+        These Terms govern the official services operated at paseo.sh, relay.paseo.sh, and
+        hub.paseo.sh. By using the official relay or hosted Hub, you agree to them. Our{" "}
+        <a href="/privacy">Privacy Policy</a> explains how those services process data.
+      </p>
+
+      <section>
+        <h2>Who provides the services</h2>
+        <PaseoLegalIdentity />
+      </section>
+
+      <section>
+        <h2>Paseo&apos;s open-source software</h2>
+        <p>
+          Paseo is open-source software licensed under the Apache License 2.0. You can install,
+          modify, and self-host it under that license without purchasing Paseo Hub or using the
+          official relay.
+        </p>
+        <p>
+          These Terms do not replace or restrict the open-source license. They apply only to
+          services operated by Paseo. A self-hosted Hub or relay is operated by whoever hosts it.
+        </p>
+      </section>
+
+      <section>
+        <h2>The official relay</h2>
+        <p>
+          The relay is an optional service that connects Paseo clients to your daemon without
+          requiring you to expose the daemon directly. Traffic is encrypted end-to-end between your
+          client and daemon. The relay carries encrypted data but cannot read its contents.
+        </p>
+        <p>
+          The relay is subject to reasonable and fair use. We may limit bandwidth, connection
+          volume, or abusive traffic when necessary to keep it reliable and secure.
+        </p>
+      </section>
+
+      <section>
+        <h2>Paseo Hub</h2>
+        <p>
+          Hub lets you connect daemons, configure workflows, receive events from connected services,
+          and instruct agents running on your infrastructure. Hub does not provide AI inference.
+        </p>
+        <p>You are responsible for:</p>
+        <ul>
+          <li>The workflows, permissions, and connected services you configure</li>
+          <li>The people you invite and the access you give them</li>
+          <li>Actions performed by your agents and connected accounts</li>
+          <li>Reviewing generated code and other agent output</li>
+          <li>Maintaining backups of your repositories and local data</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Your content</h2>
+        <p>
+          You keep ownership of your prompts, workflow configuration, code, messages, and outputs.
+          You give Paseo only the permission needed to receive, transmit, store, and process that
+          content to operate the services you request.
+        </p>
+        <p>We do not sell your content, use it for advertising, or use it to train AI models.</p>
+      </section>
+
+      <section>
+        <h2>Accounts and teams</h2>
+        <p>
+          Keep your account credentials secure. Organization owners and administrators are
+          responsible for invitations, permissions, connected services, and activity performed by
+          their members. If you use Hub for an organization, you confirm that you are authorized to
+          act for it and to process the data sent through its workflows.
+        </p>
+      </section>
+
+      <section>
+        <h2>Acceptable use</h2>
+        <p>You must not use the services to:</p>
+        <ul>
+          <li>Break applicable law or infringe another person&apos;s rights</li>
+          <li>Attack systems, distribute malware, or evade access controls</li>
+          <li>Gain unauthorized access to another account, daemon, or service</li>
+          <li>Interfere with the service or bypass reasonable usage limits</li>
+          <li>Resell the official services without our written permission</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Trials, subscriptions, and payment</h2>
+        <p>
+          Current prices, taxes, billing periods, and seat calculations are shown before purchase.
+          Trial terms are shown when you start a trial. A no-card trial ends unless you add a valid
+          payment method before it expires.
+        </p>
+        <p>
+          Paid subscriptions renew automatically for the billing period shown at checkout until
+          canceled. You can manage payment methods, invoices, and cancellation through the billing
+          portal. Cancellation normally takes effect at the end of the current paid period. Payments
+          are non-refundable except where the law requires otherwise.
+        </p>
+        <p>
+          Stripe processes payments. Paseo does not store complete payment-card details. Nothing in
+          these Terms removes cancellation, refund, withdrawal, or other rights given to you by
+          applicable consumer law.
+        </p>
+      </section>
+
+      <section>
+        <h2>Third-party services</h2>
+        <p>
+          Paseo can connect to services such as GitHub, Slack, Discord, Linear, Anthropic, and
+          OpenAI. Those services have their own terms and privacy policies. Paseo is not responsible
+          for their availability, output, or handling of data.
+        </p>
+      </section>
+
+      <section>
+        <h2>Availability and changes</h2>
+        <p>
+          We work to keep the official relay and Hub available, but do not promise uninterrupted
+          service or a service level unless we agree one in writing. We may change features,
+          introduce reasonable limits, or suspend access when needed for security, abuse prevention,
+          legal compliance, or operation of the service.
+        </p>
+        <p>
+          Where practical, we will give reasonable notice before a change that materially reduces a
+          paid service.
+        </p>
+      </section>
+
+      <section>
+        <h2>Suspension and termination</h2>
+        <p>
+          You may stop using the services or cancel your subscription at any time. We may suspend
+          access for non-payment, serious abuse, security threats, or a material breach of these
+          Terms. Where practical, we will explain the reason and allow you to correct it.
+        </p>
+      </section>
+
+      <section>
+        <h2>Warranty and liability</h2>
+        <p>
+          Software and automated agents can make mistakes. Review important actions and maintain
+          appropriate backups.
+        </p>
+        <p>
+          To the extent permitted by law, the official services are provided as available and
+          without implied warranties. Paseo is not liable for indirect or consequential losses
+          caused by agent output, third-party services, or your workflow configuration. Our total
+          liability relating to a paid service will not exceed the amount you paid for it during the
+          preceding 12 months.
+        </p>
+        <p>Nothing here limits liability or statutory rights that cannot legally be limited.</p>
+      </section>
+
+      <section>
+        <h2>Governing law</h2>
+        <p>
+          These Terms are governed by Spanish law. If you are a consumer, you keep the mandatory
+          protections and court rights provided by the law where you live.
+        </p>
+      </section>
+
+      <section>
+        <h2>Changes and contact</h2>
+        <p>
+          We may update these Terms as the services change. We will announce material changes
+          through the service or by email where appropriate. Questions can be sent to{" "}
+          <a href="mailto:hello@moboudra.com">hello@moboudra.com</a>.
+        </p>
+      </section>
+    </LegalPage>
+  );
+}

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -47,6 +47,7 @@ function discoverAgentRoutes(): string[] {
     "index",
     "sponsor",
     "privacy",
+    "terms",
   ]);
   return fs
     .readdirSync(routesDir, { withFileTypes: true })
@@ -86,6 +87,7 @@ const sitemapPages = [
   "/download",
   "/hub",
   "/privacy",
+  "/terms",
   ...discoverAgentRoutes(),
   ...discoverAlternativeRoutes(),
   ...discoverDocsRoutes(),


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs

### Reasoning

Paseo now has three distinct public data boundaries: the local open-source app, the official relay, and the hosted Hub. The existing privacy page described only local Paseo and the relay, so it no longer covered the hosted service accurately.

These pages keep one canonical legal source on paseo.sh and explicitly separate the Apache-licensed software from the official hosted services.

### Goals

- Publish canonical Terms for the official relay and hosted Hub without restricting the open-source license.
- Expand Privacy to describe the local app, relay, and Hub boundaries accurately.
- Include the operator identity and GDPR/controller details.
- Link both pages from the footer and machine-readable site index, and include Terms in the sitemap.

### Non-goals

- Add duplicate legal pages inside Hub.
- Add analytics or cookie consent.
- Change relay or Hub runtime behavior, billing, or retention.

### QA

- `npm run format:check`
- `npm run lint`
- `npm run typecheck --workspace @getpaseo/website`
- `npm run build --workspace @getpaseo/website`
- `npx vitest run packages/website/src/android-version.test.ts packages/website/src/canonical-url.test.ts packages/website/src/hub-doc-examples.test.ts packages/website/src/latest-release.test.ts` — 10 passed
- Desktop and 390×844 mobile browser QA of `/terms` and `/privacy`: verified headings, links, footer, responsive layout, and no overflow.
- Verified the generated sitemap contains both legal routes.
- Native apps were not exercised because this change only adds static website pages.

### Checklist

- [x] This PR contains one focused change.
- [x] `npm run typecheck` passes.
- [x] `npm run lint` passes.
- [x] `npm run format:check` passes.
- [x] QA evidence is included above.
- [x] Tests were added or updated where appropriate.
