### PR TITLE
feat(app): batch-select sidebar workspaces

### DIFF
--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -1,5 +1,14 @@
 import { router } from "expo-router";
-import { FolderPlus, GitBranch, Import, Server, Settings, X } from "lucide-react-native";
+import {
+  Archive,
+  FolderPlus,
+  GitBranch,
+  Import,
+  ListChecks,
+  Server,
+  Settings,
+  X,
+} from "lucide-react-native";
 import { useTranslation } from "react-i18next";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import {
@@ -27,6 +36,7 @@ import { SidebarNavRows } from "@/components/sidebar/sidebar-nav-rows";
 import { SidebarHelpMenu } from "@/components/sidebar/sidebar-help-menu";
 import { SidebarResizeHandle } from "@/components/sidebar-resize-handle";
 import { Shortcut } from "@/components/ui/shortcut";
+import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { HEADER_INNER_HEIGHT, useIsCompactFormFactor } from "@/constants/layout";
 import { useOpenAddProject } from "@/hooks/use-open-add-project";
@@ -52,6 +62,10 @@ import { openHostOverview } from "@/navigation/settings-navigation";
 import { SidebarAgentListSkeleton } from "./sidebar-agent-list-skeleton";
 import { SidebarCalloutSlot } from "./sidebar-callout-slot";
 import { SidebarWorkspaceList } from "./sidebar-workspace-list";
+import {
+  SidebarWorkspaceSelectionProvider,
+  useSidebarWorkspaceSelection,
+} from "@/components/sidebar/sidebar-workspace-selection";
 
 type SidebarTheme = ReturnType<typeof useUnistyles>["theme"];
 
@@ -104,6 +118,15 @@ interface DesktopSidebarProps extends SidebarSharedProps {
 }
 
 export const LeftSidebar = memo(function LeftSidebar({ active }: { active: boolean }) {
+  const { workspaceEntriesByKey } = useSidebarModel();
+  return (
+    <SidebarWorkspaceSelectionProvider workspaceEntriesByKey={workspaceEntriesByKey}>
+      <LeftSidebarContent active={active} />
+    </SidebarWorkspaceSelectionProvider>
+  );
+});
+
+const LeftSidebarContent = memo(function LeftSidebarContent({ active }: { active: boolean }) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
@@ -466,6 +489,41 @@ function SidebarFooter({
 }) {
   const newAgentKeys = useShortcutKeys("new-agent");
   const settingsKeys = useShortcutKeys("toggle-settings");
+  const selection = useSidebarWorkspaceSelection();
+  const { t } = useTranslation();
+
+  if (selection.isManaging) {
+    return (
+      <View style={styles.workspaceSelectionFooter} testID="sidebar-workspace-selection-footer">
+        <Button
+          variant="outline"
+          size="sm"
+          style={styles.workspaceSelectionButton}
+          disabled={selection.isArchiving || selection.availableCount === 0}
+          onPress={selection.toggleSelectAll}
+          testID="sidebar-workspace-select-all"
+        >
+          {selection.allSelected
+            ? t("sidebar.workspace.selection.deselectAll")
+            : t("sidebar.workspace.selection.selectAll")}
+        </Button>
+        <Button
+          variant="destructive"
+          size="sm"
+          style={styles.workspaceSelectionArchiveButton}
+          leftIcon={Archive}
+          loading={selection.isArchiving}
+          disabled={selection.selectedCount === 0}
+          onPress={selection.archiveSelected}
+          testID="sidebar-workspace-archive-selected"
+        >
+          {selection.isArchiving
+            ? t("sidebar.workspace.selection.archiving")
+            : t("sidebar.workspace.selection.archive", { count: selection.selectedCount })}
+        </Button>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.sidebarFooter}>
@@ -801,20 +859,73 @@ function DesktopSidebar({
 }
 
 function WorkspacesSectionHeader() {
+  const { theme } = useUnistyles();
+  const { t } = useTranslation();
+  const selection = useSidebarWorkspaceSelection();
+  const manageButtonStyle = useCallback(
+    ({ hovered = false, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.workspacesHeaderIconButton,
+      (hovered || pressed) && styles.workspacesHeaderIconButtonHovered,
+    ],
+    [],
+  );
+
   return (
     <View style={styles.workspacesSectionHeader}>
-      <Text style={styles.workspacesSectionTitle}>Workspaces</Text>
+      <Text style={styles.workspacesSectionTitle}>
+        {selection.isManaging
+          ? t("sidebar.workspace.selection.selected", { count: selection.selectedCount })
+          : t("sidebar.workspace.selection.title")}
+      </Text>
       <View style={styles.workspacesSectionActions}>
-        <Tooltip delayDuration={300}>
-          <TooltipTrigger asChild>
-            <View>
-              <SidebarDisplayPreferencesMenu />
-            </View>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" align="center" offset={8}>
-            <IconTooltipContent label="Display preferences" />
-          </TooltipContent>
-        </Tooltip>
+        {selection.isManaging ? (
+          <Button
+            variant="ghost"
+            size="xs"
+            disabled={selection.isArchiving}
+            onPress={selection.finishManaging}
+            testID="sidebar-workspace-manage-done"
+          >
+            {t("sidebar.workspace.selection.done")}
+          </Button>
+        ) : null}
+        {!selection.isManaging && selection.availableCount > 0 ? (
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t("sidebar.workspace.selection.manage")}
+                testID="sidebar-workspace-manage"
+                style={manageButtonStyle}
+                onPress={selection.beginManaging}
+              >
+                {({ hovered, pressed }) => (
+                  <ListChecks
+                    size={14}
+                    color={
+                      hovered || pressed ? theme.colors.foreground : theme.colors.foregroundMuted
+                    }
+                  />
+                )}
+              </Pressable>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" align="center" offset={8}>
+              <IconTooltipContent label={t("sidebar.workspace.selection.manage")} />
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+        {!selection.isManaging ? (
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <View>
+                <SidebarDisplayPreferencesMenu />
+              </View>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" align="center" offset={8}>
+              <IconTooltipContent label="Display preferences" />
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
       </View>
     </View>
   );
@@ -869,6 +980,16 @@ const styles = StyleSheet.create((theme) => ({
     flexDirection: "row",
     alignItems: "center",
     gap: theme.spacing[1],
+  },
+  workspacesHeaderIconButton: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius.md,
+  },
+  workspacesHeaderIconButtonHovered: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
   },
   sidebarContent: {
     flex: 1,
@@ -937,6 +1058,21 @@ const styles = StyleSheet.create((theme) => ({
     paddingVertical: theme.spacing[3],
     borderTopWidth: 1,
     borderTopColor: theme.colors.border,
+  },
+  workspaceSelectionFooter: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: theme.spacing[3],
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  workspaceSelectionButton: {
+    flex: 1,
+  },
+  workspaceSelectionArchiveButton: {
+    flex: 1.35,
   },
   footerIconRow: {
     flexDirection: "row",

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -151,6 +151,7 @@ import type { HostBadgeModel } from "@/hosts/appearance";
 import { useHostBadges } from "@/hosts/use-host-badges";
 import { useSidebarRowItems } from "@/components/sidebar/display-preferences/model";
 import { PullRequestStateIcon } from "@/git/pull-request-state-icon";
+import { useSidebarWorkspaceSelection } from "@/components/sidebar/sidebar-workspace-selection";
 
 const workspaceKeyExtractor = (workspace: SidebarWorkspacePlacement) => workspace.workspaceKey;
 
@@ -267,6 +268,8 @@ interface WorkspaceRowInnerProps {
   leadingProjectName?: string | null;
   leadingProjectIconDataUri?: string | null;
   selected: boolean;
+  selectionMode: boolean;
+  selectionChecked: boolean;
   shortcutNumber: number | null;
   showShortcutBadge: boolean;
   onPress: () => void;
@@ -1049,6 +1052,8 @@ function WorkspaceRowInner({
   leadingProjectName,
   leadingProjectIconDataUri,
   selected,
+  selectionMode,
+  selectionChecked,
   shortcutNumber,
   showShortcutBadge,
   onPress,
@@ -1103,10 +1108,17 @@ function WorkspaceRowInner({
     interaction.handlePressOut();
   }, [interaction]);
 
-  const accessibilityState = useMemo(() => ({ selected }), [selected]);
+  const accessibilityState = useMemo(
+    () => (selectionMode ? { checked: selectionChecked } : { selected }),
+    [selected, selectionChecked, selectionMode],
+  );
 
   return (
-    <SidebarWorkspaceRowFrame workspace={workspace} isDragging={isDragging}>
+    <SidebarWorkspaceRowFrame
+      workspace={workspace}
+      isDragging={isDragging}
+      disableHoverCard={selectionMode}
+    >
       {({ isHovered, contextMenuOpen, onContextMenuOpenChange, hoverHandlers }) => {
         const isDesktop = !isTouchPlatform;
         const serviceSummary = isDesktop ? selectWorkspaceServiceSummary(workspace.scripts) : null;
@@ -1132,20 +1144,22 @@ function WorkspaceRowInner({
               leadingProjectName={leadingProjectName}
               hostBadgeLabel={hostBadge?.label}
               workspaceKey={workspace.workspaceKey}
-              onCopyPath={onCopyPath}
-              onCopyBranchName={onCopyBranchName}
-              onRename={onRename}
-              onArchive={onArchive}
+              onCopyPath={selectionMode ? undefined : onCopyPath}
+              onCopyBranchName={selectionMode ? undefined : onCopyBranchName}
+              onRename={selectionMode ? undefined : onRename}
+              onArchive={selectionMode ? undefined : onArchive}
               archiveLabel={archiveLabel}
               archiveStatus={archiveStatus}
               archivePendingLabel={archivePendingLabel}
               archiveShortcutKeys={archiveShortcutKeys}
               isPinned={isPinned}
-              onTogglePin={onTogglePin}
+              onTogglePin={selectionMode ? undefined : onTogglePin}
               openInFileManagerPath={workspace.workspaceDirectory}
+              enabled={!selectionMode}
               disabled={isArchiving}
-              aria-selected={selected}
-              accessibilityRole="button"
+              aria-selected={selectionMode ? undefined : selected}
+              aria-checked={selectionMode ? selectionChecked : undefined}
+              accessibilityRole={selectionMode ? "checkbox" : "button"}
               accessibilityState={accessibilityState}
               style={workspaceRowStyle}
               highlightStyle={styles.workspaceRowPressed}
@@ -1166,28 +1180,31 @@ function WorkspaceRowInner({
                 isLoading={isArchiving || isCreating}
                 isCreating={isCreating}
                 shortcutNumber={shortcutNumber}
-                showShortcutBadge={showShortcutBadge}
+                showShortcutBadge={!selectionMode && showShortcutBadge}
                 reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
+                selectionChecked={selectionMode ? selectionChecked : undefined}
               >
-                <WorkspaceRowRightGroup
-                  workspace={workspace}
-                  backdrop={backdrop}
-                  isHovered={isHovered}
-                  isTouchPlatform={isTouchPlatform}
-                  isCreating={isCreating}
-                  showShortcutBadge={showShortcutBadge}
-                  shortcutNumber={shortcutNumber}
-                  archiveLabel={archiveLabel}
-                  archiveStatus={archiveStatus}
-                  archivePendingLabel={archivePendingLabel}
-                  archiveShortcutKeys={archiveShortcutKeys}
-                  onArchive={onArchive}
-                  onCopyBranchName={onCopyBranchName}
-                  onCopyPath={onCopyPath}
-                  onRename={onRename}
-                  isPinned={isPinned}
-                  onTogglePin={onTogglePin}
-                />
+                {selectionMode ? null : (
+                  <WorkspaceRowRightGroup
+                    workspace={workspace}
+                    backdrop={backdrop}
+                    isHovered={isHovered}
+                    isTouchPlatform={isTouchPlatform}
+                    isCreating={isCreating}
+                    showShortcutBadge={showShortcutBadge}
+                    shortcutNumber={shortcutNumber}
+                    archiveLabel={archiveLabel}
+                    archiveStatus={archiveStatus}
+                    archivePendingLabel={archivePendingLabel}
+                    archiveShortcutKeys={archiveShortcutKeys}
+                    onArchive={onArchive}
+                    onCopyBranchName={onCopyBranchName}
+                    onCopyPath={onCopyPath}
+                    onRename={onRename}
+                    isPinned={isPinned}
+                    onTogglePin={onTogglePin}
+                  />
+                )}
               </SidebarWorkspaceRowContent>
             </SidebarWorkspaceContextMenu>
           </View>
@@ -1203,6 +1220,8 @@ function WorkspaceRowWithMenu({
   leadingProjectName,
   leadingProjectIconDataUri,
   selected,
+  selectionMode,
+  selectionChecked,
   shortcutNumber,
   showShortcutBadge,
   onPress,
@@ -1220,6 +1239,8 @@ function WorkspaceRowWithMenu({
   leadingProjectName?: string | null;
   leadingProjectIconDataUri?: string | null;
   selected: boolean;
+  selectionMode: boolean;
+  selectionChecked: boolean;
   shortcutNumber: number | null;
   showShortcutBadge: boolean;
   onPress: () => void;
@@ -1299,7 +1320,7 @@ function WorkspaceRowWithMenu({
   useKeyboardActionHandler({
     handlerId: `workspace-archive-${workspace.workspaceKey}`,
     actions: ["workspace.archive"],
-    enabled: selected && !isArchiving,
+    enabled: !selectionMode && selected && !isArchiving,
     priority: 0,
     handle: () => {
       handleArchive();
@@ -1315,6 +1336,8 @@ function WorkspaceRowWithMenu({
         leadingProjectName={leadingProjectName}
         leadingProjectIconDataUri={leadingProjectIconDataUri}
         selected={selected}
+        selectionMode={selectionMode}
+        selectionChecked={selectionChecked}
         shortcutNumber={shortcutNumber}
         showShortcutBadge={showShortcutBadge}
         onPress={onPress}
@@ -1388,13 +1411,31 @@ function WorkspaceRowItem({
   isDragging = false,
   dragHandleProps,
 }: WorkspaceRowItemProps) {
+  const selection = useSidebarWorkspaceSelection();
+  const selectionChecked = selection.isWorkspaceSelected(workspace.workspaceKey);
+  const routeSelected = isWorkspaceSelected({
+    selection: activeWorkspaceSelection,
+    serverId: workspace.serverId,
+    workspaceId: workspace.workspaceId,
+    enabled: selectionEnabled,
+  });
   const handlePress = useCallback(() => {
+    if (selection.isManaging) {
+      selection.toggleWorkspace(workspace.workspaceKey);
+      return;
+    }
     if (!workspace.serverId) {
       return;
     }
     onWorkspacePress?.();
     navigateToWorkspace({ serverId: workspace.serverId, workspaceId: workspace.workspaceId });
-  }, [onWorkspacePress, workspace.serverId, workspace.workspaceId]);
+  }, [
+    onWorkspacePress,
+    selection,
+    workspace.serverId,
+    workspace.workspaceId,
+    workspace.workspaceKey,
+  ]);
 
   return (
     <WorkspaceRow
@@ -1409,16 +1450,13 @@ function WorkspaceRowItem({
       onToggleWorkspacePin={onToggleWorkspacePin}
       reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
       isCreating={isCreating}
-      selected={isWorkspaceSelected({
-        selection: activeWorkspaceSelection,
-        serverId: workspace.serverId,
-        workspaceId: workspace.workspaceId,
-        enabled: selectionEnabled,
-      })}
+      selected={selection.isManaging ? selectionChecked : routeSelected}
+      selectionMode={selection.isManaging}
+      selectionChecked={selectionChecked}
       onPress={handlePress}
-      drag={drag ?? noop}
+      drag={selection.isManaging ? noop : (drag ?? noop)}
       isDragging={isDragging}
-      dragHandleProps={dragHandleProps}
+      dragHandleProps={selection.isManaging ? undefined : dragHandleProps}
     />
   );
 }
@@ -1479,6 +1517,8 @@ function WorkspaceRow({
   reserveIdleStatusIndicatorSpace = true,
   isCreating = false,
   selected,
+  selectionMode,
+  selectionChecked,
 }: {
   workspaceEntry: SidebarWorkspaceEntry | null;
   hostBadge?: HostBadgeModel | null;
@@ -1496,6 +1536,8 @@ function WorkspaceRow({
   reserveIdleStatusIndicatorSpace?: boolean;
   isCreating?: boolean;
   selected: boolean;
+  selectionMode: boolean;
+  selectionChecked: boolean;
 }) {
   if (!workspaceEntry) {
     return null;
@@ -1508,6 +1550,8 @@ function WorkspaceRow({
       leadingProjectName={leadingProjectName}
       leadingProjectIconDataUri={leadingProjectIconDataUri}
       selected={selected}
+      selectionMode={selectionMode}
+      selectionChecked={selectionChecked}
       shortcutNumber={shortcutNumber}
       showShortcutBadge={showShortcutBadge}
       onPress={onPress}

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -79,6 +79,7 @@ import type { ToggleSidebarWorkspacePin } from "@/hooks/use-sidebar-workspace-pi
 import { DraggableList, type DraggableRenderItemInfo } from "@/components/draggable-list";
 import type { DraggableListDragHandleProps } from "@/components/draggable-list.types";
 import { useLongPressDragInteraction } from "@/components/sidebar/use-long-press-drag-interaction";
+import { useSidebarWorkspaceSelection } from "@/components/sidebar/sidebar-workspace-selection";
 
 // Themed icon wrappers
 const foregroundMutedColorMapping = (theme: Theme) => ({
@@ -524,15 +525,27 @@ const StatusWorkspaceRow = memo(function StatusWorkspaceRow({
   dragHandleProps?: DraggableListDragHandleProps;
 }) {
   const activeWorkspaceSelection = useActiveWorkspaceSelection();
-  const selected =
+  const selection = useSidebarWorkspaceSelection();
+  const routeSelected =
     activeWorkspaceSelection?.serverId === workspace.serverId &&
     activeWorkspaceSelection?.workspaceId === workspace.workspaceId;
+  const selectionChecked = selection.isWorkspaceSelected(workspace.workspaceKey);
 
   const handlePress = useCallback(() => {
+    if (selection.isManaging) {
+      selection.toggleWorkspace(workspace.workspaceKey);
+      return;
+    }
     if (!workspace.serverId) return;
     onWorkspacePress?.();
     navigateToWorkspace({ serverId: workspace.serverId, workspaceId: workspace.workspaceId });
-  }, [onWorkspacePress, workspace.serverId, workspace.workspaceId]);
+  }, [
+    onWorkspacePress,
+    selection,
+    workspace.serverId,
+    workspace.workspaceId,
+    workspace.workspaceKey,
+  ]);
 
   return (
     <StatusWorkspaceRowWithMenu
@@ -540,7 +553,9 @@ const StatusWorkspaceRow = memo(function StatusWorkspaceRow({
       hostBadge={hostBadge}
       projectName={projectName}
       projectIconDataUri={projectIconDataUri}
-      selected={selected}
+      selected={selection.isManaging ? selectionChecked : routeSelected}
+      selectionMode={selection.isManaging}
+      selectionChecked={selectionChecked}
       shortcutNumber={shortcutNumber}
       showShortcutBadge={showShortcutBadge}
       canPin={canPin}
@@ -548,9 +563,9 @@ const StatusWorkspaceRow = memo(function StatusWorkspaceRow({
       reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
       inStatusGroup={inStatusGroup}
       onPress={handlePress}
-      drag={drag}
+      drag={selection.isManaging ? undefined : drag}
       isDragging={isDragging}
-      dragHandleProps={dragHandleProps}
+      dragHandleProps={selection.isManaging ? undefined : dragHandleProps}
     />
   );
 });
@@ -561,6 +576,8 @@ function StatusWorkspaceRowWithMenu({
   projectName,
   projectIconDataUri,
   selected,
+  selectionMode,
+  selectionChecked,
   shortcutNumber,
   showShortcutBadge,
   canPin,
@@ -577,6 +594,8 @@ function StatusWorkspaceRowWithMenu({
   projectName: string;
   projectIconDataUri: string | null;
   selected: boolean;
+  selectionMode: boolean;
+  selectionChecked: boolean;
   shortcutNumber: number | null;
   showShortcutBadge: boolean;
   canPin: boolean;
@@ -654,7 +673,7 @@ function StatusWorkspaceRowWithMenu({
   useKeyboardActionHandler({
     handlerId: `workspace-archive-${workspace.workspaceKey}`,
     actions: ["workspace.archive"],
-    enabled: selected && !isArchiving,
+    enabled: !selectionMode && selected && !isArchiving,
     priority: 0,
     handle: () => {
       handleArchive();
@@ -670,6 +689,8 @@ function StatusWorkspaceRowWithMenu({
         projectName={projectName}
         projectIconDataUri={projectIconDataUri}
         selected={selected}
+        selectionMode={selectionMode}
+        selectionChecked={selectionChecked}
         shortcutNumber={shortcutNumber}
         showShortcutBadge={showShortcutBadge}
         onPress={onPress}
@@ -707,6 +728,8 @@ interface StatusWorkspaceRowInnerProps {
   projectName: string;
   projectIconDataUri: string | null;
   selected: boolean;
+  selectionMode: boolean;
+  selectionChecked: boolean;
   shortcutNumber: number | null;
   showShortcutBadge: boolean;
   onPress: () => void;
@@ -753,6 +776,8 @@ function StatusWorkspaceRowInnerContent({
   projectName,
   projectIconDataUri,
   selected,
+  selectionMode,
+  selectionChecked,
   shortcutNumber,
   showShortcutBadge,
   onPress,
@@ -790,7 +815,10 @@ function StatusWorkspaceRowInnerContent({
   const isDesktop = !isTouchPlatform;
   const serviceSummary = isDesktop ? selectWorkspaceServiceSummary(workspace.scripts) : null;
 
-  const accessibilityState = useMemo(() => ({ selected }), [selected]);
+  const accessibilityState = useMemo(
+    () => (selectionMode ? { checked: selectionChecked } : { selected }),
+    [selected, selectionChecked, selectionMode],
+  );
   const didLongPressRef = dragInteraction?.didLongPressRef;
   const startDragPress = dragInteraction?.handlePressIn;
   const moveDragPress = dragInteraction?.handleTouchMove;
@@ -815,7 +843,11 @@ function StatusWorkspaceRowInnerContent({
   }, [endDragPress]);
 
   return (
-    <SidebarWorkspaceRowFrame workspace={workspace} isDragging={isDragging}>
+    <SidebarWorkspaceRowFrame
+      workspace={workspace}
+      isDragging={isDragging}
+      disableHoverCard={selectionMode}
+    >
       {({ isHovered, contextMenuOpen, onContextMenuOpenChange, hoverHandlers }) => {
         const showShortcut = showShortcutBadge && shortcutNumber !== null;
         const {
@@ -856,20 +888,22 @@ function StatusWorkspaceRowInnerContent({
               hostBadgeLabel={hostBadge?.label}
               serviceSummary={serviceSummary}
               workspaceKey={workspace.workspaceKey}
-              onCopyPath={onCopyPath}
-              onCopyBranchName={onCopyBranchName}
-              onRename={onRename}
-              onMarkAsRead={onMarkAsRead}
-              onArchive={onArchive}
+              onCopyPath={selectionMode ? undefined : onCopyPath}
+              onCopyBranchName={selectionMode ? undefined : onCopyBranchName}
+              onRename={selectionMode ? undefined : onRename}
+              onMarkAsRead={selectionMode ? undefined : onMarkAsRead}
+              onArchive={selectionMode ? undefined : onArchive}
               archiveLabel={archiveLabel}
               archiveStatus={archiveStatus}
               archivePendingLabel={archivePendingLabel}
               archiveShortcutKeys={archiveShortcutKeys}
               isPinned={isPinned}
-              onTogglePin={onTogglePin}
+              onTogglePin={selectionMode ? undefined : onTogglePin}
               openInFileManagerPath={workspace.workspaceDirectory}
+              enabled={!selectionMode}
               disabled={isArchiving}
-              accessibilityRole="button"
+              aria-checked={selectionMode ? selectionChecked : undefined}
+              accessibilityRole={selectionMode ? "checkbox" : "button"}
               accessibilityState={accessibilityState}
               style={workspaceRowStyle}
               highlightStyle={styles.workspaceRowPressed}
@@ -889,10 +923,11 @@ function StatusWorkspaceRowInnerContent({
                 isHovered={isHovered}
                 isLoading={isArchiving}
                 shortcutNumber={shortcutNumber}
-                showShortcutBadge={showShortcutBadge}
+                showShortcutBadge={!selectionMode && showShortcutBadge}
                 reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
+                selectionChecked={selectionMode ? selectionChecked : undefined}
               >
-                {renderSlot ? (
+                {!selectionMode && renderSlot ? (
                   <StatusWorkspaceActionSlot
                     workspace={workspace}
                     backdrop={backdrop}

--- a/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
@@ -1,7 +1,14 @@
 import { memo, useMemo, useCallback, useState, type ReactNode } from "react";
 import { Text, View, type ViewStyle } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import { CircleAlert, Folder, FolderGit2, Monitor } from "lucide-react-native";
+import {
+  CircleAlert,
+  Folder,
+  FolderGit2,
+  Monitor,
+  Square,
+  SquareCheckBig,
+} from "lucide-react-native";
 import { ProjectStatusIndicator } from "@/components/sidebar/project-leading-visual";
 import type { SidebarSurfaceBackdrop } from "@/styles/surface-backdrop";
 import {
@@ -40,14 +47,18 @@ const ThemedCircleAlert = withUnistyles(CircleAlert);
 const ThemedMonitor = withUnistyles(Monitor);
 const ThemedFolder = withUnistyles(Folder);
 const ThemedFolderGit2 = withUnistyles(FolderGit2);
+const ThemedSquare = withUnistyles(Square);
+const ThemedSquareCheckBig = withUnistyles(SquareCheckBig);
 
 export function SidebarWorkspaceRowFrame({
   workspace,
   isDragging = false,
+  disableHoverCard = false,
   children,
 }: {
   workspace: SidebarWorkspaceEntry;
   isDragging?: boolean;
+  disableHoverCard?: boolean;
   children: (input: {
     isHovered: boolean;
     contextMenuOpen: boolean;
@@ -75,7 +86,7 @@ export function SidebarWorkspaceRowFrame({
       workspace={workspace}
       prHint={workspace.prHint}
       isDragging={isDragging}
-      disabled={contextMenuOpen}
+      disabled={contextMenuOpen || disableHoverCard}
     >
       {children({
         isHovered: isHovered && !contextMenuOpen && !isDragging,
@@ -100,6 +111,7 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
   shortcutNumber = null,
   showShortcutBadge = false,
   reserveIdleStatusIndicatorSpace = true,
+  selectionChecked,
   children,
 }: {
   workspace: SidebarWorkspaceEntry;
@@ -117,6 +129,8 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
   showShortcutBadge?: boolean;
   /** Keep the empty leading slot when the workspace has no active status. */
   reserveIdleStatusIndicatorSpace?: boolean;
+  /** Defined while sidebar Manage mode replaces the status glyph with a checkbox. */
+  selectionChecked?: boolean;
   children?: ReactNode;
 }) {
   const {
@@ -134,28 +148,36 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
     ],
     [isHovered, isCreating],
   );
+  let leadingVisual: ReactNode;
+  if (selectionChecked !== undefined) {
+    leadingVisual = <SidebarWorkspaceSelectionIndicator checked={selectionChecked} />;
+  } else if (leadingProjectName) {
+    leadingVisual = (
+      <ProjectStatusIndicator
+        iconDataUri={leadingProjectIconDataUri}
+        displayName={leadingProjectName}
+        projectViewKey={workspace.projectViewKey}
+        statusBucket={workspace.statusBucket}
+        backdrop={backdrop}
+        loading={isLoading}
+        testID={`sidebar-row-project-icon-${workspace.workspaceKey}`}
+      />
+    );
+  } else {
+    leadingVisual = (
+      <WorkspaceStatusIndicator
+        bucket={workspace.statusBucket}
+        workspaceKind={workspace.workspaceKind}
+        loading={isLoading}
+        reserveIdleSpace={reserveIdleStatusIndicatorSpace}
+      />
+    );
+  }
 
   return (
     <View style={styles.workspaceRowContent}>
       <View style={styles.workspaceRowMain}>
-        {leadingProjectName ? (
-          <ProjectStatusIndicator
-            iconDataUri={leadingProjectIconDataUri}
-            displayName={leadingProjectName}
-            projectViewKey={workspace.projectViewKey}
-            statusBucket={workspace.statusBucket}
-            backdrop={backdrop}
-            loading={isLoading}
-            testID={`sidebar-row-project-icon-${workspace.workspaceKey}`}
-          />
-        ) : (
-          <WorkspaceStatusIndicator
-            bucket={workspace.statusBucket}
-            workspaceKind={workspace.workspaceKind}
-            loading={isLoading}
-            reserveIdleSpace={reserveIdleStatusIndicatorSpace}
-          />
-        )}
+        {leadingVisual}
         <View style={styles.workspaceContentColumn}>
           <View style={styles.workspaceTitleRow}>
             <Text style={workspaceBranchTextStyle} numberOfLines={1}>
@@ -181,6 +203,21 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
     </View>
   );
 });
+
+function SidebarWorkspaceSelectionIndicator({ checked }: { checked: boolean }) {
+  return (
+    <View
+      style={styles.workspaceStatusDot}
+      testID={checked ? "workspace-selection-checked" : "workspace-selection-unchecked"}
+    >
+      {checked ? (
+        <ThemedSquareCheckBig size={16} uniProps={foregroundMutedColorMapping} />
+      ) : (
+        <ThemedSquare size={16} uniProps={foregroundMutedColorMapping} />
+      )}
+    </View>
+  );
+}
 
 function WorkspaceStatusIndicator({
   bucket,

--- a/packages/app/src/components/sidebar/sidebar-workspace-selection-model.ts
+++ b/packages/app/src/components/sidebar/sidebar-workspace-selection-model.ts
@@ -1,0 +1,52 @@
+import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
+import type { WorkspaceArchiveFailure } from "@/workspace/workspace-archive";
+
+export function workspaceTargetKey(input: { serverId: string; workspaceId: string }): string {
+  return `${input.serverId}:${input.workspaceId}`;
+}
+
+export function toggleWorkspaceSelection(
+  selectedWorkspaceKeys: ReadonlySet<string>,
+  workspaceKey: string,
+): Set<string> {
+  const next = new Set(selectedWorkspaceKeys);
+  if (next.has(workspaceKey)) {
+    next.delete(workspaceKey);
+  } else {
+    next.add(workspaceKey);
+  }
+  return next;
+}
+
+export function reconcileWorkspaceSelection(
+  selectedWorkspaceKeys: ReadonlySet<string>,
+  workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>,
+): Set<string> {
+  return new Set(
+    [...selectedWorkspaceKeys].filter((workspaceKey) => workspaceEntriesByKey.has(workspaceKey)),
+  );
+}
+
+export function selectAvailableWorkspaceKeys(
+  workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>,
+): Set<string> {
+  return new Set(
+    [...workspaceEntriesByKey.entries()].flatMap(([workspaceKey, workspace]) =>
+      workspace.archivingAt === null ? [workspaceKey] : [],
+    ),
+  );
+}
+
+export function resolveRemainingWorkspaceSelection(input: {
+  selectedWorkspaceKeys: ReadonlySet<string>;
+  confirmedWorkspaceKeys: ReadonlySet<string>;
+  failures: readonly WorkspaceArchiveFailure[];
+}): Set<string> {
+  const failedWorkspaceKeys = new Set(input.failures.map(workspaceTargetKey));
+  return new Set(
+    [...input.selectedWorkspaceKeys].filter(
+      (workspaceKey) =>
+        !input.confirmedWorkspaceKeys.has(workspaceKey) || failedWorkspaceKeys.has(workspaceKey),
+    ),
+  );
+}

--- a/packages/app/src/components/sidebar/sidebar-workspace-selection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-workspace-selection.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
+import {
+  reconcileWorkspaceSelection,
+  resolveRemainingWorkspaceSelection,
+  selectAvailableWorkspaceKeys,
+  toggleWorkspaceSelection,
+} from "@/components/sidebar/sidebar-workspace-selection-model";
+
+function workspace(input: {
+  serverId: string;
+  workspaceId: string;
+  archiving?: boolean;
+}): SidebarWorkspaceEntry {
+  return {
+    serverId: input.serverId,
+    workspaceId: input.workspaceId,
+    workspaceKey: `${input.serverId}:${input.workspaceId}`,
+    archivingAt: input.archiving ? "2026-08-30T00:00:00.000Z" : null,
+  } as SidebarWorkspaceEntry;
+}
+
+describe("sidebar workspace selection", () => {
+  it("toggles one workspace without mutating the current selection", () => {
+    const current = new Set(["server-1:workspace-1"]);
+
+    const added = toggleWorkspaceSelection(current, "server-1:workspace-2");
+    const removed = toggleWorkspaceSelection(added, "server-1:workspace-1");
+
+    expect(current).toEqual(new Set(["server-1:workspace-1"]));
+    expect(added).toEqual(new Set(["server-1:workspace-1", "server-1:workspace-2"]));
+    expect(removed).toEqual(new Set(["server-1:workspace-2"]));
+  });
+
+  it("selects available workspaces and reconciles rows removed by filters", () => {
+    const first = workspace({ serverId: "server-1", workspaceId: "workspace-1" });
+    const second = workspace({
+      serverId: "server-2",
+      workspaceId: "workspace-2",
+      archiving: true,
+    });
+    const entries = new Map([
+      [first.workspaceKey, first],
+      [second.workspaceKey, second],
+    ]);
+
+    expect(selectAvailableWorkspaceKeys(entries)).toEqual(new Set([first.workspaceKey]));
+    expect(
+      reconcileWorkspaceSelection(
+        new Set([first.workspaceKey, second.workspaceKey, "missing:workspace"]),
+        entries,
+      ),
+    ).toEqual(new Set([first.workspaceKey, second.workspaceKey]));
+  });
+
+  it("keeps canceled and failed workspaces selected after a partial archive", () => {
+    const remaining = resolveRemainingWorkspaceSelection({
+      selectedWorkspaceKeys: new Set(["server-1:archived", "server-1:canceled", "server-2:failed"]),
+      confirmedWorkspaceKeys: new Set(["server-1:archived", "server-2:failed"]),
+      failures: [
+        {
+          serverId: "server-2",
+          workspaceId: "failed",
+          error: new Error("offline"),
+        },
+      ],
+    });
+
+    expect(remaining).toEqual(new Set(["server-1:canceled", "server-2:failed"]));
+  });
+});

--- a/packages/app/src/components/sidebar/sidebar-workspace-selection.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-selection.tsx
@@ -1,0 +1,211 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useTranslation } from "react-i18next";
+import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
+import { getHostRuntimeStore } from "@/runtime/host-runtime";
+import { useActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
+import { useToast } from "@/contexts/toast-context";
+import { redirectIfArchivingActiveWorkspace } from "@/utils/sidebar-workspace-archive-redirect";
+import { selectProjectWorkspacesToArchive } from "@/workspace/project-workspace-archive";
+import { archiveWorkspacesOptimistically } from "@/workspace/workspace-archive";
+import { purgeArchivedWorkspaceState } from "@/workspace/use-workspace-archive";
+import {
+  reconcileWorkspaceSelection,
+  resolveRemainingWorkspaceSelection,
+  selectAvailableWorkspaceKeys,
+  toggleWorkspaceSelection,
+  workspaceTargetKey,
+} from "@/components/sidebar/sidebar-workspace-selection-model";
+
+interface SidebarWorkspaceSelectionController {
+  isManaging: boolean;
+  isArchiving: boolean;
+  selectedCount: number;
+  availableCount: number;
+  allSelected: boolean;
+  beginManaging: () => void;
+  finishManaging: () => void;
+  toggleWorkspace: (workspaceKey: string) => void;
+  isWorkspaceSelected: (workspaceKey: string) => boolean;
+  toggleSelectAll: () => void;
+  archiveSelected: () => void;
+}
+
+const SidebarWorkspaceSelectionContext = createContext<SidebarWorkspaceSelectionController | null>(
+  null,
+);
+
+export function SidebarWorkspaceSelectionProvider({
+  workspaceEntriesByKey,
+  children,
+}: {
+  workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
+  children: ReactNode;
+}) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const activeWorkspaceSelection = useActiveWorkspaceSelection();
+  const [isManaging, setIsManaging] = useState(false);
+  const [isArchiving, setIsArchiving] = useState(false);
+  const archiveInFlightRef = useRef(false);
+  const [selectedWorkspaceKeys, setSelectedWorkspaceKeys] = useState<Set<string>>(() => new Set());
+
+  const availableWorkspaceKeys = useMemo(
+    () => selectAvailableWorkspaceKeys(workspaceEntriesByKey),
+    [workspaceEntriesByKey],
+  );
+
+  useEffect(() => {
+    if (isArchiving) return;
+    setSelectedWorkspaceKeys((current) =>
+      reconcileWorkspaceSelection(current, workspaceEntriesByKey),
+    );
+  }, [isArchiving, workspaceEntriesByKey]);
+
+  const beginManaging = useCallback(() => {
+    setSelectedWorkspaceKeys(new Set());
+    setIsManaging(true);
+  }, []);
+
+  const finishManaging = useCallback(() => {
+    if (isArchiving) return;
+    setSelectedWorkspaceKeys(new Set());
+    setIsManaging(false);
+  }, [isArchiving]);
+
+  const toggleWorkspace = useCallback(
+    (workspaceKey: string) => {
+      if (isArchiving || !availableWorkspaceKeys.has(workspaceKey)) return;
+      setSelectedWorkspaceKeys((current) => toggleWorkspaceSelection(current, workspaceKey));
+    },
+    [availableWorkspaceKeys, isArchiving],
+  );
+
+  const isWorkspaceSelected = useCallback(
+    (workspaceKey: string) => selectedWorkspaceKeys.has(workspaceKey),
+    [selectedWorkspaceKeys],
+  );
+
+  const allSelected =
+    availableWorkspaceKeys.size > 0 && selectedWorkspaceKeys.size === availableWorkspaceKeys.size;
+  const toggleSelectAll = useCallback(() => {
+    if (isArchiving) return;
+    setSelectedWorkspaceKeys(allSelected ? new Set() : new Set(availableWorkspaceKeys));
+  }, [allSelected, availableWorkspaceKeys, isArchiving]);
+
+  const archiveSelected = useCallback(() => {
+    if (archiveInFlightRef.current || selectedWorkspaceKeys.size === 0) return;
+    archiveInFlightRef.current = true;
+    setIsArchiving(true);
+
+    void (async () => {
+      try {
+        const selectedWorkspaces = [...selectedWorkspaceKeys].flatMap((workspaceKey) => {
+          const workspace = workspaceEntriesByKey.get(workspaceKey);
+          return workspace ? [workspace] : [];
+        });
+        const targets = await selectProjectWorkspacesToArchive(selectedWorkspaces);
+        if (targets.length === 0) return;
+
+        const confirmedWorkspaceKeys = new Set(targets.map(workspaceTargetKey));
+        const selectedActiveWorkspace = targets.find(
+          (target) =>
+            target.serverId === activeWorkspaceSelection?.serverId &&
+            target.workspaceId === activeWorkspaceSelection.workspaceId,
+        );
+        if (selectedActiveWorkspace) {
+          redirectIfArchivingActiveWorkspace({
+            ...selectedActiveWorkspace,
+            activeWorkspaceSelection,
+          });
+        }
+
+        const failures = await archiveWorkspacesOptimistically({
+          getClient: (serverId) => getHostRuntimeStore().getClient(serverId),
+          workspaces: targets,
+        });
+        const failedWorkspaceKeys = new Set(failures.map(workspaceTargetKey));
+        for (const target of targets) {
+          if (!failedWorkspaceKeys.has(workspaceTargetKey(target))) {
+            purgeArchivedWorkspaceState(target);
+          }
+        }
+
+        const remainingSelection = resolveRemainingWorkspaceSelection({
+          selectedWorkspaceKeys,
+          confirmedWorkspaceKeys,
+          failures,
+        });
+        setSelectedWorkspaceKeys(remainingSelection);
+        if (remainingSelection.size === 0) {
+          setIsManaging(false);
+        }
+        if (failures.length > 0) {
+          let message = t("sidebar.workspace.selection.archiveFailed", {
+            count: failures.length,
+          });
+          if (failures.length === 1 && failures[0]?.error instanceof Error) {
+            message = failures[0].error.message;
+          }
+          toast.error(message);
+        }
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : t("sidebar.workspace.selection.archiveFailed"),
+        );
+      } finally {
+        archiveInFlightRef.current = false;
+        setIsArchiving(false);
+      }
+    })();
+  }, [activeWorkspaceSelection, selectedWorkspaceKeys, t, toast, workspaceEntriesByKey]);
+
+  const value = useMemo<SidebarWorkspaceSelectionController>(
+    () => ({
+      isManaging,
+      isArchiving,
+      selectedCount: selectedWorkspaceKeys.size,
+      availableCount: availableWorkspaceKeys.size,
+      allSelected,
+      beginManaging,
+      finishManaging,
+      toggleWorkspace,
+      isWorkspaceSelected,
+      toggleSelectAll,
+      archiveSelected,
+    }),
+    [
+      allSelected,
+      archiveSelected,
+      availableWorkspaceKeys.size,
+      beginManaging,
+      finishManaging,
+      isArchiving,
+      isManaging,
+      isWorkspaceSelected,
+      selectedWorkspaceKeys.size,
+      toggleSelectAll,
+      toggleWorkspace,
+    ],
+  );
+
+  return (
+    <SidebarWorkspaceSelectionContext.Provider value={value}>
+      {children}
+    </SidebarWorkspaceSelectionContext.Provider>
+  );
+}
+
+export function useSidebarWorkspaceSelection(): SidebarWorkspaceSelectionController {
+  const selection = useContext(SidebarWorkspaceSelectionContext);
+  if (!selection) throw new Error("SidebarWorkspaceSelectionProvider is required");
+  return selection;
+}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1157,6 +1157,17 @@ export const ar: TranslationResources = {
       },
     },
     workspace: {
+      selection: {
+        title: "مساحات العمل",
+        manage: "إدارة مساحات العمل",
+        selected: "تم تحديد {{count}}",
+        done: "تم",
+        selectAll: "تحديد الكل",
+        deselectAll: "إلغاء تحديد الكل",
+        archive: "أرشفة ({{count}})",
+        archiving: "جارٍ الأرشفة...",
+        archiveFailed: "تعذرت أرشفة بعض مساحات العمل",
+      },
       status: {
         serviceRunning: "الخدمة {{name}} قيد التشغيل",
         serviceUnhealthy: "الخدمة {{name}} غير سليمة",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1166,6 +1166,17 @@ export const en = {
       },
     },
     workspace: {
+      selection: {
+        title: "Workspaces",
+        manage: "Manage workspaces",
+        selected: "{{count}} selected",
+        done: "Done",
+        selectAll: "Select all",
+        deselectAll: "Deselect all",
+        archive: "Archive ({{count}})",
+        archiving: "Archiving...",
+        archiveFailed: "Some workspaces could not be archived",
+      },
       status: {
         serviceRunning: "Service {{name}} running",
         serviceUnhealthy: "Service {{name}} unhealthy",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1191,6 +1191,17 @@ export const es: TranslationResources = {
       },
     },
     workspace: {
+      selection: {
+        title: "Espacios de trabajo",
+        manage: "Gestionar espacios de trabajo",
+        selected: "{{count}} seleccionados",
+        done: "Listo",
+        selectAll: "Seleccionar todo",
+        deselectAll: "Deseleccionar todo",
+        archive: "Archivar ({{count}})",
+        archiving: "Archivando...",
+        archiveFailed: "No se pudieron archivar algunos espacios de trabajo",
+      },
       status: {
         serviceRunning: "Servicio {{name}} en ejecución",
         serviceUnhealthy: "Servicio {{name}} con fallos",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1191,6 +1191,17 @@ export const fr: TranslationResources = {
       },
     },
     workspace: {
+      selection: {
+        title: "Espaces de travail",
+        manage: "Gérer les espaces de travail",
+        selected: "{{count}} sélectionnés",
+        done: "Terminé",
+        selectAll: "Tout sélectionner",
+        deselectAll: "Tout désélectionner",
+        archive: "Archiver ({{count}})",
+        archiving: "Archivage...",
+        archiveFailed: "Certains espaces de travail n’ont pas pu être archivés",
+      },
       status: {
         serviceRunning: "Service {{name}} en cours",
         serviceUnhealthy: "Service {{name}} en échec",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1169,6 +1169,17 @@ export const ja: TranslationResources = {
       },
     },
     workspace: {
+      selection: {
+        title: "ワークスペース",
+        manage: "ワークスペースを管理",
+        selected: "{{count}}件選択中",
+        done: "完了",
+        selectAll: "すべて選択",
+        deselectAll: "すべて選択解除",
+        archive: "アーカイブ（{{count}}）",
+        archiving: "アーカイブ中...",
+        archiveFailed: "一部のワークスペースをアーカイブできませんでした",
+      },
       status: {
         serviceRunning: "サービス {{name}} 実行中",
         serviceUnhealthy: "サービス {{name}} 異常",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1164,6 +1164,17 @@ export const ko: TranslationResources = {
       },
     },
     workspace: {
+      selection: {
+        title: "워크스페이스",
+        manage: "워크스페이스 관리",
+        selected: "{{count}}개 선택됨",
+        done: "완료",
+        selectAll: "모두 선택",
+        deselectAll: "모두 선택 해제",
+        archive: "보관 ({{count}})",
+        archiving: "보관 중...",
+        archiveFailed: "일부 워크스페이스를 보관하지 못했습니다",
+      },
       status: {
         serviceRunning: "서비스 {{name}} 실행 중",
         serviceUnhealthy: "서비스 {{name}} 비정상",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1182,6 +1182,17 @@ export const ptBR: TranslationResources = {
       },
     },
     workspace: {
+      selection: {
+        title: "Espaços de trabalho",
+        manage: "Gerenciar espaços de trabalho",
+        selected: "{{count}} selecionados",
+        done: "Concluído",
+        selectAll: "Selecionar tudo",
+        deselectAll: "Desmarcar tudo",
+        archive: "Arquivar ({{count}})",
+        archiving: "Arquivando...",
+        archiveFailed: "Não foi possível arquivar alguns espaços de trabalho",
+      },
       status: {
         serviceRunning: "Serviço {{name}} em execução",
         serviceUnhealthy: "Serviço {{name}} com falha",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1173,6 +1173,17 @@ export const ru: TranslationResources = {
       },
     },
     workspace: {
+      selection: {
+        title: "Рабочие пространства",
+        manage: "Управление рабочими пространствами",
+        selected: "Выбрано: {{count}}",
+        done: "Готово",
+        selectAll: "Выбрать все",
+        deselectAll: "Снять выделение",
+        archive: "Архивировать ({{count}})",
+        archiving: "Архивация...",
+        archiveFailed: "Не удалось архивировать некоторые рабочие пространства",
+      },
       status: {
         serviceRunning: "Сервис {{name}} запущен",
         serviceUnhealthy: "Сервис {{name}} работает некорректно",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1147,6 +1147,17 @@ export const zhCN: TranslationResources = {
       },
     },
     workspace: {
+      selection: {
+        title: "工作区",
+        manage: "管理工作区",
+        selected: "已选择 {{count}} 个",
+        done: "完成",
+        selectAll: "全选",
+        deselectAll: "取消全选",
+        archive: "归档（{{count}}）",
+        archiving: "正在归档...",
+        archiveFailed: "部分工作区无法归档",
+      },
       status: {
         serviceRunning: "服务 {{name}} 运行中",
         serviceUnhealthy: "服务 {{name}} 异常",

--- a/packages/app/src/workspace/use-workspace-archive.ts
+++ b/packages/app/src/workspace/use-workspace-archive.ts
@@ -12,7 +12,10 @@ import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 import { archiveWorkspaceOptimistically } from "@/workspace/workspace-archive";
 
-function purgeArchivedWorkspaceState(input: { serverId: string; workspaceId: string }): void {
+export function purgeArchivedWorkspaceState(input: {
+  serverId: string;
+  workspaceId: string;
+}): void {
   const workspaceKey = buildWorkspaceTabPersistenceKey(input);
   if (workspaceKey) {
     useWorkspaceLayoutStore.getState().purgeWorkspace(workspaceKey);


### PR DESCRIPTION
### Linked issue

Discussion: https://github.com/getpaseo/paseo/discussions/4096

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

People who supervise many parallel agent threads accumulate finished workspaces faster than they can clean them up one menu at a time. Project-level cleanup is too broad when the same project still contains active work. A sidebar Manage mode lets the user choose the exact finished batch and archive it through the existing workspace lifecycle.

### Goals

- Add an explicit Manage / Done mode to the Workspaces section.
- Make workspace rows accessible checkboxes while managing, without navigating, dragging, opening hover cards, or exposing per-row menus.
- Provide Select all / Deselect all and Archive (N) actions on wide and compact sidebars.
- Preserve existing risky-worktree confirmations, optimistic removal, multi-host routing, active-workspace redirect, and workspace-layout cleanup.
- Keep canceled and failed workspaces selected so the user can retry.

### Non-goals

- Permanent deletion.
- Bulk pinning, labeling, renaming, or project removal.
- New daemon or protocol batch APIs.
- Changes to workspace archive semantics.

### QA

Automated verification:

- `npm run test --workspace=@getpaseo/app -- src/components/sidebar/sidebar-workspace-selection.test.ts src/components/sidebar-workspace-list.test.tsx src/workspace/project-workspace-archive.test.ts src/workspace/workspace-archive.test.ts --bail=1` — 4 files, 12 tests passed.
- `npm run typecheck` — all workspaces passed.
- `npm run lint` — 0 warnings/errors.
- `npm run format` and `git diff --check` — passed.

Manual web/Desktop QA against the isolated dev daemon:

- Wide layout: entered Manage mode, selected two of four workspaces, confirmed checked ARIA state and Archive (2), and confirmed row clicks did not navigate.
- Compact 390×844 layout: opened the sidebar, selected the same two rows, and confirmed the fixed bottom action bar remained visible without clipping.
- Confirmed Select all / Deselect all and Done state transitions.
- Captured wide and compact screenshots locally.

Native iOS and Android were not manually exercised. The implementation uses the shared React Native sidebar surfaces and accessibility state, but native presentation remains an explicit risk surface.

Known adjacent issue: #3476 reports leaked Claude processes after bulk workspace archive on 0.4.0. This PR does not change the daemon archive path and does not claim to fix that report.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense