### PR TITLE
fix(codex): bound parent subagent previews

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -138,6 +138,7 @@ type TurnTerminalEvent = Extract<
 const ONE_BY_ONE_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X1r0AAAAASUVORK5CYII=";
 const CODEX_PROVIDER = "codex";
+const MAX_SERIALIZED_PARENT_SUB_AGENT_SNAPSHOT_BYTES = 64_000;
 
 function createConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSessionConfig {
   return {
@@ -147,6 +148,13 @@ function createConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSession
     model: "gpt-5.4",
     ...overrides,
   };
+}
+
+function hasOnlyWellFormedCodePoints(text: string): boolean {
+  return Array.from(text).every((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return character.length > 1 || codePoint < 0xd800 || codePoint > 0xdfff;
+  });
 }
 
 function createSession(
@@ -2651,6 +2659,383 @@ describe("Codex app-server provider", () => {
       id: "child-thread-1",
       status: "completed",
     });
+  });
+
+  test("keeps parent sub-agent snapshots bounded while retaining canonical child activity", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-bounded-child",
+        kind: "started",
+        agentThreadId: "bounded-child-thread",
+        agentPath: "/root/bounded-child",
+      },
+    });
+    const childMessages = Array.from({ length: 20 }, (_, index) => {
+      const marker = index === 0 ? "oldest-marker" : `activity-${index}`;
+      const latestMarker = index === 19 ? " newest-marker" : "";
+      return `${String.fromCharCode(97 + index).repeat(16_000)} ${marker}${latestMarker}`;
+    });
+    for (const [index, text] of childMessages.entries()) {
+      asInternals(session).handleNotification("item/completed", {
+        threadId: "bounded-child-thread",
+        item: {
+          type: "agentMessage",
+          id: `bounded-child-message-${index}`,
+          text,
+        },
+      });
+    }
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "bounded-child-thread",
+      turn: { status: "completed" },
+    });
+
+    const parentSnapshots = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-bounded-child" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item]
+        : [],
+    );
+    expect(parentSnapshots.length).toBeGreaterThan(1);
+    expect(
+      parentSnapshots.every((item) => Buffer.byteLength(item.detail.log, "utf8") <= 32_000),
+    ).toBe(true);
+    const serializedParentBytes = parentSnapshots.reduce(
+      (total, item) => total + Buffer.byteLength(JSON.stringify(item), "utf8"),
+      0,
+    );
+    expect(serializedParentBytes).toBeLessThanOrEqual(parentSnapshots.length * 33_000);
+    expect(parentSnapshots.at(-1)).toMatchObject({ status: "completed" });
+    expect(parentSnapshots.at(-1)?.detail.log).not.toContain("oldest-marker");
+    expect(parentSnapshots.at(-1)?.detail.log).toContain("newest-marker");
+
+    const canonicalMessages = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "bounded-child-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalMessages).toEqual(childMessages);
+  });
+
+  test("bounds the root sub-agent prompt in the complete emitted snapshot", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    const prompt = `${"p".repeat(1_000_000)} newest-prompt-marker`;
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-large-prompt-child",
+        tool: "spawnAgent",
+        status: "inProgress",
+        prompt,
+        receiverThreadIds: [],
+        agentsStates: {},
+      },
+    });
+
+    const rootSnapshot = events.find(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "spawn-large-prompt-child",
+    );
+    if (rootSnapshot?.type !== "timeline" || rootSnapshot.item.type !== "tool_call") {
+      throw new Error("Expected root sub-agent snapshot");
+    }
+    expect(Buffer.byteLength(JSON.stringify(rootSnapshot.item), "utf8")).toBeLessThanOrEqual(
+      MAX_SERIALIZED_PARENT_SUB_AGENT_SNAPSHOT_BYTES,
+    );
+    expect(rootSnapshot.item.detail).toMatchObject({
+      type: "sub_agent",
+      description: expect.stringContaining("newest-prompt-marker"),
+    });
+  });
+
+  test("bounds the root sub-agent error in the complete emitted snapshot", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    const toJSON = vi.fn(() => ({ payload: "x".repeat(1_000_000) }));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-large-error-child",
+        tool: "spawnAgent",
+        status: "failed",
+        error: { toJSON },
+        prompt: "Fail safely.",
+        receiverThreadIds: [],
+        agentsStates: {},
+      },
+    });
+
+    const rootSnapshot = events.find(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "spawn-large-error-child",
+    );
+    if (rootSnapshot?.type !== "timeline" || rootSnapshot.item.type !== "tool_call") {
+      throw new Error("Expected failed root sub-agent snapshot");
+    }
+    const serialized = JSON.stringify(rootSnapshot.item);
+    expect(toJSON).not.toHaveBeenCalled();
+    expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(
+      MAX_SERIALIZED_PARENT_SUB_AGENT_SNAPSHOT_BYTES,
+    );
+    expect(rootSnapshot.item).toMatchObject({ status: "failed" });
+  });
+
+  test("keeps nested descendant snapshots bounded while retaining descendant history", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-bounded-root",
+        kind: "started",
+        agentThreadId: "bounded-root-thread",
+        agentPath: "/root/bounded-root",
+      },
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "bounded-root-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-bounded-descendant",
+        kind: "started",
+        agentThreadId: "bounded-descendant-thread",
+        agentPath: "/root/bounded-root/descendant",
+      },
+    });
+    const descendantMessages = Array.from({ length: 20 }, (_, index) => {
+      const marker = index === 0 ? "oldest-descendant-marker" : `descendant-${index}`;
+      const latestMarker = index === 19 ? " newest-descendant-marker" : "";
+      return `${String.fromCharCode(97 + index).repeat(16_000)} ${marker}${latestMarker}`;
+    });
+    for (const [index, text] of descendantMessages.entries()) {
+      asInternals(session).handleNotification("item/completed", {
+        threadId: "bounded-descendant-thread",
+        item: {
+          type: "agentMessage",
+          id: `bounded-descendant-message-${index}`,
+          text,
+        },
+      });
+    }
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "bounded-descendant-thread",
+      turn: { status: "completed" },
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "bounded-root-thread",
+      turn: { status: "completed" },
+    });
+
+    const rootSnapshots = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-bounded-root" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item]
+        : [],
+    );
+    const serializedRootBytes = rootSnapshots.reduce(
+      (total, item) => total + Buffer.byteLength(JSON.stringify(item), "utf8"),
+      0,
+    );
+    expect(serializedRootBytes).toBeLessThanOrEqual(rootSnapshots.length * 33_000);
+    expect(rootSnapshots.every((item) => Buffer.byteLength(item.detail.log, "utf8") <= 4_500)).toBe(
+      true,
+    );
+    expect(rootSnapshots.at(-1)).toMatchObject({ status: "completed" });
+    expect(rootSnapshots.at(-1)?.detail.log).not.toContain("oldest-descendant-marker");
+    expect(rootSnapshots.at(-1)?.detail.log).toContain("newest-descendant-marker");
+
+    const canonicalDescendantMessages = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "bounded-descendant-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalDescendantMessages).toEqual(descendantMessages);
+  });
+
+  test("builds the parent sub-agent preview from only the latest child activities", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-latest-child",
+        kind: "started",
+        agentThreadId: "latest-child-thread",
+        agentPath: "/root/latest-child",
+      },
+    });
+    const childMessages = Array.from({ length: 201 }, (_, index) =>
+      index === 0 ? "oldest-activity-marker" : `child activity ${index}`,
+    );
+    for (const [index, text] of childMessages.entries()) {
+      asInternals(session).handleNotification("item/completed", {
+        threadId: "latest-child-thread",
+        item: {
+          type: "agentMessage",
+          id: `latest-child-message-${index}`,
+          text,
+        },
+      });
+    }
+
+    const parentSnapshots = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-latest-child" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item]
+        : [],
+    );
+    expect(parentSnapshots.at(-1)?.detail.log).not.toContain("oldest-activity-marker");
+    expect(parentSnapshots.at(-1)?.detail.log).toContain("child activity 200");
+
+    const canonicalMessages = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "latest-child-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalMessages).toEqual(childMessages);
+  });
+
+  test("does not serialize unbounded non-sub-agent tool payloads for the parent preview", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-tool-preview-child",
+        kind: "started",
+        agentThreadId: "tool-preview-child-thread",
+        agentPath: "/root/tool-preview-child",
+      },
+    });
+    const toJSON = vi.fn(() => ({ payload: "x".repeat(1_000_000) }));
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "tool-preview-child-thread",
+      item: {
+        type: "mcpToolCall",
+        id: "large-child-tool",
+        status: "completed",
+        server: "example",
+        tool: "large_payload",
+        arguments: { toJSON },
+        result: null,
+      },
+    });
+
+    expect(toJSON).not.toHaveBeenCalled();
+    const parentSnapshot = events.findLast(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "spawn-tool-preview-child" &&
+        event.item.detail.type === "sub_agent",
+    );
+    expect(parentSnapshot?.item.detail.log).toContain("example.large_payload");
+
+    const canonicalToolCall = events.find(
+      (event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "timeline" &&
+        event.event.id === "tool-preview-child-thread" &&
+        event.event.item.type === "tool_call",
+    );
+    expect(canonicalToolCall?.event.item).toMatchObject({
+      type: "tool_call",
+      callId: "large-child-tool",
+      detail: { type: "unknown", input: { toJSON } },
+    });
+  });
+
+  test("bounds streamed multibyte child activity by UTF-8 bytes without splitting code points", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-multibyte-child",
+        kind: "started",
+        agentThreadId: "multibyte-child-thread",
+        agentPath: "/root/multibyte-child",
+      },
+    });
+    const deltas = Array.from({ length: 6 }, (_, index) =>
+      index === 5
+        ? `${"界".repeat(4_000)} 😀 newest-multibyte-marker`
+        : `${"界".repeat(4_000)} 😀 delta-${index}`,
+    );
+    for (const [index, delta] of deltas.entries()) {
+      asInternals(session).handleNotification("item/agentMessage/delta", {
+        threadId: "multibyte-child-thread",
+        itemId: `multibyte-child-message-${index}`,
+        delta,
+      });
+    }
+
+    const parentLogs = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-multibyte-child" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item.detail.log]
+        : [],
+    );
+    expect(parentLogs.length).toBeGreaterThan(1);
+    expect(parentLogs.every((log) => Buffer.byteLength(log, "utf8") <= 32_000)).toBe(true);
+    expect(parentLogs.every(hasOnlyWellFormedCodePoints)).toBe(true);
+    expect(parentLogs.at(-1)).toContain("😀 newest-multibyte-marker");
+
+    const canonicalDeltas = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "multibyte-child-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalDeltas).toEqual(deltas);
   });
 
   test("keeps a settled child completed until Codex starts another child turn", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -149,6 +149,13 @@ const CODEX_NON_ORIGINATING_APP_SERVER_CLIENT_INFO = {
 const ASSISTANT_MESSAGE_BOUNDARY_MARKDOWN = "\n\n---\n\n";
 const MAX_PENDING_SUB_AGENT_THREADS = 32;
 const MAX_PENDING_SUB_AGENT_NOTIFICATIONS_PER_THREAD = 128;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ITEMS = 200;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES = 4_000;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES = 256;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ACTIONS = 32;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ACTION_FIELD_BYTES = 256;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_BYTES = 32_000;
+const OMITTED_SUB_AGENT_ACTIVITY_PREFIX = "…\n";
 // COMPAT(codexLegacyCollabAgentToolCall): Codex <0.143 emits this shape. Added in
 // Paseo v0.1.105; remove after 2027-01-09 once the supported Codex floor is >=0.143.
 const CODEX_TOOL_THREAD_ITEM_TYPES = new Set([
@@ -207,6 +214,235 @@ function parseGoalSubcommand(args: string | undefined): GoalSubcommand {
 
 function formatOutOfBandStatusMessage(text: string): string {
   return `${text.replace(/\n+$/u, "")}\n\n`;
+}
+
+function utf8CodePointByteLength(codePoint: number): number {
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+function previousCodePointStart(text: string, end: number): number {
+  const lastIndex = end - 1;
+  const lastCodeUnit = text.charCodeAt(lastIndex);
+  if (lastCodeUnit >= 0xdc00 && lastCodeUnit <= 0xdfff && lastIndex > 0) {
+    const precedingCodeUnit = text.charCodeAt(lastIndex - 1);
+    if (precedingCodeUnit >= 0xd800 && precedingCodeUnit <= 0xdbff) {
+      return lastIndex - 1;
+    }
+  }
+  return lastIndex;
+}
+
+function utf8TailStart(text: string, maxBytes: number): number {
+  let start = text.length;
+  let retainedBytes = 0;
+  while (start > 0) {
+    const candidateStart = previousCodePointStart(text, start);
+    const codePoint = text.codePointAt(candidateStart);
+    if (codePoint === undefined) break;
+    const codePointBytes = utf8CodePointByteLength(codePoint);
+    if (retainedBytes + codePointBytes > maxBytes) break;
+    retainedBytes += codePointBytes;
+    start = candidateStart;
+  }
+  return start;
+}
+
+function tailSubAgentActivity(text: string, maxBytes: number): string {
+  const unprefixedStart = utf8TailStart(text, maxBytes);
+  if (unprefixedStart === 0) {
+    return text;
+  }
+  const prefixBytes = Buffer.byteLength(OMITTED_SUB_AGENT_ACTIVITY_PREFIX, "utf8");
+  if (maxBytes <= prefixBytes) {
+    return "";
+  }
+
+  const start = utf8TailStart(text, maxBytes - prefixBytes);
+  return `${OMITTED_SUB_AGENT_ACTIVITY_PREFIX}${text.slice(start)}`;
+}
+
+function boundedToolCallPreview(detail: ToolCallTimelineItem["detail"]): string | undefined {
+  switch (detail.type) {
+    case "shell":
+      return detail.command;
+    case "read":
+    case "edit":
+    case "write":
+      return detail.filePath;
+    case "search":
+      return detail.query;
+    case "fetch":
+      return detail.url;
+    case "worktree_setup":
+      return detail.branchName;
+    case "plain_text":
+      return detail.label ?? detail.text;
+    case "plan":
+      return detail.text;
+    case "unknown":
+      if (
+        typeof detail.input === "string" ||
+        typeof detail.input === "number" ||
+        typeof detail.input === "boolean" ||
+        typeof detail.input === "bigint"
+      ) {
+        return String(detail.input);
+      }
+      return undefined;
+    case "sub_agent":
+      return undefined;
+  }
+}
+
+function boundedToolCallPreviewName(item: ToolCallTimelineItem): string {
+  switch (item.detail.type) {
+    case "shell":
+      return "Shell";
+    case "read":
+      return "Read";
+    case "edit":
+      return "Edit";
+    case "write":
+      return "Write";
+    case "search":
+      return "Search";
+    case "fetch":
+      return "Fetch";
+    case "worktree_setup":
+      return "Worktree setup";
+    case "plan":
+      return "Plan";
+    case "sub_agent":
+    case "plain_text":
+    case "unknown":
+      return item.name;
+  }
+}
+
+function boundedToolCallError(item: ToolCallTimelineItem): unknown {
+  if (item.status !== "failed") return null;
+  return typeof item.error === "string"
+    ? tailSubAgentActivity(item.error, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES)
+    : "Tool call failed";
+}
+
+function buildBoundedToolCallPreview(
+  item: ToolCallTimelineItem,
+  subAgentLogBytes = MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES,
+): ToolCallTimelineItem {
+  const preview =
+    item.detail.type === "sub_agent" ? undefined : boundedToolCallPreview(item.detail);
+  const detail: ToolCallTimelineItem["detail"] =
+    item.detail.type === "sub_agent"
+      ? {
+          type: "sub_agent",
+          ...(item.detail.subAgentType
+            ? {
+                subAgentType: tailSubAgentActivity(
+                  item.detail.subAgentType,
+                  MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES,
+                ),
+              }
+            : {}),
+          ...(item.detail.description
+            ? {
+                description: tailSubAgentActivity(
+                  item.detail.description,
+                  MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES,
+                ),
+              }
+            : {}),
+          ...(item.detail.childSessionId
+            ? {
+                childSessionId: tailSubAgentActivity(
+                  item.detail.childSessionId,
+                  MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES,
+                ),
+              }
+            : {}),
+          log: tailSubAgentActivity(item.detail.log, subAgentLogBytes),
+          ...(item.detail.actions
+            ? {
+                actions: item.detail.actions
+                  .slice(-MAX_PARENT_SUB_AGENT_ACTIVITY_ACTIONS)
+                  .map((action) => {
+                    const boundedAction = {
+                      index: action.index,
+                      toolName: tailSubAgentActivity(
+                        action.toolName,
+                        MAX_PARENT_SUB_AGENT_ACTIVITY_ACTION_FIELD_BYTES,
+                      ),
+                    };
+                    if (!action.summary) return boundedAction;
+                    return {
+                      index: boundedAction.index,
+                      toolName: boundedAction.toolName,
+                      summary: tailSubAgentActivity(
+                        action.summary,
+                        MAX_PARENT_SUB_AGENT_ACTIVITY_ACTION_FIELD_BYTES,
+                      ),
+                    };
+                  }),
+              }
+            : {}),
+        }
+      : {
+          type: "plain_text",
+          ...(preview
+            ? {
+                label: tailSubAgentActivity(preview, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES),
+              }
+            : {}),
+        };
+  const base = {
+    type: "tool_call" as const,
+    callId: item.callId,
+    name: tailSubAgentActivity(
+      boundedToolCallPreviewName(item),
+      MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES,
+    ),
+    detail,
+  };
+  switch (item.status) {
+    case "running":
+    case "completed":
+    case "canceled":
+      return { ...base, status: item.status, error: null };
+    case "failed":
+      return { ...base, status: item.status, error: boundedToolCallError(item) };
+  }
+}
+
+function boundParentSubAgentActivityItem(item: AgentTimelineItem): AgentTimelineItem {
+  if (
+    item.type === "assistant_message" ||
+    item.type === "reasoning" ||
+    item.type === "user_message"
+  ) {
+    return {
+      ...item,
+      text: tailSubAgentActivity(item.text, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES),
+    };
+  }
+  if (item.type === "error") {
+    return {
+      ...item,
+      message: tailSubAgentActivity(item.message, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES),
+    };
+  }
+  if (item.type === "tool_call") {
+    return buildBoundedToolCallPreview(item);
+  }
+  return item;
+}
+
+function boundRootSubAgentTimelineItem(item: AgentTimelineItem): AgentTimelineItem {
+  return item.type === "tool_call" && item.detail.type === "sub_agent"
+    ? buildBoundedToolCallPreview(item, MAX_PARENT_SUB_AGENT_ACTIVITY_BYTES)
+    : item;
 }
 
 const CODEX_APP_SERVER_CAPABILITIES: AgentCapabilityFlags = {
@@ -5536,8 +5772,10 @@ export class CodexAppServerAgentSession implements AgentSession {
 
   private getSubAgentChildTimeline(state: CodexSubAgentCallState): AgentTimelineItem[] {
     return state.childItemOrder
+      .slice(-MAX_PARENT_SUB_AGENT_ACTIVITY_ITEMS)
       .map((itemId) => state.childItems.get(itemId))
-      .filter((item): item is AgentTimelineItem => Boolean(item));
+      .filter((item): item is AgentTimelineItem => Boolean(item))
+      .map(boundParentSubAgentActivityItem);
   }
 
   private emitSubAgentActivityUpdate(
@@ -5552,7 +5790,10 @@ export class CodexAppServerAgentSession implements AgentSession {
     const childTimeline = this.getSubAgentChildTimeline(state);
     const log =
       childTimeline.length > 0
-        ? curateAgentActivity(childTimeline, { labelAssistantMessages: true })
+        ? tailSubAgentActivity(
+            curateAgentActivity(childTimeline, { labelAssistantMessages: true }),
+            MAX_PARENT_SUB_AGENT_ACTIVITY_BYTES,
+          )
         : "";
     let resolvedStatus = status ?? state.toolCall.status;
     if (
@@ -5590,7 +5831,11 @@ export class CodexAppServerAgentSession implements AgentSession {
       this.emitSubAgentActivityUpdate(state.parentCallId);
       return;
     }
-    this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: nextToolCall });
+    this.emitEvent({
+      type: "timeline",
+      provider: CODEX_PROVIDER,
+      item: boundRootSubAgentTimelineItem(nextToolCall),
+    });
   }
 
   private emitProviderSubagentUpsert(
@@ -6298,7 +6543,11 @@ export class CodexAppServerAgentSession implements AgentSession {
       }
       this.warnOnIncompleteEditToolCall(timelineItem, "item_completed", parsed.item);
     }
-    this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: timelineItem });
+    this.emitEvent({
+      type: "timeline",
+      provider: CODEX_PROVIDER,
+      item: boundRootSubAgentTimelineItem(timelineItem),
+    });
     if (timelineItem.type === "assistant_message") {
       this.pendingAssistantMessageBoundary = true;
     }
@@ -6448,7 +6697,11 @@ export class CodexAppServerAgentSession implements AgentSession {
       return;
     }
     this.warnOnIncompleteEditToolCall(timelineItem, "item_started", parsed.item);
-    this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: timelineItem });
+    this.emitEvent({
+      type: "timeline",
+      provider: CODEX_PROVIDER,
+      item: boundRootSubAgentTimelineItem(timelineItem),
+    });
     if (itemId) {
       this.emittedItemStartedIds.add(itemId);
       this.pendingCommandOutputDeltas.delete(itemId);


### PR DESCRIPTION
Refs #2300

This removes the quadratic parent-copy path for Codex provider subagents.

- keep canonical child activity in the provider-subagent timeline
- limit parent snapshots to the latest 200 activities, 4 KiB per activity, and 32 KiB total
- preserve UTF-8 boundaries and nested-parent updates without copying complete descendant logs

Regression coverage exercises large, nested, and multibyte child histories.
