### PR TITLE
Traverse workspaces beyond nine

### DIFF
--- a/packages/app/src/utils/sidebar-shortcuts.test.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.test.ts
@@ -110,7 +110,7 @@ describe("buildSidebarShortcutModel", () => {
     expect(model.shortcutIndexByWorkspaceKey.get("s1:ws-repo2-main")).toBeUndefined();
   });
 
-  it("limits shortcuts to 9", () => {
+  it("keeps all traversal targets while numbering only the first 9", () => {
     const workspaces = Array.from({ length: 20 }, (_, index) =>
       workspace({
         serverId: "s",
@@ -126,9 +126,11 @@ describe("buildSidebarShortcutModel", () => {
       collapsedProjectKeys: new Set<string>(),
     });
 
-    expect(model.shortcutTargets).toHaveLength(9);
-    expect(model.shortcutTargets[0]).toEqual({ serverId: "s", workspaceId: "ws-1" });
+    expect(model.shortcutTargets).toHaveLength(20);
     expect(model.shortcutTargets[8]).toEqual({ serverId: "s", workspaceId: "ws-9" });
+    expect(model.shortcutTargets[9]).toEqual({ serverId: "s", workspaceId: "ws-10" });
+    expect(model.shortcutIndexByWorkspaceKey.get("s:ws-9")).toBe(9);
+    expect(model.shortcutIndexByWorkspaceKey.get("s:ws-10")).toBeUndefined();
   });
 
   it("excludes a collapsed project's workspaces regardless of project kind", () => {

--- a/packages/app/src/utils/sidebar-shortcuts.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.ts
@@ -70,13 +70,10 @@ export function buildSidebarShortcutSections(input: {
     }
 
     for (const workspace of section.workspaces) {
-      if (shortcutTargets.length >= maxShortcuts) {
-        break;
-      }
-
-      const shortcutNumber = shortcutTargets.length + 1;
       shortcutTargets.push(createShortcutTarget(workspace));
-      shortcutIndexByWorkspaceKey.set(workspace.workspaceKey, shortcutNumber);
+      if (shortcutTargets.length <= maxShortcuts) {
+        shortcutIndexByWorkspaceKey.set(workspace.workspaceKey, shortcutTargets.length);
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Previous/next workspace navigation receives the same target list used for numbered workspace shortcuts. That list stops at nine, so relative navigation wraps from workspace 9 to workspace 1 and cannot reach later visible workspaces.

## Fix

Keep all visible workspaces in `shortcutTargets`, preserving sidebar visual order for relative navigation. Apply the configured limit only when building `shortcutIndexByWorkspaceKey`, so digit shortcuts and badges remain limited to 1–9.

Closes #4127

## QA evidence

The regression test was first run against the old implementation and failed with:

```text
expected shortcutTargets to have a length of 20 but got 9
```

After the fix:

```text
Test Files  3 passed (3)
Tests       80 passed (80)
```

Covered files:

- `sidebar-shortcuts.test.ts`
- `route-shortcut.test.ts`
- `sidebar-projection.test.ts`

Static checks:

```text
All matched files use the correct format.
Found 0 warnings and 0 errors.
format_exit=0 lint_exit=0
```

## Platforms

The changed logic is platform-independent and runs before route navigation.

| Platform | Tested | Notes |
| --- | --- | --- |
| Linux | Automated | Unit and routing coverage |
| macOS | Not tested | No macOS host available |
| Windows | Not tested | No Windows host available |
| Web | Automated logic | No visual change |
| iOS / Android | Not manually tested | No touch behavior changed |

*Written by Terminus (AI Assistant) — raisalpwardana+terminus@gmail.com*
