### PR TITLE
docs(hub): add Forgejo provider guides

### DIFF
--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -170,6 +170,32 @@ Use `label` only with a label-added event. It has no match on other events. Use 
 
 See [GitHub triggers](/docs/hub/triggers/github) for complete triage, pull-request review, and ready-for-agent workflows.
 
+### Forgejo events and filters
+
+Use one of these semantic event names for new Forgejo workflows:
+
+| `on`                                   | Matches                                                                   |
+| -------------------------------------- | ------------------------------------------------------------------------- |
+| `forgejo.issue_created`                | An `issues` delivery whose action is `opened`.                            |
+| `forgejo.pull_request_created`         | A `pull_request` delivery whose action is `opened`.                       |
+| `forgejo.issue_comment_created`        | An `issue_comment` delivery whose action is `created`, on an issue.       |
+| `forgejo.pull_request_comment_created` | An `issue_comment` delivery whose action is `created`, on a pull request. |
+| `forgejo.issue_label_added`            | A label is added to an issue.                                             |
+| `forgejo.pull_request_label_added`     | A label is added to a pull request.                                       |
+
+Existing configurations may use `forgejo.issues`, `forgejo.issue_comment`,
+`forgejo.pull_request`, `forgejo.pull_request_review`,
+`forgejo.pull_request_review_comment`, and `forgejo.push`. Those native raw families retain
+their existing behavior.
+
+Forgejo uses the same `filters` field shape as GitHub: `from_users`, `repo`, `connection`,
+`contains`, `pattern`, `label`, and `labels`. `from_users` must be non-empty for every externally
+sourced workflow, and all supplied filters compose with AND. Forgejo `repo` and `connection`
+values refer only to the connection's explicitly enrolled repositories.
+
+See [Forgejo triggers](/docs/hub/triggers/forgejo) for complete workflows, reaction behavior, and
+the native event differences.
+
 ### Inputs and values
 
 Inputs have `type: string | number | boolean`, plus optional `required`, `default`, and `choices`. `required` and `default` cannot be combined. Finite `choices` are required when an input can choose authority such as an environment or named agent.
@@ -202,6 +228,7 @@ An environment or dynamic named-agent expression must have a finite set of possi
 | `allow_outputs` | no       | Provider output capabilities with optional `max` and `required`.                         |
 | `auto_archive`  | no       | Archive the agent after the step ends.                                                   |
 | `github`        | no       | Explicit GitHub authority for this step.                                                 |
+| `forgejo`       | no       | Explicit Forgejo authority for this step.                                                |
 
 An inline agent is static and complete:
 

--- a/public-docs/hub/forgejo.md
+++ b/public-docs/hub/forgejo.md
@@ -40,6 +40,8 @@ steps:
 An organization owner configures a repository-limited execution PAT for the connection. Hub
 checks the connection, enrolled repositories, and requested capability before it materializes the
 PAT for the running step. Hub does not create, expand, or silently replace the upstream PAT.
+Forgejo personal access tokens cannot be attenuated: after the step grant is shown to be a subset
+of that PAT, Hub injects the stored execution PAT as `FORGEJO_TOKEN`.
 
 ## Fields
 

