### PR TITLE
Fix stale OMP model after fallback

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -4257,6 +4257,8 @@ test("session config drift events update state through the stream channel", asyn
   const agent = manager.getAgent(snapshot.id);
   expect(agent?.currentModeId).toBe("build");
   expect(agent?.config.thinkingOptionId).toBe("high");
+  expect(agent?.config.model).toBe("gpt-5.4");
+
   expect(agent?.availableModes).toEqual([
     { id: "plan", label: "Plan" },
     { id: "build", label: "Build" },

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -3957,6 +3957,8 @@ export class AgentManager {
         return undefined;
       case "model_changed":
         agent.runtimeInfo = event.runtimeInfo;
+        agent.config.model = event.runtimeInfo.model ?? undefined;
+
         if (!agent.persistence && event.runtimeInfo.sessionId) {
           agent.persistence = attachPersistenceCwd(
             { provider: agent.provider, sessionId: event.runtimeInfo.sessionId },

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -652,4 +652,131 @@ describe("OMP agent client and session", () => {
       { type: "user_message", text: "hello OMP", messageId: "user-1" },
     ]);
   });
+  test("publishes the model selected by a successful fallback", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "openai-codex/gpt-5.4/mini",
+      role: "primary",
+    });
+
+    expect(omp.modelChanges()).toEqual([
+      expect.objectContaining({ model: "openai-codex/gpt-5.4/mini" }),
+    ]);
+    expect(omp.persistence()?.metadata).toMatchObject({
+      model: "openai-codex/gpt-5.4/mini",
+    });
+  });
+
+  test("keeps the fallback model when OMP state still reports the previous model", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    omp.runtime().state = {
+      ...omp.runtime().state,
+      model: { provider: "zai", id: "glm-4.7" },
+    };
+    await omp.runtimeInfo();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "opencode-go/gpt-5.4/mini",
+      role: "primary",
+    });
+
+    await expect(omp.runtimeInfo()).resolves.toMatchObject({
+      model: "opencode-go/gpt-5.4/mini",
+    });
+  });
+
+  test("clears the fallback model when OMP confirms a different model", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    omp.runtime().state = {
+      ...omp.runtime().state,
+      model: { provider: "zai", id: "glm-4.7" },
+    };
+    await omp.runtimeInfo();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "opencode-go/gpt-5.4/mini",
+      role: "primary",
+    });
+    omp.runtime().state = {
+      ...omp.runtime().state,
+      model: { provider: "openai-codex", id: "gpt-5.4" },
+    };
+
+    await expect(omp.runtimeInfo()).resolves.toMatchObject({
+      model: "openai-codex/gpt-5.4",
+    });
+  });
+
+  test("strips the thinking suffix from a fallback model reference", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "opencode-go/deepseek-v4-flash:low",
+      role: "primary",
+    });
+
+    expect(omp.modelChanges()).toEqual([
+      expect.objectContaining({ model: "opencode-go/deepseek-v4-flash" }),
+    ]);
+    expect(omp.persistence()?.metadata).toMatchObject({
+      model: "opencode-go/deepseek-v4-flash",
+    });
+  });
+
+  test("normalizes a fallback reference with api gateway and unknown thinking suffixes", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "openai-codex/gpt-5.6-luna@my-gateway:ultra",
+      role: "primary",
+    });
+
+    expect(omp.modelChanges()).toEqual([
+      expect.objectContaining({ model: "openai-codex/gpt-5.6-luna" }),
+    ]);
+    expect(omp.persistence()?.metadata).toMatchObject({
+      model: "openai-codex/gpt-5.6-luna",
+    });
+  });
+
+  test("keeps the second fallback live when OMP state returns the first suffix-free model", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    omp.runtime().state = {
+      ...omp.runtime().state,
+      model: { provider: "opencode-go", id: "deepseek-v4-flash" },
+    };
+    await omp.runtimeInfo();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "zai/glm-4.7:low",
+      role: "primary",
+    });
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "openai-codex/gpt-5.6-luna:low",
+      role: "primary",
+    });
+    // OMP's get_state never carries the suffix recorded from fallback events.
+    omp.runtime().state = {
+      ...omp.runtime().state,
+      model: { provider: "zai", id: "glm-4.7" },
+    };
+
+    await expect(omp.runtimeInfo()).resolves.toMatchObject({
+      model: "openai-codex/gpt-5.6-luna",
+    });
+  });
 });

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -732,13 +732,13 @@ describe("OMP agent client and session", () => {
     });
   });
 
