### PR TITLE
fix: keep the context-meter tooltip available and its provider usage fresh

### DIFF
--- a/packages/app/src/components/context-window-meter.tsx
+++ b/packages/app/src/components/context-window-meter.tsx
@@ -129,32 +129,55 @@ export function ContextWindowMeter({
 
   // No usage yet: reserve the footprint with a track-only ring while a session is
   // active so the real ring fades in without shifting siblings. Render nothing when
-  // no usage is expected.
+  // no usage is expected. The pending ring keeps the tooltip: a running or stalled
+  // agent with no usage report is exactly when someone hovers to check plan limits.
   if (percentage === null || maxTokens === null || usedTokens === null) {
     if (!pending) {
       return null;
     }
     return (
-      <View style={geometry.containerStyle}>
-        <Svg
-          width={geometry.svgSize}
-          height={geometry.svgSize}
-          viewBox={`0 0 ${geometry.svgSize} ${geometry.svgSize}`}
-          style={styles.svg}
-          accessibilityElementsHidden
-          importantForAccessibility="no-hide-descendants"
-        >
-          <Circle
-            cx={geometry.center}
-            cy={geometry.center}
-            r={geometry.radius}
-            fill="none"
-            stroke={theme.colors.surface3}
-            strokeWidth={geometry.strokeWidth}
-          />
-        </Svg>
-        {showPercentage ? <View style={styles.skeletonLabel} /> : null}
-      </View>
+      <Tooltip
+        open={isTooltipOpen}
+        onOpenChange={handleTooltipOpenChange}
+        delayDuration={0}
+        enabledOnDesktop
+        enabledOnMobile
+      >
+        <TooltipTrigger asChild triggerRefProp="ref">
+          <Pressable
+            style={geometry.containerStyle}
+            testID="context-window-meter"
+            accessibilityRole="image"
+            accessibilityLabel={t("contextWindow.title")}
+          >
+            <Svg
+              width={geometry.svgSize}
+              height={geometry.svgSize}
+              viewBox={`0 0 ${geometry.svgSize} ${geometry.svgSize}`}
+              style={styles.svg}
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
+            >
+              <Circle
+                cx={geometry.center}
+                cy={geometry.center}
+                r={geometry.radius}
+                fill="none"
+                stroke={theme.colors.surface3}
+                strokeWidth={geometry.strokeWidth}
+              />
+            </Svg>
+            {showPercentage ? <View style={styles.skeletonLabel} /> : null}
+          </Pressable>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="center" offset={8}>
+          <View style={styles.tooltipContent}>
+            <Text style={styles.tooltipTitle}>{t("contextWindow.title")}</Text>
+            <Text style={styles.tooltipDetail}>{t("contextWindow.pending")}</Text>
+            <ProviderUsageTooltipSection view={providerUsageView} activeProviderId={provider} />
+          </View>
+        </TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1850,6 +1850,7 @@ export const ar: TranslationResources = {
     used: "تم استخدام{{percentage}}%",
     tokens: "رموز{{used}}/{{max}}",
     sessionCost: "تكلفة الجلسة{{cost}}",
+    pending: "لم يتم الإبلاغ عن الاستخدام بعد",
     accessibility: "تم استخدام نافذة السياق{{percentage}}%",
   },
   review: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1860,6 +1860,7 @@ export const en = {
     used: "{{percentage}}% used",
     tokens: "{{used}} / {{max}} tokens",
     sessionCost: "Session cost {{cost}}",
+    pending: "No usage reported yet",
     accessibility: "Context window {{percentage}}% used",
   },
   review: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1896,6 +1896,7 @@ export const es: TranslationResources = {
     used: "{{percentage}}% utilizado",
     tokens: "Fichas{{used}}/{{max}}",
     sessionCost: "Costo de la sesión{{cost}}",
+    pending: "Aún no se ha informado el uso",
     accessibility: "Ventana de contexto{{percentage}}% utilizada",
   },
   review: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1901,6 +1901,7 @@ export const fr: TranslationResources = {
     used: "{{percentage}}% utilisé",
     tokens: "Jetons{{used}}/{{max}}",
     sessionCost: "Coût de la séance{{cost}}",
+    pending: "Aucune utilisation signalée pour le moment",
     accessibility: "Fenêtre contextuelle{{percentage}}% utilisé",
   },
   review: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1868,6 +1868,7 @@ export const ja: TranslationResources = {
     used: "{{percentage}}%使用",
     tokens: "{{used}} / {{max}}トークン",
     sessionCost: "セッションコスト: {{cost}}",
+    pending: "使用状況はまだ報告されていません",
     accessibility: "コンテキストウィンドウ{{percentage}}%使用",
   },
   review: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1860,6 +1860,7 @@ export const ko: TranslationResources = {
     used: "{{percentage}}% 사용됨",
     tokens: "{{used}} / {{max}} 토큰",
     sessionCost: "세션 비용 {{cost}}",
+    pending: "아직 사용량이 보고되지 않았습니다",
     accessibility: "컨텍스트 윈도우 {{percentage}}% 사용됨",
   },
   review: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1882,6 +1882,7 @@ export const ptBR: TranslationResources = {
     used: "{{percentage}}% usado",
     tokens: "{{used}} / {{max}} tokens",
     sessionCost: "Custo da sessão {{cost}}",
+    pending: "Nenhum uso informado ainda",
     accessibility: "Janela de contexto {{percentage}}% usada",
   },
   review: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1881,6 +1881,7 @@ export const ru: TranslationResources = {
     used: "Использовано: {{percentage}}%",
     tokens: "Токены: {{used}} / {{max}}",
     sessionCost: "Стоимость сессии: {{cost}}",
+    pending: "Данные об использовании ещё не получены",
     accessibility: "Использовано {{percentage}}% контекстного окна",
   },
   review: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1829,6 +1829,7 @@ export const zhCN: TranslationResources = {
     used: "已使用 {{percentage}}%",
     tokens: "{{used}} / {{max}} tokens",
     sessionCost: "会话费用 {{cost}}",
+    pending: "尚未报告使用情况",
     accessibility: "上下文窗口已使用 {{percentage}}%",
   },
   review: {

--- a/packages/app/src/provider-usage/use-provider-usage.ts
+++ b/packages/app/src/provider-usage/use-provider-usage.ts
@@ -14,8 +14,11 @@ export function providerUsageQueryKey(serverId: string | null | undefined) {
   return ["providerUsage", serverId ?? ""] as const;
 }
 
-async function fetchProviderUsage(client: ProviderUsageClient): Promise<ProviderUsageListPayload> {
-  return client.listProviderUsage();
+async function fetchProviderUsage(
+  client: ProviderUsageClient,
+  options?: { forceRefresh?: boolean },
+): Promise<ProviderUsageListPayload> {
+  return client.listProviderUsage(options);
 }
 
 interface UseProviderUsageOptions {
@@ -58,14 +61,16 @@ export function useProviderUsage(
   });
 
   const refresh = useCallback(async () => {
-    if (!canFetch) return;
-    await queryClient.invalidateQueries({ queryKey });
+    if (!canFetch || !client) return;
+    // An explicit refresh asks the daemon to bypass its own usage cache too;
+    // staleTime 0 makes react-query actually refetch instead of serving the
+    // client-side cache it just wrote.
     await queryClient.fetchQuery({
       queryKey,
-      queryFn,
-      staleTime: PROVIDER_USAGE_STALE_TIME_MS,
+      queryFn: () => fetchProviderUsage(client, { forceRefresh: true }),
+      staleTime: 0,
     });
-  }, [canFetch, queryClient, queryFn, queryKey]);
+  }, [canFetch, client, queryClient, queryKey]);
 
   const view = useMemo<ProviderUsageView>(() => {
     if (!serverId || !client || !isConnected) {

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -5903,6 +5903,48 @@ test("sends provider.usage.list.request and resolves provider.usage.list.respons
   });
 });
 
+test("listProviderUsage forwards forceRefresh on the wire", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const usagePromise = client.listProviderUsage({ requestId: "usage-2", forceRefresh: true });
+
+  expect(JSON.parse(assertStr(mock.sent[0]))).toEqual({
+    type: "session",
+    message: {
+      type: "provider.usage.list.request",
+      requestId: "usage-2",
+      forceRefresh: true,
+    },
+  });
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "provider.usage.list.response",
+      payload: { requestId: "usage-2", fetchedAt: "2026-06-19T00:00:00.000Z", providers: [] },
+    }),
+  );
+
+  await expect(usagePromise).resolves.toEqual({
+    requestId: "usage-2",
+    fetchedAt: "2026-06-19T00:00:00.000Z",
+    providers: [],
+  });
+});
+
 test("sends close_items_request and resolves close_items_response", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -4803,11 +4803,15 @@ export class DaemonClient {
     });
   }
 
