### PR TITLE
Increase mobile content text to 16px

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -30,7 +30,7 @@ Before adding a new component, read `components/ui/`. The primitive usually exis
 
 Hierarchy is conveyed through weight and color, not size. Most interface text is `fontSize.base`; compact metadata and hints use `fontSize.sm`. The distinction between a row's primary line and its secondary line is `foreground` versus `foregroundMuted`.
 
-The authored interface ramp uses a 14px base. New native installs default to 15px; web and desktop default to 14px. The Appearance **Interface size** setting is the rendered `fontSize.base` value and scales the rest of the UI ramp proportionally. Primary readable content has its own `fontSize.content`, which defaults to 15px on every platform. It owns message bodies, composer input, Markdown, and PR prose. Controls, navigation, metadata, tool chrome, code, diffs, editors, and terminals stay on their interface or code tokens. **Code size** remains independent.
+The authored interface ramp uses a 14px base. New native installs default to 15px; web and desktop default to 14px. The Appearance **Interface size** setting is the rendered `fontSize.base` value and scales the rest of the UI ramp proportionally. Primary readable content has its own `fontSize.content`, which defaults to 16px on native and 15px on web and desktop. It owns message bodies, composer input, Markdown, and PR prose. Controls, navigation, metadata, tool chrome, code, diffs, editors, and terminals stay on their interface or code tokens. **Code size** remains independent.
 
 Weight has three tiers, applied by role:
 

--- a/packages/app/src/hooks/use-settings/migrations.test.ts
+++ b/packages/app/src/hooks/use-settings/migrations.test.ts
@@ -20,6 +20,11 @@ function storedSendBehavior(storage: Storage): SendBehavior | undefined {
   return raw === undefined ? undefined : JSON.parse(raw).sendBehavior;
 }
 
