### PR TITLE
fix(desktop): show the window when ready-to-show never fires on Linux

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -311,6 +311,16 @@ frames non-stop, pinning ProMotion displays at 120Hz forever and draining the
 battery while the app is idle — so do not re-add it. The probe's visibility
 guards already prevent throttling from causing a false stall.
 
+### Desktop Linux hidden-window fallback
+
+On Wayland (seen on ChromeOS Linux) a window created with `show: false` can sit
+forever without a single compositor frame: the renderer loads and runs, but
+`ready-to-show` never fires, so the window is never shown and the app looks like
+it did not start while every process is alive. `showWindowWhenReady`
+(`packages/desktop/src/window/show-when-ready.ts`) shows the main window after a
+short grace period when the event does not arrive. The fallback is Linux-only;
+macOS and Windows keep waiting for `ready-to-show`.
+
 ### Daemon logs
 
 Check `$PASEO_HOME/daemon.log` for daemon logs. The default level is `info`; set

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -42,6 +42,7 @@ import {
   buildStandardContextMenuItems,
 } from "./window/window-manager.js";
 import { setupDarwinCompositorWatchdog } from "./window/compositor-watchdog/index.js";
+import { LINUX_READY_TO_SHOW_FALLBACK_MS, showWindowWhenReady } from "./window/show-when-ready.js";
 import { resolveDesktopWindowChromeMode, windowChromeModeArgument } from "./window/chrome.js";
 import { registerDialogHandlers } from "./features/dialogs.js";
 import {
@@ -750,8 +751,8 @@ async function createWindow(
     registerBrowserWebviewNavigationGuards(contents);
   });
 
-  mainWindow.once("ready-to-show", () => {
-    mainWindow.show();
+  showWindowWhenReady(mainWindow, {
+    fallbackMs: process.platform === "linux" ? LINUX_READY_TO_SHOW_FALLBACK_MS : null,
   });
 
   if (!app.isPackaged) {

--- a/packages/desktop/src/window/show-when-ready.test.ts
+++ b/packages/desktop/src/window/show-when-ready.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type ReadyToShowWindow, showWindowWhenReady } from "./show-when-ready.js";
+
+function fakeWindow() {
+  const listeners = new Map<string, Array<() => void>>();
+  let destroyed = false;
+  const win: ReadyToShowWindow & {
+    shows: number;
+    emit: (event: "ready-to-show" | "closed") => void;
+    destroy: () => void;
+  } = {
+    shows: 0,
+    once(event, listener) {
+      listeners.set(event, [...(listeners.get(event) ?? []), listener]);
+      return win;
+    },
+    show() {
+      win.shows += 1;
+    },
+    isDestroyed: () => destroyed,
+    emit(event) {
+      const queued = listeners.get(event) ?? [];
+      listeners.set(event, []);
+      for (const listener of queued) listener();
+    },
+    destroy() {
+      destroyed = true;
+    },
+  };
+  return win;
+}
+
+describe("showWindowWhenReady", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the window on ready-to-show and not again on the fallback", () => {
+    const win = fakeWindow();
+    showWindowWhenReady(win, { fallbackMs: 2_000 });
+    win.emit("ready-to-show");
+    expect(win.shows).toBe(1);
+    vi.advanceTimersByTime(5_000);
+    expect(win.shows).toBe(1);
+  });
+
+  it("shows the window after the fallback when ready-to-show never fires", () => {
+    const win = fakeWindow();
+    showWindowWhenReady(win, { fallbackMs: 2_000 });
+    vi.advanceTimersByTime(1_999);
+    expect(win.shows).toBe(0);
+    vi.advanceTimersByTime(1);
+    expect(win.shows).toBe(1);
+    win.emit("ready-to-show");
+    expect(win.shows).toBe(1);
+  });
+
+  it("does nothing on the fallback once the window closed", () => {
+    const win = fakeWindow();
+    showWindowWhenReady(win, { fallbackMs: 2_000 });
+    win.emit("closed");
+    win.destroy();
+    vi.advanceTimersByTime(5_000);
+    expect(win.shows).toBe(0);
+  });
+
+  it("never shows a destroyed window from ready-to-show", () => {
+    const win = fakeWindow();
+    showWindowWhenReady(win, { fallbackMs: null });
+    win.destroy();
+    win.emit("ready-to-show");
+    expect(win.shows).toBe(0);
+  });
+
+  it("keeps the old behaviour when the fallback is disabled", () => {
+    const win = fakeWindow();
+    showWindowWhenReady(win, { fallbackMs: null });
+    vi.advanceTimersByTime(60_000);
+    expect(win.shows).toBe(0);
+    win.emit("ready-to-show");
+    expect(win.shows).toBe(1);
+  });
+});

--- a/packages/desktop/src/window/show-when-ready.ts
+++ b/packages/desktop/src/window/show-when-ready.ts
@@ -1,0 +1,57 @@
+// COMPAT(readyToShowFallback): added in v0.7.0, re-test on every Electron upgrade,
+// remove after 2027-03-01. On Wayland (observed on ChromeOS Linux, Electron 41) a
+// BrowserWindow created with `show: false` can sit forever without producing a
+// single compositor frame: the renderer loads and runs, but never gets a
+// BeginFrame, so "ready-to-show" never fires and the window is never shown.
+// The app then looks like it did not start at all while every process is alive.
+
+// How long to wait for "ready-to-show" before showing the window regardless.
+// Normal startups fire the event well inside this on a cold ARM machine.
+export const LINUX_READY_TO_SHOW_FALLBACK_MS = 2_000;
+
+export interface ReadyToShowWindow {
+  once(event: "ready-to-show" | "closed", listener: () => void): unknown;
+  show(): void;
+  isDestroyed(): boolean;
+}
+
+export interface ShowWindowWhenReadyOptions {
+  // `null` disables the fallback and only reacts to "ready-to-show".
+  fallbackMs: number | null;
+  setTimeoutImpl?: typeof setTimeout;
+  clearTimeoutImpl?: typeof clearTimeout;
+}
+
+// Shows `win` on "ready-to-show", or after `fallbackMs` if the event never
+// arrives. Shows at most once and never after the window closed.
+export function showWindowWhenReady(
+  win: ReadyToShowWindow,
+  options: ShowWindowWhenReadyOptions,
+): void {
+  const setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
+  const clearTimeoutImpl = options.clearTimeoutImpl ?? clearTimeout;
+  let shown = false;
+  let fallback: ReturnType<typeof setTimeout> | null = null;
+
+  const show = () => {
+    if (fallback !== null) {
+      clearTimeoutImpl(fallback);
+      fallback = null;
+    }
+    if (shown || win.isDestroyed()) return;
+    shown = true;
+    win.show();
+  };
+
+  win.once("ready-to-show", show);
+  if (options.fallbackMs !== null) {
+    fallback = setTimeoutImpl(show, options.fallbackMs);
+  }
+  win.once("closed", () => {
+    shown = true;
+    if (fallback !== null) {
+      clearTimeoutImpl(fallback);
+      fallback = null;
+    }
+  });
+}


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

On Linux/Wayland (reproduced on ChromeOS Linux, Debian 13, arm64, Electron 41.2.0) launching the desktop app shows nothing: no window ever appears, while the main process, renderer, and daemon are all alive and healthy. Users see "the app does not start".

`createWindow` builds the `BrowserWindow` with `show: false` and only calls `show()` from `ready-to-show`. On this Wayland setup the hidden window never produces a single compositor frame — the renderer finishes loading and the UI is fully in the DOM, but `requestAnimationFrame` never ticks (0 frames in 2 s) and no `wl_surface.attach`/`commit` ever happens — so `ready-to-show` never fires and the window stays invisible forever.

This adds `showWindowWhenReady`: show on `ready-to-show` as before, or after a 2 s fallback when the event never arrives. Once shown, the compositor starts driving frames and the app renders normally. The fallback is Linux-only; macOS and Windows behaviour is unchanged.

### Goals

- A Linux user launching Paseo always gets a window, even when `ready-to-show` never fires.
- No behaviour change on macOS and Windows.
- Show at most once; never show a window that already closed.
- Cover the gate with unit tests.

### Non-goals

- Fixing the underlying Chromium/Wayland hidden-window frame stall (tagged `COMPAT(readyToShowFallback)` so it is re-tested on Electron upgrades).
- Linux arm64 release builds (separate PR).

### QA

Environment: ChromeOS Linux container (Debian 13, aarch64, Wayland via sommelier), Electron 41.2.0, locally built `.deb` from this branch.

Reproduced before the fix, with `WAYLAND_DEBUG=1` and a CDP probe on the renderer:

- process tree healthy, daemon on `127.0.0.1:6767`, renderer DOM complete (`New workspace`, `History`, `Schedules`, …)
- `requestAnimationFrame` ticks in 2 s: **0**; `Page.captureScreenshot` times out
- Wayland trace: `zwp_text_input`/registry only, **0** `xdg_toplevel`, **0** `wl_surface.attach` — the window was never mapped
- a minimal Electron app with the same window options (`frame: false`, `webviewTag`, `show: false`) on the same machine does fire `ready-to-show`, so the stall is specific to this app's startup.

After the fix (same machine, same flags):

- Wayland trace within 25 s: `xdg_toplevel` events 9, `wl_surface.attach` 789, frame callbacks 795
- `requestAnimationFrame` ticks in 2 s: **119**; `Page.captureScreenshot` succeeds — screenshot below
- No change on macOS/Windows (fallback disabled there by `process.platform`).

Steps run:

```
npm run typecheck --workspace=@getpaseo/desktop
npm run lint -- packages/desktop/src/main.ts packages/desktop/src/window/show-when-ready.ts packages/desktop/src/window/show-when-ready.test.ts
npm run format:files -- <same files> docs/development.md
cd packages/desktop && npx vitest run src/window/show-when-ready.test.ts   # 5 passed
```

<!-- screenshot: packages/desktop rendered window (Linux arm64) -->

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
