### PR TITLE
fix(voice): share the native audio engine between voice mode and dictation

### DIFF
--- a/packages/app/src/voice/audio-engine.native.test.ts
+++ b/packages/app/src/voice/audio-engine.native.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { FakeNativeAudioModule } from "@/voice/test-utils/fake-native-audio-module";
+
+const fakeRef = vi.hoisted(() => ({ current: null as FakeNativeAudioModule | null }));
+
+vi.mock("@/voice/native-audio-module", async () => {
+  const { createFakeNativeAudioModule } =
+    await import("@/voice/test-utils/fake-native-audio-module");
+  fakeRef.current = createFakeNativeAudioModule();
+  return { loadNativeAudioModule: () => fakeRef.current!.native };
+});
+
+import { createAudioEngine } from "@/voice/audio-engine.native";
+
+function createEngine() {
+  return createAudioEngine({
+    onCaptureData: () => undefined,
+    onVolumeLevel: () => undefined,
+  });
+}
+
+describe("native audio engine", () => {
+  /**
+   * Voice mode and dictation wrap the same native engine. Destroying the dictation wrapper used
+   * to tear that engine down under voice mode, which then failed every later capture.
+   */
+  it("keeps capturing after another engine is destroyed", async () => {
+    const state = fakeRef.current!.state;
+    const voice = createEngine();
+    await voice.initialize();
+    await voice.startCapture();
+    await voice.stopCapture();
+
+    const dictation = createEngine();
+    await dictation.initialize();
+    await dictation.startCapture();
+    await dictation.stopCapture();
+    await dictation.destroy();
+
+    await expect(voice.startCapture()).resolves.toBeUndefined();
+    expect(state.recording).toBe(true);
+    expect(state.tearDownCalls).toBe(0);
+
+    await voice.destroy();
+    expect(state.tearDownCalls).toBe(1);
+    expect(state.engineExists).toBe(false);
+  });
+});

--- a/packages/app/src/voice/audio-engine.native.ts
+++ b/packages/app/src/voice/audio-engine.native.ts
@@ -3,6 +3,12 @@ import type {
   AudioEngineCallbacks,
   AudioPlaybackSource,
 } from "@/voice/audio-engine-types";
+import { loadNativeAudioModule } from "@/voice/native-audio-module";
+import {
+  createNativeAudioSession,
+  type NativeAudioSession,
+  type NativeAudioSessionModule,
+} from "@/voice/native-audio-session";
 
 interface QueuedAudio {
   audio: AudioPlaybackSource;
@@ -66,14 +72,23 @@ function resamplePcm16(pcm: Uint8Array, fromRate: number, toRate: number): Uint8
   return out;
 }
 
+let sharedSession: NativeAudioSession | null = null;
+
+function getSharedSession(native: NativeAudioSessionModule): NativeAudioSession {
+  if (!sharedSession) {
+    sharedSession = createNativeAudioSession(native);
+  }
+  return sharedSession;
+}
+
 export function createAudioEngine(
   callbacks: AudioEngineCallbacks,
   _options?: AudioEngineTraceOptions,
 ): AudioEngine {
-  const native = require("@getpaseo/expo-two-way-audio");
+  const native = loadNativeAudioModule();
+  const session = getSharedSession(native).createOwner();
 
   const refs: {
-    initialized: boolean;
     captureActive: boolean;
     muted: boolean;
     queue: QueuedAudio[];
@@ -86,7 +101,6 @@ export function createAudioEngine(
     } | null;
     destroyed: boolean;
   } = {
-    initialized: false,
     captureActive: false,
     muted: false,
     queue: [],
@@ -133,14 +147,7 @@ export function createAudioEngine(
   );
 
   async function ensureInitialized(): Promise<void> {
-    if (refs.initialized) {
-      return;
-    }
-    const success = await native.initialize();
-    if (!success) {
-      throw new Error("expo-two-way-audio: native initialize() returned false");
-    }
-    refs.initialized = true;
+    await session.ensureReady();
   }
 
   /**
@@ -150,7 +157,7 @@ export function createAudioEngine(
    * foreground, so an unreleased session means their music never comes back.
    */
   function releaseSessionIfIdle(): void {
-    if (!refs.initialized || refs.destroyed) {
+    if (refs.destroyed || !session.isHolding()) {
       return;
     }
     if (refs.captureActive || refs.activePlayback || refs.queue.length > 0) {
@@ -255,16 +262,13 @@ export function createAudioEngine(
       this.stop();
       this.clearQueue();
       if (refs.captureActive) {
-        native.toggleRecording(false);
+        session.stopRecording();
         refs.captureActive = false;
       }
       clearPlaybackTimeout();
       refs.muted = false;
       callbacks.onVolumeLevel(0);
-      if (refs.initialized) {
-        native.tearDown();
-        refs.initialized = false;
-      }
+      session.release();
       microphoneSubscription.remove();
       volumeSubscription.remove();
       interruptionSubscription.remove();
@@ -277,13 +281,7 @@ export function createAudioEngine(
 
       try {
         await ensureMicrophonePermission();
-        await ensureInitialized();
-        const isRecording = native.toggleRecording(true);
-        if (!isRecording) {
-          throw new Error(
-            "Microphone capture could not start because Android audio focus is unavailable.",
-          );
-        }
+        await session.startRecording();
         refs.captureActive = true;
       } catch (error) {
         const wrapped = error instanceof Error ? error : new Error(String(error));
@@ -294,7 +292,7 @@ export function createAudioEngine(
 
     async stopCapture() {
       if (refs.captureActive) {
-        native.toggleRecording(false);
+        session.stopRecording();
       }
       refs.captureActive = false;
       refs.muted = false;

--- a/packages/app/src/voice/native-audio-module.ts
+++ b/packages/app/src/voice/native-audio-module.ts
@@ -1,0 +1,27 @@
+import type { NativeAudioSessionModule } from "@/voice/native-audio-session";
+
+export interface NativeAudioSubscription {
+  remove(): void;
+}
+
+/** The native surface the audio engine uses, beyond what the session owns. */
+export interface NativeAudioModule extends NativeAudioSessionModule {
+  releaseAudioSession(): void;
+  resumePlayback(): void;
+  playPCMData(pcm: Uint8Array): void;
+  stopPlayback(): void;
+  getMicrophonePermissionsAsync(): Promise<{ granted: boolean }>;
+  requestMicrophonePermissionsAsync(): Promise<{ granted: boolean }>;
+  addExpoTwoWayAudioEventListener(
+    event: string,
+    listener: (payload: never) => void,
+  ): NativeAudioSubscription;
+}
+
+/**
+ * Loaded on demand: the package calls `requireNativeModule` at import time, which throws on a
+ * binary that does not ship the native module.
+ */
+export function loadNativeAudioModule(): NativeAudioModule {
+  return require("@getpaseo/expo-two-way-audio");
+}

--- a/packages/app/src/voice/native-audio-session.test.ts
+++ b/packages/app/src/voice/native-audio-session.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createNativeAudioSession,
+  NATIVE_AUDIO_CAPTURE_UNAVAILABLE,
+  NATIVE_AUDIO_INITIALIZE_FAILED,
+} from "@/voice/native-audio-session";
+import { createFakeNativeAudioModule } from "@/voice/test-utils/fake-native-audio-module";
+
+describe("native audio session ownership", () => {
+  it("keeps recording available after another owner is destroyed", async () => {
+    const { native, state } = createFakeNativeAudioModule();
+    const session = createNativeAudioSession(native);
+
+    const voice = session.createOwner();
+    await voice.ensureReady();
+    await voice.startRecording();
+    voice.stopRecording();
+
+    const dictation = session.createOwner();
+    await dictation.ensureReady();
+    dictation.release();
+
+    expect(state.tearDownCalls).toBe(0);
+    await expect(voice.startRecording()).resolves.toBeUndefined();
+    expect(state.recording).toBe(true);
+  });
+
+  it("tears the engine down once the last owner releases", async () => {
+    const { native, state } = createFakeNativeAudioModule();
+    const session = createNativeAudioSession(native);
+
+    const voice = session.createOwner();
+    const dictation = session.createOwner();
+    await voice.ensureReady();
+    await dictation.ensureReady();
+
+    dictation.release();
+    expect(state.tearDownCalls).toBe(0);
+
+    voice.release();
+    expect(state.tearDownCalls).toBe(1);
+    expect(state.engineExists).toBe(false);
+  });
+
+  it("releases only once per owner", async () => {
+    const { native, state } = createFakeNativeAudioModule();
+    const session = createNativeAudioSession(native);
+
+    const voice = session.createOwner();
+    const dictation = session.createOwner();
+    await voice.ensureReady();
+    await dictation.ensureReady();
+
+    dictation.release();
+    dictation.release();
+
+    expect(state.tearDownCalls).toBe(0);
+    expect(voice.isHolding()).toBe(true);
+  });
+
+  it("recreates the engine when it disappeared underneath an owner", async () => {
+    const { native, state } = createFakeNativeAudioModule();
+    const session = createNativeAudioSession(native);
+
+    const voice = session.createOwner();
+    await voice.startRecording();
+    voice.stopRecording();
+
+    // Something outside this session took the engine away.
+    state.engineExists = false;
+
+    await expect(voice.startRecording()).resolves.toBeUndefined();
+    expect(state.initializeCalls).toBe(2);
+    expect(state.recording).toBe(true);
+  });
+
+  it("reports capture as unavailable when audio focus is denied", async () => {
+    const { native, state } = createFakeNativeAudioModule();
+    state.focusDenied = true;
+    const session = createNativeAudioSession(native);
+
+    const voice = session.createOwner();
+
+    await expect(voice.startRecording()).rejects.toThrow(NATIVE_AUDIO_CAPTURE_UNAVAILABLE);
+    expect(state.recording).toBe(false);
+  });
+
+  it("surfaces a failed native initialize", async () => {
+    const { native, state } = createFakeNativeAudioModule();
+    state.initializeSucceeds = false;
+    const session = createNativeAudioSession(native);
+
+    await expect(session.createOwner().ensureReady()).rejects.toThrow(
+      NATIVE_AUDIO_INITIALIZE_FAILED,
+    );
+  });
+
+  it("initializes the engine once for concurrent owners", async () => {
+    const { native, state } = createFakeNativeAudioModule();
+    const session = createNativeAudioSession(native);
+
+    await Promise.all([session.createOwner().ensureReady(), session.createOwner().ensureReady()]);
+
+    expect(state.initializeCalls).toBe(1);
+  });
+
+  it("does not hold a reference before the engine is ready", async () => {
+    const { native } = createFakeNativeAudioModule();
+    const session = createNativeAudioSession(native);
+
+    const voice = session.createOwner();
+    expect(voice.isHolding()).toBe(false);
+
+    await voice.ensureReady();
+    expect(voice.isHolding()).toBe(true);
+
+    voice.release();
+    expect(voice.isHolding()).toBe(false);
+  });
+});

--- a/packages/app/src/voice/native-audio-session.ts
+++ b/packages/app/src/voice/native-audio-session.ts
@@ -1,0 +1,109 @@
+/**
+ * Reference-counted ownership of the one native audio engine. `expo-two-way-audio` keeps a
+ * single engine per process, and voice mode and dictation each wrap it, so tearing it down is
+ * left to whichever owner releases last.
+ */
+
+/** The part of the native module that decides whether the engine exists. */
+export interface NativeAudioSessionModule {
+  initialize(): Promise<boolean>;
+  tearDown(): void;
+  toggleRecording(value: boolean): boolean;
+}
+
+export interface NativeAudioSessionOwner {
+  /** Create the native engine if no other owner has, and claim a reference to it. */
+  ensureReady(): Promise<void>;
+  /** Claim a reference and start recording, recreating the engine if it went away. */
+  startRecording(): Promise<void>;
+  stopRecording(): void;
+  /** Drop this owner's reference, tearing the engine down once nobody holds it. */
+  release(): void;
+  /** Whether this owner currently holds a reference. */
+  isHolding(): boolean;
+}
+
+export interface NativeAudioSession {
+  createOwner(): NativeAudioSessionOwner;
+}
+
+export const NATIVE_AUDIO_INITIALIZE_FAILED =
+  "expo-two-way-audio: native initialize() returned false";
+export const NATIVE_AUDIO_CAPTURE_UNAVAILABLE =
+  "Microphone capture could not start because the audio engine is unavailable. Another app may be holding audio focus.";
+
+export function createNativeAudioSession(native: NativeAudioSessionModule): NativeAudioSession {
+  const holders = new Set<object>();
+  let engineReady = false;
+  let pendingInitialize: Promise<void> | null = null;
+
+  async function initializeEngine(): Promise<void> {
+    const success = await native.initialize();
+    if (!success) {
+      throw new Error(NATIVE_AUDIO_INITIALIZE_FAILED);
+    }
+    engineReady = true;
+  }
+
+  async function createEngine(): Promise<void> {
+    if (engineReady) {
+      return;
+    }
+    if (!pendingInitialize) {
+      pendingInitialize = initializeEngine();
+    }
+    try {
+      await pendingInitialize;
+    } finally {
+      pendingInitialize = null;
+    }
+  }
+
+  return {
+    createOwner(): NativeAudioSessionOwner {
+      const owner = {};
+
+      async function ensureReady(): Promise<void> {
+        await createEngine();
+        holders.add(owner);
+      }
+
+      return {
+        ensureReady,
+
+        async startRecording() {
+          await ensureReady();
+          if (native.toggleRecording(true)) {
+            return;
+          }
+          // `false` means the engine vanished (iOS) or focus was denied (Android).
+          engineReady = false;
+          await createEngine();
+          if (!native.toggleRecording(true)) {
+            throw new Error(NATIVE_AUDIO_CAPTURE_UNAVAILABLE);
+          }
+        },
+
+        stopRecording() {
+          if (engineReady) {
+            native.toggleRecording(false);
+          }
+        },
+
+        release() {
+          if (!holders.delete(owner)) {
+            return;
+          }
+          if (holders.size === 0 && engineReady) {
+            native.tearDown();
+            engineReady = false;
+          }
+        },
+
+        isHolding() {
+          return holders.has(owner);
+        },
+      };
+    },
+  };
+}

--- a/packages/app/src/voice/test-utils/fake-native-audio-module.ts
+++ b/packages/app/src/voice/test-utils/fake-native-audio-module.ts
@@ -1,0 +1,78 @@
+import type { NativeAudioModule } from "@/voice/native-audio-module";
+
+export interface FakeNativeAudioState {
+  engineExists: boolean;
+  recording: boolean;
+  initializeCalls: number;
+  tearDownCalls: number;
+  /** Make `toggleRecording(true)` fail the way Android does when audio focus is denied. */
+  focusDenied: boolean;
+  initializeSucceeds: boolean;
+}
+
+export interface FakeNativeAudioModule {
+  native: NativeAudioModule;
+  state: FakeNativeAudioState;
+  reset(): void;
+}
+
+/** Mirrors the native module: one engine per process, failures reported as `false`. */
+export function createFakeNativeAudioModule(): FakeNativeAudioModule {
+  const state: FakeNativeAudioState = {
+    engineExists: false,
+    recording: false,
+    initializeCalls: 0,
+    tearDownCalls: 0,
+    focusDenied: false,
+    initializeSucceeds: true,
+  };
+
+  const native: NativeAudioModule = {
+    async initialize() {
+      state.initializeCalls += 1;
+      if (!state.initializeSucceeds) {
+        return false;
+      }
+      state.engineExists = true;
+      return true;
+    },
+    tearDown() {
+      state.tearDownCalls += 1;
+      state.engineExists = false;
+      state.recording = false;
+    },
+    toggleRecording(value: boolean) {
+      if (!state.engineExists || (value && state.focusDenied)) {
+        return false;
+      }
+      state.recording = value;
+      return value;
+    },
+    releaseAudioSession() {},
+    resumePlayback() {},
+    playPCMData() {},
+    stopPlayback() {},
+    async getMicrophonePermissionsAsync() {
+      return { granted: true };
+    },
+    async requestMicrophonePermissionsAsync() {
+      return { granted: true };
+    },
+    addExpoTwoWayAudioEventListener() {
+      return { remove() {} };
+    },
+  };
+
+  return {
+    native,
+    state,
+    reset() {
+      state.engineExists = false;
+      state.recording = false;
+      state.initializeCalls = 0;
+      state.tearDownCalls = 0;
+      state.focusDenied = false;
+      state.initializeSucceeds = true;
+    },
+  };
+}


### PR DESCRIPTION
Fixes #4147

## What was wrong

`expo-two-way-audio` keeps **one** engine per app process. The JS side wrapped it **twice**, each wrapper caching its own `initialized` flag:

- `VoiceProvider` — mounted at the app root (`packages/app/src/app/_layout.tsx:665`), lives for the whole process.
- Dictation — created per composer mount (`use-dictation-audio-source.native.ts:24`).

`destroy()` called `native.tearDown()`, which nils the shared engine, and the dictation wrapper destroys on unmount. So:

1. Voice mode runs once → the provider's wrapper sets `refs.initialized = true`.
2. Dictation runs → `initialize()` returns `true` early (engine already exists), so it marks itself initialized too.
3. Composer unmounts (switch agent, leave screen) → dictation `destroy()` → `tearDown()` → **engine is nil**.
4. Voice mode → `ensureInitialized()` short-circuits on the provider's now-stale flag → `toggleRecording` returns `false` → error, **every time, for the rest of the process**.

On iOS that return value can only mean one thing: `ExpoTwoWayAudioModule.swift:62-74` returns `false` solely from `guard let audioEngine = self.audioEngine else { print("AudioEngine not initialized"); return false }` — `AudioEngine.swift:309-323` returns `val` unconditionally otherwise. Android reports genuine audio-focus denial through the same `false`, which is how an iPhone ended up showing an Android audio-focus message.

## The fix

Ownership of the native engine is now reference counted in `native-audio-session.ts`: created for the first holder, torn down only when the last one releases. `startRecording` rebuilds the engine once if `toggleRecording` reports failure, so a stale engine is recoverable instead of permanent. The message no longer names a platform.

`native-audio-module.ts` is a typed lazy loader for the native module — the `require` stays inside a function because the package calls `requireNativeModule` at import time, which throws on a binary without the module linked.

## Evidence

The regression test run against the pre-fix engine (HEAD version, one line changed to use the loader seam):

```
FAIL  |unit| src/voice/audio-engine.native.test.ts > native audio engine > keeps capturing after another engine is destroyed
AssertionError: promise rejected "Error: Microphone capture could not start…" instead of resolving
Caused by: Error: Microphone capture could not start because Android audio focus is unavailable.
 ❯ Object.startCapture src/voice/audio-engine.native.ts:284:17
```

That is the exact error from #4147, reproduced in CI. With the fix:

```
$ npx vitest run src/voice --project unit
 Test Files  3 passed (3)
      Tests  27 passed (27)

$ npm --workspace packages/app run typecheck   # after npm run build:server
exit 0, no errors

$ npm run lint -- packages/app/src/voice
Found 0 warnings and 0 errors.

$ npm run format:check
All matched files use the correct format.
```

Coverage: `native-audio-session.test.ts` covers refcounting, single init under concurrent callers, engine recovery, focus-denied, and init failure. `audio-engine.native.test.ts` drives two real `createAudioEngine` wrappers over one fake native module — the regression itself. Both share the fake in `src/voice/test-utils/fake-native-audio-module.ts`.

## Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | Not yet on device | The reported platform. Repro: voice mode once → dictation → leave the composer → voice mode. Broken before, works after. |
| Android | Not yet on device | Same code path. Genuine audio-focus denial still throws, with the reworded message. |
| Web | N/A | Separate implementation in `audio-engine.web.ts`, untouched. |
| Desktop | N/A | Web implementation. |

JS-only change, so a dev-client reload is enough to verify on device — no native rebuild.
