### PR TITLE
feat(server): per-profile plan usage for pinned Claude accounts

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -290,6 +290,8 @@ Example: two different Anthropic accounts as separate profiles:
 
 Each profile appears as a separate provider in the Paseo app. You can select which one to use when launching an agent.
 
+Claude profiles that pin an account with `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) also get their own plan-usage entry: the context-meter tooltip and the host Usage page show that account's session/weekly limits under the profile's label, fetched with the pinned token. Profiles without a pinned token share the base `claude` entry, which reads the machine's active Claude login.
+
 You can also combine profiles with model overrides to pin specific models per profile:
 
 ```json

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -290,7 +290,7 @@ Example: two different Anthropic accounts as separate profiles:
 
 Each profile appears as a separate provider in the Paseo app. You can select which one to use when launching an agent.
 
-Claude profiles that pin an account with `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) also get their own plan-usage entry: the context-meter tooltip and the host Usage page show that account's session/weekly limits under the profile's label, fetched with the pinned token. Profiles without a pinned token share the base `claude` entry, which reads the machine's active Claude login.
+Claude profiles that pin an account with `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) also get their own plan-usage entry in the context-meter tooltip and the host Usage page, under the profile's label. Anthropic's usage API requires the `user:profile` scope and setup-tokens carry only inference scope, so a setup-token profile's entry reports unavailable rather than another account's numbers. A profile whose token has `user:profile` shows live limits. Profiles without a pinned token share the base `claude` entry, which reads the machine's active Claude login.
 
 You can also combine profiles with model overrides to pin specific models per profile:
 

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -290,7 +290,7 @@ Example: two different Anthropic accounts as separate profiles:
 
 Each profile appears as a separate provider in the Paseo app. You can select which one to use when launching an agent.
 
-Claude profiles that pin an account with `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) also get their own plan-usage entry in the context-meter tooltip and the host Usage page, under the profile's label. Anthropic's usage API requires the `user:profile` scope and setup-tokens carry only inference scope, so a setup-token profile's entry reports unavailable rather than another account's numbers. A profile whose token has `user:profile` shows live limits. Profiles without a pinned token share the base `claude` entry, which reads the machine's active Claude login.
+Claude profiles that pin an account with `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) also get their own plan-usage entry in the context-meter tooltip and the host Usage page, under the profile's label. Anthropic's usage API requires the `user:profile` scope, which setup-tokens do not carry, so those profiles read their session and weekly windows from the rate-limit headers of a minimal one-token API call instead — spending a few tokens of the pinned account's own quota per refresh. The plan label and per-model weekly windows exist only on the usage API, so they stay absent for setup-token profiles. Profiles without a pinned token share the base `claude` entry, which reads the machine's active Claude login.
 
 You can also combine profiles with model overrides to pin specific models per profile:
 

--- a/packages/app/src/components/context-window-meter.tsx
+++ b/packages/app/src/components/context-window-meter.tsx
@@ -129,32 +129,55 @@ export function ContextWindowMeter({
 
   // No usage yet: reserve the footprint with a track-only ring while a session is
   // active so the real ring fades in without shifting siblings. Render nothing when
-  // no usage is expected.
+  // no usage is expected. The pending ring keeps the tooltip: a running or stalled
+  // agent with no usage report is exactly when someone hovers to check plan limits.
   if (percentage === null || maxTokens === null || usedTokens === null) {
     if (!pending) {
       return null;
     }
     return (
-      <View style={geometry.containerStyle}>
-        <Svg
-          width={geometry.svgSize}
-          height={geometry.svgSize}
-          viewBox={`0 0 ${geometry.svgSize} ${geometry.svgSize}`}
-          style={styles.svg}
-          accessibilityElementsHidden
-          importantForAccessibility="no-hide-descendants"
-        >
-          <Circle
-            cx={geometry.center}
-            cy={geometry.center}
-            r={geometry.radius}
-            fill="none"
-            stroke={theme.colors.surface3}
-            strokeWidth={geometry.strokeWidth}
-          />
-        </Svg>
-        {showPercentage ? <View style={styles.skeletonLabel} /> : null}
-      </View>
+      <Tooltip
+        open={isTooltipOpen}
+        onOpenChange={handleTooltipOpenChange}
+        delayDuration={0}
+        enabledOnDesktop
+        enabledOnMobile
+      >
+        <TooltipTrigger asChild triggerRefProp="ref">
+          <Pressable
+            style={geometry.containerStyle}
+            testID="context-window-meter"
+            accessibilityRole="image"
+            accessibilityLabel={t("contextWindow.title")}
+          >
+            <Svg
+              width={geometry.svgSize}
+              height={geometry.svgSize}
+              viewBox={`0 0 ${geometry.svgSize} ${geometry.svgSize}`}
+              style={styles.svg}
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
+            >
+              <Circle
+                cx={geometry.center}
+                cy={geometry.center}
+                r={geometry.radius}
+                fill="none"
+                stroke={theme.colors.surface3}
+                strokeWidth={geometry.strokeWidth}
+              />
+            </Svg>
+            {showPercentage ? <View style={styles.skeletonLabel} /> : null}
+          </Pressable>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="center" offset={8}>
+          <View style={styles.tooltipContent}>
+            <Text style={styles.tooltipTitle}>{t("contextWindow.title")}</Text>
+            <Text style={styles.tooltipDetail}>{t("contextWindow.pending")}</Text>
+            <ProviderUsageTooltipSection view={providerUsageView} activeProviderId={provider} />
+          </View>
+        </TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1850,6 +1850,7 @@ export const ar: TranslationResources = {
     used: "تم استخدام{{percentage}}%",
     tokens: "رموز{{used}}/{{max}}",
     sessionCost: "تكلفة الجلسة{{cost}}",
+    pending: "لم يتم الإبلاغ عن الاستخدام بعد",
     accessibility: "تم استخدام نافذة السياق{{percentage}}%",
   },
   review: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1860,6 +1860,7 @@ export const en = {
     used: "{{percentage}}% used",
     tokens: "{{used}} / {{max}} tokens",
     sessionCost: "Session cost {{cost}}",
+    pending: "No usage reported yet",
     accessibility: "Context window {{percentage}}% used",
   },
   review: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1896,6 +1896,7 @@ export const es: TranslationResources = {
     used: "{{percentage}}% utilizado",
     tokens: "Fichas{{used}}/{{max}}",
     sessionCost: "Costo de la sesión{{cost}}",
+    pending: "Aún no se ha informado el uso",
     accessibility: "Ventana de contexto{{percentage}}% utilizada",
   },
   review: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1901,6 +1901,7 @@ export const fr: TranslationResources = {
     used: "{{percentage}}% utilisé",
     tokens: "Jetons{{used}}/{{max}}",
     sessionCost: "Coût de la séance{{cost}}",
+    pending: "Aucune utilisation signalée pour le moment",
     accessibility: "Fenêtre contextuelle{{percentage}}% utilisé",
   },
   review: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1868,6 +1868,7 @@ export const ja: TranslationResources = {
     used: "{{percentage}}%使用",
     tokens: "{{used}} / {{max}}トークン",
     sessionCost: "セッションコスト: {{cost}}",
+    pending: "使用状況はまだ報告されていません",
     accessibility: "コンテキストウィンドウ{{percentage}}%使用",
   },
   review: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1860,6 +1860,7 @@ export const ko: TranslationResources = {
     used: "{{percentage}}% 사용됨",
     tokens: "{{used}} / {{max}} 토큰",
     sessionCost: "세션 비용 {{cost}}",
+    pending: "아직 사용량이 보고되지 않았습니다",
     accessibility: "컨텍스트 윈도우 {{percentage}}% 사용됨",
   },
   review: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1882,6 +1882,7 @@ export const ptBR: TranslationResources = {
     used: "{{percentage}}% usado",
     tokens: "{{used}} / {{max}} tokens",
     sessionCost: "Custo da sessão {{cost}}",
+    pending: "Nenhum uso informado ainda",
     accessibility: "Janela de contexto {{percentage}}% usada",
   },
   review: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1881,6 +1881,7 @@ export const ru: TranslationResources = {
     used: "Использовано: {{percentage}}%",
     tokens: "Токены: {{used}} / {{max}}",
     sessionCost: "Стоимость сессии: {{cost}}",
+    pending: "Данные об использовании ещё не получены",
     accessibility: "Использовано {{percentage}}% контекстного окна",
   },
   review: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1829,6 +1829,7 @@ export const zhCN: TranslationResources = {
     used: "已使用 {{percentage}}%",
     tokens: "{{used}} / {{max}} tokens",
     sessionCost: "会话费用 {{cost}}",
+    pending: "尚未报告使用情况",
     accessibility: "上下文窗口已使用 {{percentage}}%",
   },
   review: {

--- a/packages/app/src/provider-usage/use-provider-usage.ts
+++ b/packages/app/src/provider-usage/use-provider-usage.ts
@@ -14,8 +14,11 @@ export function providerUsageQueryKey(serverId: string | null | undefined) {
   return ["providerUsage", serverId ?? ""] as const;
 }
 
-async function fetchProviderUsage(client: ProviderUsageClient): Promise<ProviderUsageListPayload> {
-  return client.listProviderUsage();
+async function fetchProviderUsage(
+  client: ProviderUsageClient,
+  options?: { forceRefresh?: boolean },
+): Promise<ProviderUsageListPayload> {
+  return client.listProviderUsage(options);
 }
 
 interface UseProviderUsageOptions {
@@ -58,14 +61,16 @@ export function useProviderUsage(
   });
 
   const refresh = useCallback(async () => {
-    if (!canFetch) return;
-    await queryClient.invalidateQueries({ queryKey });
+    if (!canFetch || !client) return;
+    // An explicit refresh asks the daemon to bypass its own usage cache too;
+    // staleTime 0 makes react-query actually refetch instead of serving the
+    // client-side cache it just wrote.
     await queryClient.fetchQuery({
       queryKey,
-      queryFn,
-      staleTime: PROVIDER_USAGE_STALE_TIME_MS,
+      queryFn: () => fetchProviderUsage(client, { forceRefresh: true }),
+      staleTime: 0,
     });
-  }, [canFetch, queryClient, queryFn, queryKey]);
+  }, [canFetch, client, queryClient, queryKey]);
 
   const view = useMemo<ProviderUsageView>(() => {
     if (!serverId || !client || !isConnected) {

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -5903,6 +5903,48 @@ test("sends provider.usage.list.request and resolves provider.usage.list.respons
   });
 });
 
+test("listProviderUsage forwards forceRefresh on the wire", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const usagePromise = client.listProviderUsage({ requestId: "usage-2", forceRefresh: true });
+
+  expect(JSON.parse(assertStr(mock.sent[0]))).toEqual({
+    type: "session",
+    message: {
+      type: "provider.usage.list.request",
+      requestId: "usage-2",
+      forceRefresh: true,
+    },
+  });
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "provider.usage.list.response",
+      payload: { requestId: "usage-2", fetchedAt: "2026-06-19T00:00:00.000Z", providers: [] },
+    }),
+  );
+
+  await expect(usagePromise).resolves.toEqual({
+    requestId: "usage-2",
+    fetchedAt: "2026-06-19T00:00:00.000Z",
+    providers: [],
+  });
+});
+
 test("sends close_items_request and resolves close_items_response", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -4803,11 +4803,15 @@ export class DaemonClient {
     });
   }
 
-  async listProviderUsage(options?: { requestId?: string }): Promise<ProviderUsageListPayload> {
+  async listProviderUsage(options?: {
+    requestId?: string;
+    forceRefresh?: boolean;
+  }): Promise<ProviderUsageListPayload> {
     return this.sendNamespacedCorrelatedSessionRequest({
       requestId: options?.requestId,
       message: {
         type: "provider.usage.list.request",
+        ...(options?.forceRefresh ? { forceRefresh: true } : {}),
       },
     });
   }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1682,6 +1682,9 @@ export const ProviderDiagnosticRequestMessageSchema = z.object({
 export const ProviderUsageListRequestMessageSchema = z.object({
   type: z.literal("provider.usage.list.request"),
   requestId: z.string(),
+  // Bypass the daemon-side usage cache (still subject to a short server-side
+  // floor). Optional and additive: old daemons strip it and serve the cache.
+  forceRefresh: z.boolean().optional(),
 });
 
 export const ResumeAgentRequestMessageSchema = z.object({

--- a/packages/server/src/server/session/provider/provider-catalog-session.test.ts
+++ b/packages/server/src/server/session/provider/provider-catalog-session.test.ts
@@ -305,6 +305,25 @@ describe("ProviderCatalogSession", () => {
     expect(err?.payload.requestId).toBe("u1");
   });
 
+  it("passes forceRefresh through to the usage service and defaults it off", async () => {
+    const listUsage = vi.fn(async () => ({ fetchedAt: "2026-06-19T00:00:00.000Z", providers: [] }));
+    const { subsystem, emitted } = makeSubsystem({ usage: { listUsage } });
+
+    await subsystem.handleProviderUsageListRequest({
+      type: "provider.usage.list.request",
+      requestId: "u2",
+      forceRefresh: true,
+    });
+    await subsystem.handleProviderUsageListRequest({
+      type: "provider.usage.list.request",
+      requestId: "u3",
+    });
+
+    expect(listUsage).toHaveBeenNthCalledWith(1, { forceRefresh: true });
+    expect(listUsage).toHaveBeenNthCalledWith(2, { forceRefresh: false });
+    expect(findByType(emitted, "provider.usage.list.response")?.payload.requestId).toBe("u2");
+  });
+
   it("surfaces a feature-list failure inline, not as an rpc_error", async () => {
     const { subsystem, emitted } = makeSubsystem({
       host: {

--- a/packages/server/src/server/session/provider/provider-catalog-session.ts
+++ b/packages/server/src/server/session/provider/provider-catalog-session.ts
@@ -484,7 +484,9 @@ export class ProviderCatalogSession {
     msg: Extract<SessionInboundMessage, { type: "provider.usage.list.request" }>,
   ): Promise<void> {
     try {
-      const usage = await this.providerUsageService.listUsage();
+      const usage = await this.providerUsageService.listUsage({
+        forceRefresh: msg.forceRefresh === true,
+      });
       this.host.emit({
         type: "provider.usage.list.response",
         payload: {

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -84,7 +84,7 @@ import {
   type WebSocketRuntimeDiagnosticSnapshot,
 } from "./websocket/runtime-metrics.js";
 import { ProviderUsageService } from "../services/quota-fetcher/service.js";
-import { buildProfileUsageFetchers } from "../services/quota-fetcher/profile-fetchers.js";
+import { createProfileUsageFetcherSource } from "../services/quota-fetcher/profile-fetchers.js";
 import { getProcessMemoryDiagnostics, getProcessUptimeSeconds } from "./process-diagnostics.js";
 import {
   CLIENT_SHUTDOWN_RPC_REASON,
@@ -745,13 +745,14 @@ export class VoiceAssistantWebSocketServer {
 
     this.providerUsageService = new ProviderUsageService({
       logger: this.logger,
-      // Profiles pin accounts via env tokens; derive their usage fetchers from
-      // the live config on every refresh so `paseo daemon reload` applies them.
-      dynamicFetchers: () =>
-        buildProfileUsageFetchers({
-          providers: this.daemonConfigStore.get().providers,
-          logger: this.logger,
-        }),
+      // Profiles pin accounts via env tokens; the source re-reads the live
+      // config on every refresh so `paseo daemon reload` applies them, while
+      // keeping each unchanged profile's fetcher instance (and its memory of a
+      // scope-refused token) across refreshes.
+      dynamicFetchers: createProfileUsageFetcherSource({
+        getProviders: () => this.daemonConfigStore.get().providers,
+        logger: this.logger,
+      }),
     });
 
     this.wss = this.createWebSocketServer(server, wsConfig, auth);

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -84,6 +84,7 @@ import {
   type WebSocketRuntimeDiagnosticSnapshot,
 } from "./websocket/runtime-metrics.js";
 import { ProviderUsageService } from "../services/quota-fetcher/service.js";
+import { buildProfileUsageFetchers } from "../services/quota-fetcher/profile-fetchers.js";
 import { getProcessMemoryDiagnostics, getProcessUptimeSeconds } from "./process-diagnostics.js";
 import {
   CLIENT_SHUTDOWN_RPC_REASON,
@@ -744,6 +745,13 @@ export class VoiceAssistantWebSocketServer {
 
     this.providerUsageService = new ProviderUsageService({
       logger: this.logger,
+      // Profiles pin accounts via env tokens; derive their usage fetchers from
+      // the live config on every refresh so `paseo daemon reload` applies them.
+      dynamicFetchers: () =>
+        buildProfileUsageFetchers({
+          providers: this.daemonConfigStore.get().providers,
+          logger: this.logger,
+        }),
     });
 
     this.wss = this.createWebSocketServer(server, wsConfig, auth);

--- a/packages/server/src/services/quota-fetcher/profile-fetchers.test.ts
+++ b/packages/server/src/services/quota-fetcher/profile-fetchers.test.ts
@@ -1,0 +1,55 @@
+import pino from "pino";
+import { describe, expect, it } from "vitest";
+import { buildProfileUsageFetchers } from "./profile-fetchers.js";
+
+const logger = pino({ level: "silent" });
+
+describe("buildProfileUsageFetchers", () => {
+  it("creates one fetcher per Claude profile with a pinned token, keyed by profile id", () => {
+    const fetchers = buildProfileUsageFetchers({
+      logger,
+      providers: {
+        "claude-work": {
+          extends: "claude",
+          label: "Claude (Work)",
+          env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-work" },
+        },
+        "claude-personal": {
+          extends: "claude",
+          env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-personal" },
+        },
+      },
+    });
+
+    expect(fetchers.map((f) => [f.providerId, f.displayName])).toEqual([
+      ["claude-work", "Claude (Work)"],
+      ["claude-personal", "claude-personal"],
+    ]);
+  });
+
+  it("skips disabled profiles, non-claude bases, and profiles without a token", () => {
+    const fetchers = buildProfileUsageFetchers({
+      logger,
+      providers: {
+        "claude-disabled": {
+          extends: "claude",
+          enabled: false,
+          env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-disabled" },
+        },
+        "codex-work": {
+          extends: "codex",
+          env: { OPENAI_API_KEY: "sk-openai" },
+        },
+        // Shared-login profile: the base "claude" entry already describes it.
+        "claude-shared": { extends: "claude", env: { CLAUDE_CONFIG_DIR: "/tmp/other" } },
+        "claude-blank-token": { extends: "claude", env: { CLAUDE_CODE_OAUTH_TOKEN: "   " } },
+      },
+    });
+
+    expect(fetchers).toEqual([]);
+  });
+
+  it("returns nothing when no providers are configured", () => {
+    expect(buildProfileUsageFetchers({ logger, providers: undefined })).toEqual([]);
+  });
+});

--- a/packages/server/src/services/quota-fetcher/profile-fetchers.test.ts
+++ b/packages/server/src/services/quota-fetcher/profile-fetchers.test.ts
@@ -1,6 +1,6 @@
 import pino from "pino";
 import { describe, expect, it } from "vitest";
-import { buildProfileUsageFetchers } from "./profile-fetchers.js";
+import { buildProfileUsageFetchers, createProfileUsageFetcherSource } from "./profile-fetchers.js";
 
 const logger = pino({ level: "silent" });
 
@@ -51,5 +51,54 @@ describe("buildProfileUsageFetchers", () => {
 
   it("returns nothing when no providers are configured", () => {
     expect(buildProfileUsageFetchers({ logger, providers: undefined })).toEqual([]);
+  });
+});
+
+describe("createProfileUsageFetcherSource", () => {
+  it("keeps a profile's fetcher instance across refreshes while its identity is unchanged", () => {
+    let providers: Record<string, unknown> = {
+      "claude-work": {
+        extends: "claude",
+        env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-work" },
+      },
+    };
+    const source = createProfileUsageFetcherSource({ logger, getProviders: () => providers });
+
+    const first = source()[0];
+    const second = source()[0];
+    expect(second).toBe(first);
+
+    // A new token is a new account: the cached instance (and any state it
+    // accumulated for the old token) must not carry over.
+    providers = {
+      "claude-work": {
+        extends: "claude",
+        env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-rotated" },
+      },
+    };
+    const third = source()[0];
+    expect(third).not.toBe(first);
+  });
+
+  it("drops the cached instance when the profile leaves the config", () => {
+    let providers: Record<string, unknown> = {
+      "claude-work": {
+        extends: "claude",
+        env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-work" },
+      },
+    };
+    const source = createProfileUsageFetcherSource({ logger, getProviders: () => providers });
+    const original = source()[0];
+
+    providers = {};
+    expect(source()).toEqual([]);
+
+    providers = {
+      "claude-work": {
+        extends: "claude",
+        env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-work" },
+      },
+    };
+    expect(source()[0]).not.toBe(original);
   });
 });

--- a/packages/server/src/services/quota-fetcher/profile-fetchers.ts
+++ b/packages/server/src/services/quota-fetcher/profile-fetchers.ts
@@ -43,24 +43,63 @@ export interface BuildProfileUsageFetchersOptions {
 export function buildProfileUsageFetchers(
   options: BuildProfileUsageFetchersOptions,
 ): ProviderUsageFetcher[] {
-  const fetchers: ProviderUsageFetcher[] = [];
-  for (const [providerId, entry] of Object.entries(options.providers ?? {})) {
-    const parsed = ProfileProviderConfigSchema.safeParse(entry);
-    if (!parsed.success) continue;
-    const override = parsed.data;
-    if (override.enabled === false) continue;
-    if (override.extends !== "claude") continue;
-    const token = override.env?.[CLAUDE_OAUTH_TOKEN_ENV]?.trim();
-    if (!token) continue;
-    fetchers.push(
-      new ClaudeQuotaProvider({
-        logger: options.logger,
-        fetch: options.fetch,
-        providerId,
-        displayName: override.label ?? providerId,
-        accessToken: token,
-      }),
-    );
-  }
-  return fetchers;
+  return createProfileUsageFetcherSource({
+    ...options,
+    getProviders: () => options.providers,
+  })();
+}
+
+export interface ProfileUsageFetcherSourceOptions {
+  getProviders: () => Record<string, unknown> | undefined;
+  logger: Logger;
+  fetch?: ProviderApiFetch;
+}
+
+/**
+ * A `dynamicFetchers` source that keeps fetcher instances across refreshes.
+ *
+ * The source re-reads the live config on every call so `paseo daemon reload`
+ * applies profile changes, but a qualifying profile keeps its fetcher instance
+ * for as long as its identity (id, token, label) is unchanged. The instance
+ * carries state worth keeping: the resolved ping model, and whether the usage
+ * endpoint already refused the token's scope — rebuilding it every refresh
+ * would re-knock on a permanently closed door each time. A changed token or
+ * label makes a fresh instance; profiles gone from the config drop theirs.
+ */
+export function createProfileUsageFetcherSource(
+  options: ProfileUsageFetcherSourceOptions,
+): () => ProviderUsageFetcher[] {
+  const instances = new Map<string, ClaudeQuotaProvider>();
+  return () => {
+    const fetchers: ProviderUsageFetcher[] = [];
+    const seen = new Set<string>();
+    for (const [providerId, entry] of Object.entries(options.getProviders() ?? {})) {
+      const parsed = ProfileProviderConfigSchema.safeParse(entry);
+      if (!parsed.success) continue;
+      const override = parsed.data;
+      if (override.enabled === false) continue;
+      if (override.extends !== "claude") continue;
+      const token = override.env?.[CLAUDE_OAUTH_TOKEN_ENV]?.trim();
+      if (!token) continue;
+      const displayName = override.label ?? providerId;
+      const key = `${providerId}\u0000${token}\u0000${displayName}`;
+      seen.add(key);
+      let fetcher = instances.get(key);
+      if (!fetcher) {
+        fetcher = new ClaudeQuotaProvider({
+          logger: options.logger,
+          fetch: options.fetch,
+          providerId,
+          displayName,
+          accessToken: token,
+        });
+        instances.set(key, fetcher);
+      }
+      fetchers.push(fetcher);
+    }
+    for (const key of instances.keys()) {
+      if (!seen.has(key)) instances.delete(key);
+    }
+    return fetchers;
+  };
 }

--- a/packages/server/src/services/quota-fetcher/profile-fetchers.ts
+++ b/packages/server/src/services/quota-fetcher/profile-fetchers.ts
@@ -1,0 +1,66 @@
+import type { Logger } from "pino";
+import { z } from "zod";
+import type { ProviderApiFetch, ProviderUsageFetcher } from "./provider.js";
+import { ClaudeQuotaProvider } from "./providers/claude.js";
+
+const CLAUDE_OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN";
+
+// The slice of a provider override this module reads. Validated per entry
+// because provider config schemas are passthrough records: the fields exist at
+// runtime but not in their inferred types, and one malformed entry must not
+// take down the other profiles' usage.
+const ProfileProviderConfigSchema = z
+  .object({
+    extends: z.string().optional(),
+    label: z.string().optional(),
+    enabled: z.boolean().optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .loose();
+
+export interface BuildProfileUsageFetchersOptions {
+  providers: Record<string, unknown> | undefined;
+  logger: Logger;
+  fetch?: ProviderApiFetch;
+}
+
+/**
+ * Usage fetchers for provider profiles that pin their own account.
+ *
+ * A profile extending `claude` with a CLAUDE_CODE_OAUTH_TOKEN bills to that
+ * token's account, so its usage must be fetched with that token — the shared
+ * credential stores describe whichever account the CLI is currently on. Each
+ * qualifying profile becomes its own usage entry, keyed by the profile id the
+ * app already uses as the agent's provider id, so the context-meter tooltip
+ * and the host Usage page match it exactly.
+ *
+ * Profiles without a pinned token are skipped rather than duplicated: their
+ * agents run on the shared login, which the base `claude` entry already
+ * describes. Other base providers have account-bound usage endpoints of their
+ * own and are not derivable from an env token, so only Claude profiles are
+ * covered here.
+ */
+export function buildProfileUsageFetchers(
+  options: BuildProfileUsageFetchersOptions,
+): ProviderUsageFetcher[] {
+  const fetchers: ProviderUsageFetcher[] = [];
+  for (const [providerId, entry] of Object.entries(options.providers ?? {})) {
+    const parsed = ProfileProviderConfigSchema.safeParse(entry);
+    if (!parsed.success) continue;
+    const override = parsed.data;
+    if (override.enabled === false) continue;
+    if (override.extends !== "claude") continue;
+    const token = override.env?.[CLAUDE_OAUTH_TOKEN_ENV]?.trim();
+    if (!token) continue;
+    fetchers.push(
+      new ClaudeQuotaProvider({
+        logger: options.logger,
+        fetch: options.fetch,
+        providerId,
+        displayName: override.label ?? providerId,
+        accessToken: token,
+      }),
+    );
+  }
+  return fetchers;
+}

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -22,6 +22,7 @@ import {
 const execFileAsync = promisify(execFile);
 const CLAUDE_KEYCHAIN_TIMEOUT_MS = 2_000;
 const CLAUDE_OAUTH_BETA = "oauth-2025-04-20";
+const CLAUDE_ANTHROPIC_VERSION = "2023-06-01";
 const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
 
 const ClaudeCredentialsSchema = z.object({
@@ -33,6 +34,10 @@ const ClaudeCredentialsSchema = z.object({
       rateLimitTier: z.string().optional(),
     })
     .optional(),
+});
+
+const ClaudeModelsResponseSchema = z.object({
+  data: z.array(z.object({ id: z.string() }).loose()),
 });
 
 const ClaudeUsageWindowSchema = z.object({
@@ -358,6 +363,15 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   private readonly platform: typeof process.platform;
   private readonly fetchApi: ProviderApiFetch;
   private readonly staticAccessToken: string | null;
+  /** Model id used by the header-ping fallback, resolved once per instance. */
+  private pingModelId: string | null = null;
+  /**
+   * Set once the usage endpoint has refused this instance's pinned token and
+   * the header fallback worked. A scope refusal is permanent for a token, and
+   * retrying it anyway is what attracts 429 throttling, so later refreshes go
+   * straight to the fallback.
+   */
+  private usageEndpointRefused = false;
 
   constructor(options: ClaudeQuotaProviderOptions) {
     this.providerId = options.providerId ?? "claude";
@@ -379,9 +393,32 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
 
     const { oauth } = credentials;
     const plan = buildClaudePlan(oauth.subscriptionType, oauth.rateLimitTier);
-    const resp = await this.callClaudeApi(oauth.accessToken);
+    let resp: ClaudeUsageResponse | "NEEDS_AUTH";
+    if (this.usageEndpointRefused) {
+      resp = "NEEDS_AUTH";
+    } else if (this.staticAccessToken) {
+      try {
+        resp = await this.callClaudeApi(oauth.accessToken);
+      } catch (error) {
+        // A throttled or failing usage endpoint (429/5xx) is transient, so the
+        // endpoint stays first choice on the next refresh — but this refresh
+        // can still answer from the headers instead of surfacing an error row.
+        const pinged = await this.usageFromResponseHeaders(this.staticAccessToken);
+        if (pinged) return pinged;
+        throw error;
+      }
+    } else {
+      resp = await this.callClaudeApi(oauth.accessToken);
+    }
 
     if (resp === "NEEDS_AUTH") {
+      if (this.staticAccessToken) {
+        const pinged = await this.usageFromResponseHeaders(this.staticAccessToken);
+        if (pinged) {
+          this.usageEndpointRefused = true;
+          return pinged;
+        }
+      }
       // Read-only on credentials; the Claude CLI owns refresh. See docs/providers.md.
       return unavailableUsage(this);
     }
@@ -490,6 +527,106 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   ): ClaudeCredentialRecord | null {
     const oauth = credentials.claudeAiOauth;
     return oauth?.accessToken ? { oauth: { ...oauth, accessToken: oauth.accessToken } } : null;
+  }
+
+  /**
+   * Usage derived from the rate-limit headers of a minimal `/v1/messages` call.
+   *
+   * `claude setup-token` mints inference-only tokens, and the usage endpoint
+   * requires the `user:profile` scope, so pinned profiles cannot read usage the
+   * normal way. Inference responses carry the same session and weekly windows
+   * in `anthropic-ratelimit-unified-*` headers (utilization as a 0..1
+   * fraction, verified against the usage endpoint's percentages on a token
+   * that holds both scopes), so the fallback spends one output token of the
+   * pinned account's own quota per cache refresh. The plan label and
+   * per-model weekly windows are not in the headers, so those stay absent.
+   */
+  private async usageFromResponseHeaders(token: string): Promise<ProviderUsage | null> {
+    const model = await this.resolvePingModel(token);
+    if (!model) return null;
+    let res: Response;
+    try {
+      res = await fetchProviderApi(this.fetchApi, "https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "anthropic-beta": CLAUDE_OAUTH_BETA,
+          "anthropic-version": CLAUDE_ANTHROPIC_VERSION,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 1,
+          messages: [{ role: "user", content: "." }],
+        }),
+      });
+    } catch {
+      return null;
+    }
+
+    // Parsed regardless of status: a rate-limited response still carries the
+    // headers, and an exhausted account is exactly when they matter.
+    const windows: ProviderUsageWindow[] = [];
+    for (const spec of [
+      { prefix: "5h", id: "five_hour", label: "Session" },
+      { prefix: "7d", id: "weekly", label: "Weekly" },
+    ]) {
+      const utilization = Number.parseFloat(
+        res.headers.get(`anthropic-ratelimit-unified-${spec.prefix}-utilization`) ?? "",
+      );
+      if (!Number.isFinite(utilization)) continue;
+      const usedPct = Math.max(0, Math.round(utilization * 100));
+      const resetEpochSeconds = Number.parseFloat(
+        res.headers.get(`anthropic-ratelimit-unified-${spec.prefix}-reset`) ?? "",
+      );
+      windows.push(
+        windowFromUsedPct({
+          id: spec.id,
+          label: spec.label,
+          utilizationPct: usedPct,
+          resetsAt: Number.isFinite(resetEpochSeconds)
+            ? new Date(resetEpochSeconds * 1000).toISOString()
+            : null,
+          tone: toneFromUsedPct(usedPct),
+        }),
+      );
+    }
+    if (windows.length === 0) return null;
+
+    return {
+      providerId: this.providerId,
+      displayName: this.displayName,
+      status: "available",
+      planLabel: null,
+      windows,
+      balances: [],
+      details: [],
+      error: null,
+    };
+  }
+
+  /** Cheapest listed model for the header ping, resolved once per instance. */
+  private async resolvePingModel(token: string): Promise<string | null> {
+    if (this.pingModelId) return this.pingModelId;
+    try {
+      const res = await fetchProviderApi(this.fetchApi, "https://api.anthropic.com/v1/models", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+          "anthropic-beta": CLAUDE_OAUTH_BETA,
+          "anthropic-version": CLAUDE_ANTHROPIC_VERSION,
+        },
+      });
+      if (!res.ok) return null;
+      const parsed = ClaudeModelsResponseSchema.safeParse(await res.json());
+      if (!parsed.success) return null;
+      const models = parsed.data.data;
+      const pick = models.find((m) => m.id.includes("haiku")) ?? models[0];
+      this.pingModelId = pick?.id ?? null;
+      return this.pingModelId;
+    } catch {
+      return null;
+    }
   }
 
   private async callClaudeApi(token: string): Promise<ClaudeUsageResponse | "NEEDS_AUTH"> {

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -435,11 +435,16 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   }
 
   private async readCredentials(): Promise<ClaudeCredentialRecord | null> {
-    const credPath = join(this.claudeHome, ".credentials.json");
-    const fileCredentials = await this.readCredentialFile(credPath);
-    return (
-      fileCredentials ?? (this.platform === "darwin" ? await this.readKeychainCredential() : null)
-    );
+    // On macOS the Keychain is Claude Code's canonical credential store; a
+    // `.credentials.json` there is written by third-party tools (account
+    // switchers, backups) and goes stale when they swap accounts, so the
+    // Keychain wins and the file is only a fallback. On Linux and Windows the
+    // file is the only store.
+    if (this.platform === "darwin") {
+      const keychainCredentials = await this.readKeychainCredential();
+      if (keychainCredentials) return keychainCredentials;
+    }
+    return this.readCredentialFile(join(this.claudeHome, ".credentials.json"));
   }
 
   private async readCredentialFile(path: string): Promise<ClaudeCredentialRecord | null> {

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -86,6 +86,17 @@ interface ClaudeQuotaProviderOptions {
   claudeKeychainReader?: () => Promise<unknown | null>;
   platform?: typeof process.platform;
   fetch?: ProviderApiFetch;
+  /** Report usage under this id instead of "claude" (provider profiles). */
+  providerId?: string;
+  /** Display name matching the profile's label. */
+  displayName?: string;
+  /**
+   * Use this OAuth token instead of reading the shared credential stores.
+   * Provider profiles pin accounts with CLAUDE_CODE_OAUTH_TOKEN; their usage
+   * must come from that token, not from whatever account the shared stores
+   * currently hold.
+   */
+  accessToken?: string;
 }
 
 function buildClaudePlan(
@@ -338,22 +349,26 @@ export async function readClaudeKeychainCredentials(
 }
 
 export class ClaudeQuotaProvider implements ProviderUsageFetcher {
-  readonly providerId = "claude";
-  readonly displayName = "Claude";
+  readonly providerId: string;
+  readonly displayName: string;
 
   private readonly logger: Logger;
   private readonly claudeHome: string;
   private readonly readKeychainCredentials: () => Promise<unknown | null>;
   private readonly platform: typeof process.platform;
   private readonly fetchApi: ProviderApiFetch;
+  private readonly staticAccessToken: string | null;
 
   constructor(options: ClaudeQuotaProviderOptions) {
+    this.providerId = options.providerId ?? "claude";
+    this.displayName = options.displayName ?? "Claude";
     this.logger = options.logger.child({ module: "claude-quota-provider" });
     this.claudeHome =
       options.claudeHome || process.env["CLAUDE_HOME"] || join(homedir(), ".claude");
     this.readKeychainCredentials = options.claudeKeychainReader ?? readClaudeKeychainCredentials;
     this.platform = options.platform ?? process.platform;
     this.fetchApi = options.fetch ?? fetch;
+    this.staticAccessToken = options.accessToken?.trim() || null;
   }
 
   async fetchUsage(): Promise<ProviderUsage> {
@@ -435,6 +450,13 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   }
 
   private async readCredentials(): Promise<ClaudeCredentialRecord | null> {
+    // A profile-pinned token bypasses the shared stores entirely: it identifies
+    // one account regardless of what the CLI or third-party switchers are on.
+    // subscriptionType/rateLimitTier are unknown for raw tokens, so planLabel
+    // stays null for profile entries.
+    if (this.staticAccessToken) {
+      return { oauth: { accessToken: this.staticAccessToken } };
+    }
     // On macOS the Keychain is Claude Code's canonical credential store; a
     // `.credentials.json` there is written by third-party tools (account
     // switchers, backups) and goes stale when they swap accounts, so the

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -15,6 +15,7 @@ import { KimiQuotaProvider } from "./providers/kimi.js";
 import { MiniMaxQuotaProvider } from "./providers/minimax.js";
 import { ZaiQuotaProvider } from "./providers/zai.js";
 import { ProviderUsageService } from "./service.js";
+import { buildProfileUsageFetchers } from "./profile-fetchers.js";
 
 function writeClaudeCredentials(
   dir: string,
@@ -298,6 +299,37 @@ describe("ProviderUsageService", () => {
     expect(withinFloor).toBe(first);
     expect(beyondFloor.providers[0]?.windows[0]?.usedPct).toBe(2);
     expect(calls).toBe(2);
+  });
+
+  it("re-evaluates dynamic fetchers on every refresh so config reloads apply", async () => {
+    const makeFetcher = (providerId: string) => ({
+      providerId,
+      displayName: providerId,
+      fetchUsage: async () => ({
+        providerId,
+        displayName: providerId,
+        status: "available" as const,
+        planLabel: null,
+        windows: [],
+      }),
+    });
+    let dynamic = [makeFetcher("claude-work")];
+    const service = new ProviderUsageService({
+      logger: createLogger(),
+      cacheTtlMs: 0,
+      fetchers: [makeFetcher("claude")],
+      dynamicFetchers: () => dynamic,
+    });
+
+    const first = await service.listUsage();
+    expect(first.providers.map((p) => p.providerId)).toEqual(["claude", "claude-work"]);
+
+    // Simulate `paseo daemon reload` adding a profile and removing the old one.
+    // Plain listUsage: cacheTtlMs 0 means the next read refetches, proving a
+    // reload needs no force flag (and no service lifecycle hooks) to apply.
+    dynamic = [makeFetcher("claude-personal")];
+    const second = await service.listUsage();
+    expect(second.providers.map((p) => p.providerId)).toEqual(["claude", "claude-personal"]);
   });
 
   it("deduplicates concurrent cache misses", async () => {
@@ -651,6 +683,53 @@ describe("real provider usage fetchers", () => {
       "https://api.anthropic.com/api/oauth/usage",
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: "Bearer at_file_only" }),
+      }),
+    );
+  });
+
+  it("fetches profile usage with the profile's pinned token, ignoring shared stores", async () => {
+    // Shared stores describe a DIFFERENT account than the profile's token.
+    writeClaudeCredentials(claudeHome, "at_shared_store");
+    fetchApi = mockFetch(
+      new Map([
+        ["https://api.anthropic.com/api/oauth/usage", () => jsonResponse(makeClaudeResponse())],
+      ]),
+    );
+    const logger = createLogger();
+    const fetchThroughTestDouble = ((url: RequestInfo | URL, init?: RequestInit) =>
+      fetchApi(url, init)) as typeof fetch;
+    const usageService = new ProviderUsageService({
+      logger,
+      cacheTtlMs: 0,
+      fetchers: [],
+      dynamicFetchers: () =>
+        buildProfileUsageFetchers({
+          logger,
+          fetch: fetchThroughTestDouble,
+          providers: {
+            "claude-work": {
+              extends: "claude",
+              label: "Claude (Work)",
+              env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-work" },
+            },
+          },
+        }),
+    });
+
+    const result = await usageService.listUsage();
+    const profile = findProvider(result, "claude-work");
+
+    expect(profile).toMatchObject({
+      providerId: "claude-work",
+      displayName: "Claude (Work)",
+      status: "available",
+      planLabel: null,
+    });
+    expect(profile.windows.length).toBeGreaterThan(0);
+    expect(fetchApi).toHaveBeenCalledWith(
+      "https://api.anthropic.com/api/oauth/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer sk-ant-oat01-work" }),
       }),
     );
   });

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -15,7 +15,7 @@ import { KimiQuotaProvider } from "./providers/kimi.js";
 import { MiniMaxQuotaProvider } from "./providers/minimax.js";
 import { ZaiQuotaProvider } from "./providers/zai.js";
 import { ProviderUsageService } from "./service.js";
-import { buildProfileUsageFetchers } from "./profile-fetchers.js";
+import { buildProfileUsageFetchers, createProfileUsageFetcherSource } from "./profile-fetchers.js";
 
 function writeClaudeCredentials(
   dir: string,
@@ -732,6 +732,219 @@ describe("real provider usage fetchers", () => {
         headers: expect.objectContaining({ Authorization: "Bearer sk-ant-oat01-work" }),
       }),
     );
+  });
+
+  it("falls back to rate-limit headers when the usage endpoint refuses the pinned token's scope", async () => {
+    // Setup tokens carry only the inference scope: the usage endpoint 403s,
+    // and the fetcher must derive the windows from a minimal messages call.
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api.anthropic.com/api/oauth/usage",
+          () => jsonResponse({ error: { type: "permission_error" } }, 403),
+        ],
+        [
+          "https://api.anthropic.com/v1/models",
+          () => jsonResponse({ data: [{ id: "claude-haiku-4-5-20251001" }] }),
+        ],
+        [
+          "https://api.anthropic.com/v1/messages",
+          () =>
+            new Response("{}", {
+              status: 200,
+              headers: {
+                "anthropic-ratelimit-unified-5h-utilization": "0.42",
+                "anthropic-ratelimit-unified-5h-reset": "1788144000",
+                "anthropic-ratelimit-unified-7d-utilization": "0.07",
+                "anthropic-ratelimit-unified-7d-reset": "1788688800",
+              },
+            }),
+        ],
+      ]),
+    );
+    const logger = createLogger();
+    const fetchThroughTestDouble = ((url: RequestInfo | URL, init?: RequestInit) =>
+      fetchApi(url, init)) as typeof fetch;
+    const usageService = new ProviderUsageService({
+      logger,
+      cacheTtlMs: 0,
+      fetchers: [],
+      dynamicFetchers: createProfileUsageFetcherSource({
+        logger,
+        fetch: fetchThroughTestDouble,
+        getProviders: () => ({
+          "claude-pinned": {
+            extends: "claude",
+            label: "Claude (Pinned)",
+            env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-pinned" },
+          },
+        }),
+      }),
+    });
+
+    const result = await usageService.listUsage();
+    const profile = findProvider(result, "claude-pinned");
+
+    expect(profile).toMatchObject({ status: "available", planLabel: null, error: null });
+    expect(profile.windows).toEqual([
+      expect.objectContaining({
+        id: "five_hour",
+        label: "Session",
+        usedPct: 42,
+        resetsAt: new Date(1788144000 * 1000).toISOString(),
+      }),
+      expect.objectContaining({
+        id: "weekly",
+        label: "Weekly",
+        usedPct: 7,
+        resetsAt: new Date(1788688800 * 1000).toISOString(),
+      }),
+    ]);
+    expect(fetchApi).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/messages",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer sk-ant-oat01-pinned" }),
+      }),
+    );
+  });
+
+  it("stops calling the refused usage endpoint on later refreshes once the fallback works", async () => {
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api.anthropic.com/api/oauth/usage",
+          () => jsonResponse({ error: { type: "permission_error" } }, 403),
+        ],
+        [
+          "https://api.anthropic.com/v1/models",
+          () => jsonResponse({ data: [{ id: "claude-haiku-4-5-20251001" }] }),
+        ],
+        [
+          "https://api.anthropic.com/v1/messages",
+          () =>
+            new Response("{}", {
+              status: 200,
+              headers: { "anthropic-ratelimit-unified-5h-utilization": "0.1" },
+            }),
+        ],
+      ]),
+    );
+    const logger = createLogger();
+    const fetchThroughTestDouble = ((url: RequestInfo | URL, init?: RequestInit) =>
+      fetchApi(url, init)) as typeof fetch;
+    const usageService = new ProviderUsageService({
+      logger,
+      cacheTtlMs: 0,
+      fetchers: [],
+      dynamicFetchers: createProfileUsageFetcherSource({
+        logger,
+        fetch: fetchThroughTestDouble,
+        getProviders: () => ({
+          "claude-pinned": {
+            extends: "claude",
+            env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-pinned" },
+          },
+        }),
+      }),
+    });
+
+    await usageService.listUsage();
+    await usageService.listUsage();
+
+    const calls = (fetchApi as ReturnType<typeof vi.fn>).mock.calls.map((call) => String(call[0]));
+    expect(calls.filter((url) => url.endsWith("/api/oauth/usage"))).toHaveLength(1);
+    expect(calls.filter((url) => url.endsWith("/v1/messages"))).toHaveLength(2);
+    // The ping model is resolved once and remembered alongside the refusal.
+    expect(calls.filter((url) => url.endsWith("/v1/models"))).toHaveLength(1);
+  });
+
+  it("answers from headers when the usage endpoint is throttled, without giving up on it", async () => {
+    // A 429 is transient (unlike a scope refusal), so the endpoint must stay
+    // first choice on the next refresh while this refresh still shows data.
+    fetchApi = mockFetch(
+      new Map([
+        ["https://api.anthropic.com/api/oauth/usage", () => jsonResponse({}, 429)],
+        [
+          "https://api.anthropic.com/v1/models",
+          () => jsonResponse({ data: [{ id: "claude-haiku-4-5-20251001" }] }),
+        ],
+        [
+          "https://api.anthropic.com/v1/messages",
+          () =>
+            new Response("{}", {
+              status: 200,
+              headers: { "anthropic-ratelimit-unified-5h-utilization": "0.66" },
+            }),
+        ],
+      ]),
+    );
+    const logger = createLogger();
+    const fetchThroughTestDouble = ((url: RequestInfo | URL, init?: RequestInit) =>
+      fetchApi(url, init)) as typeof fetch;
+    const usageService = new ProviderUsageService({
+      logger,
+      cacheTtlMs: 0,
+      fetchers: [],
+      dynamicFetchers: createProfileUsageFetcherSource({
+        logger,
+        fetch: fetchThroughTestDouble,
+        getProviders: () => ({
+          "claude-pinned": {
+            extends: "claude",
+            env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-pinned" },
+          },
+        }),
+      }),
+    });
+
+    const first = findProvider(await usageService.listUsage(), "claude-pinned");
+    expect(first).toMatchObject({ status: "available", error: null });
+    expect(first.windows).toEqual([
+      expect.objectContaining({ id: "five_hour", label: "Session", usedPct: 66 }),
+    ]);
+
+    await usageService.listUsage();
+    const calls = (fetchApi as ReturnType<typeof vi.fn>).mock.calls.map((call) => String(call[0]));
+    expect(calls.filter((url) => url.endsWith("/api/oauth/usage"))).toHaveLength(2);
+  });
+
+  it("reports a pinned profile unavailable when the header fallback also fails", async () => {
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api.anthropic.com/api/oauth/usage",
+          () => jsonResponse({ error: { type: "permission_error" } }, 403),
+        ],
+        [
+          "https://api.anthropic.com/v1/models",
+          () => jsonResponse({ data: [{ id: "claude-haiku-4-5-20251001" }] }),
+        ],
+        ["https://api.anthropic.com/v1/messages", () => new Response("{}", { status: 500 })],
+      ]),
+    );
+    const logger = createLogger();
+    const fetchThroughTestDouble = ((url: RequestInfo | URL, init?: RequestInit) =>
+      fetchApi(url, init)) as typeof fetch;
+    const usageService = new ProviderUsageService({
+      logger,
+      cacheTtlMs: 0,
+      fetchers: [],
+      dynamicFetchers: createProfileUsageFetcherSource({
+        logger,
+        fetch: fetchThroughTestDouble,
+        getProviders: () => ({
+          "claude-pinned": {
+            extends: "claude",
+            env: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-pinned" },
+          },
+        }),
+      }),
+    });
+
+    const result = await usageService.listUsage();
+    const profile = findProvider(result, "claude-pinned");
+
+    expect(profile).toMatchObject({ status: "unavailable", windows: [] });
   });
 
   it("fetches Codex windows and coerces string credit balances", async () => {

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -263,6 +263,43 @@ describe("ProviderUsageService", () => {
     expect(refreshed.providers[0]?.windows[0]?.usedPct).toBe(2);
   });
 
+  it("still serves the cache when a forced refresh arrives within the floor", async () => {
+    let now = Date.parse("2026-06-19T00:00:00.000Z");
+    let calls = 0;
+    const service = new ProviderUsageService({
+      logger: createLogger(),
+      now: () => now,
+      cacheTtlMs: 60_000,
+      forceRefreshMinIntervalMs: 15_000,
+      fetchers: [
+        {
+          providerId: "claude",
+          displayName: "Claude",
+          fetchUsage: async () => {
+            calls += 1;
+            return {
+              providerId: "claude",
+              displayName: "Claude",
+              status: "available",
+              planLabel: "Max 20x",
+              windows: [{ id: "session", label: "Session", usedPct: calls }],
+            };
+          },
+        },
+      ],
+    });
+
+    const first = await service.listUsage();
+    now += 5_000;
+    const withinFloor = await service.listUsage({ forceRefresh: true });
+    now += 15_000;
+    const beyondFloor = await service.listUsage({ forceRefresh: true });
+
+    expect(withinFloor).toBe(first);
+    expect(beyondFloor.providers[0]?.windows[0]?.usedPct).toBe(2);
+    expect(calls).toBe(2);
+  });
+
   it("deduplicates concurrent cache misses", async () => {
     let calls = 0;
     let resolveUsage: ((usage: ProviderUsage) => void) | null = null;
@@ -570,6 +607,50 @@ describe("real provider usage fetchers", () => {
       "https://api.anthropic.com/api/oauth/usage",
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: "Bearer at_expired" }),
+      }),
+    );
+  });
+
+  it("prefers the macOS Keychain over a .credentials.json left by other tools", async () => {
+    // Third-party account switchers maintain a file copy that goes stale when
+    // Claude Code renews the Keychain entry behind them; the Keychain is the
+    // canonical store on macOS and must win.
+    writeClaudeCredentials(claudeHome, "at_stale_file");
+    fetchApi = mockFetch(
+      new Map([
+        ["https://api.anthropic.com/api/oauth/usage", () => jsonResponse(makeClaudeResponse())],
+      ]),
+    );
+
+    const result = await service({
+      platform: "darwin",
+      keychain: async () => ({ claudeAiOauth: { accessToken: "at_keychain_fresh" } }),
+    }).listUsage();
+
+    expect(findProvider(result, "claude").status).toBe("available");
+    expect(fetchApi).toHaveBeenCalledWith(
+      "https://api.anthropic.com/api/oauth/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer at_keychain_fresh" }),
+      }),
+    );
+  });
+
+  it("falls back to .credentials.json on macOS when the Keychain is empty", async () => {
+    writeClaudeCredentials(claudeHome, "at_file_only");
+    fetchApi = mockFetch(
+      new Map([
+        ["https://api.anthropic.com/api/oauth/usage", () => jsonResponse(makeClaudeResponse())],
+      ]),
+    );
+
+    const result = await service({ platform: "darwin", keychain: async () => null }).listUsage();
+
+    expect(findProvider(result, "claude").status).toBe("available");
+    expect(fetchApi).toHaveBeenCalledWith(
+      "https://api.anthropic.com/api/oauth/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer at_file_only" }),
       }),
     );
   });

--- a/packages/server/src/services/quota-fetcher/service.ts
+++ b/packages/server/src/services/quota-fetcher/service.ts
@@ -9,6 +9,8 @@ export interface ProviderUsageServiceOptions {
   fetchers?: ProviderUsageFetcher[];
   fetch?: ProviderApiFetch;
   cacheTtlMs?: number;
+  /** Floor a forced refresh still respects, so UI-driven refreshes cannot hammer provider APIs. */
+  forceRefreshMinIntervalMs?: number;
   now?: () => number;
 }
 
@@ -18,11 +20,13 @@ export interface ProviderUsageListResult {
 }
 
 const DEFAULT_PROVIDER_USAGE_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_FORCE_REFRESH_MIN_INTERVAL_MS = 15 * 1000;
 
 export class ProviderUsageService {
   private readonly logger: Logger;
   private readonly fetchers: ProviderUsageFetcher[];
   private readonly cacheTtlMs: number;
+  private readonly forceRefreshMinIntervalMs: number;
   private readonly now: () => number;
   private cached: { fetchedAtMs: number; result: ProviderUsageListResult } | null = null;
   private inFlight: Promise<ProviderUsageListResult> | null = null;
@@ -36,16 +40,18 @@ export class ProviderUsageService {
         fetch: options.fetch,
       });
     this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_PROVIDER_USAGE_CACHE_TTL_MS;
+    this.forceRefreshMinIntervalMs =
+      options.forceRefreshMinIntervalMs ?? DEFAULT_FORCE_REFRESH_MIN_INTERVAL_MS;
     this.now = options.now ?? Date.now;
   }
 
   async listUsage(options?: { forceRefresh?: boolean }): Promise<ProviderUsageListResult> {
     const nowMs = this.now();
-    if (
-      !options?.forceRefresh &&
-      this.cached &&
-      nowMs - this.cached.fetchedAtMs < this.cacheTtlMs
-    ) {
+    // A forced refresh bypasses the cache TTL but still honors a short floor:
+    // it exists for a user explicitly asking "now", not for a hover loop to
+    // fan out to every provider API on each open.
+    const maxAgeMs = options?.forceRefresh ? this.forceRefreshMinIntervalMs : this.cacheTtlMs;
+    if (this.cached && nowMs - this.cached.fetchedAtMs < maxAgeMs) {
       return this.cached.result;
     }
 

--- a/packages/server/src/services/quota-fetcher/service.ts
+++ b/packages/server/src/services/quota-fetcher/service.ts
@@ -11,6 +11,12 @@ export interface ProviderUsageServiceOptions {
   cacheTtlMs?: number;
   /** Floor a forced refresh still respects, so UI-driven refreshes cannot hammer provider APIs. */
   forceRefreshMinIntervalMs?: number;
+  /**
+   * Fetchers derived from mutable state (provider profiles in config.json),
+   * re-evaluated on every refresh so a config reload is picked up without any
+   * service lifecycle plumbing. Static fetchers come first in the result.
+   */
+  dynamicFetchers?: () => ProviderUsageFetcher[];
   now?: () => number;
 }
 
@@ -25,6 +31,7 @@ const DEFAULT_FORCE_REFRESH_MIN_INTERVAL_MS = 15 * 1000;
 export class ProviderUsageService {
   private readonly logger: Logger;
   private readonly fetchers: ProviderUsageFetcher[];
+  private readonly dynamicFetchers: (() => ProviderUsageFetcher[]) | null;
   private readonly cacheTtlMs: number;
   private readonly forceRefreshMinIntervalMs: number;
   private readonly now: () => number;
@@ -39,6 +46,7 @@ export class ProviderUsageService {
         logger: this.logger,
         fetch: options.fetch,
       });
+    this.dynamicFetchers = options.dynamicFetchers ?? null;
     this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_PROVIDER_USAGE_CACHE_TTL_MS;
     this.forceRefreshMinIntervalMs =
       options.forceRefreshMinIntervalMs ?? DEFAULT_FORCE_REFRESH_MIN_INTERVAL_MS;
@@ -71,9 +79,10 @@ export class ProviderUsageService {
   }
 
   private async fetchFreshUsage(nowMs: number): Promise<ProviderUsageListResult> {
-    const settled = await Promise.allSettled(this.fetchers.map((fetcher) => fetcher.fetchUsage()));
+    const fetchers = [...this.fetchers, ...(this.dynamicFetchers?.() ?? [])];
+    const settled = await Promise.allSettled(fetchers.map((fetcher) => fetcher.fetchUsage()));
     const providers = settled.map((result, index) => {
-      const fetcher = this.fetchers[index];
+      const fetcher = fetchers[index];
       if (result.status === "fulfilled") {
         return result.value;
       }


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [x] New feature

### Reasoning

Paseo documents running multiple profiles of the same provider (`docs/custom-providers.md`, "Multiple profiles for the same provider") — e.g. several Anthropic accounts pinned via `claude setup-token` + `CLAUDE_CODE_OAUTH_TOKEN`, so account switching tools can't log agents out mid-run. But plan usage is blind to profiles today: the single `claude` usage entry reads the machine's shared credential stores, i.e. whichever account the CLI happens to be on. For anyone spreading work across accounts, the context-meter tooltip and the host Usage page can't answer the question that matters when a session stalls: *which account is this agent on, and how much of its session/weekly/per-model limit is left?* Worse, a pinned agent's tooltip shows either nothing or another account's numbers.

### Goals

- Every provider profile that extends `claude` and pins a `CLAUDE_CODE_OAUTH_TOKEN` gets its own usage entry, fetched with that token, keyed by the profile id and labeled with the profile's `label`.
- The context-meter tooltip picks it up with zero app changes — it already matches usage entries by the agent's provider id, which for profile agents *is* the profile id. Same for the host Usage page, which lists all entries.
- `paseo daemon reload` applies profile changes to usage with no daemon restart: profile fetchers are re-derived from live config on every usage refresh (`dynamicFetchers` on `ProviderUsageService`).
- Per-entry validation: one malformed provider entry in config can't take down other profiles' usage.
- The fetcher stays strictly read-only on credentials; a dead/revoked token yields an honest `unavailable` entry (no refresh attempts).

### Non-goals

- Usage for profiles **without** a pinned token (e.g. `CLAUDE_CONFIG_DIR`-based profiles): their agents run on a shared login, which the base `claude` entry already describes. Emitting a duplicate per profile would double-count.
- Codex/Copilot/etc. profile usage — their usage endpoints aren't derivable from a pinned env token the same way; the builder is structured so more bases can be added later.
- `planLabel` for profile entries: subscription type/tier live in the credential stores, not the token, so profile entries show windows without a plan badge.

### QA

**Automated (macOS, local):**

- `packages/server` `src/services/quota-fetcher/profile-fetchers.test.ts` — new: one fetcher per pinned Claude profile keyed by profile id + label; skips disabled profiles, non-claude bases, missing/blank tokens; empty config → no fetchers.
- `packages/server` `src/services/quota-fetcher/service.test.ts` — new: "re-evaluates dynamic fetchers on every refresh so config reloads apply" and "fetches profile usage with the profile's pinned token, ignoring shared stores" (asserts `Authorization: Bearer <profile token>` while the shared store holds a different account, `providerId`/`displayName` from the profile, `planLabel: null`). Full file: 76 passed.
- **Mutation check:** reverting `claude.ts` + `service.ts` to the base branch with the new tests in place → exactly the 3 new tests fail; restoring → green. The tests bind to the changed code.
- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm run format` ✅ (pre-commit hook re-runs all three).

**Live (dev daemon, real WebSocket RPC):**

- Added a `claude-demo-pinned` profile (synthetic token) to the dev home's `config.json`, restarted the dev daemon, and queried `provider.usage.list` over the real WS client:

```json
{
  "fetchedAt": "2026-08-30T21:18:21.319Z",
  "rows": [
    { "providerId": "claude", "displayName": "Claude", "status": "available", "planLabel": "Max 20x",
      "windows": "Session=99% | Weekly=48% | Weekly · Fable=92%" },
    { "providerId": "codex", "displayName": "Codex", "status": "available", "planLabel": "team",
      "windows": "Session=0% | Weekly=0%" },
    { "providerId": "claude-demo-pinned", "displayName": "Claude (Demo Pinned Account)",
      "status": "unavailable", "planLabel": null, "windows": "" }
  ]
}
```
*(six other built-in providers omitted — all `unavailable`, no credentials on this machine)*

- The base `claude` entry keeps real account data (via the shared stores), and the profile entry appears under its own id/label with `unavailable` status for the synthetic token — the exact honest failure a revoked token should produce. A real pinned token was exercised by the unit tests' Bearer-header assertions; I avoided copying a live account token into QA artifacts.

**Platforms:**

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | ❌     | server-only change; app consumes existing data shape |
| Android         | ❌     | 〃 |
| Web             | ✅     | RPC-level probe; tooltip/Usage-page rendering of these entries is the existing code path |
| Desktop macOS   | ❌     | 〃 |
| Desktop Windows | ❌     | 〃 |
| Desktop Linux   | ❌     | 〃 |

### Notes for review

Stacked on #4091 (`fix: keep the context-meter tooltip available and its provider usage fresh`) — both touch the Claude quota fetcher, so this branch includes that commit to avoid guaranteed conflicts. Review the last commit only; if #4091 lands first this rebases clean.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
