### PR TITLE
fix(desktop): route notification clicks to the window showing the agent

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -75,6 +75,7 @@ import { registerWorkspaceRouteNavigationRef } from "@/navigation/workspace-rout
 import { ThemedStack } from "@/navigation/themed-stack";
 import { shouldUseDesktopDaemon } from "@/desktop/daemon/desktop-daemon";
 import { AgentNavigationListener } from "@/desktop/agent-navigation";
+import { WindowViewReporter } from "@/desktop/use-report-window-view";
 import { LegacyAgentSkillsMigration } from "@/agent-skills/legacy-migration";
 import { legacyFavoriteProfileMigration } from "@/agent-profiles/migration";
 import { listenToDesktopEvent } from "@/desktop/electron/events";
@@ -918,6 +919,7 @@ function AppShell() {
       <HorizontalScrollProvider>
         <OpenProjectListener />
         <AgentNavigationListener />
+        <WindowViewReporter />
         <AppWithSidebar>
           <WorkspaceRouteNavigationBridge />
           <RootStack />

--- a/packages/app/src/components/sidebar/sidebar-model.tsx
+++ b/packages/app/src/components/sidebar/sidebar-model.tsx
@@ -14,6 +14,7 @@ import {
   type SidebarGroupMode,
 } from "@/stores/sidebar-view-store";
 import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
+import { useDesktopWindowViewStore } from "@/stores/desktop-window-view-store";
 import type { SidebarShortcutModel } from "@/utils/sidebar-shortcuts";
 import { buildSidebarProjection } from "./sidebar-projection";
 import type { SidebarProjectIconTarget } from "@/utils/sidebar-project-row-model";
@@ -112,6 +113,22 @@ export function SidebarModelProvider({
     () => new Set(filteredWorkspaceEntriesByKey.keys()),
     [filteredWorkspaceEntriesByKey],
   );
+  // Report what the sidebar shows only while it is actually active. `active === false`
+  // (or unmounting, e.g. swapping between the desktop and compact chrome branches) must
+  // clear the report rather than leave it stale: `useSidebarWorkspaceEntries` deliberately
+  // keeps its previous map when disabled, so a hidden sidebar's own key set would
+  // otherwise go on claiming workspaces it is not displaying.
+  useEffect(() => {
+    const store = useDesktopWindowViewStore.getState();
+    if (active === false) {
+      store.setVisibleWorkspaceKeys(null);
+      return;
+    }
+    store.setVisibleWorkspaceKeys([...visibleWorkspaceKeys]);
+    return () => {
+      useDesktopWindowViewStore.getState().setVisibleWorkspaceKeys(null);
+    };
+  }, [active, visibleWorkspaceKeys]);
   // The two filters prune differently on purpose. The project filter is a membership test on the
   // project itself, so a project you filtered TO survives even with no workspaces — it still owns
   // a header row you can create your first workspace under. The label filter can only ask about

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -1,6 +1,7 @@
 import { Platform } from "react-native";
 import { getElectronHost } from "@/desktop/electron/host";
 import type { BrowserKeyboardPolicy } from "@/desktop/browser/shortcuts";
+import type { WindowViewReport } from "@/desktop/window-view-report";
 import type { SessionInboundMessage, SessionOutboundMessage } from "@getpaseo/protocol/messages";
 
 type BrowserAutomationExecuteRequest = Extract<
@@ -119,6 +120,11 @@ export interface DesktopWindowBridge {
 export interface DesktopWindowModuleBridge {
   openNew?: (options?: { pendingOpenProjectPath?: string | null }) => Promise<void>;
   getCurrentWindow?: () => DesktopWindowBridge;
+  /** Report what this window currently shows, so main can route a notification click
+   * or deep link to the window already displaying the target instead of the focused
+   * or sending window. Optional: an old shell without this method leaves main's pick
+   * order unchanged. */
+  reportView?: (report: WindowViewReport) => Promise<void>;
 }
 
 export interface DesktopEventsBridge {

--- a/packages/app/src/desktop/use-report-window-view.ts
+++ b/packages/app/src/desktop/use-report-window-view.ts
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useRef } from "react";
+import { getDesktopHost } from "@/desktop/host";
+import { buildWindowViewReport, type WindowViewReport } from "@/desktop/window-view-report";
+import { useDesktopWindowViewStore } from "@/stores/desktop-window-view-store";
+
+function reportsEqual(a: WindowViewReport, b: WindowViewReport): boolean {
+  return (
+    a.visibleAgentIds.length === b.visibleAgentIds.length &&
+    a.visibleWorkspaceKeys.length === b.visibleWorkspaceKeys.length &&
+    a.visibleAgentIds.every((id, index) => id === b.visibleAgentIds[index]) &&
+    a.visibleWorkspaceKeys.every((key, index) => key === b.visibleWorkspaceKeys[index])
+  );
+}
+
+/**
+ * Sends this window's current view (visible agents, visible sidebar workspaces) to the
+ * desktop main process, so a notification click or deep link can be routed to the
+ * window already showing the target instead of the focused or sending window.
+ *
+ * `workspace-screen.tsx` and `sidebar-model.tsx` publish into
+ * `useDesktopWindowViewStore` independently; this is the one place that reads both
+ * slices and sends. `buildWindowViewReport` sorts and dedupes, so an unchanged
+ * underlying state always produces a deep-equal report — the send is skipped, because
+ * both source maps are rebuilt on nearly every session-store tick and a naive effect
+ * would ship the full workspace key list (dozens of entries) on every agent stream tick.
+ *
+ * No-ops outside Electron, and on an old shell without the `reportView` bridge method.
+ */
+export function useReportWindowView(): void {
+  const visibleAgentIdsByWorkspace = useDesktopWindowViewStore(
+    (state) => state.visibleAgentIdsByWorkspace,
+  );
+  const visibleWorkspaceKeys = useDesktopWindowViewStore((state) => state.visibleWorkspaceKeys);
+  // Only the focused workspace screen ever reports non-empty ids (see the store's
+  // doc comment), so unioning every mounted workspace's entry is always safe.
+  const visibleAgentIds = useMemo(
+    () => [...visibleAgentIdsByWorkspace.values()].flat(),
+    [visibleAgentIdsByWorkspace],
+  );
+  const lastSentRef = useRef<WindowViewReport | null>(null);
+
+  useEffect(() => {
+    const reportView = getDesktopHost()?.window?.reportView;
+    if (!reportView) {
+      return;
+    }
+    const report = buildWindowViewReport({ visibleAgentIds, visibleWorkspaceKeys });
+    if (lastSentRef.current && reportsEqual(lastSentRef.current, report)) {
+      return;
+    }
+    lastSentRef.current = report;
+    void reportView(report);
+  }, [visibleAgentIds, visibleWorkspaceKeys]);
+}
+
+export function WindowViewReporter(): null {
+  useReportWindowView();
+  return null;
+}

--- a/packages/app/src/desktop/window-view-report.test.ts
+++ b/packages/app/src/desktop/window-view-report.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildWindowViewReport } from "./window-view-report";
+
+describe("buildWindowViewReport", () => {
+  it("sorts and dedupes both fields", () => {
+    expect(
+      buildWindowViewReport({
+        visibleAgentIds: ["b", "a", "b"],
+        visibleWorkspaceKeys: ["server-1:ws-2", "server-1:ws-1", "server-1:ws-2"],
+      }),
+    ).toEqual({
+      visibleAgentIds: ["a", "b"],
+      visibleWorkspaceKeys: ["server-1:ws-1", "server-1:ws-2"],
+    });
+  });
+
+  it("reports no workspace keys while the sidebar is not actively reporting", () => {
+    expect(buildWindowViewReport({ visibleAgentIds: [], visibleWorkspaceKeys: null })).toEqual({
+      visibleAgentIds: [],
+      visibleWorkspaceKeys: [],
+    });
+  });
+
+  it("reports empty for an empty active sidebar the same as an inactive one", () => {
+    expect(buildWindowViewReport({ visibleAgentIds: [], visibleWorkspaceKeys: [] })).toEqual({
+      visibleAgentIds: [],
+      visibleWorkspaceKeys: [],
+    });
+  });
+
+  it("produces a deep-equal report for reordered, differently-deduped equivalent input", () => {
+    const a = buildWindowViewReport({
+      visibleAgentIds: ["agent-2", "agent-1"],
+      visibleWorkspaceKeys: ["server-1:ws-2", "server-1:ws-1"],
+    });
+    const b = buildWindowViewReport({
+      visibleAgentIds: ["agent-1", "agent-1", "agent-2"],
+      visibleWorkspaceKeys: ["server-1:ws-1", "server-1:ws-2", "server-1:ws-1"],
+    });
+    expect(a).toEqual(b);
+  });
+});

--- a/packages/app/src/desktop/window-view-report.ts
+++ b/packages/app/src/desktop/window-view-report.ts
@@ -1,0 +1,28 @@
+/**
+ * What this window reports to the desktop main process about what it shows. Pure and
+ * deterministic — sorts and dedupes, so two logically-equal inputs always produce two
+ * deep-equal outputs regardless of Set iteration order or which publisher last wrote to
+ * the store. `use-report-window-view.ts` relies on that to skip sending an unchanged
+ * report every time the underlying maps are rebuilt.
+ */
+export interface WindowViewReport {
+  visibleAgentIds: string[];
+  visibleWorkspaceKeys: string[];
+}
+
+export function buildWindowViewReport(state: {
+  visibleAgentIds: readonly string[];
+  // `null` means the sidebar isn't actively reporting (inactive, or not mounted yet) —
+  // distinct from `[]` ("active, showing nothing"), but both serialize to `[]` on the
+  // wire: an inactive sidebar should not claim any workspace.
+  visibleWorkspaceKeys: readonly string[] | null;
+}): WindowViewReport {
+  return {
+    visibleAgentIds: dedupeSorted(state.visibleAgentIds),
+    visibleWorkspaceKeys: dedupeSorted(state.visibleWorkspaceKeys ?? []),
+  };
+}
+
+function dedupeSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort();
+}

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -86,6 +86,7 @@ import type {
   WorkspacePanelTarget,
 } from "@/keyboard/keyboard-action-dispatcher";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
+import { useDesktopWindowViewStore } from "@/stores/desktop-window-view-store";
 import { normalizeWorkspaceTabTarget, workspaceTabTargetsEqual } from "@/workspace-tabs/identity";
 import { useVisibleAgentIds } from "./visible-agent-ids";
 import {
@@ -1920,6 +1921,15 @@ function WorkspaceScreenContent({
         .catch(() => undefined);
     }
   }, [normalizedServerId, visibleAgentIds]);
+  useEffect(() => {
+    if (!persistenceKey) {
+      return;
+    }
+    useDesktopWindowViewStore.getState().setVisibleAgentIds(persistenceKey, visibleAgentIds);
+    return () => {
+      useDesktopWindowViewStore.getState().clearVisibleAgentIds(persistenceKey);
+    };
+  }, [persistenceKey, visibleAgentIds]);
   useLayoutEffect(() => {
     if (!persistenceKey || !viewedTimelineSync) {
       return;

--- a/packages/app/src/stores/desktop-window-view-store.ts
+++ b/packages/app/src/stores/desktop-window-view-store.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+
+/**
+ * What this window currently shows, published by independent subtrees so
+ * `use-report-window-view.ts` can send one combined report to the desktop main
+ * process. Not persisted — this is live per-window state, not a setting.
+ *
+ * `visibleAgentIds` is keyed by workspace persistence key rather than a single flat
+ * list: a stacked navigator can keep more than one `WorkspaceScreen` mounted at once
+ * (that's the whole reason `useIsFocused`/`routeFocused` exists), and each publishes
+ * `[]` while unfocused. A flat "last write wins" slot would let a background screen's
+ * re-render race the focused screen's and wipe its agent ids. Only the focused
+ * workspace reports non-empty ids, so unioning every entry is always safe.
+ *
+ * `visibleWorkspaceKeys` is `null` while the sidebar isn't actively reporting (it is
+ * inactive, or hasn't mounted yet), distinct from `[]` ("active, showing nothing").
+ * `use-sidebar-workspace-entries.ts` deliberately keeps stale entries when disabled, so
+ * treating "inactive" the same as "empty" would make a hidden sidebar claim it shows
+ * nothing rather than not reporting at all — `buildWindowViewReport` needs that
+ * distinction to avoid a false negative on tier 3.
+ */
+interface DesktopWindowViewState {
+  visibleAgentIdsByWorkspace: ReadonlyMap<string, readonly string[]>;
+  visibleWorkspaceKeys: readonly string[] | null;
+  setVisibleAgentIds: (persistenceKey: string, ids: readonly string[]) => void;
+  clearVisibleAgentIds: (persistenceKey: string) => void;
+  setVisibleWorkspaceKeys: (keys: readonly string[] | null) => void;
+}
+
+export const useDesktopWindowViewStore = create<DesktopWindowViewState>((set) => ({
+  visibleAgentIdsByWorkspace: new Map(),
+  visibleWorkspaceKeys: null,
+  setVisibleAgentIds: (persistenceKey, ids) =>
+    set((state) => {
+      const next = new Map(state.visibleAgentIdsByWorkspace);
+      next.set(persistenceKey, ids);
+      return { visibleAgentIdsByWorkspace: next };
+    }),
+  clearVisibleAgentIds: (persistenceKey) =>
+    set((state) => {
+      if (!state.visibleAgentIdsByWorkspace.has(persistenceKey)) {
+        return state;
+      }
+      const next = new Map(state.visibleAgentIdsByWorkspace);
+      next.delete(persistenceKey);
+      return { visibleAgentIdsByWorkspace: next };
+    }),
+  setVisibleWorkspaceKeys: (keys) => set({ visibleWorkspaceKeys: keys }),
+}));

--- a/packages/desktop/src/agent-navigation.test.ts
+++ b/packages/desktop/src/agent-navigation.test.ts
@@ -31,3 +31,107 @@ describe("desktop agent navigation", () => {
     expect(inbox.windowReady(7)).toBeNull();
   });
 });
+
+describe("windowsShowingTarget", () => {
+  const noUrl = () => null;
+
+  it("tier 1: prefers the window already showing the agent", () => {
+    const inbox = new AgentNavigationInbox();
+    inbox.setWindowView(1, { visibleAgentIds: [], visibleWorkspaceKeys: [] });
+    inbox.setWindowView(2, { visibleAgentIds: ["agent-1"], visibleWorkspaceKeys: [] });
+
+    const result = inbox.windowsShowingTarget(
+      [1, 2],
+      { serverId: "server-1", workspaceId: null, agentId: "agent-1" },
+      noUrl,
+    );
+
+    expect(result).toEqual([2]);
+  });
+
+  it("tier 2: matches on the window's current URL, ranked above the sidebar tier", () => {
+    const inbox = new AgentNavigationInbox();
+    inbox.setWindowView(1, { visibleAgentIds: [], visibleWorkspaceKeys: ["server-1:ws-1"] });
+    inbox.setWindowView(2, { visibleAgentIds: [], visibleWorkspaceKeys: [] });
+    const urls = new Map([[2, "paseo://app/h/server-1/workspace/ws-1"]]);
+
+    const result = inbox.windowsShowingTarget(
+      [1, 2],
+      { serverId: "server-1", workspaceId: "ws-1", agentId: null },
+      (id) => urls.get(id) ?? null,
+    );
+
+    expect(result).toEqual([2, 1]);
+  });
+
+  it("tier 3: falls back to the sidebar's visible workspace keys", () => {
+    const inbox = new AgentNavigationInbox();
+    inbox.setWindowView(1, { visibleAgentIds: [], visibleWorkspaceKeys: ["server-1:ws-1"] });
+
+    const result = inbox.windowsShowingTarget(
+      [1],
+      { serverId: "server-1", workspaceId: "ws-1", agentId: null },
+      noUrl,
+    );
+
+    expect(result).toEqual([1]);
+  });
+
+  it("breaks ties within a tier by most recently focused", () => {
+    const inbox = new AgentNavigationInbox();
+    inbox.setWindowView(1, { visibleAgentIds: [], visibleWorkspaceKeys: ["server-1:ws-1"] });
+    inbox.setWindowView(2, { visibleAgentIds: [], visibleWorkspaceKeys: ["server-1:ws-1"] });
+    inbox.noteWindowFocused(1);
+    inbox.noteWindowFocused(2);
+
+    const result = inbox.windowsShowingTarget(
+      [1, 2],
+      { serverId: "server-1", workspaceId: "ws-1", agentId: null },
+      noUrl,
+    );
+
+    expect(result).toEqual([2, 1]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    const inbox = new AgentNavigationInbox();
+    inbox.setWindowView(1, { visibleAgentIds: [], visibleWorkspaceKeys: [] });
+
+    const result = inbox.windowsShowingTarget(
+      [1],
+      { serverId: "server-1", workspaceId: "ws-1", agentId: "agent-1" },
+      noUrl,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("windowLoading clears the window's view so it stops matching", () => {
+    const inbox = new AgentNavigationInbox();
+    inbox.setWindowView(1, { visibleAgentIds: ["agent-1"], visibleWorkspaceKeys: [] });
+    inbox.windowLoading(1);
+
+    const result = inbox.windowsShowingTarget(
+      [1],
+      { serverId: "server-1", workspaceId: null, agentId: "agent-1" },
+      noUrl,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("removeWindow clears the view and drops the window from focus order", () => {
+    const inbox = new AgentNavigationInbox();
+    inbox.setWindowView(1, { visibleAgentIds: ["agent-1"], visibleWorkspaceKeys: [] });
+    inbox.noteWindowFocused(1);
+    inbox.removeWindow(1);
+
+    const result = inbox.windowsShowingTarget(
+      [1],
+      { serverId: "server-1", workspaceId: null, agentId: "agent-1" },
+      noUrl,
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/desktop/src/agent-navigation.ts
+++ b/packages/desktop/src/agent-navigation.ts
@@ -1,4 +1,5 @@
 import { parseAgentDeepLink, type AgentDeepLinkTarget } from "@getpaseo/protocol/agent-deep-link";
+import { parseWorkspaceRouteUrl } from "./window/workspace-route-url.js";
 
 export function parseAgentDeepLinkFromArgv(argv: string[]): AgentDeepLinkTarget | null {
   for (const arg of argv) {
@@ -10,12 +11,31 @@ export function parseAgentDeepLinkFromArgv(argv: string[]): AgentDeepLinkTarget 
   return null;
 }
 
+/** What one window last reported about what it shows. Strict: only what the window's
+ * most recent report says is true right now — `windowLoading`/`removeWindow` clear it. */
+export interface WindowView {
+  visibleAgentIds: readonly string[];
+  visibleWorkspaceKeys: readonly string[];
+}
+
+/** What a notification click or deep link is looking for. `workspaceId`/`agentId` are
+ * null when the source (e.g. a deep link) doesn't carry that piece. */
+export interface WindowNavigationTarget {
+  serverId: string;
+  workspaceId: string | null;
+  agentId: string | null;
+}
+
 export class AgentNavigationInbox {
   private readonly readyWindows = new Set<number>();
   private readonly pendingByWindow = new Map<number, AgentDeepLinkTarget>();
+  private readonly viewsByWindow = new Map<number, WindowView>();
+  // Most-recently-focused first. Only a tie-break inside a tier, never a tier on its own.
+  private readonly focusOrder: number[] = [];
 
   windowLoading(webContentsId: number): void {
     this.readyWindows.delete(webContentsId);
+    this.viewsByWindow.delete(webContentsId);
   }
 
   windowReady(webContentsId: number): AgentDeepLinkTarget | null {
@@ -36,5 +56,77 @@ export class AgentNavigationInbox {
   removeWindow(webContentsId: number): void {
     this.readyWindows.delete(webContentsId);
     this.pendingByWindow.delete(webContentsId);
+    this.viewsByWindow.delete(webContentsId);
+    const index = this.focusOrder.indexOf(webContentsId);
+    if (index !== -1) {
+      this.focusOrder.splice(index, 1);
+    }
+  }
+
+  setWindowView(webContentsId: number, view: WindowView): void {
+    this.viewsByWindow.set(webContentsId, view);
+  }
+
+  clearWindowView(webContentsId: number): void {
+    this.viewsByWindow.delete(webContentsId);
+  }
+
+  noteWindowFocused(webContentsId: number): void {
+    const index = this.focusOrder.indexOf(webContentsId);
+    if (index !== -1) {
+      this.focusOrder.splice(index, 1);
+    }
+    this.focusOrder.unshift(webContentsId);
+  }
+
+  /**
+   * Ranks `candidateIds` by how well each shows `target`, best first. A window with no
+   * match at any tier is dropped, so an empty result means "none of these windows show
+   * it" and the caller should fall back to its own default (today's focused/visible/first
+   * order, or window creation).
+   *
+   * Tiers, in order: the window is already showing the agent; the window's current URL
+   * (which follows in-app navigation, not just the last full load) is that workspace;
+   * the window's sidebar lists that workspace. Ties within a tier go to whichever window
+   * was focused more recently.
+   */
+  windowsShowingTarget(
+    candidateIds: readonly number[],
+    target: WindowNavigationTarget,
+    getWindowUrl: (webContentsId: number) => string | null,
+  ): number[] {
+    const tierOf = (id: number): number => {
+      const view = this.viewsByWindow.get(id);
+      if (target.agentId && view?.visibleAgentIds.includes(target.agentId)) {
+        return 1;
+      }
+      if (target.workspaceId) {
+        const url = getWindowUrl(id);
+        const route = url ? parseWorkspaceRouteUrl(url) : null;
+        if (
+          route &&
+          route.serverId === target.serverId &&
+          route.workspaceId === target.workspaceId
+        ) {
+          return 2;
+        }
+        const workspaceKey = `${target.serverId}:${target.workspaceId}`;
+        if (view?.visibleWorkspaceKeys.includes(workspaceKey)) {
+          return 3;
+        }
+      }
+      return 0;
+    };
+
+    const focusRank = (id: number): number => {
+      const index = this.focusOrder.indexOf(id);
+      return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+    };
+
+    return candidateIds
+      .map((id) => ({ id, tier: tierOf(id) }))
+      .filter((entry) => entry.tier > 0)
+      .sort((a, b) => (a.tier !== b.tier ? a.tier - b.tier : focusRank(a.id) - focusRank(b.id)))
+      .map((entry) => entry.id);
   }
 }

--- a/packages/desktop/src/features/notification-click.test.ts
+++ b/packages/desktop/src/features/notification-click.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { chooseNotificationClickWindow, resolveNotificationRoute } from "./notification-click.js";
+
+describe("resolveNotificationRoute", () => {
+  it("resolves an agent target", () => {
+    expect(
+      resolveNotificationRoute({ serverId: "server-1", workspaceId: "ws-1", agentId: "agent-1" }),
+    ).toEqual({ kind: "target", serverId: "server-1", workspaceId: "ws-1", agentId: "agent-1" });
+  });
+
+  it("resolves a workspace-only target", () => {
+    expect(resolveNotificationRoute({ serverId: "server-1", workspaceId: "ws-1" })).toEqual({
+      kind: "target",
+      serverId: "server-1",
+      workspaceId: "ws-1",
+      agentId: null,
+    });
+  });
+
+  it("falls back to the sender when there is no serverId", () => {
+    expect(resolveNotificationRoute({ agentId: "agent-1" })).toEqual({ kind: "sender" });
+    expect(resolveNotificationRoute({})).toEqual({ kind: "sender" });
+    expect(resolveNotificationRoute(undefined)).toEqual({ kind: "sender" });
+  });
+
+  it("falls back to the sender for garbage field types", () => {
+    expect(resolveNotificationRoute({ serverId: 42, workspaceId: "ws-1" } as never)).toEqual({
+      kind: "sender",
+    });
+  });
+
+  it("trims whitespace-only fields to null", () => {
+    expect(resolveNotificationRoute({ serverId: "server-1", workspaceId: "   " })).toEqual({
+      kind: "target",
+      serverId: "server-1",
+      workspaceId: null,
+      agentId: null,
+    });
+  });
+});
+
+interface FakeWindow {
+  id: string;
+  focused: boolean;
+  focus(): void;
+}
+
+function fakeWindow(id: string): FakeWindow {
+  return {
+    id,
+    focused: false,
+    focus() {
+      this.focused = true;
+    },
+  };
+}
+
+describe("chooseNotificationClickWindow", () => {
+  it("delivers to the sender when the route has no target", () => {
+    const sender = fakeWindow("sender");
+    const chosen = chooseNotificationClickWindow({
+      route: { kind: "sender" },
+      candidates: [fakeWindow("A")],
+      sender,
+    });
+    expect(chosen).toBe(sender);
+  });
+
+  it("delivers to the best-ranked candidate, and focusing it is the caller's job", () => {
+    const sender = fakeWindow("sender");
+    const best = fakeWindow("B");
+    const chosen = chooseNotificationClickWindow({
+      route: { kind: "target", serverId: "server-1", workspaceId: "ws-1", agentId: null },
+      candidates: [best, fakeWindow("A")],
+      sender,
+    });
+    expect(chosen).toBe(best);
+    expect(chosen?.focused).toBe(false);
+    chosen?.focus();
+    expect(chosen?.focused).toBe(true);
+  });
+
+  it("falls back to the sender when a target route has no candidates", () => {
+    const sender = fakeWindow("sender");
+    const chosen = chooseNotificationClickWindow({
+      route: { kind: "target", serverId: "server-1", workspaceId: "ws-1", agentId: null },
+      candidates: [],
+      sender,
+    });
+    expect(chosen).toBe(sender);
+  });
+
+  it("returns null when there is no candidate and no sender", () => {
+    const chosen = chooseNotificationClickWindow({
+      route: { kind: "target", serverId: "server-1", workspaceId: "ws-1", agentId: null },
+      candidates: [],
+      sender: null,
+    });
+    expect(chosen).toBeNull();
+  });
+});

--- a/packages/desktop/src/features/notification-click.ts
+++ b/packages/desktop/src/features/notification-click.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure decision logic for routing a notification click to a window. Kept free of
+ * Electron so it is unit-testable without a running app; `notifications.ts` is the
+ * Electron wiring that calls this with real windows.
+ */
+
+export type NotificationRoute =
+  | { kind: "target"; serverId: string; workspaceId: string | null; agentId: string | null }
+  | { kind: "sender" };
+
+function readNonEmptyString(data: Record<string, unknown> | undefined, key: string): string | null {
+  const value = data?.[key];
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * `{ kind: "sender" }` means the notification data names no server, so there is
+ * nothing to look a candidate window up by — deliver to whichever window sent it,
+ * exactly as before this feature existed.
+ */
+export function resolveNotificationRoute(
+  data: Record<string, unknown> | undefined,
+): NotificationRoute {
+  const serverId = readNonEmptyString(data, "serverId");
+  if (!serverId) {
+    return { kind: "sender" };
+  }
+  return {
+    kind: "target",
+    serverId,
+    workspaceId: readNonEmptyString(data, "workspaceId"),
+    agentId: readNonEmptyString(data, "agentId"),
+  };
+}
+
+/**
+ * `candidates` is the already-ranked (best-first) list of windows showing the route's
+ * target — empty when the route is `{ kind: "sender" }` or when nothing matched. Falls
+ * back to `sender`, which is today's whole behavior.
+ */
+export function chooseNotificationClickWindow<TWindow>(input: {
+  route: NotificationRoute;
+  candidates: readonly TWindow[];
+  sender: TWindow | null;
+}): TWindow | null {
+  if (input.route.kind === "sender") {
+    return input.sender;
+  }
+  return input.candidates[0] ?? input.sender;
+}

--- a/packages/desktop/src/features/notifications.ts
+++ b/packages/desktop/src/features/notifications.ts
@@ -2,6 +2,19 @@ import path from "node:path";
 import { existsSync } from "node:fs";
 import { app, BrowserWindow, Notification, ipcMain, nativeImage } from "electron";
 import { getDesktopSettingsStore } from "../settings/desktop-settings-electron.js";
+import {
+  chooseNotificationClickWindow,
+  resolveNotificationRoute,
+  type NotificationRoute,
+} from "./notification-click.js";
+
+/**
+ * Given the resolved route, returns the windows already showing that target, ranked
+ * best first (empty when nothing matches, or when the route is `{ kind: "sender" }`).
+ * Optional so the module stays importable without one — the click then falls back to
+ * the sender, exactly as before this feature existed.
+ */
+export type NotificationClickCandidateSource = (route: NotificationRoute) => BrowserWindow[];
 
 interface NotificationInput {
   title?: unknown;
@@ -49,8 +62,7 @@ function getNotificationIcon(): Electron.NativeImage | null {
   return null;
 }
 
-function focusSenderWindow(sender: Electron.WebContents): BrowserWindow | null {
-  const win = BrowserWindow.fromWebContents(sender) ?? BrowserWindow.getAllWindows()[0] ?? null;
+function focusWindow(win: BrowserWindow | null): BrowserWindow | null {
   if (!win || win.isDestroyed()) {
     return null;
   }
@@ -78,7 +90,9 @@ export function ensureNotificationCenterRegistration(): void {
   probe.show();
 }
 
-export function registerNotificationHandlers(): void {
+export function registerNotificationHandlers(
+  getCandidateWindows?: NotificationClickCandidateSource,
+): void {
   ipcMain.handle("paseo:notification:isSupported", () => {
     return Notification.isSupported();
   });
@@ -107,7 +121,12 @@ export function registerNotificationHandlers(): void {
     activeNotifications.add(notification);
 
     notification.on("click", () => {
-      const win = focusSenderWindow(event.sender);
+      const sender =
+        BrowserWindow.fromWebContents(event.sender) ?? BrowserWindow.getAllWindows()[0] ?? null;
+      const route = resolveNotificationRoute(data);
+      const candidates = getCandidateWindows?.(route) ?? [];
+      const chosen = chooseNotificationClickWindow({ route, candidates, sender });
+      const win = focusWindow(chosen);
       if (win && data && Object.keys(data).length > 0) {
         const payload: NotificationClickPayload = { data };
         win.webContents.send("paseo:event:notification-click", payload);

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -48,6 +48,7 @@ import {
   registerNotificationHandlers,
   ensureNotificationCenterRegistration,
 } from "./features/notifications.js";
+import type { NotificationRoute } from "./features/notification-click.js";
 import { createExternalUrlOpener } from "./features/opener.js";
 import { createBrowserCaptureService } from "./features/browser-capture.js";
 import { registerEditorTargetHandlers } from "./features/editor-targets/ipc.js";
@@ -104,7 +105,12 @@ import {
   parseAgentDeepLink,
   type AgentDeepLinkTarget,
 } from "@getpaseo/protocol/agent-deep-link";
-import { AgentNavigationInbox, parseAgentDeepLinkFromArgv } from "./agent-navigation.js";
+import {
+  AgentNavigationInbox,
+  parseAgentDeepLinkFromArgv,
+  type WindowNavigationTarget,
+  type WindowView,
+} from "./agent-navigation.js";
 
 const DEV_SERVER_URL = process.env.EXPO_DEV_URL ?? "http://localhost:8081";
 const APP_SCHEME = "paseo";
@@ -375,6 +381,58 @@ ipcMain.handle("paseo:get-pending-open-project", (event) => {
 ipcMain.handle("paseo:agent-navigation:ready", (event) => {
   return agentNavigationInbox.windowReady(event.sender.id);
 });
+
+// Bounded so a malformed or runaway renderer report cannot grow unbounded main-process
+// state. Comfortably above any real sidebar (this machine's dev home has ~70 workspaces).
+const MAX_REPORTED_WINDOW_VIEW_ENTRIES = 2_000;
+
+function readReportedWindowView(rawInput: unknown): WindowView | null {
+  if (typeof rawInput !== "object" || rawInput === null) {
+    return null;
+  }
+  const { visibleAgentIds, visibleWorkspaceKeys } = rawInput as Record<string, unknown>;
+  if (!isBoundedStringArray(visibleAgentIds) || !isBoundedStringArray(visibleWorkspaceKeys)) {
+    return null;
+  }
+  return { visibleAgentIds, visibleWorkspaceKeys };
+}
+
+function isBoundedStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length <= MAX_REPORTED_WINDOW_VIEW_ENTRIES &&
+    value.every((entry) => typeof entry === "string")
+  );
+}
+
+ipcMain.handle("paseo:window:reportView", (event, rawInput: unknown) => {
+  const view = readReportedWindowView(rawInput);
+  if (!view) {
+    log.warn("[window-view] dropped malformed report", { webContentsId: event.sender.id });
+    return;
+  }
+  agentNavigationInbox.setWindowView(event.sender.id, view);
+});
+
+function getNotificationClickCandidateWindows(route: NotificationRoute): BrowserWindow[] {
+  if (route.kind !== "target") {
+    return [];
+  }
+  const target: WindowNavigationTarget = {
+    serverId: route.serverId,
+    workspaceId: route.workspaceId,
+    agentId: route.agentId,
+  };
+  const windows = BrowserWindow.getAllWindows();
+  const rankedIds = agentNavigationInbox.windowsShowingTarget(
+    windows.map((win) => win.webContents.id),
+    target,
+    (webContentsId) => webContents.fromId(webContentsId)?.getURL() ?? null,
+  );
+  return rankedIds
+    .map((webContentsId) => windows.find((win) => win.webContents.id === webContentsId))
+    .filter((win): win is BrowserWindow => win !== undefined && !win.isDestroyed());
+}
 
 ipcMain.handle("paseo:browser:register-attached", (event, rawInput: unknown) => {
   const input = readAttachedBrowserInput(rawInput);
@@ -691,6 +749,9 @@ async function createWindow(
       agentNavigationInbox.windowLoading(webContentsId);
     }
   });
+  mainWindow.on("focus", () => {
+    agentNavigationInbox.noteWindowFocused(webContentsId);
+  });
   mainWindow.on("closed", () => {
     options.onClosed?.(webContentsId);
     agentNavigationInbox.removeWindow(webContentsId);
@@ -800,6 +861,16 @@ desktopWindowOwner = createDesktopWindowOwner<AgentDeepLinkTarget>({
   agentRoute: buildAgentDeepLinkRoute,
   deliverAgent: (webContentsId, target) =>
     agentNavigationInbox.deliverOrQueue(webContentsId, target),
+  preferredWindow: (target) => {
+    const windows = BrowserWindow.getAllWindows();
+    const [bestId] = agentNavigationInbox.windowsShowingTarget(
+      windows.map((win) => win.webContents.id),
+      { serverId: target.serverId, workspaceId: null, agentId: target.agentId },
+      (webContentsId) => webContents.fromId(webContentsId)?.getURL() ?? null,
+    );
+    const win = windows.find((candidate) => candidate.webContents.id === bestId);
+    return win ? ownedDesktopWindow(win) : null;
+  },
 });
 
 // ---------------------------------------------------------------------------
@@ -941,7 +1012,7 @@ async function bootstrap(): Promise<void> {
   registerDaemonManager();
   registerWindowManager({ mode: DESKTOP_WINDOW_CHROME_MODE });
   registerDialogHandlers();
-  registerNotificationHandlers();
+  registerNotificationHandlers(getNotificationClickCandidateWindows);
   const openExternalUrl = createExternalUrlOpener({ open: shell.openExternal });
   ipcMain.handle("paseo:opener:openUrl", (_event, value: unknown) => openExternalUrl(value));
   registerEditorTargetHandlers();

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -78,6 +78,8 @@ contextBridge.exposeInMainWorld("paseoDesktop", {
       },
       setBadgeCount: (count?: number) => ipcRenderer.invoke("paseo:window:setBadgeCount", count),
     }),
+    reportView: (report: { visibleAgentIds: string[]; visibleWorkspaceKeys: string[] }) =>
+      ipcRenderer.invoke("paseo:window:reportView", report),
   },
   dialog: {
     ask: (message: string, options?: Record<string, unknown>) =>

--- a/packages/desktop/src/window/desktop-window-owner.test.ts
+++ b/packages/desktop/src/window/desktop-window-owner.test.ts
@@ -5,10 +5,13 @@ interface Target {
   id: string;
 }
 
-function harness() {
+function harness(
+  options: { preferredWindow?: (target: Target) => OwnedDesktopWindow<Target> | null } = {},
+) {
   const windows: OwnedDesktopWindow<Target>[] = [];
   const launches: Array<{ initialRoute: string | null; restoreWindowState: boolean }> = [];
   const sent: Target[] = [];
+  const focusCalls: number[] = [];
   let nextId = 1;
   let focused: OwnedDesktopWindow<Target> | null = null;
   let closeWindow = (_id: number) => {};
@@ -27,7 +30,7 @@ function harness() {
         isMinimized: () => false,
         restore: () => {},
         show: () => {},
-        focus: () => {},
+        focus: () => focusCalls.push(id),
         sendAgent: (target) => sent.push(target),
       };
       windows.push(window);
@@ -38,12 +41,14 @@ function harness() {
     focusedWindow: () => focused,
     agentRoute: (target) => `/agent/${target.id}`,
     deliverAgent: (_id, target) => target,
+    preferredWindow: options.preferredWindow,
   });
   return {
     owner,
     launches,
     sent,
     windows,
+    focusCalls,
     setFocused: (window: OwnedDesktopWindow<Target>) => {
       focused = window;
     },
@@ -78,5 +83,30 @@ describe("desktop window owner", () => {
     await h.owner.openAdditional({ pendingProjectPath: "/project/a" });
     h.close(1);
     expect(h.owner.takePendingProject(1)).toBeNull();
+  });
+
+  it("prefers the window already showing the target over the focused window", async () => {
+    let preferred: OwnedDesktopWindow<Target> | null = null;
+    const h = harness({ preferredWindow: () => preferred });
+    await h.owner.openPrimary();
+    await h.owner.openAdditional();
+    h.setFocused(h.windows[0]);
+    preferred = h.windows[1];
+
+    await h.owner.openOrFocusAgent({ id: "agent-7" });
+
+    expect(h.focusCalls).toEqual([2]);
+    expect(h.sent).toEqual([{ id: "agent-7" }]);
+  });
+
+  it("falls back to the focused window when preferredWindow finds no match", async () => {
+    const h = harness({ preferredWindow: () => null });
+    await h.owner.openPrimary();
+    h.setFocused(h.windows[0]);
+
+    await h.owner.openOrFocusAgent({ id: "agent-7" });
+
+    expect(h.focusCalls).toEqual([1]);
+    expect(h.sent).toEqual([{ id: "agent-7" }]);
   });
 });

--- a/packages/desktop/src/window/desktop-window-owner.ts
+++ b/packages/desktop/src/window/desktop-window-owner.ts
@@ -22,6 +22,9 @@ interface DesktopWindowOwnerPort<TAgentTarget> {
   focusedWindow(): OwnedDesktopWindow<TAgentTarget> | null;
   agentRoute(target: TAgentTarget): string;
   deliverAgent(webContentsId: number, target: TAgentTarget): TAgentTarget | null;
+  /** The window already showing `target`, if any — tried before `focusedWindow`. Optional
+   * so a port that doesn't track window contents (e.g. in tests) keeps today's order. */
+  preferredWindow?(target: TAgentTarget): OwnedDesktopWindow<TAgentTarget> | null;
 }
 
 export interface DesktopWindowOwner<TAgentTarget> {
@@ -70,7 +73,10 @@ export function createDesktopWindowOwner<TAgentTarget>(
     async openOrFocusAgent(target) {
       const windows = port.windows();
       const window =
-        port.focusedWindow() ?? windows.find((candidate) => candidate.isVisible()) ?? windows[0];
+        port.preferredWindow?.(target) ??
+        port.focusedWindow() ??
+        windows.find((candidate) => candidate.isVisible()) ??
+        windows[0];
       if (!window || window.isDestroyed()) {
         if (!agentWindowCreation) {
           agentWindowCreation = owner

--- a/packages/desktop/src/window/workspace-route-url.test.ts
+++ b/packages/desktop/src/window/workspace-route-url.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { parseWorkspaceRouteUrl } from "./workspace-route-url.js";
+
+describe("parseWorkspaceRouteUrl", () => {
+  it("parses a packaged paseo:// workspace route", () => {
+    expect(parseWorkspaceRouteUrl("paseo://app/h/local/workspace/abc123")).toEqual({
+      serverId: "local",
+      workspaceId: "abc123",
+    });
+  });
+
+  it("parses a dev-server workspace route", () => {
+    expect(parseWorkspaceRouteUrl("http://localhost:8081/h/local/workspace/abc123")).toEqual({
+      serverId: "local",
+      workspaceId: "abc123",
+    });
+  });
+
+  it("parses a workspace route with a trailing slash", () => {
+    expect(parseWorkspaceRouteUrl("paseo://app/h/local/workspace/abc123/")).toEqual({
+      serverId: "local",
+      workspaceId: "abc123",
+    });
+  });
+
+  it("decodes percent-encoded ids", () => {
+    expect(parseWorkspaceRouteUrl("paseo://app/h/remote%3Agithub.com/workspace/ws%2Fone")).toEqual({
+      serverId: "remote:github.com",
+      workspaceId: "ws/one",
+    });
+  });
+
+  it("ignores query and hash", () => {
+    expect(parseWorkspaceRouteUrl("paseo://app/h/local/workspace/abc123?tab=files#top")).toEqual({
+      serverId: "local",
+      workspaceId: "abc123",
+    });
+  });
+
+  it("returns null for non-workspace routes", () => {
+    expect(parseWorkspaceRouteUrl("paseo://app/h/local/agent/abc123")).toBeNull();
+    expect(parseWorkspaceRouteUrl("paseo://app/")).toBeNull();
+    expect(parseWorkspaceRouteUrl("paseo://app/h/local/workspace/")).toBeNull();
+  });
+
+  it("returns null for a malformed URL", () => {
+    expect(parseWorkspaceRouteUrl("not a url")).toBeNull();
+  });
+});

--- a/packages/desktop/src/window/workspace-route-url.ts
+++ b/packages/desktop/src/window/workspace-route-url.ts
@@ -1,0 +1,39 @@
+/**
+ * Parses a window's current URL into the workspace it names, if any.
+ *
+ * Both loading modes put the same route path in the URL: packaged windows load
+ * `paseo://app/h/<serverId>/workspace/<workspaceId>` and dev windows load the same
+ * route off the Expo dev server (`http://localhost:8081/h/<serverId>/workspace/<id>`).
+ * `webContents.getURL()` follows in-app `history.pushState` navigation under both, so
+ * this is a live read of which workspace a window is showing, not a snapshot from the
+ * last full load.
+ */
+
+export interface WorkspaceRouteMatch {
+  serverId: string;
+  workspaceId: string;
+}
+
+const WORKSPACE_ROUTE_PATTERN = /^\/h\/([^/]+)\/workspace\/([^/]+)\/?$/;
+
+export function parseWorkspaceRouteUrl(url: string): WorkspaceRouteMatch | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  const match = WORKSPACE_ROUTE_PATTERN.exec(parsed.pathname);
+  if (!match) {
+    return null;
+  }
+
+  const serverId = decodeURIComponent(match[1]);
+  const workspaceId = decodeURIComponent(match[2]);
+  if (!serverId || !workspaceId) {
+    return null;
+  }
+
+  return { serverId, workspaceId };
+}


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Reasoning

With two desktop windows open against the same daemon, filtering the sidebar to different projects in each, a notification click could pull a workspace from the wrong window's project into view. Every connected window posts its own OS notification banner for the same daemon event, and a click always focused the window that sent the banner, not the window that actually showed the target agent. Whichever duplicate banner you happened to click decided where the app jumped.

### Goals

- A notification click opens the agent in the window that already shows it: visible in a pane, on that workspace's route, or listed in that window's sidebar. Not the window that happened to post the banner.
- `paseo://` deep links use the same window lookup as notification clicks, so both entry points pick the same window.
- When no open window shows the target, fall back to today's behavior (focused window, or create one), so nothing regresses when the new per-window reports are unavailable, such as an old renderer build or dev-server drift.
- When more than one window shows the same target, the most recently focused window wins.

### Non-goals

- Duplicate banners: each window still posts its own OS banner for the same daemon event, so two open windows still show two banners and two sounds for one event. Deduping needs its own key, TTL cache, and tests, and does not change where a click lands once routing is by ownership.
- The shared sidebar-view storage key: two windows still share one localStorage key for sidebar view state, so the last writer wins and a reloading window can inherit the other window's filters. This is a real, separate bug, not caused by this change.

### QA

**Tests:**

- `packages/desktop/src/window/workspace-route-url.test.ts` (new) - parses packaged and dev-server workspace route URLs, decodes percent-encoded ids, and rejects non-workspace or malformed URLs.
- `packages/desktop/src/agent-navigation.test.ts` (extended) - the tiered `windowsShowingTarget` ranking (visible agent, URL, sidebar key), the most-recently-focused tie-break, no match, and that `windowLoading`/`removeWindow` clear a window's recorded view.
- `packages/desktop/src/features/notification-click.test.ts` (new) - route resolution from notification data, and the fallback to the sending window when no candidate matches.
- `packages/desktop/src/window/desktop-window-owner.test.ts` (extended) - `preferredWindow` wins over the default focus order, and the existing fallback still applies when it returns null.
- `packages/app/src/desktop/window-view-report.test.ts` (new) - the report payload's sort and dedupe, and that an inactive sidebar reports no workspace keys.

Ran two desktop windows against the same daemon for several days of normal work, each filtered to a different project. Before this change, clicking a notification could bring an agent from one window's project into the other window's Working list. After this change, notification clicks landed in the correct window throughout normal daily use. Did not separately exercise the deep-link path or the close-window fallback path by hand; those are covered by the unit tests above.

The additions to `workspace-screen.tsx` and `sidebar-model.tsx` are additive effects that publish derived view state to a new store. They do not change existing render or filtering logic.

Desktop-only change (Electron). Not applicable: iOS, Android, web browser.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
