### PR TITLE
Keep activity summaries aligned with tool labels

### DIFF
--- a/packages/server/src/server/agent/activity-curator.test.ts
+++ b/packages/server/src/server/agent/activity-curator.test.ts
@@ -129,9 +129,9 @@ second line'`,
 
     const result = curateAgentActivity(timeline);
 
-    expect(result).toContain("[Exec Command]");
-    expect(result).toContain("[Read File]");
-    expect(result).toContain("[Web Search]");
+    expect(result).toContain("[Exec command]");
+    expect(result).toContain("[Read file]");
+    expect(result).toContain("[Web search]");
     expect(result).not.toContain("npm run lint");
     expect(result).not.toContain("src/index.ts");
     expect(result).not.toContain("zod union");


### PR DESCRIPTION
### Linked issue

Refs #4066.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Tool display labels intentionally moved to sentence case in #4066. The activity curator already emits those shared labels, but its downstream test retained the former title-case spellings, causing the complete server suite to fail deterministically on Linux and Windows.

### Goals

- Assert the sentence-case labels emitted by the shared tool display model.
- Restore the server suite on current `main`.
- Keep the correction limited to stale expectations.

### Non-goals

- Change tool label production or presentation.
- Add casing compatibility behavior.
- Modify Hub permission work in #4088.

### QA

- Reproduced the same assertion failure on current `main` and PR #4088.
- `npm run build --workspace=@getpaseo/protocol`
- `npm exec vitest -- run packages/server/src/server/agent/activity-curator.test.ts` — 16 passed
- `npm run format`
- `npm run lint`

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense