### PR TITLE
Voice: drain TTS audio at synthesis time so replies stop losing segments

### DIFF
--- a/packages/server/src/server/agent/tts-manager.test.ts
+++ b/packages/server/src/server/agent/tts-manager.test.ts
@@ -165,26 +165,11 @@ describe("TTSManager", () => {
     await task;
   });
 
-  it("destroys prefetched streams after abort", async () => {
-    const destroyed: string[] = [];
+  it("stops emitting and resolves promptly when aborted mid-playback", async () => {
     const tts: TextToSpeechProvider = {
       async synthesizeSpeech(text: string): Promise<{ stream: Readable; format: string }> {
-        const stream = new Readable({
-          read() {
-            this.push(Buffer.from(text));
-            this.push(null);
-          },
-        });
-        const destroySpy = vi.spyOn(stream, "destroy").mockImplementation(function (
-          this: Readable,
-          error?: Error,
-        ) {
-          destroyed.push(text);
-          return Readable.prototype.destroy.call(this, error);
-        });
-        void destroySpy;
         return {
-          stream,
+          stream: Readable.from([Buffer.from(text)]),
           format: "pcm;rate=24000",
         };
       },
@@ -192,7 +177,7 @@ describe("TTSManager", () => {
 
     const manager = new TTSManager("s1", pino({ level: "silent" }), tts);
     const abort = new AbortController();
-    let firstChunkId: string | null = null;
+    const emittedChunkIds: string[] = [];
 
     const task = manager.generateAndWaitForPlayback(
       [
@@ -201,8 +186,8 @@ describe("TTSManager", () => {
         "Third sentence that should also be cleaned up if it was prefetched before the abort.",
       ].join(" "),
       (msg) => {
-        if (msg.type === "audio_output" && firstChunkId === null) {
-          firstChunkId = msg.payload.id;
+        if (msg.type === "audio_output") {
+          emittedChunkIds.push(msg.payload.id);
         }
       },
       abort.signal,
@@ -210,15 +195,15 @@ describe("TTSManager", () => {
     );
 
     await vi.waitFor(() => {
-      expect(firstChunkId).not.toBeNull();
+      expect(emittedChunkIds.length).toBe(1);
     });
 
     abort.abort();
-
     await task;
-    await vi.waitFor(() => {
-      expect(destroyed.length).toBeGreaterThanOrEqual(2);
-    });
+
+    // The aborted utterance never emits its remaining prefetched segments.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(emittedChunkIds).toHaveLength(1);
   });
 
   it("does not emit unhandled rejections when stream iteration fails", async () => {

--- a/packages/server/src/server/agent/tts-manager.ts
+++ b/packages/server/src/server/agent/tts-manager.ts
@@ -19,7 +19,7 @@ interface TtsSegment {
 
 type PreparedTtsSegment = TtsSegment & {
   format: string;
-  stream: Readable;
+  audio: Buffer;
 };
 
 type PreparedSegmentResult =
@@ -264,24 +264,46 @@ export class TTSManager {
 
     const synthStart = Date.now();
     const { stream, format } = await tts.synthesizeSpeech(segment.text);
+
+    // Drain the provider stream immediately instead of holding it until this
+    // segment's turn to play: an HTTP response body left unread while other
+    // segments stream and play has been observed to drain empty later, which
+    // silently swallowed the tail of spoken replies.
+    const buffers: Buffer[] = [];
+    try {
+      for await (const chunk of stream) {
+        if (abortSignal.aborted) {
+          break;
+        }
+        buffers.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+    } finally {
+      this.destroySpeechStream(stream);
+    }
+
+    if (abortSignal.aborted) {
+      throw new Error("TTS synthesis aborted");
+    }
+
+    const audio = Buffer.concat(buffers);
     this.logger.info(
       {
         segmentIndex: segment.index,
         resolveMs,
         synthMs: Date.now() - synthStart,
         chars: segment.text.length,
+        audioBytes: audio.length,
       },
-      `TTS segment ${segment.index} synthesized (resolve=${resolveMs}ms, synth=${Date.now() - synthStart}ms, ${segment.text.length} chars)`,
+      `TTS segment ${segment.index} synthesized (resolve=${resolveMs}ms, synth=${Date.now() - synthStart}ms, ${segment.text.length} chars, ${audio.length} bytes)`,
     );
 
-    if (abortSignal.aborted) {
-      this.destroySpeechStream(stream);
-      throw new Error("TTS synthesis aborted");
+    if (audio.length === 0) {
+      throw new Error(`TTS produced no audio for segment ${segment.index}`);
     }
 
     return {
       ...segment,
-      stream,
+      audio,
       format,
     };
   }
@@ -293,7 +315,6 @@ export class TTSManager {
     return this.synthesizeSegment(segment, abortSignal).then(
       (prepared) => {
         if (abortSignal.aborted) {
-          this.destroySpeechStream(prepared.stream);
           return { kind: "aborted" };
         }
         return { kind: "prepared", prepared };
@@ -308,17 +329,10 @@ export class TTSManager {
   }
 
   private cleanupPrefetchedSegments(inflight: Map<number, Promise<PreparedSegmentResult>>): void {
-    if (inflight.size === 0) {
-      return;
-    }
-
+    // Prefetched segments carry fully drained buffers, so there is nothing to
+    // release; swallow their settlement to avoid unhandled rejections.
     for (const pending of inflight.values()) {
-      void pending.then((result) => {
-        if (result.kind === "prepared") {
-          this.destroySpeechStream(result.prepared.stream);
-        }
-        return;
-      });
+      void pending.catch(() => undefined);
     }
   }
 
@@ -349,7 +363,7 @@ export class TTSManager {
     isVoiceMode: boolean;
   }): Promise<void> {
     const { prepared, emitMessage, abortSignal, isVoiceMode } = params;
-    const { stream, format, text } = prepared;
+    const { audio, format, text } = prepared;
 
     const audioId = uuidv4();
     let playbackResolve!: () => void;
@@ -378,23 +392,12 @@ export class TTSManager {
       this.pendingPlaybacks.delete(audioId);
       this.rememberClosedAudioId(audioId);
       playbackResolve();
-      this.destroySpeechStream(stream);
     };
 
     abortSignal.addEventListener("abort", onAbort, { once: true });
 
     try {
-      const buffers: Buffer[] = [];
-      for await (const chunk of stream) {
-        if (abortSignal.aborted) {
-          this.logger.debug("Aborted during stream collection");
-          break;
-        }
-        buffers.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      }
-
-      if (!abortSignal.aborted && buffers.length > 0) {
-        const fullBuffer = Buffer.concat(buffers);
+      if (!abortSignal.aborted && audio.length > 0) {
         const chunkId = `${audioId}:0`;
         pendingPlayback.pendingChunks = 1;
 
@@ -405,7 +408,7 @@ export class TTSManager {
             groupId: audioId,
             chunkIndex: 0,
             isLastChunk: true,
-            audio: fullBuffer.toString("base64"),
+            audio: audio.toString("base64"),
             format,
             isVoiceMode,
           },
@@ -423,9 +426,9 @@ export class TTSManager {
       await playbackPromise;
     } catch (error) {
       if (abortSignal.aborted) {
-        this.logger.debug("Audio stream closed after abort");
+        this.logger.debug("Playback wait ended after abort");
       } else {
-        this.logger.error({ err: error }, "Error streaming audio");
+        this.logger.error({ err: error }, "Error emitting audio");
         this.pendingPlaybacks.delete(audioId);
         throw error;
       }
@@ -433,7 +436,6 @@ export class TTSManager {
       if (onAbort) {
         abortSignal.removeEventListener("abort", onAbort);
       }
-      this.destroySpeechStream(stream);
     }
 
     if (abortSignal.aborted) {


### PR DESCRIPTION
## Problem

Spoken replies were losing whole segments — the tail or middle sentences of an answer silently never played. Field trace from a live daemon (OpenAI TTS, five-segment reply):

```
08:50:47.831 TTS segment 1 synthesized (synth=664ms, 179 chars)
08:50:48.117 TTS segment 0 synthesized (synth=951ms, 42 chars)
08:50:48.962 TTS segment 2 synthesized (synth=845ms, 119 chars)
08:50:52.381 TTS segment 0 playback confirmed (emit+play 4264ms)   ← played
08:50:52.382 TTS segment 1 playback confirmed (emit+play 1ms)      ← vanished
08:50:52.385 TTS segment 2 playback confirmed (emit+play 3ms)      ← vanished
08:50:59.052 TTS segment 3 playback confirmed (emit+play 5739ms)   ← played
08:50:59.053 TTS segment 4 playback confirmed (emit+play 0ms)      ← vanished
```

Root cause: prefetched segments held their provider **HTTP response streams open** until their turn to play. A response body left unread for a few seconds while other segments streamed and played was observed (OpenAI + undici) to drain **empty** — zero bytes, no error, no abort. `emitPreparedSegment` then took the "nothing to emit" path and resolved instantly (the 0–3ms "confirms" above), so the audio was never sent to the client. An instrumented run caught it directly: `TTS segment collected (0 bytes, aborted=false)`. Segments drained within ~1s of synthesis always played; segments that sat 3–6s behind a playing one drained empty.

## Change

- Each segment is drained into a `Buffer` as part of synthesis, so prefetch holds audio, not live sockets. `PreparedTtsSegment` carries `audio: Buffer` instead of `stream`.
- A zero-byte synthesis now **throws** (surfacing as an error instead of a silent skip), and the per-segment log records the collected byte count for field diagnosis.

Independent of #4010 — applies cleanly with or without it.

## QA evidence

After the fix, on the same live daemon driven from the iOS app: full multi-sentence replies play to the last word (previously reproducible loss within a few exchanges; user-confirmed fixed).

Tests on this branch (abort test updated: an aborted utterance stops emitting and resolves promptly):

```
npx vitest run src/server/agent/tts-manager.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

## Platforms

Server-only. Tested on a macOS daemon end-to-end from the iOS app with OpenAI TTS; local (sherpa/Kokoro) TTS streams are in-memory generators and are unaffected by the ordering change. Not separately tested: Android app, Windows/Linux daemons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
