### PR TITLE
Fix pinch zoom in chat image previews

### DIFF
--- a/packages/app/src/components/attachment-lightbox.test.tsx
+++ b/packages/app/src/components/attachment-lightbox.test.tsx
@@ -75,6 +75,11 @@ vi.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
 }));
 
+vi.mock("react-native-gesture-handler", () => ({
+  GestureHandlerRootView: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement("div", { "data-testid": "gesture-handler-root" }, children),
+}));
+
 vi.mock("lucide-react-native", () => {
   const createIcon = (name: string) => (props: Record<string, unknown>) =>
     React.createElement("span", { ...props, "data-icon": name });
@@ -85,11 +90,32 @@ vi.mock("lucide-react-native", () => {
 
 vi.mock("@/components/zoomable-viewport/image", () => ({
   ZoomableImage: (props: Record<string, unknown>) => {
-    return React.createElement("div", {
-      "data-testid": `${String(props.testID)}-image`,
-      "data-source": props.uri,
-      role: "img",
-    });
+    const actions = props.actions as Array<{
+      label: string;
+      onPress: () => void;
+      testID?: string;
+    }>;
+    return React.createElement(
+      "div",
+      {
+        "data-testid": `${String(props.testID)}-image`,
+        "data-source": props.uri,
+        role: "img",
+      },
+      actions.map((action) =>
+        React.createElement(
+          "button",
+          {
+            "aria-label": action.label,
+            "data-testid": action.testID,
+            key: action.label,
+            onClick: action.onPress,
+            type: "button",
+          },
+          action.label,
+        ),
+      ),
+    );
   },
 }));
 

--- a/packages/app/src/components/attachment-lightbox.tsx
+++ b/packages/app/src/components/attachment-lightbox.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Modal, Pressable, Text, View } from "react-native";
-import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { StyleSheet } from "react-native-unistyles";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { X } from "lucide-react-native";
 import { useTranslation } from "react-i18next";
 import type { AttachmentMetadata } from "@/attachments/types";
 import { useAttachmentPreviewUrl } from "@/attachments/use-attachment-preview-url";
-import { isWeb } from "@/constants/platform";
-import { WindowChromeRootRegion, WindowChromeSafeArea } from "@/utils/desktop-window";
+import { isNative, isWeb } from "@/constants/platform";
+import { WindowChromeRootRegion } from "@/utils/desktop-window";
 import { ZoomableImage } from "@/components/zoomable-viewport/image";
 import type { ViewportSize } from "@/components/zoomable-viewport/geometry";
 
@@ -20,8 +21,9 @@ interface AttachmentLightboxProps {
   onClose: () => void;
 }
 
+const ModalRoot = isNative ? GestureHandlerRootView : View;
+
 export function AttachmentLightbox({ source, onClose }: AttachmentLightboxProps) {
-  const { theme } = useUnistyles();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const metadata = source?.type === "attachment" ? source.metadata : null;
@@ -47,18 +49,28 @@ export function AttachmentLightbox({ source, onClose }: AttachmentLightboxProps)
     };
   }, [onClose, source]);
 
-  const closeButtonRowStyle = useMemo(
+  const contentLayerStyle = useMemo(
     () => [
-      styles.closeButtonRow,
+      styles.contentLayer,
       {
-        top: insets.top + theme.spacing[3],
+        paddingTop: insets.top,
+        paddingRight: insets.right,
+        paddingBottom: insets.bottom,
+        paddingLeft: insets.left,
       },
     ],
-    [insets.top, theme.spacing],
+    [insets.bottom, insets.left, insets.right, insets.top],
   );
-  const closeButtonStyle = useMemo(
-    () => [styles.closeButton, { marginRight: insets.right + theme.spacing[3] }],
-    [insets.right, theme.spacing],
+  const actions = useMemo(
+    () => [
+      {
+        icon: X,
+        label: t("message.attachments.closeImage"),
+        onPress: onClose,
+        testID: "attachment-lightbox-close",
+      },
+    ],
+    [onClose, t],
   );
 
   const handleImageError = useCallback(() => setErrored(true), []);
@@ -71,46 +83,36 @@ export function AttachmentLightbox({ source, onClose }: AttachmentLightboxProps)
 
   return (
     <Modal transparent animationType="fade" statusBarTranslucent visible onRequestClose={onClose}>
-      <WindowChromeRootRegion corners="both">
-        <View style={styles.root}>
-          <Pressable
-            testID="attachment-lightbox-backdrop"
-            accessibilityRole="button"
-            accessibilityLabel={t("message.attachments.dismissImage")}
-            onPress={onClose}
-            style={styles.backdrop}
-          />
-          <View pointerEvents="box-none" style={styles.contentLayer}>
-            <View pointerEvents="box-none" style={styles.imageArea}>
-              {hasError ? (
-                <Text style={styles.errorText}>{t("message.attachments.imageLoadFailed")}</Text>
-              ) : (
-                <View style={styles.imageViewport}>
+      <ModalRoot style={styles.root}>
+        <WindowChromeRootRegion corners="both">
+          <View style={styles.root}>
+            <Pressable
+              testID="attachment-lightbox-backdrop"
+              accessibilityRole="button"
+              accessibilityLabel={t("message.attachments.dismissImage")}
+              onPress={onClose}
+              style={styles.backdrop}
+            />
+            <View pointerEvents="box-none" style={contentLayerStyle}>
+              <View pointerEvents="box-none" style={styles.imageArea}>
+                {hasError ? (
+                  <Text style={styles.errorText}>{t("message.attachments.imageLoadFailed")}</Text>
+                ) : (
                   <ZoomableImage
                     accessibilityLabel={t("composer.attachments.openImage")}
+                    actions={actions}
                     contentSize={contentSize}
                     onError={handleImageError}
+                    style={styles.imageViewport}
                     testID="attachment-lightbox"
                     uri={url}
                   />
-                </View>
-              )}
+                )}
+              </View>
             </View>
-            <WindowChromeSafeArea placement="inline" style={closeButtonRowStyle}>
-              <Pressable
-                testID="attachment-lightbox-close"
-                accessibilityRole="button"
-                accessibilityLabel={t("message.attachments.closeImage")}
-                hitSlop={8}
-                onPress={onClose}
-                style={closeButtonStyle}
-              >
-                <X size={16} color={theme.colors.foregroundMuted} />
-              </Pressable>
-            </WindowChromeSafeArea>
           </View>
-        </View>
-      </WindowChromeRootRegion>
+        </WindowChromeRootRegion>
+      </ModalRoot>
     </Modal>
   );
 }
@@ -118,6 +120,8 @@ export function AttachmentLightbox({ source, onClose }: AttachmentLightboxProps)
 const styles = StyleSheet.create((theme) => ({
   root: {
     flex: 1,
+    minHeight: 0,
+    minWidth: 0,
   },
   backdrop: {
     position: "absolute",
@@ -133,12 +137,6 @@ const styles = StyleSheet.create((theme) => ({
     left: 0,
     right: 0,
     bottom: 0,
-  },
-  closeButtonRow: {
-    position: "absolute",
-    left: 0,
-    right: 0,
-    alignItems: "flex-end",
   },
   imageArea: {
     flex: 1,
@@ -156,16 +154,5 @@ const styles = StyleSheet.create((theme) => ({
   errorText: {
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.base,
-  },
-  closeButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    backgroundColor: theme.colors.surface2,
-    borderWidth: theme.borderWidth[1],
-    borderColor: theme.colors.border,
-    alignItems: "center",
-    justifyContent: "center",
-    zIndex: 1,
   },
 }));

--- a/packages/app/src/components/zoomable-viewport/image.tsx
+++ b/packages/app/src/components/zoomable-viewport/image.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Image, View } from "react-native";
+import { Image, View, type StyleProp, type ViewStyle } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import type { ViewportSize } from "./geometry";
 import { ZoomableViewport } from "./index";
@@ -13,6 +13,7 @@ interface ZoomableImageProps {
   maxScale?: number;
   minScale?: number;
   onError?: () => void;
+  style?: StyleProp<ViewStyle>;
   testID?: string;
   wheelActivation?: "always" | "modifier";
 }
@@ -25,6 +26,7 @@ export function ZoomableImage({
   maxScale,
   minScale = 1,
   onError,
+  style,
   testID = "zoomable-image",
   wheelActivation = "always",
 }: ZoomableImageProps) {
@@ -52,7 +54,7 @@ export function ZoomableImage({
 
   if (!resolvedSize) {
     return (
-      <View style={styles.root} testID={testID}>
+      <View style={[styles.root, style]} testID={testID}>
         <Image
           accessibilityLabel={accessibilityLabel}
           accessibilityRole="image"
@@ -73,6 +75,7 @@ export function ZoomableImage({
       contentSize={resolvedSize}
       maxScale={maxScale}
       minScale={minScale}
+      style={style}
       testID={testID}
       wheelActivation={wheelActivation}
     >

--- a/packages/app/src/components/zoomable-viewport/index.tsx
+++ b/packages/app/src/components/zoomable-viewport/index.tsx
@@ -74,6 +74,9 @@ export function ZoomableViewport({
         })
         .onUpdate((event) => {
           if (!fittedContent || !viewport) return;
+          // Android emits one final pinch update after a finger lifts. Its focal point belongs to
+          // the remaining pointer, so applying it makes the content jump as the gesture ends.
+          if (event.numberOfPointers < 2) return;
           if (!pinchReady.value) {
             pinchFocalX.value = event.focalX;
             pinchFocalY.value = event.focalY;

--- a/packages/app/src/components/zoomable-viewport/toolbar.tsx
+++ b/packages/app/src/components/zoomable-viewport/toolbar.tsx
@@ -3,6 +3,11 @@ import { Pressable, View } from "react-native";
 import { Scan, ZoomIn, ZoomOut } from "lucide-react-native";
 import { useTranslation } from "react-i18next";
 import { StyleSheet } from "react-native-unistyles";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import {
+  iconButtonChromeGlyphSize,
+  iconButtonChromeStyle,
+} from "@/components/ui/icon-button-chrome";
 import type { ZoomableViewportAction } from "./types";
 
 interface ViewportToolbarProps {
@@ -77,20 +82,31 @@ function ViewportToolbarButton({
   visible: boolean;
 }) {
   const Icon = action.icon;
-  const buttonStyle = visible ? styles.button : styles.buttonHidden;
-  const resolvedStyle = disabled ? [buttonStyle, styles.disabled] : buttonStyle;
+  const isCompact = useIsCompactFormFactor();
+  const iconSize = iconButtonChromeGlyphSize("small", isCompact);
+  const buttonStyle = React.useCallback(
+    ({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) =>
+      iconButtonChromeStyle({
+        size: "small",
+        compact: isCompact,
+        state: { hovered, pressed },
+        disabled,
+        style: visible ? styles.button : styles.buttonHidden,
+      }),
+    [disabled, isCompact, visible],
+  );
   return (
     <Pressable
       accessibilityLabel={action.label}
       accessibilityRole="button"
       disabled={disabled}
-      hitSlop={4}
+      hitSlop={isCompact ? 6 : 4}
       onPress={action.onPress}
-      style={resolvedStyle}
+      style={buttonStyle}
       testID={action.testID}
     >
       {({ hovered }) => (
-        <Icon size={14} color={hovered ? styles.iconHovered.color : styles.icon.color} />
+        <Icon size={iconSize} color={hovered ? styles.iconHovered.color : styles.icon.color} />
       )}
     </Pressable>
   );
@@ -107,20 +123,15 @@ const styles = StyleSheet.create((theme) => ({
     pointerEvents: "box-none",
   },
   button: {
-    padding: theme.spacing[1],
-    borderRadius: theme.borderRadius.md,
     backgroundColor: theme.colors.surface2,
     opacity: 1,
     pointerEvents: "auto",
   },
   buttonHidden: {
-    padding: theme.spacing[1],
-    borderRadius: theme.borderRadius.md,
     backgroundColor: theme.colors.surface2,
     opacity: 0,
     pointerEvents: "none",
   },
-  disabled: { opacity: theme.opacity[50] },
   icon: { color: theme.colors.foregroundMuted },
   iconHovered: { color: theme.colors.foreground },
 }));


### PR DESCRIPTION
### Linked issue

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Chat image previews opened inside a native `Modal`, outside the app-level gesture-handler root. Buttons still responded, but Android could not activate the pinch recognizer. Android also sends a final one-pointer pinch update after a finger lifts; applying that stale focal point made successfully zoomed images jump on release.

This gives native lightboxes their own gesture root, keeps web on its normal modal root, folds close into the existing zoom toolbar, enlarges compact controls, and ignores the invalid terminal pinch update.

### Goals

- Make pinch-to-zoom work for assistant chat images on Android.
- Keep the image stable when the pinch gesture ends.
- Put close alongside the existing zoom actions instead of floating a second control over the backdrop.
- Give compact/mobile toolbar actions appropriate visual and touch sizes.
- Preserve the desktop lightbox and zoom behavior.

### Non-goals

- Replace the shared zoomable viewport implementation.
- Change file-preview navigation or rendering.
- Redesign desktop toolbar sizing.

### QA

Android (`paseo-api35-2`, API 35, `sh.paseo.debug` dev client):

1. Opened an assistant image from the real chat stream.
2. Before the fix, a scripted two-pointer pinch left the preview unchanged while toolbar buttons still worked.
3. After the fix, the same pinch enlarged the image and enabled Zoom out and Reset.
4. Captured the frame immediately after release and again 1.5 seconds later. Both captures had SHA-256 `81546aa86a0796432fda11932cbf2836d2276604f417479ce8284835c097b612`, confirming no release snap.
5. Confirmed Zoom in, Zoom out, Reset, and Close render together in the larger compact toolbar.

Desktop web (Agent Browser, Chromium, 1440x900):

1. Opened the same assistant image from the real chat stream.
2. Confirmed the fitted lightbox renders over the full viewport.
3. Activated Zoom in and observed the image grow from its fitted bounds to 1200x540.9375; Zoom out and Reset became enabled.
4. Desktop QA caught a zero-height web modal when the native gesture root was applied cross-platform. The final implementation uses the gesture root only on native; the re-run showed a 1440x900 backdrop and working zoom.

Automated verification:

```text
npx vitest run packages/app/src/components/attachment-lightbox.test.tsx --bail=1
Test Files  1 passed (1)
Tests       7 passed (7)

npm run lint -- <five changed files>
Found 0 warnings and 0 errors.

npm run typecheck
All workspaces passed.

npm run format:files -- <five changed files>
Finished successfully.
```

Platforms tested: Android and desktop web. iOS was not tested.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense