### PR TITLE
fix(opencode): show child session prompts

### DIFF
--- a/packages/app/e2e/browser/provider-subagents.real.spec.ts
+++ b/packages/app/e2e/browser/provider-subagents.real.spec.ts
@@ -43,7 +43,6 @@ const cases: ProviderSubagentCase[] = [
     sentinel: "OPENCODE_CHILD_SENTINEL",
     expectedName: "Verify OpenCode descriptor",
     expectedSubtitle: /explore · gpt-5\.4(?: · [^\n·]+)? · \d+(?:\.\d+)?k? tokens/i,
-    expectsUserMessage: false,
     providerConfig: { model: "openai/gpt-5.4" },
     prompt:
       'Use the task tool exactly once with description "Verify OpenCode descriptor" and the explore subagent. Ask it to reply with exactly OPENCODE_CHILD_SENTINEL and do nothing else. Wait for it, then reply ROOT_DONE.',

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -6361,7 +6361,7 @@ describe("OpenCode provider subagent contract", () => {
           messageID: "msg_child_prompt",
           type: "text",
           text: "Inspect the auth flow.",
-          time: { start: 1, end: 2 },
+          time: { start: 1 },
         },
       },
     });

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -2811,7 +2811,7 @@ function appendOpenCodeTextPart(
   events: AgentStreamEvent[],
 ): void {
   if (messageRole === "user") {
-    if (!part.time?.end || !part.text || state.emittedUserMessageIds?.has(part.messageID)) {
+    if (!part.text || state.emittedUserMessageIds?.has(part.messageID)) {
       return;
     }
     state.emittedUserMessageIds?.add(part.messageID);


### PR DESCRIPTION
## Summary
Show prompts issued to OpenCode child sessions in Paseo’s provider-subagent timeline. OpenCode child text parts may be emitted without a completion timestamp, so the adapter now preserves those prompts instead of dropping them.

## Why / Context
OpenCode creates child-session prompts as user text parts, while Paseo previously required `time.end` before materializing a user message. The prompt could therefore be present in OpenCode’s transcript but absent from Paseo.

## Changes
- **OpenCode adapter**: accept non-empty user text parts without requiring `time.end`.
- **Regression coverage**: model the OpenCode child prompt payload without a completion timestamp.
- **Browser E2E**: restore the expectation that OpenCode subagent prompts are visible.

## Testing
- Targeted OpenCode translator and provider tests: 158 passed.
- Repository typecheck, lint, and formatting checks passed.
