### PR TITLE
feat(cli): expose full requestId and structured permission metadata in permit ls --json

### DIFF
--- a/packages/cli/src/commands/permit/ls.test.ts
+++ b/packages/cli/src/commands/permit/ls.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { AgentPermissionRequest } from "@getpaseo/protocol/agent-types";
+import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
+import { render } from "../../output/index.js";
+import { permitLsSchema, toListItem, type PermissionListItem } from "./ls.js";
+
+describe("permit ls", () => {
+  const agent = { id: "agent-12345678-uuid" } as unknown as AgentSnapshotPayload;
+
+  const fullPermission: AgentPermissionRequest = {
+    id: "permission-1234-uuid",
+    provider: "codex",
+    name: "shell",
+    kind: "tool",
+    title: "Run shell command?",
+    description: "echo hello",
+    input: { command: "echo hello" },
+    metadata: { workspace: "foo" },
+  };
+
+  const minimalPermission: AgentPermissionRequest = {
+    id: "permission-minimal-uuid",
+    provider: "codex",
+    name: "shell",
+    kind: "tool",
+  };
+
+  describe("toListItem", () => {
+    it("keeps legacy fields for backward compatibility", () => {
+      const item = toListItem(agent, fullPermission);
+
+      expect(item.id).toBe(fullPermission.id.slice(0, 8));
+      expect(item.agentId).toBe(agent.id);
+      expect(item.agentShortId).toBe(agent.id.slice(0, 7));
+      expect(item.name).toBe(fullPermission.name);
+      expect(item.description).toBe(fullPermission.description);
+    });
+
+    it("exposes full requestId, kind, title, input, and metadata", () => {
+      const item = toListItem(agent, fullPermission);
+
+      expect(item.requestId).toBe(fullPermission.id);
+      expect(item.kind).toBe("tool");
+      expect(item.title).toBe("Run shell command?");
+      expect(item.input).toEqual({ command: "echo hello" });
+      expect(item.metadata).toEqual({ workspace: "foo" });
+    });
+
+    it("preserves the permission kind, including question", () => {
+      const question: AgentPermissionRequest = {
+        ...minimalPermission,
+        id: "permission-question-uuid",
+        kind: "question",
+        title: "Continue?",
+        input: { options: ["yes", "no"] },
+      };
+      const item = toListItem(agent, question);
+
+      expect(item.requestId).toBe(question.id);
+      expect(item.id).toBe(question.id.slice(0, 8));
+      expect(item.kind).toBe("question");
+      expect(item.title).toBe("Continue?");
+      expect(item.input).toEqual({ options: ["yes", "no"] });
+    });
+
+    it("falls back missing optional fields to null or '-'", () => {
+      const item = toListItem(agent, minimalPermission);
+
+      expect(item.title).toBeNull();
+      expect(item.input).toBeNull();
+      expect(item.metadata).toBeNull();
+      expect(item.description).toBe("-");
+    });
+  });
+
+  describe("permitLsSchema", () => {
+    it("keeps table columns unchanged", () => {
+      expect(permitLsSchema.idField).toBe("id");
+      const fields: string[] = [];
+      for (const column of permitLsSchema.columns) {
+        fields.push(String(column.field));
+      }
+      expect(fields).toEqual(["agentShortId", "id", "name", "description"]);
+    });
+
+    it("renders JSON with full requestId, kind, title, input, metadata and legacy fields", () => {
+      const result = {
+        type: "list" as const,
+        data: [toListItem(agent, fullPermission)],
+        schema: permitLsSchema,
+      };
+
+      const json = JSON.parse(render(result, { format: "json" }));
+
+      expect(Array.isArray(json)).toBe(true);
+      expect(json).toHaveLength(1);
+
+      const [row] = json as [PermissionListItem];
+      expect(row.id).toBe(fullPermission.id.slice(0, 8));
+      expect(row.requestId).toBe(fullPermission.id);
+      expect(row.agentId).toBe(agent.id);
+      expect(row.agentShortId).toBe(agent.id.slice(0, 7));
+      expect(row.name).toBe(fullPermission.name);
+      expect(row.description).toBe(fullPermission.description);
+      expect(row.kind).toBe("tool");
+      expect(row.title).toBe("Run shell command?");
+      expect(row.input).toEqual({ command: "echo hello" });
+      expect(row.metadata).toEqual({ workspace: "foo" });
+    });
+
+    it("renders missing optional fields as null in JSON", () => {
+      const result = {
+        type: "list" as const,
+        data: [toListItem(agent, minimalPermission)],
+        schema: permitLsSchema,
+      };
+
+      const json = JSON.parse(render(result, { format: "json" }));
+      const [row] = json as [PermissionListItem];
+
+      expect(row.title).toBeNull();
+      expect(row.input).toBeNull();
+      expect(row.metadata).toBeNull();
+      expect(row.description).toBe("-");
+    });
+
+    it("uses the short id for quiet mode", () => {
+      const result = {
+        type: "list" as const,
+        data: [toListItem(agent, fullPermission)],
+        schema: permitLsSchema,
+      };
+
+      const quiet = render(result, { format: "json", quiet: true });
+      expect(quiet.trim()).toBe(fullPermission.id.slice(0, 8));
+    });
+  });
+});

--- a/packages/cli/src/commands/permit/ls.ts
+++ b/packages/cli/src/commands/permit/ls.ts
@@ -1,16 +1,25 @@
 import type { Command } from "commander";
-import type { AgentPermissionRequest } from "@getpaseo/protocol/agent-types";
+import type {
+  AgentMetadata,
+  AgentPermissionRequest,
+  AgentPermissionRequestKind,
+} from "@getpaseo/protocol/agent-types";
 import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
 import type { CommandOptions, ListResult, OutputSchema, CommandError } from "../../output/index.js";
 
-/** Permission list item for display */
+/** Permission list item for display and JSON output */
 export interface PermissionListItem {
   id: string;
+  requestId: string;
   agentId: string;
   agentShortId: string;
   name: string;
   description: string;
+  kind: AgentPermissionRequestKind;
+  title: string | null;
+  input: AgentMetadata | null;
+  metadata: AgentMetadata | null;
 }
 
 /** Schema for permit ls output */
@@ -25,16 +34,21 @@ export const permitLsSchema: OutputSchema<PermissionListItem> = {
 };
 
 /** Transform agent snapshot + permission to list item */
-function toListItem(
+export function toListItem(
   agent: AgentSnapshotPayload,
   permission: AgentPermissionRequest,
 ): PermissionListItem {
   return {
     id: permission.id.slice(0, 8),
+    requestId: permission.id,
     agentId: agent.id,
     agentShortId: agent.id.slice(0, 7),
     name: permission.name,
     description: permission.description ?? "-",
+    kind: permission.kind,
+    title: permission.title ?? null,
+    input: permission.input ?? null,
+    metadata: permission.metadata ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary

Extends `paseo permit ls --json` with structured pending permission/question data for CLI consumers. The full, non-truncated `requestId` is now available alongside `kind`, `title`, `input`, and `metadata`. Legacy fields (`id`, `agentId`, `agentShortId`, `name`, `description`) are preserved, and the human table output and `--quiet` behavior remain unchanged.

## Test plan

- [x] `npm run typecheck --workspace=@getpaseo/cli`
- [x] `npm run lint -- packages/cli/src`
- [x] `npm run build --workspace=@getpaseo/cli`
- [x] `npx vitest run src/commands/permit/ls.test.ts --bail=1`
- [x] `npx vitest run src` (274 CLI unit tests passed)
- [x] `npx tsx tests/12-permit-ls.test.ts`

Generated with [Devin](https://devin.ai)