### PR TITLE
Add plan usage for OMP-backed providers

### DIFF
--- a/packages/app/src/components/context-window-meter.tsx
+++ b/packages/app/src/components/context-window-meter.tsx
@@ -14,8 +14,10 @@ interface ContextWindowMeterProps {
   totalCostUsd?: number | null;
   showPercentage?: boolean;
   serverId?: string;
-  /** The Paseo provider key, e.g. "claude", "gemini", "codex" */
+  /** Paseo provider key, e.g. "claude", "omp", "codex". */
   provider?: string | null;
+  /** OMP model-provider prefix, e.g. "zai" in "zai/glm-5.3-flash". */
+  modelProviderId?: string | null;
   /** Reserve the meter footprint and show a loading ring while usage is pending. */
   pending?: boolean;
   /** Optional glyph envelope for icon-toolbar alignment. */
@@ -103,6 +105,7 @@ export function ContextWindowMeter({
   showPercentage = false,
   serverId,
   provider,
+  modelProviderId,
   pending = false,
   glyphSize,
 }: ContextWindowMeterProps) {
@@ -233,7 +236,11 @@ export function ContextWindowMeter({
               {t("contextWindow.sessionCost", { cost: formattedSessionCost })}
             </Text>
           ) : null}
-          <ProviderUsageTooltipSection view={providerUsageView} activeProviderId={provider} />
+          <ProviderUsageTooltipSection
+            view={providerUsageView}
+            activeProviderId={provider}
+            modelProviderId={modelProviderId}
+          />
         </View>
       </TooltipContent>
     </Tooltip>

--- a/packages/app/src/components/icons/zai-icon.tsx
+++ b/packages/app/src/components/icons/zai-icon.tsx
@@ -1,0 +1,14 @@
+import Svg, { Path } from "react-native-svg";
+
+interface ZaiIconProps {
+  size?: number;
+  color?: string;
+}
+
+export function ZaiIcon({ size = 16, color = "currentColor" }: ZaiIconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 16 16" fill={color} fillRule="evenodd">
+      <Path d="M8.07 1.333 6.618 3.302H.435l1.452-1.969h6.184ZM15.503 12.699l-1.451 1.968H7.891l1.449-1.968h6.163ZM16 1.333 6.176 14.667H0L9.824 1.333H16Z" />
+    </Svg>
+  );
+}

--- a/packages/app/src/components/provider-icon-name.test.ts
+++ b/packages/app/src/components/provider-icon-name.test.ts
@@ -12,6 +12,8 @@ describe("resolveProviderIconName", () => {
     expect(resolveProviderIconName("kiro")).toEqual({ kind: "builtin", id: "kiro" });
     expect(resolveProviderIconName("claude")).toEqual({ kind: "builtin", id: "claude" });
     expect(resolveProviderIconName("omp")).toEqual({ kind: "builtin", id: "omp" });
+    expect(resolveProviderIconName("pi")).toEqual({ kind: "builtin", id: "pi" });
+
     expect(resolveProviderIconName("minimax")).toEqual({ kind: "builtin", id: "minimax" });
   });
 

--- a/packages/app/src/components/provider-icons.ts
+++ b/packages/app/src/components/provider-icons.ts
@@ -8,6 +8,7 @@ import { MiniMaxIcon } from "@/components/icons/minimax-icon";
 import { OpenCodeIcon } from "@/components/icons/opencode-icon";
 import { OmpIcon } from "@/components/icons/omp-icon";
 import { PiIcon } from "@/components/icons/pi-icon";
+import { ZaiIcon } from "@/components/icons/zai-icon";
 import { ACP_PROVIDER_CATALOG } from "@/data/acp-provider-catalog";
 import { resolveProviderIconName } from "@/components/provider-icon-name";
 
@@ -26,7 +27,9 @@ const BUILTIN_PROVIDER_ICONS: Record<string, ProviderIconComponent> = {
   minimax: MiniMaxIcon as unknown as ProviderIconComponent,
   omp: OmpIcon as unknown as ProviderIconComponent,
   opencode: OpenCodeIcon as unknown as ProviderIconComponent,
+  "opencode-go": OpenCodeIcon as unknown as ProviderIconComponent,
   pi: PiIcon as unknown as ProviderIconComponent,
+  zai: ZaiIcon as unknown as ProviderIconComponent,
 };
 
 const CATALOG_ICON_SVGS = new Map(

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -271,6 +271,7 @@ function renderContextWindowMeter(
   showPercentage: boolean,
   serverId: string,
   provider: string | null,
+  modelProviderId: string | null,
   pending: boolean,
   glyphSize: number,
 ): ReactElement | null {
@@ -286,6 +287,7 @@ function renderContextWindowMeter(
       showPercentage={showPercentage}
       serverId={serverId}
       provider={provider}
+      modelProviderId={modelProviderId}
       pending={pending}
       glyphSize={glyphSize}
     />
@@ -1952,6 +1954,10 @@ function ComposerContentImpl({
   const contextWindowPending = agentState.status === "initializing" || isAgentRunning;
   const contextWindowMeterGlyphSize = isCompactLayout ? ICON_SIZE.md : buttonIconSize;
 
+  const modelProviderId =
+    agentState.provider === "pi" || agentState.provider === "omp"
+      ? (agentState.model?.split("/", 1)[0] ?? null)
+      : null;
   const contextWindowMeter = useMemo(
     () =>
       renderContextWindowMeter(
@@ -1961,6 +1967,7 @@ function ComposerContentImpl({
         false,
         serverId,
         agentState.provider,
+        modelProviderId,
         contextWindowPending,
         contextWindowMeterGlyphSize,
       ),
@@ -1970,6 +1977,7 @@ function ComposerContentImpl({
       agentState.totalCostUsd,
       serverId,
       agentState.provider,
+      modelProviderId,
       contextWindowPending,
       contextWindowMeterGlyphSize,
     ],

--- a/packages/app/src/provider-usage/tooltip-match.ts
+++ b/packages/app/src/provider-usage/tooltip-match.ts
@@ -1,0 +1,17 @@
+import type { ProviderUsage } from "./types";
+
+/** Resolves plan usage for the active agent; OMP uses its model-provider prefix. */
+export function matchProviderUsage(
+  providers: ProviderUsage[],
+  activeProviderId: string | null | undefined,
+  modelProviderId?: string | null,
+): ProviderUsage | null {
+  const activeProvider = activeProviderId?.toLowerCase();
+  const modelProvider = modelProviderId?.toLowerCase();
+  let target = activeProvider;
+  if (activeProvider === "pi" || activeProvider === "omp") {
+    target = modelProvider === "openai-codex" ? "codex" : modelProvider;
+  }
+  if (!target) return null;
+  return providers.find((usage) => usage.providerId.toLowerCase() === target) ?? null;
+}

--- a/packages/app/src/provider-usage/tooltip-section.test.ts
+++ b/packages/app/src/provider-usage/tooltip-section.test.ts
@@ -1,0 +1,59 @@
+import type { ProviderUsage } from "./types";
+import { matchProviderUsage } from "./tooltip-match";
+import { describe, expect, it } from "vitest";
+
+const providers: ProviderUsage[] = [
+  {
+    providerId: "claude",
+    displayName: "Claude",
+    status: "available",
+    planLabel: "Pro",
+    windows: [],
+  },
+  {
+    providerId: "zai",
+    displayName: "Z.ai",
+    status: "available",
+    planLabel: "lite",
+    windows: [],
+  },
+  {
+    providerId: "opencode-go",
+    displayName: "OpenCode Go",
+    status: "available",
+    planLabel: "OpenCode Go",
+    windows: [],
+  },
+  {
+    providerId: "codex",
+    displayName: "Codex",
+    status: "available",
+    planLabel: "ChatGPT Plus",
+    windows: [],
+  },
+];
+
+describe("matchProviderUsage", () => {
+  it("matches ordinary agents by their Paseo provider", () => {
+    expect(matchProviderUsage(providers, "claude")).toMatchObject({ providerId: "claude" });
+  });
+
+  it("matches OMP agents by their active model-provider prefix", () => {
+    expect(matchProviderUsage(providers, "omp", "zai")).toMatchObject({ providerId: "zai" });
+    expect(matchProviderUsage(providers, "pi", "opencode-go")).toMatchObject({
+      providerId: "opencode-go",
+    });
+  });
+
+  it("maps the OMP OpenAI model provider to Codex usage", () => {
+    expect(matchProviderUsage(providers, "omp", "openai-codex")).toMatchObject({
+      providerId: "codex",
+      planLabel: "ChatGPT Plus",
+    });
+  });
+
+  it("does not show a subscription when the OMP model has no known provider usage", () => {
+    expect(matchProviderUsage(providers, "omp", "openrouter")).toBeNull();
+    expect(matchProviderUsage(providers, "pi")).toBeNull();
+  });
+});

--- a/packages/app/src/provider-usage/tooltip-section.tsx
+++ b/packages/app/src/provider-usage/tooltip-section.tsx
@@ -2,16 +2,8 @@ import { Text, View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { ProviderUsageCard } from "./card";
 import { providerUsageCopy } from "./copy";
-import type { ProviderUsage, ProviderUsageView } from "./types";
-
-function matchProvider(
-  providers: ProviderUsage[],
-  activeProviderId: string | null | undefined,
-): ProviderUsage | null {
-  if (!activeProviderId) return null;
-  const target = activeProviderId.toLowerCase();
-  return providers.find((usage) => usage.providerId.toLowerCase() === target) ?? null;
-}
+import type { ProviderUsageView } from "./types";
+import { matchProviderUsage } from "./tooltip-match";
 
 // Renders the active agent's provider usage inside the context-meter tooltip.
 // Returns nothing when the active provider has no usage entry, so the meter's
@@ -19,9 +11,11 @@ function matchProvider(
 export function ProviderUsageTooltipSection({
   view,
   activeProviderId,
+  modelProviderId,
 }: {
   view: ProviderUsageView;
   activeProviderId: string | null | undefined;
+  modelProviderId?: string | null;
 }) {
   if (view.kind === "loading") {
     return (
@@ -41,7 +35,7 @@ export function ProviderUsageTooltipSection({
     );
   }
 
-  const usage = matchProvider(view.payload.providers, activeProviderId);
+  const usage = matchProviderUsage(view.payload.providers, activeProviderId, modelProviderId);
   if (!usage) return null;
 
   return (

--- a/packages/protocol/src/provider-icon-names.ts
+++ b/packages/protocol/src/provider-icon-names.ts
@@ -5,8 +5,11 @@ export const BUILTIN_PROVIDER_ICON_NAMES = [
   "kiro",
   "minimax",
   "omp",
-  "opencode",
   "pi",
+
+  "opencode",
+  "opencode-go",
+  "zai",
 ];
 
 export const ACP_PROVIDER_ICON_NAMES = [

--- a/packages/server/src/services/quota-fetcher/manifest.ts
+++ b/packages/server/src/services/quota-fetcher/manifest.ts
@@ -6,6 +6,7 @@ import type {
 import { ClaudeQuotaProvider } from "./providers/claude.js";
 import { CodexQuotaProvider } from "./providers/codex.js";
 import { CopilotQuotaProvider } from "./providers/copilot.js";
+import { OpencodeGoQuotaProvider } from "./providers/opencode-go.js";
 import { CursorQuotaProvider } from "./providers/cursor.js";
 import { GrokQuotaProvider } from "./providers/grok.js";
 import { KimiQuotaProvider } from "./providers/kimi.js";
@@ -48,6 +49,10 @@ export const PROVIDER_USAGE_FETCHERS: readonly ProviderUsageFetcherManifestEntry
   {
     providerId: "kimi",
     create: (options) => new KimiQuotaProvider({ logger: options.logger, fetch: options.fetch }),
+  },
+  {
+    providerId: "opencode-go",
+    create: (options) => new OpencodeGoQuotaProvider({ logger: options.logger }),
   },
   {
     providerId: "minimax",

--- a/packages/server/src/services/quota-fetcher/providers/codex.ts
+++ b/packages/server/src/services/quota-fetcher/providers/codex.ts
@@ -101,9 +101,35 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
   }
 
   async fetchUsage(): Promise<ProviderUsage> {
-    const fromCodex = await this.fetchCodexUsage();
-    if (fromCodex) return fromCodex;
+    const auth = await this.readCodexAuth();
+    const accessToken = auth?.tokens?.access_token;
+    if (!auth || !accessToken) {
+      // No native credentials: OMP may still carry the active account.
+      return this.fetchOmpUsage();
+    }
 
+    try {
+      const { account_id } = auth.tokens ?? {};
+      const resp = await this.callCodexApi(accessToken, account_id);
+      if (resp === "NEEDS_AUTH") {
+        // Read-only on credentials; the Codex CLI owns refresh. OMP may hold
+        // a different, valid account.
+        return this.fetchOmpUsage();
+      }
+      return this.toUsage(resp);
+    } catch (error) {
+      // Native credentials exist but the fetch itself failed: surface the
+      // error instead of silently substituting another account's quota.
+      this.logger.debug({ err: error }, "Codex usage fetch failed");
+      return unavailableUsage({
+        providerId: this.providerId,
+        displayName: this.displayName,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async fetchOmpUsage(): Promise<ProviderUsage> {
     const report = await this.omp.fetchReport("openai-codex");
     const fromOmp = report
       ? providerUsageFromOmpReport({
@@ -113,21 +139,6 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
         })
       : null;
     return fromOmp ?? unavailableUsage(this);
-  }
-
-  private async fetchCodexUsage(): Promise<ProviderUsage | null> {
-    const auth = await this.readCodexAuth();
-    const accessToken = auth?.tokens?.access_token;
-    if (!auth || !accessToken) return null;
-
-    try {
-      const { account_id } = auth.tokens ?? {};
-      const resp = await this.callCodexApi(accessToken, account_id);
-      return resp === "NEEDS_AUTH" ? null : this.toUsage(resp);
-    } catch (error) {
-      this.logger.debug({ err: error }, "Codex usage fetch failed");
-      return null;
-    }
   }
 
   private toUsage(resp: CodexUsageResponse): ProviderUsage {

--- a/packages/server/src/services/quota-fetcher/providers/codex.ts
+++ b/packages/server/src/services/quota-fetcher/providers/codex.ts
@@ -17,6 +17,7 @@ import {
   unavailableUsage,
   windowFromUsedPct,
 } from "../usage.js";
+import { OmpUsageRunner, providerUsageFromOmpReport, type OmpUsageExec } from "./omp-usage.js";
 
 const CodexAuthSchema = z.object({
   tokens: z
@@ -64,6 +65,8 @@ interface CodexQuotaProviderOptions {
   logger: Logger;
   codexHome?: string;
   fetch?: ProviderApiFetch;
+  exec?: OmpUsageExec;
+  ompCommand?: [string, ...string[]];
 }
 
 function codexWindow(
@@ -81,29 +84,50 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
   readonly displayName = "Codex";
 
   private readonly codexHome: string;
+  private readonly logger: Logger;
+
   private readonly fetchApi: ProviderApiFetch;
+  private readonly omp: OmpUsageRunner;
 
   constructor(options: CodexQuotaProviderOptions) {
+    this.logger = options.logger;
     this.codexHome = options.codexHome || process.env["CODEX_HOME"] || join(homedir(), ".codex");
     this.fetchApi = options.fetch ?? fetch;
+    this.omp = new OmpUsageRunner({
+      logger: options.logger,
+      command: options.ompCommand,
+      exec: options.exec,
+    });
   }
 
   async fetchUsage(): Promise<ProviderUsage> {
+    const fromCodex = await this.fetchCodexUsage();
+    if (fromCodex) return fromCodex;
+
+    const report = await this.omp.fetchReport("openai-codex");
+    const fromOmp = report
+      ? providerUsageFromOmpReport({
+          report,
+          providerId: this.providerId,
+          displayName: this.displayName,
+        })
+      : null;
+    return fromOmp ?? unavailableUsage(this);
+  }
+
+  private async fetchCodexUsage(): Promise<ProviderUsage | null> {
     const auth = await this.readCodexAuth();
     const accessToken = auth?.tokens?.access_token;
-    if (!auth || !accessToken) {
-      return unavailableUsage(this);
+    if (!auth || !accessToken) return null;
+
+    try {
+      const { account_id } = auth.tokens ?? {};
+      const resp = await this.callCodexApi(accessToken, account_id);
+      return resp === "NEEDS_AUTH" ? null : this.toUsage(resp);
+    } catch (error) {
+      this.logger.debug({ err: error }, "Codex usage fetch failed");
+      return null;
     }
-
-    const { account_id } = auth.tokens ?? {};
-    const resp = await this.callCodexApi(accessToken, account_id);
-
-    if (resp === "NEEDS_AUTH") {
-      // Read-only on credentials; the Codex CLI owns refresh. See docs/providers.md.
-      return unavailableUsage(this);
-    }
-
-    return this.toUsage(resp);
   }
 
   private toUsage(resp: CodexUsageResponse): ProviderUsage {

--- a/packages/server/src/services/quota-fetcher/providers/omp-usage.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/omp-usage.test.ts
@@ -1,0 +1,355 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import type { OmpUsageExec, OmpUsageReport } from "./omp-usage.js";
+import { OmpUsageRunner, providerUsageFromOmpReport } from "./omp-usage.js";
+import { CodexQuotaProvider } from "./codex.js";
+import { OpencodeGoQuotaProvider } from "./opencode-go.js";
+import { ZaiQuotaProvider } from "./zai.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function ompOutput(reports: unknown[]): string {
+  return JSON.stringify({ generatedAt: 1, reports });
+}
+
+function zaiReport(overrides: Partial<OmpUsageReport> = {}): OmpUsageReport {
+  return {
+    provider: "zai",
+    fetchedAt: 1_788_033_537_027,
+    limits: [
+      {
+        id: "zai:credits:5h",
+        label: "ZAI 5 Hours Credit Quota",
+        scope: { provider: "zai", windowId: "5h", shared: true },
+        window: { id: "5h", label: "5 Hours", durationMs: 18_000_000, resetsAt: 1_788_046_030_953 },
+        amount: {
+          used: 1074,
+          limit: 2000,
+          remaining: 925,
+          usedFraction: 0.537,
+          remainingFraction: 0.463,
+          unit: "credits",
+        },
+      },
+      {
+        id: "zai:credits:1w",
+        label: "ZAI Weekly Credit Quota",
+        scope: { provider: "zai", windowId: "1w", shared: true },
+        window: { id: "1w", label: "Weekly", durationMs: 604_800_000, resetsAt: 1_788_528_006_997 },
+        amount: { used: 4844, limit: 10_000, unit: "credits" },
+      },
+    ],
+    metadata: { planType: "lite", email: "user@example.com" },
+    ...overrides,
+  } as OmpUsageReport;
+}
+
+function execReturning(stdout: string): OmpUsageExec {
+  return async () => ({ stdout, stderr: "" });
+}
+
+const failingExec: OmpUsageExec = async () => {
+  throw new Error("spawn omp ENOENT");
+};
+
+describe("OmpUsageRunner", () => {
+  it("runs omp usage for the requested provider and returns its report", async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const runner = new OmpUsageRunner({
+      logger: createTestLogger(),
+      command: ["omp", "--profile", "work"],
+      exec: async (command, args) => {
+        calls.push({ command, args });
+        return { stdout: ompOutput([zaiReport()]), stderr: "" };
+      },
+    });
+
+    const report = await runner.fetchReport("zai");
+
+    expect(calls).toEqual([
+      {
+        command: "omp",
+        args: ["--profile", "work", "usage", "--json", "--provider", "zai"],
+      },
+    ]);
+    expect(report?.provider).toBe("zai");
+    expect(report?.limits).toHaveLength(2);
+  });
+
+  it("returns null when the provider has no report", async () => {
+    const runner = new OmpUsageRunner({
+      logger: createTestLogger(),
+      exec: execReturning(ompOutput([{ provider: "openai-codex", limits: [] }])),
+    });
+
+    await expect(runner.fetchReport("zai")).resolves.toBeNull();
+  });
+
+  it("returns null when omp fails or prints garbage", async () => {
+    const failing = new OmpUsageRunner({ logger: createTestLogger(), exec: failingExec });
+    const garbage = new OmpUsageRunner({
+      logger: createTestLogger(),
+      exec: execReturning("not json"),
+    });
+
+    await expect(failing.fetchReport("zai")).resolves.toBeNull();
+    await expect(garbage.fetchReport("zai")).resolves.toBeNull();
+  });
+});
+
+describe("providerUsageFromOmpReport", () => {
+  it("maps limits into windows with percent, reset time, tone, and plan label", () => {
+    const usage = providerUsageFromOmpReport({
+      report: zaiReport(),
+      providerId: "zai",
+      displayName: "Z.ai",
+    });
+
+    expect(usage).toEqual({
+      providerId: "zai",
+      displayName: "Z.ai",
+      status: "available",
+      planLabel: "lite",
+      sourceLabel: "Oh My Pi",
+      fetchedAt: "2026-08-29T19:58:57.027Z",
+      windows: [
+        {
+          id: "zai:credits:5h",
+          label: "ZAI 5 Hours Credit Quota",
+          usedPct: 53.7,
+          remainingPct: 46.3,
+          resetsAt: "2026-08-29T23:27:10.953Z",
+          tone: "ok",
+        },
+        {
+          id: "zai:credits:1w",
+          label: "ZAI Weekly Credit Quota",
+          usedPct: 48.44,
+          remainingPct: 51.56,
+          resetsAt: "2026-09-04T13:20:06.997Z",
+          tone: "ok",
+        },
+      ],
+      balances: [],
+      details: [],
+      error: null,
+    });
+  });
+
+  it("derives percent from used/limit when usedFraction is absent", () => {
+    const report = zaiReport();
+    const limits = report.limits ?? [];
+    (limits[0] as { amount: Record<string, unknown> }).amount = { used: 50, limit: 200 };
+
+    const usage = providerUsageFromOmpReport({
+      report,
+      providerId: "zai",
+      displayName: "Z.ai",
+    });
+
+    expect(usage?.windows[0]?.usedPct).toBe(25);
+  });
+
+  it("returns null when no limit carries usable amounts", () => {
+    const usage = providerUsageFromOmpReport({
+      report: zaiReport({ limits: [{ id: "x", amount: null }] }),
+      providerId: "zai",
+      displayName: "Z.ai",
+    });
+
+    expect(usage).toBeNull();
+  });
+});
+
+describe("ZaiQuotaProvider", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers the OMP report over the env-key subscription listing", async () => {
+    const provider = new ZaiQuotaProvider({
+      logger: createTestLogger(),
+      fetch: (() => {
+        throw new Error("must not hit the subscription API");
+      }) as typeof fetch,
+      exec: execReturning(ompOutput([zaiReport()])),
+    });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usage.status).toBe("available");
+    expect(usage.sourceLabel).toBe("Oh My Pi");
+    expect(usage.windows.map((window) => window.id)).toEqual(["zai:credits:5h", "zai:credits:1w"]);
+  });
+
+  it("falls back to the env-key subscription listing when OMP has no report", async () => {
+    vi.stubEnv("ZAI_API_KEY", "zai_test_token");
+    const provider = new ZaiQuotaProvider({
+      logger: createTestLogger(),
+      fetch: (async () =>
+        new Response(
+          JSON.stringify({
+            data: [{ productName: "GLM Coding Max", status: "VALID" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )) as typeof fetch,
+      exec: execReturning(ompOutput([])),
+    });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usage.status).toBe("available");
+    expect(usage.planLabel).toBe("GLM Coding Max");
+    expect(usage.windows).toEqual([]);
+  });
+
+  it("stays unavailable when OMP has no report and no env key is set", async () => {
+    vi.stubEnv("ZAI_API_KEY", "");
+    vi.stubEnv("GLM_API_KEY", "");
+    const provider = new ZaiQuotaProvider({
+      logger: createTestLogger(),
+      exec: failingExec,
+    });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usage.status).toBe("unavailable");
+  });
+});
+
+describe("CodexQuotaProvider", () => {
+  it("prefers OpenAI plan usage reported by OMP", async () => {
+    const provider = new CodexQuotaProvider({
+      logger: createTestLogger(),
+      fetch: (() => {
+        throw new Error("must not hit the Codex API");
+      }) as typeof fetch,
+      exec: execReturning(
+        ompOutput([
+          {
+            provider: "openai-codex",
+            fetchedAt: 1_788_033_538_807,
+            limits: [
+              {
+                id: "primary",
+                label: "5 hours",
+                amount: { usedFraction: 0.12 },
+                window: { resetsAt: 1_788_042_238_807 },
+              },
+            ],
+            metadata: { planType: "ChatGPT Plus" },
+          },
+        ]),
+      ),
+    });
+
+    await expect(provider.fetchUsage()).resolves.toMatchObject({
+      providerId: "codex",
+      displayName: "Codex",
+      sourceLabel: "Oh My Pi",
+      planLabel: "ChatGPT Plus",
+    });
+  });
+
+  it("prefers native Codex usage over an available OMP report", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "paseo-codex-"));
+    try {
+      await writeFile(
+        join(codexHome, "auth.json"),
+        JSON.stringify({ tokens: { access_token: "codex_test_token" } }),
+      );
+      const provider = new CodexQuotaProvider({
+        logger: createTestLogger(),
+        codexHome,
+        fetch: (async () =>
+          new Response(
+            JSON.stringify({
+              plan_type: "Pro",
+              rate_limit: { primary_window: { used_percent: 12 } },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          )) as typeof fetch,
+        exec: execReturning(
+          ompOutput([
+            {
+              provider: "openai-codex",
+              limits: [{ id: "primary", amount: { usedFraction: 0.12 } }],
+              metadata: { planType: "ChatGPT Plus" },
+            },
+          ]),
+        ),
+      });
+
+      await expect(provider.fetchUsage()).resolves.toMatchObject({
+        providerId: "codex",
+        planLabel: "Pro",
+      });
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("OpencodeGoQuotaProvider", () => {
+  it("maps the OMP report with 5h, weekly, and monthly windows", async () => {
+    const provider = new OpencodeGoQuotaProvider({
+      logger: createTestLogger(),
+      exec: execReturning(
+        ompOutput([
+          {
+            provider: "opencode-go",
+            fetchedAt: 1_788_033_538_807,
+            limits: [
+              {
+                id: "rolling-5h",
+                label: "5 Hour limit",
+                scope: { provider: "opencode-go", windowId: "5h" },
+                window: { id: "5h", resetsAt: 1_788_042_238_807 },
+                amount: { used: 2, limit: null, usedFraction: 0.02, unit: "percent" },
+              },
+              {
+                id: "weekly",
+                label: "Weekly limit",
+                scope: { provider: "opencode-go", windowId: "7d" },
+                window: { id: "7d", resetsAt: 1_788_134_400_807 },
+                amount: { used: 23, limit: null, usedFraction: 0.23, unit: "percent" },
+              },
+              {
+                id: "monthly",
+                label: "Monthly limit",
+                scope: { provider: "opencode-go", windowId: "monthly" },
+                window: { id: "monthly", resetsAt: 1_788_600_167_807 },
+                amount: { used: 98, limit: null, usedFraction: 0.98, unit: "percent" },
+              },
+            ],
+            metadata: { planType: "OpenCode Go" },
+          },
+        ]),
+      ),
+    });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usage).toMatchObject({
+      providerId: "opencode-go",
+      displayName: "OpenCode Go",
+      status: "available",
+      planLabel: "OpenCode Go",
+    });
+    expect(usage.windows.map((window) => window.usedPct)).toEqual([2, 23, 98]);
+    expect(usage.windows[2]?.tone).toBe("danger");
+  });
+
+  it("is unavailable when OMP cannot serve the report", async () => {
+    const provider = new OpencodeGoQuotaProvider({
+      logger: createTestLogger(),
+      exec: failingExec,
+    });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usage.status).toBe("unavailable");
+  });
+});

--- a/packages/server/src/services/quota-fetcher/providers/omp-usage.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/omp-usage.test.ts
@@ -221,36 +221,44 @@ describe("ZaiQuotaProvider", () => {
 
 describe("CodexQuotaProvider", () => {
   it("prefers OpenAI plan usage reported by OMP", async () => {
-    const provider = new CodexQuotaProvider({
-      logger: createTestLogger(),
-      fetch: (() => {
-        throw new Error("must not hit the Codex API");
-      }) as typeof fetch,
-      exec: execReturning(
-        ompOutput([
-          {
-            provider: "openai-codex",
-            fetchedAt: 1_788_033_538_807,
-            limits: [
-              {
-                id: "primary",
-                label: "5 hours",
-                amount: { usedFraction: 0.12 },
-                window: { resetsAt: 1_788_042_238_807 },
-              },
-            ],
-            metadata: { planType: "ChatGPT Plus" },
-          },
-        ]),
-      ),
-    });
+    // Isolated CODEX_HOME: the OMP path must be reachable without any
+    // native Codex credentials on the machine.
+    const codexHome = await mkdtemp(join(tmpdir(), "paseo-codex-"));
+    try {
+      const provider = new CodexQuotaProvider({
+        logger: createTestLogger(),
+        codexHome,
+        fetch: (() => {
+          throw new Error("must not hit the Codex API");
+        }) as typeof fetch,
+        exec: execReturning(
+          ompOutput([
+            {
+              provider: "openai-codex",
+              fetchedAt: 1_788_033_538_807,
+              limits: [
+                {
+                  id: "primary",
+                  label: "5 hours",
+                  amount: { usedFraction: 0.12 },
+                  window: { resetsAt: 1_788_042_238_807 },
+                },
+              ],
+              metadata: { planType: "ChatGPT Plus" },
+            },
+          ]),
+        ),
+      });
 
-    await expect(provider.fetchUsage()).resolves.toMatchObject({
-      providerId: "codex",
-      displayName: "Codex",
-      sourceLabel: "Oh My Pi",
-      planLabel: "ChatGPT Plus",
-    });
+      await expect(provider.fetchUsage()).resolves.toMatchObject({
+        providerId: "codex",
+        displayName: "Codex",
+        sourceLabel: "Oh My Pi",
+        planLabel: "ChatGPT Plus",
+      });
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
   });
 
   it("prefers native Codex usage over an available OMP report", async () => {
@@ -290,8 +298,64 @@ describe("CodexQuotaProvider", () => {
       await rm(codexHome, { recursive: true, force: true });
     }
   });
-});
+  it("keeps the native fetch error instead of substituting an OMP quota", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "paseo-codex-"));
+    try {
+      await writeFile(
+        join(codexHome, "auth.json"),
+        JSON.stringify({ tokens: { access_token: "codex_test_token" } }),
+      );
+      const provider = new CodexQuotaProvider({
+        logger: createTestLogger(),
+        codexHome,
+        fetch: (() => {
+          throw new Error("network down");
+        }) as typeof fetch,
+        exec: () => {
+          throw new Error("must not run OMP after a native failure");
+        },
+      });
 
+      const usage = await provider.fetchUsage();
+      expect(usage.status).toBe("error");
+      expect(usage.error).toContain("network down");
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to OMP when the native token needs re-auth", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "paseo-codex-"));
+    try {
+      await writeFile(
+        join(codexHome, "auth.json"),
+        JSON.stringify({ tokens: { access_token: "codex_test_token" } }),
+      );
+      const provider = new CodexQuotaProvider({
+        logger: createTestLogger(),
+        codexHome,
+        fetch: (async () => new Response("unauthorized", { status: 401 })) as typeof fetch,
+        exec: execReturning(
+          ompOutput([
+            {
+              provider: "openai-codex",
+              limits: [{ id: "primary", amount: { usedFraction: 0.42 } }],
+              metadata: { planType: "ChatGPT Plus" },
+            },
+          ]),
+        ),
+      });
+
+      await expect(provider.fetchUsage()).resolves.toMatchObject({
+        status: "available",
+        sourceLabel: "Oh My Pi",
+        planLabel: "ChatGPT Plus",
+      });
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+});
 describe("OpencodeGoQuotaProvider", () => {
   it("maps the OMP report with 5h, weekly, and monthly windows", async () => {
     const provider = new OpencodeGoQuotaProvider({

--- a/packages/server/src/services/quota-fetcher/providers/omp-usage.ts
+++ b/packages/server/src/services/quota-fetcher/providers/omp-usage.ts
@@ -92,6 +92,10 @@ export class OmpUsageRunner {
         { timeout: OMP_USAGE_TIMEOUT_MS, maxBuffer: OMP_USAGE_MAX_BUFFER },
       );
       const parsed = OmpUsageOutputSchema.parse(JSON.parse(stdout));
+      // `omp usage --json` currently reports one aggregated record per
+      // provider even with several authenticated accounts. If OMP starts
+      // emitting per-account reports, this must resolve the active
+      // credential instead of the first match.
       return parsed.reports?.find((report) => report.provider === providerId) ?? null;
     } catch (error) {
       this.logger.debug({ err: error, providerId }, "OMP usage fetch failed");

--- a/packages/server/src/services/quota-fetcher/providers/omp-usage.ts
+++ b/packages/server/src/services/quota-fetcher/providers/omp-usage.ts
@@ -1,0 +1,148 @@
+import type { Logger } from "pino";
+import { z } from "zod";
+import type { ProviderUsage, ProviderUsageWindow } from "../../../server/messages.js";
+import { execCommand } from "../../../utils/spawn.js";
+import { toIsoStringOrNull, toneFromUsedPct, usedPctOf, windowFromUsedPct } from "../usage.js";
+
+const DEFAULT_OMP_COMMAND: [string, ...string[]] = [process.env.OMP_COMMAND ?? "omp"];
+const OMP_USAGE_TIMEOUT_MS = 15_000;
+// The z.ai report embeds hourly model-usage history; keep headroom for it.
+const OMP_USAGE_MAX_BUFFER = 10 * 1024 * 1024;
+
+const OmpUsageAmountSchema = z
+  .object({
+    used: z.number().nullish(),
+    limit: z.number().nullish(),
+    remaining: z.number().nullish(),
+    usedFraction: z.number().nullish(),
+    remainingFraction: z.number().nullish(),
+    unit: z.string().nullish(),
+  })
+  .passthrough();
+
+const OmpUsageWindowSchema = z
+  .object({
+    id: z.string().optional(),
+    label: z.string().optional(),
+    resetsAt: z.number().nullish(),
+  })
+  .passthrough();
+
+const OmpUsageLimitSchema = z
+  .object({
+    id: z.string(),
+    label: z.string().nullish(),
+    scope: z.object({ windowId: z.string().nullish() }).passthrough().nullish(),
+    window: OmpUsageWindowSchema.nullish(),
+    amount: OmpUsageAmountSchema.nullish(),
+  })
+  .passthrough();
+
+const OmpUsageReportSchema = z
+  .object({
+    provider: z.string(),
+    fetchedAt: z.number().nullish(),
+    limits: z.array(OmpUsageLimitSchema).nullish(),
+    metadata: z.object({ planType: z.string().nullish() }).passthrough().nullish(),
+  })
+  .passthrough();
+
+const OmpUsageOutputSchema = z
+  .object({ reports: z.array(OmpUsageReportSchema).nullish() })
+  .passthrough();
+
+export type OmpUsageReport = z.infer<typeof OmpUsageReportSchema>;
+export type OmpUsageLimit = z.infer<typeof OmpUsageLimitSchema>;
+
+/** Structurally `execCommand` from utils/spawn; injectable for tests. */
+export type OmpUsageExec = (
+  command: string,
+  args: string[],
+  options?: { timeout?: number; maxBuffer?: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+export interface OmpUsageRunnerOptions {
+  logger: Logger;
+  command?: [string, ...string[]];
+  exec?: OmpUsageExec;
+}
+
+/**
+ * Reads one provider's usage report from the OMP CLI (`omp usage --json`).
+ * Returns null when OMP is missing, not logged in for the provider, or the
+ * output cannot be parsed — callers decide what fallback to show.
+ */
+export class OmpUsageRunner {
+  private readonly command: [string, ...string[]];
+  private readonly exec: OmpUsageExec;
+  private readonly logger: Logger;
+
+  constructor(options: OmpUsageRunnerOptions) {
+    this.command = options.command ?? DEFAULT_OMP_COMMAND;
+    this.exec = options.exec ?? execCommand;
+    this.logger = options.logger;
+  }
+
+  async fetchReport(providerId: string): Promise<OmpUsageReport | null> {
+    const [command, ...prefixArgs] = this.command;
+    try {
+      const { stdout } = await this.exec(
+        command,
+        [...prefixArgs, "usage", "--json", "--provider", providerId],
+        { timeout: OMP_USAGE_TIMEOUT_MS, maxBuffer: OMP_USAGE_MAX_BUFFER },
+      );
+      const parsed = OmpUsageOutputSchema.parse(JSON.parse(stdout));
+      return parsed.reports?.find((report) => report.provider === providerId) ?? null;
+    } catch (error) {
+      this.logger.debug({ err: error, providerId }, "OMP usage fetch failed");
+      return null;
+    }
+  }
+}
+
+/**
+ * Maps an OMP usage report into the Paseo provider-usage shape. Returns null
+ * when the report carries no usable window so callers can fall back.
+ */
+export function providerUsageFromOmpReport(input: {
+  report: OmpUsageReport;
+  providerId: string;
+  displayName: string;
+}): ProviderUsage | null {
+  const windows: ProviderUsageWindow[] = [];
+  for (const limit of input.report.limits ?? []) {
+    const amount = limit.amount;
+    const usedPct =
+      typeof amount?.usedFraction === "number" && Number.isFinite(amount.usedFraction)
+        ? amount.usedFraction * 100
+        : usedPctOf(amount?.used, amount?.limit);
+    if (usedPct === null) continue;
+    windows.push(
+      windowFromUsedPct({
+        id: limit.id,
+        label: limit.label ?? limit.id,
+        utilizationPct: usedPct,
+        resetsAt:
+          typeof limit.window?.resetsAt === "number"
+            ? toIsoStringOrNull(limit.window.resetsAt)
+            : null,
+        tone: toneFromUsedPct(usedPct),
+      }),
+    );
+  }
+  if (windows.length === 0) return null;
+
+  return {
+    providerId: input.providerId,
+    displayName: input.displayName,
+    status: "available",
+    planLabel: input.report.metadata?.planType ?? null,
+    sourceLabel: "Oh My Pi",
+    fetchedAt:
+      typeof input.report.fetchedAt === "number" ? toIsoStringOrNull(input.report.fetchedAt) : null,
+    windows,
+    balances: [],
+    details: [],
+    error: null,
+  };
+}

--- a/packages/server/src/services/quota-fetcher/providers/opencode-go.ts
+++ b/packages/server/src/services/quota-fetcher/providers/opencode-go.ts
@@ -1,0 +1,41 @@
+import type { Logger } from "pino";
+import type { ProviderUsage } from "../../../server/messages.js";
+import type { ProviderUsageFetcher } from "../provider.js";
+import { unavailableUsage } from "../usage.js";
+import { OmpUsageRunner, providerUsageFromOmpReport, type OmpUsageExec } from "./omp-usage.js";
+
+interface OpencodeGoQuotaProviderOptions {
+  logger: Logger;
+  exec?: OmpUsageExec;
+  ompCommand?: [string, ...string[]];
+}
+
+/** OpenCode Go plan usage. Data comes from OMP, which owns the plan's auth. */
+export class OpencodeGoQuotaProvider implements ProviderUsageFetcher {
+  readonly providerId = "opencode-go";
+  readonly displayName = "OpenCode Go";
+
+  private readonly omp: OmpUsageRunner;
+
+  constructor(options: OpencodeGoQuotaProviderOptions) {
+    this.omp = new OmpUsageRunner({
+      logger: options.logger,
+      command: options.ompCommand,
+      exec: options.exec,
+    });
+  }
+
+  async fetchUsage(): Promise<ProviderUsage> {
+    const report = await this.omp.fetchReport(this.providerId);
+    const usage = report
+      ? providerUsageFromOmpReport({
+          report,
+          providerId: this.providerId,
+          displayName: this.displayName,
+        })
+      : null;
+    if (usage) return usage;
+
+    return unavailableUsage(this);
+  }
+}

--- a/packages/server/src/services/quota-fetcher/providers/zai.ts
+++ b/packages/server/src/services/quota-fetcher/providers/zai.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ProviderUsage, ProviderUsageDetail } from "../../../server/messages.js";
 import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
 import { ApiOptionalStringSchema, fetchProviderApi, unavailableUsage } from "../usage.js";
+import { OmpUsageRunner, providerUsageFromOmpReport, type OmpUsageExec } from "./omp-usage.js";
 
 const ZaiUsageResponseSchema = z.object({
   data: z
@@ -20,6 +21,8 @@ const ZaiUsageResponseSchema = z.object({
 interface ZaiQuotaProviderOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
+  exec?: OmpUsageExec;
+  ompCommand?: [string, ...string[]];
 }
 
 export class ZaiQuotaProvider implements ProviderUsageFetcher {
@@ -28,13 +31,36 @@ export class ZaiQuotaProvider implements ProviderUsageFetcher {
 
   private readonly logger: Logger;
   private readonly fetchApi: ProviderApiFetch;
+  private readonly omp: OmpUsageRunner;
 
   constructor(options: ZaiQuotaProviderOptions) {
     this.logger = options.logger;
     this.fetchApi = options.fetch ?? fetch;
+    this.omp = new OmpUsageRunner({
+      logger: options.logger,
+      command: options.ompCommand,
+      exec: options.exec,
+    });
   }
 
   async fetchUsage(): Promise<ProviderUsage> {
+    // OMP owns the Z.AI coding-plan OAuth flow and knows the 5h/weekly credit
+    // quota windows; its report wins whenever it has one. The legacy env-key
+    // subscription listing below only identifies the plan, no usage.
+    const report = await this.omp.fetchReport(this.providerId);
+    const fromOmp = report
+      ? providerUsageFromOmpReport({
+          report,
+          providerId: this.providerId,
+          displayName: this.displayName,
+        })
+      : null;
+    if (fromOmp) return fromOmp;
+
+    return this.fetchSubscriptionStatus();
+  }
+
+  private async fetchSubscriptionStatus(): Promise<ProviderUsage> {
     const token = process.env["ZAI_API_KEY"] || process.env["GLM_API_KEY"];
     if (!token) return unavailableUsage(this);
 

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -13,6 +13,8 @@ import { CursorQuotaProvider } from "./providers/cursor.js";
 import { GrokQuotaProvider } from "./providers/grok.js";
 import { KimiQuotaProvider } from "./providers/kimi.js";
 import { MiniMaxQuotaProvider } from "./providers/minimax.js";
+import { OpencodeGoQuotaProvider } from "./providers/opencode-go.js";
+import type { OmpUsageExec } from "./providers/omp-usage.js";
 import { ZaiQuotaProvider } from "./providers/zai.js";
 import { ProviderUsageService } from "./service.js";
 
@@ -173,6 +175,9 @@ function usageFetcher(usage: ProviderUsage): ProviderUsageFetcher {
     fetchUsage: async () => usage,
   };
 }
+const failingOmpExec: OmpUsageExec = async () => {
+  throw new Error("omp is not available in tests");
+};
 
 function findProvider(result: { providers: ProviderUsage[] }, providerId: string): ProviderUsage {
   const provider = result.providers.find((candidate) => candidate.providerId === providerId);
@@ -422,14 +427,19 @@ describe("real provider usage fetchers", () => {
           platform: options.platform,
           fetch: fetchThroughTestDouble,
         }),
-        new CodexQuotaProvider({ logger, codexHome, fetch: fetchThroughTestDouble }),
+        new CodexQuotaProvider({
+          logger,
+          codexHome,
+          fetch: fetchThroughTestDouble,
+          exec: failingOmpExec,
+        }),
         new CopilotQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
         new CursorQuotaProvider({
           logger,
           fetch: fetchThroughTestDouble,
           homeDir: options.cursorHomeDir,
         }),
-        new ZaiQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
+        new ZaiQuotaProvider({ logger, fetch: fetchThroughTestDouble, exec: failingOmpExec }),
         new GrokQuotaProvider({
           logger,
           fetch: fetchThroughTestDouble,
@@ -451,6 +461,7 @@ describe("real provider usage fetchers", () => {
           credentialsPath:
             options.miniMaxCredentialsPath ?? join(homeDir, ".mmx", "credentials.json"),
         }),
+        new OpencodeGoQuotaProvider({ logger, exec: failingOmpExec }),
       ],
       cacheTtlMs: 0,
     });
@@ -1363,6 +1374,7 @@ describe("usage bars escalate as they fill", () => {
     const usage = await new CodexQuotaProvider({
       logger: createLogger(),
       codexHome,
+      exec: failingOmpExec,
       fetch: mockFetch(
         new Map([
           [


### PR DESCRIPTION
### Linked issue

[Discussion #4072](https://github.com/getpaseo/paseo/discussions/4072)

Depends on #4074 for immediate active-provider synchronization after an OMP fallback — without it the tooltip can keep the pre-fallback provider's quota until the next turn boundary.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

People running OMP-backed agents can route a session through Z.AI, OpenCode Go, or Codex, but the context-meter tooltip previously matched only the wrapper provider (`omp`). The active provider's plan usage was therefore unavailable at the point where users decide whether to continue or switch models. This change resolves OMP to its active model provider, adds plan-usage fetchers for supported provider endpoints, and gives Z.AI a first-party icon.

### Goals

- Fetch Z.AI usage through its OAuth usage endpoint.
- Fetch OpenCode Go plan usage from its dashboard API.
- Reuse Codex usage for OMP-backed Codex models.
- Match OMP agents to the active model provider in the context-meter tooltip.
- Render Z.AI consistently in provider labels and icons.

### Non-goals

- Change OMP fallback behavior or selected-model synchronization; that bug fix is in #4074.
- Add usage support for providers without a stable authenticated endpoint.
- Change account management, subscription setup, or quota-refresh scheduling.

### QA

Automated:

```text
npx vitest run packages/app/src/components/provider-icon-name.test.ts packages/app/src/provider-usage/tooltip-section.test.ts packages/server/src/services/quota-fetcher/providers/omp-usage.test.ts packages/server/src/services/quota-fetcher/service.test.ts --bail=1
Test Files  4 passed (4)
Tests  92 passed (92)

npm run typecheck
passed

npm run lint
Found 0 warnings and 0 errors.

npm run format
Finished on 4183 files.
```

Manual:

- Windows: one real OMP fallback through the configured chain updated plan-usage data for its active provider.
- Linux (WSL): automated coverage only.
- macOS, iOS, Android, and Docker: not tested. Web (browser): tooltips for Z.AI, Codex, and OpenCode Go plus the host Settings → Usage page verified against the dev daemon (screenshots below).

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

## Screenshots (web)

All four providers resolve through the OMP agent; the composer tooltip and the host Settings → Usage page pick up the matching plan usage. Model selection alone is enough to switch the matched provider — no request needed for the tooltip to appear.

| Z.AI (`zai/glm-4.7`) | Codex (`openai-codex/gpt-5.4-mini`) |
|---|---|
| ![Z.AI plan usage tooltip](https://raw.githubusercontent.com/gray-graff/paseo/qa/pr-4075-screens/qa/web-zai-tooltip.webp) | ![Codex plan usage tooltip](https://raw.githubusercontent.com/gray-graff/paseo/qa/pr-4075-screens/qa/web-codex-tooltip.webp) |

| OpenCode Go (`opencode-go/ox-alpha-free`) | Host Settings → Usage |
|---|---|
| ![OpenCode Go plan usage tooltip](https://raw.githubusercontent.com/gray-graff/paseo/qa/pr-4075-screens/qa/web-opencode-go-tooltip.webp) | ![Usage page with OMP provider cards](https://raw.githubusercontent.com/gray-graff/paseo/qa/pr-4075-screens/qa/web-usage-settings.webp) |