+function storedContentFontSize(storage: Storage): number | undefined {
+  const raw = storage.entries.get(APP_SETTINGS_KEY);
+  return raw === undefined ? undefined : JSON.parse(raw).contentFontSize;
+}
+
 /** An in-memory storage whose write to `failingKey` always throws, as a full disk would. */
 function createFailingWriteStorage(failingKey: string): Storage {
   const storage = createInMemoryKeyValueStorage();
@@ -79,6 +84,47 @@ describe("migrateAppSettings", () => {
     await migrateAppSettings(settingsWith("interrupt"), storage);
 
     expect(appliedIds(storage)).toEqual(["some-later-migration", "steer-default"]);
+  });
+
+  it("migrates every mobile 15px content preference to 16px", async () => {
+    const storage = createInMemoryKeyValueStorage();
+    const settings = { ...settingsWith("steer"), contentFontSize: 15 };
+
+    const result = await migrateAppSettings(settings, storage, undefined, { native: true });
+
+    expect(result.contentFontSize).toBe(16);
+    expect(storedContentFontSize(storage)).toBe(16);
+    expect(appliedIds(storage)).toEqual(["steer-default", "mobile-content-16"]);
+  });
+
+  it("leaves a 15px web content preference unchanged", async () => {
+    const storage = createInMemoryKeyValueStorage();
+    const settings = { ...settingsWith("steer"), contentFontSize: 15 };
+
+    const result = await migrateAppSettings(settings, storage, undefined, { native: false });
+
+    expect(result.contentFontSize).toBe(15);
+    expect(storedContentFontSize(storage)).toBeUndefined();
+    expect(appliedIds(storage)).toEqual(["steer-default"]);
+  });
+
+  it("lets a mobile user choose 15px after the default migration ran", async () => {
+    const storage = createInMemoryKeyValueStorage();
+    await migrateAppSettings(
+      { ...settingsWith("steer"), contentFontSize: 15 },
+      storage,
+      undefined,
+      { native: true },
+    );
+
+    const result = await migrateAppSettings(
+      { ...settingsWith("steer"), contentFontSize: 15 },
+      storage,
+      undefined,
+      { native: true },
+    );
+
+    expect(result.contentFontSize).toBe(15);
   });
 
   it("stays unmarked when the settings write fails, so a later launch retries", async () => {

--- a/packages/app/src/hooks/use-settings/migrations.ts
+++ b/packages/app/src/hooks/use-settings/migrations.ts
@@ -13,6 +13,9 @@ const AppliedMigrationsSchema = z.strictObject({ applied: z.array(z.string()) })
  */
 const STEER_DEFAULT_MIGRATION = "steer-default";
 
+/** Existing mobile installs materialized the old 15px content default in storage. */
+const MOBILE_CONTENT_16_MIGRATION = "mobile-content-16";
+
 /**
  * Brings stored settings up to date, returning what the caller should use. Owns both writes so
  * the marker can only ever be written after the settings it describes: a failed marker write
@@ -23,6 +26,7 @@ export async function migrateAppSettings(
   settings: AppSettings,
   storage: KeyValueStorage,
   stored?: PersistedAppSettings,
+  options: { native?: boolean } = {},
 ): Promise<AppSettings> {
   const migrationMarker = await readValidatedJson(
     storage,
@@ -30,12 +34,26 @@ export async function migrateAppSettings(
     AppliedMigrationsSchema,
   );
   const applied = new Set(migrationMarker?.applied ?? []);
-  if (applied.has(STEER_DEFAULT_MIGRATION)) {
+  let addedMigration = false;
+
+  let migrated = settings;
+  if (!applied.has(STEER_DEFAULT_MIGRATION)) {
+    migrated =
+      migrated.sendBehavior === "interrupt" ? { ...migrated, sendBehavior: "steer" } : migrated;
+    applied.add(STEER_DEFAULT_MIGRATION);
+    addedMigration = true;
+  }
+
+  if (options.native && !applied.has(MOBILE_CONTENT_16_MIGRATION)) {
+    migrated = migrated.contentFontSize === 15 ? { ...migrated, contentFontSize: 16 } : migrated;
+    applied.add(MOBILE_CONTENT_16_MIGRATION);
+    addedMigration = true;
+  }
+
+  if (!addedMigration) {
     return settings;
   }
 
-  const migrated: AppSettings =
-    settings.sendBehavior === "interrupt" ? { ...settings, sendBehavior: "steer" } : settings;
   if (migrated !== settings) {
     const storedSidebarRowItems = stored?.sidebarRowItems ?? {};
     await storage.setItem(
@@ -48,7 +66,6 @@ export async function migrateAppSettings(
     );
   }
 
-  applied.add(STEER_DEFAULT_MIGRATION);
   await storage.setItem(SETTINGS_MIGRATIONS_KEY, JSON.stringify({ applied: [...applied] }));
   return migrated;
 }

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -659,8 +659,8 @@ describe("appearance settings", () => {
     expect(defaultUiBaseFontSize(false)).toBe(14);
   });
 
-  it("uses a 15px content default on mobile and web", () => {
-    expect(defaultContentFontSize(true)).toBe(15);
+  it("uses a 16px content default on mobile and a 15px default on web", () => {
+    expect(defaultContentFontSize(true)).toBe(16);
     expect(defaultContentFontSize(false)).toBe(15);
     expect(DEFAULT_CONTENT_FONT_SIZE).toBe(defaultContentFontSize(false));
   });

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -52,7 +52,7 @@ export const DEFAULT_UI_BASE_FONT_SIZE = defaultUiBaseFontSize(isNative);
 export const MIN_UI_BASE_FONT_SIZE = 10;
 export const MAX_UI_BASE_FONT_SIZE = 21;
 export function defaultContentFontSize(native: boolean): number {
-  return native ? 15 : FONT_SIZE.content;
+  return native ? 16 : FONT_SIZE.content;
 }
 
 export const DEFAULT_CONTENT_FONT_SIZE = defaultContentFontSize(isNative);
@@ -75,7 +75,7 @@ export interface AppSettings {
   uiFontFamily: string; // "" = platform default UI stack
   monoFontFamily: string; // "" = platform default mono stack
   uiBaseFontSize: number; // clamped px, platform default 14 or 15
-  contentFontSize: number; // clamped px, default 15
+  contentFontSize: number; // clamped px, platform default 15 or 16
   codeFontSize: number; // clamped px, default 12
   syntaxTheme: SyntaxThemeId; // default "one"
   workspaceTitleSource: WorkspaceTitleSource;
@@ -343,7 +343,7 @@ export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<Ap
       await writeAppSettings(deps.storage, read.stored, read.settings);
     }
     const { needsWrite: _needsWrite, ...stored } = read.stored;
-    return await migrateAppSettings(read.settings, deps.storage, stored);
+    return await migrateAppSettings(read.settings, deps.storage, stored, { native: isNative });
   } catch (error) {
     console.error("[AppSettings] Failed to load settings:", error);
     throw error;


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Docs

### Reasoning

Mobile interface chrome remains compact at 15px, while primary readable content now defaults to 16px. Existing mobile installs materialized the old 15px content default, so a one-time migration updates those values without preventing users from deliberately selecting 15px afterward. Web and desktop retain their 15px content default.

### Goals

- Default mobile interface text to 15px and readable content to 16px.
- Migrate every existing mobile content preference at 15px to 16px exactly once.
- Preserve an explicit 15px choice made after migration.
- Leave web and desktop defaults unchanged.

### Non-goals

- Change code, diff, editor, or terminal typography.
- Change web or desktop content defaults.
- Remove 15px as a valid user-selected mobile content size.

### QA

Android API 35 emulator (`paseo-composer-growth-api35`) using the installed `sh.paseo.debug` dev client and a fresh Metro bundle from this branch:

1. Seeded real React Native AsyncStorage with `uiBaseFontSize: 15`, `contentFontSize: 15`, and only the prior `steer-default` migration marker. Relaunched the app. Appearance showed **Interface size 15px** and **Content size 16px**; SQLite persisted `15|16` and `{"applied":["steer-default","mobile-content-16"]}`.
2. Relaunched again and confirmed the migrated `15|16` values persisted.
3. Changed Content size back to 15px after migration, submitted it, and relaunched. SQLite remained `15|15` with the new marker present, proving the migration does not override a later user choice.
4. Cleared only the debug app data and launched from a true fresh state. SQLite initialized to `15|16` with both migration markers. Restored the emulator AsyncStorage backup afterward and closed all device sessions.

Automated verification:

```text
npx vitest run packages/app/src/hooks/use-settings/storage.test.ts packages/app/src/hooks/use-settings/migrations.test.ts packages/app/src/styles/theme.test.ts packages/app/src/appearance/apply.test.ts --bail=1
Test Files  4 passed (4)
Tests  104 passed (104)

npm run typecheck
passed

npm run lint
Found 0 warnings and 0 errors.

npm run format
Finished successfully; only the five intended files changed.
```

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense