### PR TITLE
Cycle tabs in the focused pane

### DIFF
--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -217,10 +217,16 @@ describe("keyboard-shortcuts", () => {
       payload: { delta: 1 },
     },
     {
-      name: "matches tab relative navigation via Alt+Shift+]",
-      event: { key: "}", code: "BracketRight", altKey: true, shiftKey: true },
+      name: "matches tab relative navigation via Ctrl+Tab",
+      event: { key: "Tab", code: "Tab", ctrlKey: true },
       action: "workspace.tab.navigate.relative",
       payload: { delta: 1 },
+    },
+    {
+      name: "matches reverse tab relative navigation via Ctrl+Shift+Tab",
+      event: { key: "Tab", code: "Tab", ctrlKey: true, shiftKey: true },
+      action: "workspace.tab.navigate.relative",
+      payload: { delta: -1 },
     },
     {
       name: "matches Mod+T to open new tab",
@@ -349,20 +355,6 @@ describe("keyboard-shortcuts", () => {
       event: { key: "\u2020", code: "KeyT", metaKey: true, altKey: true },
       context: { isMac: true },
       action: "theme.cycle",
-    },
-    {
-      name: "matches Alt+Shift+[ to previous tab on macOS when Option substitutes event.key",
-      event: { key: "\u201D", code: "BracketLeft", altKey: true, shiftKey: true },
-      context: { isMac: true },
-      action: "workspace.tab.navigate.relative",
-      payload: { delta: -1 },
-    },
-    {
-      name: "matches Alt+Shift+] to next tab on macOS when Option substitutes event.key",
-      event: { key: "\u2019", code: "BracketRight", altKey: true, shiftKey: true },
-      context: { isMac: true },
-      action: "workspace.tab.navigate.relative",
-      payload: { delta: 1 },
     },
     {
       name: "matches Alt+[ to previous workspace on macOS web when Option substitutes event.key",

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -689,9 +689,9 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
 
   // --- Tab relative navigation ---
   {
-    id: "workspace-tab-navigate-relative-alt-shift-left",
+    id: "workspace-tab-navigate-relative-ctrl-shift-tab",
     action: "workspace.tab.navigate.relative",
-    combo: "Alt+Shift+[",
+    combo: "Ctrl+Shift+Tab",
     when: { commandCenter: false },
     payload: { type: "delta", delta: -1 },
     help: {
@@ -701,9 +701,9 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
     },
   },
   {
-    id: "workspace-tab-navigate-relative-alt-shift-right",
+    id: "workspace-tab-navigate-relative-ctrl-tab",
     action: "workspace.tab.navigate.relative",
-    combo: "Alt+Shift+]",
+    combo: "Ctrl+Tab",
     when: { commandCenter: false },
     payload: { type: "delta", delta: 1 },
     help: {

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -159,6 +159,7 @@ import {
   workspaceAgentVisibilityEqual,
 } from "@/workspace-tabs/agent-visibility";
 import { deriveWorkspacePaneState } from "@/screens/workspace/workspace-pane-state";
+import { getWorkspaceRelativeTabId } from "@/screens/workspace/workspace-tab-navigation";
 import {
   buildWorkspacePaneContentModel,
   WorkspacePaneContent,
@@ -3125,14 +3126,14 @@ function WorkspaceScreenContent({
           return true;
         }
         case "workspace.tab.navigate-relative": {
-          if (tabs.length > 0) {
-            const currentIndex = tabs.findIndex((tab) => tab.tabId === activeTabId);
-            const fromIndex = currentIndex >= 0 ? currentIndex : 0;
-            const nextIndex = (fromIndex + action.delta + tabs.length) % tabs.length;
-            const next = tabs[nextIndex] ?? null;
-            if (next?.tabId) {
-              navigateToTabId(next.tabId);
-            }
+          const paneId = focusedPaneTabState.pane?.id;
+          const nextTabId = getWorkspaceRelativeTabId(
+            focusedPaneTabState.tabs.map((tab) => tab.descriptor.tabId),
+            focusedPaneTabState.activeTabId,
+            action.delta,
+          );
+          if (persistenceKey && paneId && nextTabId) {
+            selectWorkspaceTabInPane(persistenceKey, paneId, nextTabId);
           }
           return true;
         }
@@ -3147,8 +3148,10 @@ function WorkspaceScreenContent({
       handleCreateBrowserTab,
       handleCreateNewTab,
       handleCreateTerminal,
-      focusedPaneTabState.pane?.id,
+      focusedPaneTabState,
       navigateToTabId,
+      persistenceKey,
+      selectWorkspaceTabInPane,
       tabs,
     ],
   );

--- a/packages/app/src/screens/workspace/workspace-tab-navigation.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-navigation.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { getWorkspaceRelativeTabId } from "./workspace-tab-navigation";
+
+describe("getWorkspaceRelativeTabId", () => {
+  it("cycles in order and wraps in both directions", () => {
+    const tabIds = ["left-a", "left-b", "left-c"];
+
+    expect(getWorkspaceRelativeTabId(tabIds, "left-a", 1)).toBe("left-b");
+    expect(getWorkspaceRelativeTabId(tabIds, "left-c", 1)).toBe("left-a");
+    expect(getWorkspaceRelativeTabId(tabIds, "left-a", -1)).toBe("left-c");
+  });
+});

--- a/packages/app/src/screens/workspace/workspace-tab-navigation.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-navigation.ts
@@ -1,0 +1,10 @@
+export function getWorkspaceRelativeTabId(
+  tabIds: readonly string[],
+  activeTabId: string | null,
+  delta: 1 | -1,
+): string | null {
+  if (tabIds.length === 0) return null;
+  const currentIndex = tabIds.indexOf(activeTabId ?? "");
+  const fromIndex = currentIndex >= 0 ? currentIndex : 0;
+  return tabIds[(fromIndex + delta + tabIds.length) % tabIds.length] ?? null;
+}


### PR DESCRIPTION
## Problem

Paseo's existing relative-tab shortcut cycles the workspace-wide tab list. In a split layout, that can move focus out of the pane the user is working in. The conventional desktop shortcuts, `Ctrl+Tab` and `Ctrl+Shift+Tab`, are also not available by default.

## Change

- Bind next/previous tab to `Ctrl+Tab` and `Ctrl+Shift+Tab` through the existing configurable shortcut system.
- Resolve relative navigation from the focused pane's ordered tab list.
- Select the adjacent tab in that same pane with wraparound.
- Keep the behavior independent of tab target type.

Closes #4124

## QA evidence

### Automated

```text
$ bun x vitest run packages/app/src/screens/workspace/workspace-tab-navigation.test.ts packages/app/src/keyboard/keyboard-shortcuts.test.ts --bail=1 --maxWorkers=1 --no-file-parallelism
Test Files  2 passed (2)
Tests       127 passed (127)
```

```text
$ bun x oxfmt --check <changed files>
All matched files use the correct format.
format_exit=0

$ bun x oxlint <changed files>
Found 0 warnings and 0 errors.
lint_exit=0
```

The new shortcut test was run before implementation and failed because `Ctrl+Tab` had no matching action.

### Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| Linux desktop | Automated | Shortcut resolution, pane-local ordering, wraparound |
| Web | Not manually tested | Shortcut routing is shared |
| macOS desktop | Not tested | No macOS host available |
| Windows desktop | Not tested | No Windows host available |
| iOS | Not affected | Hardware keyboard behavior not claimed |
| Android | Not affected | Hardware keyboard behavior not claimed |

## Known verification limitation

The app workspace typecheck currently fails in the dependency tree because Bun installed two incompatible Vitest declaration versions (`vitest` and `@vitest/browser`); no diagnostic points to the changed files. CI uses the canonical npm lockfile install and is the authoritative full typecheck.

*Written by Terminus (AI Assistant) — raisalpwardana+terminus@gmail.com*