-  async listProviderUsage(options?: { requestId?: string }): Promise<ProviderUsageListPayload> {
+  async listProviderUsage(options?: {
+    requestId?: string;
+    forceRefresh?: boolean;
+  }): Promise<ProviderUsageListPayload> {
     return this.sendNamespacedCorrelatedSessionRequest({
       requestId: options?.requestId,
       message: {
         type: "provider.usage.list.request",
+        ...(options?.forceRefresh ? { forceRefresh: true } : {}),
       },
     });
   }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1682,6 +1682,9 @@ export const ProviderDiagnosticRequestMessageSchema = z.object({
 export const ProviderUsageListRequestMessageSchema = z.object({
   type: z.literal("provider.usage.list.request"),
   requestId: z.string(),
+  // Bypass the daemon-side usage cache (still subject to a short server-side
+  // floor). Optional and additive: old daemons strip it and serve the cache.
+  forceRefresh: z.boolean().optional(),
 });
 
 export const ResumeAgentRequestMessageSchema = z.object({

--- a/packages/server/src/server/session/provider/provider-catalog-session.test.ts
+++ b/packages/server/src/server/session/provider/provider-catalog-session.test.ts
@@ -305,6 +305,25 @@ describe("ProviderCatalogSession", () => {
     expect(err?.payload.requestId).toBe("u1");
   });
 
+  it("passes forceRefresh through to the usage service and defaults it off", async () => {
+    const listUsage = vi.fn(async () => ({ fetchedAt: "2026-06-19T00:00:00.000Z", providers: [] }));
+    const { subsystem, emitted } = makeSubsystem({ usage: { listUsage } });
+
+    await subsystem.handleProviderUsageListRequest({
+      type: "provider.usage.list.request",
+      requestId: "u2",
+      forceRefresh: true,
+    });
+    await subsystem.handleProviderUsageListRequest({
+      type: "provider.usage.list.request",
+      requestId: "u3",
+    });
+
+    expect(listUsage).toHaveBeenNthCalledWith(1, { forceRefresh: true });
+    expect(listUsage).toHaveBeenNthCalledWith(2, { forceRefresh: false });
+    expect(findByType(emitted, "provider.usage.list.response")?.payload.requestId).toBe("u2");
+  });
+
   it("surfaces a feature-list failure inline, not as an rpc_error", async () => {
     const { subsystem, emitted } = makeSubsystem({
       host: {

--- a/packages/server/src/server/session/provider/provider-catalog-session.ts
+++ b/packages/server/src/server/session/provider/provider-catalog-session.ts
@@ -484,7 +484,9 @@ export class ProviderCatalogSession {
     msg: Extract<SessionInboundMessage, { type: "provider.usage.list.request" }>,
   ): Promise<void> {
     try {
-      const usage = await this.providerUsageService.listUsage();
+      const usage = await this.providerUsageService.listUsage({
+        forceRefresh: msg.forceRefresh === true,
+      });
       this.host.emit({
         type: "provider.usage.list.response",
         payload: {

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -435,11 +435,16 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   }
 
   private async readCredentials(): Promise<ClaudeCredentialRecord | null> {
-    const credPath = join(this.claudeHome, ".credentials.json");
-    const fileCredentials = await this.readCredentialFile(credPath);
-    return (
-      fileCredentials ?? (this.platform === "darwin" ? await this.readKeychainCredential() : null)
-    );
+    // On macOS the Keychain is Claude Code's canonical credential store; a
+    // `.credentials.json` there is written by third-party tools (account
+    // switchers, backups) and goes stale when they swap accounts, so the
+    // Keychain wins and the file is only a fallback. On Linux and Windows the
+    // file is the only store.
+    if (this.platform === "darwin") {
+      const keychainCredentials = await this.readKeychainCredential();
+      if (keychainCredentials) return keychainCredentials;
+    }
+    return this.readCredentialFile(join(this.claudeHome, ".credentials.json"));
   }
 
   private async readCredentialFile(path: string): Promise<ClaudeCredentialRecord | null> {

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -263,6 +263,43 @@ describe("ProviderUsageService", () => {
     expect(refreshed.providers[0]?.windows[0]?.usedPct).toBe(2);
   });
 
+  it("still serves the cache when a forced refresh arrives within the floor", async () => {
+    let now = Date.parse("2026-06-19T00:00:00.000Z");
+    let calls = 0;
+    const service = new ProviderUsageService({
+      logger: createLogger(),
+      now: () => now,
+      cacheTtlMs: 60_000,
+      forceRefreshMinIntervalMs: 15_000,
+      fetchers: [
+        {
+          providerId: "claude",
+          displayName: "Claude",
+          fetchUsage: async () => {
+            calls += 1;
+            return {
+              providerId: "claude",
+              displayName: "Claude",
+              status: "available",
+              planLabel: "Max 20x",
+              windows: [{ id: "session", label: "Session", usedPct: calls }],
+            };
+          },
+        },
+      ],
+    });
+
+    const first = await service.listUsage();
+    now += 5_000;
+    const withinFloor = await service.listUsage({ forceRefresh: true });
+    now += 15_000;
+    const beyondFloor = await service.listUsage({ forceRefresh: true });
+
+    expect(withinFloor).toBe(first);
+    expect(beyondFloor.providers[0]?.windows[0]?.usedPct).toBe(2);
+    expect(calls).toBe(2);
+  });
+
   it("deduplicates concurrent cache misses", async () => {
     let calls = 0;
     let resolveUsage: ((usage: ProviderUsage) => void) | null = null;
@@ -570,6 +607,50 @@ describe("real provider usage fetchers", () => {
       "https://api.anthropic.com/api/oauth/usage",
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: "Bearer at_expired" }),
+      }),
+    );
+  });
+
+  it("prefers the macOS Keychain over a .credentials.json left by other tools", async () => {
+    // Third-party account switchers maintain a file copy that goes stale when
+    // Claude Code renews the Keychain entry behind them; the Keychain is the
+    // canonical store on macOS and must win.
+    writeClaudeCredentials(claudeHome, "at_stale_file");
+    fetchApi = mockFetch(
+      new Map([
+        ["https://api.anthropic.com/api/oauth/usage", () => jsonResponse(makeClaudeResponse())],
+      ]),
+    );
+
+    const result = await service({
+      platform: "darwin",
+      keychain: async () => ({ claudeAiOauth: { accessToken: "at_keychain_fresh" } }),
+    }).listUsage();
+
+    expect(findProvider(result, "claude").status).toBe("available");
+    expect(fetchApi).toHaveBeenCalledWith(
+      "https://api.anthropic.com/api/oauth/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer at_keychain_fresh" }),
+      }),
+    );
+  });
+
+  it("falls back to .credentials.json on macOS when the Keychain is empty", async () => {
+    writeClaudeCredentials(claudeHome, "at_file_only");
+    fetchApi = mockFetch(
+      new Map([
+        ["https://api.anthropic.com/api/oauth/usage", () => jsonResponse(makeClaudeResponse())],
+      ]),
+    );
+
+    const result = await service({ platform: "darwin", keychain: async () => null }).listUsage();
+
+    expect(findProvider(result, "claude").status).toBe("available");
+    expect(fetchApi).toHaveBeenCalledWith(
+      "https://api.anthropic.com/api/oauth/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer at_file_only" }),
       }),
     );
   });

--- a/packages/server/src/services/quota-fetcher/service.ts
+++ b/packages/server/src/services/quota-fetcher/service.ts
@@ -9,6 +9,8 @@ export interface ProviderUsageServiceOptions {
   fetchers?: ProviderUsageFetcher[];
   fetch?: ProviderApiFetch;
   cacheTtlMs?: number;
+  /** Floor a forced refresh still respects, so UI-driven refreshes cannot hammer provider APIs. */
+  forceRefreshMinIntervalMs?: number;
   now?: () => number;
 }
 
@@ -18,11 +20,13 @@ export interface ProviderUsageListResult {
 }
 
 const DEFAULT_PROVIDER_USAGE_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_FORCE_REFRESH_MIN_INTERVAL_MS = 15 * 1000;
 
 export class ProviderUsageService {
   private readonly logger: Logger;
   private readonly fetchers: ProviderUsageFetcher[];
   private readonly cacheTtlMs: number;
+  private readonly forceRefreshMinIntervalMs: number;
   private readonly now: () => number;
   private cached: { fetchedAtMs: number; result: ProviderUsageListResult } | null = null;
   private inFlight: Promise<ProviderUsageListResult> | null = null;
@@ -36,16 +40,18 @@ export class ProviderUsageService {
         fetch: options.fetch,
       });
     this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_PROVIDER_USAGE_CACHE_TTL_MS;
+    this.forceRefreshMinIntervalMs =
+      options.forceRefreshMinIntervalMs ?? DEFAULT_FORCE_REFRESH_MIN_INTERVAL_MS;
     this.now = options.now ?? Date.now;
   }
 
   async listUsage(options?: { forceRefresh?: boolean }): Promise<ProviderUsageListResult> {
     const nowMs = this.now();
-    if (
-      !options?.forceRefresh &&
-      this.cached &&
-      nowMs - this.cached.fetchedAtMs < this.cacheTtlMs
-    ) {
+    // A forced refresh bypasses the cache TTL but still honors a short floor:
+    // it exists for a user explicitly asking "now", not for a hover loop to
+    // fan out to every provider API on each open.
+    const maxAgeMs = options?.forceRefresh ? this.forceRefreshMinIntervalMs : this.cacheTtlMs;
+    if (this.cached && nowMs - this.cached.fetchedAtMs < maxAgeMs) {
       return this.cached.result;
     }
 


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [x] Bug fix

### Reasoning

The context-window meter's tooltip is the one place to check plan usage while an agent works, and it goes quiet in exactly the situations where you need it most:

1. **While an agent is initializing or running with no usage reported yet** (including a stalled first turn), the meter renders a track-only ring with no tooltip at all. Hovering does nothing, so "is this stalled or just slow, and how much of my session/weekly limit is left?" is unanswerable from the UI.
2. **On macOS, Claude plan usage can silently read the wrong credentials.** The Claude quota fetcher preferred `~/.claude/.credentials.json` over the Keychain. Vanilla Claude Code on macOS stores credentials only in the Keychain; a `.credentials.json` there is typically maintained by third-party account switchers/backup tools and goes stale when they swap or renew logins. When the file's token dies, the tooltip shows Claude as unavailable (or the wrong account's numbers) even though the CLI itself is healthy.
3. **The tooltip's refresh could serve 5-minute-old data.** Opening the tooltip invalidated the app-side react-query cache, but the daemon then served its own 5-minute cache — so "refresh on open" often changed nothing right after an account/auth change.

### Goals

- Hovering the meter always answers "what's my provider usage": the pending (no-usage-yet) ring now carries the same tooltip, with a "No usage reported yet" line plus the provider-usage section.
- Claude usage on macOS reads the Keychain first and falls back to `.credentials.json`, matching Claude Code's own storage precedence. The fetcher stays strictly read-only on credentials.
- Opening the tooltip (and the host Usage page's Refresh) asks the daemon to bypass its usage cache via a new optional `forceRefresh` field on `provider.usage.list.request` — additive and backward-compatible both ways (an old daemon strips the unknown field and serves its cache; an old client never sends it, and the daemon defaults it off).
- A daemon-side floor (15s) keeps forced refreshes from fanning out to every provider API under hover spam.

### Non-goals

- Per-provider-profile usage (usage for `extends: claude` profiles pinned to different accounts) — separate feature, not touched here.
- Any change to agent authentication or credential writing; the quota fetcher remains read-only.

### QA

**Automated (all run locally, macOS):**

- `packages/server` `src/services/quota-fetcher/service.test.ts` — **71 passed**, including new tests: "prefers the macOS Keychain over a .credentials.json left by other tools", "falls back to .credentials.json on macOS when the Keychain is empty", "still serves the cache when a forced refresh arrives within the floor".
- `packages/server` `src/server/session/provider/provider-catalog-session.test.ts` — **12 passed**, including new "passes forceRefresh through to the usage service and defaults it off".
- `packages/client` `src/daemon-client.test.ts` — **116 passed**, including new "listProviderUsage forwards forceRefresh on the wire".
- `packages/app` `src/i18n/resources.test.ts` — **36 passed** (new `contextWindow.pending` key added to all 9 locales).
- **Mutation check:** reverting the three fixes (claude.ts, service.ts, provider-catalog-session.ts) with the new tests in place → exactly the 3 new tests fail (`3 failed | 80 passed`); restoring the fixes → all green. The regression tests demonstrably bind to the changed code.
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 warnings) · `npm run format:check` ✅ (pre-commit hook re-ran all three).

**Live end-to-end (dev daemon + Expo web, macOS, Chromium via Playwright):**

- *Before, pending state:* on the old build, mid-turn with no usage reported, hovering the ring's exact pixels produces **no tooltip** (screenshot: `tooltip-pending-before.png`; DOM text probe for "Context window" → `NONE`).
- *After, pending state:* same scenario on this branch — tooltip shows: `Context window / No usage reported yet / Claude · Max 20x / Session 79% · resets 4h / Weekly 45% · resets 10h / Weekly · Fable 86% · resets 10h / Extra usage Disabled` (screenshot: `tooltip-pending-after.png`).
- *After, ready state:* completed agent shows context stats (2% used, 23k/1m tokens, session cost) plus the plan section (screenshot: `tooltip-ready.png`). This machine has a third-party `~/.claude/.credentials.json` sitting alongside the Keychain (the exact drift scenario) — plan data resolves via the Keychain-first path.
- Screenshots: three PNGs captured (`tooltip-pending-before.png`, `tooltip-pending-after.png`, `tooltip-ready.png`) — being attached to this description via the web UI.

**Platforms:**

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | ❌     | not tested; tooltip opens on press via existing `enabledOnMobile` path |
| Android         | ❌     | not tested |
| Web             | ✅     | Chromium 1440×900, dev daemon, real Claude agent |
| Desktop macOS   | ❌     | not tested directly; same web code path |
| Desktop Windows | ❌     | not tested |
| Desktop Linux   | ❌     | not tested; Linux/Windows keep file-only credential reads (unchanged) |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