-  test("normalizes a fallback reference with api gateway and unknown thinking suffixes", async () => {
+  test("normalizes a fallback reference with api gateway and thinking suffix", async () => {
     const omp = new OmpHarness();
     await omp.start();
 
     omp.runtime().emit({
       type: "retry_fallback_succeeded",
-      model: "openai-codex/gpt-5.6-luna@my-gateway:ultra",
+      model: "openai-codex/gpt-5.6-luna@my-gateway:high",
       role: "primary",
     });
 
@@ -770,6 +770,86 @@ describe("OMP agent client and session", () => {
       role: "primary",
     });
     // OMP's get_state never carries the suffix recorded from fallback events.
+    omp.runtime().state = {
+      ...omp.runtime().state,
+      model: { provider: "zai", id: "glm-4.7" },
+    };
+
+    await expect(omp.runtimeInfo()).resolves.toMatchObject({
+      model: "openai-codex/gpt-5.6-luna",
+    });
+  });
+
+  test("keeps literal :free routing suffixes in a fallback model reference", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "openrouter/meta-llama/llama-3:free",
+      role: "primary",
+    });
+
+    expect(omp.modelChanges()).toEqual([
+      expect.objectContaining({ model: "openrouter/meta-llama/llama-3:free" }),
+    ]);
+  });
+
+  test("resolves a restored primary only through the explicit model_changed signal", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    omp.runtime().state = {
+      ...omp.runtime().state,
+      model: { provider: "zai", id: "glm-4.7" },
+    };
+    await omp.runtimeInfo();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "opencode-go/deepseek-v4-flash",
+      role: "primary",
+    });
+    // Cooldown expiry restored the primary, but a lagging get_state still
+    // reports the pre-fallback model — indistinguishable from stale state.
+    omp.runtime().state = {
+      ...omp.runtime().state,
+      model: { provider: "zai", id: "glm-4.7" },
+    };
+    await expect(omp.runtimeInfo()).resolves.toMatchObject({
+      model: "opencode-go/deepseek-v4-flash",
+    });
+
+    // OMP emits model_changed for the restore; the state fetched after it
+    // is the first fresh read of the restored primary.
+    omp.runtime().emit({ type: "model_changed" });
+    await waitForImmediate();
+    await waitForImmediate();
+    await expect(omp.runtimeInfo()).resolves.toMatchObject({
+      model: "zai/glm-4.7",
+    });
+    expect(omp.modelChanges().at(-1)).toMatchObject({ model: "zai/glm-4.7" });
+  });
+
+  test("keeps the latest fallback when a delayed state reports an older pre-fallback model", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    omp.runtime().state = {
+      ...omp.runtime().state,
+      model: { provider: "zai", id: "glm-4.7" },
+    };
+    await omp.runtimeInfo();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "opencode-go/deepseek-v4-flash",
+      role: "primary",
+    });
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "openai-codex/gpt-5.6-luna",
+      role: "primary",
+    });
+    // A get_state dispatched before both fallbacks finally lands.
     omp.runtime().state = {
       ...omp.runtime().state,
       model: { provider: "zai", id: "glm-4.7" },

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -827,6 +827,38 @@ describe("OMP agent client and session", () => {
     expect(omp.modelChanges().at(-1)).toMatchObject({ model: "zai/glm-4.7" });
   });
 
+  test("ignores a stale :max catalog lookup after a newer fallback", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    let resolveCatalog: ((models: { provider: string; id: string }[]) => void) | null = null;
+    omp.runtime().getAvailableModels = () => {
+      const { promise, resolve } = Promise.withResolvers<{ provider: string; id: string }[]>();
+      resolveCatalog = resolve;
+      return promise;
+    };
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "zai/glm-4.7:max",
+      role: "primary",
+    });
+    await waitForImmediate();
+    // A newer fallback wins before the pending :max lookup for A resolves.
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "opencode-go/deepseek-v4-flash",
+      role: "primary",
+    });
+    await waitForImmediate();
+
+    resolveCatalog?.([{ provider: "zai", id: "glm-4.7:max" }]);
+    await waitForImmediate();
+    await waitForImmediate();
+
+    expect(omp.modelChanges().at(-1)).toMatchObject({ model: "opencode-go/deepseek-v4-flash" });
+    expect(omp.persistence()?.metadata).toMatchObject({ model: "opencode-go/deepseek-v4-flash" });
+  });
+
   test("resolves a restored primary only through the explicit model_changed signal", async () => {
     const omp = new OmpHarness();
     await omp.start();

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -795,6 +795,38 @@ describe("OMP agent client and session", () => {
     ]);
   });
 
