### PR TITLE
fix(server): reconcile the provider runtime after a forced cancellation

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -46,7 +46,17 @@ into that contract; lifecycle callers do not interpret provider-specific errors.
 
 After an acknowledged interrupt, the manager settles the captured run even when no terminal event
 arrives or the run was still waiting for its provider turn id. The captured run token prevents an
-older cancellation from settling a newer turn. If interruption is rejected or times out, the agent
+older cancellation from settling a newer turn. A forced settlement leaves the provider session
+suspect: it may still own the foreground turn it never ended, and real sessions guard that slot by
+refusing every later `startTurn`. The manager therefore swaps the session in place after a forced
+settlement — resume a replacement from the persistence handle, close the suspect runtime, and
+re-register under the same agent id with timeline and identity intact. Reload itself stays
+close-first because a persisted thread can have only one writer. The provider-side turn is never
+cleared without replacing the runtime that owns it. If no replacement can be built, the existing
+session stays registered: when the provider was actually idle it still works, and when it was wedged
+the agent is no worse off than before the swap attempt.
+
+If interruption is rejected or times out, the agent
 keeps its active foreground turn and replacement, reload, rewind, and Stop report the failure.
 Accepting new work after an ambiguous interruption would create a split-brain session.
 

--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -52,9 +52,10 @@ refusing every later `startTurn`. The manager therefore swaps the session in pla
 settlement — resume a replacement from the persistence handle, close the suspect runtime, and
 re-register under the same agent id with timeline and identity intact. Reload itself stays
 close-first because a persisted thread can have only one writer. The provider-side turn is never
-cleared without replacing the runtime that owns it. If no replacement can be built, the existing
-session stays registered: when the provider was actually idle it still works, and when it was wedged
-the agent is no worse off than before the swap attempt.
+cleared without replacing the runtime that owns it. If the replacement cannot be completed safely —
+resume, persist, or close — the existing session stays registered: when the provider was actually
+idle it still works, and when it was wedged the agent is no worse off than before the swap attempt.
+Prompt admission waits for that swap; it does not attach a follow-up to the suspect runtime.
 
 If interruption is rejected or times out, the agent
 keeps its active foreground turn and replacement, reload, rewind, and Stop report the failure.

--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -55,7 +55,9 @@ close-first because a persisted thread can have only one writer. The provider-si
 cleared without replacing the runtime that owns it. If the replacement cannot be completed safely —
 resume, persist, or close — the existing session stays registered: when the provider was actually
 idle it still works, and when it was wedged the agent is no worse off than before the swap attempt.
-Prompt admission waits for that swap; it does not attach a follow-up to the suspect runtime.
+Prompt admission waits until foreground and lifecycle mutation tails have
+drained, then starts on the registered runtime. It does not attach a
+follow-up to the suspect runtime.
 
 If interruption is rejected or times out, the agent
 keeps its active foreground turn and replacement, reload, rewind, and Stop report the failure.

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -10414,87 +10414,155 @@ test("forced cancellation keeps the existing session when no replacement can be 
   expect(manager.getAgent(snapshot.id)?.activeForegroundTurnId).toBeNull();
 }, 10_000);
 
-test.each(["hang", "reject"] as const)(
-  "forced-cancel reconcile does not leave two provider runtimes when the old close fails: %s",
-  async (failure) => {
-    const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-close-fail-"));
-    const storagePath = join(workdir, "agents");
-    const storage = new AgentStorage(storagePath, logger);
+test("forced-cancel reconcile keeps the existing session when the old close hangs", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-close-hang-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
 
-    class CloseFailingWedgedSession extends WedgedForegroundSession {
-      override async close(): Promise<void> {
-        if (failure === "reject") throw new Error("close rejected");
-        await new Promise(() => {});
-      }
+  class HangCloseWedgedSession extends WedgedForegroundSession {
+    override async close(): Promise<void> {
+      await new Promise(() => {});
+    }
+  }
+
+  class HangCloseWedgedClient extends TestAgentClient {
+    readonly wedgedSessions: HangCloseWedgedSession[] = [];
+    readonly resumedSessions: CloseRecordingTestAgentSession[] = [];
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      const session = new HangCloseWedgedSession(config);
+      this.wedgedSessions.push(session);
+      return session;
     }
 
-    class CloseFailingWedgedClient extends TestAgentClient {
-      readonly wedgedSessions: CloseFailingWedgedSession[] = [];
-      readonly resumedSessions: CloseRecordingTestAgentSession[] = [];
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      const session = new CloseRecordingTestAgentSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+      this.resumedSessions.push(session);
+      return session;
+    }
+  }
 
-      override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
-        const session = new CloseFailingWedgedSession(config);
-        this.wedgedSessions.push(session);
-        return session;
-      }
+  const client = new HangCloseWedgedClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000505",
+    rescueTimeouts: {
+      ...FAST_CANCEL_RESCUE_TIMEOUTS,
+      reloadSessionCloseMs: 10,
+    },
+  });
 
-      override async resumeSession(
-        _handle: AgentPersistenceHandle,
-        config?: Partial<AgentSessionConfig>,
-      ): Promise<AgentSession> {
-        const session = new CloseRecordingTestAgentSession({
-          provider: "codex",
-          cwd: config?.cwd ?? workdir,
-        });
-        this.resumedSessions.push(session);
-        return session;
-      }
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining — ends when the cancellation force-settles the turn
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+
+  const cancelResult = await manager.cancelAgentRun(snapshot.id);
+  expect(cancelResult.status).toBe("settled");
+  await firstRunDrain;
+
+  const live = manager.getAgent(snapshot.id);
+  expect(client.wedgedSessions).toHaveLength(1);
+  expect(client.resumedSessions).toHaveLength(1);
+  expect(live?.id).toBe(snapshot.id);
+  expect(live?.session).toBe(client.wedgedSessions[0]);
+  expect(live?.lifecycle).toBe("idle");
+  expect(live?.cwd).toBe(workdir);
+  expect(client.wedgedSessions[0]?.closed).toBe(false);
+  expect(client.resumedSessions[0]?.closed).toBe(true);
+  const record = await storage.get(snapshot.id);
+  expect(record?.lastStatus).toBe("idle");
+  expect(record?.archivedAt ?? null).toBeNull();
+}, 10_000);
+
+test("forced-cancel reconcile keeps the existing session when the old close rejects", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-close-reject-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  class RejectCloseWedgedSession extends WedgedForegroundSession {
+    override async close(): Promise<void> {
+      throw new Error("close rejected");
+    }
+  }
+
+  class RejectCloseWedgedClient extends TestAgentClient {
+    readonly wedgedSessions: RejectCloseWedgedSession[] = [];
+    readonly resumedSessions: CloseRecordingTestAgentSession[] = [];
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      const session = new RejectCloseWedgedSession(config);
+      this.wedgedSessions.push(session);
+      return session;
     }
 
-    const client = new CloseFailingWedgedClient();
-    const manager = new AgentManager({
-      clients: { codex: client },
-      registry: storage,
-      logger,
-      idFactory: () => "00000000-0000-4000-8000-000000000505",
-      rescueTimeouts: {
-        ...FAST_CANCEL_RESCUE_TIMEOUTS,
-        reloadSessionCloseMs: 10,
-      },
-    });
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      const session = new CloseRecordingTestAgentSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+      this.resumedSessions.push(session);
+      return session;
+    }
+  }
 
-    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
-      workspaceId: undefined,
-    });
-    const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
-    const firstRunDrain = (async () => {
-      for await (const _event of firstRun) {
-        // Draining — ends when the cancellation force-settles the turn
-      }
-    })();
-    await manager.waitForAgentRunStart(snapshot.id);
+  const client = new RejectCloseWedgedClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000509",
+    rescueTimeouts: {
+      ...FAST_CANCEL_RESCUE_TIMEOUTS,
+      reloadSessionCloseMs: 10,
+    },
+  });
 
-    const cancelResult = await manager.cancelAgentRun(snapshot.id);
-    expect(cancelResult.status).toBe("settled");
-    await firstRunDrain;
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining — ends when the cancellation force-settles the turn
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
 
-    const live = manager.getAgent(snapshot.id);
-    const original = client.wedgedSessions[0];
-    const replacement = client.resumedSessions[0];
-    expect(client.resumedSessions).toHaveLength(1);
-    expect(original).toBeDefined();
-    expect(replacement).toBeDefined();
-    // A failed close must not create two authoritative runtimes. Keep the
-    // existing session registered and close the unused replacement.
-    expect(live?.session).toBe(original);
-    expect(live?.lifecycle).toBe("idle");
-    expect(replacement?.closed).toBe(true);
-    const record = await storage.get(snapshot.id);
-    expect(record?.lastStatus).toBe("idle");
-    expect(record?.archivedAt ?? null).toBeNull();
-  },
-  10_000,
-);
+  const cancelResult = await manager.cancelAgentRun(snapshot.id);
+  expect(cancelResult.status).toBe("settled");
+  await firstRunDrain;
+
+  const live = manager.getAgent(snapshot.id);
+  expect(client.wedgedSessions).toHaveLength(1);
+  expect(client.resumedSessions).toHaveLength(1);
+  expect(live?.id).toBe(snapshot.id);
+  expect(live?.session).toBe(client.wedgedSessions[0]);
+  expect(live?.lifecycle).toBe("idle");
+  expect(live?.cwd).toBe(workdir);
+  expect(client.wedgedSessions[0]?.closed).toBe(false);
+  expect(client.resumedSessions[0]?.closed).toBe(true);
+  const record = await storage.get(snapshot.id);
+  expect(record?.lastStatus).toBe("idle");
+  expect(record?.archivedAt ?? null).toBeNull();
+}, 10_000);
 
 test("forced-cancel reconcile serializes an immediate follow-up onto the replacement runtime", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-followup-"));
@@ -10570,6 +10638,143 @@ test("forced-cancel reconcile serializes an immediate follow-up onto the replace
   expect(client.wedgedSessions[0]?.closed).toBe(true);
   expect(client.wedgedSessions[0]?.startTurnCalls).toBe(1);
   expect(manager.getAgent(snapshot.id)?.session).toBe(client.resumedSessions[0]);
+  expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
+}, 10_000);
+
+test("forced-cancel follow-up waits for a lifecycle mutation chained after the captured swap tail", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-second-order-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  class SecondOrderResumedSession extends CloseRecordingTestAgentSession {
+    startTurnCalls = 0;
+    private readonly latchClose: boolean;
+    private readonly onLatchedCloseStarted?: () => void;
+    private readonly latchedCloseAllowed?: Promise<void>;
+
+    constructor(
+      config: AgentSessionConfig,
+      options?: {
+        latchClose?: boolean;
+        onLatchedCloseStarted?: () => void;
+        latchedCloseAllowed?: Promise<void>;
+      },
+    ) {
+      super(config);
+      this.latchClose = options?.latchClose === true;
+      this.onLatchedCloseStarted = options?.onLatchedCloseStarted;
+      this.latchedCloseAllowed = options?.latchedCloseAllowed;
+    }
+
+    override async startTurn(): Promise<{ turnId: string }> {
+      this.startTurnCalls += 1;
+      return super.startTurn();
+    }
+
+    override async close(): Promise<void> {
+      if (this.latchClose) {
+        this.onLatchedCloseStarted?.();
+        if (this.latchedCloseAllowed) {
+          await this.latchedCloseAllowed;
+        }
+      }
+      await super.close();
+    }
+  }
+
+  class SecondOrderRaceClient extends WedgedForegroundClient {
+    readonly resumeStarted = deferred<void>();
+    readonly resumeAllowed = deferred<void>();
+    readonly reloadCloseStarted = deferred<void>();
+    readonly reloadCloseAllowed = deferred<void>();
+    readonly resumedSessions: SecondOrderResumedSession[] = [];
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      const latchClose = this.resumedSessions.length === 0;
+      if (latchClose) {
+        this.resumeStarted.resolve();
+        await this.resumeAllowed.promise;
+      }
+      const session = new SecondOrderResumedSession(
+        {
+          provider: "codex",
+          cwd: config?.cwd ?? workdir,
+        },
+        latchClose
+          ? {
+              latchClose: true,
+              onLatchedCloseStarted: () => this.reloadCloseStarted.resolve(),
+              latchedCloseAllowed: this.reloadCloseAllowed.promise,
+            }
+          : undefined,
+      );
+      this.resumedSessions.push(session);
+      return session;
+    }
+  }
+
+  const client = new SecondOrderRaceClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000508",
+    rescueTimeouts: FAST_CANCEL_RESCUE_TIMEOUTS,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining — ends when the cancellation force-settles the turn
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+
+  const cancelPromise = manager.cancelAgentRun(snapshot.id);
+  await client.resumeStarted.promise;
+
+  const followUpEvents: AgentStreamEvent[] = [];
+  let followUpError: unknown;
+  const followUp = manager.streamAgent(snapshot.id, "follow-up during chained reload");
+  const followUpDrain = (async () => {
+    try {
+      for await (const event of followUp) {
+        followUpEvents.push(event);
+      }
+    } catch (error) {
+      followUpError = error;
+    }
+  })();
+
+  // Chain a close-first reload behind the in-flight swap, then chain a second
+  // reload while that close is latched. A one-shot wait that captured the first
+  // reload's tail admits onto its replacement before the second reload starts.
+  const reloadDuringSwap = manager.reloadAgentSession(snapshot.id);
+  client.resumeAllowed.resolve();
+  await client.reloadCloseStarted.promise;
+  const chainedReload = manager.reloadAgentSession(snapshot.id);
+  client.reloadCloseAllowed.resolve();
+
+  await expect(cancelPromise).resolves.toEqual({ status: "settled" });
+  await firstRunDrain;
+  const reloadedDuringSwap = await reloadDuringSwap;
+  const reloadedChained = await chainedReload;
+  await followUpDrain;
+
+  expect(followUpError).toBeUndefined();
+  expect(followUpEvents.some((event) => event.type === "turn_completed")).toBe(true);
+  expect(client.wedgedSessions[0]?.closed).toBe(true);
+  expect(client.wedgedSessions[0]?.startTurnCalls).toBe(1);
+  expect(client.resumedSessions.map((session) => session.startTurnCalls)).toEqual([0, 0, 1]);
+  expect(reloadedDuringSwap.session).toBe(client.resumedSessions[1]);
+  expect(reloadedChained.session).toBe(client.resumedSessions[2]);
+  expect(manager.getAgent(snapshot.id)?.session).toBe(client.resumedSessions[2]);
   expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
 }, 10_000);
 
@@ -10650,6 +10855,68 @@ test("forced-cancel reconcile keeps the existing session when closed-snapshot pe
   expect(record?.lastStatus).toBe("idle");
   expect(record?.archivedAt ?? null).toBeNull();
   expect(record?.persistence).toEqual(snapshot.persistence);
+}, 10_000);
+
+test("forced-cancel reconcile propagates shutdown and keeps the existing session", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-shutdown-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  class ShutdownLatchedResumeClient extends WedgedForegroundClient {
+    readonly resumeStarted = deferred<void>();
+    readonly resumeAllowed = deferred<void>();
+    readonly resumedSessions: CloseRecordingTestAgentSession[] = [];
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      this.resumeStarted.resolve();
+      await this.resumeAllowed.promise;
+      const session = new CloseRecordingTestAgentSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+      this.resumedSessions.push(session);
+      return session;
+    }
+  }
+
+  const client = new ShutdownLatchedResumeClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000510",
+    rescueTimeouts: FAST_CANCEL_RESCUE_TIMEOUTS,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining — ends when the cancellation force-settles the turn
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+
+  const cancelPromise = manager.cancelAgentRun(snapshot.id);
+  await client.resumeStarted.promise;
+  manager.prepareForShutdown();
+  client.resumeAllowed.resolve();
+
+  await expect(cancelPromise).rejects.toBeInstanceOf(AgentManagerShuttingDownError);
+  await firstRunDrain;
+
+  expect(client.resumedSessions).toHaveLength(1);
+  expect(client.resumedSessions[0]?.closed).toBe(true);
+  expect(client.wedgedSessions).toHaveLength(1);
+  expect(client.wedgedSessions[0]?.closed).toBe(false);
+  expect(manager.getAgent(snapshot.id)?.session).toBe(client.wedgedSessions[0]);
+  expect(manager.getAgent(snapshot.id)?.id).toBe(snapshot.id);
+  expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
 }, 10_000);
 
 test("a genuinely running foreground turn still rejects a concurrent prompt", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -10414,6 +10414,244 @@ test("forced cancellation keeps the existing session when no replacement can be 
   expect(manager.getAgent(snapshot.id)?.activeForegroundTurnId).toBeNull();
 }, 10_000);
 
+test.each(["hang", "reject"] as const)(
+  "forced-cancel reconcile does not leave two provider runtimes when the old close fails: %s",
+  async (failure) => {
+    const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-close-fail-"));
+    const storagePath = join(workdir, "agents");
+    const storage = new AgentStorage(storagePath, logger);
+
+    class CloseFailingWedgedSession extends WedgedForegroundSession {
+      override async close(): Promise<void> {
+        if (failure === "reject") throw new Error("close rejected");
+        await new Promise(() => {});
+      }
+    }
+
+    class CloseFailingWedgedClient extends TestAgentClient {
+      readonly wedgedSessions: CloseFailingWedgedSession[] = [];
+      readonly resumedSessions: CloseRecordingTestAgentSession[] = [];
+
+      override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+        const session = new CloseFailingWedgedSession(config);
+        this.wedgedSessions.push(session);
+        return session;
+      }
+
+      override async resumeSession(
+        _handle: AgentPersistenceHandle,
+        config?: Partial<AgentSessionConfig>,
+      ): Promise<AgentSession> {
+        const session = new CloseRecordingTestAgentSession({
+          provider: "codex",
+          cwd: config?.cwd ?? workdir,
+        });
+        this.resumedSessions.push(session);
+        return session;
+      }
+    }
+
+    const client = new CloseFailingWedgedClient();
+    const manager = new AgentManager({
+      clients: { codex: client },
+      registry: storage,
+      logger,
+      idFactory: () => "00000000-0000-4000-8000-000000000505",
+      rescueTimeouts: {
+        ...FAST_CANCEL_RESCUE_TIMEOUTS,
+        reloadSessionCloseMs: 10,
+      },
+    });
+
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+    const firstRunDrain = (async () => {
+      for await (const _event of firstRun) {
+        // Draining — ends when the cancellation force-settles the turn
+      }
+    })();
+    await manager.waitForAgentRunStart(snapshot.id);
+
+    const cancelResult = await manager.cancelAgentRun(snapshot.id);
+    expect(cancelResult.status).toBe("settled");
+    await firstRunDrain;
+
+    const live = manager.getAgent(snapshot.id);
+    const original = client.wedgedSessions[0];
+    const replacement = client.resumedSessions[0];
+    expect(client.resumedSessions).toHaveLength(1);
+    expect(original).toBeDefined();
+    expect(replacement).toBeDefined();
+    // A failed close must not create two authoritative runtimes. Keep the
+    // existing session registered and close the unused replacement.
+    expect(live?.session).toBe(original);
+    expect(live?.lifecycle).toBe("idle");
+    expect(replacement?.closed).toBe(true);
+    const record = await storage.get(snapshot.id);
+    expect(record?.lastStatus).toBe("idle");
+    expect(record?.archivedAt ?? null).toBeNull();
+  },
+  10_000,
+);
+
+test("forced-cancel reconcile serializes an immediate follow-up onto the replacement runtime", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-followup-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  class LatchedResumeWedgedClient extends WedgedForegroundClient {
+    readonly resumeStarted = deferred<void>();
+    readonly resumeAllowed = deferred<void>();
+    readonly resumedSessions: CloseRecordingTestAgentSession[] = [];
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      this.resumeStarted.resolve();
+      await this.resumeAllowed.promise;
+      const session = new CloseRecordingTestAgentSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+      this.resumedSessions.push(session);
+      return session;
+    }
+  }
+
+  const client = new LatchedResumeWedgedClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000506",
+    rescueTimeouts: FAST_CANCEL_RESCUE_TIMEOUTS,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining — ends when the cancellation force-settles the turn
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+
+  const cancelPromise = manager.cancelAgentRun(snapshot.id);
+  await client.resumeStarted.promise;
+
+  // Pause is after the no-run check and after swap is queued, at resume.
+  // An ordinary follow-up must wait for that swap rather than attaching to
+  // the still-registered wedged runtime or being cleared by it.
+  const followUpEvents: AgentStreamEvent[] = [];
+  let followUpError: unknown;
+  const followUp = manager.streamAgent(snapshot.id, "immediate follow-up");
+  const followUpDrain = (async () => {
+    try {
+      for await (const event of followUp) {
+        followUpEvents.push(event);
+      }
+    } catch (error) {
+      followUpError = error;
+    }
+  })();
+
+  client.resumeAllowed.resolve();
+  await expect(cancelPromise).resolves.toEqual({ status: "settled" });
+  await firstRunDrain;
+  await followUpDrain;
+
+  expect(followUpError).toBeUndefined();
+  expect(followUpEvents.some((event) => event.type === "turn_completed")).toBe(true);
+  expect(client.wedgedSessions[0]?.closed).toBe(true);
+  expect(client.wedgedSessions[0]?.startTurnCalls).toBe(1);
+  expect(manager.getAgent(snapshot.id)?.session).toBe(client.resumedSessions[0]);
+  expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
+}, 10_000);
+
+test("forced-cancel reconcile keeps the existing session when closed-snapshot persistence fails", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-persist-fail-"));
+  const storagePath = join(workdir, "agents");
+
+  class FailClosedPersistStorage extends AgentStorage {
+    failClosedSnapshots = false;
+
+    override async applySnapshot(
+      agent: ManagedAgent,
+      options?: { title?: string | null; internal?: boolean },
+    ): Promise<void> {
+      if (this.failClosedSnapshots && agent.lifecycle === "closed") {
+        throw new Error("simulated persist failure");
+      }
+      await super.applySnapshot(agent, options);
+    }
+  }
+
+  const storage = new FailClosedPersistStorage(storagePath, logger);
+
+  class PersistFailWedgedClient extends WedgedForegroundClient {
+    readonly resumedSessions: CloseRecordingTestAgentSession[] = [];
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      const session = new CloseRecordingTestAgentSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+      this.resumedSessions.push(session);
+      return session;
+    }
+  }
+
+  const client = new PersistFailWedgedClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000507",
+    rescueTimeouts: FAST_CANCEL_RESCUE_TIMEOUTS,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining — ends when the cancellation force-settles the turn
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+  const timelineBefore = manager.getTimeline(snapshot.id);
+
+  storage.failClosedSnapshots = true;
+  const cancelResult = await manager.cancelAgentRun(snapshot.id);
+  expect(cancelResult.status).toBe("settled");
+  await firstRunDrain;
+
+  const live = manager.getAgent(snapshot.id);
+  expect(client.resumedSessions).toHaveLength(1);
+  expect(client.resumedSessions[0]?.closed).toBe(true);
+  expect(client.wedgedSessions[0]?.closed).toBe(false);
+  expect(live?.session).toBe(client.wedgedSessions[0]);
+  expect(live?.lifecycle).toBe("idle");
+  expect(live?.id).toBe(snapshot.id);
+  expect(live?.cwd).toBe(workdir);
+  expect(live?.workspaceId).toBe(snapshot.workspaceId);
+  expect(manager.getTimeline(snapshot.id)).toEqual(timelineBefore);
+  await manager.flushForShutdown();
+  const record = await storage.get(snapshot.id);
+  expect(record?.lastStatus).toBe("idle");
+  expect(record?.archivedAt ?? null).toBeNull();
+  expect(record?.persistence).toEqual(snapshot.persistence);
+}, 10_000);
+
 test("a genuinely running foreground turn still rejects a concurrent prompt", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-concurrent-gate-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -68,6 +68,25 @@ function deferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
+interface CollectedAgentStream {
+  events: AgentStreamEvent[];
+  error: unknown;
+}
+
+async function collectAgentStream(
+  stream: AsyncIterable<AgentStreamEvent>,
+): Promise<CollectedAgentStream> {
+  const events: AgentStreamEvent[] = [];
+  try {
+    for await (const event of stream) {
+      events.push(event);
+    }
+    return { events, error: undefined };
+  } catch (error) {
+    return { events, error };
+  }
+}
+
 function waitForAgentLifecycle(
   manager: AgentManager,
   agentId: string,
@@ -10615,23 +10634,12 @@ test("forced-cancel reconcile serializes an immediate follow-up onto the replace
   // Pause is after the no-run check and after swap is queued, at resume.
   // An ordinary follow-up must wait for that swap rather than attaching to
   // the still-registered wedged runtime or being cleared by it.
-  const followUpEvents: AgentStreamEvent[] = [];
-  let followUpError: unknown;
-  const followUp = manager.streamAgent(snapshot.id, "immediate follow-up");
-  const followUpDrain = (async () => {
-    try {
-      for await (const event of followUp) {
-        followUpEvents.push(event);
-      }
-    } catch (error) {
-      followUpError = error;
-    }
-  })();
+  const followUpDrain = collectAgentStream(manager.streamAgent(snapshot.id, "immediate follow-up"));
 
   client.resumeAllowed.resolve();
   await expect(cancelPromise).resolves.toEqual({ status: "settled" });
   await firstRunDrain;
-  await followUpDrain;
+  const { events: followUpEvents, error: followUpError } = await followUpDrain;
 
   expect(followUpError).toBeUndefined();
   expect(followUpEvents.some((event) => event.type === "turn_completed")).toBe(true);
@@ -10739,18 +10747,9 @@ test("forced-cancel follow-up waits for a lifecycle mutation chained after the c
   const cancelPromise = manager.cancelAgentRun(snapshot.id);
   await client.resumeStarted.promise;
 
-  const followUpEvents: AgentStreamEvent[] = [];
-  let followUpError: unknown;
-  const followUp = manager.streamAgent(snapshot.id, "follow-up during chained reload");
-  const followUpDrain = (async () => {
-    try {
-      for await (const event of followUp) {
-        followUpEvents.push(event);
-      }
-    } catch (error) {
-      followUpError = error;
-    }
-  })();
+  const followUpDrain = collectAgentStream(
+    manager.streamAgent(snapshot.id, "follow-up during chained reload"),
+  );
 
   // Chain a close-first reload behind the in-flight swap, then chain a second
   // reload while that close is latched. A one-shot wait that captured the first
@@ -10765,7 +10764,7 @@ test("forced-cancel follow-up waits for a lifecycle mutation chained after the c
   await firstRunDrain;
   const reloadedDuringSwap = await reloadDuringSwap;
   const reloadedChained = await chainedReload;
-  await followUpDrain;
+  const { events: followUpEvents, error: followUpError } = await followUpDrain;
 
   expect(followUpError).toBeUndefined();
   expect(followUpEvents.some((event) => event.type === "turn_completed")).toBe(true);

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -10194,52 +10194,80 @@ test("authoritative timeline records a daemon-handled submitted prompt before it
   }
 });
 
-test("replaceAgentRun succeeds when foreground turn terminal event is never delivered", async () => {
+// A provider session that models the wedge behind #349/#3256: it guards its
+// single foreground-turn slot the way real ACP/Codex sessions do, accepts
+// interruption without emitting a terminal event, and keeps the slot until the
+// session is closed. Once wedged, every later startTurn on the same session is
+// refused with "A foreground turn is already active".
+class WedgedForegroundSession extends TestAgentSession {
+  closed = false;
+  startTurnCalls = 0;
+  private foregroundSlot: string | null = null;
+  private wedgedTurnCounter = 0;
+
+  override async startTurn(): Promise<{ turnId: string }> {
+    this.startTurnCalls += 1;
+    if (this.foregroundSlot) {
+      throw new Error("A foreground turn is already active");
+    }
+    const turnId = `turn-wedged-${++this.wedgedTurnCounter}`;
+    this.foregroundSlot = turnId;
+    setTimeout(() => {
+      this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+      // No terminal event: the provider never settles this turn.
+    }, 0);
+    return { turnId };
+  }
+
+  override async interrupt(): Promise<void> {
+    // Acknowledged (session/cancel is a notification), but no terminal event
+    // follows and the foreground slot stays occupied.
+  }
+
+  override async close(): Promise<void> {
+    this.closed = true;
+    this.foregroundSlot = null;
+  }
+}
+
+class WedgedForegroundClient extends TestAgentClient {
+  readonly wedgedSessions: WedgedForegroundSession[] = [];
+  readonly resumedSessions: TestAgentSession[] = [];
+
+  override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+    const session = new WedgedForegroundSession(config);
+    this.wedgedSessions.push(session);
+    return session;
+  }
+
+  override async resumeSession(
+    handle: AgentPersistenceHandle,
+    config?: Partial<AgentSessionConfig>,
+    launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    const session = await super.resumeSession(handle, config, launchContext);
+    this.resumedSessions.push(session as TestAgentSession);
+    return session;
+  }
+}
+
+const FAST_CANCEL_RESCUE_TIMEOUTS = {
+  interruptSessionMs: 200,
+  acknowledgedInterruptSettleMs: 25,
+};
+
+test("replaceAgentRun succeeds when the provider session still owns its foreground turn", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-stale-fg-"));
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
-  const allowSecondRunToEnd = deferred<void>();
-
-  // Session where the first foreground turn never emits a terminal event
-  // (simulates the claude-agent pendingInterruptAbort suppression bug),
-  // and interrupt() does not produce events either.
-  class StaleForegroundSession extends TestAgentSession {
-    override async startTurn(): Promise<{ turnId: string }> {
-      this.interrupted = false;
-      const turnId = `turn-${++this.turnIdCounter}`;
-      const turnNum = this.turnIdCounter;
-
-      setTimeout(async () => {
-        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
-        if (turnNum === 1) {
-          // First turn: emit turn_started but NEVER emit a terminal event.
-          // This simulates the provider suppressing the result.
-        } else {
-          // Subsequent turns: complete normally
-          await allowSecondRunToEnd.promise;
-          this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
-        }
-      }, 0);
-      return { turnId };
-    }
-
-    override async interrupt(): Promise<void> {
-      this.interrupted = true;
-      // No events produced — the terminal event was suppressed
-    }
-  }
-
-  class StaleForegroundClient extends TestAgentClient {
-    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
-      return new StaleForegroundSession(config);
-    }
-  }
+  const client = new WedgedForegroundClient();
 
   const manager = new AgentManager({
-    clients: { codex: new StaleForegroundClient() },
+    clients: { codex: client },
     registry: storage,
     logger,
     idFactory: () => "00000000-0000-4000-8000-000000000500",
+    rescueTimeouts: FAST_CANCEL_RESCUE_TIMEOUTS,
   });
 
   const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
@@ -10250,7 +10278,7 @@ test("replaceAgentRun succeeds when foreground turn terminal event is never deli
   const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
   const firstRunDrain = (async () => {
     for await (const _event of firstRun) {
-      // Draining — will hang until force-cleaned
+      // Draining — ends when the cancellation force-settles the turn
     }
   })();
 
@@ -10258,11 +10286,11 @@ test("replaceAgentRun succeeds when foreground turn terminal event is never deli
 
   const beforeReplace = manager.getAgent(snapshot.id);
   expect(beforeReplace?.lifecycle).toBe("running");
-  expect(beforeReplace?.activeForegroundTurnId).toBe("turn-1");
+  expect(beforeReplace?.activeForegroundTurnId).toBe("turn-wedged-1");
 
-  // Replace the hung run. cancelAgentRun will time out after 2s because
-  // no terminal event arrives. After the fix, it should force-clear the
-  // stale foreground state so streamAgent can proceed.
+  // Replace the hung run. Cancellation times out because no terminal event
+  // arrives, and the wedged session keeps refusing new foreground turns, so
+  // Paseo must swap in a reloaded session before starting the replacement.
   const secondRun = await manager.replaceAgentRun(snapshot.id, "replacement prompt");
   const collectedEvents: AgentStreamEvent[] = [];
   const secondRunDrain = (async () => {
@@ -10271,15 +10299,255 @@ test("replaceAgentRun succeeds when foreground turn terminal event is never deli
     }
   })();
 
-  await manager.waitForAgentRunStart(snapshot.id);
-  allowSecondRunToEnd.resolve();
-
   await secondRunDrain;
   await firstRunDrain;
 
+  expect(client.wedgedSessions).toHaveLength(1);
+  expect(client.wedgedSessions[0]?.closed).toBe(true);
+  expect(client.resumedSessions).toHaveLength(1);
   expect(collectedEvents.some((e) => e.type === "turn_completed")).toBe(true);
   expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
   expect(manager.getAgent(snapshot.id)?.activeForegroundTurnId).toBeNull();
+}, 10_000);
+
+test("forced cancellation reconciles a provider session that still owns its foreground turn", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-reconcile-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const client = new WedgedForegroundClient();
+
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000501",
+    rescueTimeouts: FAST_CANCEL_RESCUE_TIMEOUTS,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+
+  const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining — ends when the cancellation force-settles the turn
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+
+  // Stop the run. The provider acknowledges but never settles, so the
+  // cancellation force-cancels and must reconcile the desynced runtime.
+  const cancelResult = await manager.cancelAgentRun(snapshot.id);
+  expect(cancelResult.status).toBe("settled");
+  await firstRunDrain;
+
+  expect(client.wedgedSessions).toHaveLength(1);
+  expect(client.wedgedSessions[0]?.closed).toBe(true);
+  expect(client.resumedSessions).toHaveLength(1);
+  expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
+  expect(manager.getAgent(snapshot.id)?.activeForegroundTurnId).toBeNull();
+
+  // The regression from #349/#3256: the next plain prompt (not a replace)
+  // must reach a live session instead of the wedged one.
+  const secondRun = manager.streamAgent(snapshot.id, "prompt after cancel");
+  const collectedEvents: AgentStreamEvent[] = [];
+  for await (const event of secondRun) {
+    collectedEvents.push(event);
+  }
+  expect(collectedEvents.some((e) => e.type === "turn_completed")).toBe(true);
+  expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
+
+  // Restart truthfulness: the durable record reflects a resumable idle agent.
+  await manager.flushForShutdown();
+  const record = await storage.get(snapshot.id);
+  expect(record?.lastStatus).toBe("idle");
+  expect(record?.archivedAt ?? null).toBeNull();
+}, 10_000);
+
+test("forced cancellation keeps the existing session when no replacement can be built", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-forced-cancel-degrade-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  class ResumeRefusingClient extends WedgedForegroundClient {
+    resumeAttempts = 0;
+
+    override async resumeSession(): Promise<AgentSession> {
+      this.resumeAttempts += 1;
+      throw new Error("provider binary unavailable");
+    }
+  }
+  const client = new ResumeRefusingClient();
+
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000502",
+    rescueTimeouts: FAST_CANCEL_RESCUE_TIMEOUTS,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+
+  const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining — ends when the cancellation force-settles the turn
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+
+  const cancelResult = await manager.cancelAgentRun(snapshot.id);
+  expect(cancelResult.status).toBe("settled");
+  await firstRunDrain;
+
+  // The swap was attempted but no replacement could be built. The agent must
+  // not be torn down for it: when the provider side is actually idle the old
+  // session still works, and when it is wedged the agent is no worse off
+  // than before the swap attempt. Cancellation itself still settled.
+  expect(client.resumeAttempts).toBe(1);
+  expect(client.wedgedSessions[0]?.closed).toBe(false);
+  expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
+  expect(manager.getAgent(snapshot.id)?.activeForegroundTurnId).toBeNull();
+}, 10_000);
+
+test("a genuinely running foreground turn still rejects a concurrent prompt", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-concurrent-gate-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const finishTurn = deferred<void>();
+
+  class RunningSession extends TestAgentSession {
+    override async startTurn(): Promise<{ turnId: string }> {
+      const turnId = "turn-running-1";
+      setTimeout(async () => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+        await finishTurn.promise;
+        this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
+      }, 0);
+      return { turnId };
+    }
+  }
+  class RunningClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new RunningSession(config);
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new RunningClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000503",
+    rescueTimeouts: FAST_CANCEL_RESCUE_TIMEOUTS,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  const firstRun = manager.streamAgent(snapshot.id, "long running prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+
+  expect(() => manager.streamAgent(snapshot.id, "concurrent prompt")).toThrow(
+    /already has an active run/,
+  );
+
+  finishTurn.resolve();
+  await firstRunDrain;
+  expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
+});
+
+test("a cancellation the provider settles in time does not reload the session", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-clean-cancel-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  class CleanCancelSession extends TestAgentSession {
+    closed = false;
+    private activeTurnId: string | null = null;
+
+    override async startTurn(): Promise<{ turnId: string }> {
+      const turnId = "turn-clean-1";
+      this.activeTurnId = turnId;
+      setTimeout(() => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+      }, 0);
+      return { turnId };
+    }
+
+    override async interrupt(): Promise<void> {
+      const turnId = this.activeTurnId;
+      if (turnId) {
+        this.activeTurnId = null;
+        this.pushEvent({
+          type: "turn_canceled",
+          provider: this.provider,
+          reason: "interrupted",
+          turnId,
+        });
+      }
+    }
+
+    override async close(): Promise<void> {
+      this.closed = true;
+    }
+  }
+  const cleanSessions: CleanCancelSession[] = [];
+  class CleanCancelClient extends TestAgentClient {
+    resumeCalls = 0;
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      const session = new CleanCancelSession(config);
+      cleanSessions.push(session);
+      return session;
+    }
+
+    override async resumeSession(
+      handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+      launchContext?: AgentLaunchContext,
+    ): Promise<AgentSession> {
+      this.resumeCalls += 1;
+      return super.resumeSession(handle, config, launchContext);
+    }
+  }
+  const client = new CleanCancelClient();
+
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000504",
+    rescueTimeouts: FAST_CANCEL_RESCUE_TIMEOUTS,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  const firstRun = manager.streamAgent(snapshot.id, "cancel me cleanly");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+
+  const cancelResult = await manager.cancelAgentRun(snapshot.id);
+  expect(cancelResult.status).toBe("settled");
+  await firstRunDrain;
+
+  expect(client.resumeCalls).toBe(0);
+  expect(cleanSessions).toHaveLength(1);
+  expect(cleanSessions[0]?.closed).toBe(false);
+  expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
 }, 10_000);
 
 class RecordingPersistedAgentsClient implements AgentClient {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1558,8 +1558,10 @@ export class AgentManager {
   // replacement first, then closes the previous runtime and re-registers under
   // the same agent id while preserving labels, timeline, and durable identity.
   // Resume-first is required for forced-cancel reconcile: if no replacement can
-  // be built, the existing session stays registered. Reload stays close-first
-  // because a persisted thread can have only one writer.
+  // be built, the existing session stays registered. A failed persist or close
+  // after that resume also keeps the existing session registered and closes the
+  // unused replacement. Reload stays close-first because a persisted thread can
+  // have only one writer.
   // Callers are responsible for making sure no run is in flight.
   private async swapRegisteredSessionRuntime(
     agentId: string,
@@ -1610,21 +1612,29 @@ export class AgentManager {
     try {
       this.assertAcceptingAgentRegistrations();
 
-      this.paseoToolPolicies.set(agentId, paseoToolPolicy);
-      this.cancelRunningProviderSubagents(agentId);
-      const closedExisting = this.prepareAgentForClosure(existing, "agent reloaded");
+      // Persist a closed snapshot before touching the live runtime. If this
+      // fails, the existing session stays registered and the replacement is
+      // closed below. Close the suspect runtime next while it is still the
+      // registered session: a failed close must not register a second writer.
+      await this.persistSnapshot(this.asClosedAgentSnapshot(existing));
       try {
-        await this.persistSnapshot(closedExisting);
-      } finally {
+        await this.closeReloadedSession(existing.session, agentId);
+      } catch (error) {
         try {
-          await this.closeReloadedSession(existing.session, agentId);
-        } catch (error) {
+          await this.persistSnapshot(existing);
+        } catch (revertError) {
           this.logger.warn(
-            { err: error, agentId },
-            "Failed to close previous session during forced-cancel reconcile",
+            { err: revertError, agentId },
+            "Failed to revert closed snapshot after previous session close failed",
           );
         }
+        throw error;
       }
+      await this.drainSessionEvents(agentId);
+
+      this.paseoToolPolicies.set(agentId, paseoToolPolicy);
+      this.cancelRunningProviderSubagents(agentId);
+      this.prepareAgentForClosure(existing, "agent reloaded");
 
       if (rehydrateFromDisk) {
         this.timelineStore.delete(agentId);
@@ -2515,7 +2525,26 @@ export class AgentManager {
       throw new Error(`Agent ${agentId} already has an active run`);
     }
 
-    const agent = existingAgent;
+    if (this.foregroundMutationTails.has(agentId) || this.lifecycleMutationTails.has(agentId)) {
+      return async function* streamAfterMutations(this: AgentManager) {
+        await this.foregroundMutationTails.get(agentId);
+        await this.lifecycleMutationTails.get(agentId);
+        yield* this.admitForegroundAgentStream(agentId, prompt, options);
+      }.call(this);
+    }
+
+    return this.admitForegroundAgentStream(agentId, prompt, options);
+  }
+
+  private admitForegroundAgentStream(
+    agentId: string,
+    prompt: AgentPromptInput,
+    options?: AgentRunOptions,
+  ): AsyncGenerator<AgentStreamEvent> {
+    const agent = this.requireSessionAgent(agentId);
+    if (agent.activeForegroundTurnId || this.runs.hasRun(agentId)) {
+      throw new Error(`Agent ${agentId} already has an active run`);
+    }
     const isReplacement = agent.pendingReplacement;
     agent.lastError = undefined;
 
@@ -3713,6 +3742,24 @@ export class AgentManager {
     };
   }
 
+  private asClosedAgentSnapshot(agent: LiveManagedAgent): ManagedAgentClosed {
+    return {
+      ...agent,
+      lifecycle: "closed",
+      session: null,
+      activeForegroundTurnId: null,
+      activeTurnId: null,
+      activeTurnStartedAt: null,
+      pendingPermissions: new Map(),
+      bufferedPermissionResolutions: new Map(),
+      inFlightPermissionResponses: new Set(),
+      pendingReplacement: false,
+      foregroundTurnWaiters: new Set(),
+      finalizedForegroundTurnIds: new Set(),
+      unsubscribeSession: null,
+    };
+  }
+
   private prepareAgentForClosure(
     agent: LiveManagedAgent,
     cancelReason: string,
@@ -3731,21 +3778,7 @@ export class AgentManager {
       turnId,
     }));
     this.runs.clearAgentRun(agent.id);
-    return {
-      ...agent,
-      lifecycle: "closed",
-      session: null,
-      activeForegroundTurnId: null,
-      activeTurnId: null,
-      activeTurnStartedAt: null,
-      pendingPermissions: new Map(),
-      bufferedPermissionResolutions: new Map(),
-      inFlightPermissionResponses: new Set(),
-      pendingReplacement: false,
-      foregroundTurnWaiters: new Set(),
-      finalizedForegroundTurnIds: new Set(),
-      unsubscribeSession: null,
-    };
+    return this.asClosedAgentSnapshot(agent);
   }
 
   private discardRetainedAgentState(agentId: string): void {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2527,13 +2527,30 @@ export class AgentManager {
 
     if (this.foregroundMutationTails.has(agentId) || this.lifecycleMutationTails.has(agentId)) {
       return async function* streamAfterMutations(this: AgentManager) {
-        await this.foregroundMutationTails.get(agentId);
-        await this.lifecycleMutationTails.get(agentId);
+        await this.waitForAgentMutations(agentId);
         yield* this.admitForegroundAgentStream(agentId, prompt, options);
       }.call(this);
     }
 
     return this.admitForegroundAgentStream(agentId, prompt, options);
+  }
+
+  // Drain every mutation that is queued by the time the previous tail
+  // resolves. A one-shot get() of the tails present at entry misses a
+  // lifecycle mutation chained after that lookup and before admission.
+  // After this returns, has() is false; admitForegroundAgentStream must
+  // install the pending run in the same turn, with no await in between.
+  private async waitForAgentMutations(agentId: string): Promise<void> {
+    while (this.foregroundMutationTails.has(agentId) || this.lifecycleMutationTails.has(agentId)) {
+      const foreground = this.foregroundMutationTails.get(agentId);
+      if (foreground) {
+        await foreground;
+      }
+      const lifecycle = this.lifecycleMutationTails.get(agentId);
+      if (lifecycle) {
+        await lifecycle;
+      }
+    }
   }
 
   private admitForegroundAgentStream(
@@ -3156,6 +3173,9 @@ export class AgentManager {
         "cancelAgentRun: reloaded provider session after forced cancellation",
       );
     } catch (error) {
+      if (!(error instanceof Error) || error instanceof AgentManagerShuttingDownError) {
+        throw error;
+      }
       this.logger.warn(
         { err: error, agentId },
         "cancelAgentRun: failed to swap provider session after forced cancellation",

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -259,6 +259,18 @@ export interface ProviderAvailability {
 interface AgentManagerRescueTimeouts {
   reloadSessionCloseMs?: number;
   interruptSessionMs?: number;
+  acknowledgedInterruptSettleMs?: number;
+}
+
+function resolveRescueTimeouts(
+  overrides: AgentManagerRescueTimeouts | undefined,
+): Required<AgentManagerRescueTimeouts> {
+  return {
+    reloadSessionCloseMs: overrides?.reloadSessionCloseMs ?? RELOAD_SESSION_CLOSE_TIMEOUT_MS,
+    interruptSessionMs: overrides?.interruptSessionMs ?? INTERRUPT_SESSION_TIMEOUT_MS,
+    acknowledgedInterruptSettleMs:
+      overrides?.acknowledgedInterruptSettleMs ?? INTERRUPT_SESSION_TIMEOUT_MS,
+  };
 }
 
 interface ProviderEnabledFlag {
@@ -742,12 +754,7 @@ export class AgentManager {
     this.resolvePaseoToolPolicy = options.resolvePaseoToolPolicy ?? (() => undefined);
     this.appendSystemPrompt = options.appendSystemPrompt ?? "";
     this.logger = options.logger.child({ module: "agent", component: "agent-manager" });
-    this.rescueTimeouts = {
-      reloadSessionCloseMs:
-        options.rescueTimeouts?.reloadSessionCloseMs ?? RELOAD_SESSION_CLOSE_TIMEOUT_MS,
-      interruptSessionMs:
-        options.rescueTimeouts?.interruptSessionMs ?? INTERRUPT_SESSION_TIMEOUT_MS,
-    };
+    this.rescueTimeouts = resolveRescueTimeouts(options.rescueTimeouts);
     this.beforeSteerUnavailableFallback = options.beforeSteerUnavailableFallback;
     this.agentStreamCoalescer = new AgentStreamCoalescer({
       windowMs: options.agentStreamCoalesceWindowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
@@ -1543,6 +1550,105 @@ export class AgentManager {
         if (session) {
           await this.closeUnregisteredSession(session);
         }
+      }
+    }
+  }
+
+  // Replaces a registered agent's provider session in place: builds the
+  // replacement first, then closes the previous runtime and re-registers under
+  // the same agent id while preserving labels, timeline, and durable identity.
+  // Resume-first is required for forced-cancel reconcile: if no replacement can
+  // be built, the existing session stays registered. Reload stays close-first
+  // because a persisted thread can have only one writer.
+  // Callers are responsible for making sure no run is in flight.
+  private async swapRegisteredSessionRuntime(
+    agentId: string,
+    overrides?: Partial<AgentSessionConfig>,
+    options?: { rehydrateFromDisk?: boolean },
+  ): Promise<ManagedAgent> {
+    this.assertAcceptingAgentRegistrations();
+    const existing = this.requireSessionAgent(agentId);
+    const rehydrateFromDisk = options?.rehydrateFromDisk ?? false;
+    const preservedHistoryPrimed = existing.historyPrimed;
+    const preservedLastUsage = existing.lastUsage;
+    const preservedLastError = existing.lastError;
+    const preservedAttention = existing.attention;
+    const handle = existing.persistence;
+    const provider = handle?.provider ?? existing.provider;
+    const client = this.requireClient(provider);
+    const refreshConfig = {
+      ...existing.config,
+      ...overrides,
+      provider,
+    } as AgentSessionConfig;
+    const { storedConfig, launchConfig, paseoToolPolicy } = await this.prepareSessionConfig(
+      refreshConfig,
+      agentId,
+    );
+    const launchContext = await this.buildLaunchContext(
+      agentId,
+      client,
+      storedConfig.cwd,
+      paseoToolPolicy,
+      undefined,
+      { reason: "refresh", purpose: "interactive", workspaceId: existing.workspaceId },
+    );
+    const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
+    if (
+      Object.keys(storedConfig.mcpServers ?? {}).length > 0 &&
+      existing.session.capabilities.supportsMcpServers !== true
+    ) {
+      throw new Error(`Provider '${provider}' does not support MCP servers`);
+    }
+
+    const session = handle
+      ? await client.resumeSession(handle, providerLaunchConfig, launchContext)
+      : await client.createSession(providerLaunchConfig, launchContext);
+    await this.requireExternalMcpSupport(session, storedConfig);
+
+    let handedToRegistration = false;
+    try {
+      this.assertAcceptingAgentRegistrations();
+
+      this.paseoToolPolicies.set(agentId, paseoToolPolicy);
+      this.cancelRunningProviderSubagents(agentId);
+      const closedExisting = this.prepareAgentForClosure(existing, "agent reloaded");
+      try {
+        await this.persistSnapshot(closedExisting);
+      } finally {
+        try {
+          await this.closeReloadedSession(existing.session, agentId);
+        } catch (error) {
+          this.logger.warn(
+            { err: error, agentId },
+            "Failed to close previous session during forced-cancel reconcile",
+          );
+        }
+      }
+
+      if (rehydrateFromDisk) {
+        this.timelineStore.delete(agentId);
+        for (const event of this.providerSubagents.deleteParent(agentId)) {
+          this.dispatch({ type: "provider_subagent", event });
+        }
+      }
+
+      handedToRegistration = true;
+      return this.registerSession(session, storedConfig, agentId, {
+        labels: existing.labels,
+        workspaceId: existing.workspaceId,
+        owner: existing.owner,
+        createdAt: existing.createdAt,
+        updatedAt: existing.updatedAt,
+        lastUserMessageAt: existing.lastUserMessageAt,
+        historyPrimed: rehydrateFromDisk ? false : preservedHistoryPrimed,
+        lastUsage: preservedLastUsage,
+        lastError: preservedLastError,
+        attention: preservedAttention,
+      });
+    } finally {
+      if (!handedToRegistration) {
+        await this.closeUnregisteredSession(session);
       }
     }
   }
@@ -2931,7 +3037,7 @@ export class AgentManager {
     const settlement = await this.waitWithTimeout({
       operation: run.settledPromise,
       timeoutMs: interruptAcknowledged
-        ? INTERRUPT_SESSION_TIMEOUT_MS
+        ? this.rescueTimeouts.acknowledgedInterruptSettleMs
         : this.rescueTimeouts.interruptSessionMs,
     });
 
@@ -2939,6 +3045,7 @@ export class AgentManager {
       return { status: settlement === "completed" ? "settled" : "refused" };
     }
 
+    let providerRuntimeSuspect = false;
     const runTurnId = this.runs.getTurnId(agentId);
     if (settlement === "timed_out" && runTurnId) {
       this.logger.warn(
@@ -2952,6 +3059,7 @@ export class AgentManager {
         turnId: runTurnId,
       });
       await run.settledPromise;
+      providerRuntimeSuspect = run.kind === "foreground";
     } else if (settlement === "timed_out" && run.kind === "foreground") {
       this.logger.warn(
         { agentId, kind: run.kind },
@@ -2963,6 +3071,7 @@ export class AgentManager {
         this.touchUpdatedAt(agent);
         this.emitState(agent);
       }
+      providerRuntimeSuspect = true;
     } else if (settlement === "timed_out" && run.kind === "autonomous") {
       this.logger.warn(
         { agentId, kind: run.kind },
@@ -2980,7 +3089,49 @@ export class AgentManager {
       this.touchUpdatedAt(agent);
       this.emitState(agent);
     }
+    if (providerRuntimeSuspect) {
+      await this.reconcileProviderRuntimeAfterForcedCancel(agentId);
+    }
     return { status: "settled" };
+  }
+
+  /**
+   * A forced cancellation settles the daemon's run state, but the provider
+   * session may still own its foreground turn: the interrupt was acknowledged,
+   * yet no terminal event arrived inside the settle window. Leaving that
+   * session registered can strand the agent — real provider sessions guard
+   * their single foreground-turn slot, so every later startTurn is refused
+   * with "A foreground turn is already active" until the runtime is replaced
+   * (#349, #3256). Reload the session in place so provider turn ownership
+   * matches the settled daemon state. Clearing provider turn state without
+   * replacing the runtime is not an option here: a genuinely running turn
+   * must keep refusing concurrent prompts. If no replacement session can be
+   * built, keep the existing runtime registered — when the provider side was
+   * actually idle (rather than wedged) the old session still works, and when
+   * it was wedged the agent is no worse off than before the swap attempt.
+   */
+  private async reconcileProviderRuntimeAfterForcedCancel(agentId: string): Promise<void> {
+    if (this.runs.hasRun(agentId)) {
+      // A new run raced in behind the settlement; its owner drives the session now.
+      return;
+    }
+    if (!this.agents.get(agentId)?.session) {
+      return;
+    }
+    try {
+      await this.trackAgentRegistrationOperation(
+        this.runLifecycleMutation(agentId, () => this.swapRegisteredSessionRuntime(agentId)),
+      );
+      this.logger.info(
+        { agentId },
+        "cancelAgentRun: reloaded provider session after forced cancellation",
+      );
+    } catch (error) {
+      this.logger.warn(
+        { err: error, agentId },
+        "cancelAgentRun: failed to swap provider session after forced cancellation",
+      );
+    }
   }
 
   private async cancelAgentRunBefore(

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -3155,6 +3155,43 @@ describe("ACPAgentSession", () => {
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
   });
 
+  // The wedge behind #349/#3256: session/cancel is a notification, so
+  // interrupt() resolves without provider confirmation. If the agent process
+  // never answers the outstanding session/prompt, the foreground turn stays
+  // active — the split-brain guard must keep refusing new turns on this
+  // session, and only close() may release the slot. The AgentManager relies
+  // on exactly this contract when it swaps the session after a forced
+  // cancellation.
+  test("interrupt without a terminal event keeps the foreground turn until close", async () => {
+    const terminated: Array<number | undefined> = [];
+    const session = createSession(async (pid) => {
+      terminated.push(pid);
+    });
+    const prompt = vi.fn(() => new Promise<PromptResponse>(() => {}));
+    const cancel = vi.fn(async () => {});
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<{ connection: unknown }>(session).connection = { prompt, cancel };
+
+    const { turnId } = await session.startTurn("hello");
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBe(turnId);
+
+    // The cancel notification is sent and interrupt() resolves, but the
+    // provider never emits a terminal event for the turn.
+    await session.interrupt();
+    expect(cancel).toHaveBeenCalledWith({ sessionId: "session-1" });
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBe(turnId);
+
+    // Split-brain guard: the session refuses another foreground turn.
+    await expect(session.startTurn("follow-up")).rejects.toThrow(
+      "A foreground turn is already active",
+    );
+
+    // Closing the session is the reconciliation path: it releases the slot.
+    await session.close();
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+  });
+
   test("flushes an image-only provider echo before a rejected turn finishes", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];


### PR DESCRIPTION
## Problem

Cancelling a foreground turn can permanently strand an agent behind
`A foreground turn is already active` (#349, #3256; #1936 is an older report of the same
error family on a Hermes/ACP agent).

The divergence is between two owners of "is a turn running":

1. **Daemon side.** `cancelAgentRunNow` interrupts the session. ACP's
   `session/cancel` is a *notification* — `ACPAgentSession.interrupt()` resolves
   as soon as it is sent, so the interrupt is "acknowledged" without any provider
   confirmation. If no terminal event arrives inside the settle window, the
   manager force-cancels: it synthesizes `turn_canceled`, settles the run, and
   reports the agent idle.

2. **Provider side.** The session still owns the turn it never ended.
   `ACPAgentSession` only clears `activeForegroundTurnId` in `finishTurn()` (which
   needs the `session/prompt` response that never came) or in `close()` (which
   nobody calls). Codex guards its slot the same way.

Every later `startTurn` on that session is refused by the provider's
foreground-turn guard. The daemon's own gate (`already has an active run`) is
open — the daemon believes the agent idle — so each prompt reaches the poisoned
session, fails, and marks the agent `error`. The agent is unusable until archival
or a manual reload. #3256 reproduces this in a manual cancel/retry flow and, per
the follow-up report, in MCP `send_agent_message_request` and parent/child
notification fan-out, where children land in durable `error` with
`lastError: "A foreground turn is already active"`.

```
cancelAgentRun: acknowledged turn still active after timeout, force-canceling
handleStreamEvent: turn_failed
A foreground turn is already active
    at ACPAgentSession.startTurn (.../providers/acp-agent.js:971)
    at AgentManager.streamForwarder (.../agent-manager.js:1358)
```

## Design invariant

After the manager has force-canceled its side of a foreground run, it must not
keep using a provider runtime whose foreground-turn ownership can no longer be
trusted. Reconcile by replacing/resuming the runtime while preserving the Paseo
agent, its timeline, session continuity, and identity. Never merely clear local
turn state and pretend the provider agrees — that is the split-brain
`docs/agent-lifecycle.md` forbids.

## Fix

One focused change in `AgentManager`: **after a forced settlement of a foreground
run, swap the provider session in place** via `swapRegisteredSessionRuntime`:

- resume a replacement session from the persistence handle (or `createSession`
  when the agent has no handle),
- close the suspect runtime (bounded by `reloadSessionCloseMs`),
- re-register under the same agent id, preserving labels, timeline, workspace,
  owner, usage, and attention.

User-facing reload stays **close-first** after #4353 (a persisted thread can have
only one writer). Forced-cancel reconcile stays **resume-first** so a failed
replacement cannot tear down a still-usable session.

Provider-side turn state is **never cleared without replacing the runtime that
owns it**, so the split-brain guard is intact: a genuinely running turn keeps
refusing concurrent prompts, and an unacknowledged interrupt still refuses
replacement exactly as before (the `refused` path is untouched).

If no replacement can be built (provider binary gone, shutdown in progress), the
existing session **stays registered**: when the provider side was actually idle —
the already-settled drift #3742 recovers — the old session still works, and when
it was wedged the agent is no worse off than before the swap attempt. The
fallback never tears down an agent that a replacement could not be built for.

Because the swap runs inside the cancellation's foreground mutation, it is
serialized against concurrent stop/replace calls, and it covers **every**
follow-up path — plain prompts, `replaceAgentRun`, MCP sends, schedules — not
just the replace flow.

`rescueTimeouts.acknowledgedInterruptSettleMs` makes the acknowledged-interrupt
settle window configurable (production default unchanged at
`INTERRUPT_SESSION_TIMEOUT_MS`) so the regression tests run deterministically
instead of sleeping through real 2 s waits.

`docs/agent-lifecycle.md` § Cancellation is updated to document the reconcile.

## Relationship to existing work

- **#4325** (closed 2026-09-08 by @boudra in favor of this PR) settled the ACP
  foreground turn locally on `interrupt()`. That is the split-brain shape this
  PR refuses: we never clear provider turn state without replacing the runtime.
- **#4353** (merged) made reload close-first so an idle session writer is
  released before resume. This PR does not reuse that order for forced-cancel
  reconcile; see Fix.
- **#2679** recovers the stale session lazily inside `replaceAgentRun`. That heals
  the replace flow but leaves the plain-prompt path stranded: after a standalone
  cancel the agent settles idle with no run, so the next `sendPromptToAgent`
  routes through plain `streamAgent` and still hits the wedged session (the
  mobile reproduction in #3256). Reconciling at the force-cancel point heals both,
  and the replace flow is covered by the same swap.
- **#3742** (merged) handles the inverse drift — provider already settled, daemon
  still holding the run — and this change preserves its contract: ambiguous
  (unacknowledged) interruptions still refuse replacement.
- **#3640 / #3674 / #3683** repair the Codex provider's foreground slot from
  inside the provider (teardown waits, disposeClient release). Complementary,
  provider-local; this PR is the provider-agnostic manager-level reconcile and
  does not duplicate them.
- **#2118** (withdrawn) cleared the turn locally in `interrupt()`; that shape is
  exactly what `docs/agent-lifecycle.md` forbids — accepting new work on a
  session whose prior turn may still be running is a split-brain. This PR never
  reuses a session whose turn state is ambiguous; it replaces the runtime.
- **Not** an attempt at #3964 (generic ACP `steerActiveTurn`): mid-turn steering
  of a *healthy* busy turn remains out of scope and unimplemented here. This PR
  is only about stale foreground-turn ownership after a manager-side forced
  cancellation.

## Regression coverage

`agent-manager.test.ts` (all fixtures model guarded providers — a session that
refuses `startTurn` while its slot is held, like real ACP/Codex sessions):

- **forced cancellation reconciles a provider session that still owns its
  foreground turn** — the #3256 shape: cancel force-settles, the wedged session
  is closed, a resumed session registers, the next *plain* prompt completes, and
  the durable record is `idle` (truthful across restart). Red on main with the
  exact production error; green with the fix.
- **replaceAgentRun succeeds when the provider session still owns its foreground
  turn** — the existing stale-foreground test upgraded from a forgiving fake to a
  guarded one; red on main, green with the fix.
- **forced cancellation keeps the existing session when no replacement can be
  built** — resume fails; the agent stays registered and idle, nothing is torn
  down.
- **a genuinely running foreground turn still rejects a concurrent prompt** —
  the daemon gate, unchanged.
- **a cancellation the provider settles in time does not reload the session** —
  clean cancels keep their session; no resume, no close.
- **forced-cancel reconcile keeps the existing session when the old close hangs**
  and **when the old close rejects** — Greptile P1 #1 / P2 test quality: two
  deterministic scenarios; failed close keeps the existing session registered
  and closes the unused replacement. Session identity, lifecycle, cwd, and
  close-state are asserted (no `toBeDefined()`).
- **forced-cancel reconcile serializes an immediate follow-up onto the
  replacement runtime** — Greptile P1 #2 first-order: latched resume, then a
  concurrent prompt; the follow-up completes on the replacement, not the wedged
  session.
- **forced-cancel follow-up waits for a lifecycle mutation chained after the
  captured swap tail** — Greptile P1 #2 second-order: a one-shot tail wait is
  not atomic; admission now drains until no mutation tails remain, and
  `startTurn` lands only on the last resumed session (`[0, 0, 1]`).
- **forced-cancel reconcile propagates shutdown and keeps the existing session**
  — Greptile P2 error handling: `AgentManagerShuttingDownError` propagates;
  operational `Error`s stay settled and keep-registered.
- **forced-cancel reconcile keeps the existing session when closed-snapshot
  persistence fails** — Greptile P1 #3: replacement is closed, identity /
  timeline / durable idle record survive.

`providers/acp-agent.test.ts`:

- **interrupt without a terminal event keeps the foreground turn until close** —
  pins the ACP wedge contract the manager relies on: `session/cancel` resolves
  without confirmation, the slot survives, `startTurn` refuses, `close()`
  releases.

## Refresh against main (2026-09-09)

Rebased onto current `getpaseo/paseo` `main` at
`fdf3b4b` (`fix(app): show loading state for restored terminal titles` #4553).
PR is **MERGEABLE**. Current `main` still force-cancels without swapping the
provider runtime — no equivalent upstream fix.

Conflict: only `packages/server/src/server/agent/agent-manager.ts`. Resolution
kept `runs.getTurnId()` from current main and the `providerRuntimeSuspect` /
reconcile path from this PR. No other files conflicted.

## Refresh against main (2026-09-16)

Rebased onto current `getpaseo/paseo` `main` at
`64b1a62ed` (`Fix voice reply latency and hide internal prompt wrappers` #4927).
Current `main` still force-cancels without swapping the provider runtime — no
equivalent upstream fix.

Conflict: only `packages/server/src/server/agent/agent-manager.test.ts`.
Resolution kept both helpers — `drainAsyncGenerator` from current main and
`collectAgentStream` from this PR. No production-code conflict. Design and
attribution unchanged: resume-first forced-cancel reconcile, #4353 close-first
reload, original four commits and Co-Authored-By trailers preserved.

## Validation

### Greptile P1 court (head `0979e9e`, 2026-09-09)

Greptile opened three P1s against `317b192`. All three reproduced with
latched/deterministic fixtures (no sleeps). Smallest repairs landed; resume-first
forced-cancel reconcile and #4353 close-first reload are unchanged.

- **P1 #1 CONFIRMED + FIXED** (`swapRegisteredSessionRuntime` close catch at
  former L1626): replacement registered while old `close()` hung or rejected —
  two provider-active runtimes, one Paseo-registered. Failed close now keeps the
  existing session registered and closes the unused replacement.
- **P1 #2 CONFIRMED + FIXED** (`reconcileProviderRuntimeAfterForcedCancel` no-run
  check at former L3124): immediate `streamAgent` during latched resume attached
  to the wedged runtime (`A foreground turn is already active`). Prompt admission
  now waits for the foreground/lifecycle mutation tails, then starts on the
  replacement.
- **P1 #3 CONFIRMED + FIXED** (`persistSnapshot(closedExisting)` at former L1617):
  persist failure still closed both runtimes and left no registered agent. Closed
  snapshot persist now happens before unregistration/close; failure keeps the
  existing session and closes the unused replacement.

New tests in `agent-manager.test.ts`: close hang/reject, latched follow-up,
closed-snapshot persist failure.

### Battery after the P1 repairs (packages/server, vitest 4.1.6)

- Focused reconcile + Greptile P1 battery — **9 passed** (previous 5, plus close
  hang, close reject, latched follow-up, persist-failure keeps session)
- `npx vitest run src/server/agent/agent-manager.test.ts` — **189 passed**
- `acp-agent.test.ts`, `generic-acp-agent.test.ts`,
  `codex-app-server-agent.process-exit.test.ts`, `agent-prompt.test.ts`,
  `mcp-server.test.ts`, `rewind/rewind.test.ts` — **254 passed**
- `codex-app-server-agent.test.ts`, `.features.test.ts`, `.spawn-error.test.ts`,
  `session.test.ts`, `session.workspaces.test.ts`, `lifecycle-command.test.ts`,
  `permission-response.test.ts` — **434 passed / 4 pre-existing skips**
- Combined this pass: **877 passed / 4 skipped**
- Codex already-idle self-heal preserved (`replacement self-heals when Codex
  reports that the tracked turn is already idle`)
- `npm run typecheck` — passed (full monorepo)
- `oxlint` + `oxfmt --check` — clean
- Red demonstration against current main's force-cancel path (reconcile skipped
  on this tree, `acknowledgedInterruptSettleMs` kept so the test is deterministic):
  `replaceAgentRun succeeds when the provider session still owns its foreground
  turn` fails with `Error: A foreground turn is already active` from the fixture
  guard — the production stack shape. `origin/main` has no
  `reconcileProviderRuntimeAfterForcedCancel`.
- Backport check (from the original landing): the commit cherry-picks cleanly
  onto **v0.5.2** and **v0.6.1**; on each, the same three-suite battery passed
  **279/279** and `npm run build --workspace=@getpaseo/server` was clean. Not
  re-run in this refresh.

## Review Round 2 (2026-09-09)

Greptile re-reviewed `0979e9e`. P1 #1 and P1 #3 stay resolved. This round is
head `c2fba12`.

- **P1 #2 CONFIRMED + FIXED (second-order).** A one-shot `get()` of the mutation
  tails present at `streamAgent` entry is not an atomic boundary: after those
  promises are captured, `runLifecycleMutation` can chain another mutation onto
  the same agent. Deterministic latch proof (no sleeps): force-cancel swap
  latched at first resume; ordinary follow-up started; close-first reload chained
  behind the swap and latched in `close()`; a second reload queued while that
  close was held. On `0979e9e` the follow-up `startTurn` landed on the first
  reload's replacement (`startTurnCalls === [0, 1, 0]`). `waitForAgentMutations`
  now loops until neither tail map `has(agentId)`. Chained tails are `set`
  synchronously when queued, so the next `has()` sees them. After the loop,
  `startTurnCalls === [0, 0, 1]` and the live session is the last resumed
  runtime. Empty-tail admission stays synchronous (`createPendingRun` in the
  same turn). No global lock, no retries, no sleeps.
- **P2 error handling CONFIRMED + FIXED.** The reconcile catch rethrows
  non-`Error` values and `AgentManagerShuttingDownError`. Other `Error`s are
  operational swap failures (resume / persist / close / MCP) whose
  keep-registered recovery must not fail the already-settled cancel. Shutdown
  during latched resume rejects cancel with `AgentManagerShuttingDownError`,
  keeps the existing session, and closes the unused replacement.
- **P2 test quality CONFIRMED + FIXED.** Close hang and close reject are
  separate tests. Assertions are session identity, lifecycle, cwd, original
  still registered/`closed === false`, unused replacement `closed === true`,
  durable `idle`.

### Battery after Round 2 (packages/server, vitest 4.1.6)

- Focused reconcile + Round 2 battery — **11 passed**
- `npx vitest run src/server/agent/agent-manager.test.ts` — **191 passed**
- ACP wedged-interrupt + Codex already-idle self-heal — **passed**
- Broader: `acp-agent.test.ts`, four Codex files, `session.test.ts`,
  `session.workspaces.test.ts`, `agent-prompt.test.ts`,
  `lifecycle-command.test.ts`, `permission-response.test.ts` — **561 passed /
  4 pre-existing skips**
- `mcp-server.test.ts` — **119 passed**; `generic-acp-agent.test.ts` +
  `rewind/rewind.test.ts` — **8 passed**
- Combined this pass: **879 passed / 4 skipped**
- `npm run typecheck` — passed (full monorepo)
- `oxlint` + `oxfmt --check` on the touched files — clean
- Preserved: resume-first forced-cancel reconcile, #4353 close-first user
  reload, Codex already-idle self-heal, P1 #1/#3 keep-registered repairs,
  provider-generic scope.

## Live production evidence

Deployed as a patched `@getpaseo/server` build to two production daemons running
a **generic-ACP provider** (an external ACP agent server binary):

- macOS, launchd-managed daemon, Paseo **0.6.1**
- Linux (systemd), Paseo **0.5.2**

Live wedge harness: start a real foreground turn, `SIGSTOP` the provider process
mid-turn (so it can never deliver a terminal event), `paseo stop` (the daemon
logs `acknowledged turn still active after timeout, force-canceling`), then send
an **ordinary follow-up prompt** — the plain-send path #2679 does not cover.

- **Unpatched 0.6.1 baseline (live):** the follow-up send failed with
  `Failed to send message: A foreground turn is already active` and the agent
  stuck in `error` — the exact field failure (also observed the same morning on
  a real user agent, three force-cancel log lines, session had to be archived).
- **Patched, 3 consecutive rounds on each daemon (6 total):** every round the
  force-cancel was followed by
  `cancelAgentRun: reloaded provider session after forced cancellation`, the
  ordinary follow-up **completed**, the old provider process was reaped
  (SIGTERM→SIGKILL escalation), exactly one provider process remained, and the
  agent kept its id and full timeline across the swap.
- **Normal-cancel control:** a healthy cancel settled in 2–3 s with no
  force-cancel and no session swap (provider PID stable), and follow-ups worked.
- **Busy-turn control:** a genuinely running turn stayed `running`, completed
  naturally, and triggered no reconcile — the repair does not mask legitimate
  active-turn behavior.

## QA notes, trade-offs, disclosure

- The `daemon-e2e/*.real.e2e` suites and desktop/mobile client QA were not run
  (no provider credentials in the bench environment); live coverage above was
  collected with the CLI against real daemons instead.
- Trade-off to review: after a forced cancellation the cancel call now also pays
  the provider resume before returning. This only occurs on the
  already-pathological force-cancel path (previously: a permanently wedged
  agent), and matches what a user-initiated reload would cost. During a
  `replaceAgentRun` recovery the UI may show a brief `idle` between the swap's
  re-registration and the replacement turn starting.
- Residual limitation (documented, not regressed): a *wedged* provider whose
  resume also fails stays wedged — identical to current main; the log line
  `failed to swap provider session after forced cancellation` makes it visible.
  And as noted above, this PR does not implement generic ACP `steerActiveTurn`
  (#3964).
- AI-assistance disclosure: this fix was developed and tested with an AI
  engineering agent (Sagan, running on Cursor; "FABLE-5" session), directed and
  reviewed by @natearizona. Every claim above is backed by the committed tests,
  run logs, and the live-daemon evidence — not model diagnosis. The commit
  carries a co-author trailer naming the agent.



