### PR TITLE
fix(app): commit default model for slow-probing providers

### DIFF
--- a/packages/app/src/composer/draft/create-flow.ts
+++ b/packages/app/src/composer/draft/create-flow.ts
@@ -93,7 +93,7 @@ interface UseDraftAgentCreateFlowOptions<TDraftAgent, TCreateResult> {
   onBeforeSubmit?: (ctx: CreateRequestContext) => Promise<void> | void;
   onCreateStart?: () => void;
   createRequest: (ctx: CreateRequestContext) => Promise<CreateRequestResult<TCreateResult>>;
-  buildDraftAgent: (attempt: CreateAttempt) => TDraftAgent;
+  buildDraftAgent: (attempt: CreateAttempt) => TDraftAgent | null;
   onCreateSuccess: (ctx: { result: TCreateResult; attempt: CreateAttempt }) => Promise<void> | void;
   onCreateError?: (error: Error) => void;
 }

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -156,7 +156,7 @@ async function submitDraftCreateRequest(input: {
     featureValues: Record<string, unknown> | undefined;
   };
   hostDisconnectedMessage: string;
-  selectModelMessage: string;
+  providerNotSelectedMessage: string;
 }): Promise<{ agentId: string | null; result: AgentSnapshotPayload }> {
   const {
     attempt,
@@ -179,7 +179,7 @@ async function submitDraftCreateRequest(input: {
 
   const provider = autoSubmitConfig?.provider ?? composerState.selectedProvider;
   if (!provider) {
-    throw new Error(input.selectModelMessage);
+    throw new Error(input.providerNotSelectedMessage);
   }
   const modeIdOverride = resolveDraftModeIdOverride({
     autoSubmitConfig,
@@ -227,8 +227,7 @@ function buildDraftAgentSnapshot(input: {
     selectedProvider: string | null;
     agentControls: { features?: Agent["features"] };
   };
-  selectModelMessage: string;
-}): Agent {
+}): Agent | null {
   const { attempt, serverId, tabId, workspaceDirectory, autoSubmitConfig, composerState } = input;
   invariant(workspaceDirectory, "Workspace directory is required");
   const now = attempt.timestamp;
@@ -241,8 +240,9 @@ function buildDraftAgentSnapshot(input: {
     selectedMode: composerState.selectedMode,
   });
   const provider = autoSubmitConfig?.provider ?? composerState.selectedProvider;
+  // Gated at submit, not asserted during render — null keeps the tab off the error boundary.
   if (!provider) {
-    throw new Error(input.selectModelMessage);
+    return null;
   }
   return {
     serverId,
@@ -505,7 +505,6 @@ export function WorkspaceDraftAgentTab({
         workspaceDirectory: draftWorkingDirectory,
         autoSubmitConfig,
         composerState,
-        selectModelMessage: t("workspaceSetup.errors.selectModel"),
       }),
     createRequest: async ({ attempt, text, images, attachments, cwd }) =>
       submitDraftCreateRequest({
@@ -520,7 +519,7 @@ export function WorkspaceDraftAgentTab({
         autoSubmitConfig,
         composerState,
         hostDisconnectedMessage: t("workspace.terminal.hostDisconnected"),
-        selectModelMessage: t("workspaceSetup.errors.selectModel"),
+        providerNotSelectedMessage: t("providerSelection.readiness.providerNotSelected"),
       }),
     onCreateSuccess: ({ result }) => {
       clearDraftInput("sent");

--- a/packages/app/src/hooks/use-agent-form-state.test.tsx
+++ b/packages/app/src/hooks/use-agent-form-state.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
+import type { FormPreferences } from "./use-form-preferences";
+
+// The hook reads the provider snapshot, form preferences, and host list through
+// these three hooks; drive them directly so the loading→ready transition is
+// deterministic rather than dependent on react-query and the daemon.
+const snapshot: { entries: ProviderSnapshotEntry[] | undefined } = { entries: undefined };
+const preferences: { value: FormPreferences } = { value: {} };
+
+vi.mock("./use-providers-snapshot", () => ({
+  useProvidersSnapshot: () => ({
+    entries: snapshot.entries,
+    isLoading: snapshot.entries === undefined,
+    isRefreshing: false,
+    error: null,
+    refresh: vi.fn(async () => {}),
+    refetchIfStale: vi.fn(),
+  }),
+}));
+
+vi.mock("./use-form-preferences", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-form-preferences")>();
+  return {
+    ...actual,
+    useFormPreferences: () => ({
+      preferences: preferences.value,
+      isLoading: false,
+      updatePreferences: vi.fn(async () => preferences.value),
+    }),
+  };
+});
+
+vi.mock("@/runtime/host-runtime", () => ({
+  useHosts: () => [{ serverId: "s1" }],
+}));
+
+import { useAgentFormState } from "./use-agent-form-state";
+
+const KIRO_MODEL = {
+  provider: "kiro",
+  id: "claude-opus-4.8",
+  label: "Claude Opus 4.8",
+  isDefault: true,
+};
+
+function kiroEntry(status: ProviderSnapshotEntry["status"]): ProviderSnapshotEntry {
+  return {
+    provider: "kiro",
+    status,
+    enabled: true,
+    label: "Kiro",
+    description: "",
+    defaultModeId: "",
+    modes: [],
+    ...(status === "ready" ? { models: [KIRO_MODEL] } : {}),
+  };
+}
+
+function renderFormState() {
+  return renderHook(() =>
+    useAgentFormState({
+      initialServerId: "s1",
+      initialValues: { serverId: "s1", workingDir: "/repo" },
+      isVisible: true,
+      isCreateFlow: true,
+    }),
+  );
+}
+
+describe("useAgentFormState — slow-probing provider", () => {
+  beforeEach(() => {
+    snapshot.entries = undefined;
+    preferences.value = {};
+  });
+
+  it("commits a provider picked while it is still probing (loading)", () => {
+    snapshot.entries = [kiroEntry("loading")];
+    const { result } = renderFormState();
+
+    act(() => {
+      result.current.setProviderAndModelFromUser("kiro", "");
+    });
+
+    expect(result.current.selectedProvider).toBe("kiro");
+  });
+
+  it("backfills the default model once the committed provider reaches ready", () => {
+    snapshot.entries = [kiroEntry("loading")];
+    const { result, rerender } = renderFormState();
+
+    act(() => {
+      result.current.setProviderAndModelFromUser("kiro", "");
+    });
+    expect(result.current.selectedProvider).toBe("kiro");
+    expect(result.current.selectedModel).toBe("");
+
+    snapshot.entries = [kiroEntry("ready")];
+    rerender();
+
+    expect(result.current.selectedProvider).toBe("kiro");
+    expect(result.current.selectedModel).toBe("claude-opus-4.8");
+  });
+
+  it("auto-resolves a remembered probing provider and backfills on ready", () => {
+    preferences.value = { provider: "kiro" };
+    snapshot.entries = [kiroEntry("loading")];
+    const { result, rerender } = renderFormState();
+
+    expect(result.current.selectedProvider).toBe("kiro");
+
+    snapshot.entries = [kiroEntry("ready")];
+    rerender();
+
+    expect(result.current.selectedModel).toBe("claude-opus-4.8");
+  });
+});

--- a/packages/app/src/hooks/use-agent-form-state.ts
+++ b/packages/app/src/hooks/use-agent-form-state.ts
@@ -33,7 +33,6 @@ import {
   INITIAL_AGENT_FORM_RESOLUTION,
   INITIAL_USER_MODIFIED,
   RESOLVABLE_PROVIDER_STATUSES,
-  SELECTABLE_PROVIDER_STATUSES,
   type FormInitialValues,
   type FormState,
   type ProviderModelsByProvider,
@@ -289,13 +288,6 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
       }),
     [snapshotEntries, snapshotProviderDefinitions],
   );
-  const snapshotSelectableProviderDefinitionMap = useMemo(() => {
-    return buildProviderDefinitionMapForStatuses({
-      snapshotEntries,
-      providerDefinitions: snapshotProviderDefinitions,
-      statuses: SELECTABLE_PROVIDER_STATUSES,
-    });
-  }, [snapshotEntries, snapshotProviderDefinitions]);
   const snapshotAllProviderModels = useMemo(
     () => buildAllProviderModels(snapshotEntries),
     [snapshotEntries],
@@ -326,7 +318,7 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
   });
   const providerDefinitions = snapshotProviderDefinitions;
   const providerDefinitionMap = snapshotProviderDefinitionMap;
-  const selectableProviderDefinitionMap = snapshotSelectableProviderDefinitionMap;
+  const committableProviderDefinitionMap = snapshotResolvableProviderDefinitionMap;
   const allProviderModels = snapshotAllProviderModels;
   const modelSelectorProviders = snapshotModelSelectorProviders;
   const availableModels = snapshotSelectedProviderModels;
@@ -388,6 +380,24 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
     snapshotResolvableProviderDefinitionMap,
   ]);
 
+  // COMPLETE_RESOLUTION is one-shot, so backfill the model when a provider
+  // committed while loading later reaches ready.
+  useEffect(() => {
+    const provider = formState.provider;
+    if (!provider) return;
+    if (normalizeSelectedModelId(formState.model) !== "") return;
+    if (snapshotSelectedEntry?.status !== "ready") return;
+    const providerModels = filterSelectableModels(snapshotSelectedEntry.models ?? null);
+    if (!providerModels || providerModels.length === 0) return;
+    const providerPrefs = preferenceOverlayRef.current.current().providerPreferences?.[provider];
+    dispatch({
+      type: "RECONCILE_RESOLVED_PROVIDER",
+      provider,
+      providerModels,
+      providerPrefs,
+    });
+  }, [formState.provider, formState.model, snapshotSelectedEntry]);
+
   const onlineServerIdsKey = onlineServerIds.join("|");
   useEffect(() => {
     const canAutoSelectServerId = shouldAutoSelectServerId({
@@ -422,10 +432,10 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
 
   const setProviderAndModelFromUser = useCallback(
     (provider: AgentProvider, modelId: string) => {
-      if (!selectableProviderDefinitionMap.has(provider)) {
+      if (!committableProviderDefinitionMap.has(provider)) {
         return;
       }
-      const providerDef = selectableProviderDefinitionMap.get(provider);
+      const providerDef = committableProviderDefinitionMap.get(provider);
       const providerModels = allProviderModels.get(provider) ?? null;
       const providerPrefs = preferenceOverlayRef.current.current().providerPreferences?.[provider];
       const normalizedModelId = normalizeSelectedModelId(modelId);
@@ -449,7 +459,7 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
         }),
       );
     },
-    [allProviderModels, selectableProviderDefinitionMap, updateCurrentPreferences],
+    [allProviderModels, committableProviderDefinitionMap, updateCurrentPreferences],
   );
 
   const clearProviderSelectionFromUser = useCallback(() => {
@@ -459,12 +469,12 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
   const applyProfileFromUser = useCallback(
     (profile: MaterializedAgentProfile) => {
       const provider = profile.provider as AgentProvider;
-      if (!selectableProviderDefinitionMap.has(provider)) {
+      if (!committableProviderDefinitionMap.has(provider)) {
         return;
       }
 
       const previousProvider = formState.provider;
-      const providerDef = selectableProviderDefinitionMap.get(provider);
+      const providerDef = committableProviderDefinitionMap.get(provider);
       const providerModels = allProviderModels.get(provider) ?? null;
       const providerPrefs = preferenceOverlayRef.current.current().providerPreferences?.[provider];
       const action = {
@@ -504,7 +514,7 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
       formState,
       providerDefinitionMap,
       resolution,
-      selectableProviderDefinitionMap,
+      committableProviderDefinitionMap,
       updateCurrentPreferences,
       userModified,
     ],

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1549,6 +1549,7 @@ export const ar: TranslationResources = {
       noModelAvailable: "لا يوجد نموذج متاح للموفر المحدد",
       workspaceDirectoryNotFound: "لم يتم العثور على دليل Workspace",
       hostDisconnected: "Host غير متصل",
+      providerNotSelected: "اختر موفراً",
     },
   },
   pairing: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1559,6 +1559,7 @@ export const en = {
       noModelAvailable: "No model is available for the selected provider",
       workspaceDirectoryNotFound: "Workspace directory not found",
       hostDisconnected: "Host is not connected",
+      providerNotSelected: "Select a provider",
     },
   },
   pairing: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1593,6 +1593,7 @@ export const es: TranslationResources = {
       noModelAvailable: "No hay ningún modelo disponible para el proveedor seleccionado",
       workspaceDirectoryNotFound: "DirectorioWorkspaceno encontrado",
       hostDisconnected: "Hostno está conectado",
+      providerNotSelected: "Selecciona un proveedor",
     },
   },
   pairing: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1597,6 +1597,7 @@ export const fr: TranslationResources = {
       noModelAvailable: "Aucun modèle n'est disponible pour le fournisseur sélectionné",
       workspaceDirectoryNotFound: "RépertoireWorkspaceintrouvable",
       hostDisconnected: "Hostn'est pas connecté",
+      providerNotSelected: "Sélectionnez un fournisseur",
     },
   },
   pairing: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1564,6 +1564,7 @@ export const ja: TranslationResources = {
       noModelAvailable: "選択したプロバイダーで利用可能なモデルがありません",
       workspaceDirectoryNotFound: "ワークスペースディレクトリが見つかりません",
       hostDisconnected: "ホストが接続されていません",
+      providerNotSelected: "プロバイダーを選択してください",
     },
   },
   pairing: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1559,6 +1559,7 @@ export const ko: TranslationResources = {
       noModelAvailable: "선택한 프로바이더에 사용 가능한 모델이 없습니다",
       workspaceDirectoryNotFound: "워크스페이스 디렉터리를 찾을 수 없습니다",
       hostDisconnected: "호스트가 연결되어 있지 않습니다",
+      providerNotSelected: "프로바이더를 선택하세요",
     },
   },
   pairing: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1579,6 +1579,7 @@ export const ptBR: TranslationResources = {
       noModelAvailable: "Nenhum modelo disponível para o provedor selecionado",
       workspaceDirectoryNotFound: "Diretório do workspace não encontrado",
       hostDisconnected: "Host não está conectado",
+      providerNotSelected: "Selecione um provedor",
     },
   },
   pairing: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1576,6 +1576,7 @@ export const ru: TranslationResources = {
       noModelAvailable: "Для выбранного провайдера нет доступных моделей.",
       workspaceDirectoryNotFound: "Каталог рабочего пространства не найден",
       hostDisconnected: "Хост не подключён",
+      providerNotSelected: "Выберите провайдера",
     },
   },
   pairing: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1532,6 +1532,7 @@ export const zhCN: TranslationResources = {
       noModelAvailable: "所选 provider 没有可用模型",
       workspaceDirectoryNotFound: "Workspace 目录未找到",
       hostDisconnected: "Host 未连接",
+      providerNotSelected: "请选择 provider",
     },
   },
   pairing: {

--- a/packages/app/src/provider-selection/provider-selection.test.ts
+++ b/packages/app/src/provider-selection/provider-selection.test.ts
@@ -391,6 +391,28 @@ describe("combined model selector data", () => {
     ).toEqual({ ok: true });
   });
 
+  it("reports a provider-worded reason when no provider is committed", () => {
+    expect(
+      resolveSubmissionReadiness({
+        text: "hello",
+        allowsEmptyAutoSubmit: false,
+        providerCount: 1,
+        selection: {
+          provider: null,
+          modelId: "",
+          availableModels: [],
+          isModelLoading: false,
+        },
+        autoSubmitConfig: null,
+        workspaceDirectory: "/repo",
+        hasClient: true,
+      }),
+    ).toEqual({
+      ok: false,
+      reason: i18n.t("providerSelection.readiness.providerNotSelected"),
+    });
+  });
+
   it("uses the active app language for utility labels", async () => {
     await i18n.changeLanguage("zh-CN");
     try {

--- a/packages/app/src/provider-selection/provider-selection.ts
+++ b/packages/app/src/provider-selection/provider-selection.ts
@@ -333,7 +333,7 @@ export function resolveSubmissionReadiness(input: {
     return { ok: false, reason: i18n.t("providerSelection.readiness.noProviders") };
   }
   if (!(input.autoSubmitConfig?.provider ?? input.selection.provider)) {
-    return { ok: false, reason: i18n.t("providerSelection.selectModel") };
+    return { ok: false, reason: i18n.t("providerSelection.readiness.providerNotSelected") };
   }
   if (input.selection.isModelLoading) {
     return { ok: false, reason: i18n.t("providerSelection.readiness.modelDefaultsLoading") };

--- a/packages/app/src/provider-selection/resolve-agent-form.test.ts
+++ b/packages/app/src/provider-selection/resolve-agent-form.test.ts
@@ -1037,6 +1037,101 @@ describe("resolveAgentForm", () => {
 
       expect(next.form.thinkingOptionId).toBe("low");
     });
+
+    it("commits a provider picked while probing with an empty model when no catalog is present", () => {
+      const state = makeState();
+      const next = resolveAgentForm(state, {
+        type: "SET_PROVIDER_AND_MODEL_FROM_USER",
+        provider: "codex",
+        modelId: "",
+        providerDef: TEST_CODEX_DEFINITION,
+        providerModels: null,
+      });
+
+      expect(next.form.provider).toBe("codex");
+      expect(next.form.model).toBe("");
+      expect(next.userModified.provider).toBe(true);
+      expect(next.userModified.model).toBe(true);
+    });
+  });
+
+  describe("RECONCILE_RESOLVED_PROVIDER", () => {
+    it("backfills the default model and thinking when the committed provider becomes ready", () => {
+      const state = makeState({ provider: "codex", model: "", modeId: "auto" });
+      const next = resolveAgentForm(state, {
+        type: "RECONCILE_RESOLVED_PROVIDER",
+        provider: "codex",
+        providerModels: CODEX_MODELS,
+      });
+
+      expect(next.form.model).toBe("gpt-5.3-codex");
+      expect(next.form.thinkingOptionId).toBe("xhigh");
+      expect(next.userModified.model).toBe(false);
+    });
+
+    it("is idempotent: a second reconcile after the model is filled returns state unchanged", () => {
+      const state = makeState({ provider: "codex", model: "", modeId: "auto" });
+      const filled = resolveAgentForm(state, {
+        type: "RECONCILE_RESOLVED_PROVIDER",
+        provider: "codex",
+        providerModels: CODEX_MODELS,
+      });
+      const again = resolveAgentForm(filled, {
+        type: "RECONCILE_RESOLVED_PROVIDER",
+        provider: "codex",
+        providerModels: CODEX_MODELS,
+      });
+
+      expect(again).toBe(filled);
+    });
+
+    it("does not override a user-chosen model", () => {
+      const state = makeState(
+        { provider: "codex", model: "gpt-5.4-codex" },
+        { provider: true, model: true },
+      );
+      const next = resolveAgentForm(state, {
+        type: "RECONCILE_RESOLVED_PROVIDER",
+        provider: "codex",
+        providerModels: CODEX_MODELS,
+      });
+
+      expect(next).toBe(state);
+      expect(next.form.model).toBe("gpt-5.4-codex");
+    });
+
+    it("is a no-op when the resolved catalog is empty", () => {
+      const state = makeState({ provider: "codex", model: "" });
+      const next = resolveAgentForm(state, {
+        type: "RECONCILE_RESOLVED_PROVIDER",
+        provider: "codex",
+        providerModels: [],
+      });
+
+      expect(next).toBe(state);
+    });
+
+    it("is a no-op when the reconciled provider is not the committed provider", () => {
+      const state = makeState({ provider: "claude", model: "" });
+      const next = resolveAgentForm(state, {
+        type: "RECONCILE_RESOLVED_PROVIDER",
+        provider: "codex",
+        providerModels: CODEX_MODELS,
+      });
+
+      expect(next).toBe(state);
+    });
+
+    it("backfills after a pick-while-probing left model empty despite userModified.model", () => {
+      const state = makeState({ provider: "codex", model: "" }, { provider: true, model: true });
+      const next = resolveAgentForm(state, {
+        type: "RECONCILE_RESOLVED_PROVIDER",
+        provider: "codex",
+        providerModels: CODEX_MODELS,
+      });
+
+      expect(next.form.model).toBe("gpt-5.3-codex");
+    });
   });
 
   describe("SET_MODE_FROM_USER", () => {

--- a/packages/app/src/provider-selection/resolve-agent-form.ts
+++ b/packages/app/src/provider-selection/resolve-agent-form.ts
@@ -66,7 +66,6 @@ export const RESOLVABLE_PROVIDER_STATUSES = new Set<ProviderSnapshotEntry["statu
   "ready",
   "loading",
 ]);
-export const SELECTABLE_PROVIDER_STATUSES = new Set<ProviderSnapshotEntry["status"]>(["ready"]);
 
 export type AgentFormAction =
   | { type: "REQUEST_RESOLUTION" }
@@ -97,6 +96,12 @@ export type AgentFormAction =
       providerModels: AgentModelDefinition[] | null;
       providerPrefs?: ProviderPrefs | undefined;
     }
+  | {
+      type: "RECONCILE_RESOLVED_PROVIDER";
+      provider: AgentProvider;
+      providerModels: AgentModelDefinition[] | null;
+      providerPrefs?: ProviderPrefs | undefined;
+    }
   | { type: "SET_MODE_FROM_USER"; modeId: string }
   | {
       type: "SET_MODEL_FROM_USER";
@@ -113,6 +118,10 @@ export type AgentFormAction =
 
 type CompleteResolutionAction = Extract<AgentFormAction, { type: "COMPLETE_RESOLUTION" }>;
 type ApplyProfileAction = Extract<AgentFormAction, { type: "APPLY_PROFILE_FROM_USER" }>;
+type ReconcileResolvedProviderAction = Extract<
+  AgentFormAction,
+  { type: "RECONCILE_RESOLVED_PROVIDER" }
+>;
 
 export function normalizeSelectedModelId(modelId: string | null | undefined): string {
   return typeof modelId === "string" ? modelId.trim() : "";
@@ -615,6 +624,39 @@ function applyProfile(state: AgentFormReducerState, action: ApplyProfileAction) 
   };
 }
 
+// Keyed on an empty model slot (not userModified.model) so a pick-while-probing
+// that resolved to "" is still backfilled once the catalog arrives.
+function reconcileResolvedProvider(
+  state: AgentFormReducerState,
+  action: ReconcileResolvedProviderAction,
+): AgentFormReducerState {
+  if (
+    state.form.provider !== action.provider ||
+    normalizeSelectedModelId(state.form.model) !== ""
+  ) {
+    return state;
+  }
+  const nextModelId = resolveDefaultModelId(action.providerModels);
+  if (!nextModelId) {
+    return state;
+  }
+  const nextThinkingOptionId = state.userModified.thinkingOptionId
+    ? state.form.thinkingOptionId
+    : pickNextThinkingOptionForProvider({
+        providerModels: action.providerModels,
+        providerPrefs: action.providerPrefs,
+        modelId: nextModelId,
+      });
+  return {
+    ...state,
+    form: {
+      ...state.form,
+      model: nextModelId,
+      thinkingOptionId: nextThinkingOptionId,
+    },
+  };
+}
+
 export function resolveAgentForm(
   state: AgentFormReducerState,
   action: AgentFormAction,
@@ -674,6 +716,9 @@ export function resolveAgentForm(
     case "APPLY_PROFILE_FROM_USER": {
       return applyProfile(state, action);
     }
+
+    case "RECONCILE_RESOLVED_PROVIDER":
+      return reconcileResolvedProvider(state, action);
 
     case "SET_MODE_FROM_USER":
       return {


### PR DESCRIPTION
### Linked issue

Fixes #3961

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Starting a New Workspace with a slow-probing custom/ACP provider (e.g. Kiro) showed a default model but crashed on send. `buildDraftAgentSnapshot` threw for a null `selectedProvider`. The provider sits in `status:"loading"` during its ACP probe, so the ready-only guards dropped an early pick, and the one-shot `COMPLETE_RESOLUTION` never reconciled once the provider became ready.

The fix applies to any enabled provider still probing, with no provider-id branching. Providers are now committable while `ready` or `loading`. Once the committed provider becomes ready, its default model is backfilled from the catalog; this is keyed on an empty model slot, so a user's own choice is never overridden. A missing provider is gated at submit rather than thrown during render.

### Goals

- Send with the shown default on a still-probing provider — no crash, no manual re-selection.
- Keep committed draft state and the model-selector display in agreement.

### Non-goals

- Change server-side Kiro/ACP probe timing or the snapshot `status`/`enabled` model.
- Touch composer flows outside the New Workspace draft-create path.

### QA

Reproduced at the hook level with a deterministic loading→ready transition. Pre-fix: `expected null to be 'kiro'` (provider dropped) and `expected '' to be 'claude-opus-4.8'` (model never backfilled). After the fix:

```text
npx vitest run packages/app/src/hooks/use-agent-form-state.test.tsx packages/app/src/provider-selection/resolve-agent-form.test.ts packages/app/src/provider-selection/provider-selection.test.ts --bail=1   # 91 passed
npm run typecheck   # passed
npm run lint        # 0 warnings, 0 errors (changed files)
npm run format      # passed
```

Not exercised on-device against a real Kiro session — verified by unit and regression tests only.

### Risk surface

Draft provider/model resolution in the New Workspace path. Ready-only providers behave as before; disabled/unavailable picks are still dropped; the reconcile is idempotent and never overrides a user-chosen model.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