+  test("keeps a literal :max model id when the catalog confirms it", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    omp.runtime().models = [{ provider: "zai", id: "glm-4.7:max" }];
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "zai/glm-4.7:max",
+      role: "primary",
+    });
+    await waitForImmediate();
+    await waitForImmediate();
+
+    expect(omp.modelChanges().at(-1)).toMatchObject({ model: "zai/glm-4.7:max" });
+    expect(omp.persistence()?.metadata).toMatchObject({ model: "zai/glm-4.7:max" });
+  });
+
+  test("treats :max as a thinking level when no literal catalog id exists", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.runtime().emit({
+      type: "retry_fallback_succeeded",
+      model: "zai/glm-4.7:max",
+      role: "primary",
+    });
+    await waitForImmediate();
+    await waitForImmediate();
+
+    expect(omp.modelChanges().at(-1)).toMatchObject({ model: "zai/glm-4.7" });
+  });
+
   test("resolves a restored primary only through the explicit model_changed signal", async () => {
     const omp = new OmpHarness();
     await omp.start();

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -83,6 +83,7 @@ import type {
   OmpSessionState,
   OmpThinkingLevel,
 } from "./rpc-types.js";
+import { OmpThinkingLevelSchema } from "./rpc-types.js";
 import {
   parseToolArgs,
   parseToolResult,
@@ -487,10 +488,14 @@ function modelToId(model: OmpModel | null | undefined): string | null {
   return model?.provider && model.id ? `${model.provider}/${model.id}` : null;
 }
 
+const OMP_THINKING_SUFFIX_RE = new RegExp(`:(?:${OmpThinkingLevelSchema.options.join("|")})$`);
+const OMP_GATEWAY_SUFFIX_RE = /@[^:/@]+$/;
+
 function parseOmpModelReference(model: string): OmpModel | null {
-  // OMP renders fallback targets as `provider/id[@gateway]:<thinking level>`;
-  // catalog ids carry neither decoration, so normalize both away.
-  const reference = model.replace(/:[^:/@]+$/, "").replace(/@[^:/@]+$/, "");
+  // OMP renders fallback targets as `provider/id[@gateway]:<thinking level>`.
+  // Catalog ids can carry their own `:suffix` segments (e.g. OpenRouter's
+  // `:free` routing), so strip only actual thinking levels, then the gateway.
+  const reference = model.replace(OMP_THINKING_SUFFIX_RE, "").replace(OMP_GATEWAY_SUFFIX_RE, "");
   const providerEnd = reference.indexOf("/");
   if (providerEnd <= 0 || providerEnd === reference.length - 1) return null;
   return { provider: reference.slice(0, providerEnd), id: reference.slice(providerEnd + 1) };
@@ -878,7 +883,7 @@ export class OmpAgentSession implements AgentSession {
   private readonly subagentCardTracker: OmpSubagentCardTracker;
   private lastTodoItem: Extract<AgentTimelineItem, { type: "todo" }> | null = null;
   private state: OmpSessionState;
-  private fallbackModel: { model: OmpModel; previousModelId: string | null } | null = null;
+  private fallbackModel: { model: OmpModel; staleModelIds: Set<string> } | null = null;
 
   private readonly currentModeId: string | null;
   private readonly providerIdleScheduler: OmpProviderIdleScheduler;
@@ -1645,10 +1650,14 @@ export class OmpAgentSession implements AgentSession {
     const model = parseOmpModelReference(event.model);
     if (!model) return;
 
-    this.fallbackModel = {
-      model,
-      previousModelId: modelToId(this.state.model),
-    };
+    // Every getState result produced before this event is stale: it can only
+    // report one of the models the session already served, never a fresh one.
+    const staleModelIds = this.fallbackModel
+      ? new Set(this.fallbackModel.staleModelIds)
+      : new Set<string>();
+    const previousModelId = modelToId(this.state.model);
+    if (previousModelId) staleModelIds.add(previousModelId);
+    this.fallbackModel = { model, staleModelIds };
     this.state = { ...this.state, model };
     this.config.model = modelToId(model) ?? undefined;
     this.emit({
@@ -1656,6 +1665,25 @@ export class OmpAgentSession implements AgentSession {
       provider: this.provider,
       runtimeInfo: this.runtimeInfoFromState(),
     });
+  }
+
+  /** OMP signals every session model switch, including the automatic
+   * cooldown-expiry restore back to primary. The state fetched right after
+   * the signal is the first one that can be trusted without model-id
+   * heuristics. */
+  private handleModelChangedRuntimeEvent(): void {
+    this.fallbackModel = null;
+    void this.refreshState()
+      .then(() =>
+        this.emit({
+          type: "model_changed",
+          provider: this.provider,
+          runtimeInfo: this.runtimeInfoFromState(),
+        }),
+      )
+      .catch((error: unknown) => {
+        this.logger.debug({ err: error }, "OMP state unavailable after model_changed");
+      });
   }
 
   private handleExtraRuntimeEvent(event: OmpRuntimeEvent): boolean {
@@ -1716,6 +1744,9 @@ export class OmpAgentSession implements AgentSession {
         this.logger.debug({ event }, "Dropped malformed OMP command update event");
       }
       return true;
+    }
+    if (event.type === "model_changed") {
+      this.handleModelChangedRuntimeEvent();
     }
     if (event.type === "retry_fallback_succeeded") {
       this.handleRetryFallbackSucceeded(event);
@@ -2215,7 +2246,21 @@ export class OmpAgentSession implements AgentSession {
   }
   private applyFreshState(state: OmpSessionState): void {
     this.state = state;
-    if (this.fallbackModel && modelToId(state.model) !== this.fallbackModel.previousModelId) {
+    const fallback = this.fallbackModel;
+    if (!fallback) return;
+    const stateModelId = modelToId(state.model);
+    if (!stateModelId) return;
+    if (stateModelId === modelToId(fallback.model)) {
+      // Fresh state already reports the fallback target; the override is
+      // redundant.
+      this.fallbackModel = null;
+      return;
+    }
+    // A lagging getState may report any pre-fallback model, which is
+    // indistinguishable from the cooldown-expiry restore back to primary.
+    // Only the explicit OMP `model_changed` signal resolves that, so keep
+    // the override while the state reports a known-stale model id.
+    if (!fallback.staleModelIds.has(stateModelId)) {
       this.fallbackModel = null;
     }
   }

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -883,6 +883,7 @@ export class OmpAgentSession implements AgentSession {
   private readonly subagentCardTracker: OmpSubagentCardTracker;
   private lastTodoItem: Extract<AgentTimelineItem, { type: "todo" }> | null = null;
   private state: OmpSessionState;
+  private fallbackGeneration = 0;
   private fallbackModel: { model: OmpModel; staleModelIds: Set<string> } | null = null;
 
   private readonly currentModeId: string | null;
@@ -1282,6 +1283,7 @@ export class OmpAgentSession implements AgentSession {
       ...this.state,
       model,
     };
+    this.fallbackGeneration += 1;
     this.fallbackModel = null;
 
     this.config.model = `${model.provider}/${model.id}`;
@@ -1655,9 +1657,13 @@ export class OmpAgentSession implements AgentSession {
     // (e.g. `glm-4.7:max`). Confirm against OMP's model catalog in the
     // background and correct the reference when the literal id exists.
     if (event.model.endsWith(":max") && modelToId(model) !== event.model.replace(/@[^:/@]+$/, "")) {
+      const generation = this.fallbackGeneration;
       void this.runtimeSession
         .getAvailableModels(null)
         .then((models) => {
+          // A newer fallback, restore, or manual model switch supersedes
+          // this lookup; never resurrect an older fallback target.
+          if (generation !== this.fallbackGeneration) return;
           const literal = models.find(
             (candidate) =>
               candidate.provider === model.provider && candidate.id === `${model.id}:max`,
@@ -1675,6 +1681,7 @@ export class OmpAgentSession implements AgentSession {
   }
 
   private applyFallbackModel(model: OmpModel): void {
+    this.fallbackGeneration += 1;
     // Every getState result produced before this event is stale: it can only
     // report one of the models the session already served, never a fresh one.
     const staleModelIds = this.fallbackModel
@@ -1697,6 +1704,7 @@ export class OmpAgentSession implements AgentSession {
    * the signal is the first one that can be trusted without model-id
    * heuristics. */
   private handleModelChangedRuntimeEvent(): void {
+    this.fallbackGeneration += 1;
     this.fallbackModel = null;
     void this.refreshState()
       .then(() =>

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -1650,6 +1650,31 @@ export class OmpAgentSession implements AgentSession {
     const model = parseOmpModelReference(event.model);
     if (!model) return;
 
+    this.applyFallbackModel(model);
+    // `:max` is ambiguous: a thinking level and a real model-id suffix
+    // (e.g. `glm-4.7:max`). Confirm against OMP's model catalog in the
+    // background and correct the reference when the literal id exists.
+    if (event.model.endsWith(":max") && modelToId(model) !== event.model.replace(/@[^:/@]+$/, "")) {
+      void this.runtimeSession
+        .getAvailableModels(null)
+        .then((models) => {
+          const literal = models.find(
+            (candidate) =>
+              candidate.provider === model.provider && candidate.id === `${model.id}:max`,
+          );
+          if (!literal) return;
+          return this.applyFallbackModel(literal);
+        })
+        .catch((error: unknown) => {
+          this.logger.debug(
+            { err: error },
+            "OMP model catalog unavailable for :max disambiguation",
+          );
+        });
+    }
+  }
+
+  private applyFallbackModel(model: OmpModel): void {
     // Every getState result produced before this event is stale: it can only
     // report one of the models the session already served, never a fresh one.
     const staleModelIds = this.fallbackModel
@@ -1747,6 +1772,7 @@ export class OmpAgentSession implements AgentSession {
     }
     if (event.type === "model_changed") {
       this.handleModelChangedRuntimeEvent();
+      return true;
     }
     if (event.type === "retry_fallback_succeeded") {
       this.handleRetryFallbackSucceeded(event);

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -487,6 +487,15 @@ function modelToId(model: OmpModel | null | undefined): string | null {
   return model?.provider && model.id ? `${model.provider}/${model.id}` : null;
 }
 
+function parseOmpModelReference(model: string): OmpModel | null {
+  // OMP renders fallback targets as `provider/id[@gateway]:<thinking level>`;
+  // catalog ids carry neither decoration, so normalize both away.
+  const reference = model.replace(/:[^:/@]+$/, "").replace(/@[^:/@]+$/, "");
+  const providerEnd = reference.indexOf("/");
+  if (providerEnd <= 0 || providerEnd === reference.length - 1) return null;
+  return { provider: reference.slice(0, providerEnd), id: reference.slice(providerEnd + 1) };
+}
+
 function ompAssistantText(message: Extract<OmpAgentMessage, { role: "assistant" }>): string | null {
   const text = message.content
     .flatMap((part) => {
@@ -869,6 +878,8 @@ export class OmpAgentSession implements AgentSession {
   private readonly subagentCardTracker: OmpSubagentCardTracker;
   private lastTodoItem: Extract<AgentTimelineItem, { type: "todo" }> | null = null;
   private state: OmpSessionState;
+  private fallbackModel: { model: OmpModel; previousModelId: string | null } | null = null;
+
   private readonly currentModeId: string | null;
   private readonly providerIdleScheduler: OmpProviderIdleScheduler;
   private readonly noTurnScheduler: OmpNoTurnScheduler;
@@ -1044,10 +1055,14 @@ export class OmpAgentSession implements AgentSession {
 
   async getRuntimeInfo(): Promise<AgentRuntimeInfo> {
     await this.refreshState();
+    return this.runtimeInfoFromState();
+  }
+
+  private runtimeInfoFromState(): AgentRuntimeInfo {
     return {
       provider: this.provider,
       sessionId: this.state.sessionId,
-      model: modelToId(this.state.model),
+      model: modelToId(this.fallbackModel?.model ?? this.state.model),
       thinkingOptionId: resolveThinkingOptionId(
         this.lastKnownThinkingOptionId,
         this.state.thinkingLevel,
@@ -1262,6 +1277,8 @@ export class OmpAgentSession implements AgentSession {
       ...this.state,
       model,
     };
+    this.fallbackModel = null;
+
     this.config.model = `${model.provider}/${model.id}`;
   }
 
@@ -1622,6 +1639,24 @@ export class OmpAgentSession implements AgentSession {
       item: { type: "assistant_message", text },
     });
   }
+  private handleRetryFallbackSucceeded(
+    event: Extract<OmpRuntimeEvent, { type: "retry_fallback_succeeded" }>,
+  ): void {
+    const model = parseOmpModelReference(event.model);
+    if (!model) return;
+
+    this.fallbackModel = {
+      model,
+      previousModelId: modelToId(this.state.model),
+    };
+    this.state = { ...this.state, model };
+    this.config.model = modelToId(model) ?? undefined;
+    this.emit({
+      type: "model_changed",
+      provider: this.provider,
+      runtimeInfo: this.runtimeInfoFromState(),
+    });
+  }
 
   private handleExtraRuntimeEvent(event: OmpRuntimeEvent): boolean {
     if (
@@ -1682,6 +1717,10 @@ export class OmpAgentSession implements AgentSession {
       }
       return true;
     }
+    if (event.type === "retry_fallback_succeeded") {
+      this.handleRetryFallbackSucceeded(event);
+    }
+
     const mappedEvent = mapOmpRuntimeEventToTimelineItem(event);
     if (!mappedEvent.handled) {
       return false;
@@ -2159,7 +2198,7 @@ export class OmpAgentSession implements AgentSession {
     while (!this.closed && this.activeTurnStarted && this.currentTurnIdForEvent() === turnId) {
       try {
         const state = await this.runtimeSession.getState();
-        this.state = state;
+        this.applyFreshState(state);
         if (!state.isStreaming && !state.isCompacting) {
           this.completeTurn(turnId, messages);
           return;
@@ -2172,7 +2211,13 @@ export class OmpAgentSession implements AgentSession {
   }
 
   private async refreshState(): Promise<void> {
-    this.state = await this.runtimeSession.getState();
+    this.applyFreshState(await this.runtimeSession.getState());
+  }
+  private applyFreshState(state: OmpSessionState): void {
+    this.state = state;
+    if (this.fallbackModel && modelToId(state.model) !== this.fallbackModel.previousModelId) {
+      this.fallbackModel = null;
+    }
   }
 
   private async refreshAfterTurn(finalUsage: Promise<void>): Promise<void> {

--- a/packages/server/src/server/agent/providers/omp/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/omp/rpc-types.ts
@@ -466,6 +466,11 @@ const OmpSubagentEventSchema = z
   })
   .passthrough();
 
+/** OMP emits this bare signal on every session model switch, including the
+ * automatic fallback→primary restore; the new model arrives via getState. */
+export const OmpModelChangedEventSchema = z
+  .object({ type: z.literal("model_changed") })
+  .passthrough();
 export const OmpRuntimeEventSchema = z.discriminatedUnion("type", [
   ...OmpAgentSessionEventSchema.options,
   OmpExtensionUiRequestSchema,
@@ -494,6 +499,7 @@ export const OmpRuntimeEventSchema = z.discriminatedUnion("type", [
   OmpRpcHostToolCallRequestSchema,
   OmpRpcHostToolCancelRequestSchema,
   OmpRpcHostToolUpdateSchema,
+  OmpModelChangedEventSchema,
 ]);
 
 const OmpCommandBase = { id: z.string().optional() };

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -397,6 +397,17 @@ export class OmpHarness {
   eventTypes(): AgentStreamEvent["type"][] {
     return this.events.map((event) => event.type);
   }
+  modelChanges() {
+    return this.events.flatMap((event) =>
+      event.type === "model_changed" ? [event.runtimeInfo] : [],
+    );
+  }
+  async runtimeInfo() {
+    return await this.requireSession().getRuntimeInfo();
+  }
+  persistence() {
+    return this.requireSession().describePersistence();
+  }
 
   async history(): Promise<AgentTimelineItem[]> {
     const items: AgentTimelineItem[] = [];


### PR DESCRIPTION
Closes #4073


### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

OMP can successfully move a running agent to a fallback provider while Paseo keeps the previously configured model in session state. The model selector then describes neither the active session nor the persisted session configuration. This change treats the fallback-success event as an authoritative runtime model change and normalizes OMP's decorated model references while preserving non-thinking routing suffixes such as `:free`. The temporary override is now resolved through OMP's explicit `model_changed` event: a cooldown-expiry restore back to primary is indistinguishable from stale state by model id alone, so known-stale model ids keep the override until that signal arrives. A trailing `:max` is ambiguous between a thinking level and a real model-id suffix (e.g. `glm-4.7:max`), so the parsed reference is confirmed against OMP's model catalog in the background and corrected when the literal id exists; a generation guard drops the lookup result when a newer fallback, restore, or manual model switch has superseded it.

### Goals

- Show the model OMP selected after a fallback.
- Persist that model through Paseo's `model_changed` path.
- Keep the fallback target visible while delayed state polling still reports the prior model.
- Resolve the override on OMP's explicit `model_changed` signal, covering the automatic restore back to primary.

### Non-goals

- Change OMP's fallback policy or configured fallback chains.
- Add provider usage reporting. That enhancement is tracked in [discussion #4072](https://github.com/getpaseo/paseo/discussions/4072).
- Change model selection for non-OMP providers.

### QA

Automated:

```text
npx vitest run packages/server/src/server/agent/providers/omp/agent.test.ts packages/server/src/server/agent/agent-manager.test.ts --bail=1
Test Files  2 passed (2)
Tests  209 passed (209)

npm run typecheck
passed

npm run lint
Found 0 warnings and 0 errors.

npm run format
Finished on 4177 files.
```

Manual:

- Windows: exercised one real OMP fallback through the configured provider chain. Paseo then showed the active fallback model instead of the prior configured model.
- Linux (WSL): automated coverage only.
- macOS, iOS, Android, web, Docker: not tested; this PR changes daemon session state only and does not modify client rendering.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
