### PR TITLE
fix(acp): keep session/load replay until updates drain

### DIFF
--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -311,10 +311,10 @@ const CATALOG_DATA = [
     id: "qoder",
     title: "Qoder CLI",
     description: "AI coding assistant with agentic capabilities",
-    version: "1.1.4",
+    version: "1.1.37",
     iconId: "qoder",
     installLink: "https://qoder.com",
-    command: ["npx", "-y", "@qoder-ai/qodercli@1.1.4", "--acp"],
+    command: ["npx", "-y", "@qoder-ai/qodercli@1.1.37", "--acp"],
   },
   {
     id: "qwen-code",

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -3579,6 +3579,7 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
           ...args.capabilities,
         },
         handle: args.handle,
+        historyReplayIdleMs: 0,
       },
     );
 
@@ -3757,6 +3758,92 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
     expect(assistantMessages[1].messageId).toBe(assistantMessages[0].messageId);
     expect(assistantMessages[2].messageId).toEqual(expect.any(String));
     expect(assistantMessages[2].messageId).not.toBe(assistantMessages[0].messageId);
+  });
+
+  test("keeps session/update replay after the session/load result", async () => {
+    let session!: ACPAgentSession;
+    const loadSession = async () => {
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "user_message_chunk",
+          messageId: "user-1",
+          content: { type: "text", text: "first prompt" },
+        } as SessionUpdate,
+      });
+      return {
+        sessionId: "session-1",
+        modes: null,
+        models: null,
+        configOptions: [],
+      };
+    };
+    ({ session } = makeTestSession({
+      capabilities: { loadSession: true },
+      handle: { sessionId: "session-1", provider: "qoder" },
+      loadSession,
+    }));
+
+    await session.initializeResumedSession();
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "assistant-1",
+        content: { type: "text", text: "first reply" },
+      } as SessionUpdate,
+    });
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        messageId: "user-2",
+        content: { type: "text", text: "follow up" },
+      } as SessionUpdate,
+    });
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "assistant-2",
+        content: { type: "text", text: "second reply" },
+      } as SessionUpdate,
+    });
+
+    const history: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      history.push(event);
+    }
+    expect(history).toEqual([
+      {
+        type: "timeline",
+        provider: session.provider,
+        item: { type: "user_message", text: "first prompt", messageId: "user-1" },
+      },
+      {
+        type: "timeline",
+        provider: session.provider,
+        item: {
+          type: "assistant_message",
+          text: "first reply",
+          messageId: "assistant-1",
+        },
+      },
+      {
+        type: "timeline",
+        provider: session.provider,
+        item: { type: "user_message", text: "follow up", messageId: "user-2" },
+      },
+      {
+        type: "timeline",
+        provider: session.provider,
+        item: {
+          type: "assistant_message",
+          text: "second reply",
+          messageId: "assistant-2",
+        },
+      },
+    ]);
   });
 
   test("loadSession is always called with mcpServers even when supportsMcpServers is false", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -127,6 +127,14 @@ import {
 import { withTimeout } from "../../../utils/promise-timeout.js";
 
 const ACP_AUTO_ACCEPT_FEATURE_ID = "auto_accept";
+const ACP_HISTORY_REPLAY_IDLE_MS = 50;
+const ACP_HISTORY_REPLAY_MAX_MS = 15_000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 
 function assertChildWithPipes(
   child: ChildProcess,
@@ -471,6 +479,7 @@ interface ACPAgentSessionOptions {
   launchEnv?: Record<string, string>;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
+  historyReplayIdleMs?: number;
   terminateProcess?: ProcessTerminator;
 }
 
@@ -1458,6 +1467,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private closed = false;
   private historyPending = false;
   private replayingHistory = false;
+  private historyReplaySettled = false;
+  private lastHistoryReplayAt = 0;
+  private readonly historyReplayIdleMs: number;
   private bootstrapThreadEventPending = false;
   private readonly terminateProcess: ProcessTerminator;
 
@@ -1491,6 +1503,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.currentTitle = config.title ?? null;
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
+    this.historyReplayIdleMs = options.historyReplayIdleMs ?? ACP_HISTORY_REPLAY_IDLE_MS;
     this.extensionCommandsParser = options.extensionCommandsParser;
   }
 
@@ -1543,7 +1556,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
       const sessionCapabilities = this.agentCapabilities?.sessionCapabilities;
       if (this.agentCapabilities?.loadSession) {
-        this.replayingHistory = true;
+        this.beginHistoryReplay();
         const response = await this.runACPRequest(() =>
           this.connection!.loadSession({
             sessionId: handle.sessionId,
@@ -1551,9 +1564,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
             mcpServers: this.acpMcpServers(),
           }),
         );
-        this.deliverTranslatedEvents(this.flushPendingUserMessage());
-        this.replayingHistory = false;
-        this.historyPending = this.persistedHistory.length > 0;
         this.applySessionState(response);
       } else if (sessionCapabilities?.resume) {
         const response = await this.runACPRequest(() =>
@@ -1607,6 +1617,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     prompt: AgentPromptInput,
     options?: AgentRunOptions,
   ): Promise<{ turnId: string }> {
+    await this.settleHistoryReplay();
     if (this.closed) {
       throw new Error(`${this.provider} session is closed`);
     }
@@ -1667,6 +1678,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+    await this.settleHistoryReplay();
     if (!this.historyPending || this.persistedHistory.length === 0) {
       return;
     }
@@ -1676,6 +1688,41 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     for (const item of history) {
       yield { type: "timeline", provider: this.provider, item };
     }
+  }
+
+  private beginHistoryReplay(): void {
+    this.replayingHistory = true;
+    this.historyReplaySettled = false;
+    this.lastHistoryReplayAt = Date.now();
+  }
+
+  private finishHistoryReplay(): void {
+    if (this.historyReplaySettled) {
+      return;
+    }
+    this.deliverTranslatedEvents(this.flushPendingUserMessage());
+    this.replayingHistory = false;
+    this.historyPending = this.persistedHistory.length > 0;
+    this.historyReplaySettled = true;
+  }
+
+  private async settleHistoryReplay(): Promise<void> {
+    if (!this.replayingHistory || this.historyReplaySettled) {
+      return;
+    }
+    const idleMs = this.historyReplayIdleMs;
+    if (idleMs > 0) {
+      const deadline = Date.now() + ACP_HISTORY_REPLAY_MAX_MS;
+      for (;;) {
+        const remainingIdle = idleMs - (Date.now() - this.lastHistoryReplayAt);
+        const remainingMax = deadline - Date.now();
+        if (remainingIdle <= 0 || remainingMax <= 0) {
+          break;
+        }
+        await delay(Math.min(remainingIdle, remainingMax));
+      }
+    }
+    this.finishHistoryReplay();
   }
 
   async getRuntimeInfo(): Promise<AgentRuntimeInfo> {
@@ -2300,6 +2347,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       "provider.acp.parsed_event",
     );
     this.deliverTranslatedEvents(events);
+    if (this.replayingHistory) {
+      this.lastHistoryReplayAt = Date.now();
+    }
   }
 
   private deliverTranslatedEvents(events: AgentStreamEvent[]): void {


### PR DESCRIPTION
### Linked issue

Closes #4108

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Reopening a Qoder agent after a daemon restart showed an empty or first-turn-only timeline even though Qoder still had the full transcript on disk.

Two things stacked:

1. The in-app catalog still pins `npx -y @qoder-ai/qodercli@1.1.4 --acp`. 1.1.4's ACP resume does not replay history. 1.1.37 does (`loadSession: true`, 58 `session/update`s for a real 8-turn session).
2. Even on 1.1.37, Paseo stopped collecting replay as soon as the `session/load` JSON-RPC **result** arrived. On a real session that result came after the first `user_message_chunk`, with the remaining turns after it. Those later updates were treated as live events and never entered `persistedHistory`, so `paseo agent reload` returned `TIMELINE 3`.

This keeps `replayingHistory` on until `streamHistory` / `startTurn`, waits a short idle so buffered stdio can flush, then hydrates. The catalog pin moves to 1.1.37 so a fresh Qoder install actually emits that replay.

### Goals

- ACP `session/load` replay includes `session/update`s that arrive after the JSON-RPC result
- A regression test covers that arrival order
- Qoder catalog command uses `@qoder-ai/qodercli@1.1.37`

### Non-goals

- Changing how Claude/Codex read jsonl
- Import-session UI
- Backporting to 0.6.1
- Making the idle window configurable in user config

### QA

**Unit**

```
npm run test:unit --workspace=@getpaseo/server -- src/server/agent/providers/acp-agent.test.ts
```

98 passed, including `keeps session/update replay after the session/load result`.

**Before (Desktop 0.6.1, catalog 1.1.4, real session `3bfea925-…`)**

- Daemon: `Agent resumed from persistence`, then 1 outbound stream event for that agent
- Qoder ACP log: `entrypoint: acp`, `version: unknown`, no `SessionStart:resume`
- Transcript file still ~379KB

**1.1.37 ACP `session/load` probe (stdio)**

- 58 `session/update`s: 8 user, 14 assistant, 15 thought, 20 tool_call
- JSON-RPC result arrived after the first user chunk; remaining history after the result

**After pointing 0.6.1 at local 1.1.37 and `paseo agent reload` (without this drain fix)**

```
STATUS    TIMELINE
reloaded  3
```

`paseo agent logs --filter text` only showed the first user prompt + first thought.

This PR cannot be live-verified against Desktop 0.6.1 (that build does not include it). Coverage is the unit test plus the captured 1.1.37 load stream from #4108.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             |        | n/a (daemon) |
| Android         |        | n/a |
| Web             |        | n/a |
| Desktop macOS   | x      | repro + 1.1.37 ACP probe on 0.6.1; fix covered by unit test |
| Desktop Windows |        | not tested |
| Desktop Linux   |        | not tested |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes (pre-commit)
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense