### PR TITLE
fix(server): namespace generated Codex model_providers entries

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -39,6 +39,7 @@ catalog probe. `PASEO_PROVIDER_REFRESH_TIMEOUT_MS` sets it when the config field
 - [Z.AI (Zhipu) coding plan](#zai-zhipu-coding-plan)
 - [Alibaba Cloud (Qwen) coding plan](#alibaba-cloud-qwen-coding-plan)
 - [Codex with a custom OpenAI-compatible endpoint](#codex-with-a-custom-openai-compatible-endpoint)
+- [Ollama Cloud](#ollama-cloud)
 - [Multiple profiles for the same provider](#multiple-profiles-for-the-same-provider)
 - [Custom binary for a provider](#custom-binary-for-a-provider)
 - [Disabling a provider](#disabling-a-provider)
@@ -252,6 +253,59 @@ requires_openai_auth = false
 - Set `models` explicitly. Custom endpoints expose their own model IDs (`anthropic/claude-opus-4-7`, `qwen/qwen3-coder`, `local/llama`, etc.), and Paseo does not discover them automatically for Codex.
 - To run multiple endpoints side-by-side, define multiple entries that each extend `"codex"` with different IDs, labels, and env. Each appears as its own provider in the app.
 - If you only want to override the binary (e.g. a nightly Codex build) without changing the endpoint, omit `OPENAI_BASE_URL` and use `command` instead — see [Custom binary for a provider](#custom-binary-for-a-provider).
+
+---
+
+## Ollama Cloud
+
+[Ollama Cloud](https://ollama.com) hosts open-weight models behind an OpenAI-compatible
+API. It serves the Responses API, so it works with a provider that extends `"codex"`.
+These are open models such as Kimi, GLM, Qwen and DeepSeek, not OpenAI models.
+
+### Setup
+
+1. Create an API key at [ollama.com](https://ollama.com)
+2. Add a provider entry in config.json:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "ollama-cloud": {
+        "extends": "codex",
+        "label": "Ollama",
+        "description": "Ollama Cloud open models over the OpenAI Responses API",
+        "env": {
+          "OPENAI_API_KEY": "<your-ollama-api-key>",
+          "OPENAI_BASE_URL": "https://ollama.com"
+        },
+        "models": [
+          { "id": "kimi-k2.7-code", "label": "Kimi K2.7 Code", "isDefault": true },
+          { "id": "kimi-k3", "label": "Kimi K3" },
+          { "id": "glm-5.3", "label": "GLM 5.3" },
+          { "id": "qwen3.5:397b", "label": "Qwen3.5 397B" },
+          { "id": "deepseek-v4-pro:0813", "label": "DeepSeek V4 Pro" }
+        ]
+      }
+    }
+  }
+}
+```
+
+Model ids are whatever `GET https://ollama.com/v1/models` returns for your account.
+Codex has no metadata for them and will warn that it is falling back to defaults,
+which is expected and harmless.
+
+### Notes
+
+- Do not name the provider `ollama`. Codex ships a built-in provider with that id, and
+  Paseo derives the generated Codex `model_providers` entry from the provider id. Paseo
+  namespaces the generated key (`paseo-<id>`) so the two cannot collide, but keeping the
+  id distinct also keeps the provider list readable next to a local Ollama setup.
+- The local Ollama daemon on `http://localhost:11434` serves chat completions rather
+  than the Responses API, so it does not work with `extends: "codex"`. Use Ollama Cloud
+  for this integration, or reach a local daemon through an agent that speaks chat
+  completions.
 
 ---
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -1712,9 +1712,9 @@ describe("Codex app-server provider", () => {
       OPENAI_BASE_URL: "https://custom-relay.example.com",
     });
     expect(capturedThreadStartConfig(capturedRequests)).toEqual({
-      model_provider: "codex-iisb",
+      model_provider: "paseo-codex-iisb",
       model_providers: {
-        "codex-iisb": {
+        "paseo-codex-iisb": {
           name: "Custom Codex",
           base_url: "https://custom-relay.example.com/v1",
           env_key: "OPENAI_API_KEY",
@@ -1732,10 +1732,25 @@ describe("Codex app-server provider", () => {
     );
 
     expect(capturedThreadStartConfig(capturedRequests)).toEqual({
-      model_provider: "codex-custom",
+      model_provider: "paseo-codex-custom",
       model_providers: {
-        "codex-custom": expect.objectContaining({
+        "paseo-codex-custom": expect.objectContaining({
           base_url: "https://custom-relay.example.com/v1",
+        }),
+      },
+    });
+  });
+
+  test("namespaces provider ids that collide with Codex built-ins", async () => {
+    // `ollama` is a reserved Codex provider id: without namespacing, Codex rejects
+    // the generated config outright and the agent never starts.
+    const capturedRequests = await runCustomCodexProviderTurn("ollama", "https://ollama.com");
+
+    expect(capturedThreadStartConfig(capturedRequests)).toEqual({
+      model_provider: "paseo-ollama",
+      model_providers: {
+        "paseo-ollama": expect.objectContaining({
+          base_url: "https://ollama.com/v1",
         }),
       },
     });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3218,10 +3218,15 @@ function buildCodexCustomProviderConfig(
     providerConfig.env_key = "OPENAI_API_KEY";
     providerConfig.requires_openai_auth = false;
   }
+  // Codex reserves its built-in provider ids and rejects a config that redefines
+  // one, failing the whole launch. Paseo provider ids are user-chosen, so namespace
+  // the generated entry to keep every id usable. The key is internal to the Codex
+  // config; the user-visible label still comes from `name`.
+  const providerKey = `paseo-${customProvider.id}`;
   return {
-    model_provider: customProvider.id,
+    model_provider: providerKey,
     model_providers: {
-      [customProvider.id]: providerConfig,
+      [providerKey]: providerConfig,
     },
   };
 }


### PR DESCRIPTION
## Problem

A custom provider that extends `"codex"` writes its own id straight into the generated Codex config, as both `model_provider` and the `model_providers` key ([codex-app-server-agent.ts#L3221](https://github.com/getpaseo/paseo/blob/main/packages/server/src/server/agent/providers/codex-app-server-agent.ts#L3221)).

Codex reserves its built-in provider ids and refuses any config that redefines one. So a provider named after the backend it points at fails at config load, and the agent never starts:

```
Error loading config.toml: model_providers contains reserved built-in provider IDs: `ollama`.
Built-in providers cannot be overridden. Rename your custom provider (for example, `openai-custom`).
```

`ollama` is the one I hit, and Codex reserves others too. The naming that collides is the naming the docs encourage, since the worked examples name a provider after its endpoint.

## Fix

Prefix the generated key with `paseo-`, so any provider id stays usable. The key is internal to the Codex config, and the user-visible label still comes from `name`, so nothing changes in the UI.

Also documents Ollama Cloud in `docs/custom-providers.md` next to the existing Z.AI and Qwen sections. That is the setup the collision surfaced on, and it needs the fix to work at all, so it is here rather than in a separate PR.

## QA evidence

Repro before the fix, driving `codex` with exactly the config Paseo generates for a provider with id `ollama`:

```
$ codex exec --skip-git-repo-check -s read-only \
    -c model_provider=ollama \
    -c 'model_providers.ollama={name="Ollama",base_url="https://ollama.com/v1",wire_api="responses",env_key="OPENAI_API_KEY",requires_openai_auth=false}' \
    -m kimi-k2.7-code "Reply with exactly: ok"

Error loading config.toml: model_providers contains reserved built-in provider IDs: `ollama`.
Built-in providers cannot be overridden. Rename your custom provider (for example, `openai-custom`).
```

Same call with the namespaced key the fix produces:

```
$ codex exec --skip-git-repo-check -s read-only \
    -c model_provider=paseo-ollama \
    -c 'model_providers.paseo-ollama={name="Ollama",base_url="https://ollama.com/v1",wire_api="responses",env_key="OPENAI_API_KEY",requires_openai_auth=false}' \
    -m kimi-k2.7-code "Reply with exactly: ok"

codex
ok
tokens used: 9,493
```

Checks:

```
$ npx vitest run src/server/agent/providers/codex-app-server-agent.test.ts
 Test Files  1 passed (1)
      Tests  147 passed (147)

$ npm run typecheck:server
typecheck exit=0

$ npm run lint -- packages/server/src/server/agent/providers/codex-app-server-agent.ts packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
Found 0 warnings and 0 errors.

$ npm run format:check:files -- docs/custom-providers.md packages/server/src/server/agent/providers/codex-app-server-agent.ts packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
Checking formatting... Finished in 272ms on 3 files
```

## Tests

Added `namespaces provider ids that collide with Codex built-ins`, which asserts the generated config for a provider with id `ollama`. It fails without the change. The two existing custom-provider tests were updated for the new key.

## Platforms

Server-side only, no UI. Tested on Linux (x64, Node 22.22.3, codex-cli 0.145.0). Not tested on macOS or Windows.

Written with an agent, reviewed and tested by me.