### PR TITLE
feat(app): sort sidebar projects by recent activity

### DIFF
--- a/packages/app/e2e/browser/sidebar-project-sort.spec.ts
+++ b/packages/app/e2e/browser/sidebar-project-sort.spec.ts
@@ -1,0 +1,91 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import { projectEquivalenceViewKey } from "../support/helpers/project-view-key";
+import { closeSidebarDisplayPreferences, openSidebarDisplayPage } from "../support/helpers/sidebar";
+import { seedWorkspace } from "../support/helpers/seed-client";
+import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
+
+async function rowTestIds(rows: Locator) {
+  return rows.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute("data-testid")),
+  );
+}
+
+// The immediate-drag gesture from sidebar-reorder.spec.ts, trimmed to project rows.
+async function dragFirstRowAfterSecond(rows: Locator) {
+  const before = await rowTestIds(rows);
+  const sourceBox = await rows.nth(0).boundingBox();
+  const targetBox = await rows.nth(1).boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("Expected two visible project rows");
+
+  const page = rows.page();
+  const source = { x: sourceBox.x + sourceBox.width / 2, y: sourceBox.y + sourceBox.height / 2 };
+  const target = { x: targetBox.x + targetBox.width / 2, y: targetBox.y + targetBox.height / 2 };
+  await page.mouse.move(source.x, source.y);
+  await page.mouse.down();
+  await page.mouse.move(source.x, source.y + 7);
+  await page.mouse.move(target.x, target.y, { steps: 4 });
+  await page.mouse.up();
+  await expect.poll(() => rowTestIds(rows)).toEqual([before[1], before[0]]);
+  return [before[1], before[0]];
+}
+
+async function selectProjectSort(page: Page, mode: "manual" | "recent") {
+  await openSidebarDisplayPage(page, "sidebar-display-project-sort");
+  await page.getByTestId(`sidebar-project-sort-${mode}`).click();
+  await closeSidebarDisplayPreferences(page);
+}
+
+test("recent-activity sort reorders projects live and leaves the manual order alone", async ({
+  page,
+}) => {
+  const olderProject = await seedWorkspace({ repoPrefix: "sidebar-sort-older-" });
+  const newerProject = await seedWorkspace({ repoPrefix: "sidebar-sort-newer-" });
+
+  try {
+    await gotoAppShell(page);
+    await waitForSidebarHydration(page);
+
+    const olderRow = `sidebar-project-row-${projectEquivalenceViewKey(olderProject.projectKey)}`;
+    const newerRow = `sidebar-project-row-${projectEquivalenceViewKey(newerProject.projectKey)}`;
+    const rows = page.locator(`[data-testid="${olderRow}"], [data-testid="${newerRow}"]`);
+    await expect(rows).toHaveCount(2);
+
+    // Establish a manual order the sort cannot mistake for its own output: whatever the
+    // appearance order is, reverse it by drag.
+    const manualOrder = await dragFirstRowAfterSecond(rows);
+
+    // The newer project holds the freshest workspace activity, so recency puts it on top.
+    await selectProjectSort(page, "recent");
+    await expect.poll(() => rowTestIds(rows)).toEqual([newerRow, olderRow]);
+
+    // Fresh activity in the older project bumps it to the top without any manual reorder.
+    const bump = await olderProject.client.createWorkspace({
+      source: {
+        kind: "directory",
+        path: olderProject.repoPath,
+        projectId: olderProject.projectId,
+      },
+      title: "Freshest workspace",
+    });
+    if (!bump.workspace) throw new Error(bump.error ?? "Failed to seed the bump workspace");
+    await expect.poll(() => rowTestIds(rows)).toEqual([olderRow, newerRow]);
+
+    // The preference survives a reload. The persisted sidebar-view schema is strict, so an
+    // unknown key would reset every sidebar setting on parse.
+    await page.reload();
+    await waitForSidebarHydration(page);
+    await expect.poll(() => rowTestIds(rows)).toEqual([olderRow, newerRow]);
+    await page.getByTestId("sidebar-display-preferences-menu").click();
+    await expect(page.getByTestId("sidebar-display-project-sort")).toContainText("Recent activity");
+    await closeSidebarDisplayPreferences(page);
+
+    // Switching back to manual restores the dragged order untouched.
+    await selectProjectSort(page, "manual");
+    await expect.poll(() => rowTestIds(rows)).toEqual(manualOrder);
+  } finally {
+    await olderProject.cleanup();
+    await newerProject.cleanup();
+  }
+});

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -2189,6 +2189,11 @@ function ProjectModeList({
 
   const handleProjectDragEnd = useCallback(
     (reorderedProjects: SidebarProjectEntry[]) => {
+      // A drop position taken from a recency-sorted view says nothing about the manual
+      // order, so don't let it overwrite one; the sort reasserts itself anyway.
+      if (useSidebarViewStore.getState().projectSort === "recent") {
+        return;
+      }
       const reorderedProjectKeys = reorderedProjects.map((project) => project.viewKey);
       const currentProjectOrder = getProjectOrder();
       if (

--- a/packages/app/src/components/sidebar/display-preferences/menu.tsx
+++ b/packages/app/src/components/sidebar/display-preferences/menu.tsx
@@ -21,6 +21,8 @@ import {
   GitBranch,
   GitPullRequest,
   Globe,
+  GripVertical,
+  History,
   Server,
   Settings2,
   Tag,
@@ -49,6 +51,7 @@ import {
   hasActiveSidebarLabelFilter,
   SIDEBAR_UNLABELLED_LABEL_KEY,
   type SidebarGroupMode,
+  type SidebarProjectSortMode,
 } from "@/stores/sidebar-view-store";
 import { workspaceLabelKey, type WorkspaceLabelColor } from "@getpaseo/protocol/workspace-labels";
 import type { WorkspaceTitleSource } from "@/hooks/use-settings";
@@ -91,6 +94,12 @@ const GROUPING_ICONS: Record<SidebarGroupMode, OptionIcon> = {
   status: withUnistyles(CircleDashed),
 };
 
+// Manual is the drag order, so it wears the drag handle; recent wears the activity clock.
+const PROJECT_SORT_ICONS: Record<SidebarProjectSortMode, OptionIcon> = {
+  manual: withUnistyles(GripVertical),
+  recent: withUnistyles(History),
+};
+
 const TITLE_SOURCE_ICONS: Record<WorkspaceTitleSource, OptionIcon> = {
   title: withUnistyles(Type),
   branch: withUnistyles(GitBranch),
@@ -121,12 +130,18 @@ const TRAILING_ICONS: Record<SidebarTrailingChoice, OptionIcon> = {
 };
 
 const GROUPING_MODES: readonly SidebarGroupMode[] = ["project", "status"];
+const PROJECT_SORT_MODES: readonly SidebarProjectSortMode[] = ["manual", "recent"];
 const TITLE_SOURCES: readonly WorkspaceTitleSource[] = ["title", "branch"];
 const TRAILING_CHOICES: readonly SidebarTrailingChoice[] = ["diff", "timestamp"];
 
 const GROUPING_LABEL_KEYS: Record<SidebarGroupMode, string> = {
   project: "sidebar.display.grouping.project",
   status: "sidebar.display.grouping.status",
+};
+
+const PROJECT_SORT_LABEL_KEYS: Record<SidebarProjectSortMode, string> = {
+  manual: "sidebar.display.projectSort.manual",
+  recent: "sidebar.display.projectSort.recent",
 };
 
 const TITLE_SOURCE_LABEL_KEYS: Record<WorkspaceTitleSource, string> = {
@@ -202,6 +217,20 @@ export function SidebarDisplayPreferencesMenu(): ReactElement {
             selectedValue={preferences.grouping}
             onSelect={preferences.setGrouping}
             testIDPrefix="sidebar-grouping"
+          />
+        ),
+      },
+      {
+        id: "projectSort",
+        title: t("sidebar.display.projectSort.label"),
+        content: (
+          <OptionList
+            values={PROJECT_SORT_MODES}
+            icons={PROJECT_SORT_ICONS}
+            labelKeys={PROJECT_SORT_LABEL_KEYS}
+            selectedValue={preferences.projectSort}
+            onSelect={preferences.setProjectSort}
+            testIDPrefix="sidebar-project-sort"
           />
         ),
       },
@@ -308,6 +337,16 @@ export function SidebarDisplayPreferencesMenu(): ReactElement {
           >
             {t("sidebar.display.grouping.label")}
           </MenuSubTrigger>
+          {/* Only project grouping renders project sections, so only it gets a sort row. */}
+          {preferences.grouping === "project" ? (
+            <MenuSubTrigger
+              id="projectSort"
+              value={t(PROJECT_SORT_LABEL_KEYS[preferences.projectSort])}
+              testID="sidebar-display-project-sort"
+            >
+              {t("sidebar.display.projectSort.label")}
+            </MenuSubTrigger>
+          ) : null}
           <MenuSubTrigger
             id="titleSource"
             value={t(TITLE_SOURCE_LABEL_KEYS[preferences.titleSource])}

--- a/packages/app/src/components/sidebar/display-preferences/model.ts
+++ b/packages/app/src/components/sidebar/display-preferences/model.ts
@@ -8,6 +8,7 @@ import {
   useSidebarViewStore,
   type SidebarGroupMode,
   type SidebarLabelFilter,
+  type SidebarProjectSortMode,
 } from "@/stores/sidebar-view-store";
 import { DEFAULT_SIDEBAR_CHECKS_DISPLAY, type SidebarChecksDisplay } from "./checks-display";
 import { DEFAULT_SIDEBAR_ROW_ITEMS, type SidebarRowItem, type SidebarRowItems } from "./row-items";
@@ -18,6 +19,8 @@ export type SidebarTrailingChoice = Exclude<SidebarWorkspaceTrailing, "none">;
 export interface SidebarDisplayPreferences {
   grouping: SidebarGroupMode;
   setGrouping: (mode: SidebarGroupMode) => void;
+  projectSort: SidebarProjectSortMode;
+  setProjectSort: (mode: SidebarProjectSortMode) => void;
   titleSource: WorkspaceTitleSource;
   setTitleSource: (source: WorkspaceTitleSource) => void;
   rowItems: SidebarRowItems;
@@ -50,6 +53,8 @@ export interface SidebarDisplayPreferences {
 export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
   const grouping = useSidebarViewStore((state) => state.groupMode);
   const setGrouping = useSidebarViewStore((state) => state.setGroupMode);
+  const projectSort = useSidebarViewStore((state) => state.projectSort);
+  const setProjectSort = useSidebarViewStore((state) => state.setProjectSort);
   const hostFilters = useSidebarViewStore((state) => state.hostFilters);
   const toggleHostFilter = useSidebarViewStore((state) => state.toggleHostFilter);
   const clearHostFilters = useSidebarViewStore((state) => state.clearHostFilters);
@@ -106,6 +111,8 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
     () => ({
       grouping,
       setGrouping,
+      projectSort,
+      setProjectSort,
       titleSource: workspaceTitleSource,
       setTitleSource,
       rowItems: sidebarRowItems,
@@ -127,6 +134,8 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
     [
       grouping,
       setGrouping,
+      projectSort,
+      setProjectSort,
       workspaceTitleSource,
       setTitleSource,
       sidebarRowItems,

--- a/packages/app/src/components/sidebar/sidebar-model.tsx
+++ b/packages/app/src/components/sidebar/sidebar-model.tsx
@@ -6,6 +6,7 @@ import {
   type SidebarWorkspacesListResult,
 } from "@/hooks/use-sidebar-workspaces-list";
 import { useSidebarWorkspaceEntries } from "@/hooks/use-sidebar-workspace-entries";
+import { sortSidebarProjectsByRecentActivity } from "@/hooks/sidebar-workspaces-view-model";
 import { usePinnedSidebarKeys, type PinnedSidebarGroups } from "@/hooks/use-sidebar-pins";
 import { useSidebarCollapsedSectionsStore } from "@/stores/sidebar-collapsed-sections-store";
 import {
@@ -56,6 +57,7 @@ export function SidebarModelProvider({
 }) {
   const list = useSidebarWorkspacesList({ enabled: active });
   const groupMode = useSidebarViewStore((state) => state.groupMode);
+  const projectSort = useSidebarViewStore((state) => state.projectSort);
   const labelFilter = useSidebarViewStore((state) => state.labelFilter);
   const projectFilters = useSidebarViewStore((state) => state.projectFilters);
   const reconcileLabelFilter = useSidebarViewStore((state) => state.reconcileLabelFilter);
@@ -95,7 +97,9 @@ export function SidebarModelProvider({
   // anything; the label filter reads `labels`, which only exists on an entry. Hydration opens a
   // live session-store subscription over every workspace on every visible host, so widening this
   // for a filter that does not need it costs a retained-but-inactive sidebar real work.
-  const needsWorkspaceEntries = groupMode !== "project" || hasActiveLabelFilter;
+  // The recent project sort reads `statusEnteredAt`, which only exists on a hydrated entry.
+  const needsWorkspaceEntries =
+    groupMode !== "project" || hasActiveLabelFilter || projectSort === "recent";
   const workspaceEntriesByKey = useSidebarWorkspaceEntries(
     list.workspacePlacements,
     active !== false || needsWorkspaceEntries,
@@ -138,10 +142,22 @@ export function SidebarModelProvider({
     list.projects,
     visibleWorkspaceKeys,
   ]);
-  const pinnedKeys = usePinnedSidebarKeys(filteredProjects);
+  // Recency sorts the whole (filtered) project list; timestamps come from the unfiltered
+  // entries map so a label filter can't change which workspace stands for a project.
+  const orderedProjects = useMemo(
+    () =>
+      projectSort === "recent"
+        ? sortSidebarProjectsByRecentActivity({
+            projects: filteredProjects,
+            workspaceEntriesByKey,
+          })
+        : filteredProjects,
+    [filteredProjects, projectSort, workspaceEntriesByKey],
+  );
+  const pinnedKeys = usePinnedSidebarKeys(orderedProjects);
   const projectionInput = useMemo(
     () => ({
-      projects: filteredProjects,
+      projects: orderedProjects,
       pinnedKeys,
       pinnedWorkspaceOrder,
       workspaceEntriesByKey: filteredWorkspaceEntriesByKey,
@@ -156,7 +172,7 @@ export function SidebarModelProvider({
       collapsedWorkspaceGroupKeys,
       groupMode,
       list.projectNamesByViewKey,
-      filteredProjects,
+      orderedProjects,
       pinnedCollapsed,
       pinnedKeys,
       pinnedWorkspaceOrder,
@@ -167,7 +183,7 @@ export function SidebarModelProvider({
   const value = useMemo(
     () => ({
       ...list,
-      projects: filteredProjects,
+      projects: orderedProjects,
       allProjects: list.projects,
       resolvedProjectFilters,
       hasProjectsBeforeFilter: list.projects.length > 0,
@@ -185,7 +201,7 @@ export function SidebarModelProvider({
       collapsedProjectKeys,
       groupMode,
       list,
-      filteredProjects,
+      orderedProjects,
       projection,
       toggleProjectCollapsed,
       filteredWorkspaceEntriesByKey,

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -13,6 +13,7 @@ import {
   deriveProjectStatusBucket,
   deriveSidebarLoadingState,
   shouldShowSidebarHostLabels,
+  sortSidebarProjectsByRecentActivity,
   type ProjectStatusSession,
   type SidebarProjectEntry,
   type SidebarWorkspacePlacement,
@@ -196,6 +197,76 @@ describe("applyStoredOrdering", () => {
     });
 
     expect(result).toBe(baseline);
+  });
+});
+
+describe("sortSidebarProjectsByRecentActivity", () => {
+  function entryWithActivity(workspaceId: string, statusEnteredAt: Date | null) {
+    return createSidebarWorkspaceEntry({
+      serverId: "srv",
+      workspace: workspace({
+        id: workspaceId,
+        name: workspaceId,
+        projectId: "proj",
+        projectDisplayName: "proj",
+        status: "running",
+        statusEnteredAt,
+      }),
+    });
+  }
+
+  function entriesByKey(entries: ReturnType<typeof entryWithActivity>[]) {
+    return new Map(entries.map((entry) => [entry.workspaceKey, entry]));
+  }
+
+  it("puts the project with the freshest workspace activity first", () => {
+    const projects = [
+      sidebarProject({ projectKey: "stale", workspaceKeys: ["srv:ws-old"] }),
+      sidebarProject({ projectKey: "fresh", workspaceKeys: ["srv:ws-idle", "srv:ws-new"] }),
+    ];
+    const result = sortSidebarProjectsByRecentActivity({
+      projects,
+      workspaceEntriesByKey: entriesByKey([
+        entryWithActivity("ws-old", new Date("2026-08-01T00:00:00Z")),
+        entryWithActivity("ws-idle", new Date("2026-07-01T00:00:00Z")),
+        entryWithActivity("ws-new", new Date("2026-08-30T00:00:00Z")),
+      ]),
+    });
+
+    expect(result.map((entry) => entry.viewKey)).toEqual(["fresh", "stale"]);
+  });
+
+  it("keeps projects without timestamps in incoming order after dated ones", () => {
+    const projects = [
+      sidebarProject({ projectKey: "undated-1", workspaceKeys: ["srv:ws-u1"] }),
+      sidebarProject({ projectKey: "dated", workspaceKeys: ["srv:ws-dated"] }),
+      sidebarProject({ projectKey: "undated-2", workspaceKeys: ["srv:ws-u2"] }),
+    ];
+    const result = sortSidebarProjectsByRecentActivity({
+      projects,
+      workspaceEntriesByKey: entriesByKey([
+        entryWithActivity("ws-dated", new Date("2026-08-01T00:00:00Z")),
+        entryWithActivity("ws-u1", null),
+      ]),
+    });
+
+    expect(result.map((entry) => entry.viewKey)).toEqual(["dated", "undated-1", "undated-2"]);
+  });
+
+  it("returns the input array when nothing moves", () => {
+    const projects = [
+      sidebarProject({ projectKey: "first", workspaceKeys: ["srv:ws-1"] }),
+      sidebarProject({ projectKey: "second", workspaceKeys: ["srv:ws-2"] }),
+    ];
+    const result = sortSidebarProjectsByRecentActivity({
+      projects,
+      workspaceEntriesByKey: entriesByKey([
+        entryWithActivity("ws-1", new Date("2026-08-30T00:00:00Z")),
+        entryWithActivity("ws-2", new Date("2026-08-01T00:00:00Z")),
+      ]),
+    });
+
+    expect(result).toBe(projects);
   });
 });
 

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -480,6 +480,44 @@ export function shouldShowSidebarHostLabels(projects: SidebarProjectEntry[]): bo
   return serverIds.size >= 2;
 }
 
+/**
+ * Projects with the freshest workspace activity first, for the "recent" project sort.
+ *
+ * Recency is the latest `statusEnteredAt` among a project's hydrated workspace entries — the
+ * same timestamp the rows show, already merged with root-agent activity. Projects without a
+ * timestamp keep their incoming (manual) order after every dated one. Returns the input array
+ * when nothing moves, so memoized consumers don't churn.
+ */
+export function sortSidebarProjectsByRecentActivity(input: {
+  projects: SidebarProjectEntry[];
+  workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
+}): SidebarProjectEntry[] {
+  if (input.projects.length <= 1) {
+    return input.projects;
+  }
+
+  const keyed = input.projects.map((project, index) => {
+    let latest = Number.NEGATIVE_INFINITY;
+    for (const placement of project.workspaces) {
+      const enteredAt = input.workspaceEntriesByKey.get(placement.workspaceKey)?.statusEnteredAt;
+      const time = enteredAt?.getTime();
+      if (time !== undefined && Number.isFinite(time) && time > latest) {
+        latest = time;
+      }
+    }
+    return { project, index, latest };
+  });
+
+  keyed.sort((left, right) =>
+    left.latest === right.latest ? left.index - right.index : right.latest - left.latest,
+  );
+
+  if (keyed.every((entry, index) => entry.index === index)) {
+    return input.projects;
+  }
+  return keyed.map((entry) => entry.project);
+}
+
 export function applyStoredOrdering<T>(input: {
   items: T[];
   storedOrder: string[];

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1033,6 +1033,11 @@ export const ar: TranslationResources = {
         status: "الحالة",
         labels: "التسميات",
       },
+      projectSort: {
+        label: "ترتيب المشاريع",
+        manual: "يدوي",
+        recent: "النشاط الأخير",
+      },
       titleSource: {
         label: "العنوان",
         title: "العنوان",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1042,6 +1042,11 @@ export const en = {
         status: "Status",
         labels: "Labels",
       },
+      projectSort: {
+        label: "Sort projects",
+        manual: "Manual",
+        recent: "Recent activity",
+      },
       titleSource: {
         label: "Title",
         title: "Title",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1067,6 +1067,11 @@ export const es: TranslationResources = {
         status: "Estado",
         labels: "Etiquetas",
       },
+      projectSort: {
+        label: "Ordenar proyectos",
+        manual: "Manual",
+        recent: "Actividad reciente",
+      },
       titleSource: {
         label: "Título",
         title: "Título",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1066,6 +1066,11 @@ export const fr: TranslationResources = {
         status: "Statut",
         labels: "Libellés",
       },
+      projectSort: {
+        label: "Tri des projets",
+        manual: "Manuel",
+        recent: "Activité récente",
+      },
       titleSource: {
         label: "Titre",
         title: "Titre",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1044,6 +1044,11 @@ export const ja: TranslationResources = {
         status: "ステータス",
         labels: "ラベル",
       },
+      projectSort: {
+        label: "プロジェクトの並び順",
+        manual: "手動",
+        recent: "最近のアクティビティ",
+      },
       titleSource: {
         label: "タイトル",
         title: "タイトル",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1040,6 +1040,11 @@ export const ko: TranslationResources = {
         status: "상태",
         labels: "레이블",
       },
+      projectSort: {
+        label: "프로젝트 정렬",
+        manual: "수동",
+        recent: "최근 활동",
+      },
       titleSource: {
         label: "제목",
         title: "제목",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1058,6 +1058,11 @@ export const ptBR: TranslationResources = {
         status: "Status",
         labels: "Etiquetas",
       },
+      projectSort: {
+        label: "Ordenar projetos",
+        manual: "Manual",
+        recent: "Atividade recente",
+      },
       titleSource: {
         label: "Título",
         title: "Título",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1048,6 +1048,11 @@ export const ru: TranslationResources = {
         status: "Статус",
         labels: "Метки",
       },
+      projectSort: {
+        label: "Сортировка проектов",
+        manual: "Вручную",
+        recent: "Недавняя активность",
+      },
       titleSource: {
         label: "Заголовок",
         title: "Заголовок",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1025,6 +1025,11 @@ export const zhCN: TranslationResources = {
         status: "状态",
         labels: "标签",
       },
+      projectSort: {
+        label: "项目排序",
+        manual: "手动",
+        recent: "最近活动",
+      },
       titleSource: {
         label: "标题",
         title: "标题",

--- a/packages/app/src/stores/sidebar-view-store.test.ts
+++ b/packages/app/src/stores/sidebar-view-store.test.ts
@@ -93,6 +93,7 @@ describe("sidebar view store", () => {
       }),
     ).toEqual({
       groupMode: "status",
+      projectSort: "manual",
       hostFilters: [],
       projectFilters: [],
       labelFilter: { labels: [] },
@@ -107,6 +108,7 @@ describe("sidebar view store", () => {
       }),
     ).toEqual({
       groupMode: "status",
+      projectSort: "manual",
       hostFilters: ["host-a"],
       projectFilters: [],
       labelFilter: { labels: [] },
@@ -121,6 +123,7 @@ describe("sidebar view store", () => {
       }),
     ).toEqual({
       groupMode: "status",
+      projectSort: "manual",
       hostFilters: ["host-a", "host-b"],
       projectFilters: [],
       labelFilter: { labels: [] },
@@ -231,6 +234,7 @@ describe("sidebar view store", () => {
       }),
     ).toEqual({
       groupMode: "project",
+      projectSort: "manual",
       hostFilters: ["host-a"],
       projectFilters: ["project-a", "project-b"],
       labelFilter: { labels: [] },
@@ -240,6 +244,7 @@ describe("sidebar view store", () => {
   it("never keeps project filters from state the schema rejects", () => {
     expect(migrateSidebarViewState({ projectFilters: "project-a" })).toEqual({
       groupMode: "project",
+      projectSort: "manual",
       hostFilters: [],
       projectFilters: [],
       labelFilter: { labels: [] },

--- a/packages/app/src/stores/sidebar-view-store.ts
+++ b/packages/app/src/stores/sidebar-view-store.ts
@@ -7,6 +7,12 @@ import { createValidatedPersistStorage } from "@/storage/validated-persist-stora
 
 export type SidebarGroupMode = "project" | "status";
 
+/**
+ * How the project sections are ordered. "manual" is the persisted drag order;
+ * "recent" puts the project with the freshest workspace activity first.
+ */
+export type SidebarProjectSortMode = "manual" | "recent";
+
 const SIDEBAR_VIEW_STORAGE_KEY = "sidebar-view";
 const LEGACY_SIDEBAR_GROUP_MODE_STORAGE_KEY = "sidebar-group-mode";
 const SIDEBAR_VIEW_STORE_VERSION = 6;
@@ -47,6 +53,7 @@ function toggleFilterEntry(list: readonly string[], key: string): string[] {
 
 interface SidebarViewStoreState {
   groupMode: SidebarGroupMode;
+  projectSort: SidebarProjectSortMode;
   // Empty means "all hosts". A non-empty list pins the sidebar to those hosts.
   hostFilters: string[];
   /**
@@ -62,6 +69,7 @@ interface SidebarViewStoreState {
   projectFilters: string[];
   labelFilter: SidebarLabelFilter;
   setGroupMode: (mode: SidebarGroupMode) => void;
+  setProjectSort: (mode: SidebarProjectSortMode) => void;
   toggleHostFilter: (serverId: string) => void;
   clearHostFilters: () => void;
   toggleProjectFilter: (viewKey: string) => void;
@@ -74,17 +82,20 @@ interface SidebarViewStoreState {
 
 interface SidebarViewPersistedState {
   groupMode: SidebarGroupMode;
+  projectSort: SidebarProjectSortMode;
   hostFilters: string[];
   projectFilters: string[];
   labelFilter: SidebarLabelFilter;
 }
 
 const PersistedSidebarGroupModeSchema = z.enum(["project", "status", "label"]);
+const PersistedSidebarProjectSortSchema = z.enum(["manual", "recent"]);
 const SidebarLabelFilterSchema = z.object({
   labels: z.array(z.string()),
 });
 const SidebarViewPersistedStateSchema = z.strictObject({
   groupMode: PersistedSidebarGroupModeSchema.optional(),
+  projectSort: PersistedSidebarProjectSortSchema.optional(),
   hostFilters: z.array(z.string()).optional(),
   hostFilter: z.string().nullable().optional(),
   projectFilters: z.array(z.string()).optional(),
@@ -123,6 +134,7 @@ export function migrateSidebarViewState(persistedState: unknown): SidebarViewPer
   if (!result.success) {
     return {
       groupMode: "project",
+      projectSort: "manual",
       hostFilters: [],
       projectFilters: [],
       labelFilter: emptyLabelFilter(),
@@ -134,6 +146,7 @@ export function migrateSidebarViewState(persistedState: unknown): SidebarViewPer
   if (legacyGroupMode) {
     return {
       groupMode: legacyGroupMode,
+      projectSort: "manual",
       hostFilters: [],
       projectFilters: [],
       labelFilter: emptyLabelFilter(),
@@ -142,6 +155,7 @@ export function migrateSidebarViewState(persistedState: unknown): SidebarViewPer
 
   return {
     groupMode: state.groupMode === "status" ? "status" : "project",
+    projectSort: state.projectSort ?? "manual",
     hostFilters: readHostFilters(state),
     projectFilters: state.projectFilters ?? [],
     labelFilter: state.labelFilter
@@ -179,10 +193,12 @@ export const useSidebarViewStore = create<SidebarViewStoreState>()(
   persist(
     (set) => ({
       groupMode: "project",
+      projectSort: "manual",
       hostFilters: [],
       projectFilters: [],
       labelFilter: emptyLabelFilter(),
       setGroupMode: (mode) => set({ groupMode: mode }),
+      setProjectSort: (mode) => set({ projectSort: mode }),
       toggleHostFilter: (serverId) =>
         set((state) => ({ hostFilters: toggleFilterEntry(state.hostFilters, serverId) })),
       clearHostFilters: () => set({ hostFilters: [] }),
@@ -229,6 +245,7 @@ export const useSidebarViewStore = create<SidebarViewStoreState>()(
       ),
       partialize: (state) => ({
         groupMode: state.groupMode,
+        projectSort: state.projectSort,
         hostFilters: state.hostFilters,
         projectFilters: state.projectFilters,
         labelFilter: state.labelFilter,


### PR DESCRIPTION
Product discussion: https://github.com/getpaseo/paseo/discussions/4138 (the same request was filed earlier as #2626 and auto-closed per the issues-are-for-bugs policy).

Adds a **Sort projects** preference to the sidebar display menu, shown when grouping by project. **Manual** is the existing drag order; **Recent activity** puts the project with the freshest workspace activity first, so with many projects the one you are actually working in is always at the top.

## Design decisions

- Recency is the latest `statusEnteredAt` among a project's workspace entries — the same timestamp the workspace rows already show (workspace status merged with root-agent activity), so the sort always agrees with what the rows display.
- The default stays **Manual**; nothing changes until you opt in.
- Projects without a timestamp keep their manual relative order, after every dated project.
- Drag-and-drop is ignored while the recency sort is active: a drop position taken from a sorted view says nothing about the manual order, so it never overwrites it. Switching back to Manual restores the drag order exactly as you left it.
- Timestamps come from the unfiltered entries map, so an active label filter cannot change which workspace stands for a project.
- The sort row only appears in project grouping (status grouping has no project sections).
- Persisted as an optional key in the sidebar-view store's strict schema — existing persisted state keeps parsing, no version bump.

## QA

### Automated coverage

New Playwright e2e exercising the full journey — drag a manual order, switch to Recent activity, watch fresh activity in another project reorder the list live, reload to prove the preference survives the strict persisted schema, switch back to Manual and get the drag order back:

```
npx playwright test --project=browser e2e/browser/sidebar-project-sort.spec.ts
  ✓  1 [browser] › e2e/browser/sidebar-project-sort.spec.ts:41:5 › recent-activity sort reorders projects live and leaves the manual order alone (1.2m)
  1 passed
```

New unit tests for the sort (freshest-first, undated projects keep manual order after dated ones, identity return when nothing moves) plus the store migration carrying the new key:

```
npx vitest run src/hooks/sidebar-workspaces-view-model.test.ts src/stores/sidebar-view-store.test.ts src/components/sidebar-workspace-list.test.tsx src/i18n/resources.test.ts --bail=1
 Test Files  4 passed (4)
      Tests  99 passed (99)
```

`npm run typecheck` and `npm run lint` clean. All nine locales carry the new strings.

Re-verified on a rebase onto `main` at `da8c1b5c9`, 80 commits past the original branch point: the rebase is conflict-free, and `npm run typecheck`, `npm run lint`, `npm run format:check`, the e2e spec and the four unit files above are all green on it.

### Manual

I deployed the built web UI onto my own live daemon and use it with a dozen projects: the row appears under the display menu in project grouping, Recent activity keeps the active project on top as agents report activity, and Manual brings back my drag order.

_The sort row under the display menu, shown only in project grouping:_

![Sort projects menu row](https://raw.githubusercontent.com/gengjiawen/paseo/pr-4140-evidence/.qa/pr-4140/sort-menu.png)

_Four projects. Manual is the drag order; Recent activity puts the freshest first:_

![Manual versus Recent activity](https://raw.githubusercontent.com/gengjiawen/paseo/pr-4140-evidence/.qa/pr-4140/manual-vs-recent.png)

_Fresh activity in `design-system` moves it to the top with no manual reorder:_

![Activity bump reorders live](https://raw.githubusercontent.com/gengjiawen/paseo/pr-4140-evidence/.qa/pr-4140/activity-bump.png)

### Platform matrix

| Platform | Tested | Notes |
| --------------- | ------ | ----- |
| iOS | ❌ | Cross-platform code paths only — zustand store, pure sort, existing menu/OptionList components; no platform gates added |
| Android | ❌ | Same as iOS |
| Web | ✅ | Playwright e2e + unit tests; author-verified on a live deployment |
| Desktop macOS | ❌ | Same code path as web; untested |
| Desktop Windows | ❌ | Same code path as web; untested |
| Desktop Linux | ❌ | Same code path as web; untested |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

