### PR TITLE
fix(server): keep daemon alive when JSONL RPC stdin hits EPIPE

### DIFF
--- a/packages/server/src/server/agent/providers/jsonl-rpc-process.test.ts
+++ b/packages/server/src/server/agent/providers/jsonl-rpc-process.test.ts
@@ -54,6 +54,14 @@ readline.createInterface({ input: process.stdin, crlfDelay: Infinity }).on("line
 });
 `;
 
+const CLOSED_STDIN_CHILD_SOURCE = String.raw`
+const fs = require("node:fs");
+
+fs.closeSync(0);
+process.stdout.write(JSON.stringify({ type: "stdin_closed" }) + "\n");
+setInterval(() => {}, 1_000);
+`;
+
 interface InMemoryChildProcess extends ChildProcessWithoutNullStreams {
   stdin: PassThrough;
   stdout: PassThrough;
@@ -63,6 +71,7 @@ interface InMemoryChildProcess extends ChildProcessWithoutNullStreams {
 interface StartProcessOptions {
   child?: ChildProcessWithoutNullStreams;
   defaultRequestTimeoutMs?: number;
+  source?: string;
 }
 
 function createInMemoryChildProcess(): InMemoryChildProcess {
@@ -85,7 +94,7 @@ function startProcess(options: StartProcessOptions = {}): JsonlRpcProcess {
   return new JsonlRpcProcess({
     launch: {
       command: process.execPath,
-      args: ["-e", CHILD_SOURCE, "--", "resolved-arg"],
+      args: ["-e", options.source ?? CHILD_SOURCE, "--", "resolved-arg"],
       cwd: process.cwd(),
       env: { JSONL_RPC_TEST_VALUE: "resolved-env" },
     },
@@ -222,7 +231,7 @@ describe("JsonlRpcProcess", () => {
     await rejection;
   });
 
-  test("treats a synchronous stdin write EPIPE as a closed process", async () => {
+  test("closes the transport when a direct send synchronously throws EPIPE", async () => {
     const child = createInMemoryChildProcess();
     const transport = startProcess({ child });
 
@@ -230,8 +239,27 @@ describe("JsonlRpcProcess", () => {
       throw Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
     };
 
-    await expect(transport.request({ type: "hang" })).rejects.toThrow("write EPIPE");
+    expect(() => transport.send({ type: "notice" })).not.toThrow();
     await expect(transport.request({ type: "echo", value: "after" })).rejects.toThrow(
+      "JSONL RPC process is closed",
+    );
+  });
+
+  test("keeps the parent alive when a real child closes its stdin pipe", async () => {
+    const transport = startProcess({ source: CLOSED_STDIN_CHILD_SOURCE });
+    const stdinClosed = new Promise<void>((resolve) => {
+      const unsubscribe = transport.onMessage((message) => {
+        if (message.type !== "stdin_closed") return;
+        unsubscribe();
+        resolve();
+      });
+    });
+
+    await stdinClosed;
+    await expect(transport.request({ type: "echo", value: "after" })).rejects.toThrow(
+      /EPIPE|stdin is not writable/,
+    );
+    await expect(transport.request({ type: "echo", value: "later" })).rejects.toThrow(
       "JSONL RPC process is closed",
     );
   });

--- a/packages/server/src/server/agent/providers/jsonl-rpc-process.test.ts
+++ b/packages/server/src/server/agent/providers/jsonl-rpc-process.test.ts
@@ -222,6 +222,47 @@ describe("JsonlRpcProcess", () => {
     await rejection;
   });
 
+  test("treats a synchronous stdin write EPIPE as a closed process", async () => {
+    const child = createInMemoryChildProcess();
+    const transport = startProcess({ child });
+
+    child.stdin.write = () => {
+      throw Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    };
+
+    await expect(transport.request({ type: "hang" })).rejects.toThrow("write EPIPE");
+    await expect(transport.request({ type: "echo", value: "after" })).rejects.toThrow(
+      "JSONL RPC process is closed",
+    );
+  });
+
+  test("stdin error events close the transport instead of becoming uncaught exceptions", async () => {
+    const child = createInMemoryChildProcess();
+    const transport = startProcess({ child });
+    const request = transport.request({ type: "hang" });
+    const err = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+
+    child.stdin.emit("error", err);
+
+    await expect(request).rejects.toThrow("write EPIPE");
+    await expect(transport.request({ type: "echo", value: "after" })).rejects.toThrow(
+      "JSONL RPC process is closed",
+    );
+  });
+
+  test("a non-writable stdin closes the transport instead of hanging the request", async () => {
+    const child = createInMemoryChildProcess();
+    const transport = startProcess({ child });
+    child.stdin.end();
+
+    await expect(transport.request({ type: "hang" })).rejects.toThrow(
+      "JSONL RPC stdin is not writable",
+    );
+    await expect(transport.request({ type: "echo", value: "after" })).rejects.toThrow(
+      "JSONL RPC process is closed",
+    );
+  });
+
   test("reassembles protocol v2 chunked responses into the logical frame", async () => {
     const child = createInMemoryChildProcess();
     const transport = startProcess({ child });

--- a/packages/server/src/server/agent/providers/jsonl-rpc-process.test.ts
+++ b/packages/server/src/server/agent/providers/jsonl-rpc-process.test.ts
@@ -245,24 +245,28 @@ describe("JsonlRpcProcess", () => {
     );
   });
 
-  test("keeps the parent alive when a real child closes its stdin pipe", async () => {
-    const transport = startProcess({ source: CLOSED_STDIN_CHILD_SOURCE });
-    const stdinClosed = new Promise<void>((resolve) => {
-      const unsubscribe = transport.onMessage((message) => {
-        if (message.type !== "stdin_closed") return;
-        unsubscribe();
-        resolve();
+  // Closing fd 0 does not sever the inherited pipe on Windows, so this fixture cannot produce EPIPE.
+  test.skipIf(process.platform === "win32")(
+    "keeps the parent alive when a real child closes its stdin pipe",
+    async () => {
+      const transport = startProcess({ source: CLOSED_STDIN_CHILD_SOURCE });
+      const stdinClosed = new Promise<void>((resolve) => {
+        const unsubscribe = transport.onMessage((message) => {
+          if (message.type !== "stdin_closed") return;
+          unsubscribe();
+          resolve();
+        });
       });
-    });
 
-    await stdinClosed;
-    await expect(transport.request({ type: "echo", value: "after" })).rejects.toThrow(
-      /EPIPE|stdin is not writable/,
-    );
-    await expect(transport.request({ type: "echo", value: "later" })).rejects.toThrow(
-      "JSONL RPC process is closed",
-    );
-  });
+      await stdinClosed;
+      await expect(transport.request({ type: "echo", value: "after" })).rejects.toThrow(
+        /EPIPE|stdin is not writable/,
+      );
+      await expect(transport.request({ type: "echo", value: "later" })).rejects.toThrow(
+        "JSONL RPC process is closed",
+      );
+    },
+  );
 
   test("stdin error events close the transport instead of becoming uncaught exceptions", async () => {
     const child = createInMemoryChildProcess();

--- a/packages/server/src/server/agent/providers/jsonl-rpc-process.ts
+++ b/packages/server/src/server/agent/providers/jsonl-rpc-process.ts
@@ -104,6 +104,9 @@ export class JsonlRpcProcess {
         this.stderrBuffer = this.stderrBuffer.slice(-STDERR_BUFFER_LIMIT);
       }
     });
+    this.child.stdin.on("error", (error) => {
+      this.handleStdinError(error);
+    });
     this.child.on("error", (error) => {
       this.failAll(error instanceof Error ? error : new Error(String(error)));
     });
@@ -173,10 +176,18 @@ export class JsonlRpcProcess {
   }
 
   send(message: Record<string, unknown>): void {
-    if (this.disposed || this.child.stdin.destroyed || !this.child.stdin.writable) {
+    if (this.disposed) {
       return;
     }
-    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    if (this.child.stdin.destroyed || !this.child.stdin.writable) {
+      this.handleStdinError(new Error(`${this.diagnosticName} stdin is not writable`));
+      return;
+    }
+    try {
+      this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    } catch (error) {
+      this.handleStdinError(error);
+    }
   }
 
   async close(error = new Error(`${this.diagnosticName} process is closed`)): Promise<void> {
@@ -241,6 +252,15 @@ export class JsonlRpcProcess {
       return;
     }
     pending.resolve(response.data);
+  }
+
+  private handleStdinError(error: unknown): void {
+    if (this.disposed) {
+      return;
+    }
+    const err = error instanceof Error ? error : new Error(String(error));
+    this.options.logger.warn({ err }, `${this.diagnosticName} stdin write failed`);
+    void this.close(err);
   }
 
   private failAll(error: Error): void {


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

You MUST read CONTRIBUTING.md before sending a PR.
-->

### Linked issue

Closes #4047

Related: #550 (same crash class, WebSocket-only fix)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A dead Claude/OMP JSONL child currently kills the whole daemon. `JsonlRpcProcess.send()` writes to `child.stdin` with no error listener and no try/catch. Node treats that `write EPIPE` as `uncaughtException`, the worker exits code 1, and every other agent/session on the host goes with it.

#550 already guarded WebSocket send paths. The JSONL RPC stdin pipe used by Claude and OMP was still uncovered. I hit this on desktop-managed `0.7.0-beta.2`: two fatal `write EPIPE` frames from `JsonlRpcProcess.send`, then `Claude runtime exited unexpectedly` with code 143, then `Worker exited (code 1)`.

This PR keeps the failure on that transport. The agent turn fails; the daemon stays up.

### Goals

- `stdin.write()` throwing `EPIPE` does not become process-level `uncaughtException`
- a stdin `'error'` event does not become process-level `uncaughtException`
- a non-writable stdin fails the in-flight request immediately instead of hanging until the RPC timeout
- later requests on that transport reject with `JSONL RPC process is closed`

### Non-goals

- Changing provider cancel/SIGTERM behavior
- Guarding stdout/stderr error events
- Changing how the agent UI presents a failed turn

### QA

Production crash (desktop-managed daemon `0.7.0-beta.2`, macOS arm64, Node 24.14.0 inside Electron 41.2.0):

```text
Uncaught exception — daemon crashing
Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:159:15)
    at Writable.write (node:internal/streams/writable:508:10)
    at JsonlRpcProcess.send (.../jsonl-rpc-process.js:105:26)
    at new Promise (<anonymous>)
Claude runtime exited unexpectedly  code=143
Worker exited (code 1). Supervisor shutting down.
```

Regression tests added in `jsonl-rpc-process.test.ts` for the three Node paths: sync `write()` throw, stdin `'error'` event, and `writable === false`.

```text
$ npx vitest run packages/server/src/server/agent/providers/jsonl-rpc-process.test.ts --bail=1 --reporter=verbose
 Test Files  1 passed (1)
      Tests  13 passed (13)
   Duration  774ms
```

Hook on commit: lint, format, and workspace typecheck passed.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | no     | daemon-only change |
| Android         | no     | daemon-only change |
| Web             | no     | daemon-only change |
| Desktop macOS   | yes    | unit tests + production stack from local daemon.log |
| Desktop Windows | no     | same Node stdin APIs; not run here |
| Desktop Linux   | no     | same Node stdin APIs; not run here |

I did not reproduce the crash against a live Claude CLI in this checkout. The two in-memory cases are the Node failure modes from the production stack (`write()` throw at the `send()` call site, and an `'error'` event with no listener).

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense