### PR TITLE
Voice: accept newer OpenAI TTS models, voices, and delivery instructions

### DIFF
--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -147,7 +147,10 @@ const FeatureVoiceModeSchema = z
       .object({
         provider: SpeechProviderIdSchema.optional(),
         model: z.string().min(1).optional(),
-        voice: z.enum(["alloy", "echo", "fable", "onyx", "nova", "shimmer"]).optional(),
+        // Free-form: OpenAI adds voices faster than we can enumerate them, and
+        // custom baseUrl endpoints ship their own voice names entirely.
+        voice: z.string().trim().min(1).optional(),
+        instructions: z.string().trim().min(1).optional(),
         speakerId: z.number().int().optional(),
         speed: z.number().optional(),
       })

--- a/packages/server/src/server/speech/providers/openai/config.test.ts
+++ b/packages/server/src/server/speech/providers/openai/config.test.ts
@@ -203,4 +203,39 @@ describe("resolveOpenAiSpeechConfig", () => {
     expect(resolved?.stt?.apiKey).toBe("stt-only-key");
     expect(resolved?.tts).toBeUndefined();
   });
+
+  test("resolves a newer TTS model, custom voice, and instructions from voiceMode config", () => {
+    const persisted = PersistedConfigSchema.parse({
+      features: {
+        voiceMode: {
+          tts: {
+            provider: "openai",
+            model: "gpt-4o-mini-tts",
+            voice: "marin",
+            instructions: "Speak quickly and calmly, like a copilot reading a checklist.",
+          },
+        },
+      },
+    });
+    const env = { OPENAI_API_KEY: "sk-test" } as NodeJS.ProcessEnv;
+
+    const resolved = resolveOpenAiSpeechConfig({ env, persisted, providers: ALL_OPENAI });
+
+    expect(resolved?.tts?.model).toBe("gpt-4o-mini-tts");
+    expect(resolved?.tts?.voice).toBe("marin");
+    expect(resolved?.tts?.instructions).toBe(
+      "Speak quickly and calmly, like a copilot reading a checklist.",
+    );
+  });
+
+  test("defaults TTS to tts-1/alloy with no instructions when unconfigured", () => {
+    const persisted = PersistedConfigSchema.parse({});
+    const env = { OPENAI_API_KEY: "sk-test" } as NodeJS.ProcessEnv;
+
+    const resolved = resolveOpenAiSpeechConfig({ env, persisted, providers: ALL_OPENAI });
+
+    expect(resolved?.tts?.model).toBe("tts-1");
+    expect(resolved?.tts?.voice).toBe("alloy");
+    expect(resolved?.tts?.instructions).toBeUndefined();
+  });
 });

--- a/packages/server/src/server/speech/providers/openai/config.ts
+++ b/packages/server/src/server/speech/providers/openai/config.ts
@@ -12,10 +12,6 @@ export interface OpenAiSpeechProviderConfig {
   tts?: Partial<TTSConfig> & { apiKey?: string };
 }
 
-const OpenAiTtsVoiceSchema = z.enum(["alloy", "echo", "fable", "onyx", "nova", "shimmer"]);
-
-const OpenAiTtsModelSchema = z.enum(["tts-1", "tts-1-hd"]);
-
 const NumberLikeSchema = z.union([z.number(), z.string().trim().min(1)]);
 
 const OptionalFiniteNumberSchema = NumberLikeSchema.pipe(
@@ -44,14 +40,13 @@ const OpenAiSttOptionsSchema = z.object({
   sttModel: OptionalTrimmedStringSchema,
 });
 
+// Model and voice are open strings: OpenAI ships new TTS models (gpt-4o-mini-tts)
+// and voices (ash, coral, marin, ...) without notice, and custom baseUrl
+// endpoints accept their own names. The endpoint rejects invalid values.
 const OpenAiTtsOptionsSchema = z.object({
-  ttsVoice: z.string().trim().toLowerCase().pipe(OpenAiTtsVoiceSchema).default("alloy"),
-  ttsModel: z
-    .string()
-    .trim()
-    .toLowerCase()
-    .pipe(OpenAiTtsModelSchema)
-    .default(DEFAULT_OPENAI_TTS_MODEL),
+  ttsVoice: z.string().trim().toLowerCase().min(1).default("alloy"),
+  ttsModel: z.string().trim().toLowerCase().min(1).default(DEFAULT_OPENAI_TTS_MODEL),
+  ttsInstructions: OptionalTrimmedStringSchema,
 });
 
 function isOpenAiProviderActive(provider: { enabled?: boolean; provider: string }): boolean {
@@ -115,6 +110,10 @@ function buildOpenAiTtsInput(params: {
       env.TTS_MODEL,
       pickIfOpenAi(providers.voiceTts, persisted.features?.voiceMode?.tts?.model),
       DEFAULT_OPENAI_TTS_MODEL,
+    ]),
+    ttsInstructions: firstDefined<string>([
+      env.TTS_INSTRUCTIONS,
+      pickIfOpenAi(providers.voiceTts, persisted.features?.voiceMode?.tts?.instructions),
     ]),
   };
 }
@@ -201,6 +200,7 @@ function buildTtsConfig(
     ...(baseUrl ? { baseUrl } : {}),
     voice: options.ttsVoice,
     model: options.ttsModel,
+    ...(options.ttsInstructions ? { instructions: options.ttsInstructions } : {}),
     responseFormat: "pcm",
   };
 }

