### PR TITLE
Restore normal Bluetooth audio after Android dictation

### DIFF
--- a/docs/mobile-testing.md
+++ b/docs/mobile-testing.md
@@ -259,7 +259,9 @@ background music stays paused. On iOS this is not just a "while recording" probl
 `.playAndRecord`/`.voiceChat` category is non-mixing and survives backgrounding, and iOS re-asserts
 it every time the app returns to the foreground — so one dictation turn kills music for the life of
 the process, on every open, until the app is force-quit. Android holds
-`AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE` with the same effect.
+`AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE` with the same effect. It must also reset
+`MODE_IN_COMMUNICATION` and clear the selected communication device; abandoning focus alone can
+leave Bluetooth earbuds on their narrow-band call route without an active microphone indicator.
 
 `createAudioEngine` (`packages/app/src/voice/audio-engine.native.ts`) calls
 `releaseAudioSession()` whenever capture stops and the playback queue drains, and the iOS module
@@ -267,9 +269,9 @@ also releases on `OnAppEntersBackground`. The native side re-guards on `isRecord
 `speechPlayer.isPlaying`, because the native engine is a singleton shared by multiple JS engine
 wrappers (voice provider + dictation) and only it knows the true state.
 
-This cannot be validated by a JS test — verify on a device: play music, open Paseo, use dictation
-once, stop, and confirm the music resumes; then background/foreground the app and confirm it keeps
-playing.
+This cannot be validated by a JS test — verify on a device: play music through Bluetooth earbuds,
+open Paseo, use dictation once, stop, and confirm the music resumes at full quality; then
+background/foreground the app and confirm it keeps playing at full quality.
 
 ## Unistyles + Reanimated
 

--- a/packages/expo-two-way-audio/android/src/main/java/expo/modules/twowayaudio/AudioEngine.kt
+++ b/packages/expo-two-way-audio/android/src/main/java/expo/modules/twowayaudio/AudioEngine.kt
@@ -35,6 +35,7 @@ class AudioEngine (context: Context) {
     private val executorServiceMicrophone = Executors.newFixedThreadPool(1)
     private val executorServicePlayback = Executors.newFixedThreadPool(1)
     private var speakerDevice: AudioDeviceInfo? = null
+    private var communicationRouteActive = false
     private var bridgeWindowStartedAtMs = System.currentTimeMillis()
     private var micEvents = 0
     private var micBytes = 0L
@@ -82,25 +83,26 @@ class AudioEngine (context: Context) {
     @SuppressLint("NewApi")
     private fun initializeAudio(context:Context) {
         audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+        activateCommunicationRoute()
         if (!requestAudioFocus()) {
             handleAudioFocusBlocked()
         }
-
-        // Route audio to external device if connected, otherwise route to speaker
-        updateAudioRouting()
 
         // Listen for changes in audio routing
         audioManager.registerAudioDeviceCallback(object:android.media.AudioDeviceCallback(){
             override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
                 Log.d("AudioEngine", "onAudioDevicesAdded")
                 super.onAudioDevicesAdded(addedDevices)
-                updateAudioRouting()
+                if (communicationRouteActive) {
+                    updateAudioRouting()
+                }
             }
             override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
                 Log.d("AudioEngine", "onAudioDevicesRemoved")
                 super.onAudioDevicesRemoved(removedDevices)
-                updateAudioRouting()
+                if (communicationRouteActive) {
+                    updateAudioRouting()
+                }
             }
         }, null)
 
@@ -169,10 +171,29 @@ class AudioEngine (context: Context) {
         }
     }
 
+    @SuppressLint("NewApi")
+    private fun activateCommunicationRoute() {
+        communicationRouteActive = true
+        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+        updateAudioRouting()
+    }
+
+    @SuppressLint("NewApi")
+    private fun releaseCommunicationRoute() {
+        communicationRouteActive = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            audioManager.clearCommunicationDevice()
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.isSpeakerphoneOn = false
+        }
+        audioManager.mode = AudioManager.MODE_NORMAL
+    }
+
     /**
-     * Give audio focus back once we are neither recording nor playing. The focus request is
-     * AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE, so holding it after a dictation turn leaves the
-     * user's music paused indefinitely.
+     * Give the complete communication session back once we are neither recording nor playing.
+     * Focus pauses the user's music, while MODE_IN_COMMUNICATION and the selected communication
+     * device can leave Bluetooth earbuds on their narrow-band call route after capture stops.
      */
     @SuppressLint("NewApi")
     fun releaseAudioSession() {
@@ -186,6 +207,7 @@ class AudioEngine (context: Context) {
         if (::audioTrack.isInitialized) {
             audioTrack.pause()
         }
+        releaseCommunicationRoute()
     }
 
     /**
@@ -209,6 +231,7 @@ class AudioEngine (context: Context) {
         if (audioFocusRequest != null) {
             return
         }
+        activateCommunicationRoute()
         requestAudioFocus()
         if (::audioTrack.isInitialized) {
             audioTrack.play()
@@ -273,6 +296,7 @@ class AudioEngine (context: Context) {
         if (::audioTrack.isInitialized) {
             audioTrack.pause()
         }
+        releaseCommunicationRoute()
         audioSampleQueue.clear()
         isPlaying = false
         isRecordingBeforePause = false
@@ -283,6 +307,7 @@ class AudioEngine (context: Context) {
     @RequiresApi(Build.VERSION_CODES.Q)
     @SuppressLint("MissingPermission")
     private fun startRecording(): Boolean {
+        activateCommunicationRoute()
         if (!requestAudioFocus()) {
             handleAudioFocusBlocked()
             return false
@@ -453,6 +478,7 @@ class AudioEngine (context: Context) {
         if (!wasRecordingBeforePause && !isPlaying) {
             return
         }
+        activateCommunicationRoute()
         if (!requestAudioFocus()) {
             handleAudioFocusBlocked()
             return
@@ -489,13 +515,11 @@ class AudioEngine (context: Context) {
     fun tearDown() {
         stopRecording()
         audioTrack.stop()
-        audioManager.mode = AudioManager.MODE_NORMAL
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            audioManager.clearCommunicationDevice()
-        }
+        releaseCommunicationRoute()
         audioFocusRequest?.let { request ->
             audioManager.abandonAudioFocusRequest(request)
         }
+        audioFocusRequest = null
         executorServiceMicrophone.shutdownNow()
     }
 


### PR DESCRIPTION
Android now gives up its communication audio route when dictation stops, restoring normal media routing instead of leaving Bluetooth earbuds in call-quality mode. Later dictation and voice playback reacquire the route when needed.

### Linked issue

Refs #2485 — #2866 released Android audio focus but explicitly left `MODE_IN_COMMUNICATION` and the selected communication device for follow-up; this PR completes that remaining Android scope.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Stopping dictation released `AudioRecord` and abandoned exclusive focus, but Paseo remained registered as a communication-mode requester and communication-route client. On affected Bluetooth devices that stale ownership keeps output on the narrow-band call route even though Android no longer shows an active microphone.

The native Android audio engine owns focus, mode, and communication-device selection, so it now releases and reacquires those resources together. Audio-device callbacks are gated by the same route ownership state so a Bluetooth connect or disconnect event cannot restore communication routing while the engine is idle.

### Goals

- Restore normal Android media routing when capture and playback are idle.
- Reacquire communication routing for later dictation and voice playback.
- Prevent idle audio-device callbacks from resurrecting the communication route.
- Preserve focus interruption and background/foreground behavior.

### Non-goals

- Change dictation transcription, playback timing, or UI behavior.
- Change iOS audio-session behavior.
- Claim audible Bluetooth-hardware QA from the emulator; verification observes Android's authoritative audio ownership and route state.

### QA

Failing-first Android emulator repro on the pre-fix APK:

1. Opened an existing composer and started dictation.
2. Stopped dictation with **Insert transcription**.
3. Ran `adb shell dumpsys audio`.
4. Observed recording and focus stop, but Paseo remained in the `MODE_IN_COMMUNICATION` owner stack and `Communication route clients` list.

Post-fix verification on a freshly built and installed debug APK:

```text
During dictation:
Requested mode = MODE_IN_COMMUNICATION
Actual mode = MODE_IN_COMMUNICATION
Package: sh.paseo.debug
CommunicationRouteClient ... mPlaybackActive: true mRecordingActive: true

Immediately after stopping:
Requested mode = MODE_NORMAL
Actual mode = MODE_NORMAL
Mode owner stack: Empty
Communication route clients: Empty
mScoAudioState: SCO_STATE_INACTIVE
```

Repeated the capture/release cycle with both insert and cancel, then backgrounded and foregrounded Paseo. Each capture reacquired communication routing; each stop cleared the owner and route; foregrounding while idle kept `MODE_NORMAL` with no route client.

Verification commands:

- `npm run android:development --workspace=@getpaseo/app` — Gradle build and emulator install passed.
- `./gradlew :app:assembleDebug` — passed after the final native callback guard.
- `npm run typecheck` — passed.
- `npm run lint` — 0 warnings, 0 errors.
- `npm run format` — passed.
- `git diff --check` — passed.

The emulator has no physical Bluetooth earbuds, so audible codec quality was not directly observed. Android's mode-owner stack, communication-route list, focus stack, and SCO state were verified before and after the change.

### Risk surface

Android native audio routing only. The main risk is subsequent capture or playback failing to restore communication routing; repeated reacquisition and release cycles passed on the emulator. API 31+ clears `setCommunicationDevice`; older supported Android versions reset the legacy speakerphone override and return to `MODE_NORMAL`.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
