### PR TITLE
feat(app): pin workspace tabs

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -108,7 +108,8 @@ only the route's explicit Unarchive or Restore action changes the archived works
 History navigation preserves the selected agent as an explicit recovery target. If both that agent
 and its workspace are archived, the workspace recovery action restores the workspace and unarchives
 the selected agent as one user action. Other archived agents in the restored workspace remain
-recoverable from History. Opening one pins its tab and renders the archived-agent callout. Authoritative
+recoverable from History. Opening one keeps its tab visible during reconciliation and renders the
+archived-agent callout. Authoritative
 timeline catch-up may load provider history with a runtime-only `history` resume purpose, which must
 leave both Paseo's `archivedAt` and the provider's native archive state unchanged. **Unarchive** remains
 the only transition back to an interactive runtime: it runs the provider's native unarchive hook

--- a/packages/app/e2e/browser/pinned-tabs.spec.ts
+++ b/packages/app/e2e/browser/pinned-tabs.spec.ts
@@ -1,0 +1,115 @@
+import { mkdir } from "node:fs/promises";
+import { expect, test, type Page } from "../support/fixtures";
+import { clickNewTerminal, gotoWorkspace } from "../support/helpers/launcher";
+import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
+
+const QA_DIR = "/tmp/pinned-tabs-qa";
+
+interface OpenTerminalTab {
+  id: string;
+  tab: ReturnType<Page["getByTestId"]>;
+}
+
+async function listTerminalIds(workspace: SeededWorkspace): Promise<string[]> {
+  const result = await workspace.client.listTerminals(workspace.repoPath, undefined, {
+    workspaceId: workspace.workspaceId,
+  });
+  return result.terminals.map((terminal) => terminal.id);
+}
+
+async function openTerminalTab(page: Page, workspace: SeededWorkspace): Promise<OpenTerminalTab> {
+  const previousIds = new Set(await listTerminalIds(workspace));
+  await clickNewTerminal(page);
+
+  let createdId: string | undefined;
+  await expect
+    .poll(
+      async () => {
+        const ids = await listTerminalIds(workspace);
+        const createdIds = ids.filter((id) => !previousIds.has(id));
+        createdId = createdIds[0];
+        return createdIds;
+      },
+      { timeout: 30_000 },
+    )
+    .toHaveLength(1);
+  if (!createdId) {
+    throw new Error("New terminal did not appear in the isolated daemon");
+  }
+
+  const tab = page.getByTestId(`workspace-tab-terminal_${createdId}`).filter({ visible: true });
+  await expect(tab).toBeVisible({ timeout: 30_000 });
+  return { id: createdId, tab };
+}
+
+function pinGlyph(tab: OpenTerminalTab["tab"]) {
+  return tab.locator('svg:has(path[d="M12 17v5"])');
+}
+
+async function openTabContextMenu(tab: OpenTerminalTab): Promise<void> {
+  await tab.tab.click({ button: "right" });
+  await expect(tab.tab.page().getByTestId(`workspace-tab-context-terminal_${tab.id}`)).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+async function acceptCloseOtherTabs(page: Page, tab: OpenTerminalTab): Promise<void> {
+  await openTabContextMenu(tab);
+  const closeOthers = page.getByTestId(`workspace-tab-context-terminal_${tab.id}-close-others`);
+  await expect(closeOthers).toHaveText("Close other tabs");
+
+  const dialogMessage = page.waitForEvent("dialog").then(async (dialog) => {
+    const message = dialog.message();
+    await dialog.accept();
+    return message;
+  });
+  await closeOthers.click();
+  await expect(dialogMessage).resolves.toContain("Close other tabs?");
+}
+
+test.describe("Pinned workspace tabs", () => {
+  test("pins a terminal tab and protects it from Close other tabs", async ({ page }) => {
+    test.setTimeout(120_000);
+    await mkdir(QA_DIR, { recursive: true });
+    const workspace = await seedWorkspace({ repoPrefix: "pinned-tabs-" });
+
+    try {
+      await gotoWorkspace(page, workspace.workspaceId);
+      const pinned = await openTerminalTab(page, workspace);
+      const anchor = await openTerminalTab(page, workspace);
+
+      await openTabContextMenu(pinned);
+      const pinItem = page.getByTestId(`workspace-tab-context-terminal_${pinned.id}-pin`);
+      await expect(pinItem).toHaveText("Pin tab");
+      await page.screenshot({ path: `${QA_DIR}/01-pin-tab-menu.png`, fullPage: false });
+      await pinItem.click();
+
+      await expect(pinGlyph(pinned.tab)).toBeVisible({ timeout: 10_000 });
+      await page.screenshot({ path: `${QA_DIR}/02-pinned-tab-row.png`, fullPage: false });
+
+      const disposable = await openTerminalTab(page, workspace);
+      await acceptCloseOtherTabs(page, anchor);
+
+      await expect(pinned.tab).toBeVisible();
+      await expect(pinGlyph(pinned.tab)).toBeVisible();
+      await expect(anchor.tab).toBeVisible();
+      await expect(disposable.tab).toHaveCount(0, { timeout: 30_000 });
+      await page.screenshot({
+        path: `${QA_DIR}/03-close-others-pinned-survives.png`,
+        fullPage: false,
+      });
+
+      await openTabContextMenu(pinned);
+      const unpinItem = page.getByTestId(`workspace-tab-context-terminal_${pinned.id}-pin`);
+      await expect(unpinItem).toHaveText("Unpin tab");
+      await unpinItem.click();
+      await expect(pinGlyph(pinned.tab)).toHaveCount(0);
+
+      await acceptCloseOtherTabs(page, anchor);
+      await expect(anchor.tab).toBeVisible();
+      await expect(pinned.tab).toHaveCount(0, { timeout: 30_000 });
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+});

--- a/packages/app/e2e/browser/pinned-tabs.spec.ts
+++ b/packages/app/e2e/browser/pinned-tabs.spec.ts
@@ -77,6 +77,7 @@ test.describe("Pinned workspace tabs", () => {
       await gotoWorkspace(page, workspace.workspaceId);
       const pinned = await openTerminalTab(page, workspace);
       const anchor = await openTerminalTab(page, workspace);
+      const disposable = await openTerminalTab(page, workspace);
 
       await openTabContextMenu(pinned);
       const pinItem = page.getByTestId(`workspace-tab-context-terminal_${pinned.id}-pin`);
@@ -85,15 +86,16 @@ test.describe("Pinned workspace tabs", () => {
       await pinItem.click();
 
       await expect(pinGlyph(pinned.tab)).toBeVisible({ timeout: 10_000 });
+      await expect(page.locator('[data-testid^="workspace-tab-terminal_"]:visible')).toHaveCount(3);
       await page.screenshot({ path: `${QA_DIR}/02-pinned-tab-row.png`, fullPage: false });
 
-      const disposable = await openTerminalTab(page, workspace);
-      await acceptCloseOtherTabs(page, anchor);
+      await acceptCloseOtherTabs(page, pinned);
 
       await expect(pinned.tab).toBeVisible();
       await expect(pinGlyph(pinned.tab)).toBeVisible();
-      await expect(anchor.tab).toBeVisible();
+      await expect(anchor.tab).toHaveCount(0, { timeout: 30_000 });
       await expect(disposable.tab).toHaveCount(0, { timeout: 30_000 });
+      await expect(page.locator('[data-testid^="workspace-tab-terminal_"]:visible')).toHaveCount(1);
       await page.screenshot({
         path: `${QA_DIR}/03-close-others-pinned-survives.png`,
         fullPage: false,
@@ -105,8 +107,9 @@ test.describe("Pinned workspace tabs", () => {
       await unpinItem.click();
       await expect(pinGlyph(pinned.tab)).toHaveCount(0);
 
-      await acceptCloseOtherTabs(page, anchor);
-      await expect(anchor.tab).toBeVisible();
+      const unpinnedAnchor = await openTerminalTab(page, workspace);
+      await acceptCloseOtherTabs(page, unpinnedAnchor);
+      await expect(unpinnedAnchor.tab).toBeVisible();
       await expect(pinned.tab).toHaveCount(0, { timeout: 30_000 });
     } finally {
       await workspace.cleanup();

--- a/packages/app/e2e/browser/pinned-tabs.spec.ts
+++ b/packages/app/e2e/browser/pinned-tabs.spec.ts
@@ -1,9 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import { expect, test, type Page } from "../support/fixtures";
 import { clickNewTerminal, gotoWorkspace } from "../support/helpers/launcher";
 import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
-
-const QA_DIR = "/tmp/pinned-tabs-qa";
 
 interface OpenTerminalTab {
   id: string;
@@ -68,9 +65,8 @@ async function acceptCloseOtherTabs(page: Page, tab: OpenTerminalTab): Promise<v
 }
 
 test.describe("Pinned workspace tabs", () => {
-  test("pins a terminal tab and protects it from Close other tabs", async ({ page }) => {
+  test("pins a terminal tab and protects it from Close other tabs", async ({ page }, testInfo) => {
     test.setTimeout(120_000);
-    await mkdir(QA_DIR, { recursive: true });
     const workspace = await seedWorkspace({ repoPrefix: "pinned-tabs-" });
 
     try {
@@ -82,22 +78,25 @@ test.describe("Pinned workspace tabs", () => {
       await openTabContextMenu(pinned);
       const pinItem = page.getByTestId(`workspace-tab-context-terminal_${pinned.id}-pin`);
       await expect(pinItem).toHaveText("Pin tab");
-      await page.screenshot({ path: `${QA_DIR}/01-pin-tab-menu.png`, fullPage: false });
+      await page.screenshot({ path: testInfo.outputPath("01-pin-tab-menu.png"), fullPage: false });
       await pinItem.click();
 
       await expect(pinGlyph(pinned.tab)).toBeVisible({ timeout: 10_000 });
       await expect(page.locator('[data-testid^="workspace-tab-terminal_"]:visible')).toHaveCount(3);
-      await page.screenshot({ path: `${QA_DIR}/02-pinned-tab-row.png`, fullPage: false });
+      await page.screenshot({
+        path: testInfo.outputPath("02-pinned-tab-row.png"),
+        fullPage: false,
+      });
 
-      await acceptCloseOtherTabs(page, pinned);
+      await acceptCloseOtherTabs(page, anchor);
 
       await expect(pinned.tab).toBeVisible();
       await expect(pinGlyph(pinned.tab)).toBeVisible();
-      await expect(anchor.tab).toHaveCount(0, { timeout: 30_000 });
+      await expect(anchor.tab).toBeVisible();
       await expect(disposable.tab).toHaveCount(0, { timeout: 30_000 });
-      await expect(page.locator('[data-testid^="workspace-tab-terminal_"]:visible')).toHaveCount(1);
+      await expect(page.locator('[data-testid^="workspace-tab-terminal_"]:visible')).toHaveCount(2);
       await page.screenshot({
-        path: `${QA_DIR}/03-close-others-pinned-survives.png`,
+        path: testInfo.outputPath("03-close-others-pinned-survives.png"),
         fullPage: false,
       });
 
@@ -107,9 +106,8 @@ test.describe("Pinned workspace tabs", () => {
       await unpinItem.click();
       await expect(pinGlyph(pinned.tab)).toHaveCount(0);
 
-      const unpinnedAnchor = await openTerminalTab(page, workspace);
-      await acceptCloseOtherTabs(page, unpinnedAnchor);
-      await expect(unpinnedAnchor.tab).toBeVisible();
+      await acceptCloseOtherTabs(page, anchor);
+      await expect(anchor.tab).toBeVisible();
       await expect(pinned.tab).toHaveCount(0, { timeout: 30_000 });
     } finally {
       await workspace.cleanup();

--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -77,6 +77,7 @@ import { ExplorerSidebarDock } from "@/screens/workspace/explorer-sidebar";
 import {
   WorkspaceTabPresentationResolver,
   WorkspaceTabIcon,
+  WorkspaceTabPinIcon,
 } from "@/screens/workspace/workspace-tab-presentation";
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
 import {
@@ -112,6 +113,7 @@ interface SplitContainerProps {
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
+  onTogglePinTab: (tabId: string) => void;
   onCloseTabsToLeft: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
@@ -325,6 +327,7 @@ export function SplitContainer({
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
+  onTogglePinTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -678,6 +681,7 @@ export function SplitContainer({
                   onCopyFilePath={onCopyFilePath}
                   onReloadAgent={onReloadAgent}
                   onRenameTab={onRenameTab}
+                  onTogglePinTab={onTogglePinTab}
                   onCloseTabsToLeft={onCloseTabsToLeft}
                   onCloseTabsToRight={onCloseTabsToRight}
                   onCloseOtherTabs={onCloseOtherTabs}
@@ -725,6 +729,7 @@ export function SplitContainer({
                   closingTabIds={closingTabIds}
                   onSelectTab={onSelectTabInPane}
                   onCloseTab={onCloseTab}
+                  onTogglePinTab={onTogglePinTab}
                   onCreateNewTab={handleCreateExplorerTab}
                   onMoveTabToMain={handleMoveExplorerTabToMain}
                   buildPaneContentModel={buildPaneContentModel}
@@ -772,6 +777,7 @@ function DragOverlayTabChip({
             tabId: tab.tabId,
             kind: tab.target.kind,
             target: tab.target,
+            isPinned: tab.isPinned === true,
           }
         : null,
     [tab],
@@ -828,6 +834,7 @@ function DragOverlayTabChipInner({
         return (
           <View style={chipStyle}>
             <WorkspaceTabIcon presentation={presentation} active size={14} backdrop="surface1" />
+            <WorkspaceTabPinIcon isPinned={tab.isPinned === true} />
             <Text numberOfLines={1} style={chipLabelStyle}>
               {label}
             </Text>
@@ -940,6 +947,7 @@ function SplitNodeView({
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
+  onTogglePinTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -1028,6 +1036,7 @@ function SplitNodeView({
             onCopyFilePath={onCopyFilePath}
             onReloadAgent={onReloadAgent}
             onRenameTab={onRenameTab}
+            onTogglePinTab={onTogglePinTab}
             onCloseTabsToLeft={onCloseTabsToLeft}
             onCloseTabsToRight={onCloseTabsToRight}
             onCloseOtherTabs={onCloseOtherTabs}
@@ -1080,6 +1089,7 @@ function SplitNodeView({
               onCopyFilePath={onCopyFilePath}
               onReloadAgent={onReloadAgent}
               onRenameTab={onRenameTab}
+              onTogglePinTab={onTogglePinTab}
               onCloseTabsToLeft={onCloseTabsToLeft}
               onCloseTabsToRight={onCloseTabsToRight}
               onCloseOtherTabs={onCloseOtherTabs}
@@ -1140,6 +1150,7 @@ function SplitPaneView({
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
+  onTogglePinTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -1275,6 +1286,7 @@ function SplitPaneView({
             onCopyFilePath={onCopyFilePath}
             onReloadAgent={onReloadAgent}
             onRenameTab={onRenameTab}
+            onTogglePinTab={onTogglePinTab}
             onCloseTabsToLeft={handleCloseTabsToLeft}
             onCloseTabsToRight={handleCloseTabsToRight}
             onCloseOtherTabs={handleCloseOtherTabs}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -578,6 +578,8 @@ export const ar: TranslationResources = {
         copyTerminalId: "نسخ معرف المحطة",
         copyFilePath: "Copy file path",
         rename: "إعادة تسمية",
+        pinTab: "تثبيت علامة التبويب",
+        unpinTab: "إلغاء تثبيت علامة التبويب",
         closeAbove: "إغلاق علامات التبويب أعلاه",
         closeBelow: "إغلاق علامات التبويب أدناه",
         closeLeft: "بالقرب من اليسار",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -576,6 +576,8 @@ export const en = {
         copyTerminalId: "Copy terminal id",
         copyFilePath: "Copy file path",
         rename: "Rename",
+        pinTab: "Pin tab",
+        unpinTab: "Unpin tab",
         closeAbove: "Close tabs above",
         closeBelow: "Close tabs below",
         closeLeft: "Close to the left",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -582,6 +582,8 @@ export const es: TranslationResources = {
         copyTerminalId: "Copiar ID del terminal",
         copyFilePath: "Copy file path",
         rename: "Rebautizar",
+        pinTab: "Fijar pestaña",
+        unpinTab: "Desfijar pestaña",
         closeAbove: "Cerrar pestañas arriba",
         closeBelow: "Cerrar pestañas a continuación",
         closeLeft: "Cerrar pestañas a la izquierda",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -582,6 +582,8 @@ export const fr: TranslationResources = {
         copyTerminalId: "Copier l'identifiant du terminal",
         copyFilePath: "Copy file path",
         rename: "Rebaptiser",
+        pinTab: "Épingler l'onglet",
+        unpinTab: "Désépingler l'onglet",
         closeAbove: "Fermer les onglets ci-dessus",
         closeBelow: "Fermer les onglets ci-dessous",
         closeLeft: "Près de la gauche",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -582,6 +582,8 @@ export const ja: TranslationResources = {
         copyTerminalId: "ターミナルIDをコピー",
         copyFilePath: "ファイルパスをコピー",
         rename: "名前を変更",
+        pinTab: "タブをピン留め",
+        unpinTab: "タブのピン留めを解除",
         closeAbove: "上のタブを閉じる",
         closeBelow: "下のタブを閉じる",
         closeLeft: "左のタブを閉じる",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -579,6 +579,8 @@ export const ko: TranslationResources = {
         copyTerminalId: "터미널 ID 복사",
         copyFilePath: "파일 경로 복사",
         rename: "이름 변경",
+        pinTab: "탭 고정",
+        unpinTab: "탭 고정 해제",
         closeAbove: "위쪽 탭 닫기",
         closeBelow: "아래쪽 탭 닫기",
         closeLeft: "왼쪽 탭 닫기",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -582,6 +582,8 @@ export const ptBR: TranslationResources = {
         copyTerminalId: "Copiar ID do terminal",
         copyFilePath: "Copiar caminho do arquivo",
         rename: "Renomear",
+        pinTab: "Fixar aba",
+        unpinTab: "Desafixar aba",
         closeAbove: "Fechar abas acima",
         closeBelow: "Fechar abas abaixo",
         closeLeft: "Fechar à esquerda",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -583,6 +583,8 @@ export const ru: TranslationResources = {
         copyTerminalId: "Скопировать идентификатор терминала",
         copyFilePath: "Скопировать путь к файлу",
         rename: "Переименовать",
+        pinTab: "Закрепить вкладку",
+        unpinTab: "Открепить вкладку",
         closeAbove: "Закрыть вкладки выше",
         closeBelow: "Закрыть вкладки ниже",
         closeLeft: "Закрыть вкладки слева",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -578,6 +578,8 @@ export const zhCN: TranslationResources = {
         copyTerminalId: "复制 Terminal ID",
         copyFilePath: "Copy file path",
         rename: "重命名",
+        pinTab: "固定标签页",
+        unpinTab: "取消固定标签页",
         closeAbove: "关闭上方标签",
         closeBelow: "关闭下方标签",
         closeLeft: "关闭左侧标签",

--- a/packages/app/src/screens/workspace/explorer-sidebar-tab-rail.tsx
+++ b/packages/app/src/screens/workspace/explorer-sidebar-tab-rail.tsx
@@ -38,6 +38,7 @@ import type { PanelIconProps } from "@/panels/panel-registry";
 import { panelTargetSupportsHost } from "@/plugins/workspace-panels/locations";
 import type { Theme } from "@/styles/theme";
 import type { SurfaceBackdrop } from "@/styles/surface-backdrop";
+import { isWorkspaceTabTargetPersistent } from "@/workspace-tabs/model";
 import {
   HorizontalScrollBoundaryShades,
   useHorizontalScrollBoundary,
@@ -112,6 +113,7 @@ function ExplorerSidebarTab({
     [item.tab.tabId, onMoveTabToMain],
   );
   const canMoveToMain = panelTargetSupportsHost(normalizedServerId, item.tab.target, "main");
+  const canPinTab = isWorkspaceTabTargetPersistent(item.tab.target);
   const moveToMainLeading = useMemo(
     () => <ThemedArrowLeftToLine size={14} uniProps={mutedColorMapping} />,
     [],
@@ -171,18 +173,22 @@ function ExplorerSidebarTab({
             </ContextMenuItem>
           ) : null}
           {canMoveToMain ? <ContextMenuSeparator /> : null}
-          <ContextMenuItem
-            testID={`explorer-sidebar-tab-${item.tab.tabId}-pin`}
-            leading={pinLeading}
-            onSelect={handleTogglePin}
-          >
-            {t(
-              item.tab.isPinned === true
-                ? "workspace.tabs.menu.unpinTab"
-                : "workspace.tabs.menu.pinTab",
-            )}
-          </ContextMenuItem>
-          <ContextMenuSeparator />
+          {canPinTab ? (
+            <>
+              <ContextMenuItem
+                testID={`explorer-sidebar-tab-${item.tab.tabId}-pin`}
+                leading={pinLeading}
+                onSelect={handleTogglePin}
+              >
+                {t(
+                  item.tab.isPinned === true
+                    ? "workspace.tabs.menu.unpinTab"
+                    : "workspace.tabs.menu.pinTab",
+                )}
+              </ContextMenuItem>
+              <ContextMenuSeparator />
+            </>
+          ) : null}
           <ContextMenuItem leading={closeLeading} onSelect={handleClose}>
             {t("workspace.tabs.menu.close")}
           </ContextMenuItem>
@@ -202,6 +208,7 @@ function ExplorerSidebarTab({
       isDragging,
       item,
       canMoveToMain,
+      canPinTab,
       closeLeading,
       pinLeading,
       moveToMainLeading,

--- a/packages/app/src/screens/workspace/explorer-sidebar-tab-rail.tsx
+++ b/packages/app/src/screens/workspace/explorer-sidebar-tab-rail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState, type ComponentType, type ReactNode } from "react";
 import { Text, View } from "react-native";
-import { ArrowLeftToLine, Plus, X } from "lucide-react-native";
+import { ArrowLeftToLine, Pin, Plus, X } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
 import Animated from "react-native-reanimated";
@@ -23,6 +23,7 @@ import { iconButtonChromeGlyphSize } from "@/components/ui/icon-button-chrome";
 import { HEADER_CONTROL_HEIGHT } from "@/components/ui/control-geometry";
 import {
   WorkspaceTabIcon,
+  WorkspaceTabPinIcon,
   WorkspaceTabPresentationResolver,
   type WorkspaceTabPresentation,
 } from "@/screens/workspace/workspace-tab-presentation";
@@ -56,6 +57,7 @@ interface ExplorerSidebarTabRailProps {
   tabDropPreviewIndex: number | null;
   onNavigateTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
+  onTogglePinTab: (tabId: string) => void;
   onCreateNewTab: () => void;
   onMoveTabToMain: (tabId: string) => void;
   onReorderTabs: (tabs: WorkspaceTabDescriptor[]) => void;
@@ -76,6 +78,7 @@ function ExplorerSidebarTab({
   dragHandleProps,
   onNavigateTab,
   onCloseTab,
+  onTogglePinTab,
   onMoveTabToMain,
   normalizedServerId,
   normalizedWorkspaceId,
@@ -85,6 +88,7 @@ function ExplorerSidebarTab({
   dragHandleProps?: DraggableListDragHandleProps;
   onNavigateTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
+  onTogglePinTab: (tabId: string) => void;
   onMoveTabToMain: (tabId: string) => void;
   normalizedServerId: string;
   normalizedWorkspaceId: string;
@@ -100,6 +104,9 @@ function ExplorerSidebarTab({
   const handleClose = useCallback(() => {
     void onCloseTab(item.tab.tabId);
   }, [item.tab.tabId, onCloseTab]);
+  const handleTogglePin = useCallback(() => {
+    onTogglePinTab(item.tab.tabId);
+  }, [item.tab.tabId, onTogglePinTab]);
   const handleMoveToMain = useCallback(
     () => onMoveTabToMain(item.tab.tabId),
     [item.tab.tabId, onMoveTabToMain],
@@ -110,6 +117,7 @@ function ExplorerSidebarTab({
     [],
   );
   const closeLeading = useMemo(() => <ThemedX size={14} uniProps={mutedColorMapping} />, []);
+  const pinLeading = useMemo(() => <ThemedPin size={14} uniProps={mutedColorMapping} />, []);
   const accessibilityState = useMemo(() => ({ selected: item.isActive }), [item.isActive]);
   const renderPresentation = useCallback(
     (presentation: WorkspaceTabPresentation) => (
@@ -141,6 +149,7 @@ function ExplorerSidebarTab({
                 strokeWidth={1.5}
                 backdrop={resolveExplorerSidebarTabBackdrop()}
               />
+              <WorkspaceTabPinIcon isPinned={item.tab.isPinned === true} />
               <Text
                 selectable={false}
                 numberOfLines={1}
@@ -162,6 +171,18 @@ function ExplorerSidebarTab({
             </ContextMenuItem>
           ) : null}
           {canMoveToMain ? <ContextMenuSeparator /> : null}
+          <ContextMenuItem
+            testID={`explorer-sidebar-tab-${item.tab.tabId}-pin`}
+            leading={pinLeading}
+            onSelect={handleTogglePin}
+          >
+            {t(
+              item.tab.isPinned === true
+                ? "workspace.tabs.menu.unpinTab"
+                : "workspace.tabs.menu.pinTab",
+            )}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
           <ContextMenuItem leading={closeLeading} onSelect={handleClose}>
             {t("workspace.tabs.menu.close")}
           </ContextMenuItem>
@@ -174,6 +195,7 @@ function ExplorerSidebarTab({
       handleHoverIn,
       handleHoverOut,
       handleClose,
+      handleTogglePin,
       handleMoveToMain,
       handlePress,
       hovered,
@@ -181,6 +203,7 @@ function ExplorerSidebarTab({
       item,
       canMoveToMain,
       closeLeading,
+      pinLeading,
       moveToMainLeading,
       t,
     ],
@@ -209,6 +232,7 @@ function CatalogIcon({
 
 const ThemedCatalogIcon = withUnistyles(CatalogIcon);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
+const ThemedPin = withUnistyles(Pin);
 const ThemedPlus = withUnistyles(Plus);
 const ThemedX = withUnistyles(X);
 
@@ -260,6 +284,7 @@ export function ExplorerSidebarTabRail({
   tabDropPreviewIndex,
   onNavigateTab,
   onCloseTab,
+  onTogglePinTab,
   onCreateNewTab,
   onMoveTabToMain,
   onReorderTabs,
@@ -313,6 +338,7 @@ export function ExplorerSidebarTabRail({
             dragHandleProps={dragHandleProps}
             onNavigateTab={onNavigateTab}
             onCloseTab={onCloseTab}
+            onTogglePinTab={onTogglePinTab}
             onMoveTabToMain={onMoveTabToMain}
             normalizedServerId={normalizedServerId}
             normalizedWorkspaceId={normalizedWorkspaceId}
@@ -327,6 +353,7 @@ export function ExplorerSidebarTabRail({
       normalizedWorkspaceId,
       onNavigateTab,
       onCloseTab,
+      onTogglePinTab,
       onMoveTabToMain,
       tabDropPreviewIndex,
       tabs.length,

--- a/packages/app/src/screens/workspace/explorer-sidebar.tsx
+++ b/packages/app/src/screens/workspace/explorer-sidebar.tsx
@@ -25,6 +25,7 @@ interface ExplorerSidebarDockProps {
   tabDropPreview: TabDropPreview | null;
   onSelectTab: (paneId: string, tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
+  onTogglePinTab: (tabId: string) => void;
   onCreateNewTab: () => void;
   onMoveTabToMain: (tabId: string) => void;
   onReorderTabsInPane: (paneId: string, tabIds: string[]) => void;
@@ -47,6 +48,7 @@ export function ExplorerSidebarDock({
   tabDropPreview,
   onSelectTab,
   onCloseTab,
+  onTogglePinTab,
   onCreateNewTab,
   onMoveTabToMain,
   onReorderTabsInPane,
@@ -97,6 +99,7 @@ export function ExplorerSidebarDock({
               }
               onNavigateTab={handleSelectTab}
               onCloseTab={onCloseTab}
+              onTogglePinTab={onTogglePinTab}
               onCreateNewTab={onCreateNewTab}
               onMoveTabToMain={onMoveTabToMain}
               onReorderTabs={handleReorderTabs}

--- a/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
+++ b/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
@@ -3,6 +3,7 @@ import {
   buildBulkCloseConfirmationMessage,
   classifyBulkClosableTabs,
   closeBulkWorkspaceTabs,
+  selectBulkCloseTabs,
 } from "@/screens/workspace/workspace-bulk-close";
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
 
@@ -33,7 +34,34 @@ function makeFileTab(path: string): WorkspaceTabDescriptor {
   };
 }
 
+function pinned(tab: WorkspaceTabDescriptor): WorkspaceTabDescriptor {
+  return { ...tab, isPinned: true };
+}
+
 describe("workspace bulk close helpers", () => {
+  it("skips pinned tabs when selecting tabs before, after, or around an anchor", () => {
+    const left = makeFileTab("/repo/left.ts");
+    const pinnedLeft = pinned(makeAgentTab("pinned-left"));
+    const anchor = pinned(makeTerminalTab("anchor"));
+    const pinnedRight = pinned(makeFileTab("/repo/pinned-right.ts"));
+    const right = makeAgentTab("right");
+    const tabs = [left, pinnedLeft, anchor, pinnedRight, right];
+
+    expect(selectBulkCloseTabs(tabs, anchor.tabId, "before")).toEqual([left]);
+    expect(selectBulkCloseTabs(tabs, anchor.tabId, "after")).toEqual([right]);
+    expect(selectBulkCloseTabs(tabs, anchor.tabId, "others")).toEqual([left, right]);
+  });
+
+  it("returns no bulk-close candidates when the anchor is missing or every candidate is pinned", () => {
+    const anchor = makeAgentTab("anchor");
+    const tabs = [pinned(makeFileTab("/repo/left.ts")), anchor, pinned(makeTerminalTab("right"))];
+
+    expect(selectBulkCloseTabs(tabs, "missing", "others")).toEqual([]);
+    expect(selectBulkCloseTabs(tabs, anchor.tabId, "before")).toEqual([]);
+    expect(selectBulkCloseTabs(tabs, anchor.tabId, "after")).toEqual([]);
+    expect(selectBulkCloseTabs(tabs, anchor.tabId, "others")).toEqual([]);
+  });
+
   it("classifies agent, terminal, and passive tabs for shared bulk close handling", () => {
     const groups = classifyBulkClosableTabs([
       makeAgentTab("a1"),
@@ -210,5 +238,23 @@ describe("workspace bulk close helpers", () => {
     expect(closeItems).toHaveBeenCalledWith({ agentIds: ["root"], terminalIds: [] });
     expect(preparedSubagents).toEqual(["child"]);
     expect(cleanedTabs).toEqual(["agent_child", "agent_root"]);
+  });
+
+  it("still closes a pinned tab when it is explicitly supplied", async () => {
+    const tab = pinned(makeFileTab("/repo/pinned.ts"));
+    const cleanedTabs: string[] = [];
+
+    await closeBulkWorkspaceTabs({
+      groups: classifyBulkClosableTabs([tab]),
+      client: null,
+      closeTab: async (_tabId, action) => action(),
+      closeLayoutOnlyAgent: async () => {},
+      closeWorkspaceTabWithCleanup: ({ tabId }) => {
+        cleanedTabs.push(tabId);
+      },
+      logLabel: "explicit tab",
+    });
+
+    expect(cleanedTabs).toEqual([tab.tabId]);
   });
 });

--- a/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
+++ b/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
@@ -47,19 +47,32 @@ describe("workspace bulk close helpers", () => {
     const right = makeAgentTab("right");
     const tabs = [left, pinnedLeft, anchor, pinnedRight, right];
 
-    expect(selectBulkCloseTabs(tabs, anchor.tabId, "before")).toEqual([left]);
-    expect(selectBulkCloseTabs(tabs, anchor.tabId, "after")).toEqual([right]);
-    expect(selectBulkCloseTabs(tabs, anchor.tabId, "others")).toEqual([left, right]);
+    expect(selectBulkCloseTabs({ tabs, anchorTabId: anchor.tabId, selection: "before" })).toEqual([
+      left,
+    ]);
+    expect(selectBulkCloseTabs({ tabs, anchorTabId: anchor.tabId, selection: "after" })).toEqual([
+      right,
+    ]);
+    expect(selectBulkCloseTabs({ tabs, anchorTabId: anchor.tabId, selection: "others" })).toEqual([
+      left,
+      right,
+    ]);
   });
 
   it("returns no bulk-close candidates when the anchor is missing or every candidate is pinned", () => {
     const anchor = makeAgentTab("anchor");
     const tabs = [pinned(makeFileTab("/repo/left.ts")), anchor, pinned(makeTerminalTab("right"))];
 
-    expect(selectBulkCloseTabs(tabs, "missing", "others")).toEqual([]);
-    expect(selectBulkCloseTabs(tabs, anchor.tabId, "before")).toEqual([]);
-    expect(selectBulkCloseTabs(tabs, anchor.tabId, "after")).toEqual([]);
-    expect(selectBulkCloseTabs(tabs, anchor.tabId, "others")).toEqual([]);
+    expect(selectBulkCloseTabs({ tabs, anchorTabId: "missing", selection: "others" })).toEqual([]);
+    expect(selectBulkCloseTabs({ tabs, anchorTabId: anchor.tabId, selection: "before" })).toEqual(
+      [],
+    );
+    expect(selectBulkCloseTabs({ tabs, anchorTabId: anchor.tabId, selection: "after" })).toEqual(
+      [],
+    );
+    expect(selectBulkCloseTabs({ tabs, anchorTabId: anchor.tabId, selection: "others" })).toEqual(
+      [],
+    );
   });
 
   it("classifies agent, terminal, and passive tabs for shared bulk close handling", () => {

--- a/packages/app/src/screens/workspace/workspace-bulk-close.ts
+++ b/packages/app/src/screens/workspace/workspace-bulk-close.ts
@@ -34,6 +34,29 @@ export const DEFAULT_BULK_CLOSE_CONFIRMATION_LABELS: BulkCloseConfirmationLabels
   agents: ({ agents }) => `This will archive ${agents} agent(s).`,
 };
 
+export type BulkCloseSelection = "before" | "after" | "others";
+
+export function selectBulkCloseTabs(
+  tabs: WorkspaceTabDescriptor[],
+  anchorTabId: string,
+  selection: BulkCloseSelection,
+): WorkspaceTabDescriptor[] {
+  const anchorIndex = tabs.findIndex((tab) => tab.tabId === anchorTabId);
+  if (anchorIndex < 0) {
+    return [];
+  }
+
+  let candidates: WorkspaceTabDescriptor[];
+  if (selection === "before") {
+    candidates = tabs.slice(0, anchorIndex);
+  } else if (selection === "after") {
+    candidates = tabs.slice(anchorIndex + 1);
+  } else {
+    candidates = tabs.filter((tab) => tab.tabId !== anchorTabId);
+  }
+  return candidates.filter((tab) => tab.isPinned !== true);
+}
+
 interface CloseWorkspaceTabWithCleanupInput {
   tabId: string;
   target?: WorkspaceTabDescriptor["target"];

--- a/packages/app/src/screens/workspace/workspace-bulk-close.ts
+++ b/packages/app/src/screens/workspace/workspace-bulk-close.ts
@@ -36,11 +36,14 @@ export const DEFAULT_BULK_CLOSE_CONFIRMATION_LABELS: BulkCloseConfirmationLabels
 
 export type BulkCloseSelection = "before" | "after" | "others";
 
-export function selectBulkCloseTabs(
-  tabs: WorkspaceTabDescriptor[],
-  anchorTabId: string,
-  selection: BulkCloseSelection,
-): WorkspaceTabDescriptor[] {
+interface SelectBulkCloseTabsInput {
+  tabs: WorkspaceTabDescriptor[];
+  anchorTabId: string;
+  selection: BulkCloseSelection;
+}
+
+export function selectBulkCloseTabs(input: SelectBulkCloseTabsInput): WorkspaceTabDescriptor[] {
+  const { tabs, anchorTabId, selection } = input;
   const anchorIndex = tabs.findIndex((tab) => tab.tabId === anchorTabId);
   if (anchorIndex < 0) {
     return [];
@@ -55,6 +58,66 @@ export function selectBulkCloseTabs(
     candidates = tabs.filter((tab) => tab.tabId !== anchorTabId);
   }
   return candidates.filter((tab) => tab.isPinned !== true);
+}
+
+interface BulkCloseTabsRequest {
+  tabsToClose: WorkspaceTabDescriptor[];
+  title: string;
+  logLabel: string;
+}
+
+interface WorkspaceTabBulkCloseLabels {
+  beforeTitle: string;
+  afterTitle: string;
+  othersTitle: string;
+}
+
+interface CreateWorkspaceTabBulkCloseActionsInput {
+  closeTabs: (input: BulkCloseTabsRequest) => Promise<boolean>;
+  labels: WorkspaceTabBulkCloseLabels;
+}
+
+export interface WorkspaceTabBulkCloseActions {
+  closeTabsBefore: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void>;
+  closeTabsAfter: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void>;
+  closeOtherTabs: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void>;
+}
+
+interface CloseSelectedTabsInput {
+  selection: BulkCloseSelection;
+  tabId: string;
+  paneTabs: WorkspaceTabDescriptor[];
+}
+
+export function createWorkspaceTabBulkCloseActions(
+  input: CreateWorkspaceTabBulkCloseActionsInput,
+): WorkspaceTabBulkCloseActions {
+  const titles: Record<BulkCloseSelection, string> = {
+    before: input.labels.beforeTitle,
+    after: input.labels.afterTitle,
+    others: input.labels.othersTitle,
+  };
+  const logLabels: Record<BulkCloseSelection, string> = {
+    before: "to the left",
+    after: "to the right",
+    others: "from close other tabs",
+  };
+  async function closeSelectedTabs(args: CloseSelectedTabsInput): Promise<void> {
+    const { selection, tabId, paneTabs } = args;
+    await input.closeTabs({
+      tabsToClose: selectBulkCloseTabs({ tabs: paneTabs, anchorTabId: tabId, selection }),
+      title: titles[selection],
+      logLabel: logLabels[selection],
+    });
+  }
+
+  return {
+    closeTabsBefore: (tabId, paneTabs) =>
+      closeSelectedTabs({ selection: "before", tabId, paneTabs }),
+    closeTabsAfter: (tabId, paneTabs) => closeSelectedTabs({ selection: "after", tabId, paneTabs }),
+    closeOtherTabs: (tabId, paneTabs) =>
+      closeSelectedTabs({ selection: "others", tabId, paneTabs }),
+  };
 }
 
 interface CloseWorkspaceTabWithCleanupInput {

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -55,7 +55,6 @@ import {
   WorkspaceTabPresentationResolver,
   WorkspaceTabIcon,
   WorkspaceTabPinIcon,
-  WORKSPACE_TAB_PIN_ICON_SIZE,
   type WorkspaceTabPresentation,
 } from "@/screens/workspace/workspace-tab-presentation";
 import { buildDeterministicWorkspaceTabId } from "@/workspace-tabs/identity";
@@ -67,7 +66,7 @@ import {
 } from "@/screens/workspace/workspace-tab-menu";
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
 import type { SurfaceBackdrop } from "@/styles/surface-backdrop";
-import type { Theme } from "@/styles/theme";
+import { ICON_SIZE, type Theme } from "@/styles/theme";
 import { RenderProfile } from "@/utils/render-profiler";
 import { TrailingActionScrim } from "@/components/ui/trailing-action-scrim";
 import { useKeyboardActionHandler } from "@/hooks/use-keyboard-action-handler";
@@ -441,7 +440,7 @@ function completeWorkspaceTabLabelWidths(
     // The modified dot sits in the content row, so a modified tab needs that much more width
     // before its label starts truncating.
     const modifiedAllowance = modified ? TAB_CONTENT_GAP + TAB_MODIFIED_DOT_SIZE : 0;
-    const pinAllowance = TAB_CONTENT_GAP + WORKSPACE_TAB_PIN_ICON_SIZE;
+    const pinAllowance = TAB_CONTENT_GAP + ICON_SIZE.xs;
     widths.push(measurement.width + TAB_LABEL_LAYOUT_ALLOWANCE + modifiedAllowance + pinAllowance);
   }
   return widths;

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -22,6 +22,7 @@ import {
   Ellipsis,
   Maximize,
   Minimize,
+  Pin,
   Plus,
   X,
 } from "lucide-react-native";
@@ -53,6 +54,8 @@ import { retainWorkspaceTabMeasuredWidth } from "@/screens/workspace/workspace-t
 import {
   WorkspaceTabPresentationResolver,
   WorkspaceTabIcon,
+  WorkspaceTabPinIcon,
+  WORKSPACE_TAB_PIN_ICON_SIZE,
   type WorkspaceTabPresentation,
 } from "@/screens/workspace/workspace-tab-presentation";
 import { buildDeterministicWorkspaceTabId } from "@/workspace-tabs/identity";
@@ -124,6 +127,7 @@ const ThemedRows2 = withUnistyles(Rows2);
 const ThemedEllipsis = withUnistyles(Ellipsis);
 const ThemedMaximize = withUnistyles(Maximize);
 const ThemedMinimize = withUnistyles(Minimize);
+const ThemedPin = withUnistyles(Pin);
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
 const extraMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundExtraMuted });
@@ -360,6 +364,8 @@ function TabContextMenuItem({
         return <ThemedCopyX size={16} uniProps={mutedColorMapping} />;
       case "pencil":
         return <ThemedPencil size={16} uniProps={mutedColorMapping} />;
+      case "pin":
+        return <ThemedPin size={16} uniProps={mutedColorMapping} />;
       case "x":
         return <ThemedX size={16} uniProps={mutedColorMapping} />;
       default:
@@ -435,7 +441,8 @@ function completeWorkspaceTabLabelWidths(
     // The modified dot sits in the content row, so a modified tab needs that much more width
     // before its label starts truncating.
     const modifiedAllowance = modified ? TAB_CONTENT_GAP + TAB_MODIFIED_DOT_SIZE : 0;
-    widths.push(measurement.width + TAB_LABEL_LAYOUT_ALLOWANCE + modifiedAllowance);
+    const pinAllowance = TAB_CONTENT_GAP + WORKSPACE_TAB_PIN_ICON_SIZE;
+    widths.push(measurement.width + TAB_LABEL_LAYOUT_ALLOWANCE + modifiedAllowance + pinAllowance);
   }
   return widths;
 }
@@ -459,6 +466,7 @@ interface WorkspaceDesktopTabsRowProps {
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
+  onTogglePinTab: (tabId: string) => void;
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
@@ -600,6 +608,7 @@ function resolveChipBackdrop({
 
 function TabHandleContent({
   presentation,
+  isPinned,
   isHighlighted,
   showLabel,
   backdrop,
@@ -608,6 +617,7 @@ function TabHandleContent({
   modifiedTestId,
 }: {
   presentation: WorkspaceTabPresentation;
+  isPinned: boolean;
   isHighlighted: boolean;
   showLabel: boolean;
   backdrop: SurfaceBackdrop;
@@ -626,6 +636,7 @@ function TabHandleContent({
       <View style={styles.tabIcon}>
         <WorkspaceTabIcon presentation={presentation} active={isHighlighted} backdrop={backdrop} />
       </View>
+      <WorkspaceTabPinIcon isPinned={isPinned} />
       {showLabel && presentation.titleState === "loading" ? (
         <View style={tabLabelSkeletonStyle} />
       ) : null}
@@ -792,6 +803,7 @@ function TabChip({
             >
               <TabHandleContent
                 presentation={presentation}
+                isPinned={tab.isPinned === true}
                 isHighlighted={isHighlighted}
                 showLabel={showLabel}
                 backdrop={chipBackdrop}
@@ -947,6 +959,7 @@ function ResolvedWorkspaceDesktopTabsRow({
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
+  onTogglePinTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -1024,6 +1037,8 @@ function ResolvedWorkspaceDesktopTabsRow({
       copyTerminalId: t("workspace.tabs.menu.copyTerminalId"),
       copyFilePath: t("workspace.tabs.menu.copyFilePath"),
       rename: t("workspace.tabs.menu.rename"),
+      pinTab: t("workspace.tabs.menu.pinTab"),
+      unpinTab: t("workspace.tabs.menu.unpinTab"),
       closeAbove: t("workspace.tabs.menu.closeAbove"),
       closeBelow: t("workspace.tabs.menu.closeBelow"),
       closeLeft: t("workspace.tabs.menu.closeLeft"),
@@ -1202,6 +1217,7 @@ function ResolvedWorkspaceDesktopTabsRow({
           onCopyFilePath={onCopyFilePath}
           onReloadAgent={onReloadAgent}
           onRenameTab={onRenameTab}
+          onTogglePinTab={onTogglePinTab}
           onCloseTabsToLeft={onCloseTabsToLeft}
           onCloseTabsToRight={onCloseTabsToRight}
           onCloseOtherTabs={onCloseOtherTabs}
@@ -1234,6 +1250,7 @@ function ResolvedWorkspaceDesktopTabsRow({
       onNavigateTab,
       onReloadAgent,
       onRenameTab,
+      onTogglePinTab,
       setHoveredCloseTabKey,
       tabMenuLabels,
       tabDropPreviewIndex,
@@ -1347,6 +1364,7 @@ function ResolvedDesktopTabChip({
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
+  onTogglePinTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -1372,6 +1390,7 @@ function ResolvedDesktopTabChip({
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
+  onTogglePinTab: (tabId: string) => void;
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
@@ -1400,6 +1419,7 @@ function ResolvedDesktopTabChip({
         onCopyFilePath,
         onReloadAgent,
         onRenameTab,
+        onTogglePinTab,
         onCloseTab,
         onCloseTabsToLeft,
         onCloseTabsToRight,
@@ -1420,6 +1440,7 @@ function ResolvedDesktopTabChip({
       labels,
       onReloadAgent,
       onRenameTab,
+      onTogglePinTab,
       tabCount,
     ],
   );

--- a/packages/app/src/screens/workspace/workspace-pane-close.test.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-close.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import { executeCloseWorkspacePaneAction } from "@/screens/workspace/workspace-pane-close";
+import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+import type { WorkspaceLayout } from "@/stores/workspace-layout-store";
+
+function createTab(
+  tabId: string,
+  target: WorkspaceTabDescriptor["target"],
+  isPinned = false,
+): WorkspaceTabDescriptor {
+  return {
+    key: tabId,
+    tabId,
+    kind: target.kind,
+    target,
+    isPinned,
+  };
+}
+
+describe("workspace pane close action", () => {
+  it("relocates pinned tabs before the real action tears down the pane", async () => {
+    const pinnedAgentTab = createTab("agent_pinned", { kind: "agent", agentId: "pinned" }, true);
+    const pinnedTerminalTab = createTab(
+      "terminal_pinned",
+      { kind: "terminal", terminalId: "pinned" },
+      true,
+    );
+    const unpinnedTab = createTab("file_/repo/temporary.ts", {
+      kind: "file",
+      path: "/repo/temporary.ts",
+    });
+    const survivingTab = createTab("agent_surviving", {
+      kind: "agent",
+      agentId: "surviving",
+    });
+    const layout: WorkspaceLayout = {
+      root: {
+        kind: "group",
+        group: {
+          id: "root",
+          direction: "horizontal",
+          sizes: [0.5, 0.5],
+          children: [
+            {
+              kind: "pane",
+              pane: {
+                id: "closing",
+                tabIds: [pinnedAgentTab.tabId, pinnedTerminalTab.tabId, unpinnedTab.tabId],
+                focusedTabId: unpinnedTab.tabId,
+              },
+            },
+            {
+              kind: "pane",
+              pane: {
+                id: "surviving",
+                tabIds: [survivingTab.tabId],
+                focusedTabId: survivingTab.tabId,
+              },
+            },
+          ],
+        },
+      },
+      focusedPaneId: "closing",
+    };
+    const closeTabs = vi.fn(async () => true);
+    const moveTabToPane = vi.fn(() => true);
+    const closePane = vi.fn();
+
+    const closed = await executeCloseWorkspacePaneAction({
+      layout,
+      paneId: "closing",
+      explorerSidebarPaneId: null,
+      tabsById: new Map([
+        [pinnedAgentTab.tabId, pinnedAgentTab],
+        [pinnedTerminalTab.tabId, pinnedTerminalTab],
+        [unpinnedTab.tabId, unpinnedTab],
+        [survivingTab.tabId, survivingTab],
+      ]),
+      title: "Close pane",
+      closeTabs,
+      moveTabToPane,
+      closePane,
+    });
+
+    expect(closed).toBe(true);
+    expect(closeTabs).toHaveBeenCalledWith({
+      tabsToClose: [unpinnedTab],
+      title: "Close pane",
+      logLabel: "from pane close",
+    });
+    expect(moveTabToPane).toHaveBeenNthCalledWith(1, pinnedAgentTab.tabId, "surviving");
+    expect(moveTabToPane).toHaveBeenNthCalledWith(2, pinnedTerminalTab.tabId, "surviving");
+    expect(closePane).toHaveBeenCalledWith("closing");
+    expect(moveTabToPane.mock.invocationCallOrder[0]).toBeLessThan(
+      closePane.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("blocks the final pane before any tab teardown", async () => {
+    const pinnedTab = createTab(
+      "file_/repo/pinned.ts",
+      { kind: "file", path: "/repo/pinned.ts" },
+      true,
+    );
+    const layout: WorkspaceLayout = {
+      root: {
+        kind: "pane",
+        pane: {
+          id: "main",
+          tabIds: [pinnedTab.tabId],
+          focusedTabId: pinnedTab.tabId,
+        },
+      },
+      focusedPaneId: "main",
+    };
+    const closeTabs = vi.fn(async () => true);
+    const moveTabToPane = vi.fn(() => true);
+    const closePane = vi.fn();
+
+    const closed = await executeCloseWorkspacePaneAction({
+      layout,
+      paneId: "main",
+      explorerSidebarPaneId: null,
+      tabsById: new Map([[pinnedTab.tabId, pinnedTab]]),
+      title: "Close pane",
+      closeTabs,
+      moveTabToPane,
+      closePane,
+    });
+
+    expect(closed).toBe(false);
+    expect(closeTabs).not.toHaveBeenCalled();
+    expect(moveTabToPane).not.toHaveBeenCalled();
+    expect(closePane).not.toHaveBeenCalled();
+  });
+
+  it("keeps the pane open when the layout store rejects a pinned-tab relocation", async () => {
+    const pinnedTab = createTab("changes_tree", { kind: "changes_tree" }, true);
+    const layout: WorkspaceLayout = {
+      root: {
+        kind: "group",
+        group: {
+          id: "root",
+          direction: "horizontal",
+          sizes: [0.25, 0.75],
+          children: [
+            {
+              kind: "pane",
+              pane: {
+                id: "explorer",
+                tabIds: [pinnedTab.tabId],
+                focusedTabId: pinnedTab.tabId,
+              },
+            },
+            {
+              kind: "pane",
+              pane: { id: "main", tabIds: [], focusedTabId: null },
+            },
+          ],
+        },
+      },
+      focusedPaneId: "explorer",
+    };
+    const closeTabs = vi.fn(async () => true);
+    const moveTabToPane = vi.fn(() => false);
+    const closePane = vi.fn();
+
+    const closed = await executeCloseWorkspacePaneAction({
+      layout,
+      paneId: "explorer",
+      explorerSidebarPaneId: "explorer",
+      tabsById: new Map([[pinnedTab.tabId, pinnedTab]]),
+      title: "Close pane",
+      closeTabs,
+      moveTabToPane,
+      closePane,
+    });
+
+    expect(closed).toBe(false);
+    expect(closeTabs).toHaveBeenCalledWith({
+      tabsToClose: [],
+      title: "Close pane",
+      logLabel: "from pane close",
+    });
+    expect(moveTabToPane).toHaveBeenCalledWith(pinnedTab.tabId, "main");
+    expect(closePane).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/screens/workspace/workspace-pane-close.test.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-close.test.ts
@@ -62,6 +62,7 @@ describe("workspace pane close action", () => {
       },
       focusedPaneId: "closing",
     };
+    const canMoveTabsToPane = vi.fn(() => true);
     const closeTabs = vi.fn(async () => true);
     const moveTabToPane = vi.fn(() => true);
     const closePane = vi.fn();
@@ -77,17 +78,25 @@ describe("workspace pane close action", () => {
         [survivingTab.tabId, survivingTab],
       ]),
       title: "Close pane",
+      canMoveTabsToPane,
       closeTabs,
       moveTabToPane,
       closePane,
     });
 
     expect(closed).toBe(true);
+    expect(canMoveTabsToPane).toHaveBeenCalledWith(
+      [pinnedAgentTab.tabId, pinnedTerminalTab.tabId],
+      "surviving",
+    );
     expect(closeTabs).toHaveBeenCalledWith({
       tabsToClose: [unpinnedTab],
       title: "Close pane",
       logLabel: "from pane close",
     });
+    expect(canMoveTabsToPane.mock.invocationCallOrder[0]).toBeLessThan(
+      closeTabs.mock.invocationCallOrder[0],
+    );
     expect(moveTabToPane).toHaveBeenNthCalledWith(1, pinnedAgentTab.tabId, "surviving");
     expect(moveTabToPane).toHaveBeenNthCalledWith(2, pinnedTerminalTab.tabId, "surviving");
     expect(closePane).toHaveBeenCalledWith("closing");
@@ -113,6 +122,7 @@ describe("workspace pane close action", () => {
       },
       focusedPaneId: "main",
     };
+    const canMoveTabsToPane = vi.fn(() => true);
     const closeTabs = vi.fn(async () => true);
     const moveTabToPane = vi.fn(() => true);
     const closePane = vi.fn();
@@ -123,19 +133,25 @@ describe("workspace pane close action", () => {
       explorerSidebarPaneId: null,
       tabsById: new Map([[pinnedTab.tabId, pinnedTab]]),
       title: "Close pane",
+      canMoveTabsToPane,
       closeTabs,
       moveTabToPane,
       closePane,
     });
 
     expect(closed).toBe(false);
+    expect(canMoveTabsToPane).not.toHaveBeenCalled();
     expect(closeTabs).not.toHaveBeenCalled();
     expect(moveTabToPane).not.toHaveBeenCalled();
     expect(closePane).not.toHaveBeenCalled();
   });
 
-  it("keeps the pane open when the layout store rejects a pinned-tab relocation", async () => {
+  it("does not tear down unpinned tabs when relocation preflight fails", async () => {
     const pinnedTab = createTab("changes_tree", { kind: "changes_tree" }, true);
+    const unpinnedTab = createTab("file_/repo/temporary.ts", {
+      kind: "file",
+      path: "/repo/temporary.ts",
+    });
     const layout: WorkspaceLayout = {
       root: {
         kind: "group",
@@ -148,8 +164,8 @@ describe("workspace pane close action", () => {
               kind: "pane",
               pane: {
                 id: "explorer",
-                tabIds: [pinnedTab.tabId],
-                focusedTabId: pinnedTab.tabId,
+                tabIds: [pinnedTab.tabId, unpinnedTab.tabId],
+                focusedTabId: unpinnedTab.tabId,
               },
             },
             {
@@ -161,28 +177,30 @@ describe("workspace pane close action", () => {
       },
       focusedPaneId: "explorer",
     };
+    const canMoveTabsToPane = vi.fn(() => false);
     const closeTabs = vi.fn(async () => true);
-    const moveTabToPane = vi.fn(() => false);
+    const moveTabToPane = vi.fn(() => true);
     const closePane = vi.fn();
 
     const closed = await executeCloseWorkspacePaneAction({
       layout,
       paneId: "explorer",
       explorerSidebarPaneId: "explorer",
-      tabsById: new Map([[pinnedTab.tabId, pinnedTab]]),
+      tabsById: new Map([
+        [pinnedTab.tabId, pinnedTab],
+        [unpinnedTab.tabId, unpinnedTab],
+      ]),
       title: "Close pane",
+      canMoveTabsToPane,
       closeTabs,
       moveTabToPane,
       closePane,
     });
 
     expect(closed).toBe(false);
-    expect(closeTabs).toHaveBeenCalledWith({
-      tabsToClose: [],
-      title: "Close pane",
-      logLabel: "from pane close",
-    });
-    expect(moveTabToPane).toHaveBeenCalledWith(pinnedTab.tabId, "main");
+    expect(canMoveTabsToPane).toHaveBeenCalledWith([pinnedTab.tabId], "main");
+    expect(closeTabs).not.toHaveBeenCalled();
+    expect(moveTabToPane).not.toHaveBeenCalled();
     expect(closePane).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/screens/workspace/workspace-pane-close.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-close.ts
@@ -18,6 +18,7 @@ interface ExecuteCloseWorkspacePaneActionInput {
   explorerSidebarPaneId?: string | null;
   tabsById: ReadonlyMap<string, WorkspaceTabDescriptor>;
   title: string;
+  canMoveTabsToPane: (tabIds: readonly string[], paneId: string) => boolean;
   closeTabs: (input: CloseTabsRequest) => Promise<boolean>;
   moveTabToPane: (tabId: string, paneId: string) => boolean;
   closePane: (paneId: string) => void;
@@ -47,6 +48,10 @@ export async function executeCloseWorkspacePaneAction(
     } else if (descriptor) {
       tabsToClose.push(descriptor);
     }
+  }
+
+  if (pinnedTabIds.length > 0 && !input.canMoveTabsToPane(pinnedTabIds, destinationPane.id)) {
+    return false;
   }
 
   const closed = await input.closeTabs({

--- a/packages/app/src/screens/workspace/workspace-pane-close.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-close.ts
@@ -1,0 +1,68 @@
+import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+import {
+  canDismissPaneInLayout,
+  collectAllPanes,
+  findPaneById,
+  type WorkspaceLayout,
+} from "@/stores/workspace-layout-store";
+
+interface CloseTabsRequest {
+  tabsToClose: WorkspaceTabDescriptor[];
+  title: string;
+  logLabel: string;
+}
+
+interface ExecuteCloseWorkspacePaneActionInput {
+  layout: WorkspaceLayout;
+  paneId: string;
+  explorerSidebarPaneId?: string | null;
+  tabsById: ReadonlyMap<string, WorkspaceTabDescriptor>;
+  title: string;
+  closeTabs: (input: CloseTabsRequest) => Promise<boolean>;
+  moveTabToPane: (tabId: string, paneId: string) => boolean;
+  closePane: (paneId: string) => void;
+}
+
+export async function executeCloseWorkspacePaneAction(
+  input: ExecuteCloseWorkspacePaneActionInput,
+): Promise<boolean> {
+  const pane = findPaneById(input.layout.root, input.paneId);
+  if (!pane || !canDismissPaneInLayout(input.layout, input.paneId, input.explorerSidebarPaneId)) {
+    return false;
+  }
+
+  const destinationPane = collectAllPanes(input.layout.root).find(
+    (candidate) => candidate.id !== input.paneId && candidate.id !== input.explorerSidebarPaneId,
+  );
+  if (!destinationPane) {
+    return false;
+  }
+
+  const pinnedTabIds: string[] = [];
+  const tabsToClose: WorkspaceTabDescriptor[] = [];
+  for (const tabId of pane.tabIds) {
+    const descriptor = input.tabsById.get(tabId);
+    if (descriptor?.isPinned === true) {
+      pinnedTabIds.push(tabId);
+    } else if (descriptor) {
+      tabsToClose.push(descriptor);
+    }
+  }
+
+  const closed = await input.closeTabs({
+    tabsToClose,
+    title: input.title,
+    logLabel: "from pane close",
+  });
+  if (!closed) {
+    return false;
+  }
+
+  for (const tabId of pinnedTabIds) {
+    if (!input.moveTabToPane(tabId, destinationPane.id)) {
+      return false;
+    }
+  }
+  input.closePane(input.paneId);
+  return true;
+}

--- a/packages/app/src/screens/workspace/workspace-pane-state.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-state.ts
@@ -58,6 +58,7 @@ function normalizeWorkspaceTab(tab: WorkspaceTab): WorkspaceTab | null {
     tabId,
     target,
     createdAt: tab.createdAt,
+    ...(tab.isPinned === true ? { isPinned: true } : {}),
     state: tab.state,
   };
 }
@@ -99,6 +100,7 @@ function normalizeWorkspacePaneTabs(tabs: WorkspaceTab[]): NormalizeWorkspacePan
         tabId: normalizedTab.tabId,
         kind: normalizedTab.target.kind,
         target: normalizedTab.target,
+        isPinned: normalizedTab.isPinned === true,
         state: normalizedTab.state,
       },
     });

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -61,10 +61,9 @@ import { type ExplorerCheckoutContext } from "@/stores/explorer-checkout-context
 import { traceInstant } from "@/performance/native-trace";
 import { useSessionStore, type WorkspaceDescriptor } from "@/stores/session-store";
 import {
-  canDismissPaneInLayout,
   collectAllTabs,
   DEFAULT_PANE_ID,
-  findPaneById,
+  findPaneContainingTab,
   getFocusedBrowserId,
   FOCUSED_PANE_PLACEMENT,
   selectExplorerSidebarPaneId,
@@ -180,8 +179,9 @@ import {
   type BulkCloseConfirmationLabels,
   classifyBulkClosableTabs,
   closeBulkWorkspaceTabs,
-  selectBulkCloseTabs,
+  createWorkspaceTabBulkCloseActions,
 } from "@/screens/workspace/workspace-bulk-close";
+import { executeCloseWorkspacePaneAction } from "@/screens/workspace/workspace-pane-close";
 import { resolveCloseAgentTabPolicy } from "@/subagents";
 import {
   getPanelInstanceAttributes,
@@ -2908,20 +2908,21 @@ function WorkspaceScreenContent({
     ],
   );
 
-  const handleCloseTabsToLeftInPane = useCallback(
-    async (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => {
-      const index = paneTabs.findIndex((tab) => tab.tabId === tabId);
-      if (index < 0) {
-        return;
-      }
-      await handleBulkCloseTabs({
-        tabsToClose: selectBulkCloseTabs(paneTabs, tabId, "before"),
-        title: t("workspace.tabs.confirmations.closeTabsLeftTitle"),
-        logLabel: "to the left",
-      });
-    },
+  const bulkCloseActions = useMemo(
+    () =>
+      createWorkspaceTabBulkCloseActions({
+        closeTabs: handleBulkCloseTabs,
+        labels: {
+          beforeTitle: t("workspace.tabs.confirmations.closeTabsLeftTitle"),
+          afterTitle: t("workspace.tabs.confirmations.closeTabsRightTitle"),
+          othersTitle: t("workspace.tabs.confirmations.closeOtherTabsTitle"),
+        },
+      }),
     [handleBulkCloseTabs, t],
   );
+  const handleCloseTabsToLeftInPane = bulkCloseActions.closeTabsBefore;
+  const handleCloseTabsToRightInPane = bulkCloseActions.closeTabsAfter;
+  const handleCloseOtherTabsInPane = bulkCloseActions.closeOtherTabs;
 
   const handleCloseTabsToLeft = useCallback(
     async (tabId: string) => {
@@ -2930,37 +2931,11 @@ function WorkspaceScreenContent({
     [handleCloseTabsToLeftInPane, tabs],
   );
 
-  const handleCloseTabsToRightInPane = useCallback(
-    async (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => {
-      const index = paneTabs.findIndex((tab) => tab.tabId === tabId);
-      if (index < 0) {
-        return;
-      }
-      await handleBulkCloseTabs({
-        tabsToClose: selectBulkCloseTabs(paneTabs, tabId, "after"),
-        title: t("workspace.tabs.confirmations.closeTabsRightTitle"),
-        logLabel: "to the right",
-      });
-    },
-    [handleBulkCloseTabs, t],
-  );
-
   const handleCloseTabsToRight = useCallback(
     async (tabId: string) => {
       await handleCloseTabsToRightInPane(tabId, tabs);
     },
     [handleCloseTabsToRightInPane, tabs],
-  );
-
-  const handleCloseOtherTabsInPane = useCallback(
-    async (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => {
-      await handleBulkCloseTabs({
-        tabsToClose: selectBulkCloseTabs(paneTabs, tabId, "others"),
-        title: t("workspace.tabs.confirmations.closeOtherTabsTitle"),
-        logLabel: "from close other tabs",
-      });
-    },
-    [handleBulkCloseTabs, t],
   );
 
   const handleCloseOtherTabs = useCallback(
@@ -2975,31 +2950,31 @@ function WorkspaceScreenContent({
       if (!persistenceKey || !workspaceLayout) {
         return;
       }
-      const pane = findPaneById(workspaceLayout.root, paneId);
-      // Ask before tearing anything down. The layout refuses to dismiss the final
-      // visible pane, and discovering that after closing its tabs would cost the
-      // user the tabs and leave the pane standing.
-      if (!pane || !canDismissPaneInLayout(workspaceLayout, paneId, explorerSidebarPaneId)) {
-        return;
-      }
-      const tabsToClose = pane.tabIds.flatMap((tabId) => {
-        const tab = allTabDescriptorsById.get(tabId);
-        return tab ? [tab] : [];
-      });
-      const closed = await handleBulkCloseTabs({
-        tabsToClose,
+      await executeCloseWorkspacePaneAction({
+        layout: workspaceLayout,
+        paneId,
+        explorerSidebarPaneId,
+        tabsById: allTabDescriptorsById,
         title: t("workspace.tabs.confirmations.closePaneTitle"),
-        logLabel: "from pane close",
+        closeTabs: handleBulkCloseTabs,
+        moveTabToPane: (tabId, destinationPaneId) => {
+          moveWorkspaceTabToPane(persistenceKey, tabId, destinationPaneId);
+          const nextLayout = useWorkspaceLayoutStore.getState().layoutByWorkspace[persistenceKey];
+          return (
+            nextLayout !== undefined &&
+            findPaneContainingTab(nextLayout.root, tabId)?.id === destinationPaneId
+          );
+        },
+        closePane: (closingPaneId) => {
+          closeWorkspacePane(persistenceKey, closingPaneId);
+        },
       });
-      if (!closed) {
-        return;
-      }
-      closeWorkspacePane(persistenceKey, paneId);
     },
     [
       allTabDescriptorsById,
       closeWorkspacePane,
       handleBulkCloseTabs,
+      moveWorkspaceTabToPane,
       persistenceKey,
       t,
       workspaceLayout,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -117,6 +117,7 @@ import { useOpenAgentTabLabels } from "@/subagents/use-open-agent-tab-labels";
 import {
   WorkspaceTabPresentationResolver,
   WorkspaceTabIcon,
+  WorkspaceTabPinIcon,
   WorkspaceTabOptionRow,
   type WorkspaceTabPresentation,
 } from "@/screens/workspace/workspace-tab-presentation";
@@ -179,6 +180,7 @@ import {
   type BulkCloseConfirmationLabels,
   classifyBulkClosableTabs,
   closeBulkWorkspaceTabs,
+  selectBulkCloseTabs,
 } from "@/screens/workspace/workspace-bulk-close";
 import { resolveCloseAgentTabPolicy } from "@/subagents";
 import {
@@ -416,6 +418,7 @@ interface MobileWorkspaceTabSwitcherProps {
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
+  onTogglePinTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
   onCloseTabsBelow: (tabId: string) => Promise<void> | void;
@@ -471,6 +474,8 @@ function ResolvedMobileActiveTabTrigger({
             <WorkspaceTabIcon presentation={presentation} active backdrop={backdrop} />
           </View>
 
+          <WorkspaceTabPinIcon isPinned={activeTab.isPinned === true} />
+
           <Text style={styles.switcherTriggerText} numberOfLines={1}>
             {presentation.titleState === "loading"
               ? t("workspace.tabs.loading")
@@ -523,6 +528,7 @@ function MobileWorkspaceTabOption({
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
+  onTogglePinTab,
   onCloseTab,
   onCloseTabsAbove,
   onCloseTabsBelow,
@@ -542,6 +548,7 @@ function MobileWorkspaceTabOption({
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
+  onTogglePinTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
   onCloseTabsBelow: (tabId: string) => Promise<void> | void;
@@ -555,6 +562,8 @@ function MobileWorkspaceTabOption({
       copyTerminalId: t("workspace.tabs.menu.copyTerminalId"),
       copyFilePath: t("workspace.tabs.menu.copyFilePath"),
       rename: t("workspace.tabs.menu.rename"),
+      pinTab: t("workspace.tabs.menu.pinTab"),
+      unpinTab: t("workspace.tabs.menu.unpinTab"),
       closeAbove: t("workspace.tabs.menu.closeAbove"),
       closeBelow: t("workspace.tabs.menu.closeBelow"),
       closeLeft: t("workspace.tabs.menu.closeLeft"),
@@ -579,6 +588,7 @@ function MobileWorkspaceTabOption({
     onCopyFilePath,
     onReloadAgent,
     onRenameTab,
+    onTogglePinTab,
     onCloseTab,
     onCloseTabsBefore: onCloseTabsAbove,
     onCloseTabsAfter: onCloseTabsBelow,
@@ -616,13 +626,14 @@ function MobileWorkspaceTabOption({
     (presentation: WorkspaceTabPresentation) => (
       <WorkspaceTabOptionRow
         presentation={presentation}
+        isPinned={tab.isPinned === true}
         selected={selected}
         active={active}
         onPress={onPress}
         trailingAccessory={trailingAccessory}
       />
     ),
-    [selected, active, onPress, trailingAccessory],
+    [selected, active, onPress, tab.isPinned, trailingAccessory],
   );
 
   return (
@@ -651,6 +662,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
+  onTogglePinTab,
   onCloseTab,
   onCloseTabsAbove,
   onCloseTabsBelow,
@@ -708,6 +720,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
           onCopyFilePath={onCopyFilePath}
           onReloadAgent={onReloadAgent}
           onRenameTab={onRenameTab}
+          onTogglePinTab={onTogglePinTab}
           onCloseTab={onCloseTab}
           onCloseTabsAbove={onCloseTabsAbove}
           onCloseTabsBelow={onCloseTabsBelow}
@@ -727,6 +740,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
       onCopyFilePath,
       onReloadAgent,
       onRenameTab,
+      onTogglePinTab,
       onCloseTab,
       onCloseTabsAbove,
       onCloseTabsBelow,
@@ -827,6 +841,7 @@ function useStableTabDescriptorMap(tabDescriptors: WorkspaceTabDescriptor[]) {
         cachedDescriptor &&
         cachedDescriptor.key === tabDescriptor.key &&
         cachedDescriptor.kind === tabDescriptor.kind &&
+        cachedDescriptor.isPinned === tabDescriptor.isPinned &&
         cachedDescriptor.state === tabDescriptor.state &&
         workspaceTabTargetsEqual(cachedDescriptor.target, tabDescriptor.target)
       ) {
@@ -1839,6 +1854,7 @@ function WorkspaceScreenContent({
   const focusWorkspaceTab = useWorkspaceLayoutStore((state) => state.focusTab);
   const selectWorkspaceTabInPane = useWorkspaceLayoutStore((state) => state.selectTabInPane);
   const closeWorkspaceTab = useWorkspaceLayoutStore((state) => state.closeTab);
+  const toggleWorkspaceTabPinned = useWorkspaceLayoutStore((state) => state.toggleTabPinned);
   const unpinWorkspaceAgent = useWorkspaceLayoutStore((state) => state.unpinAgent);
   const hideWorkspaceAgent = useWorkspaceLayoutStore((state) => state.hideAgent);
   const setWorkspaceTabState = useWorkspaceLayoutStore((state) => state.setTabState);
@@ -1854,6 +1870,14 @@ function WorkspaceScreenContent({
       checkout: activeExplorerCheckout,
     });
   }, [activeExplorerCheckout, isMobile, persistenceKey]);
+  const handleTogglePinTab = useCallback(
+    (tabId: string) => {
+      if (persistenceKey) {
+        toggleWorkspaceTabPinned(persistenceKey, tabId);
+      }
+    },
+    [persistenceKey, toggleWorkspaceTabPinned],
+  );
   const paneFocusSuppressedRef = useRef(false);
   const resizeWorkspaceSplit = useWorkspaceLayoutStore((state) => state.resizeSplit);
   const reorderWorkspaceTabsInPane = useWorkspaceLayoutStore((state) => state.reorderTabsInPane);
@@ -2294,6 +2318,7 @@ function WorkspaceScreenContent({
         tabId: tab.tabId,
         kind: tab.target.kind,
         target: tab.target,
+        isPinned: tab.isPinned === true,
       });
     }
     return map;
@@ -2890,7 +2915,7 @@ function WorkspaceScreenContent({
         return;
       }
       await handleBulkCloseTabs({
-        tabsToClose: paneTabs.slice(0, index),
+        tabsToClose: selectBulkCloseTabs(paneTabs, tabId, "before"),
         title: t("workspace.tabs.confirmations.closeTabsLeftTitle"),
         logLabel: "to the left",
       });
@@ -2912,7 +2937,7 @@ function WorkspaceScreenContent({
         return;
       }
       await handleBulkCloseTabs({
-        tabsToClose: paneTabs.slice(index + 1),
+        tabsToClose: selectBulkCloseTabs(paneTabs, tabId, "after"),
         title: t("workspace.tabs.confirmations.closeTabsRightTitle"),
         logLabel: "to the right",
       });
@@ -2929,9 +2954,8 @@ function WorkspaceScreenContent({
 
   const handleCloseOtherTabsInPane = useCallback(
     async (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => {
-      const tabsToClose = paneTabs.filter((tab) => tab.tabId !== tabId);
       await handleBulkCloseTabs({
-        tabsToClose,
+        tabsToClose: selectBulkCloseTabs(paneTabs, tabId, "others"),
         title: t("workspace.tabs.confirmations.closeOtherTabsTitle"),
         logLabel: "from close other tabs",
       });
@@ -3952,6 +3976,7 @@ function WorkspaceScreenContent({
         onCopyFilePath={handleCopyFilePath}
         onReloadAgent={handleReloadAgent}
         onRenameTab={handleRenameTab}
+        onTogglePinTab={handleTogglePinTab}
         onCloseTabsToLeft={handleCloseTabsToLeftInPane}
         onCloseTabsToRight={handleCloseTabsToRightInPane}
         onCloseOtherTabs={handleCloseOtherTabsInPane}
@@ -3988,6 +4013,7 @@ function WorkspaceScreenContent({
     handleCopyFilePath,
     handleReloadAgent,
     handleRenameTab,
+    handleTogglePinTab,
     handleCloseTabsToLeftInPane,
     handleCloseTabsToRightInPane,
     handleCloseOtherTabsInPane,
@@ -4031,6 +4057,7 @@ function WorkspaceScreenContent({
           onCopyFilePath={handleCopyFilePath}
           onReloadAgent={handleReloadAgent}
           onRenameTab={handleRenameTab}
+          onTogglePinTab={handleTogglePinTab}
           onCloseTab={handleCloseTabById}
           onCloseTabsAbove={handleCloseTabsToLeft}
           onCloseTabsBelow={handleCloseTabsToRight}
@@ -4055,6 +4082,7 @@ function WorkspaceScreenContent({
             onCopyFilePath={handleCopyFilePath}
             onReloadAgent={handleReloadAgent}
             onRenameTab={handleRenameTab}
+            onTogglePinTab={handleTogglePinTab}
             onCloseTabsToLeft={handleCloseTabsToLeft}
             onCloseTabsToRight={handleCloseTabsToRight}
             onCloseOtherTabs={handleCloseOtherTabs}

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -66,12 +66,14 @@ import {
   findPaneContainingTab,
   getFocusedBrowserId,
   FOCUSED_PANE_PLACEMENT,
+  resolveExplorerSidebarPaneId,
   selectExplorerSidebarPaneId,
   type WorkspaceLayout,
   type WorkspaceTabPlacement,
   useWorkspaceLayoutStore,
   useWorkspaceLayoutStoreHydrated,
 } from "@/stores/workspace-layout-store";
+import { moveTabToPaneInLayout } from "@/stores/workspace-layout-actions";
 import {
   buildWorkspaceTabPersistenceKey,
   type WorkspaceTab,
@@ -191,6 +193,7 @@ import { findAdjacentPane } from "@/utils/split-navigation";
 import { supportsDesktopPaneSplits, useIsCompactFormFactor } from "@/constants/layout";
 import { getIsElectron, isNative, isWeb } from "@/constants/platform";
 import type { SurfaceBackdrop } from "@/styles/surface-backdrop";
+import { panelTargetSupportsHostForWorkspaceKey } from "@/plugins/workspace-panels/locations";
 import { buildHostRootRoute, buildSettingsHostRoute } from "@/utils/host-routes";
 import { useWorkspaceTerminals } from "@/screens/workspace/terminals/use-workspace-terminals";
 import type { TerminalProfile } from "@getpaseo/protocol/messages";
@@ -2956,6 +2959,48 @@ function WorkspaceScreenContent({
         explorerSidebarPaneId,
         tabsById: allTabDescriptorsById,
         title: t("workspace.tabs.confirmations.closePaneTitle"),
+        canMoveTabsToPane: (tabIds, destinationPaneId) => {
+          const layoutState = useWorkspaceLayoutStore.getState();
+          let candidateLayout = layoutState.layoutByWorkspace[persistenceKey];
+          if (!candidateLayout) {
+            return false;
+          }
+          const liveExplorerSidebarPaneId = resolveExplorerSidebarPaneId(
+            candidateLayout,
+            layoutState.explorerSidebarPaneIdByWorkspace[persistenceKey],
+          );
+          const destinationHost =
+            destinationPaneId === liveExplorerSidebarPaneId ? "explorer" : "main";
+          for (const tabId of tabIds) {
+            const movingTab = collectAllTabs(candidateLayout.root).find(
+              (tab) => tab.tabId === tabId,
+            );
+            if (
+              !movingTab ||
+              !panelTargetSupportsHostForWorkspaceKey(
+                persistenceKey,
+                movingTab.target,
+                destinationHost,
+              )
+            ) {
+              return false;
+            }
+            const nextLayout = moveTabToPaneInLayout({
+              layout: candidateLayout,
+              tabId,
+              toPaneId: destinationPaneId,
+              explorerSidebarPaneId: liveExplorerSidebarPaneId,
+            });
+            if (
+              !nextLayout ||
+              findPaneContainingTab(nextLayout.root, tabId)?.id !== destinationPaneId
+            ) {
+              return false;
+            }
+            candidateLayout = nextLayout;
+          }
+          return true;
+        },
         closeTabs: handleBulkCloseTabs,
         moveTabToPane: (tabId, destinationPaneId) => {
           moveWorkspaceTabToPane(persistenceKey, tabId, destinationPaneId);

--- a/packages/app/src/screens/workspace/workspace-tab-bulk-close-actions.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-bulk-close-actions.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(async () => null),
+    setItem: vi.fn(async () => {}),
+    removeItem: vi.fn(async () => {}),
+  },
+}));
+
+import {
+  classifyBulkClosableTabs,
+  closeBulkWorkspaceTabs,
+  createWorkspaceTabBulkCloseActions,
+} from "@/screens/workspace/workspace-bulk-close";
+import { deriveWorkspacePaneState } from "@/screens/workspace/workspace-pane-state";
+import { buildWorkspaceTabMenuEntries } from "@/screens/workspace/workspace-tab-menu";
+import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+import { collectAllTabs, createWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
+import type { WorkspaceTabTarget } from "@/workspace-tabs/model";
+
+type HarnessTabName = "left" | "pinnedAgent" | "anchor" | "pinnedTerminal" | "right";
+
+interface BulkCloseMenuCase {
+  menuEntryKey: "close-before" | "close-after" | "close-others";
+  remainingTabs: HarnessTabName[];
+}
+
+interface BulkCloseMenuHarness {
+  menuEntries: ReturnType<typeof buildWorkspaceTabMenuEntries>;
+  closeItems: ReturnType<typeof vi.fn>;
+  waitForClose: () => Promise<void>;
+  getOpenTabIds: () => string[];
+  tabIds: Record<HarnessTabName, string>;
+}
+
+function createBulkCloseMenuHarness(): BulkCloseMenuHarness {
+  let nodeId = 0;
+  const workspaceKey = "server:workspace";
+  const store = createWorkspaceLayoutStore({
+    createNodeId: (prefix) => `${prefix}-${(nodeId += 1)}`,
+    createFocusRestorationToken: () => "focus-token",
+  });
+
+  function openTab(target: WorkspaceTabTarget): string {
+    const tabId = store.getState().openTab({ workspaceKey, target, intent: "new" });
+    if (!tabId) throw new Error(`Failed to open ${target.kind} tab`);
+    return tabId;
+  }
+
+  const leftTabId = openTab({ kind: "file", path: "/repo/left.ts" });
+  const pinnedAgentTabId = openTab({ kind: "agent", agentId: "pinned-agent" });
+  const anchorTabId = openTab({ kind: "file", path: "/repo/anchor.ts" });
+  const pinnedTerminalTabId = openTab({ kind: "terminal", terminalId: "pinned-terminal" });
+  const rightTabId = openTab({ kind: "file", path: "/repo/right.ts" });
+  const initialLayout = store.getState().layoutByWorkspace[workspaceKey];
+  for (const tab of collectAllTabs(initialLayout.root)) {
+    if (tab.target.kind === "new_tab") store.getState().closeTab(workspaceKey, tab.tabId);
+  }
+  store.getState().toggleTabPinned(workspaceKey, pinnedAgentTabId);
+  store.getState().toggleTabPinned(workspaceKey, pinnedTerminalTabId);
+
+  function getDescriptors(): WorkspaceTabDescriptor[] {
+    const layout = store.getState().layoutByWorkspace[workspaceKey];
+    return deriveWorkspacePaneState({
+      layout,
+      paneId: "main",
+      tabs: collectAllTabs(layout.root),
+    }).tabs.map((tab) => tab.descriptor);
+  }
+
+  const paneTabs = getDescriptors();
+  const anchorTab = paneTabs.find((tab) => tab.tabId === anchorTabId);
+  if (!anchorTab) throw new Error("Anchor tab is missing");
+
+  const closeItems = vi.fn(async () => ({ agents: [], terminals: [], requestId: "request-1" }));
+  const actions = createWorkspaceTabBulkCloseActions({
+    labels: {
+      beforeTitle: "Close tabs to the left?",
+      afterTitle: "Close tabs to the right?",
+      othersTitle: "Close other tabs?",
+    },
+    closeTabs: async ({ tabsToClose, logLabel }) => {
+      await closeBulkWorkspaceTabs({
+        groups: classifyBulkClosableTabs(tabsToClose),
+        client: { closeItems },
+        closeTab: async (_tabId, action) => action(),
+        closeLayoutOnlyAgent: async () => {},
+        closeWorkspaceTabWithCleanup: ({ tabId }) => {
+          store.getState().closeTab(workspaceKey, tabId);
+        },
+        logLabel,
+      });
+      return true;
+    },
+  });
+  const pendingCloses: Array<Promise<void>> = [];
+  const menuEntries = buildWorkspaceTabMenuEntries({
+    surface: "desktop",
+    tab: anchorTab,
+    index: paneTabs.indexOf(anchorTab),
+    tabCount: paneTabs.length,
+    menuTestIDBase: "workspace-tab-context-anchor",
+    onCopyResumeCommand: vi.fn(),
+    onCopyAgentId: vi.fn(),
+    onCopyTerminalId: vi.fn(),
+    onCopyFilePath: vi.fn(),
+    onReloadAgent: vi.fn(),
+    onRenameTab: vi.fn(),
+    onTogglePinTab: vi.fn(),
+    onCloseTab: vi.fn(),
+    onCloseTabsBefore: (tabId) => {
+      pendingCloses.push(actions.closeTabsBefore(tabId, paneTabs));
+    },
+    onCloseTabsAfter: (tabId) => {
+      pendingCloses.push(actions.closeTabsAfter(tabId, paneTabs));
+    },
+    onCloseOtherTabs: (tabId) => {
+      pendingCloses.push(actions.closeOtherTabs(tabId, paneTabs));
+    },
+  });
+
+  return {
+    menuEntries,
+    closeItems,
+    waitForClose: async () => {
+      await Promise.all(pendingCloses);
+    },
+    getOpenTabIds: () => getDescriptors().map((tab) => tab.tabId),
+    tabIds: {
+      left: leftTabId,
+      pinnedAgent: pinnedAgentTabId,
+      anchor: anchorTabId,
+      pinnedTerminal: pinnedTerminalTabId,
+      right: rightTabId,
+    },
+  };
+}
+
+describe("workspace tab bulk-close actions", () => {
+  it.each<BulkCloseMenuCase>([
+    {
+      menuEntryKey: "close-before",
+      remainingTabs: ["pinnedAgent", "anchor", "pinnedTerminal", "right"],
+    },
+    {
+      menuEntryKey: "close-after",
+      remainingTabs: ["left", "pinnedAgent", "anchor", "pinnedTerminal"],
+    },
+    {
+      menuEntryKey: "close-others",
+      remainingTabs: ["pinnedAgent", "anchor", "pinnedTerminal"],
+    },
+  ])("protects pinned tabs through the $menuEntryKey context-menu action", async (testCase) => {
+    const harness = createBulkCloseMenuHarness();
+    const menuEntry = harness.menuEntries.find(
+      (entry) => entry.kind === "item" && entry.key === testCase.menuEntryKey,
+    );
+    if (!menuEntry || menuEntry.kind !== "item") {
+      throw new Error(`${testCase.menuEntryKey} menu entry is missing`);
+    }
+
+    menuEntry.onSelect();
+    await harness.waitForClose();
+
+    const remainingTabIds = testCase.remainingTabs.map((name) => harness.tabIds[name]);
+    expect(harness.getOpenTabIds()).toEqual(remainingTabIds);
+    expect(harness.closeItems).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -381,7 +381,6 @@ describe("buildWorkspaceTabMenuEntries", () => {
   });
 
   it.each<WorkspaceTabDescriptor["target"]>([
-    { kind: "new_tab" },
     { kind: "draft", draftId: "draft-1" },
     { kind: "agent", agentId: "agent-1" },
     { kind: "provider_subagent", parentAgentId: "parent-1", subagentId: "child-1" },
@@ -394,8 +393,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     { kind: "working_diff" },
     { kind: "plugin", pluginId: "plugin-1", panelId: "panel-1", context: "workspace" },
     { kind: "setup", workspaceId: "workspace-1" },
-    { kind: "commit_diff", sha: "abc123" },
-  ])("shows the pin action for $kind tabs", (target) => {
+  ])("shows the pin action for persistent $kind tabs", (target) => {
     const tab: WorkspaceTabDescriptor = {
       key: `tab-${target.kind}`,
       tabId: `tab-${target.kind}`,
@@ -430,6 +428,41 @@ describe("buildWorkspaceTabMenuEntries", () => {
         testID: `workspace-tab-context-${tab.tabId}-pin`,
       }),
     );
+  });
+
+  it.each<WorkspaceTabDescriptor["target"]>([
+    { kind: "new_tab" },
+    { kind: "commit_diff", sha: "abc123" },
+  ])("omits the pin action for ephemeral $kind tabs", (target) => {
+    const tab: WorkspaceTabDescriptor = {
+      key: `tab-${target.kind}`,
+      tabId: `tab-${target.kind}`,
+      kind: target.kind,
+      target,
+    };
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab,
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: `workspace-tab-context-${tab.tabId}`,
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onCopyTerminalId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onTogglePinTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    expect(entries).not.toContainEqual(
+      expect.objectContaining({ kind: "item", key: "toggle-pin" }),
+    );
+    expect(entries).not.toContainEqual({ kind: "separator", key: "pin-separator" });
   });
 
   it("switches to Unpin tab and dispatches the toggle for a pinned tab", () => {

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -38,6 +38,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyFilePath,
       onReloadAgent,
       onRenameTab,
+      onTogglePinTab: vi.fn(),
       onCloseTab,
       onCloseTabsBefore,
       onCloseTabsAfter,
@@ -48,6 +49,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       "Copy resume command",
       "Copy agent id",
       "Rename",
+      "Pin tab",
       "Close to the left",
       "Close to the right",
       "Close other tabs",
@@ -69,6 +71,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
+      onTogglePinTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -79,6 +82,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       "Copy resume command",
       "Copy agent id",
       "Rename",
+      "Pin tab",
       "Close tabs above",
       "Close tabs below",
       "Close other tabs",
@@ -87,7 +91,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     ]);
   });
 
-  it("omits agent copy actions and rename for draft tabs", () => {
+  it("omits agent copy actions and rename for draft tabs while keeping pin", () => {
     const entries = buildWorkspaceTabMenuEntries({
       surface: "mobile",
       tab: {
@@ -105,6 +109,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
+      onTogglePinTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -118,7 +123,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       false,
     );
     expect(entries.some((entry) => entry.kind === "item" && entry.label === "Rename")).toBe(false);
-    expect(entries.some((entry) => entry.kind === "separator")).toBe(false);
+    expect(entries.some((entry) => entry.kind === "item" && entry.label === "Pin tab")).toBe(true);
+    expect(entries.some((entry) => entry.kind === "separator")).toBe(true);
   });
 
   it("adds reload tooltip copy for agent tabs", () => {
@@ -134,6 +140,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
+      onTogglePinTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -164,6 +171,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab,
+      onTogglePinTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -200,6 +208,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab,
+      onTogglePinTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -209,6 +218,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     const labels = entries.filter((entry) => entry.kind === "item").map((entry) => entry.label);
     expect(labels[0]).toBe("Copy terminal id");
     expect(labels[1]).toBe("Rename");
+    expect(labels[2]).toBe("Pin tab");
     expect(labels).not.toContain("Copy resume command");
     expect(labels).not.toContain("Copy agent id");
     expect(labels).not.toContain("Copy file path");
@@ -251,6 +261,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyFilePath,
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
+      onTogglePinTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -259,6 +270,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
 
     const labels = entries.filter((entry) => entry.kind === "item").map((entry) => entry.label);
     expect(labels[0]).toBe("Copy file path");
+    expect(labels[1]).toBe("Pin tab");
     expect(labels).not.toContain("Copy resume command");
     expect(labels).not.toContain("Copy agent id");
     expect(labels).not.toContain("Rename");
@@ -294,6 +306,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
+      onTogglePinTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsToLeft: vi.fn(),
       onCloseTabsToRight: vi.fn(),
@@ -325,6 +338,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
+      onTogglePinTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -362,7 +376,94 @@ describe("buildWorkspaceTabMenuEntries", () => {
     const terminalSeparator = terminalEntries
       .slice(terminalEntries.indexOf(terminalRename) + 1)
       .find((entry) => entry.kind === "separator");
-    expect(agentSeparator?.key).toBe("rename-separator");
-    expect(terminalSeparator?.key).toBe("rename-separator");
+    expect(agentSeparator?.key).toBe("pin-separator");
+    expect(terminalSeparator?.key).toBe("pin-separator");
+  });
+
+  it.each<WorkspaceTabDescriptor["target"]>([
+    { kind: "new_tab" },
+    { kind: "draft", draftId: "draft-1" },
+    { kind: "agent", agentId: "agent-1" },
+    { kind: "provider_subagent", parentAgentId: "parent-1", subagentId: "child-1" },
+    { kind: "terminal", terminalId: "terminal-1" },
+    { kind: "browser", browserId: "browser-1" },
+    { kind: "changes_tree" },
+    { kind: "files" },
+    { kind: "pull_request" },
+    { kind: "file", path: "/repo/file.ts" },
+    { kind: "working_diff" },
+    { kind: "plugin", pluginId: "plugin-1", panelId: "panel-1", context: "workspace" },
+    { kind: "setup", workspaceId: "workspace-1" },
+    { kind: "commit_diff", sha: "abc123" },
+  ])("shows the pin action for $kind tabs", (target) => {
+    const tab: WorkspaceTabDescriptor = {
+      key: `tab-${target.kind}`,
+      tabId: `tab-${target.kind}`,
+      kind: target.kind,
+      target,
+    };
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab,
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: `workspace-tab-context-${tab.tabId}`,
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onCopyTerminalId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onTogglePinTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        kind: "item",
+        key: "toggle-pin",
+        label: "Pin tab",
+        icon: "pin",
+        testID: `workspace-tab-context-${tab.tabId}-pin`,
+      }),
+    );
+  });
+
+  it("switches to Unpin tab and dispatches the toggle for a pinned tab", () => {
+    const onTogglePinTab = vi.fn();
+    const onCloseTab = vi.fn();
+    const tab = { ...createAgentTab(), isPinned: true };
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab,
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-context-agent_123",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onCopyTerminalId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onTogglePinTab,
+      onCloseTab,
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    const pinEntry = entries.find((entry) => entry.kind === "item" && entry.key === "toggle-pin");
+    if (!pinEntry || pinEntry.kind !== "item") throw new Error("Pin entry missing");
+    pinEntry.onSelect();
+    expect(pinEntry.label).toBe("Unpin tab");
+    expect(onTogglePinTab).toHaveBeenCalledWith(tab.tabId);
+
+    const closeEntry = entries.find((entry) => entry.kind === "item" && entry.key === "close");
+    if (!closeEntry || closeEntry.kind !== "item") throw new Error("Close entry missing");
+    closeEntry.onSelect();
+    expect(onCloseTab).toHaveBeenCalledWith(tab.tabId);
   });
 });

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -11,6 +11,8 @@ export interface WorkspaceTabMenuLabels {
   copyTerminalId: string;
   copyFilePath: string;
   rename: string;
+  pinTab: string;
+  unpinTab: string;
   closeAbove: string;
   closeBelow: string;
   closeLeft: string;
@@ -27,6 +29,8 @@ export const DEFAULT_WORKSPACE_TAB_MENU_LABELS: WorkspaceTabMenuLabels = {
   copyTerminalId: i18n.t("workspace.tabs.menu.copyTerminalId"),
   copyFilePath: i18n.t("workspace.tabs.menu.copyFilePath"),
   rename: i18n.t("workspace.tabs.menu.rename"),
+  pinTab: i18n.t("workspace.tabs.menu.pinTab"),
+  unpinTab: i18n.t("workspace.tabs.menu.unpinTab"),
   closeAbove: i18n.t("workspace.tabs.menu.closeAbove"),
   closeBelow: i18n.t("workspace.tabs.menu.closeBelow"),
   closeLeft: i18n.t("workspace.tabs.menu.closeLeft"),
@@ -49,6 +53,7 @@ export type WorkspaceTabMenuEntry =
         | "arrow-right-to-line"
         | "copy-x"
         | "pencil"
+        | "pin"
         | "x";
       hint?: string;
       tooltip?: string;
@@ -74,6 +79,7 @@ interface BuildWorkspaceTabMenuEntriesInput {
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
+  onTogglePinTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsBefore: (tabId: string) => Promise<void> | void;
   onCloseTabsAfter: (tabId: string) => Promise<void> | void;
@@ -91,6 +97,7 @@ interface BuildWorkspaceDesktopTabActionsInput {
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
+  onTogglePinTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
@@ -178,6 +185,7 @@ export function buildWorkspaceTabMenuEntries(
     onCopyFilePath,
     onReloadAgent,
     onRenameTab,
+    onTogglePinTab,
     onCloseTab,
     onCloseTabsBefore,
     onCloseTabsAfter,
@@ -254,11 +262,22 @@ export function buildWorkspaceTabMenuEntries(
         onRenameTab(tab);
       },
     });
-    entries.push({
-      kind: "separator",
-      key: "rename-separator",
-    });
   }
+
+  entries.push({
+    kind: "item",
+    key: "toggle-pin",
+    label: tab.isPinned === true ? labels.unpinTab : labels.pinTab,
+    icon: "pin",
+    testID: `${menuTestIDBase}-pin`,
+    onSelect: () => {
+      onTogglePinTab(tab.tabId);
+    },
+  });
+  entries.push({
+    kind: "separator",
+    key: "pin-separator",
+  });
 
   entries.push({
     kind: "item",
@@ -339,6 +358,7 @@ export function buildWorkspaceDesktopTabActions(
       onCopyFilePath: input.onCopyFilePath,
       onReloadAgent: input.onReloadAgent,
       onRenameTab: input.onRenameTab,
+      onTogglePinTab: input.onTogglePinTab,
       onCloseTab: input.onCloseTab,
       onCloseTabsBefore: input.onCloseTabsToLeft,
       onCloseTabsAfter: input.onCloseTabsToRight,

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -2,6 +2,7 @@ import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-
 import { i18n } from "@/i18n/i18next";
 import { encodeFilePathForPathSegment, encodeWorkspaceIdForPathSegment } from "@/utils/host-routes";
 import { buildDeterministicWorkspaceTabId } from "@/workspace-tabs/identity";
+import { isWorkspaceTabTargetPersistent } from "@/workspace-tabs/model";
 
 export type WorkspaceTabMenuSurface = "desktop" | "mobile";
 
@@ -195,6 +196,7 @@ export function buildWorkspaceTabMenuEntries(
   const isFirstTab = index === 0;
   const isLastTab = index === tabCount - 1;
   const isOnlyTab = tabCount <= 1;
+  const isPersistentTab = isWorkspaceTabTargetPersistent(tab.target);
   const entries: WorkspaceTabMenuEntry[] = [];
 
   if (tab.target.kind === "agent") {
@@ -264,20 +266,22 @@ export function buildWorkspaceTabMenuEntries(
     });
   }
 
-  entries.push({
-    kind: "item",
-    key: "toggle-pin",
-    label: tab.isPinned === true ? labels.unpinTab : labels.pinTab,
-    icon: "pin",
-    testID: `${menuTestIDBase}-pin`,
-    onSelect: () => {
-      onTogglePinTab(tab.tabId);
-    },
-  });
-  entries.push({
-    kind: "separator",
-    key: "pin-separator",
-  });
+  if (isPersistentTab) {
+    entries.push({
+      kind: "item",
+      key: "toggle-pin",
+      label: tab.isPinned === true ? labels.unpinTab : labels.pinTab,
+      icon: "pin",
+      testID: `${menuTestIDBase}-pin`,
+      onSelect: () => {
+        onTogglePinTab(tab.tabId);
+      },
+    });
+    entries.push({
+      kind: "separator",
+      key: "pin-separator",
+    });
+  }
 
   entries.push({
     kind: "item",

--- a/packages/app/src/screens/workspace/workspace-tab-model.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-model.test.ts
@@ -133,6 +133,26 @@ describe("deriveWorkspaceTabModel", () => {
     expect(model.activeTab?.descriptor.target).toEqual({ kind: "agent", agentId: "agent-1" });
   });
 
+  it("preserves user-facing pinned state on derived tab descriptors", () => {
+    const model = deriveWorkspaceTabModel({
+      tabs: [
+        {
+          tabId: "browser_browser-a",
+          target: { kind: "browser", browserId: "browser-a" },
+          createdAt: 1,
+          isPinned: true,
+        },
+        {
+          tabId: "file_/repo/worktree/README.md",
+          target: { kind: "file", path: "/repo/worktree/README.md" },
+          createdAt: 2,
+        },
+      ],
+    });
+
+    expect(model.tabs.map((tab) => tab.descriptor.isPinned)).toEqual([true, false]);
+  });
+
   it("normalizes file paths and discards invalid tabs", () => {
     const model = deriveWorkspaceTabModel({
       tabs: [

--- a/packages/app/src/screens/workspace/workspace-tab-presentation.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-presentation.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { i18n as testI18n } from "@/i18n/i18next";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ICON_SIZE } from "@/styles/theme";
+import {
+  WorkspaceTabOptionRow,
+  type WorkspaceTabPresentation,
+} from "@/screens/workspace/workspace-tab-presentation";
+
+vi.hoisted(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: () => ({
+      matches: false,
+      media: "",
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+void testI18n;
+
+vi.mock("lucide-react-native", () => {
+  const StubIcon = () => null;
+  const Pin = ({ size }: { size?: number }) =>
+    React.createElement("svg", { "data-icon": "Pin", "data-size": size });
+  return {
+    Check: StubIcon,
+    CircleAlert: StubIcon,
+    Pin,
+  };
+});
+
+vi.mock("@/components/status-ring", () => ({
+  StatusRing: () => null,
+}));
+
+vi.mock("@/panels/register-panels", () => ({
+  ensurePanelsRegistered: () => undefined,
+}));
+
+vi.mock("@/panels/panel-registry", () => ({
+  getPanelRegistration: () => undefined,
+}));
+
+vi.mock("@/panels/panel-instance-attributes", () => ({
+  usePanelInstanceAttributes: () => ({ modified: false }),
+}));
+
+const presentation: WorkspaceTabPresentation = {
+  key: "file_source.ts",
+  kind: "file",
+  label: "source.ts",
+  subtitle: "src/source.ts",
+  tooltip: "src/source.ts",
+  modified: false,
+  titleState: "ready",
+  icon: () => null,
+  statusBucket: null,
+};
+
+describe("WorkspaceTabOptionRow pin affordance", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("React", React);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  function renderRow(isPinned: boolean) {
+    act(() => {
+      root.render(
+        <WorkspaceTabOptionRow
+          presentation={presentation}
+          isPinned={isPinned}
+          selected={false}
+          active={false}
+          onPress={vi.fn()}
+        />,
+      );
+    });
+  }
+
+  function getPinSlot(): HTMLElement {
+    const slot = container.firstElementChild?.firstElementChild?.children.item(1);
+    if (!(slot instanceof HTMLElement)) {
+      throw new Error("Workspace tab pin slot did not render");
+    }
+    return slot;
+  }
+
+  it("keeps the pin slot geometry stable while toggling the rendered pin", () => {
+    renderRow(false);
+
+    const unpinnedSlot = getPinSlot();
+    const unpinnedGeometry = {
+      width: getComputedStyle(unpinnedSlot).width,
+      height: getComputedStyle(unpinnedSlot).height,
+      flexShrink: getComputedStyle(unpinnedSlot).flexShrink,
+    };
+    expect(container.querySelector('[data-icon="Pin"]')).toBeNull();
+    expect(unpinnedGeometry).toEqual({
+      width: `${ICON_SIZE.xs}px`,
+      height: `${ICON_SIZE.xs}px`,
+      flexShrink: "0",
+    });
+
+    renderRow(true);
+
+    const pinnedSlot = getPinSlot();
+    const pin = container.querySelector('[data-icon="Pin"]');
+    expect(pinnedSlot).toBe(unpinnedSlot);
+    expect(pin?.getAttribute("data-size")).toBe(String(ICON_SIZE.xs));
+    expect({
+      width: getComputedStyle(pinnedSlot).width,
+      height: getComputedStyle(pinnedSlot).height,
+      flexShrink: getComputedStyle(pinnedSlot).flexShrink,
+    }).toEqual(unpinnedGeometry);
+  });
+});

--- a/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
@@ -16,7 +16,7 @@ import {
   STATUS_INDICATOR_ALERT_SIZE,
   STATUS_INDICATOR_DOT_SIZE,
 } from "@/utils/status-indicator-geometry";
-import type { Theme } from "@/styles/theme";
+import { ICON_SIZE, type Theme } from "@/styles/theme";
 import { usePanelInstanceAttributes } from "@/panels/panel-instance-attributes";
 
 export interface WorkspaceTabPresentation {
@@ -33,7 +33,7 @@ export interface WorkspaceTabPresentation {
 
 const DEFAULT_STATUS_DOT_OFFSET = -2;
 const STATUS_ALERT_OFFSET = -3;
-export const WORKSPACE_TAB_PIN_ICON_SIZE = 12;
+export const WORKSPACE_TAB_PIN_ICON_SIZE = ICON_SIZE.xs;
 
 interface WorkspaceTabPresentationResolverProps {
   tab: WorkspaceTabDescriptor;

--- a/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
@@ -33,7 +33,6 @@ export interface WorkspaceTabPresentation {
 
 const DEFAULT_STATUS_DOT_OFFSET = -2;
 const STATUS_ALERT_OFFSET = -3;
-export const WORKSPACE_TAB_PIN_ICON_SIZE = ICON_SIZE.xs;
 
 interface WorkspaceTabPresentationResolverProps {
   tab: WorkspaceTabDescriptor;
@@ -191,9 +190,7 @@ export function WorkspaceTabIcon({
 export function WorkspaceTabPinIcon({ isPinned }: { isPinned: boolean }): ReactElement {
   return (
     <View style={styles.pinIconSlot} accessibilityElementsHidden>
-      {isPinned ? (
-        <ThemedPin size={WORKSPACE_TAB_PIN_ICON_SIZE} uniProps={mutedColorMapping} />
-      ) : null}
+      {isPinned ? <ThemedPin size={ICON_SIZE.xs} uniProps={mutedColorMapping} /> : null}
     </View>
   );
 }
@@ -281,8 +278,8 @@ const styles = StyleSheet.create((theme) => ({
     flexShrink: 0,
   },
   pinIconSlot: {
-    width: WORKSPACE_TAB_PIN_ICON_SIZE,
-    height: WORKSPACE_TAB_PIN_ICON_SIZE,
+    width: ICON_SIZE.xs,
+    height: ICON_SIZE.xs,
     flexShrink: 0,
     alignItems: "center",
     justifyContent: "center",

--- a/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, type ReactElement, type ReactNode } from "react";
 import { Pressable, Text, View, type PressableStateCallbackType } from "react-native";
-import { Check, CircleAlert } from "lucide-react-native";
+import { Check, CircleAlert, Pin } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
 import invariant from "tiny-invariant";
@@ -33,6 +33,7 @@ export interface WorkspaceTabPresentation {
 
 const DEFAULT_STATUS_DOT_OFFSET = -2;
 const STATUS_ALERT_OFFSET = -3;
+export const WORKSPACE_TAB_PIN_ICON_SIZE = 12;
 
 interface WorkspaceTabPresentationResolverProps {
   tab: WorkspaceTabDescriptor;
@@ -127,6 +128,7 @@ interface WorkspaceTabIconProps {
 
 const ThemedCheckIcon = withUnistyles(Check);
 const ThemedCircleAlert = withUnistyles(CircleAlert);
+const ThemedPin = withUnistyles(Pin);
 const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
 const needsInputAlertMapping = (theme: Theme) => ({
   color: theme.colors.surface0,
@@ -186,8 +188,19 @@ export function WorkspaceTabIcon({
   );
 }
 
+export function WorkspaceTabPinIcon({ isPinned }: { isPinned: boolean }): ReactElement {
+  return (
+    <View style={styles.pinIconSlot} accessibilityElementsHidden>
+      {isPinned ? (
+        <ThemedPin size={WORKSPACE_TAB_PIN_ICON_SIZE} uniProps={mutedColorMapping} />
+      ) : null}
+    </View>
+  );
+}
+
 interface WorkspaceTabOptionRowProps {
   presentation: WorkspaceTabPresentation;
+  isPinned: boolean;
   selected: boolean;
   active: boolean;
   onPress: () => void;
@@ -196,6 +209,7 @@ interface WorkspaceTabOptionRowProps {
 
 export function WorkspaceTabOptionRow({
   presentation,
+  isPinned,
   selected,
   active,
   onPress,
@@ -232,6 +246,7 @@ export function WorkspaceTabOptionRow({
                   backdrop={optionActive ? "surface1" : "surface0"}
                 />
               </View>
+              <WorkspaceTabPinIcon isPinned={isPinned} />
               <View style={styles.optionContent}>
                 <Text numberOfLines={1} style={styles.optionLabel}>
                   {presentation.titleState === "loading"
@@ -264,6 +279,13 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     justifyContent: "center",
     flexShrink: 0,
+  },
+  pinIconSlot: {
+    width: WORKSPACE_TAB_PIN_ICON_SIZE,
+    height: WORKSPACE_TAB_PIN_ICON_SIZE,
+    flexShrink: 0,
+    alignItems: "center",
+    justifyContent: "center",
   },
   statusDot: {
     position: "absolute",

--- a/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.test.tsx
@@ -36,6 +36,7 @@ vi.mock("lucide-react-native", () => {
     CopyX: StubIcon,
     Ellipsis: StubIcon,
     Pencil: StubIcon,
+    Pin: StubIcon,
     RotateCw: StubIcon,
     X: StubIcon,
   };
@@ -132,6 +133,7 @@ function terminalTab(): WorkspaceTabDescriptor {
 function renderAccessory(
   tab: WorkspaceTabDescriptor,
   onRenameTab: (tab: WorkspaceTabDescriptor) => void,
+  onTogglePinTab: (tabId: string) => void = vi.fn(),
 ): { base: string; unmount: () => void } {
   const base = `workspace-tab-menu-${tab.tabId}`;
   const menuEntries = buildWorkspaceTabMenuEntries({
@@ -146,6 +148,7 @@ function renderAccessory(
     onCopyFilePath: vi.fn(),
     onReloadAgent: vi.fn(),
     onRenameTab,
+    onTogglePinTab,
     onCloseTab: vi.fn(),
     onCloseTabsBefore: vi.fn(),
     onCloseTabsAfter: vi.fn(),
@@ -228,5 +231,17 @@ describe("MobileTabTrailingAccessory", () => {
     fireEvent.click(renameButton as HTMLElement);
 
     expect(onRenameTab).toHaveBeenCalledWith(terminalTab());
+  });
+
+  it("reaches Pin tab for a compact session", () => {
+    const onTogglePinTab = vi.fn();
+    const rendered = renderAccessory(agentTab(), vi.fn(), onTogglePinTab);
+    current = rendered;
+
+    const pinButton = document.querySelector(`[data-testid="${rendered.base}-pin"]`);
+    expect(pinButton).not.toBeNull();
+    fireEvent.click(pinButton as HTMLElement);
+
+    expect(onTogglePinTab).toHaveBeenCalledWith("agent_123");
   });
 });

--- a/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.tsx
@@ -9,6 +9,7 @@ import {
   CopyX,
   Ellipsis,
   Pencil,
+  Pin,
   RotateCw,
   X,
 } from "lucide-react-native";
@@ -29,6 +30,7 @@ const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
 const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
 const ThemedCopyX = withUnistyles(CopyX);
 const ThemedPencil = withUnistyles(Pencil);
+const ThemedPin = withUnistyles(Pin);
 const ThemedX = withUnistyles(X);
 
 const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
@@ -59,6 +61,8 @@ function MobileTabDropdownMenuItem({
         return <ThemedCopyX size={16} uniProps={mutedColorMapping} />;
       case "pencil":
         return <ThemedPencil size={16} uniProps={mutedColorMapping} />;
+      case "pin":
+        return <ThemedPin size={16} uniProps={mutedColorMapping} />;
       case "x":
         return <ThemedX size={16} uniProps={mutedColorMapping} />;
       default:

--- a/packages/app/src/screens/workspace/workspace-tabs-types.ts
+++ b/packages/app/src/screens/workspace/workspace-tabs-types.ts
@@ -5,5 +5,6 @@ export interface WorkspaceTabDescriptor {
   tabId: string;
   kind: WorkspaceTabTarget["kind"];
   target: WorkspaceTabTarget;
+  isPinned?: boolean;
   state?: import("@getpaseo/protocol/agent-types").JsonValue;
 }

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -381,6 +381,7 @@ function normalizeWorkspaceTab(value: unknown): WorkspaceTab | null {
     tabId,
     target,
     createdAt: typeof tab.createdAt === "number" ? tab.createdAt : Date.now(),
+    ...(tab.isPinned === true ? { isPinned: true } : {}),
     ...(tab.state !== undefined ? { state: tab.state } : {}),
   };
 }
@@ -881,6 +882,7 @@ function replaceTabInTree(
     tabId: string;
     nextTabId: string;
     target: WorkspaceTabTarget;
+    isPinned?: boolean;
     state?: JsonValue;
   },
 ): SplitNodeInternal {
@@ -898,6 +900,7 @@ function replaceTabInTree(
             tabId: input.nextTabId,
             target: input.target,
             createdAt: tab.createdAt,
+            ...((input.isPinned ?? tab.isPinned) === true ? { isPinned: true } : {}),
             ...(input.state !== undefined ? { state: input.state } : {}),
           };
         }),
@@ -1786,6 +1789,27 @@ export function setTabStateInLayout(input: {
   });
 }
 
+export function setTabPinnedInLayout(input: {
+  layout: WorkspaceLayout;
+  tabId: string;
+  isPinned: boolean;
+}): WorkspaceLayout | null {
+  const layout = asInternalLayout(input.layout);
+  const tab = collectAllTabs(layout.root).find((candidate) => candidate.tabId === input.tabId);
+  if (!tab || tab.isPinned === input.isPinned) return null;
+  return withNormalizedParentTabMap({
+    root: replaceTabInTree(layout.root, {
+      tabId: tab.tabId,
+      nextTabId: tab.tabId,
+      target: tab.target,
+      isPinned: input.isPinned,
+      state: tab.state,
+    }),
+    focusedPaneId: layout.focusedPaneId,
+    parentTabIdByTabId: input.layout.parentTabIdByTabId,
+  });
+}
+
 export function convertDraftToAgentInLayout(
   input: ConvertDraftToAgentInLayoutInput,
 ): ConvertDraftToAgentInLayoutResult | null {
@@ -1804,11 +1828,20 @@ export function convertDraftToAgentInLayout(
     collectAllTabs(layout.root).find((tab) => tab.tabId === canonicalTabId) ?? null;
 
   if (existingCanonicalTab && existingCanonicalTab.tabId !== input.tabId) {
-    const nextLayout =
+    let nextLayout = input.layout;
+    if (currentTab.isPinned === true && existingCanonicalTab.isPinned !== true) {
+      nextLayout =
+        setTabPinnedInLayout({
+          layout: nextLayout,
+          tabId: existingCanonicalTab.tabId,
+          isPinned: true,
+        }) ?? nextLayout;
+    }
+    nextLayout =
       closeTabInLayout({
-        layout: input.layout,
+        layout: nextLayout,
         tabId: input.tabId,
-      }) ?? input.layout;
+      }) ?? nextLayout;
     return {
       layout:
         focusTabInLayout({
@@ -2279,6 +2312,23 @@ function buildEntityTabGroups(initialTabs: WorkspaceTab[]): Map<string, EntityTa
   return entityGroups;
 }
 
+function preserveEntityGroupPinnedState(input: {
+  layout: WorkspaceLayout;
+  keeper: WorkspaceTab;
+  tabs: WorkspaceTab[];
+}): WorkspaceLayout {
+  if (input.keeper.isPinned === true || !input.tabs.some((tab) => tab.isPinned === true)) {
+    return input.layout;
+  }
+  return (
+    setTabPinnedInLayout({
+      layout: input.layout,
+      tabId: input.keeper.tabId,
+      isPinned: true,
+    }) ?? input.layout
+  );
+}
+
 function collapseStaleEntityTabs(input: {
   layout: WorkspaceLayout;
   snapshot: WorkspaceTabSnapshot;
@@ -2465,6 +2515,11 @@ export function reconcileWorkspaceTabs(
         parentTabIdByTabId: nextLayout.parentTabIdByTabId,
       });
     }
+    nextLayout = preserveEntityGroupPinnedState({
+      layout: nextLayout,
+      keeper,
+      tabs: group.tabs,
+    });
     for (const tab of group.tabs) {
       if (tab.tabId === keeper.tabId) {
         continue;

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -1,6 +1,10 @@
 import invariant from "tiny-invariant";
 import type { JsonValue } from "@getpaseo/protocol/agent-types";
-import type { WorkspaceTab, WorkspaceTabTarget } from "@/workspace-tabs/model";
+import {
+  isWorkspaceTabTargetPersistent,
+  type WorkspaceTab,
+  type WorkspaceTabTarget,
+} from "@/workspace-tabs/model";
 import { MIN_SPLIT_SIZE } from "@/stores/workspace-layout-constants";
 import { panelResourceKey, panelSupportsHost } from "@/panels/panel-manifest";
 import { defaultWorkspaceLayoutIds } from "@/stores/workspace-layout-ids";
@@ -1096,7 +1100,7 @@ export function collectAllPanes(root: SplitNode): SplitPane[] {
 }
 
 function isEphemeralTab(tab: WorkspaceTab): boolean {
-  return tab.target.kind === "commit_diff" || tab.target.kind === "new_tab";
+  return !isWorkspaceTabTargetPersistent(tab.target);
 }
 
 function stripEphemeralTabsFromNode(node: SplitNodeInternal): SplitNodeInternal {

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -126,6 +126,13 @@ function collectTabIds(root: SplitNode): string[] {
   return collectAllTabs(root).map((tab) => tab.tabId);
 }
 
+function findTabById(root: SplitNode, tabId: string) {
+  for (const tab of collectAllTabs(root)) {
+    if (tab.tabId === tabId) return tab;
+  }
+  return undefined;
+}
+
 function collectContentTabs(root: SplitNode): WorkspaceTab[] {
   return contentTabs(collectAllTabs(root));
 }
@@ -1225,6 +1232,68 @@ describe("workspace-layout-store actions", () => {
     const tabs = collectAllTabs(restored.getState().layoutByWorkspace[workspaceKey].root);
     expect(tabs.find((tab) => tab.tabId === first)?.state).toEqual(firstState);
     expect(tabs.find((tab) => tab.tabId === second)?.state).toEqual(secondState);
+  });
+
+  it("persists user-pinned tab state and still allows an explicit close", async () => {
+    await AsyncStorage.removeItem("workspace-layout-state");
+    const workspaceKey = createWorkspaceKey();
+    const source = createWorkspaceLayoutStore(createDeterministicWorkspaceLayoutIds());
+    await source.persist.rehydrate();
+    const pinnedTabId = source.getState().openTab({
+      workspaceKey,
+      target: { kind: "browser", browserId: "browser-1" },
+      intent: "new",
+    });
+    const unpinnedTabId = source.getState().openTab({
+      workspaceKey,
+      target: { kind: "file", path: "/repo/README.md" },
+      intent: "new",
+    });
+    expect(pinnedTabId).toBeTruthy();
+    expect(unpinnedTabId).toBeTruthy();
+    source.getState().toggleTabPinned(workspaceKey, pinnedTabId as string);
+
+    await vi.waitFor(async () => {
+      const persisted = await AsyncStorage.getItem("workspace-layout-state");
+      const root = JSON.parse(persisted ?? "{}").state.layoutByWorkspace[workspaceKey].root;
+      expect(findTabById(root, pinnedTabId as string)?.isPinned).toBe(true);
+      expect(findTabById(root, unpinnedTabId as string)?.isPinned).toBeUndefined();
+    });
+
+    const restored = createWorkspaceLayoutStore(createDeterministicWorkspaceLayoutIds());
+    await restored.persist.rehydrate();
+    const restoredTabs = collectAllTabs(restored.getState().layoutByWorkspace[workspaceKey].root);
+    expect(restoredTabs.find((tab) => tab.tabId === pinnedTabId)?.isPinned).toBe(true);
+    expect(restoredTabs.find((tab) => tab.tabId === unpinnedTabId)?.isPinned).toBeUndefined();
+
+    restored.getState().closeTab(workspaceKey, pinnedTabId as string);
+    expect(
+      collectAllTabs(restored.getState().layoutByWorkspace[workspaceKey].root).some(
+        (tab) => tab.tabId === pinnedTabId,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps pinned state when replacing a tab target", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const tabId = store.openTab({
+      workspaceKey,
+      target: { kind: "file", path: "/repo/a.ts" },
+      intent: "new",
+    });
+    expect(tabId).toBeTruthy();
+    store.toggleTabPinned(workspaceKey, tabId as string);
+
+    const replacementTabId = store.replaceTab(workspaceKey, tabId as string, {
+      kind: "file",
+      path: "/repo/b.ts",
+    });
+    const replacement = collectAllTabs(
+      workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey].root,
+    ).find((tab) => tab.tabId === replacementTabId);
+
+    expect(replacement?.isPinned).toBe(true);
   });
 
   it("leaves an Explorer background tab in the only other pane instead of emptying it", () => {
@@ -3196,6 +3265,7 @@ describe("workspace-layout-store actions", () => {
       targetPaneId: "main",
       position: "right",
     });
+    store.toggleTabPinned(workspaceKey, draftTabId!);
 
     const nextTabId = store.convertDraftToAgent(workspaceKey, draftTabId!, "agent-1");
     const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
@@ -3205,6 +3275,9 @@ describe("workspace-layout-store actions", () => {
     expect(collectContentTabs(layout.root).map((tab) => tab.tabId)).toEqual(["agent_agent-1"]);
     expect(layout.focusedPaneId).toBe(splitPaneId);
     expect(findPaneContainingTab(layout.root, "agent_agent-1")?.id).toBe(splitPaneId);
+    expect(collectAllTabs(layout.root).find((tab) => tab.tabId === agentTabId)?.isPinned).toBe(
+      true,
+    );
   });
 
   it("reconcileTabs canonicalizes duplicates and prunes stale entity tabs from hydrated snapshots", () => {
@@ -3226,6 +3299,7 @@ describe("workspace-layout-store actions", () => {
                   tabId: "draft_agent",
                   target: { kind: "agent", agentId: "agent-1" },
                   createdAt: 1,
+                  isPinned: true,
                 },
                 {
                   tabId: "agent_agent-1",
@@ -3276,6 +3350,7 @@ describe("workspace-layout-store actions", () => {
       tabId: "agent_agent-1",
       target: { kind: "agent", agentId: "agent-1" },
       createdAt: 2,
+      isPinned: true,
     });
     expect(layout.focusedPaneId).toBe("main");
     expect(findPaneById(layout.root, "main")?.focusedTabId).toBe("agent_agent-1");

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -43,6 +43,7 @@ import {
   reorderFocusedPaneTabsInLayout,
   reorderPaneTabsInLayout,
   setPaneHiddenInLayout,
+  setTabPinnedInLayout,
   setTabStateInLayout,
   selectTabInPaneInLayout,
   splitPaneEmptyInLayout,
@@ -127,6 +128,7 @@ interface WorkspaceLayoutStore {
     target: WorkspaceTabTarget,
     state?: JsonValue,
   ) => string | null;
+  toggleTabPinned: (workspaceKey: string, tabId: string) => void;
   setTabState: (workspaceKey: string, tabId: string, state: JsonValue | undefined) => void;
   convertDraftToAgent: (workspaceKey: string, tabId: string, agentId: string) => string | null;
   reconcileTabs: (workspaceKey: string, snapshot: WorkspaceTabSnapshot) => void;
@@ -239,6 +241,7 @@ const WorkspaceTabStorageSchema = z.strictObject({
   tabId: z.string(),
   target: WorkspaceTabTargetStorageSchema,
   createdAt: z.number(),
+  isPinned: z.boolean().optional(),
   state: z.json().optional(),
 });
 const SplitNodeStorageSchema: z.ZodType<SplitNode> = z.lazy(() =>
@@ -1137,6 +1140,33 @@ export function createWorkspaceLayoutStore(
             },
           }));
           return result.tabId;
+        },
+        toggleTabPinned: (workspaceKey, tabId) => {
+          const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+          const normalizedTabId = trimNonEmpty(tabId);
+          if (!normalizedWorkspaceKey || !normalizedTabId) return;
+          set((state) => {
+            const currentLayout = getWorkspaceLayout(
+              state.layoutByWorkspace,
+              normalizedWorkspaceKey,
+            );
+            const tab = collectAllTabs(currentLayout.root).find(
+              (candidate) => candidate.tabId === normalizedTabId,
+            );
+            if (!tab) return state;
+            const layout = setTabPinnedInLayout({
+              layout: currentLayout,
+              tabId: normalizedTabId,
+              isPinned: tab.isPinned !== true,
+            });
+            if (!layout) return state;
+            return {
+              layoutByWorkspace: {
+                ...state.layoutByWorkspace,
+                [normalizedWorkspaceKey]: layout,
+              },
+            };
+          });
         },
         setTabState: (workspaceKey, tabId, tabState) => {
           const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);

--- a/packages/app/src/workspace-tabs/model.test.ts
+++ b/packages/app/src/workspace-tabs/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildWorkspaceTabPersistenceKey } from "./model";
+import { buildWorkspaceTabPersistenceKey, isWorkspaceTabTargetPersistent } from "./model";
 
 describe("buildWorkspaceTabPersistenceKey", () => {
   it("trims and joins opaque server and workspace ids", () => {
@@ -14,5 +14,14 @@ describe("buildWorkspaceTabPersistenceKey", () => {
   it("rejects incomplete identities", () => {
     expect(buildWorkspaceTabPersistenceKey({ serverId: "", workspaceId: "workspace" })).toBeNull();
     expect(buildWorkspaceTabPersistenceKey({ serverId: "server", workspaceId: "  " })).toBeNull();
+  });
+});
+
+describe("isWorkspaceTabTargetPersistent", () => {
+  it("matches the workspace layout persistence policy", () => {
+    expect(isWorkspaceTabTargetPersistent({ kind: "new_tab" })).toBe(false);
+    expect(isWorkspaceTabTargetPersistent({ kind: "commit_diff", sha: "abc123" })).toBe(false);
+    expect(isWorkspaceTabTargetPersistent({ kind: "agent", agentId: "agent-1" })).toBe(true);
+    expect(isWorkspaceTabTargetPersistent({ kind: "file", path: "/repo/README.md" })).toBe(true);
   });
 });

--- a/packages/app/src/workspace-tabs/model.ts
+++ b/packages/app/src/workspace-tabs/model.ts
@@ -56,6 +56,10 @@ export interface WorkspaceTab {
   state?: JsonValue;
 }
 
+export function isWorkspaceTabTargetPersistent(target: WorkspaceTabTarget): boolean {
+  return target.kind !== "commit_diff" && target.kind !== "new_tab";
+}
+
 export function buildWorkspaceTabPersistenceKey(input: {
   serverId: string;
   workspaceId: string;

--- a/packages/app/src/workspace-tabs/model.ts
+++ b/packages/app/src/workspace-tabs/model.ts
@@ -52,6 +52,7 @@ export interface WorkspaceTab {
   tabId: string;
   target: WorkspaceTabTarget;
   createdAt: number;
+  isPinned?: boolean;
   state?: JsonValue;
 }
 


### PR DESCRIPTION
## The problem

Workspace tabs accumulate over long sessions: a couple of anchors (the main agent session, a long-running terminal, a reference file) mixed into short-lived scratch tabs. Every bulk-close gesture — "Close other tabs", "Close to the left/right" — treats all tabs the same, so keeping anchors around means closing scratch tabs one by one, or reopening anchors after a bulk close. There is no way to say "this tab matters, keep it".

## What changes

Users can pin any persistent workspace tab:

- **Pin tab / Unpin tab** in the tab context menu (pin icon, next to Rename), for every persistent tab kind — agent, terminal, file, browser. Ephemeral targets that never persist (New Tab, commit diff) don't offer the action.
- Pinned tabs show a **pin affordance** in the tab row (desktop row, compact rows, Explorer tab rail). The icon slot is always mounted, so toggling pin causes no layout shift.
- **Bulk closes skip pinned tabs**: "Close other tabs", "Close to the left", "Close to the right" — from the tab menu, keyboard, and Command Center. An explicit "Close" on a pinned tab itself still closes it.
- **Close Pane is pin-safe** (Cmd+Shift+W / Command Center): pinned tabs are relocated to a surviving pane. Relocation is preflighted atomically — if a move isn't possible, the pane close is blocked instead of tearing pinned tabs down.
- Pin state **persists across restarts** with the workspace layout. `isPinned` is optional, so previously persisted layouts load unchanged.

This is separate from the existing internal `pinnedAgentIds` visibility-reconciliation mechanism, which is untouched.

## Tests

Unit/integration (vitest, run from `packages/app`):

- `workspace-tab-menu.test.ts` — Pin/Unpin item per tab kind, label switching, toggle dispatch, no pin for ephemeral kinds
- `workspace-tab-model.test.ts`, `workspace-tabs/model.test.ts` — pinned state on the tab model and persistence eligibility
- `workspace-bulk-close.test.ts` + `workspace-tab-bulk-close-actions.test.ts` — close before/after/others skip pinned, driven through the real store + menu handlers, not the selector in isolation
- `workspace-pane-close.test.ts` — relocation, final-pane block, and failure-path atomicity (unpinned tabs present; zero mutations when relocation fails)
- `workspace-tab-presentation.test.tsx` — rendered pin slot, stable width/height/flexShrink across pin toggles
- `workspace-layout-store.test.ts` — persistence, tab replacement, reconciliation

Browser e2e: `e2e/browser/pinned-tabs.spec.ts` — a real Playwright run (isolated daemon + Metro harness) that creates three terminal tabs through the real UI, pins via the real context menu, and verifies "Close other tabs" from an unpinned anchor keeps the pinned tab, then that unpinning restores normal close behavior. Mutation-checked: with the pinned filter removed, the spec fails; restored, it passes.

## QA evidence

Commands run on this branch:

```
$ cd packages/app && npx vitest run src/screens/workspace/workspace-tab-menu.test.ts \
    src/screens/workspace/workspace-tab-model.test.ts src/screens/workspace/workspace-bulk-close.test.ts \
    src/screens/workspace/workspace-pane-close.test.ts src/screens/workspace/workspace-tab-bulk-close-actions.test.ts \
    src/screens/workspace/workspace-tab-presentation.test.tsx src/workspace-tabs/model.test.ts \
    src/stores/workspace-layout-store.test.ts src/screens/workspace/workspace-tab-trailing-accessory.test.tsx

 Test Files  9 passed (9)
      Tests  181 passed (181)
```

```
$ cd packages/app && E2E_WORKERS=1 npx playwright test --project=browser e2e/browser/pinned-tabs.spec.ts

  ✓  1 [browser] › e2e/browser/pinned-tabs.spec.ts › pins a terminal tab and protects it from Close other tabs (7.5s)
  1 passed (22.4s)
```

`npm run typecheck`, targeted `npm run lint -- <changed files>` (0 warnings/errors), and `npm run format:check` all pass.

Screenshots captured from the e2e run:

| Pin in the context menu | Pinned tab in the row | After "Close other tabs" |
| --- | --- | --- |
| [![Pin tab menu item](https://raw.githubusercontent.com/aliozkanozdurmus/paseo/qa-assets/pinned-tabs/01-pin-tab-menu.png)](https://raw.githubusercontent.com/aliozkanozdurmus/paseo/qa-assets/pinned-tabs/01-pin-tab-menu.png) | [![Pinned tab row](https://raw.githubusercontent.com/aliozkanozdurmus/paseo/qa-assets/pinned-tabs/02-pinned-tab-row.png)](https://raw.githubusercontent.com/aliozkanozdurmus/paseo/qa-assets/pinned-tabs/02-pinned-tab-row.png) | [![Pinned tab survives close others](https://raw.githubusercontent.com/aliozkanozdurmus/paseo/qa-assets/pinned-tabs/03-close-others-pinned-survives.png)](https://raw.githubusercontent.com/aliozkanozdurmus/paseo/qa-assets/pinned-tabs/03-close-others-pinned-survives.png) |

Video of the full interaction: [pinned-tabs-e2e.webm](https://github.com/aliozkanozdurmus/paseo/blob/qa-assets/pinned-tabs/pinned-tabs-e2e.webm)

## Platforms

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | No     | Menu items come from the shared menu model that feeds the mobile sheet; compact rows render the pin via the shared accessory (unit-covered). No device run. |
| Android         | No     | Same as iOS. |
| Web             | Yes    | Chromium e2e spec + vitest suite above; screenshots/video from that run. |
| Desktop macOS   | No     | Same web code path; not run in the Electron shell. |
| Desktop Windows | No     | Same as macOS. |
| Desktop Linux   | No     | Same as macOS. |

Daemon and protocol are untouched — this is an app-side change only.

## Notes

I know feature PRs here normally start with a product discussion; this one is framed workflow-first per the contributing guide, and I'm happy to open a Discussion or reshape any part of it (icon, placement, close semantics) to fit the direction you want. Maintainer edits are enabled.
