### PR TITLE
feat(plugins): allow daemon API opt-out

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -40,7 +40,7 @@ runtime-safe: run `paseo reload` after editing `config.json`. Enabling starts ev
 enabled plugin; disabling tears them all down without restarting the daemon. Plugin source entries
 remain lifecycle-owned and do not reload from manual config edits.
 
-The directory contains an identity-only manifest, one entry point, and local typechecking support:
+The directory contains a manifest, one entry point, and local typechecking support:
 
 ```text
 my-plugin/
@@ -59,9 +59,15 @@ SDK contract changes.
 
 ```json
 {
-  "id": "my-plugin"
+  "id": "my-plugin",
+  "daemonApi": false
 }
 ```
+
+Set `daemonApi` to `false` when server handlers do not use the handler context's `paseo` API.
+Paseo then skips the plugin's daemon session and global agent stream. The field defaults to `true`
+for compatibility. Client-side `usePaseo()` remains available; accessing `paseo` from a server
+handler while disabled fails that RPC explicitly.
 
 The config key is the runtime plugin ID. The manifest ID is the default selected during install;
 `--id` overrides it. Existing configuration is not renamed when the manifest changes, and the

--- a/packages/server/src/server/plugins/manifest.ts
+++ b/packages/server/src/server/plugins/manifest.ts
@@ -4,7 +4,9 @@ import { z } from "zod";
 import { PluginIdSchema } from "@getpaseo/protocol/messages";
 
 const MANIFEST_FILENAME = "paseo-plugin.json";
-const PluginManifestSchema = z.object({ id: PluginIdSchema }).strict();
+const PluginManifestSchema = z
+  .object({ id: PluginIdSchema, daemonApi: z.boolean().default(true) })
+  .strict();
 
 export type PluginManifest = z.infer<typeof PluginManifestSchema>;
 

--- a/packages/server/src/server/plugins/plugin-process-protocol.ts
+++ b/packages/server/src/server/plugins/plugin-process-protocol.ts
@@ -1,5 +1,11 @@
 export type PluginProcessRequest =
-  | { type: "initialize"; pluginId: string; bundle: string; appVersion: string }
+  | {
+      type: "initialize";
+      pluginId: string;
+      bundle: string;
+      appVersion: string;
+      daemonApi: boolean;
+    }
   | { type: "invoke"; requestId: string; method: string; input: unknown }
   | { type: "shutdown" }
   | { type: "paseo_frame"; data: string | Uint8Array; isBinary: boolean }

--- a/packages/server/src/server/plugins/plugin-process.ts
+++ b/packages/server/src/server/plugins/plugin-process.ts
@@ -6,8 +6,8 @@ import {
   type PluginHandlerContext,
   type PluginRpcContract,
 } from "@getpaseo/plugin/server";
-import { createPaseoApi, type PaseoApi } from "@getpaseo/client";
-import { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import type { PaseoApi } from "@getpaseo/client";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { createPluginDaemonTransportFactory } from "./daemon-transport.js";
 import { isPluginClientOnlySdkSpecifier, isPluginSdkSpecifier } from "./plugin-sdk-specifiers.js";
 
@@ -24,6 +24,14 @@ let daemonClient: DaemonClient | null = null;
 let paseo: PaseoApi | null = null;
 let stopping = false;
 const nodeRequire = createRequire(import.meta.url);
+
+class DisabledDaemonApiContext implements PluginHandlerContext {
+  get paseo(): PaseoApi {
+    throw new Error("Plugin daemon API is disabled in paseo-plugin.json");
+  }
+}
+
+const disabledDaemonApiContext = new DisabledDaemonApiContext();
 
 function send(message: PluginProcessMessage): void {
   process.send?.(message);
@@ -104,16 +112,22 @@ const transportFactory = createPluginDaemonTransportFactory({
 });
 
 async function initialize(message: Extract<PluginProcessRequest, { type: "initialize" }>) {
-  daemonClient = new DaemonClient({
-    url: `ipc://plugin/${encodeURIComponent(message.pluginId)}`,
-    clientId: `plugin:${message.pluginId}`,
-    clientType: "cli",
-    appVersion: message.appVersion,
-    reconnect: { enabled: false },
-    transportFactory,
-  });
-  paseo = createPaseoApi(daemonClient);
-  await daemonClient.connect();
+  if (message.daemonApi) {
+    const [{ createPaseoApi }, { DaemonClient }] = await Promise.all([
+      import("@getpaseo/client"),
+      import("@getpaseo/client/internal/daemon-client"),
+    ]);
+    daemonClient = new DaemonClient({
+      url: `ipc://plugin/${encodeURIComponent(message.pluginId)}`,
+      clientId: `plugin:${message.pluginId}`,
+      clientType: "cli",
+      appVersion: message.appVersion,
+      reconnect: { enabled: false },
+      transportFactory,
+    });
+    paseo = createPaseoApi(daemonClient);
+    await daemonClient.connect();
+  }
   evaluateBundle(message.bundle);
   send({ type: "ready", methods: [...handlers.keys()].sort() });
 }
@@ -128,8 +142,10 @@ async function shutdown(): Promise<void> {
   } catch (error) {
     console.error("Plugin cleanup failed", error);
   }
-  await daemonClient?.close().catch(() => undefined);
-  await sendAndWait({ type: "paseo_close" });
+  if (daemonClient) {
+    await daemonClient.close().catch(() => undefined);
+    await sendAndWait({ type: "paseo_close" });
+  }
   daemonClient = null;
   paseo = null;
   process.disconnect();
@@ -161,8 +177,7 @@ process.on("message", (message: PluginProcessRequest) => {
   void registered.contract.input
     .parseAsync(message.input)
     .then((input) => {
-      if (!paseo) throw new Error("Plugin Paseo API is unavailable");
-      return registered.handler(input, { paseo });
+      return registered.handler(input, paseo ? { paseo } : disabledDaemonApiContext);
     })
     .then((output) => registered.contract.output.parseAsync(output))
     .then(

--- a/packages/server/src/server/plugins/runtime.posix.test.ts
+++ b/packages/server/src/server/plugins/runtime.posix.test.ts
@@ -494,6 +494,37 @@ export default function contribute(plugin: unknown) {
     await runtime.stopAll();
   });
 
+  it("runs RPC-only plugins without a daemon API session", async () => {
+    const directory = await createPlugin(
+      "rpc-only",
+      `import type { PluginContext } from "@getpaseo/plugin";
+import { defineRpc } from "@getpaseo/plugin/server";
+import { z } from "zod";
+
+const pingRpc = defineRpc({
+  name: "ping",
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+});
+
+export default function contribute(plugin: PluginContext) {
+  plugin.handle(pingRpc, async () => ({ ok: true }));
+  return () => undefined;
+}`,
+    );
+    await writeFile(
+      path.join(directory, "paseo-plugin.json"),
+      JSON.stringify({ id: "rpc-only", daemonApi: false }),
+      "utf8",
+    );
+    const runtime = new PluginRuntime(pino({ level: "silent" }), "0.7.0");
+
+    await runtime.startPlugin("rpc-only", directory);
+
+    await expect(runtime.invoke("rpc-only", "ping", {})).resolves.toEqual({ ok: true });
+    await runtime.stopAll();
+  });
+
   it("loads one index.tsx, exposes its client bundle, and invokes its server RPC", async () => {
     const directory = await createPlugin(
       "hello",

--- a/packages/server/src/server/plugins/runtime.ts
+++ b/packages/server/src/server/plugins/runtime.ts
@@ -47,8 +47,7 @@ interface LoadedPlugin {
   child: PluginChild;
   outputCapture: PluginOutputCapture;
   pending: Map<string, PendingInvocation>;
-  sessionSocket: PluginSessionSocket;
-  sessionClosed: Promise<void>;
+  session: { socket: PluginSessionSocket; closed: Promise<void> } | null;
 }
 
 interface PluginRuntimeDependencies {
@@ -315,23 +314,28 @@ export class PluginRuntime {
     configuredPath: string,
   ): Promise<LoadedPlugin> {
     const directory = path.resolve(configuredPath);
-    await readPluginManifest(directory);
+    const manifest = await readPluginManifest(directory);
     const entryPath = await resolveEntryPath(directory);
     const bundles = await compilePlugin(entryPath);
-    const sessionHost = this.sessionHost;
-    if (!sessionHost) throw new Error("Plugin Paseo session host is not attached");
     const child = this.spawnChild();
     const outputCapture = new PluginOutputCapture(child, (stream, message) => {
       this.appendLog(pluginId, stream, message);
     });
-    const sessionSocket = new PluginSessionSocket(child);
     const pending = new Map<string, PendingInvocation>();
-    const sessionAttachment = await sessionHost
-      .attachPluginSocket(pluginId, sessionSocket)
-      .catch((error) => {
+    let session: LoadedPlugin["session"] = null;
+    if (manifest.daemonApi) {
+      const sessionHost = this.sessionHost;
+      if (!sessionHost) {
+        terminatePluginChild(child);
+        throw new Error("Plugin Paseo session host is not attached");
+      }
+      const socket = new PluginSessionSocket(child);
+      const attachment = await sessionHost.attachPluginSocket(pluginId, socket).catch((error) => {
         terminatePluginChild(child);
         throw error;
       });
+      session = { socket, closed: attachment.closed };
+    }
     let loaded: LoadedPlugin | null = null;
     let methods: string[];
     try {
@@ -349,9 +353,9 @@ export class PluginRuntime {
         };
         child.on("message", (message) => {
           if (message.type === "paseo_frame") {
-            sessionSocket.receive(message.data, message.isBinary);
+            session?.socket.receive(message.data, message.isBinary);
           } else if (message.type === "paseo_close") {
-            sessionSocket.peerClosed();
+            session?.socket.peerClosed();
           } else if (message.type === "ready") {
             if (settled) return;
             settled = true;
@@ -364,7 +368,7 @@ export class PluginRuntime {
           }
         });
         child.on("close", () => {
-          sessionSocket.peerClosed();
+          session?.socket.peerClosed();
           if (!loaded) {
             fail(new Error(`Plugin ${pluginId} exited during initialization`));
             return;
@@ -376,11 +380,12 @@ export class PluginRuntime {
           pluginId,
           appVersion: this.daemonVersion,
           bundle: bundles.serverBundle,
+          daemonApi: manifest.daemonApi,
         }).catch(fail);
       });
     } catch (error) {
-      sessionSocket.close();
-      await sessionAttachment.closed;
+      session?.socket.close();
+      await session?.closed;
       terminatePluginChild(child);
       throw error;
     }
@@ -391,8 +396,7 @@ export class PluginRuntime {
       child,
       outputCapture,
       pending,
-      sessionSocket,
-      sessionClosed: sessionAttachment.closed,
+      session,
     };
     this.logger.info({ pluginId, methods }, "Loaded plugin");
     return loaded;
@@ -409,21 +413,21 @@ export class PluginRuntime {
   }
 
   private async handleChildClose(loaded: LoadedPlugin): Promise<void> {
-    loaded.sessionSocket.peerClosed();
+    loaded.session?.socket.peerClosed();
     const wasPublished = this.plugins.get(loaded.id) === loaded;
     if (wasPublished) {
       this.plugins.delete(loaded.id);
     }
     this.rejectPending(loaded, `Plugin process exited: ${loaded.id}`);
-    await loaded.sessionClosed;
+    await loaded.session?.closed;
     if (wasPublished) this.notify(loaded.id, `Plugin process exited: ${loaded.id}`);
   }
 
   private async stopPlugin(loaded: LoadedPlugin): Promise<void> {
     this.appendLog(loaded.id, "stdout", "[paseo] Stopping plugin");
     if (loaded.child.killed) {
-      loaded.sessionSocket.peerClosed();
-      await loaded.sessionClosed;
+      loaded.session?.socket.peerClosed();
+      await loaded.session?.closed;
       this.appendLog(loaded.id, "stdout", "[paseo] Plugin stopped");
       return;
     }
@@ -436,8 +440,8 @@ export class PluginRuntime {
       await send(loaded.child, { type: "shutdown" }).catch(() => undefined);
     }
     await closed;
-    loaded.sessionSocket.peerClosed();
-    await loaded.sessionClosed;
+    loaded.session?.socket.peerClosed();
+    await loaded.session?.closed;
     this.appendLog(loaded.id, "stdout", "[paseo] Plugin stopped");
   }
 


### PR DESCRIPTION
## Summary

- add a backward-compatible `daemonApi` plugin manifest flag, defaulting to `true`
- skip the plugin's internal daemon session and lazily avoid loading `@getpaseo/client` when `daemonApi` is `false`
- keep plugin RPC handlers available; accessing handler-context `paseo` fails explicitly when opted out
- document the manifest option and cover the real forked worker path

## Motivation

Every plugin worker currently creates a full `DaemonClient` session even when its server handlers never use `context.paseo`. That makes RPC-only plugins receive the daemon's global agent stream and retain the full client-side session state.

This showed up under active agent traffic as unrelated RPC-only workers growing together from roughly 186 MiB RSS each to more than 700 MiB. A three-run production-build probe against the emitted `plugin-process.js` measured an idle worker at:

| Manifest | Mean worker RSS |
| --- | ---: |
| default / `daemonApi: true` | 166,685 KiB (162.8 MiB) |
| `daemonApi: false` | 60,709 KiB (59.3 MiB) |

That is a 103.5 MiB (63.6%) baseline reduction before accounting for the avoided stream growth.

The opt-out is explicit so existing manifests and plugins using the server-side `PaseoApi` retain current behavior.

## Test plan

- `npx vitest run packages/server/src/server/plugins/runtime.posix.test.ts --bail=1` — 23 passed
- `npx vitest run packages/server/src/server/plugins/plugin-paseo-api.e2e.test.ts --bail=1` — 2 passed
- `npm run build:server`
- pre-commit `npm run lint`, formatting checks, and typechecks for all workspaces
