### PR TITLE
Show merge queue status for queued pull requests

### DIFF
--- a/packages/app/src/components/sidebar/workspace-meta-row/index.tsx
+++ b/packages/app/src/components/sidebar/workspace-meta-row/index.tsx
@@ -222,8 +222,7 @@ function PullRequestItem({ hint }: { hint: PrHint }) {
       )}
       <Text style={isHovered ? styles.prTextHovered : styles.prText} numberOfLines={1}>
         {hint.number}
-        {/* An open change request is the unremarkable case and says nothing extra; a merged
-            or closed one is why the row still looks like it has work in it. */}
+        {/* An open change request is the unremarkable case and says nothing extra. */}
         {hint.state === "open" ? "" : ` ${t(PR_STATE_LABEL_KEYS[hint.state])}`}
       </Text>
     </Pressable>
@@ -301,6 +300,7 @@ function ServiceItem({ summary }: { summary: WorkspaceServiceSummary }) {
 const successMapping = (theme: Theme) => ({ color: theme.colors.statusSuccess });
 
 const PR_STATE_LABEL_KEYS = {
+  queued: "workspace.git.pr.states.queued",
   merged: "workspace.git.pr.states.merged",
   closed: "workspace.git.pr.states.closed",
 } as const;

--- a/packages/app/src/git/client-forge-module.ts
+++ b/packages/app/src/git/client-forge-module.ts
@@ -122,6 +122,7 @@ export interface ClientForgeFactsEntry<TFacts extends ForgeSpecificEnvelope> {
   readonly family: TFacts["forge"];
   parse: (facts: unknown) => TFacts | null;
   deriveMergeCapability: (facts: unknown) => MergeCapability | null;
+  deriveIsQueuedForMerge: (facts: unknown) => boolean;
   readonly nativeFallbackChecks: readonly NativeFallbackCheckEntry[];
 }
 
@@ -129,6 +130,7 @@ export interface ClientForgeFactsRegistration<TFacts extends ForgeSpecificEnvelo
   readonly family: TFacts["forge"];
   readonly schema: z.ZodType<TFacts>;
   readonly deriveMergeCapability?: (facts: TFacts) => MergeCapability;
+  readonly deriveIsQueuedForMerge?: (facts: TFacts) => boolean;
   readonly nativeFallbackChecks?: readonly NativeFallbackCheckEntry[];
 }
 
@@ -186,6 +188,13 @@ export function defineForgeFacts<TFacts extends ForgeSpecificEnvelope>(
       }
       const parsed = parseFacts(registration.schema, facts);
       return parsed ? registration.deriveMergeCapability(parsed) : null;
+    },
+    deriveIsQueuedForMerge: (facts) => {
+      if (!registration.deriveIsQueuedForMerge) {
+        return false;
+      }
+      const parsed = parseFacts(registration.schema, facts);
+      return parsed ? registration.deriveIsQueuedForMerge(parsed) : false;
     },
     nativeFallbackChecks: registration.nativeFallbackChecks ?? [],
   };

--- a/packages/app/src/git/forges/github.ts
+++ b/packages/app/src/git/forges/github.ts
@@ -96,5 +96,6 @@ export const githubForgeLogic = {
     family: "github",
     schema: GithubMergeFactsSchema,
     deriveMergeCapability: deriveGithubMergeCapability,
+    deriveIsQueuedForMerge: (facts) => facts.isInMergeQueue,
   }),
 } satisfies ClientForgeLogicModule<GithubMergeFacts>;

--- a/packages/app/src/git/forges/index.ts
+++ b/packages/app/src/git/forges/index.ts
@@ -32,3 +32,9 @@ export function parseClientForgeFacts(facts: unknown): ForgeSpecificEnvelope | n
   }
   return null;
 }
+
+export function deriveIsQueuedForMerge(facts: unknown): boolean {
+  return CLIENT_FORGE_LOGIC_MODULES.some(
+    (module) => module.facts?.deriveIsQueuedForMerge(facts) === true,
+  );
+}

--- a/packages/app/src/git/pr-hint.test.ts
+++ b/packages/app/src/git/pr-hint.test.ts
@@ -35,6 +35,48 @@ describe("selectPrHintFromStatus", () => {
     expect(hint?.forge).toBe("bitbucket");
   });
 
