### PR TITLE
fix(app): keep chat synchronized with keyboard

### DIFF
--- a/docs/floating-panels.md
+++ b/docs/floating-panels.md
@@ -132,30 +132,21 @@ quietly relying on:
 
 The fix for transforms is Gotcha 3. The fix for context is Gotcha 7.
 
-## Gotcha 3 — Reanimated transforms vs `measureInWindow`
+## Gotcha 3 — Keyboard layout and portal anchors
 
-`measureInWindow` returns the view's _current_ screen position. In theory that
-includes Reanimated-applied transforms (Reanimated updates native view
-properties, and Android's `getLocationInWindow` reads transformed coords). In
-practice it's racy — the measurement may snapshot mid-animation, and on Android
-with Reanimated worklets the result is not always stable.
+Move the chat surface with worklet-driven bottom padding from
+`KeyboardShiftProvider`. Padding keeps the stream, composer, visual position,
+and native hit testing in the same layout. Do not translate the stream and
+composer independently.
 
-If the panel cannot stay inside the transformed ancestor, do not try to track
-the keyboard by re-measuring on every frame. Instead,
-**slave the popover's transform to the same `KeyboardShiftProvider` SharedValue
-the composer uses**:
+Do not use the controller's raw keyboard progress for the padding. It can retain
+a nonzero value after the keyboard closes. The shared provider normalizes that
+state and reconciles native animation-end events.
 
-1. Snapshot `openShift = shift.value` at the moment you measure the anchor.
-2. Apply `useAnimatedStyle(() => ({ transform: [{ translateY: openShift.value - shift.value }] }))`
-   to the popover wrapper.
-
-When `shift` equals `openShift`, the translate is 0 and the popover sits at
-the measured position. When the keyboard moves afterward, the delta translates
-the popover by exactly the amount the composer translates. They move in
-lockstep, no re-measurement needed. Do not call
-`useReanimatedKeyboardAnimation()` directly for app UI offset policy; Android
-can briefly report a stale nonzero height with closed progress, and the shared
-provider is where that is normalized.
+`measureInWindow` already includes the dock's current padding layout. When a
+portal opens, snapshot the current shift and apply only the subsequent shift
+delta to its animated `bottom`. Adding the full shift moves the portal twice and
+can place it over the composer controls.
 
 The provider also reconciles iOS from the controller's native `onEnd` event.
 The controller's stock iOS shared values update at move start and during an

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dev:server:raw": "npm run dev --workspace=@getpaseo/server",
     "dev:app": "cross-env PASEO_LISTEN=127.0.0.1:6768 EXPO_PORT=8081 ./scripts/dev-app.sh",
     "test:e2e:mobile": "./scripts/test-mobile-agent-device.sh",
+    "test:e2e:composer-keyboard:android": "./packages/app/e2e/mobile/composer-keyboard/android.sh",
     "dev:website": "npm run dev --workspace=@getpaseo/website",
     "postinstall": "node scripts/postinstall-patches.mjs",
     "prepare": "lefthook install --force",

--- a/packages/app/e2e/mobile/composer-keyboard/android.sh
+++ b/packages/app/e2e/mobile/composer-keyboard/android.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+STATE_DIR="${REPO_ROOT}/.dev/agent-device-composer-keyboard"
+ARTIFACTS_DIR="${REPO_ROOT}/.dev/agent-device-artifacts/composer-keyboard-android"
+SESSION="composer-keyboard-android"
+APP_ID="${PASEO_COMPOSER_KEYBOARD_APP_ID:-sh.paseo.debug}"
+DEVICE="${PASEO_COMPOSER_KEYBOARD_DEVICE:-paseo-api35}"
+HELPER_IME="com.callstack.agentdevice.imehelper/.TestInputMethodService"
+GBOARD_IME="com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME"
+ASSERT="${REPO_ROOT}/packages/app/e2e/mobile/composer-keyboard/assert-composer-keyboard.mjs"
+STALL_HERMES="${REPO_ROOT}/packages/app/e2e/mobile/composer-keyboard/stall-hermes.mjs"
+METRO_PORT="${PASEO_MOBILE_E2E_METRO_PORT:-8082}"
+DAEMON_HOST="${PASEO_COMPOSER_KEYBOARD_DAEMON_HOST:-127.0.0.1:6770}"
+DAEMON_HOME="${PASEO_COMPOSER_KEYBOARD_DAEMON_HOME:-${REPO_ROOT}/.dev/composer-e2e-home}"
+SERVER_ID="${PASEO_COMPOSER_KEYBOARD_SERVER_ID:-}"
+MESSAGE=$'keyboard invariant line one\nline two\nline three\nline four'
+AGENT_TITLE="Keyboard dismiss QA $(date +%s)"
+
+if [[ -z "${SERVER_ID}" ]]; then
+  if [[ ! -f "${DAEMON_HOME}/server-id" ]]; then
+    echo "Missing ${DAEMON_HOME}/server-id; set PASEO_COMPOSER_KEYBOARD_SERVER_ID" >&2
+    exit 1
+  fi
+  SERVER_ID="$(<"${DAEMON_HOME}/server-id")"
+fi
+
+ad() {
+  AGENT_DEVICE_STATE_DIR="${STATE_DIR}" agent-device "$@" --session "${SESSION}"
+}
+
+capture_screen() {
+  local output_path="$1"
+  ad screenshot "${output_path}" >/dev/null
+}
+
+snapshot_json() {
+  local output_path="$1"
+  ad snapshot -i --json >"${output_path}"
+}
+
+clear_input() {
+  ad fill 'editable=true' "x" --settle
+  adb shell input keycombination 113 29
+  adb shell input keyevent 67
+}
+
+clear_focused_input_with_adb() {
+  adb shell input keycombination 113 29
+  adb shell input keyevent 67
+}
+
+wait_for_ime() {
+  local expected="$1"
+  local previous_top=""
+  local stable_count=0
+  for _ in $(seq 1 30); do
+    local window_state
+    window_state="$(adb shell dumpsys window)"
+    if [[ "${expected}" == "true" ]]; then
+      local ime_top
+      ime_top="$(printf '%s' "${window_state}" | sed -n 's/.*type=ime frame=\[0,\([0-9][0-9]*\)\].*visible=true.*/\1/p' | head -1)"
+      if [[ -n "${ime_top}" && "${ime_top}" -gt 0 ]]; then
+        if [[ "${ime_top}" == "${previous_top}" ]]; then
+          stable_count="$((stable_count + 1))"
+        else
+          stable_count=0
+          previous_top="${ime_top}"
+        fi
+        if [[ "${stable_count}" -ge 2 ]]; then
+          return
+        fi
+      fi
+    elif ! printf '%s' "${window_state}" | rg -q "type=ime .*visible=true"; then
+      return
+    fi
+    sleep 0.1
+  done
+  echo "IME did not become visible=${expected}" >&2
+  exit 1
+}
+
+ime_is_visible() {
+  adb shell dumpsys window | rg -q "type=ime .*visible=true"
+}
+
+open_gboard() {
+  local x="$1"
+  local y="$2"
+  adb shell ime set "${GBOARD_IME}" >/dev/null
+  if ime_is_visible; then
+    adb shell input keyevent BACK
+    wait_for_ime false
+  fi
+  adb shell input tap "${x}" "${y}"
+  wait_for_ime true
+  local keyboard_shift
+  keyboard_shift="$(read_keyboard_shift)"
+  adb shell input tap "${x}" "$((y - keyboard_shift))"
+}
+
+read_keyboard_shift() {
+  local ime_top
+  local navigation_top
+  ime_top="$(adb shell dumpsys window | sed -n 's/.*type=ime frame=\[0,\([0-9][0-9]*\)\].*visible=true.*/\1/p' | head -1)"
+  navigation_top="$(adb shell dumpsys window | sed -n 's/.*type=navigationBars frame=\[0,\([0-9][0-9]*\)\].*/\1/p' | head -1)"
+  printf '%s\n' "$((navigation_top - ime_top))"
+}
+
+cleanup() {
+  adb shell ime set "${HELPER_IME}" >/dev/null 2>&1 || true
+  AGENT_DEVICE_STATE_DIR="${STATE_DIR}" agent-device daemon stop --clean >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT INT TERM
+cleanup
+mkdir -p "${STATE_DIR}" "${ARTIFACTS_DIR}"
+
+workspaces_json="$(env -u PASEO_CALLER_AGENT_ID -u PASEO_AGENT_ID -u PASEO_WORKSPACE_ID \
+  npm run --silent cli -- workspace ls --json --host "${DAEMON_HOST}")"
+workspace_id="$(node -e '
+  const workspaces = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+  const cwd = process.argv[1];
+  const workspace = workspaces.find((candidate) => candidate.cwd === cwd);
+  if (!workspace) process.exit(1);
+  process.stdout.write(workspace.workspaceId);
+' "${REPO_ROOT}" <<<"${workspaces_json}")"
+
+AGENT_DEVICE_STATE_DIR="${STATE_DIR}" agent-device open "${APP_ID}" \
+  --platform android \
+  --device "${DEVICE}" \
+  --session "${SESSION}"
+adb shell am force-stop "${APP_ID}"
+adb shell am start \
+  -a android.intent.action.VIEW \
+  -d "exp+voice-mobile://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A${METRO_PORT}" \
+  "${APP_ID}" >/dev/null
+sleep 3
+
+# Create the fixture while the client is connected so its directory replica observes the insert.
+run_json="$(env -u PASEO_CALLER_AGENT_ID -u PASEO_AGENT_ID -u PASEO_WORKSPACE_ID \
+  npm run --silent cli -- run "Exercise the composer keyboard invariant flow" \
+  --background \
+  --title "${AGENT_TITLE}" \
+  --provider mock \
+  --model e2e-fast-stream \
+  --workspace "${workspace_id}" \
+  --cwd "${REPO_ROOT}" \
+  --host "${DAEMON_HOST}" \
+  --json)"
+agent_id="$(node -e '
+  const result = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+  process.stdout.write(result.agentId);
+' <<<"${run_json}")"
+sleep 3
+
+adb shell am start \
+  -a android.intent.action.VIEW \
+  -d "paseo://h/${SERVER_ID}/agent/${agent_id}" \
+  "${APP_ID}" >/dev/null
+sleep 5
+# The development-client bootstrap can consume the first link while Expo Router is mounting.
+# Deliver the target again after the root navigator is live.
+adb shell am start \
+  -a android.intent.action.VIEW \
+  -d "paseo://h/${SERVER_ID}/agent/${agent_id}" \
+  "${APP_ID}" >/dev/null
+ad wait "text=\"${AGENT_TITLE}\"" 45000
+ad wait 'editable=true' 10000
+clear_input
+ad keyboard dismiss || true
+ad wait 'label="Message, @files, /commands"' 10000
+
+snapshot_json "${ARTIFACTS_DIR}/baseline.json"
+capture_screen "${ARTIFACTS_DIR}/baseline.png"
+read -r input_x input_y baseline_input_height < <(
+  node "${ASSERT}" rect "${ARTIFACTS_DIR}/baseline.json" "Message, @files, /commands"
+)
+read -r model_x model_y _ < <(
+  node "${ASSERT}" rect "${ARTIFACTS_DIR}/baseline.json" "combined-model-selector"
+)
+read -r attach_x attach_y _ < <(
+  node "${ASSERT}" rect "${ARTIFACTS_DIR}/baseline.json" "message-input-attach-button"
+)
+read -r _ header_y _ < <(
+  node "${ASSERT}" rect "${ARTIFACTS_DIR}/baseline.json" "workspace-tab-switcher-trigger"
+)
+
+adb shell input keyevent HOME
+adb shell am start -n "${APP_ID}/.MainActivity" >/dev/null
+sleep 1
+open_gboard "${input_x}" "${input_y}"
+clear_focused_input_with_adb
+keyboard_shift="$(read_keyboard_shift)"
+adb shell input keyevent 76
+sleep 1
+capture_screen "${ARTIFACTS_DIR}/command-popover.png"
+ad wait 'id="composer-autocomplete-popover"' 10000
+ad wait 'text="/exit"' 10000
+model_open_y="$((model_y - keyboard_shift))"
+adb shell input tap "${model_x}" "${model_open_y}"
+sleep 1
+capture_screen "${ARTIFACTS_DIR}/model-selector-open.png"
+adb shell ime set "${HELPER_IME}" >/dev/null
+ad wait 'id="compact-provider-list"' 10000
+ad press 'label="Close"' --settle
+adb shell input tap "${input_x}" "${input_y}"
+clear_focused_input_with_adb
+ad wait 'editable=true' 10000
+
+adb shell input keyevent HOME
+adb shell am start -n "${APP_ID}/.MainActivity" >/dev/null
+sleep 1
+open_gboard "${input_x}" "${input_y}"
+clear_focused_input_with_adb
+adb shell input keyevent 76
+sleep 1
+adb shell ime set "${HELPER_IME}" >/dev/null
+ad wait 'id="composer-autocomplete-popover"' 10000
+ad wait 'text="/exit"' 10000
+snapshot_json "${ARTIFACTS_DIR}/command-popover.json"
+node "${ASSERT}" above-y \
+  "${ARTIFACTS_DIR}/command-popover.json" \
+  "/exit, Archive the current agent" \
+  "$((input_y - baseline_input_height / 2))"
+adb shell input keyevent 67
+ad wait 'label="Message, @files, /commands"' 10000
+
+ad fill 'label="Message, @files, /commands"' "${MESSAGE}" --settle
+snapshot_json "${ARTIFACTS_DIR}/multiline-first.json"
+ad fill 'editable=true focused=true' "${MESSAGE}" --settle
+snapshot_json "${ARTIFACTS_DIR}/multiline-second.json"
+node "${ASSERT}" same-input-height \
+  "${ARTIFACTS_DIR}/multiline-first.json" \
+  "${ARTIFACTS_DIR}/multiline-second.json"
+
+adb shell input keyevent HOME
+adb shell am start -n "${APP_ID}/.MainActivity" >/dev/null
+sleep 1
+open_gboard "${input_x}" "${input_y}"
+
+keyboard_shift="$(read_keyboard_shift)"
+capture_screen "${ARTIFACTS_DIR}/keyboard-open.png"
+
+node "${ASSERT}" same-header \
+  "${ARTIFACTS_DIR}/baseline.png" \
+  "${ARTIFACTS_DIR}/keyboard-open.png" \
+  "$((header_y + 48))"
+
+read -r changes_x changes_y _ < <(
+  node "${ASSERT}" rect "${ARTIFACTS_DIR}/multiline-second.json" "Open Changes tab"
+)
+adb shell input tap "${changes_x}" "$((changes_y - keyboard_shift))"
+ad wait 'id="changes-header"' 10000
+capture_screen "${ARTIFACTS_DIR}/changes-control-open.png"
+ad press 'label="Close Explorer sidebar"' --settle
+ad wait "text=\"${AGENT_TITLE}\"" 10000
+ad wait 'editable=true' 10000
+
+open_gboard "${input_x}" "${input_y}"
+keyboard_shift="$(read_keyboard_shift)"
+adb shell input tap "${attach_x}" "$((attach_y - keyboard_shift))"
+sleep 1
+adb shell ime set "${HELPER_IME}" >/dev/null
+ad wait 'id="message-input-attachment-menu-content"' 10000
+ad press 540 600 --settle
+
+open_gboard "${input_x}" "${input_y}"
+keyboard_shift="$(read_keyboard_shift)"
+adb shell input tap 983 "$((attach_y - keyboard_shift))"
+wait_for_ime false
+adb shell ime set "${HELPER_IME}" >/dev/null
+ad wait text "keyboard invariant line one" 10000
+snapshot_json "${ARTIFACTS_DIR}/after-submit.json"
+node "${ASSERT}" has-exact-text "${ARTIFACTS_DIR}/after-submit.json" "${MESSAGE}"
+node "${ASSERT}" same-input-height \
+  "${ARTIFACTS_DIR}/baseline.json" \
+  "${ARTIFACTS_DIR}/after-submit.json"
+
+open_gboard "${input_x}" "${input_y}"
+adb shell input keyevent BACK
+wait_for_ime false
+sleep 0.5
+capture_screen "${ARTIFACTS_DIR}/hidden-focused-baseline.png"
+
+open_gboard "${input_x}" "${input_y}"
+node "${STALL_HERMES}" "${METRO_PORT}" 3000 "${APP_ID}" &
+stall_pid="$!"
+sleep 0.25
+adb shell input keyevent BACK
+wait_for_ime false
+sleep 0.5
+capture_screen "${ARTIFACTS_DIR}/hidden-during-js-stall.png"
+wait "${stall_pid}"
+capture_screen "${ARTIFACTS_DIR}/hidden-after-js-stall.png"
+node "${ASSERT}" same-region \
+  "${ARTIFACTS_DIR}/hidden-focused-baseline.png" \
+  "${ARTIFACTS_DIR}/hidden-during-js-stall.png" \
+  1400 \
+  430
+node "${ASSERT}" same-region \
+  "${ARTIFACTS_DIR}/hidden-focused-baseline.png" \
+  "${ARTIFACTS_DIR}/hidden-after-js-stall.png" \
+  1400 \
+  430
+
+echo "Composer keyboard invariants passed"

--- a/packages/app/e2e/mobile/composer-keyboard/assert-composer-keyboard.mjs
+++ b/packages/app/e2e/mobile/composer-keyboard/assert-composer-keyboard.mjs
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import process from "node:process";
+import sharp from "sharp";
+
+const [, , command, ...args] = process.argv;
+
+if (command === "rect") {
+  const [snapshotPath, identifier] = args;
+  const snapshot = JSON.parse(await fs.readFile(snapshotPath, "utf8"));
+  const node = snapshot.data.nodes.find(
+    (candidate) => candidate.identifier === identifier || candidate.label === identifier,
+  );
+  if (!node) throw new Error(`Missing node: ${identifier}`);
+  const { x, y, width, height } = node.rect;
+  process.stdout.write(`${Math.round(x + width / 2)} ${Math.round(y + height / 2)} ${height}\n`);
+} else if (command === "above-y") {
+  const [snapshotPath, upperIdentifier, lowerYArgument] = args;
+  const snapshot = JSON.parse(await fs.readFile(snapshotPath, "utf8"));
+  const upper = snapshot.data.nodes.find(
+    (candidate) => candidate.identifier === upperIdentifier || candidate.label === upperIdentifier,
+  );
+  if (!upper) throw new Error(`Missing node: ${upperIdentifier}`);
+  const upperBottom = upper.rect.y + upper.rect.height;
+  const lowerY = Number(lowerYArgument);
+  if (upperBottom > lowerY) {
+    throw new Error(
+      `${upperIdentifier} extends below the composer top: ${upperBottom} > ${lowerY}`,
+    );
+  }
+} else if (command === "same-header") {
+  const [baselinePath, keyboardPath, headerBottomArgument] = args;
+  const headerBottom = Number(headerBottomArgument);
+  const crop = { left: 0, top: 64, width: 1080, height: headerBottom - 64 };
+  const [baseline, keyboard] = await Promise.all([
+    sharp(baselinePath).extract(crop).removeAlpha().raw().toBuffer(),
+    sharp(keyboardPath).extract(crop).removeAlpha().raw().toBuffer(),
+  ]);
+  let changed = 0;
+  for (let index = 0; index < baseline.length; index += 1) {
+    if (Math.abs(baseline[index] - keyboard[index]) > 8) changed += 1;
+  }
+  const changedRatio = changed / baseline.length;
+  if (changedRatio > 0.01) {
+    throw new Error(`Header changed while the keyboard opened (${changedRatio.toFixed(3)})`);
+  }
+} else if (command === "same-input-height") {
+  const [firstPath, secondPath] = args;
+  const readInputHeight = async (snapshotPath) => {
+    const snapshot = JSON.parse(await fs.readFile(snapshotPath, "utf8"));
+    const input = snapshot.data.nodes.find((candidate) => candidate.type.endsWith("EditText"));
+    if (!input) throw new Error(`Missing composer input in ${snapshotPath}`);
+    return input.rect.height;
+  };
+  const [firstHeight, secondHeight] = await Promise.all([
+    readInputHeight(firstPath),
+    readInputHeight(secondPath),
+  ]);
+  if (firstHeight !== secondHeight) {
+    throw new Error(`Composer height drifted from ${firstHeight} to ${secondHeight}`);
+  }
+} else if (command === "has-exact-text") {
+  const [snapshotPath, expected] = args;
+  const snapshot = JSON.parse(await fs.readFile(snapshotPath, "utf8"));
+  if (!snapshot.data.nodes.some((candidate) => candidate.label === expected)) {
+    throw new Error(`Missing exact text in ${snapshotPath}: ${expected}`);
+  }
+} else if (command === "same-region") {
+  const [firstPath, secondPath, topArgument, heightArgument, failureMessage] = args;
+  const crop = {
+    left: 0,
+    top: Number(topArgument),
+    width: 1080,
+    height: Number(heightArgument),
+  };
+  const [first, second] = await Promise.all([
+    sharp(firstPath).extract(crop).removeAlpha().raw().toBuffer(),
+    sharp(secondPath).extract(crop).removeAlpha().raw().toBuffer(),
+  ]);
+  let changed = 0;
+  for (let index = 0; index < first.length; index += 1) {
+    if (Math.abs(first[index] - second[index]) > 8) changed += 1;
+  }
+  const changedRatio = changed / first.length;
+  if (changedRatio > 0.02) {
+    throw new Error(
+      `${failureMessage ?? "Composer region changed during the JS stall"} (${changedRatio.toFixed(3)})`,
+    );
+  }
+} else {
+  throw new Error(`Unknown command: ${command}`);
+}

--- a/packages/app/e2e/mobile/composer-keyboard/stall-hermes.mjs
+++ b/packages/app/e2e/mobile/composer-keyboard/stall-hermes.mjs
@@ -1,0 +1,35 @@
+import process from "node:process";
+import { WebSocket } from "ws";
+
+const [, , metroPortArgument, durationArgument, appId] = process.argv;
+const metroPort = Number(metroPortArgument);
+const duration = Number(durationArgument);
+const targets = await fetch(`http://127.0.0.1:${metroPort}/json/list`).then((response) =>
+  response.json(),
+);
+const target = targets.find((candidate) => candidate.appId === appId);
+if (!target) throw new Error(`Missing Hermes target for ${appId}`);
+
+await new Promise((resolve, reject) => {
+  const socket = new WebSocket(target.webSocketDebuggerUrl);
+  const timeout = setTimeout(() => reject(new Error("Hermes stall timed out")), duration + 5000);
+  socket.on("open", () => {
+    socket.send(
+      JSON.stringify({
+        id: 1,
+        method: "Runtime.evaluate",
+        params: {
+          expression: `(() => { const deadline = Date.now() + ${duration}; while (Date.now() < deadline) {} })()`,
+        },
+      }),
+    );
+  });
+  socket.on("message", (message) => {
+    const response = JSON.parse(message.toString());
+    if (response.id !== 1) return;
+    clearTimeout(timeout);
+    socket.close();
+    resolve();
+  });
+  socket.on("error", reject);
+});

--- a/packages/app/src/components/keyboard-dock.d.ts
+++ b/packages/app/src/components/keyboard-dock.d.ts
@@ -1,0 +1,1 @@
+export * from "./keyboard-dock.native";

--- a/packages/app/src/components/keyboard-dock.native.tsx
+++ b/packages/app/src/components/keyboard-dock.native.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import type { ViewProps } from "react-native";
+import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import { useKeyboardShift } from "@/hooks/keyboard-shift-context";
+
+interface KeyboardDockProps extends ViewProps {
+  children: ReactNode;
+}
+
+export function KeyboardDock({ children, style, ...props }: KeyboardDockProps) {
+  const { shift } = useKeyboardShift();
+  const keyboardPaddingStyle = useAnimatedStyle(() => ({
+    paddingBottom: shift.value,
+  }));
+
+  return (
+    <Animated.View style={[style, keyboardPaddingStyle]} {...props}>
+      {children}
+    </Animated.View>
+  );
+}

--- a/packages/app/src/components/keyboard-dock.web.tsx
+++ b/packages/app/src/components/keyboard-dock.web.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+import { View, type ViewProps } from "react-native";
+
+interface KeyboardDockProps extends ViewProps {
+  children: ReactNode;
+}
+
+export function KeyboardDock(props: KeyboardDockProps) {
+  return <View {...props} />;
+}

--- a/packages/app/src/components/ui/autocomplete-popover.tsx
+++ b/packages/app/src/components/ui/autocomplete-popover.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ReactElement, type RefObject } from 
 import { Keyboard, View, useWindowDimensions } from "react-native";
 import { Portal } from "@gorhom/portal";
 import Animated, { useAnimatedStyle, useSharedValue } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { StyleSheet } from "react-native-unistyles";
 import { Autocomplete, type AutocompleteOption } from "@/components/ui/autocomplete";
 import {
@@ -63,9 +64,10 @@ export function AutocompletePopover({
   // React Compiler memoizes effect captures by reading SharedValue.value during render.
   const [relativeAnchorRect, setRelativeAnchorRect] = useState<RelativeAnchorRect | null>(null);
   const windowDimensions = useWindowDimensions();
+  const safeAreaInsets = useSafeAreaInsets();
   const portalHostName = useFloatingPanelPortalHostName();
   const { shift } = useKeyboardShift();
-  const openShift = useSharedValue(0);
+  const measuredShift = useSharedValue(0);
 
   useEffect(() => {
     if (!visible || (options.length > 0 && selectedIndex < 0)) {
@@ -88,7 +90,7 @@ export function AutocompletePopover({
           width: anchorRect.width,
           hostHeight: hostRect.height,
         });
-        openShift.value = shift.value;
+        measuredShift.value = shift.value;
         return undefined;
       });
     };
@@ -110,7 +112,7 @@ export function AutocompletePopover({
     selectedIndex,
     anchorRef,
     portalHostName,
-    openShift,
+    measuredShift,
     shift,
     windowDimensions.width,
     windowDimensions.height,
@@ -120,20 +122,22 @@ export function AutocompletePopover({
     if (!relativeAnchorRect) return null;
     return inlineUnistylesStyle({
       position: "absolute" as const,
-      bottom: relativeAnchorRect.hostHeight - relativeAnchorRect.y + OFFSET_FROM_ANCHOR,
       left: relativeAnchorRect.x,
       width: relativeAnchorRect.width,
     });
   }, [relativeAnchorRect]);
 
-  const animatedTransformStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: openShift.value - shift.value }],
-  }));
-
-  const composedStyle = useMemo(
-    () => [baseStyle, animatedTransformStyle],
-    [baseStyle, animatedTransformStyle],
-  );
+  const anchorY = relativeAnchorRect?.y ?? 0;
+  const baseBottom = relativeAnchorRect
+    ? relativeAnchorRect.hostHeight - relativeAnchorRect.y + OFFSET_FROM_ANCHOR
+    : 0;
+  const keyboardLayoutStyle = useAnimatedStyle(() => {
+    const shiftDelta = shift.value - measuredShift.value;
+    return {
+      bottom: baseBottom + shiftDelta,
+      maxHeight: Math.max(0, anchorY - shiftDelta - safeAreaInsets.top - OFFSET_FROM_ANCHOR * 2),
+    };
+  }, [anchorY, baseBottom, safeAreaInsets.top]);
 
   if (!visible || !relativeAnchorRect || !baseStyle) return null;
   if (options.length > 0 && selectedIndex < 0) return null;
@@ -141,7 +145,10 @@ export function AutocompletePopover({
   return (
     <Portal hostName={portalHostName}>
       <View style={styles.overlay} pointerEvents="box-none">
-        <Animated.View testID="composer-autocomplete-popover" style={composedStyle}>
+        <Animated.View
+          testID="composer-autocomplete-popover"
+          style={[baseStyle, keyboardLayoutStyle]}
+        >
           <Autocomplete
             options={options}
             selectedIndex={selectedIndex}

--- a/packages/app/src/components/ui/autocomplete.tsx
+++ b/packages/app/src/components/ui/autocomplete.tsx
@@ -288,6 +288,8 @@ export function Autocomplete({
 
 const styles = StyleSheet.create((theme: Theme) => ({
   outerWrapper: {
+    flexShrink: 1,
+    minHeight: 0,
     gap: theme.spacing[1],
   },
   detailCard: {
@@ -315,6 +317,8 @@ const styles = StyleSheet.create((theme: Theme) => ({
     marginTop: theme.spacing[1],
   },
   container: {
+    flexShrink: 1,
+    minHeight: 0,
     backgroundColor: theme.colors.surface1,
     borderWidth: theme.borderWidth[1],
     borderColor: theme.colors.borderAccent,

--- a/packages/app/src/components/ui/text-input/text-input.native.test.tsx
+++ b/packages/app/src/components/ui/text-input/text-input.native.test.tsx
@@ -92,6 +92,45 @@ describe("EditingTextInputNative", () => {
     expect(handleRef.current?.getText()).toBe("");
   });
 
+  it("replaces the native input when clearing text", () => {
+    const handleRef = createRef<EditingTextInputHandle>();
+
+    act(() => {
+      root?.render(
+        <EditingTextInput
+          ref={handleRef}
+          initialValue="line one\nline two\nline three"
+          onChangeText={noop}
+        />,
+      );
+    });
+    const grownInput = container?.querySelector("input");
+
+    act(() => {
+      handleRef.current?.replaceText("");
+    });
+
+    expect(container?.querySelector("input")).not.toBe(grownInput);
+  });
+
+  it("restores focus after replacing a cleared native input", () => {
+    const handleRef = createRef<EditingTextInputHandle>();
+
+    act(() => {
+      root?.render(<EditingTextInput ref={handleRef} initialValue="message" />);
+    });
+    const originalInput = container?.querySelector("input");
+    if (!originalInput) throw new Error("Expected native input");
+    Object.assign(originalInput, { isFocused: () => true });
+    originalInput.focus();
+
+    act(() => {
+      handleRef.current?.replaceText("");
+    });
+
+    expect(document.activeElement).toBe(container?.querySelector("input"));
+  });
+
   it("updates textRef and text when replaceText receives non-empty text", () => {
     const handleRef = createRef<EditingTextInputHandle>();
 

--- a/packages/app/src/components/ui/text-input/text-input.native.tsx
+++ b/packages/app/src/components/ui/text-input/text-input.native.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from "react";
 import { TextInput } from "react-native";
 import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import PasteInput, {
@@ -11,7 +11,7 @@ import type { EditingTextInputHandle, EditingTextInputProps } from "./types";
 type NativeInput = (TextInput | PasteTextInputInstance) & {
   blur(): void;
   focus(): void;
-  isFocused(): boolean;
+  isFocused?(): boolean;
   clear?(): void;
   replaceText?(text: string, selection?: { start: number; end: number }): void;
   setNativeProps?(props: { text?: string; selection?: { start: number; end: number } }): void;
@@ -35,26 +35,41 @@ export const EditingTextInput = forwardRef<EditingTextInputHandle, EditingTextIn
     const inputRef = useRef<NativeInput | null>(null);
     const initialTextRef = useRef(initialValue);
     const textRef = useRef(initialTextRef.current);
+    const restoreFocusAfterResetRef = useRef(false);
+    const [nativeInputRevision, setNativeInputRevision] = useState(0);
+
+    const assignInputRef = useCallback((input: NativeInput | null) => {
+      inputRef.current = input;
+      if (!input || !restoreFocusAfterResetRef.current) return;
+      restoreFocusAfterResetRef.current = false;
+      input.focus();
+    }, []);
 
     useImperativeHandle(ref, () => ({
       focus: () => inputRef.current?.focus(),
       blur: () => inputRef.current?.blur(),
-      isFocused: () => inputRef.current?.isFocused() ?? false,
+      isFocused: () => inputRef.current?.isFocused?.() ?? false,
       getText: () => textRef.current,
       replaceText: (nextText, selection) => {
         textRef.current = nextText;
+        if (nextText === "") {
+          restoreFocusAfterResetRef.current = inputRef.current?.isFocused?.() ?? false;
+          if (inputRef.current?.replaceText) {
+            inputRef.current.replaceText(nextText, selection);
+          } else {
+            inputRef.current?.clear?.();
+          }
+          setNativeInputRevision((revision) => revision + 1);
+          return;
+        }
         if (inputRef.current?.replaceText) {
           inputRef.current.replaceText(nextText, selection);
           return;
         }
-        if (nextText === "") {
-          inputRef.current?.clear?.();
-        } else {
-          inputRef.current?.setNativeProps?.({
-            text: nextText,
-            ...(selection ? { selection } : {}),
-          });
-        }
+        inputRef.current?.setNativeProps?.({
+          text: nextText,
+          ...(selection ? { selection } : {}),
+        });
         if (selection) inputRef.current?.setSelection?.(selection.start, selection.end);
       },
       getNativeRef: () => inputRef.current?.getNativeRef?.() ?? inputRef.current,
@@ -82,8 +97,9 @@ export const EditingTextInput = forwardRef<EditingTextInputHandle, EditingTextIn
       return (
         <PasteInput
           {...props}
-          ref={inputRef as React.Ref<PasteTextInputInstance>}
-          defaultValue={initialTextRef.current}
+          key={nativeInputRevision}
+          ref={assignInputRef as React.Ref<PasteTextInputInstance>}
+          defaultValue={textRef.current}
           onChangeText={handleChangeText}
           onPaste={handlePaste}
         />
@@ -93,8 +109,9 @@ export const EditingTextInput = forwardRef<EditingTextInputHandle, EditingTextIn
       return (
         <BottomSheetTextInput
           {...props}
-          ref={inputRef as unknown as React.Ref<never>}
-          defaultValue={initialTextRef.current}
+          key={nativeInputRevision}
+          ref={assignInputRef as unknown as React.Ref<never>}
+          defaultValue={textRef.current}
           onChangeText={handleChangeText}
         />
       );
@@ -102,8 +119,9 @@ export const EditingTextInput = forwardRef<EditingTextInputHandle, EditingTextIn
     return (
       <TextInput
         {...props}
-        ref={inputRef as React.Ref<TextInput>}
-        defaultValue={initialTextRef.current}
+        key={nativeInputRevision}
+        ref={assignInputRef as React.Ref<TextInput>}
+        defaultValue={textRef.current}
         onChangeText={handleChangeText}
       />
     );

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -5,6 +5,7 @@ import type { TFunction } from "i18next";
 import { SquarePen } from "lucide-react-native";
 import React, {
   memo,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -14,7 +15,6 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet as RNStyleSheet, Text, View } from "react-native";
-import ReanimatedAnimated from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import invariant from "tiny-invariant";
@@ -22,6 +22,7 @@ import { shallow, useShallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { AgentStreamView, type AgentStreamViewHandle } from "@/agent-stream/view";
 import { ArchivedAgentCallout } from "@/components/archived-agent-callout";
+import { KeyboardDock } from "@/components/keyboard-dock";
 import { FileDropZone } from "@/components/file-drop/file-drop-zone";
 import { useRetainedPanelActive } from "@/components/retained-panel";
 import { Composer } from "@/composer";
@@ -57,7 +58,6 @@ import {
   useAgentScreenStateMachine,
 } from "@/hooks/use-agent-screen-state-machine";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
-import { useKeyboardShiftStyle } from "@/hooks/use-keyboard-shift-style";
 import { useContainerWidthBelow } from "@/hooks/use-container-width";
 import { reconcileMissingAgentStateWithPresentAgent } from "@/panels/agent-panel-load-state";
 import {
@@ -885,9 +885,6 @@ function ChatAgentContent({
     clearOnAgentBlurRef.current = attentionController.clearOnAgentBlur;
   }, [attentionController.clearOnAgentBlur]);
 
-  const { style: animatedKeyboardStyle } = useKeyboardShiftStyle({
-    mode: "translate",
-  });
   const shouldPresentReconnectToast =
     isPaneVisible && connectionStatus !== "online" && connectionStatus !== "idle";
 
@@ -1169,11 +1166,6 @@ function ChatAgentContent({
     visibilityCatchUpStatus,
   ]);
 
-  const animatedContentStyle = useMemo(
-    () => [animatedStaticStyles.content, animatedKeyboardStyle],
-    [animatedKeyboardStyle],
-  );
-
   const nonReadyView = renderChatAgentNonReadyView({
     viewState,
     effectiveAgent,
@@ -1210,7 +1202,6 @@ function ChatAgentContent({
       toast={toastState}
       dismiss={dismissToast}
       streamViewRef={streamViewRef}
-      animatedContentStyle={animatedContentStyle}
       handleComposerHeightChange={handleComposerHeightChange}
       handleMessageSent={handleMessageSent}
       handleRewindComplete={handleRewindComplete}
@@ -1240,7 +1231,6 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
   toast,
   dismiss,
   streamViewRef,
-  animatedContentStyle,
   handleComposerHeightChange,
   handleMessageSent,
   handleRewindComplete,
@@ -1266,7 +1256,6 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
   toast: ToastState | null;
   dismiss: () => void;
   streamViewRef: React.RefObject<AgentStreamViewHandle | null>;
-  animatedContentStyle: object[];
   handleComposerHeightChange: (height: number) => void;
   handleMessageSent: () => void;
   handleRewindComplete: () => void;
@@ -1362,7 +1351,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
     </RenderProfile>
   );
   const streamContent = (
-    <ReanimatedAnimated.View style={animatedContentStyle}>
+    <View style={animatedStaticStyles.content}>
       <RenderProfile id={`AgentStreamSection:${agentId}`}>
         <AgentStreamSection
           streamViewRef={streamViewRef}
@@ -1391,7 +1380,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
           hasPluginComposerPills={hasPluginComposerPills}
         />
       ) : null}
-    </ReanimatedAnimated.View>
+    </View>
   );
   const contentContainer = <View style={styles.contentContainer}>{streamContent}</View>;
 
@@ -1402,7 +1391,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
       onRewindComplete={handleRewindComplete}
     >
       <View style={styles.root}>
-        <FileDropZone style={styles.container} disabled={isArchivingCurrentAgent}>
+        <DockedChatSurface disabled={isArchivingCurrentAgent}>
           {contentContainer}
 
           {showHistorySyncError ? (
@@ -1437,7 +1426,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
           ) : null}
 
           <ToastViewport toast={toast} onDismiss={dismiss} placement="panel" />
-        </FileDropZone>
+        </DockedChatSurface>
 
         {isArchivingCurrentAgent ? (
           <View style={styles.archivingOverlay} testID="agent-archiving-overlay">
@@ -1450,6 +1439,16 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
     </RewindComposerRestoreProvider>
   );
 });
+
+function DockedChatSurface({ children, disabled }: { children: ReactNode; disabled: boolean }) {
+  return (
+    <KeyboardDock style={styles.container}>
+      <FileDropZone style={styles.container} disabled={disabled}>
+        {children}
+      </FileDropZone>
+    </KeyboardDock>
+  );
+}
 
 const AgentStreamSection = memo(function AgentStreamSection({
   streamViewRef,
@@ -1702,26 +1701,19 @@ function ActiveAgentComposer({
     ],
   );
 
-  const { style: composerKeyboardStyle } = useKeyboardShiftStyle({
-    mode: "translate",
-  });
-
   const inputAreaStyle = useMemo(
-    () => [
-      animatedStaticStyles.inputAreaWrapper,
-      { paddingBottom: insets.bottom },
-      composerKeyboardStyle,
-    ],
-    [insets.bottom, composerKeyboardStyle],
+    () => [animatedStaticStyles.inputAreaWrapper, { paddingBottom: insets.bottom }],
+    [insets.bottom],
   );
 
   return (
-    <ReanimatedAnimated.View style={inputAreaStyle} onLayout={onInputAreaLayout}>
+    <View style={inputAreaStyle} onLayout={onInputAreaLayout}>
       <Composer
         agentId={agentId}
         serverId={serverId}
         workspaceId={workspaceId}
         externalKeyboardShift
+        blurOnSubmit
         isPaneFocused={isPaneFocused}
         value={agentInputDraft.text}
         onChangeText={agentInputDraft.editText}
@@ -1742,7 +1734,7 @@ function ActiveAgentComposer({
         onClientSlashCommand={handleClientSlashCommand}
         isCompactLayout={isCompactComposerLayout}
       />
-    </ReanimatedAnimated.View>
+    </View>
   );
 }
 

--- a/patches/@mattermost+react-native-paste-input+2.0.1.patch
+++ b/patches/@mattermost+react-native-paste-input+2.0.1.patch
@@ -27,6 +27,18 @@ index 73466dd..8440ac9 100644
    }
  
    auto textSize = textLayoutManager_
+diff --git a/node_modules/@mattermost/react-native-paste-input/android/src/main/java/com/mattermost/pasteinputtext/PasteInputEditText.kt b/node_modules/@mattermost/react-native-paste-input/android/src/main/java/com/mattermost/pasteinputtext/PasteInputEditText.kt
+index 9e429b8..1d10014 100644
+--- a/node_modules/@mattermost/react-native-paste-input/android/src/main/java/com/mattermost/pasteinputtext/PasteInputEditText.kt
++++ b/node_modules/@mattermost/react-native-paste-input/android/src/main/java/com/mattermost/pasteinputtext/PasteInputEditText.kt
+@@ -36,2 +36,2 @@ class PasteInputEditText(context: ThemedReactContext) : ReactEditText(context) {
+-  override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection {
+-    val ic = super.onCreateInputConnection(outAttrs)
++  override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
++    val ic = super.onCreateInputConnection(outAttrs) ?: return null
+@@ -58 +58 @@ class PasteInputEditText(context: ThemedReactContext) : ReactEditText(context) {
+-    return InputConnectionCompat.createWrapper(ic!!, outAttrs, callback)
++    return InputConnectionCompat.createWrapper(ic, outAttrs, callback)
 diff --git a/node_modules/@mattermost/react-native-paste-input/lib/commonjs/PasteInput.js b/node_modules/@mattermost/react-native-paste-input/lib/commonjs/PasteInput.js
 index 51b9dfa..501badf 100644
 --- a/node_modules/@mattermost/react-native-paste-input/lib/commonjs/PasteInput.js


### PR DESCRIPTION
### Linked issue

Closes #4027 — Android first-message submission could hard-crash while the IME restarted a composer input that was being detached.

Related lineage:
- [#3681](https://github.com/getpaseo/paseo/pull/3681) restored intrinsic iOS composer growth.
- [#3740](https://github.com/getpaseo/paseo/pull/3740) consolidated composer height measurement across lifecycles.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [x] Docs

### Reasoning

The active chat moved the stream and composer through separate transforms. During keyboard timing races those pixels could diverge from layout and native hit geometry: the composer could remain raised with no keyboard, disappear under a visible keyboard, move without the conversation, or show press highlights while controls did not activate. Clearing a submitted multiline native input could also retain its old intrinsic height. On Android 13, first-message submission could additionally hard-crash because the native paste input force-unwrapped the base input connection after blur/unmount, even though Android permits that connection to be null.

Dock the complete chat surface with one worklet-driven bottom padding value from the normalized keyboard provider. This keeps the header fixed while the stream, composer, and native touch bounds reflow together. Portal autocomplete uses the same shift delta from its measured anchor, and clearing a native multiline input remounts its native view to discard stale intrinsic height.

### Goals

- Keep keyboard visibility and composer placement synchronized on iOS and Android, including during a JavaScript stall.
- Move the conversation and composer together without moving the workspace header.
- Keep model, Changes, attachment, send, and command controls interactive while the keyboard is visible.
- Keep command results above the composer without covering its controls.
- Dismiss the keyboard on submit and reset multiline input height.
- Keep first-message submission alive when Android restarts the IME during composer teardown.
- Lock the interaction into one repeatable Android device flow.

### Non-goals

- No visual redesign of the composer or keyboard spacing.
- No change to web keyboard behavior.
- No change to general composer growth policy or maximum height.
- No platform-specific layout policy; native platforms share the same dock contract.

### QA

Android emulator, freshly rebuilt dev client:

- Rebuilt and installed the native client with `./gradlew compileDebugKotlin --no-daemon` and `./gradlew installDebug --no-daemon`; both passed.
- Drove New Agent → entered a first message → selected a model → sent. The draft became a running agent, the input reset, the app remained foreground, and filtered logcat contained no `AndroidRuntime` fatal entry. The available emulator is Android 15; the reporter supplied two identical Android 13 fatal stacks on 0.5.2 and 0.7 beta 2.
- The stack terminates at the dependency force-unwrapping `super.onCreateInputConnection(...)`; the patch now preserves the nullable Android contract.

Keyboard/composer regression flow:

- `npm run test:e2e:composer-keyboard:android` — passed.
- The flow opens the software keyboard and verifies the header does not move while the complete chat surface reflows.
- It opens the command results, model selector, Changes panel, and attachment menu while the keyboard is visible and verifies every control activates.
- It enters the same four-line draft twice and verifies height does not accumulate.
- It submits the exact multiline message, verifies keyboard dismissal and baseline input-height reset, then blocks Hermes for three seconds while dismissing the keyboard and verifies no delayed composer movement.

Manual iPhone verification:

- Header position remained fixed while the stream and composer reflowed together with the software keyboard.
- Model selector, Changes, attachment menu, and command results remained usable above the keyboard.
- A four-line message submitted exactly, dismissed the keyboard, reset to single-line height, and remained synchronized after five seconds.
- The iOS Hermes-stall case was not run because the public Metro session did not expose a Hermes debugger target.

Focused checks:

- `npx vitest run packages/app/src/components/ui/text-input/text-input.native.test.tsx --bail=1` — 5 passed.
- `npm run typecheck` — passed across all workspaces.
- `npm run lint` — 0 warnings, 0 errors.
- `npm run format` — passed.

Risk surface: native keyboard animation and portal anchoring. The Android flow exercises native window geometry and controls through real taps; iOS received the same interaction smoke test without the synthetic JavaScript stall.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
