### PR TITLE
feat(desktop): publish Linux arm64 desktop builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -212,10 +212,20 @@ jobs:
   publish-linux:
     needs: [create-release]
     if: ${{ always() && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped') && ((github.event_name == 'workflow_dispatch' && (github.event.inputs.platform == 'all' || github.event.inputs.platform == 'linux')) || (github.event_name == 'push' && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'desktop-v') || startsWith(github.ref_name, 'desktop-linux-v')))) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            electron_arch: x64
+            manifest: linux
+          - runner: ubuntu-22.04-arm
+            electron_arch: arm64
+            manifest: linux-arm64
     permissions:
       contents: write
       packages: read
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@v4
@@ -269,7 +279,7 @@ jobs:
           PASEO_DESKTOP_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/desktop-smoke
         run: |
           set -euo pipefail
-          build_args=(-- --publish never --linux --x64)
+          build_args=(-- --publish never --linux --${{ matrix.electron_arch }})
           build_args+=("-c.publish.releaseType=$RELEASE_TYPE")
           build_args+=("-c.publish.channel=$RELEASE_CHANNEL")
           npm run build:desktop "${build_args[@]}"
@@ -278,7 +288,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-smoke-linux-x64
+          name: desktop-smoke-linux-${{ matrix.electron_arch }}
           path: ${{ runner.temp }}/desktop-smoke
           if-no-files-found: ignore
           retention-days: 7
@@ -305,7 +315,7 @@ jobs:
         if: env.SHOULD_PUBLISH != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-linux
+          name: desktop-linux-${{ matrix.electron_arch }}
           path: ${{ env.DESKTOP_PACKAGE_PATH }}/release/*
           retention-days: 7
 
@@ -313,8 +323,8 @@ jobs:
         if: env.SHOULD_PUBLISH == 'true' && env.IS_SMOKE_TAG != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: linux-manifest
-          path: ${{ env.DESKTOP_PACKAGE_PATH }}/release/${{ env.RELEASE_CHANNEL }}-linux.yml
+          name: linux-manifest-${{ matrix.electron_arch }}
+          path: ${{ env.DESKTOP_PACKAGE_PATH }}/release/${{ env.RELEASE_CHANNEL }}-${{ matrix.manifest }}.yml
           retention-days: 1
 
   publish-windows:
@@ -466,12 +476,12 @@ jobs:
           pattern: mac-manifest-*
           path: release-manifests
 
-      - name: Download Linux manifest artifact
+      - name: Download Linux manifest artifacts
         if: env.IS_SMOKE_TAG != 'true' && needs.publish-linux.result == 'success'
         uses: actions/download-artifact@v4
         with:
-          name: linux-manifest
-          path: release-manifests/linux-manifest
+          pattern: linux-manifest-*
+          path: release-manifests
 
       - name: Download Windows manifest artifact
         if: env.IS_SMOKE_TAG != 'true' && needs.publish-windows.result == 'success'
@@ -500,7 +510,8 @@ jobs:
           fi
 
           if [[ "${{ needs.publish-linux.result }}" == "success" ]]; then
-            cp "linux-manifest/${RELEASE_CHANNEL}-linux.yml" "$manifests_dir/"
+            # x64 publishes <channel>-linux.yml, arm64 <channel>-linux-arm64.yml; no merge needed.
+            cp linux-manifest-*/"${RELEASE_CHANNEL}"-linux*.yml "$manifests_dir/"
           fi
 
           if [[ "${{ needs.publish-windows.result }}" == "success" ]]; then

--- a/docs/release.md
+++ b/docs/release.md
@@ -176,7 +176,7 @@ Use the beta path when you need to:
 
 Stable desktop releases go out via a linear time-based rollout for automatic update checks: 0% admitted when the updater manifests appear, 100% admitted 36 hours later, linear ramp in between. Manual checks bypass the rollout so a user can install immediately when they click **Check**. Beta releases bypass the rollout entirely — beta users always receive updates immediately.
 
-The rollout is driven by a `rolloutHours` field stamped into the GitHub Release manifests (`latest-mac.yml`, `latest-linux.yml`, `latest.yml`) by the `finalize-rollout` job in `desktop-release.yml`.
+The rollout is driven by a `rolloutHours` field stamped into the GitHub Release manifests (`latest-mac.yml`, `latest-linux.yml`, `latest-linux-arm64.yml`, `latest.yml`) by the `finalize-rollout` job in `desktop-release.yml`.
 
 Desktop release builds now publish in two phases:
 
@@ -337,8 +337,9 @@ release branch and tag, npm dist-tags, the GitHub Release body and assets,
 desktop updater manifests, the published Docker image, and the applicable EAS
 workflow. Inspect the GitHub Release itself and confirm that the macOS, Linux,
 Windows, and Android APK assets are present along with the channel manifests
-(`latest-mac.yml`, `latest-linux.yml`, and `latest.yml` for stable;
-`beta-mac.yml`, `beta-linux.yml`, and `beta.yml` for beta).
+(`latest-mac.yml`, `latest-linux.yml`, `latest-linux-arm64.yml`, and `latest.yml`
+for stable; `beta-mac.yml`, `beta-linux.yml`, `beta-linux-arm64.yml`, and `beta.yml`
+for beta).
 
 For stable releases, also confirm every required mobile build, upload, store
 submission, and review-submission job for the release commit. For betas, confirm
@@ -587,7 +588,7 @@ Each beta entry records what its testers receive. Promotion produces the single 
 - [ ] npm shows the version under the `beta` dist-tag, not `latest`
 - [ ] The GitHub prerelease exists with the changelog body and every expected macOS, Linux, Windows, and Android APK asset
 - [ ] GitHub `Desktop Release` workflow for the `v*-beta.N` tag is green
-- [ ] The GitHub prerelease contains `beta-mac.yml`, `beta-linux.yml`, and `beta.yml`
+- [ ] The GitHub prerelease contains `beta-mac.yml`, `beta-linux.yml`, `beta-linux-arm64.yml`, and `beta.yml`
 - [ ] GitHub `Android APK Release` workflow for the same tag is green
 - [ ] GitHub `Docker` workflow is green and the versioned beta image is published without moving `latest`
 - [ ] GitHub `Release Notes Sync` mirrored the beta entry into the prerelease body
@@ -610,7 +611,7 @@ Each beta entry records what its testers receive. Promotion produces the single 
 - [ ] Move npm's `beta` dist-tag to the new stable version for every published package and verify both `latest` and `beta` resolve to it
 - [ ] The published GitHub Release exists with the changelog body and every expected macOS, Linux, Windows, and Android APK asset
 - [ ] GitHub `Desktop Release` workflow for the `v*` tag is green
-- [ ] The GitHub Release contains `latest-mac.yml`, `latest-linux.yml`, and `latest.yml`
+- [ ] The GitHub Release contains `latest-mac.yml`, `latest-linux.yml`, `latest-linux-arm64.yml`, and `latest.yml`
 - [ ] GitHub `Android APK Release` workflow for the same tag is green
 - [ ] GitHub `Docker` workflow is green and both the versioned and `latest` images are published
 - [ ] GitHub `Release Notes Sync` is green and the release body matches the stable changelog entry


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

There is no Linux arm64 desktop build. The `publish-linux` job in `desktop-release.yml` runs only on `ubuntu-22.04` with `--linux --x64`, while macOS ships arm64+x64 and Windows ships x64+arm64. Users on arm64 Linux (Chromebooks with ChromeOS Linux, Raspberry Pi 5, Ampere/Graviton desktops, Asahi) have no installer.

The code is already arm64-ready: Electron 41 ships linux-arm64, every native dependency has arm64 prebuilds (`node-pty` prebuilds, `sherpa-onnx-linux-arm64`, `@img/sharp-linux-arm64`, the SDK's `arm64-linux` ripgrep), and `scripts/after-pack.js` already maps and prunes per-arch. Only the CI plumbing is missing.

This turns the Linux job into a matrix over x64 (unchanged: `ubuntu-22.04`) and arm64 (`ubuntu-22.04-arm`, free for public repos). A native arm64 runner is used rather than cross-building, because npm resolves the platform-specific optional dependencies at `npm ci` time — an x64 host would package x64 native modules into the arm64 app. electron-builder emits a separate updater manifest per Linux arch (`<channel>-linux.yml` for x64, `<channel>-linux-arm64.yml` for arm64) and electron-updater on arm64 reads the arm64 one, so `finalize-rollout` now stamps and uploads both.

### Goals

- Every desktop release publishes `Paseo-arm64.AppImage`, `Paseo-<version>-arm64.deb`, `.rpm`, and `.tar.gz` next to the x64 assets.
- Auto-update works for arm64 Linux installs via `<channel>-linux-arm64.yml`, stamped with the same `rolloutHours`/`releaseDate` as the other manifests.
- x64 Linux output and file names are unchanged.

### Non-goals

- Website download page: it currently only picks the `x86_64` AppImage (`packages/website/src/latest-release.ts`); adding an arm64 link is a follow-up.
- Cross-compiling arm64 on the x64 runner.
- Changing Linux targets (still AppImage, deb, rpm, tar.gz).

### QA

I cannot run the GitHub workflow against this repository, so the workflow change is validated by a YAML parse plus a local end-to-end build on real arm64 hardware with the same electron-builder invocation the job runs:

Environment: ChromeOS Linux container, Debian 13, aarch64 (8 cores, 6.5 GB RAM), Node 24, `npm ci` from the lockfile.

```
npm run build:desktop -- --publish never --linux AppImage deb --arm64
```

Output in `packages/desktop/release/`:

- `Paseo-arm64.AppImage` (146 MB), `Paseo-0.7.0-beta.2-arm64.deb` (110 MB, `Architecture: arm64`)
- `latest-linux-arm64.yml` with both files and sha512 — the file name electron-updater requests on arm64
- `after-pack` pruned to `linux-arm64` prebuilds only

Installed the `.deb` with `apt install` and launched the app: the daemon starts on `127.0.0.1:6767`, the renderer connects to it, and the home screen renders (screenshot of the running arm64 app below). Text input in the app was checked on this machine with the ChromeOS Korean IME. (This machine's Wayland setup also needs #4079 for the window to appear; the build itself is unaffected.)

Not exercised here: the `rpm` target on the arm runner (needs `rpmbuild`, which the `ubuntu-*-arm` images ship like the x64 images), and the workflow itself. Suggest one `workflow_dispatch` run with `platform: linux`, `publish: false` before the next tag; artifacts land as `desktop-linux-x64` and `desktop-linux-arm64`.

<!-- screenshot: running arm64 build -->

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes (no TS changes)
- [x] `npm run lint` passes (no TS changes)
- [x] `npm run format` passes
- [x] QA evidence
- [ ] Tests added or updated where it made sense (workflow-only change)