+  it("marks an open GitHub pull request in the merge queue as queued", () => {
+    const hint = selectPrHintFromStatus({
+      ...githubStatus,
+      forgeSpecific: { forge: "github", isInMergeQueue: true },
+    });
+
+    expect(hint?.state).toBe("queued");
+  });
+
+  it("does not call a pull request queued just because its repository uses a merge queue", () => {
+    const hint = selectPrHintFromStatus({
+      ...githubStatus,
+      forgeSpecific: {
+        forge: "github",
+        isMergeQueueEnabled: true,
+        isInMergeQueue: false,
+      },
+    });
+
+    expect(hint?.state).toBe("open");
+  });
+
+  it("reads merge-queue facts from an older daemon's GitHub envelope", () => {
+    const hint = selectPrHintFromStatus({
+      ...githubStatus,
+      github: { isInMergeQueue: true },
+    });
+
+    expect(hint?.state).toBe("queued");
+  });
+
+  it("keeps merged and closed states terminal even if queue facts are stale", () => {
+    const forgeSpecific = { forge: "github", isInMergeQueue: true };
+
+    expect(selectPrHintFromStatus({ ...githubStatus, isMerged: true, forgeSpecific })?.state).toBe(
+      "merged",
+    );
+    expect(selectPrHintFromStatus({ ...githubStatus, state: "closed", forgeSpecific })?.state).toBe(
+      "closed",
+    );
+  });
+
   it("returns null when the url has no parseable change-request number", () => {
     expect(
       selectPrHintFromStatus({ url: "https://example.com/x", state: "open", isMerged: false }),

--- a/packages/app/src/git/pr-hint.ts
+++ b/packages/app/src/git/pr-hint.ts
@@ -1,10 +1,11 @@
 import { normalizeForge, type Forge } from "@/git/forge";
 import type { PresentableCheck } from "@/git/check-presentation";
+import { deriveIsQueuedForMerge } from "@/git/forges";
 
 export interface PrHint {
   url: string;
   number: number;
-  state: "open" | "merged" | "closed";
+  state: "open" | "queued" | "merged" | "closed";
   /** Forge backing this change request, so badges render the right brand mark. */
   forge: Forge;
   checks?: PrHintCheck[];
@@ -25,6 +26,21 @@ interface PrStatusLike {
   checksStatus?: string;
   reviewDecision?: string | null;
   forge?: string;
+  forgeSpecific?: unknown;
+  github?: unknown;
+}
+
+function queueFacts(status: PrStatusLike): unknown {
+  if (status.forgeSpecific !== null && status.forgeSpecific !== undefined) {
+    return status.forgeSpecific;
+  }
+  // COMPAT(forgeSpecific): forgeSpecific shipped in v0.2.0-beta.1. A daemon
+  // predating it emits GitHub facts only through `status.github`. Remove after
+  // 2027-01-17 once the supported daemon floor is >= v0.2.0.
+  if (typeof status.github === "object" && status.github !== null) {
+    return { forge: "github", ...status.github };
+  }
+  return null;
 }
 
 function parsePullRequestNumber(url: string): number | null {
@@ -57,10 +73,11 @@ export function selectPrHintFromStatus(
     return null;
   }
 
-  let state: "merged" | "open" | "closed";
+  let state: PrHint["state"];
   if (status.isMerged || status.state === "merged") state = "merged";
-  else if (status.state === "open") state = "open";
-  else state = "closed";
+  else if (status.state === "open") {
+    state = deriveIsQueuedForMerge(queueFacts(status)) ? "queued" : "open";
+  } else state = "closed";
 
   return {
     url: status.url,

--- a/packages/app/src/git/pull-request-state-icon.tsx
+++ b/packages/app/src/git/pull-request-state-icon.tsx
@@ -1,18 +1,26 @@
-import { GitMerge, GitPullRequest, GitPullRequestClosed } from "lucide-react-native";
+import {
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestArrow,
+  GitPullRequestClosed,
+} from "lucide-react-native";
 import { withUnistyles } from "react-native-unistyles";
 import type { Theme } from "@/styles/theme";
 import type { PrHint } from "@/git/pr-hint";
 
 const ThemedGitPullRequest = withUnistyles(GitPullRequest);
+const ThemedGitPullRequestArrow = withUnistyles(GitPullRequestArrow);
 const ThemedGitMerge = withUnistyles(GitMerge);
 const ThemedGitPullRequestClosed = withUnistyles(GitPullRequestClosed);
 
 const successMapping = (theme: Theme) => ({ color: theme.colors.statusSuccess });
 const mergedMapping = (theme: Theme) => ({ color: theme.colors.statusMerged });
+const queuedMapping = (theme: Theme) => ({ color: theme.colors.statusWarning });
 const dangerMapping = (theme: Theme) => ({ color: theme.colors.statusDanger });
 
 const PRESENTATION = {
   open: { Icon: ThemedGitPullRequest, color: successMapping },
+  queued: { Icon: ThemedGitPullRequestArrow, color: queuedMapping },
   merged: { Icon: ThemedGitMerge, color: mergedMapping },
   closed: { Icon: ThemedGitPullRequestClosed, color: dangerMapping },
 } as const;

--- a/packages/app/src/git/pull-request-state-icon.tsx
+++ b/packages/app/src/git/pull-request-state-icon.tsx
@@ -1,10 +1,10 @@
-import { GitGraph, GitMerge, GitPullRequest, GitPullRequestClosed } from "lucide-react-native";
+import { GitMerge, GitPullRequest, GitPullRequestClosed, ListEnd } from "lucide-react-native";
 import { withUnistyles } from "react-native-unistyles";
 import type { Theme } from "@/styles/theme";
 import type { PrHint } from "@/git/pr-hint";
 
 const ThemedGitPullRequest = withUnistyles(GitPullRequest);
-const ThemedGitGraph = withUnistyles(GitGraph);
+const ThemedListEnd = withUnistyles(ListEnd);
 const ThemedGitMerge = withUnistyles(GitMerge);
 const ThemedGitPullRequestClosed = withUnistyles(GitPullRequestClosed);
 
@@ -15,7 +15,7 @@ const dangerMapping = (theme: Theme) => ({ color: theme.colors.statusDanger });
 
 const PRESENTATION = {
   open: { Icon: ThemedGitPullRequest, color: successMapping },
-  queued: { Icon: ThemedGitGraph, color: queuedMapping },
+  queued: { Icon: ThemedListEnd, color: queuedMapping },
   merged: { Icon: ThemedGitMerge, color: mergedMapping },
   closed: { Icon: ThemedGitPullRequestClosed, color: dangerMapping },
 } as const;

--- a/packages/app/src/git/pull-request-state-icon.tsx
+++ b/packages/app/src/git/pull-request-state-icon.tsx
@@ -1,15 +1,10 @@
-import {
-  GitMerge,
-  GitPullRequest,
-  GitPullRequestArrow,
-  GitPullRequestClosed,
-} from "lucide-react-native";
+import { GitGraph, GitMerge, GitPullRequest, GitPullRequestClosed } from "lucide-react-native";
 import { withUnistyles } from "react-native-unistyles";
 import type { Theme } from "@/styles/theme";
 import type { PrHint } from "@/git/pr-hint";
 
 const ThemedGitPullRequest = withUnistyles(GitPullRequest);
-const ThemedGitPullRequestArrow = withUnistyles(GitPullRequestArrow);
+const ThemedGitGraph = withUnistyles(GitGraph);
 const ThemedGitMerge = withUnistyles(GitMerge);
 const ThemedGitPullRequestClosed = withUnistyles(GitPullRequestClosed);
 
@@ -20,7 +15,7 @@ const dangerMapping = (theme: Theme) => ({ color: theme.colors.statusDanger });
 
 const PRESENTATION = {
   open: { Icon: ThemedGitPullRequest, color: successMapping },
-  queued: { Icon: ThemedGitPullRequestArrow, color: queuedMapping },
+  queued: { Icon: ThemedGitGraph, color: queuedMapping },
   merged: { Icon: ThemedGitMerge, color: mergedMapping },
   closed: { Icon: ThemedGitPullRequestClosed, color: dangerMapping },
 } as const;

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -66,6 +66,18 @@ describe("createSidebarWorkspaceEntry forge threading", () => {
     });
     expect(entry.prHint).toMatchObject({ number: 42, forge: "github" });
   });
+
+  it("surfaces a GitHub pull request queued for merge", () => {
+    const descriptor = workspaceWithForge("github", "https://github.com/acme/repo/pull/42");
+    descriptor.githubRuntime!.pullRequest!.forgeSpecific = {
+      forge: "github",
+      isInMergeQueue: true,
+    };
+
+    const entry = createSidebarWorkspaceEntry({ serverId: "srv", workspace: descriptor });
+
+    expect(entry.prHint).toMatchObject({ number: 42, forge: "github", state: "queued" });
+  });
 });
 
 describe("createSidebarWorkspaceEntry workspace directory label", () => {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -953,6 +953,7 @@ export const ar: TranslationResources = {
         },
         states: {
           draft: "مسودة",
+          queued: "في قائمة انتظار الدمج",
           merged: "تم الدمج",
           closed: "مغلق",
           open: "يفتح",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -962,6 +962,7 @@ export const en = {
         },
         states: {
           draft: "Draft",
+          queued: "Queued",
           merged: "Merged",
           closed: "Closed",
           open: "Open",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -984,6 +984,7 @@ export const es: TranslationResources = {
         },
         states: {
           draft: "Borrador",
+          queued: "En cola para fusionar",
           merged: "Fusionado",
           closed: "Cerrado",
           open: "Abierto",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -983,6 +983,7 @@ export const fr: TranslationResources = {
         },
         states: {
           draft: "Brouillon",
+          queued: "En attente de fusion",
           merged: "Fusionné",
           closed: "Fermé",
           open: "Ouvrir",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -964,6 +964,7 @@ export const ja: TranslationResources = {
         },
         states: {
           draft: "ドラフト",
+          queued: "マージ待ち",
           merged: "マージ済み",
           closed: "クローズ済み",
           open: "オープン",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -960,6 +960,7 @@ export const ko: TranslationResources = {
         },
         states: {
           draft: "초안",
+          queued: "병합 대기 중",
           merged: "병합됨",
           closed: "닫힘",
           open: "열림",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -975,6 +975,7 @@ export const ptBR: TranslationResources = {
         },
         states: {
           draft: "Rascunho",
+          queued: "Na fila para mesclagem",
           merged: "Mergeada",
           closed: "Fechada",
           open: "Aberta",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -968,6 +968,7 @@ export const ru: TranslationResources = {
         },
         states: {
           draft: "Черновик",
+          queued: "В очереди на слияние",
           merged: "Объединён",
           closed: "Закрыт",
           open: "Открыт",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -945,6 +945,7 @@ export const zhCN: TranslationResources = {
         },
         states: {
           draft: "Draft",
+          queued: "等待合并",
           merged: "已 merge",
           closed: "已关闭",
           open: "Open",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3746,6 +3746,7 @@ export const WorkspaceGitHubRuntimePayloadSchema = z
         repoOwner: z.string().optional(),
         repoName: z.string().optional(),
         github: z.unknown().optional(),
+        forgeSpecific: z.unknown().optional(),
       })
       .nullable()
       .optional(),

--- a/packages/protocol/src/messages.workspaces.test.ts
+++ b/packages/protocol/src/messages.workspaces.test.ts
@@ -919,6 +919,10 @@ describe("workspace message schemas", () => {
                 headRefName: "workspace-git-service",
                 isMerged: false,
                 checks,
+                forgeSpecific: {
+                  forge: "github",
+                  isInMergeQueue: true,
+                },
               },
               error: null,
               refreshedAt: "2026-04-12T00:00:00.000Z",
@@ -941,6 +945,10 @@ describe("workspace message schemas", () => {
     });
     expect(parsed.payload.entries[0]?.githubRuntime?.pullRequest?.title).toBe("Runtime payloads");
     expect(parsed.payload.entries[0]?.githubRuntime?.pullRequest?.checks).toEqual(checks);
+    expect(parsed.payload.entries[0]?.githubRuntime?.pullRequest?.forgeSpecific).toEqual({
+      forge: "github",
+      isInMergeQueue: true,
+    });
   });
 
   test("older workspace parsers ignore additive runtime fields", () => {


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Workspace rows collapse every unmerged GitHub pull request to open even when GitHub reports that it has entered the merge queue. This makes a queued workspace look like it still needs someone to merge it. Preserve the existing GitHub merge-queue fact in workspace payloads and derive a distinct queued presentation in the app.

### Goals

- Show queued GitHub pull requests as Queued in workspace status.
- Use a distinct pending merge-queue icon and warning color.
- Keep merged and closed states authoritative if queue facts are stale.
- Preserve compatibility with the legacy GitHub facts envelope.
- Localize the queued label in every supported locale.

### Non-goals

- Change how pull requests enter or leave GitHub merge queues.
- Treat every repository with merge queues enabled as though each open PR is queued.
- Add merge-queue support for forges that do not report this fact.

### QA

Automated coverage:

- `npx vitest run packages/app/src/hooks/sidebar-workspaces-view-model.test.ts packages/app/src/git/pr-hint.test.ts packages/app/src/i18n/resources.test.ts packages/protocol/src/messages.workspaces.test.ts --bail=1`
  - 4 test files passed
  - 124 tests passed
- `npm run typecheck` passed across all workspaces.
- `npm run lint` passed with 0 warnings and 0 errors.
- `npm run format` passed.

Behavior covered by tests:

- An open PR with `isInMergeQueue: true` resolves to queued.
- Merge-queue-enabled repositories do not mark PRs queued unless the PR is actually in the queue.
- Merged and closed states win over stale queue facts.
- Current and legacy GitHub fact envelopes resolve the same queued state.
- Workspace protocol parsing preserves forge-specific queue facts.

Before:
<img width="320" height="240" alt="01-before-sidebar" src="https://github.com/user-attachments/assets/6f403f46-cf5f-4bcc-8aae-18d74e7a3aea" />
After:
<img width="320" height="240" alt="02-after-sidebar" src="https://github.com/user-attachments/assets/139ff977-2428-4e5c-ac4f-ae26bdfce86d" />


### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [X] QA evidence
- [x] Tests added or updated where it made sense