--- a/public-docs/hub/forgejo.md
+++ b/public-docs/hub/forgejo.md
@@ -1,0 +1,87 @@
+---
+title: Forgejo access
+description: Grant one workflow step repository-limited Forgejo authority and Git setup.
+nav: Forgejo access
+order: 65.5
+category: Hub
+---
+
+# Forgejo access
+
+A trigger grants no Forgejo credential. Put a `forgejo` block on the step that needs repository
+authority:
+
+```yaml
+name: implement-request
+on: forgejo.issue_comment_created
+max_runtime: 2h
+filters:
+  repo: example/project
+  contains: "@paseo"
+  from_users: [maintainer]
+steps:
+  - id: implement
+    environment: development
+    max_runtime: 90m
+    idle_timeout: 10m
+    agent: codex
+    forgejo:
+      connection: example-forgejo
+      repositories: [example/project]
+      contents: write
+      issues: write
+    prompt:
+      - text: |
+          Implement the request, push a branch, and open a pull request.
+          Call hub.finish_execution when done.
+          ${{ paseo.prompt }}
+```
+
+An organization owner configures a repository-limited execution PAT for the connection. Hub
+checks the connection, enrolled repositories, and requested capability before it materializes the
+PAT for the running step. Hub does not create, expand, or silently replace the upstream PAT.
+
+## Fields
+
+| Field          | Notes                                                                                                                         |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `connection`   | Active Forgejo connection slug in the workflow organization.                                                                  |
+| `repositories` | Enrolled `owner/name` repositories the step may reach. Defaults to the triggering repository only on a Forgejo-triggered run. |
+| `contents`     | `read` or `write` repository-content capability. Defaults to `read`.                                                          |
+| `issues`       | `read` or `write` issue, comment, and reaction capability. Defaults to `read`.                                                |
+
+For a non-Forgejo trigger, `repositories` is required. Requested repositories and capabilities cannot
+exceed the enrolled repository list or the execution PAT. A step cannot declare both `github` and
+`forgejo` authority.
+
+## Agent environment
+
+Hub supplies `FORGEJO_TOKEN` and process-scoped Git configuration only to the step with a
+`forgejo` block:
+
+- Commits use the connected Forgejo identity.
+- Git remotes for the approved Forgejo origin are rewritten to HTTPS.
+- Git credentials read `FORGEJO_TOKEN` at use time.
+- User-global and system Git configuration are ignored, and terminal credential prompts are disabled.
+- The daemon host's Git identity and credentials are not read or changed.
+
+`FORGEJO_TOKEN` and Hub's Git configuration variables are reserved when a step has a `forgejo`
+block; workflow `env` cannot replace them. The token is not retained in the workflow definition,
+durable launch data, logs, or diagnostics.
+
+## Keep authority on the worker
+
+A classifier can read untrusted request text without Forgejo authority. Put the `forgejo` block
+only on the later branch that makes a change. [Workflow routing](/docs/hub/workflows#route-from-a-classifier)
+shows the ordered classifier/worker shape.
+
+Configure the connection and execution PAT through [Forgejo for Hub](/docs/hub/self-hosting/forgejo).
+Connection values for other integrations remain explicit step environment values:
+
+```yaml
+env:
+  SOME_TOKEN: "${{ paseo.connections.some-connection.token }}"
+```
+
+Hub resolves the value for the step and does not persist it. See [Hub security](/docs/hub/security)
+for provider and host boundaries.

--- a/public-docs/hub/index.md
+++ b/public-docs/hub/index.md
@@ -19,7 +19,7 @@ A daemon runs agents on one machine, for you. Paseo Hub is the layer above your 
 
 What that gives you today:
 
-- Agents that start on their own, from activity in GitHub, Slack, and Discord.
+- Agents that start on their own, from activity in GitHub, Forgejo, Slack, and Discord.
 - Configuration that lives in a repository and deploys when you push.
 - A record of everything that arrived, what it matched, and what ran.
 - One place for your team to see all of it.
@@ -47,10 +47,11 @@ Guided setup deploys the bundle, and mentioning the bot starts an agent on your 
 4. [Triggers](/docs/hub/triggers)
 5. [Workflows](/docs/hub/workflows)
 6. [GitHub access](/docs/hub/github)
-7. [Configuration](/docs/hub/configuration)
-8. [Security](/docs/hub/security)
+7. [Forgejo access](/docs/hub/forgejo)
+8. [Configuration](/docs/hub/configuration)
+9. [Security](/docs/hub/security)
 
-If a workflow accepts requests from GitHub, Slack, Discord, or the API, read [Hub security](/docs/hub/security) before giving an agent access to a working directory or output capability.
+If a workflow accepts requests from GitHub, Forgejo, Slack, Discord, or the API, read [Hub security](/docs/hub/security) before giving an agent access to a working directory or output capability.
 
 ## Run Hub yourself
 

--- a/public-docs/hub/self-hosting/forgejo.md
+++ b/public-docs/hub/self-hosting/forgejo.md
@@ -1,0 +1,98 @@
+---
+title: Forgejo for Hub
+description: Approve a Forgejo instance, connect repository-limited accounts, and receive signed events.
+nav: Forgejo
+order: 75.5
+category: Hub
+---
+
+# Forgejo for Hub
+
+Forgejo is not a GitHub App integration. An instance operator approves the Forgejo origin first,
+then organization owners connect accounts to that approved instance. This keeps origin approval
+separate from each organization's repository and PAT choices.
+
+## Approve an instance
+
+In Hub's Forgejo settings, an instance operator enters the canonical HTTPS origin and chooses
+whether Hub may reach a private-network address. Hub checks the Forgejo identity and requires
+Forgejo `16.0.3` or later before the instance becomes active.
+
+Approve a private-network origin only when the Hub deployment is intentionally allowed to reach
+it. Organization owners cannot enter a URL during connection setup; they choose an approved
+`instanceId`. The public resource for an approved connection contains only `slug`, `instanceId`,
+`accountLogin`, and enrolled `repositories`, never the origin or a credential.
+
+Run the instance health check after a Forgejo upgrade, certificate change, DNS change, or other
+identity change. An incompatible, unreachable, or identity-drifted instance needs operator review
+before it can be used safely.
+
+## Connect an organization
+
+An organization owner creates a connection from an approved instance, a connection slug, a
+claimed Forgejo username, and a repository-limited personal access token. The token must include
+one issue capability (`read:issue` or `write:issue`) and one repository capability
+(`read:repository` or `write:repository`). Hub rejects OAuth2 credentials, passwords, unscoped
+tokens, and unrelated scopes.
+
+Enroll only the repositories the connection needs. The connection PAT supports event intake,
+repository health, and reactions. Configure a separate repository-limited execution PAT when a
+workflow needs a `forgejo` step-authority block. Hub checks the execution PAT's repositories and
+capabilities at step launch; it never widens either boundary.
+
+Rotate or revoke the connection and execution PATs in the Forgejo connection lifecycle controls.
+Use rotation when an upstream token's identity, scope, or repository list changes. Do not put a PAT
+in `.paseo` configuration files.
+
+## Webhook delivery
+
+Forgejo event triggers need a public HTTPS Hub URL that Forgejo can reach. Set the stable public
+Hub URL before configuring webhooks:
+
+```dotenv
+PASEO_HUB_APP_URL=https://hub.example.com
+```
+
+A Hub instance can connect to Forgejo and read repository-backed configuration without an inbound
+webhook. Event triggers and automatic configuration synchronization need the callback to be
+reachable.
+
+After repositories are enrolled, choose one webhook mode:
+
+- **Automatic:** provide a one-time webhook-admin PAT. Hub creates or reconciles managed hooks,
+  verifies them, then discards that PAT.
+- **Manual:** Hub gives you a callback URL and webhook secret. Add those values to every enrolled
+  Forgejo repository yourself.
+
+Both modes use `push`, `issues`, `issue_comment`, `pull_request`, `pull_request_review`, and
+`pull_request_review_comment`. Hub verifies each Forgejo HMAC signature before accepting a
+delivery. Keep the webhook secret in Forgejo's webhook configuration, never in the repository.
+
+## Configuration source and triggers
+
+Select **Forgejo** as a project's configuration source, then choose one enrolled repository. Hub
+records the source kind as `forgejo`, reads the `.paseo` bundle from that repository's default
+branch, and records the exact commit used for each synchronization. A default-branch push can
+synchronize the source; the project also provides an explicit sync action.
+
+Author semantic `forgejo.*` triggers in `.paseo/workflows/` and grant repository authority only
+through a step-level `forgejo` block. See [Forgejo triggers](/docs/hub/triggers/forgejo) and
+[Forgejo access](/docs/hub/forgejo) for complete workflow examples.
+
+## Cleanup and troubleshooting
+
+Before disconnecting, inspect the impact preview. Hub blocks future Forgejo execution and removes
+managed hooks where it can; manual hooks remain yours to remove. When a managed hook cannot be
+removed, the disconnect reports `REMOTE_CLEANUP_PENDING`. Use **Resume remote cleanup** with a
+one-time webhook-admin PAT to finish the remote deletion. Hub uses that PAT for recovery only; it
+does not become a connection credential.
+
+| Symptom                           | Check and remediation                                                                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No approved instance is available | Ask an instance operator to approve the canonical HTTPS origin and verify Forgejo `16.0.3` or later.                                                    |
+| A PAT is rejected                 | Restrict it to repositories and include one issue and one repository capability. Do not use OAuth2, a password, an unscoped token, or unrelated scopes. |
+| A repository is absent            | Confirm that the connection PAT can see it, then enroll it before selecting it for hooks or configuration.                                              |
+| Events are missing                | Confirm Hub's public HTTPS URL, callback URL, webhook secret, selected repositories, and required event families.                                       |
+| Reactions are missing             | Confirm that the event has a reaction target and the connection PAT has `write:issue` for that enrolled repository.                                     |
+| Health is degraded                | Rotate or replace a changed connection PAT, then recheck the instance, repository, and hook health.                                                     |
+| `REMOTE_CLEANUP_PENDING` remains  | Resume remote cleanup with a one-time webhook-admin PAT; do not create a broader permanent connection for cleanup.                                      |

--- a/public-docs/hub/self-hosting/forgejo.md
+++ b/public-docs/hub/self-hosting/forgejo.md
@@ -25,7 +25,7 @@ it. Organization owners cannot enter a URL during connection setup; they choose 
 
 Run the instance health check after a Forgejo upgrade, certificate change, DNS change, or other
 identity change. An incompatible, unreachable, or identity-drifted instance needs operator review
-before it can be used safely.
+before it can be used safely. Scheduled recovery continues in the background while Hub is running.
 
 ## Connect an organization
 
@@ -38,7 +38,14 @@ tokens, and unrelated scopes.
 Enroll only the repositories the connection needs. The connection PAT supports event intake,
 repository health, and reactions. Configure a separate repository-limited execution PAT when a
 workflow needs a `forgejo` step-authority block. Hub checks the execution PAT's repositories and
-capabilities at step launch; it never widens either boundary.
+capabilities at step launch; it never widens either boundary. Forgejo cannot mint a narrower token
+for a step that requested a subset of that PAT; the injected `FORGEJO_TOKEN` is the stored
+execution PAT after subset validation. Store a narrower execution PAT when a step must not inherit
+the broader credential.
+
+Hub also runs bounded scheduled recovery on the frozen health interval without an operator
+request. On-demand instance health checks still use the same coordinator. Automatic retry never
+claims `REMOTE_CLEANUP_PENDING` work.
 
 Rotate or revoke the connection and execution PATs in the Forgejo connection lifecycle controls.
 Use rotation when an upstream token's identity, scope, or repository list changes. Do not put a PAT

--- a/public-docs/hub/self-hosting/index.md
+++ b/public-docs/hub/self-hosting/index.md
@@ -14,7 +14,7 @@ The shortest path is one command:
 npx @getpaseo/hub
 ```
 
-Open <http://localhost:3000>. A fresh Hub creates its embedded database and authentication secret, then guides you through creating the operator account and the GitHub, Slack, or Discord apps you want.
+Open <http://localhost:3000>. A fresh Hub creates its embedded database and authentication secret, then guides you through creating the operator account and configuring the GitHub, Forgejo, Slack, or Discord providers you want.
 
 Follow the [quickstart](/docs/hub/quickstart) to connect Slack over Socket Mode and run the first workflow without a public server.
 
@@ -34,7 +34,7 @@ Embedded mode supports one Hub process per data directory. It is intended for a 
 
 Hub defaults to `http://localhost:3000`. That is enough for its dashboard, daemons, Slack Socket Mode, and providers that connect out from Hub.
 
-GitHub event triggers use webhooks and need a public HTTPS address. Repository access can still work without the webhook. Slack's optional Webhooks transport also needs public HTTPS; Socket Mode does not.
+GitHub and Forgejo event triggers use webhooks and need a public HTTPS address. Repository access and repository-backed configuration can still work without an inbound webhook. Slack's optional Webhooks transport also needs public HTTPS; Socket Mode does not.
 
 When Hub is available at a stable public origin, set it before starting:
 
@@ -59,7 +59,7 @@ The database also stores Hub's generated authentication secret. Set `PASEO_HUB_A
 
 ## App configuration
 
-The operator configures GitHub, Slack, and Discord under **Apps**. Hub verifies the credentials before saving them in its database and starts the same provider runtime used by environment-configured deployments.
+The operator configures GitHub, Slack, Discord, and approved Forgejo instances in Hub. Hub verifies provider setup before saving it in its database and starts the same provider runtime used by environment-configured deployments.
 
 Environment variables remain available for deployments that manage secrets outside Hub. A complete environment configuration takes precedence over a saved application and appears as **Managed by environment** in the dashboard.
 
@@ -90,7 +90,7 @@ DISCORD_CLIENT_SECRET=
 DISCORD_BOT_TOKEN=
 ```
 
-See [GitHub](/docs/hub/self-hosting/github-app), [Slack](/docs/hub/self-hosting/slack-app), and [Discord](/docs/hub/self-hosting/discord-app) for provider behavior and connection steps.
+See [GitHub](/docs/hub/self-hosting/github-app), [Forgejo](/docs/hub/self-hosting/forgejo), [Slack](/docs/hub/self-hosting/slack-app), and [Discord](/docs/hub/self-hosting/discord-app) for provider behavior and connection steps.
 
 ## Bootstrap from environment
 

--- a/public-docs/hub/triggers/forgejo.md
+++ b/public-docs/hub/triggers/forgejo.md
@@ -1,0 +1,193 @@
+---
+title: Forgejo triggers
+description: Start Hub workflows from specific Forgejo issues, pull requests, comments, and labels.
+nav: Forgejo
+order: 67.5
+category: Hub
+---
+
+# Forgejo triggers
+
+Use semantic Forgejo events to start a workflow from one Forgejo action. Add the workflow below to
+a repository whose `.paseo/hub.yml` defines the `dev` environment and `codex` agent, then activate
+the bundle.
+
+## Triage new issues
+
+`.paseo/workflows/triage-issue.yml`:
+
+```yaml
+name: triage-issue
+on: forgejo.issue_created
+max_runtime: 2h
+filters:
+  repo: example/project
+  from_users: [maintainer]
+steps:
+  - id: triage
+    environment: dev
+    max_runtime: 30m
+    idle_timeout: 5m
+    agent: codex
+    forgejo:
+      connection: example-forgejo
+      repositories: [example/project]
+      issues: write
+    prompt:
+      - text: |
+          Triage the new issue. Add appropriate labels and leave a short comment.
+          Use this event context:
+          ${{ paseo.context }}
+          Call hub.finish_execution when done.
+```
+
+`forgejo.issue_created` fires only when someone opens an issue. `from_users` is required and
+matches the Forgejo login that caused the event.
+
+## Review new pull requests
+
+`.paseo/workflows/review-pull-request.yml`:
+
+```yaml
+name: review-pull-request
+on: forgejo.pull_request_created
+max_runtime: 2h
+filters:
+  repo: example/project
+  from_users: [maintainer]
+steps:
+  - id: review
+    environment: dev
+    max_runtime: 90m
+    idle_timeout: 10m
+    agent: codex
+    forgejo:
+      connection: example-forgejo
+      repositories: [example/project]
+      contents: read
+      issues: write
+    prompt:
+      - text: |
+          Review the new pull request and submit your findings through Forgejo.
+          Use this event context:
+          ${{ paseo.context }}
+          Call hub.finish_execution when done.
+```
+
+`forgejo.pull_request_created` fires only when someone opens a pull request.
+
+## Respond to new comments
+
+`.paseo/workflows/respond-to-issue-comment.yml`:
+
+```yaml
+name: respond-to-issue-comment
+on: forgejo.issue_comment_created
+max_runtime: 2h
+filters:
+  repo: example/project
+  contains: "@paseo"
+  from_users: [maintainer]
+steps:
+  - id: respond
+    environment: dev
+    max_runtime: 30m
+    idle_timeout: 5m
+    agent: codex
+    forgejo:
+      connection: example-forgejo
+      repositories: [example/project]
+      issues: write
+    prompt:
+      - text: |
+          Respond to the new issue comment. Address this request:
+          ${{ paseo.prompt }}
+          Use this event context:
+          ${{ paseo.context }}
+          Call hub.finish_execution when done.
+```
+
+Use `forgejo.issue_comment_created` for an issue discussion and
+`forgejo.pull_request_comment_created` for a pull-request conversation. Forgejo delivers both as
+issue comments; Hub separates them. A comment on a changed line is covered by the raw
+`forgejo.pull_request_review_comment` family.
+
+For `forgejo.issue_comment_created`, `forgejo.pull_request_comment_created`, and
+`forgejo.issue_comment`, Hub reacts with `eyes` when it accepts a delivery, `+1` when the agent
+completes, and `-1` when the agent fails or is terminated, where the event subject supports
+reactions. A submitted review has no reaction target.
+
+## Start work when an issue becomes ready
+
+`.paseo/workflows/implement-ready-issue.yml`:
+
+```yaml
+name: implement-ready-issue
+on: forgejo.issue_label_added
+max_runtime: 2h
+filters:
+  repo: example/project
+  label: ready-for-agent
+  from_users: [maintainer]
+steps:
+  - id: implement
+    environment: dev
+    max_runtime: 90m
+    idle_timeout: 10m
+    agent: codex
+    forgejo:
+      connection: example-forgejo
+      repositories: [example/project]
+      contents: write
+      issues: write
+    prompt:
+      - text: |
+          Implement the issue that was marked ready for an agent. Create a branch,
+          push it, and open a pull request. Use this event context:
+          ${{ paseo.context }}
+          Call hub.finish_execution when done.
+```
+
+`label` matches the label this event added. The match is case-insensitive, so `ready-for-agent`
+also matches `Ready-For-Agent`.
+
+## Choose the event
+
+| `on`                                   | Fires when                                           |
+| -------------------------------------- | ---------------------------------------------------- |
+| `forgejo.issue_created`                | An issue is opened.                                  |
+| `forgejo.pull_request_created`         | A pull request is opened.                            |
+| `forgejo.issue_comment_created`        | A comment is created on an issue.                    |
+| `forgejo.pull_request_comment_created` | A conversation comment is created on a pull request. |
+| `forgejo.issue_label_added`            | A label is added to an issue.                        |
+| `forgejo.pull_request_label_added`     | A label is added to a pull request.                  |
+
+Choose `forgejo.issue_comment_created` for a comment on an issue and
+`forgejo.pull_request_comment_created` for a conversation comment on a pull request. A semantic
+workflow and a raw-family workflow can both match the same delivery, so they start separate runs.
+
+## Filter Forgejo events
+
+Every externally sourced workflow needs a non-empty `from_users` allowlist. Forgejo filters
+compose with AND: the repository, connection, sender, content, changed label, and required current
+labels must all match.
+
+`contains` and `pattern` inspect the title plus body for issue and pull-request events. For comment
+events, they inspect the comment body. `contains` is a substring match; `pattern` matches the
+start.
+
+Use `label` with `forgejo.issue_label_added` or `forgejo.pull_request_label_added` when the added
+label itself matters. Use `labels` when the item must currently have every listed label. Both
+compare labels case-insensitively. The [configuration reference](/docs/hub/configuration/hub-yml#forgejo-events-and-filters)
+lists the field contract.
+
+## Native raw families
+
+Existing workflows can continue to use `forgejo.issues`, `forgejo.issue_comment`,
+`forgejo.pull_request`, `forgejo.pull_request_review`,
+`forgejo.pull_request_review_comment`, and `forgejo.push`. Prefer the semantic events above for
+new workflows. Forgejo's event headers, payloads, and supported reaction targets stay native to
+Forgejo; this is a capability match, not a GitHub protocol emulation.
+
+A Forgejo trigger grants no token. Authority is the `forgejo` block on the step that needs it. See
+[Forgejo access](/docs/hub/forgejo) for the repository and capability boundary.

--- a/public-docs/hub/triggers/index.md
+++ b/public-docs/hub/triggers/index.md
@@ -34,23 +34,30 @@ Field-by-field detail is in the [configuration reference](/docs/hub/configuratio
 
 ## Events
 
-| `on`                                  | Fires when                                           |
-| ------------------------------------- | ---------------------------------------------------- |
-| `github.issue_created`                | An issue is opened.                                  |
-| `github.pull_request_created`         | A pull request is opened.                            |
-| `github.issue_comment_created`        | A comment is created on an issue.                    |
-| `github.pull_request_comment_created` | A conversation comment is created on a pull request. |
-| `github.issue_label_added`            | A label is added to an issue.                        |
-| `github.pull_request_label_added`     | A label is added to a pull request.                  |
-| `slack.mention`                       | The bot is mentioned in a channel.                   |
-| `discord.mention`                     | The bot is mentioned in a guild.                     |
-| `manual.run`                          | A run started from the API.                          |
+| `on`                                   | Fires when                                           |
+| -------------------------------------- | ---------------------------------------------------- |
+| `github.issue_created`                 | An issue is opened.                                  |
+| `github.pull_request_created`          | A pull request is opened.                            |
+| `github.issue_comment_created`         | A comment is created on an issue.                    |
+| `github.pull_request_comment_created`  | A conversation comment is created on a pull request. |
+| `github.issue_label_added`             | A label is added to an issue.                        |
+| `github.pull_request_label_added`      | A label is added to a pull request.                  |
+| `forgejo.issue_created`                | An issue is opened.                                  |
+| `forgejo.pull_request_created`         | A pull request is opened.                            |
+| `forgejo.issue_comment_created`        | A comment is created on an issue.                    |
+| `forgejo.pull_request_comment_created` | A conversation comment is created on a pull request. |
+| `forgejo.issue_label_added`            | A label is added to an issue.                        |
+| `forgejo.pull_request_label_added`     | A label is added to a pull request.                  |
+| `slack.mention`                        | The bot is mentioned in a channel.                   |
+| `discord.mention`                      | The bot is mentioned in a guild.                     |
+| `manual.run`                           | A run started from the API.                          |
 
-New GitHub workflows should use a semantic event. The five legacy events remain compatible: `github.issues`, `github.issue_comment`, `github.pull_request_review`, `github.pull_request_review_comment`, and `github.push`. See [GitHub triggers](/docs/hub/triggers/github) for complete workflows and when to use each event.
+New GitHub and Forgejo workflows should use a semantic event. The GitHub legacy events remain compatible: `github.issues`, `github.issue_comment`, `github.pull_request_review`, `github.pull_request_review_comment`, and `github.push`. Forgejo also accepts its native raw families for existing workflows. See [GitHub triggers](/docs/hub/triggers/github) and [Forgejo triggers](/docs/hub/triggers/forgejo) for complete workflows and when to use each event.
 
 Each provider page documents its events and the data they expose:
 
 - [GitHub triggers](/docs/hub/triggers/github)
+- [Forgejo triggers](/docs/hub/triggers/forgejo)
 - [Slack triggers](/docs/hub/triggers/slack)
 - [Discord triggers](/docs/hub/triggers/discord)
 
@@ -62,18 +69,18 @@ The allowlist is what keeps a stranger's comment on a public issue from starting
 
 An allowlist is one layer of defense. It does not make a permitted account trustworthy after compromise or make prompt injection harmless. See [Hub security](/docs/hub/security) before choosing the daemon, working directory, provider policy, and outputs for an external trigger.
 
-| Filter       | Applies to                | Matches                                                              |
-| ------------ | ------------------------- | -------------------------------------------------------------------- |
-| `from_users` | all                       | GitHub: login. Slack and Discord: **user id**, not display name      |
-| `repo`       | GitHub                    | `owner/name`                                                         |
-| `workspace`  | Slack                     | Team id, `T01234567`                                                 |
-| `guild`      | Discord                   | Guild id                                                             |
-| `channels`   | Slack, Discord            | Channel ids                                                          |
-| `contains`   | all                       | GitHub substring; Slack and Discord invocation prefix                |
-| `pattern`    | all                       | Invocation prefix                                                    |
-| `connection` | all                       | A connection slug, when the organization has several                 |
-| `label`      | GitHub label-added events | The label added by this delivery, case-insensitively                 |
-| `labels`     | GitHub                    | Every listed current issue or pull-request label, case-insensitively |
+| Filter       | Applies to                            | Matches                                                                     |
+| ------------ | ------------------------------------- | --------------------------------------------------------------------------- |
+| `from_users` | all                                   | GitHub and Forgejo: login. Slack and Discord: **user id**, not display name |
+| `repo`       | GitHub, Forgejo                       | `owner/name`                                                                |
+| `workspace`  | Slack                                 | Team id, `T01234567`                                                        |
+| `guild`      | Discord                               | Guild id                                                                    |
+| `channels`   | Slack, Discord                        | Channel ids                                                                 |
+| `contains`   | all                                   | GitHub and Forgejo substring; Slack and Discord invocation prefix           |
+| `pattern`    | all                                   | Invocation prefix                                                           |
+| `connection` | all                                   | A connection slug, when the organization has several                        |
+| `label`      | GitHub and Forgejo label-added events | The label added by this delivery, case-insensitively                        |
+| `labels`     | GitHub, Forgejo                       | Every listed current issue or pull-request label, case-insensitively        |
 
 All conditions must pass. There is no `any` mode.
 
@@ -102,6 +109,6 @@ Put `allow_outputs` on the step that should reply. The reply capabilities are `s
 - Set `max` when a step needs more than one update.
 - Set `required: true` when the step must emit at least one reply before it can finish. A required type must be registered and available for the execution context.
 
-GitHub has no reply capability; a step with a [`github` block](/docs/hub/github) comments through `gh` instead. The [output capability reference](/docs/hub/configuration/hub-yml#output-capabilities) has the contract.
+GitHub and Forgejo have no reply capability. A step with a [`github` block](/docs/hub/github) or [`forgejo` block](/docs/hub/forgejo) acts through that provider's explicit authority instead. The [output capability reference](/docs/hub/configuration/hub-yml#output-capabilities) has the contract.
 
 The declaration grants the `hub.reply` tool; the prompt has to tell the agent to call it. See [Tell the agent which tool to call](/docs/hub/workflows#tell-the-agent-which-tool-to-call).


### PR DESCRIPTION
## Summary

- add public Forgejo access, trigger, and self-hosting guides
- document approved-instance setup, repository-limited PATs, signed webhooks, `forgejo` configuration sources, step authority, rotation, health, reactions, and cleanup recovery
- link Forgejo from the Hub overview, triggers, self-hosting, and configuration reference

## Validation

- `npm run format:check:files -- <7 changed public-docs files>`
- `npx vitest run packages/website/src/hub-doc-examples.test.ts --bail=1` (2 passed)
- `npm run lint`
- `npm run typecheck` remains blocked by the existing `packages/app/src/components/draggable-list.native.tsx:122` React Native type error after workspace declarations were rebuilt; the website workspace typecheck completed

## Scope

Documentation only. No Hub runtime behavior, credentials, deployment, or provider configuration is included.