### PR TITLE
Fix Codex rewind on paginated threads

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -104,6 +104,10 @@ interface CollaborationModeRecord {
 }
 
 interface CodexSessionTestAccess {
+  codexUserMessageTurns(): {
+    resolve(messageId: string): { index: number; turnId: string | null } | null;
+    count(): number;
+  };
   ensureThreadLoaded(): Promise<void>;
   handleToolApprovalRequest(params: unknown): Promise<unknown>;
   handleNotification(method: string, params: unknown): void;
@@ -499,13 +503,14 @@ function markdownImageSource(markdown: string): string {
 
 function emitCodexUserMessage(
   appServer: FakeCodexAppServer,
-  input: { id: string; text: string; threadId?: string },
+  input: { id: string; text: string; threadId?: string; turnId?: string },
 ): void {
   appServer.child.stdout.write(
     `${JSON.stringify({
       method: "item/started",
       params: {
         threadId: input.threadId ?? "thread-1",
+        ...(input.turnId ? { turnId: input.turnId } : {}),
         item: {
           type: "userMessage",
           id: input.id,
@@ -1662,6 +1667,62 @@ describe("Codex app-server provider", () => {
     await session.revertConversation({ messageId: "codex-first" });
 
     expect(appServer.recordedRollbacks).toEqual([{ threadId: "forked-thread", numTurns: 2 }]);
+    await expect(session.getRuntimeInfo()).resolves.toMatchObject({
+      sessionId: "forked-thread",
+    });
+    appServer.assertNoErrors();
+    await session.close();
+  });
+
+  test("rewinds a paginated conversation through the public session capability", async () => {
+    const appServer = createFakeCodexAppServer({
+      "thread/read": () => ({
+        thread: { id: "thread-1", historyMode: "paginated", turns: [] },
+      }),
+      "thread/rollback": () => {
+        throw new Error("paginated threads do not support thread/rollback");
+      },
+    });
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    await session.startTurn("remember first");
+    emitCodexUserMessage(appServer, {
+      id: "codex-first",
+      text: "remember first",
+      turnId: "turn-first",
+    });
+    appServer.completeTurn();
+    await session.startTurn("remember second");
+    emitCodexUserMessage(appServer, {
+      id: "codex-second",
+      text: "remember second",
+      turnId: "turn-second",
+    });
+    appServer.completeTurn();
+
+    await session.revertConversation({ messageId: "codex-first" });
+
+    const forkRequests = appServer
+      .requests()
+      .filter((request) => request.method === "thread/fork")
+      .map((request) => request.params);
+    expect(forkRequests).toEqual([
+      {
+        threadId: "thread-1",
+        beforeTurnId: "turn-first",
+        cwd: "/workspace/project",
+        model: "gpt-5.4",
+        serviceTier: null,
+        excludeTurns: false,
+        persistExtendedHistory: true,
+      },
+    ]);
+    expect(appServer.recordedRollbacks).toEqual([]);
     await expect(session.getRuntimeInfo()).resolves.toMatchObject({
       sessionId: "forked-thread",
     });
@@ -3815,6 +3876,35 @@ describe("Codex app-server provider", () => {
         },
       },
     ]);
+  });
+
+  test("retains native turn ids from persisted user messages", async () => {
+    const session = createSession();
+    session.client = {
+      request: vi.fn(async () => ({
+        thread: {
+          turns: [
+            {
+              id: "native-turn-1",
+              items: [
+                {
+                  type: "userMessage",
+                  id: "message-history",
+                  content: [{ type: "text", text: "History prompt" }],
+                },
+              ],
+            },
+          ],
+        },
+      })),
+    };
+
+    await asInternals(session).loadPersistedHistory();
+
+    expect(asInternals(session).codexUserMessageTurns().resolve("message-history")).toEqual({
+      index: 0,
+      turnId: "native-turn-1",
+    });
   });
 
   test("loads mixed legacy and MultiAgentV2 sub-agent history", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -429,6 +429,7 @@ interface CodexConfiguredDefaults {
 interface PersistedTimelineEntry {
   item: AgentTimelineItem;
   timestamp?: string;
+  providerTurnId?: string;
 }
 
 interface PersistedSubAgentRoute {
@@ -1990,6 +1991,9 @@ async function loadCodexThreadHistoryTimeline(params: {
         timeline.push({
           item: settledTimelineItem,
           timestamp: timestamp ?? undefined,
+          ...(timelineItem.type === "user_message" && typeof turn.id === "string"
+            ? { providerTurnId: turn.id }
+            : {}),
         });
         for (const childThreadId of readCodexHistoricalSubAgentThreadIds(item)) {
           subAgentTimelineIndexByThreadId.set(childThreadId, timeline.length - 1);
@@ -2162,6 +2166,7 @@ const ItemTextDeltaNotificationSchema = z
 const ItemLifecycleNotificationSchema = z
   .object({
     threadId: z.string().optional(),
+    turnId: z.string().optional(),
     item: z
       .object({
         id: z.string().optional(),
@@ -2183,12 +2188,25 @@ const CodexEventThreadIdFields = {
   thread_id: z.string().optional(),
 };
 
+const CodexEventTurnIdFields = {
+  turnId: z.string().optional(),
+  turn_id: z.string().optional(),
+};
+
 function getCodexEventThreadId(params: {
   threadId?: string;
   thread_id?: string;
   msg: { threadId?: string; thread_id?: string };
 }): string | null {
   return params.threadId ?? params.thread_id ?? params.msg.threadId ?? params.msg.thread_id ?? null;
+}
+
+function getCodexEventTurnId(params: {
+  turnId?: string;
+  turn_id?: string;
+  msg: { turnId?: string; turn_id?: string };
+}): string | null {
+  return params.turnId ?? params.turn_id ?? params.msg.turnId ?? params.msg.turn_id ?? null;
 }
 
 const CodexEventTurnAbortedNotificationSchema = z
@@ -2219,9 +2237,11 @@ const CodexEventTaskCompleteNotificationSchema = z
 const CodexEventItemLifecycleNotificationSchema = z
   .object({
     ...CodexEventThreadIdFields,
+    ...CodexEventTurnIdFields,
     msg: z
       .object({
         ...CodexEventThreadIdFields,
+        ...CodexEventTurnIdFields,
         type: z.enum(["item_started", "item_completed"]),
         item: z
           .object({
@@ -2402,12 +2422,14 @@ type ParsedCodexNotification =
       kind: "item_completed";
       source: "item" | "codex_event";
       threadId: string | null;
+      turnId: string | null;
       item: { id?: string; type?: string; [key: string]: unknown };
     }
   | {
       kind: "item_started";
       source: "item" | "codex_event";
       threadId: string | null;
+      turnId: string | null;
       item: { id?: string; type?: string; [key: string]: unknown };
     }
   | {
@@ -2664,6 +2686,7 @@ const CodexNotificationSchema = z.union([
         kind: "item_completed",
         source: "item",
         threadId: params.threadId ?? null,
+        turnId: params.turnId ?? null,
         item: params.item,
       }),
     ),
@@ -2681,6 +2704,7 @@ const CodexNotificationSchema = z.union([
         kind: "item_started",
         source: "item",
         threadId: params.threadId ?? null,
+        turnId: params.turnId ?? null,
         item: params.item,
       }),
     ),
@@ -2701,6 +2725,7 @@ const CodexNotificationSchema = z.union([
         kind: "item_started",
         source: "codex_event",
         threadId: getCodexEventThreadId(params),
+        turnId: getCodexEventTurnId(params),
         item: params.msg.item,
       }),
     ),
@@ -2721,6 +2746,7 @@ const CodexNotificationSchema = z.union([
         kind: "item_completed",
         source: "codex_event",
         threadId: getCodexEventThreadId(params),
+        turnId: getCodexEventTurnId(params),
         item: params.msg.item,
       }),
     ),
@@ -3317,6 +3343,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   private latestPlanResult: { callId: string; text: string; turnId: string | null } | null = null;
   private readonly userMessageTurnIndexes = new Map<string, number>();
   private readonly userMessageTurnIds: string[] = [];
+  private readonly userMessageProviderTurnIds = new Map<string, string>();
   private pendingManualCompactionStarts = 0;
   private compactionTriggerByItemId = new Map<string, "auto" | "manual">();
   private pendingRootCompactionItemIds = new Set<string>();
@@ -3761,7 +3788,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.resetCodexUserMessageTurns();
     for (const entry of timeline) {
       if (entry.item.type === "user_message") {
-        this.rememberCodexUserMessageTurn(entry.item.messageId);
+        this.rememberCodexUserMessageTurn(entry.item.messageId, entry.providerTurnId);
       }
     }
     this.persistedHistory = timeline;
@@ -4250,28 +4277,42 @@ export class CodexAppServerAgentSession implements AgentSession {
     );
   }
 
-  private rememberCodexUserMessageTurn(messageId: string | null | undefined): boolean {
+  private rememberCodexUserMessageTurn(
+    messageId: string | null | undefined,
+    providerTurnId?: string | null,
+  ): boolean {
     if (typeof messageId !== "string" || messageId.length === 0) {
       return false;
     }
     if (this.userMessageTurnIndexes.has(messageId)) {
+      if (providerTurnId) {
+        this.userMessageProviderTurnIds.set(messageId, providerTurnId);
+      }
       return false;
     }
     this.userMessageTurnIndexes.set(messageId, this.userMessageTurnIds.length);
     this.userMessageTurnIds.push(messageId);
+    if (providerTurnId) {
+      this.userMessageProviderTurnIds.set(messageId, providerTurnId);
+    }
     return true;
   }
 
   private resetCodexUserMessageTurns(): void {
     this.userMessageTurnIndexes.clear();
     this.userMessageTurnIds.length = 0;
+    this.userMessageProviderTurnIds.clear();
   }
 
   private truncateCodexUserMessageTurns(numTurns: number): void {
     if (numTurns <= 0) {
       return;
     }
-    this.userMessageTurnIds.length = Math.max(0, this.userMessageTurnIds.length - numTurns);
+    const retainedCount = Math.max(0, this.userMessageTurnIds.length - numTurns);
+    const removedMessageIds = this.userMessageTurnIds.splice(retainedCount);
+    for (const messageId of removedMessageIds) {
+      this.userMessageProviderTurnIds.delete(messageId);
+    }
     this.userMessageTurnIndexes.clear();
     this.userMessageTurnIds.forEach((messageId, index) => {
       this.userMessageTurnIndexes.set(messageId, index);
@@ -4280,7 +4321,12 @@ export class CodexAppServerAgentSession implements AgentSession {
 
   private codexUserMessageTurns(): CodexUserMessageTurnIndex {
     return {
-      resolve: (messageId) => this.userMessageTurnIndexes.get(messageId) ?? null,
+      resolve: (messageId) => {
+        const index = this.userMessageTurnIndexes.get(messageId);
+        return index === undefined
+          ? null
+          : { index, turnId: this.userMessageProviderTurnIds.get(messageId) ?? null };
+      },
       count: () => this.userMessageTurnIds.length,
     };
   }
@@ -6442,7 +6488,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       this.emitSubAgentActivityUpdate(childSubAgentCallId, "running");
       return;
     }
-    if (!this.rememberCodexUserMessageTurn(timelineItem.messageId)) {
+    if (!this.rememberCodexUserMessageTurn(timelineItem.messageId, parsed.turnId)) {
       return;
     }
     const clientMessageId = timelineItem.clientMessageId ?? this.activeClientMessageId;

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.ts
@@ -50,6 +50,7 @@ type UnexpectedTerminationHandler = (error: Error) => void;
 
 export interface CodexThreadForkParams {
   threadId: string;
+  beforeTurnId?: string | null;
   path?: string | null;
   model?: string | null;
   modelProvider?: string | null;

--- a/packages/server/src/server/agent/providers/codex/rewind.test.ts
+++ b/packages/server/src/server/agent/providers/codex/rewind.test.ts
@@ -51,16 +51,25 @@ class FakeCodex implements CodexRewindClient {
     };
   }
 
-  request(): Promise<unknown> {
-    throw new Error("FakeCodex uses typed thread methods");
+  request(method: string): Promise<unknown> {
+    if (method === "thread/read") {
+      return Promise.resolve({ thread: { id: "source-thread", historyMode: "legacy" } });
+    }
+    throw new Error(`Unexpected request: ${method}`);
   }
 }
 
 class CodexMessageTurns implements CodexUserMessageTurnIndex {
-  constructor(private readonly indexesByMessageId: Map<string, number>) {}
+  constructor(
+    private readonly indexesByMessageId: Map<string, number>,
+    private readonly turnIdsByMessageId: Map<string, string> = new Map(),
+  ) {}
 
-  resolve(messageId: string): number | null {
-    return this.indexesByMessageId.get(messageId) ?? null;
+  resolve(messageId: string): { index: number; turnId: string | null } | null {
+    const index = this.indexesByMessageId.get(messageId);
+    return index === undefined
+      ? null
+      : { index, turnId: this.turnIdsByMessageId.get(messageId) ?? null };
   }
 
   count(): number {
@@ -129,6 +138,95 @@ describe("Codex Rewind", () => {
 
     expect(codex.recordedRollbacks).toEqual([{ threadId: "forked-thread", numTurns: 2 }]);
     expect(reboundThreadId).toBe("forked-thread");
+  });
+
+  test("rewinds a paginated conversation with one bounded fork and no rollback", async () => {
+    class PaginatedCodex extends FakeCodex {
+      override request(method: string): Promise<unknown> {
+        if (method === "thread/read") {
+          return Promise.resolve({ thread: { id: "source-thread", historyMode: "paginated" } });
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      }
+
+      override rollbackThread(): Promise<CodexThreadRollbackResponse> {
+        throw new Error("paginated threads do not support thread/rollback");
+      }
+    }
+
+    const codex = new PaginatedCodex();
+    const userMessageTurns = new CodexMessageTurns(
+      new Map([
+        ["codex-first", 0],
+        ["codex-second", 1],
+      ]),
+      new Map([
+        ["codex-first", "turn-first"],
+        ["codex-second", "turn-second"],
+      ]),
+    );
+    let reboundThreadId: string | null = null;
+
+    await revertCodexConversation({
+      client: codex,
+      threadId: "source-thread",
+      messageId: "codex-first",
+      cwd: "/workspace/project",
+      model: "gpt-5.4-mini",
+      serviceTier: null,
+      userMessageTurns,
+      setThreadId: (threadId) => {
+        reboundThreadId = threadId;
+      },
+    });
+
+    expect(codex.recordedForks).toEqual([
+      {
+        threadId: "source-thread",
+        beforeTurnId: "turn-first",
+        cwd: "/workspace/project",
+        model: "gpt-5.4-mini",
+        serviceTier: null,
+        excludeTurns: false,
+        persistExtendedHistory: true,
+      },
+    ]);
+    expect(codex.recordedRollbacks).toEqual([]);
+    expect(reboundThreadId).toBe("forked-thread");
+  });
+
+  test("does not fork a paginated thread when the target turn id is unavailable", async () => {
+    class PaginatedCodex extends FakeCodex {
+      override request(method: string): Promise<unknown> {
+        if (method === "thread/read") {
+          return Promise.resolve({ thread: { id: "source-thread", historyMode: "paginated" } });
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      }
+    }
+
+    const codex = new PaginatedCodex();
+    const userMessageTurns = new CodexMessageTurns(new Map([["codex-first", 0]]));
+    let reboundThreadId: string | null = null;
+
+    await expect(
+      revertCodexConversation({
+        client: codex,
+        threadId: "source-thread",
+        messageId: "codex-first",
+        cwd: "/workspace/project",
+        model: "gpt-5.4-mini",
+        serviceTier: null,
+        userMessageTurns,
+        setThreadId: (threadId) => {
+          reboundThreadId = threadId;
+        },
+      }),
+    ).rejects.toThrow("Codex could not find the turn containing user message codex-first");
+
+    expect(codex.recordedForks).toEqual([]);
+    expect(codex.recordedRollbacks).toEqual([]);
+    expect(reboundThreadId).toBeNull();
   });
 
   test("declines to rewind when the user message is not in the Codex thread", async () => {

--- a/packages/server/src/server/agent/providers/codex/rewind.ts
+++ b/packages/server/src/server/agent/providers/codex/rewind.ts
@@ -16,8 +16,28 @@ export interface CodexRewindClient {
 }
 
 export interface CodexUserMessageTurnIndex {
-  resolve(messageId: string): number | null;
+  resolve(messageId: string): { index: number; turnId: string | null } | null;
   count(): number;
+}
+
+type CodexThreadHistoryMode = "legacy" | "paginated";
+
+async function readCodexThreadHistoryMode(
+  client: CodexRewindClient,
+  threadId: string,
+): Promise<CodexThreadHistoryMode> {
+  const response = await client.request("thread/read", { threadId, includeTurns: false });
+  if (typeof response !== "object" || response === null || !("thread" in response)) {
+    throw new Error("Codex thread/read did not return thread metadata");
+  }
+  const thread = response.thread;
+  if (typeof thread !== "object" || thread === null || !("historyMode" in thread)) {
+    return "legacy";
+  }
+  if (thread.historyMode === "legacy" || thread.historyMode === "paginated") {
+    return thread.historyMode;
+  }
+  throw new Error(`Codex thread/read returned unknown history mode ${String(thread.historyMode)}`);
 }
 
 async function forkCodexThread(
@@ -54,15 +74,33 @@ export async function revertCodexConversation(input: {
     throw new Error("Codex thread is not ready for rewind");
   }
 
-  const targetTurnIndex = input.userMessageTurns.resolve(input.messageId);
-  if (targetTurnIndex === null) {
+  const targetTurn = input.userMessageTurns.resolve(input.messageId);
+  if (targetTurn === null) {
     throw new Error(`Codex could not find user message ${input.messageId} in the current thread`);
   }
 
   const currentUserTurnCount = input.userMessageTurns.count();
-  const numTurns = currentUserTurnCount - targetTurnIndex;
+  const numTurns = currentUserTurnCount - targetTurn.index;
   if (numTurns < 0) {
     throw new Error(`Codex user message ${input.messageId} is outside the current thread`);
+  }
+
+  const historyMode = await readCodexThreadHistoryMode(input.client, input.threadId);
+  if (historyMode === "paginated") {
+    if (!targetTurn.turnId) {
+      throw new Error(`Codex could not find the turn containing user message ${input.messageId}`);
+    }
+    const forked = await forkCodexThread(input.client, {
+      threadId: input.threadId,
+      beforeTurnId: targetTurn.turnId,
+      cwd: input.cwd ?? null,
+      model: input.model ?? null,
+      serviceTier: input.serviceTier ?? null,
+      excludeTurns: false,
+      persistExtendedHistory: true,
+    });
+    await input.setThreadId(forked.thread.id);
+    return;
   }
 
   // Fork is non-destructive: the old thread file stays on disk and remains


### PR DESCRIPTION
### Linked issue

Closes #4104

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Codex 0.151.0 changed newly created durable threads to paginated history. Paseo's rewind path always created an unbounded native fork and then called the deprecated `thread/rollback`; paginated threads reject that second operation with `paginated threads do not support thread/rollback`. The first operation had already persisted a fork, so every failed rewind also left an orphan native thread.

Codex exposes the history representation on `thread/read`. Paginated history and bounded `thread/fork.beforeTurnId` shipped together, so Paseo now reads that protocol-owned capability and performs a single bounded fork before the selected native turn. The old source thread remains recoverable, preserving Paseo's established non-destructive rewind semantics. Legacy history keeps the existing fork-plus-rollback sequence for older Codex releases.

The provider now owns the native turn boundary alongside each Paseo user-message ID, both from live item notifications and resumed thread history. A missing boundary fails before any fork is created.

Alternatives rejected:

- `thread/revert`: mutates the source thread and removes Paseo's recoverable-fork behavior.
- forcing legacy history: pins Paseo to a deprecated representation instead of supporting Codex's durable default.
- version checks or rollback fallbacks: the app-server reports `historyMode` directly, and paginated history has supported bounded fork since its introduction.
- UI error handling: would leave the producer bug and orphan fork intact.

### Goals

- Rewind paginated Codex threads without calling `thread/rollback`.
- Preserve recoverable rewind semantics for legacy and paginated histories.
- Preserve compatibility with Codex versions predating paginated history.
- Prevent failed rewinds from creating the orphan fork reported in #4104.

### Non-goals

- Change file-system undo behavior; conversation rewind still leaves workspace edits on disk.
- Replace recoverable rewind with same-thread destructive revert.
- Add provider-version conditionals or force legacy thread history.
- Keep the issue-specific diagnostic script. Its durable coverage belongs in the public provider regression and real-provider E2E harness.

### QA

#### Red regression before production changes

```text
$ npx vitest run packages/server/src/server/agent/providers/codex/rewind.test.ts --bail=1
Test Files  1 failed (1)
Tests       1 failed | 3 passed (4)
Error: paginated threads do not support thread/rollback
```

The failing test modeled the exact sequence: paginated `thread/read` -> unbounded `thread/fork` -> rejected `thread/rollback`.

#### Focused automated tests after the fix

```text
$ npx vitest run packages/server/src/server/agent/providers/codex/rewind.test.ts --bail=1
Test Files  1 passed (1)
Tests       5 passed (5)

$ npx vitest run packages/server/src/server/agent/providers/codex/app-server-transport.test.ts --bail=1
Test Files  1 passed (1)
Tests       7 passed (7)

$ npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1
Test Files  1 passed (1)
Tests       148 passed (148)
```

Coverage includes the same public rewind capability on legacy and paginated histories, live native turn capture, resumed-history turn capture, and the pre-fork failure boundary when a paginated target lacks a native turn ID.

#### Real published Codex app-server matrix

Each command ran the existing isolated real-provider daemon test with authenticated model traffic. It exercised `thread/start` -> actual turn and file edit -> public Paseo conversation rewind -> forked timeline reload, and verified the workspace edit remained. No fake app-server or model endpoint was used.

```text
$ PATH=".../@openai/codex@0.144.0/node_modules/.bin:$PATH" npx vitest run packages/server/src/server/daemon-e2e/codex-rewind.real.e2e.test.ts --bail=1 -t "rewinds a real Codex conversation after a single edit turn"
Test Files  1 passed (1)
Tests       1 passed | 2 skipped (3)

$ PATH=".../@openai/codex@0.150.1/node_modules/.bin:$PATH" npx vitest run packages/server/src/server/daemon-e2e/codex-rewind.real.e2e.test.ts --bail=1 -t "rewinds a real Codex conversation after a single edit turn"
Test Files  1 passed (1)
Tests       1 passed | 2 skipped (3)

$ PATH=".../@openai/codex@0.151.0/node_modules/.bin:$PATH" npx vitest run packages/server/src/server/daemon-e2e/codex-rewind.real.e2e.test.ts --bail=1 -t "rewinds a real Codex conversation after a single edit turn"
Test Files  1 passed (1)
Tests       1 passed | 2 skipped (3)
```

0.144.0 covers the installed legacy release, 0.150.1 covers the requested predecessor, and 0.151.0 is the current published release and covers the paginated default that exposed #4104.

#### Repository gates

```text
$ npm run typecheck
exit 0

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format
Finished on 4196 files.

$ npm run format:check
All matched files use the correct format.
```

Risk is limited to Codex conversation rewind and native turn-ID bookkeeping. The wire protocol and app UI are unchanged.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