--- a/packages/server/src/server/speech/providers/openai/tts.test.ts
+++ b/packages/server/src/server/speech/providers/openai/tts.test.ts
@@ -39,4 +39,43 @@ describe("OpenAITTS", () => {
       baseURL: "https://speech.example.com/v1",
     });
   });
+
+  test("sends custom model, voice, and instructions on instruction-capable models", async () => {
+    const { Readable } = await import("node:stream");
+    speechCreateMock.mockResolvedValue({ body: Readable.from([Buffer.from("x")]) });
+    const provider = new OpenAITTS(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini-tts",
+        voice: "marin",
+        instructions: "Speak calmly.",
+      },
+      pino({ level: "silent" }),
+    );
+
+    await provider.synthesizeSpeech("Hello there.");
+
+    expect(speechCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-4o-mini-tts",
+        voice: "marin",
+        instructions: "Speak calmly.",
+      }),
+    );
+  });
+
+  test("omits instructions for the tts-1 generation, which rejects the parameter", async () => {
+    const { Readable } = await import("node:stream");
+    speechCreateMock.mockResolvedValue({ body: Readable.from([Buffer.from("x")]) });
+    const provider = new OpenAITTS(
+      { apiKey: "sk-test", model: "tts-1", instructions: "Speak calmly." },
+      pino({ level: "silent" }),
+    );
+
+    await provider.synthesizeSpeech("Hello there.");
+
+    const args = speechCreateMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(args.model).toBe("tts-1");
+    expect("instructions" in args).toBe(false);
+  });
 });

--- a/packages/server/src/server/speech/providers/openai/tts.ts
+++ b/packages/server/src/server/speech/providers/openai/tts.ts
@@ -8,9 +8,15 @@ export type { SpeechStreamResult };
 export interface TTSConfig {
   apiKey: string;
   baseUrl?: string;
-  model?: "tts-1" | "tts-1-hd";
-  voice?: "alloy" | "echo" | "fable" | "onyx" | "nova" | "shimmer";
+  model?: "tts-1" | "tts-1-hd" | "gpt-4o-mini-tts" | (string & {});
+  voice?: "alloy" | "echo" | "fable" | "onyx" | "nova" | "shimmer" | (string & {});
+  /** Delivery steering (tone, pace, accent). Ignored by tts-1/tts-1-hd. */
+  instructions?: string;
   responseFormat?: "mp3" | "opus" | "aac" | "flac" | "wav" | "pcm";
+}
+
+function modelSupportsInstructions(model: string): boolean {
+  return model !== "tts-1" && model !== "tts-1-hd";
 }
 
 export class OpenAITTS implements TextToSpeechProvider {
@@ -54,10 +60,15 @@ export class OpenAITTS implements TextToSpeechProvider {
         "Synthesizing speech",
       );
 
+      const model = this.config.model!;
       const response = await this.openaiClient.audio.speech.create({
-        model: this.config.model!,
+        model,
         voice: this.config.voice!,
         input: text,
+        // The tts-1 generation rejects the instructions parameter outright.
+        ...(this.config.instructions && modelSupportsInstructions(model)
+          ? { instructions: this.config.instructions }
+          : {}),
         response_format: this.config.responseFormat as
           | "mp3"
           | "opus"


### PR DESCRIPTION
## Problem

The OpenAI TTS config hard-codes the `tts-1` generation (`z.enum(["tts-1", "tts-1-hd"])`) and its six voices. That locks out `gpt-4o-mini-tts` — which sounds substantially more natural — and every voice OpenAI has shipped since (ash, ballad, coral, sage, verse, marin, cedar), plus the `instructions` parameter that steers delivery on the newer models. Custom `baseUrl` deployments are also stuck with OpenAI's 2023 names for their own voices.

## Change

- `features.voiceMode.tts.model` and `.voice` are open strings (trimmed, non-empty). The endpoint rejects invalid values, so the daemon doesn't need to chase OpenAI's catalog.
- New optional `features.voiceMode.tts.instructions` (env: `TTS_INSTRUCTIONS`) — delivery steering ("speak quickly and calmly"). The `tts-1` generation rejects the parameter outright, so it's omitted for `tts-1`/`tts-1-hd`.
- Defaults unchanged (`tts-1` / `alloy`): existing configs behave identically.

## QA evidence

Live probe through the updated provider (real API, `gpt-4o-mini-tts`): all nine current voices synthesize —

```
marin: OK (38400 bytes)   cedar: OK (103200 bytes)  coral: OK (93600 bytes)
ash: OK (52800 bytes)     sage: OK (55200 bytes)    ballad: OK (88800 bytes)
verse: OK (43200 bytes)   alloy: OK (93600 bytes)   nova: OK (38400 bytes)
```

Daily-driven for several days on a live daemon with `gpt-4o-mini-tts` + marin/cedar from the iOS app.

Tests (new: custom model/voice/instructions resolve from voiceMode config; defaults stay tts-1/alloy; instructions passed on capable models and omitted for tts-1):

```
npx vitest run src/server/speech/providers/openai/config.test.ts src/server/speech/providers/openai/tts.test.ts src/server/persisted-config.test.ts
 Test Files  3 passed (3)
      Tests  59 passed (59)
```

## Platforms

Server-only. Tested on a macOS daemon end-to-end from the iOS app. Not separately tested: Android app, Windows/Linux daemons (no platform-specific code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
