### PR TITLE
Keep the web composer ready for consecutive messages

### DIFF
--- a/packages/app/e2e/browser/composer-focus.spec.ts
+++ b/packages/app/e2e/browser/composer-focus.spec.ts
@@ -1,0 +1,29 @@
+import { test } from "../support/fixtures";
+import {
+  expectComposerDraft,
+  expectComposerFocused,
+  expectComposerVisible,
+  submitMessage,
+  typeIntoFocusedComposer,
+} from "../support/helpers/composer";
+import { openAgentRoute, seedMockAgentWorkspace } from "../support/helpers/mock-agent";
+
+test("submitting a message leaves the composer ready for the next message", async ({ page }) => {
+  const agent = await seedMockAgentWorkspace({
+    repoPrefix: "composer-focus-",
+    title: "Composer focus",
+  });
+
+  try {
+    await openAgentRoute(page, agent);
+    await expectComposerVisible(page);
+
+    await submitMessage(page, "First message");
+    await expectComposerFocused(page);
+
+    await typeIntoFocusedComposer(page, "Second message");
+    await expectComposerDraft(page, "Second message");
+  } finally {
+    await agent.cleanup();
+  }
+});

--- a/packages/app/e2e/support/helpers/composer.ts
+++ b/packages/app/e2e/support/helpers/composer.ts
@@ -38,6 +38,10 @@ export async function expectComposerEditable(page: Page): Promise<void> {
   await expect(composerInput(page)).toBeEditable({ timeout: 15_000 });
 }
 
+export async function expectComposerFocused(page: Page): Promise<void> {
+  await expect(composerInput(page)).toBeFocused();
+}
+
 export async function submitMessage(page: Page, text: string): Promise<void> {
   const input = composerInput(page);
   await expect(input).toBeEditable({ timeout: 30_000 });
@@ -47,6 +51,10 @@ export async function submitMessage(page: Page, text: string): Promise<void> {
 
 export async function fillComposerDraft(page: Page, text: string): Promise<void> {
   await composerInput(page).fill(text);
+}
+
+export async function typeIntoFocusedComposer(page: Page, text: string): Promise<void> {
+  await page.keyboard.type(text);
 }
 
 export async function sendDraftToQueue(page: Page): Promise<void> {

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -47,7 +47,7 @@ import {
   MAX_CONTENT_WIDTH,
   useIsCompactFormFactor,
 } from "@/constants/layout";
-import { isWeb } from "@/constants/platform";
+import { isNative, isWeb } from "@/constants/platform";
 import { useAgentAttentionClear } from "@/hooks/use-agent-attention-clear";
 import { useAgentInputDraft, type AgentInputDraft } from "@/composer/draft/input-draft";
 import {
@@ -1713,7 +1713,7 @@ function ActiveAgentComposer({
         serverId={serverId}
         workspaceId={workspaceId}
         externalKeyboardShift
-        blurOnSubmit
+        blurOnSubmit={isNative}
         isPaneFocused={isPaneFocused}
         value={agentInputDraft.text}
         onChangeText={agentInputDraft.editText}


### PR DESCRIPTION
### Linked issue

Refs #178

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The keyboard-sync change in #4044 made the active-agent composer blur after submission so native keyboards dismiss. Browser and Electron composers share that caller, so they also lost focus and interrupted consecutive keyboard-driven messages. Submission blur now applies only on native platforms.

### Goals

- Keep the active-agent composer focused after web and Electron submissions.
- Preserve native keyboard dismissal after submission.
- Lock the regression with a real-browser test that types the next message without refocusing.

### Non-goals

- Change focus behavior in draft, new-workspace, or dialog composers.
- Change native keyboard or layout behavior.
- Add new focus state or coordination machinery.

### QA

Red repro against the previous behavior:

```text
npm run test:e2e --workspace=@getpaseo/app -- e2e/browser/composer-focus.spec.ts
Expected: focused
Received: inactive
1 failed
```

Green verification with this change:

```text
npm run test:e2e --workspace=@getpaseo/app -- e2e/browser/composer-focus.spec.ts
1 passed (17.6s)

npm run format
Finished on 4174 files

npm run typecheck
All workspace typechecks passed

npm run lint
Found 0 warnings and 0 errors.
```

| Platform | Tested | Notes |
| --- | --- | --- |
| Web | Yes | Real Chromium E2E with isolated daemon |
| Desktop | No | Uses the same non-native composer path |
| iOS | No | Native blur behavior remains enabled |
| Android | No | Native blur behavior remains enabled |

### Risk surface

The change is limited to the active-agent composer submission blur gate. It affects ordinary and immediate slash-command submissions on web and Electron; native behavior is preserved. No visual layout changes.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense