### PR TITLE
fix(codex): lazily page provider subagent history

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -3611,7 +3611,7 @@ test("importProviderSession imports the selected session without listing and pub
   expect(manager.listProviderSubagents(imported.id)).toEqual([
     expect.objectContaining({ id: "thread-child", title: "Imported child", status: "completed" }),
   ]);
-  expect(manager.fetchProviderSubagentTimeline(imported.id, "thread-child").rows).toEqual([
+  expect((await manager.fetchProviderSubagentTimeline(imported.id, "thread-child")).rows).toEqual([
     expect.objectContaining({ item: { type: "assistant_message", text: "Child result" } }),
   ]);
   expect(events).toHaveLength(3);
@@ -3878,6 +3878,815 @@ test("reloadAgentSession terminalizes running provider children when preserving 
   expect(manager.listProviderSubagents(snapshot.id)).toEqual([
     expect.objectContaining({ id: "running-child", status: "canceled" }),
   ]);
+});
+
+test("fetchProviderSubagentTimeline single-flights lazy provider history and ingests it once", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-history-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const loadGate = deferred<void>();
+  let activeSession: LazyProviderChildSession | null = null;
+  class LazyProviderChildSession extends TestAgentSession {
+    loadCalls = 0;
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      this.loadCalls += 1;
+      await loadGate.promise;
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded lazily." },
+          },
+        },
+      ];
+    }
+  }
+  class LazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new LazyProviderChildSession(config);
+      return activeSession;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new LazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000120",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const firstTimeline = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  const secondTimeline = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  await vi.waitFor(() => expect(activeSession?.loadCalls).toBe(1));
+  loadGate.resolve();
+
+  const timelines = await Promise.all([firstTimeline, secondTimeline]);
+  for (const timeline of timelines) {
+    expect(timeline).toMatchObject({
+      rows: [
+        expect.objectContaining({ item: { type: "assistant_message", text: "Loaded lazily." } }),
+      ],
+    });
+  }
+  expect(timelines[0]?.rows).toHaveLength(1);
+});
+
+test("reloadAgentSession preserves completed lazy provider history without replaying it", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-hot-reload-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const sessions: ReloadableLazyProviderChildSession[] = [];
+  class ReloadableLazyProviderChildSession extends TestAgentSession {
+    readonly loadedSubagentIds = new Set<string>();
+    loadCalls = 0;
+
+    getLoadedProviderSubagentHistoryIds(): readonly string[] {
+      return [...this.loadedSubagentIds];
+    }
+
+    seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+      for (const subagentId of subagentIds) {
+        this.loadedSubagentIds.add(subagentId);
+      }
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      if (this.loadedSubagentIds.has(subagentId)) {
+        return [];
+      }
+      this.loadCalls += 1;
+      this.loadedSubagentIds.add(subagentId);
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded once across reloads." },
+          },
+        },
+      ];
+    }
+  }
+  class ReloadableLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): AgentSession {
+      const session = new ReloadableLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new ReloadableLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000124",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const beforeReload = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  expect(beforeReload.rows).toHaveLength(1);
+  expect(sessions[0]?.loadCalls).toBe(1);
+
+  await manager.reloadAgentSession(snapshot.id);
+  const afterReload = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(0);
+  expect(afterReload.rows).toEqual(beforeReload.rows);
+});
+
+test("reloadAgentSession preserves a lazy provider history load that finishes during replacement", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-reload-race-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const childLoadStarted = deferred<void>();
+  const childLoadGate = deferred<void>();
+  const resumeStarted = deferred<void>();
+  const resumeGate = deferred<void>();
+  const sessions: RacingReloadLazyProviderChildSession[] = [];
+  class RacingReloadLazyProviderChildSession extends TestAgentSession {
+    readonly loadedSubagentIds = new Set<string>();
+    loadCalls = 0;
+
+    getLoadedProviderSubagentHistoryIds(): readonly string[] {
+      return [...this.loadedSubagentIds];
+    }
+
+    seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+      for (const subagentId of subagentIds) {
+        this.loadedSubagentIds.add(subagentId);
+      }
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      if (this.loadedSubagentIds.has(subagentId)) {
+        return [];
+      }
+      this.loadCalls += 1;
+      if (sessions[0] === this) {
+        childLoadStarted.resolve();
+        await childLoadGate.promise;
+      }
+      this.loadedSubagentIds.add(subagentId);
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded while reload waits." },
+          },
+        },
+      ];
+    }
+  }
+  class RacingReloadLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): RacingReloadLazyProviderChildSession {
+      const session = new RacingReloadLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      resumeStarted.resolve();
+      await resumeGate.promise;
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new RacingReloadLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000126",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const childFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  await childLoadStarted.promise;
+  const reload = manager.reloadAgentSession(snapshot.id);
+  childLoadGate.resolve();
+  const loadedDuringReload = await childFetch;
+  await resumeStarted.promise;
+  resumeGate.resolve();
+  await reload;
+
+  const afterReload = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(0);
+  expect(afterReload.rows).toEqual(loadedDuringReload.rows);
+  expect(afterReload.rows).toHaveLength(1);
+});
+
+test("reloadAgentSession atomically admits a provider history fetch started in the same turn", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-admission-race-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const childLoadStarted = deferred<void>();
+  const childLoadGate = deferred<void>();
+  const resumeStarted = deferred<void>();
+  const resumeGate = deferred<void>();
+  const sessions: AdmissionRaceLazyProviderChildSession[] = [];
+  class AdmissionRaceLazyProviderChildSession extends TestAgentSession {
+    readonly loadedSubagentIds = new Set<string>();
+    loadCalls = 0;
+
+    getLoadedProviderSubagentHistoryIds(): readonly string[] {
+      return [...this.loadedSubagentIds];
+    }
+
+    seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+      for (const subagentId of subagentIds) {
+        this.loadedSubagentIds.add(subagentId);
+      }
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      if (this.loadedSubagentIds.has(subagentId)) {
+        return [];
+      }
+      this.loadCalls += 1;
+      if (sessions[0] === this) {
+        childLoadStarted.resolve();
+        await childLoadGate.promise;
+      }
+      this.loadedSubagentIds.add(subagentId);
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Admitted before reload." },
+          },
+        },
+      ];
+    }
+  }
+  class AdmissionRaceLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): AdmissionRaceLazyProviderChildSession {
+      const session = new AdmissionRaceLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      resumeStarted.resolve();
+      await resumeGate.promise;
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new AdmissionRaceLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000127",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const childFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  const reload = manager.reloadAgentSession(snapshot.id);
+  await childLoadStarted.promise;
+  childLoadGate.resolve();
+  const admittedTimeline = await childFetch;
+  await resumeStarted.promise;
+  resumeGate.resolve();
+  await reload;
+
+  const afterReload = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(0);
+  expect(afterReload.rows).toEqual(admittedTimeline.rows);
+  expect(afterReload.rows).toHaveLength(1);
+});
+
+test("reloadAgentSession aborts a stuck provider history load and releases waiting fetches", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-stuck-reload-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const stuckLoadStarted = deferred<void>();
+  const sessions: StuckReloadLazyProviderChildSession[] = [];
+  class StuckReloadLazyProviderChildSession extends TestAgentSession {
+    loadCalls = 0;
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      this.loadCalls += 1;
+      if (sessions[0] === this) {
+        stuckLoadStarted.resolve();
+        return await new Promise(() => undefined);
+      }
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Retried on the replacement session." },
+          },
+        },
+      ];
+    }
+  }
+  class StuckReloadLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): StuckReloadLazyProviderChildSession {
+      const session = new StuckReloadLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new StuckReloadLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000128",
+    rescueTimeouts: { reloadSessionCloseMs: 10 },
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const stuckFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  const stuckFetchRejection = expect(stuckFetch).rejects.toThrow(
+    "Provider subagent history load aborted for reload",
+  );
+  await stuckLoadStarted.promise;
+  const reload = manager.reloadAgentSession(snapshot.id);
+  const waitingFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  await expect(
+    Promise.race([
+      reload.then(() => "reloaded"),
+      new Promise<"timed_out">((resolve) => setTimeout(() => resolve("timed_out"), 200)),
+    ]),
+  ).resolves.toBe("reloaded");
+  await stuckFetchRejection;
+  await expect(waitingFetch).resolves.toMatchObject({
+    rows: [
+      expect.objectContaining({
+        item: { type: "assistant_message", text: "Retried on the replacement session." },
+      }),
+    ],
+  });
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(1);
+});
+
+test("closeAgent aborts and removes a stuck provider history load", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-stuck-close-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const stuckLoadStarted = deferred<void>();
+  let activeSession: StuckCloseLazyProviderChildSession | null = null;
+  class StuckCloseLazyProviderChildSession extends TestAgentSession {
+    override async loadProviderSubagentHistory(): Promise<
+      Extract<AgentStreamEvent, { type: "provider_subagent" }>[]
+    > {
+      stuckLoadStarted.resolve();
+      return await new Promise(() => undefined);
+    }
+  }
+  class StuckCloseLazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new StuckCloseLazyProviderChildSession(config);
+      return activeSession;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new StuckCloseLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000129",
+    rescueTimeouts: { reloadSessionCloseMs: 10 },
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const stuckFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  const stuckFetchRejection = expect(stuckFetch).rejects.toThrow(
+    "Provider subagent history load aborted because agent closed",
+  );
+  await stuckLoadStarted.promise;
+
+  await manager.closeAgent(snapshot.id);
+
+  expect(
+    (
+      manager as unknown as {
+        providerSubagentHistoryLoads: Map<string, unknown>;
+      }
+    ).providerSubagentHistoryLoads.size,
+  ).toBe(0);
+  await stuckFetchRejection;
+});
+
+test("reloadAgentSession rehydrates lazy provider history when requested", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-rehydrate-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const sessions: RehydratingLazyProviderChildSession[] = [];
+  class RehydratingLazyProviderChildSession extends TestAgentSession {
+    readonly loadedSubagentIds = new Set<string>();
+    loadCalls = 0;
+
+    getLoadedProviderSubagentHistoryIds(): readonly string[] {
+      return [...this.loadedSubagentIds];
+    }
+
+    seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+      for (const subagentId of subagentIds) {
+        this.loadedSubagentIds.add(subagentId);
+      }
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      if (this.loadedSubagentIds.has(subagentId)) {
+        return [];
+      }
+      this.loadCalls += 1;
+      this.loadedSubagentIds.add(subagentId);
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Reloaded from disk." },
+          },
+        },
+      ];
+    }
+  }
+  class RehydratingLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): AgentSession {
+      const session = new RehydratingLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new RehydratingLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000125",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+  await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  await manager.reloadAgentSession(snapshot.id, undefined, { rehydrateFromDisk: true });
+  const rehydrated = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(1);
+  expect(rehydrated.rows).toMatchObject([
+    { item: { type: "assistant_message", text: "Reloaded from disk." } },
+  ]);
+  expect(rehydrated.rows).toHaveLength(1);
+});
+
+test("reloadAgentSession waits for an in-flight provider history load before replacing it", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-reload-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const loadStarted = deferred<void>();
+  const loadGate = deferred<void>();
+  let activeSession: ReloadingLazyProviderChildSession | null = null;
+  class ReloadingLazyProviderChildSession extends TestAgentSession {
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      loadStarted.resolve();
+      await loadGate.promise;
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded by the replaced session." },
+          },
+        },
+      ];
+    }
+  }
+  class ReloadingLazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new ReloadingLazyProviderChildSession(config);
+      return activeSession;
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new TestAgentSession({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new ReloadingLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000121",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const timelinePromise = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  await loadStarted.promise;
+  let reloadSettled = false;
+  const reload = manager.reloadAgentSession(snapshot.id).finally(() => {
+    reloadSettled = true;
+  });
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  expect(reloadSettled).toBe(false);
+  loadGate.resolve();
+
+  await expect(timelinePromise).resolves.toMatchObject({
+    rows: [
+      expect.objectContaining({
+        item: { type: "assistant_message", text: "Loaded by the replaced session." },
+      }),
+    ],
+  });
+  await reload;
+});
+
+test("fetchProviderSubagentTimeline ingests lazy history while a turn is pending", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-pending-run-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const startEntered = deferred<void>();
+  const startGate = deferred<void>();
+  let activeSession: PendingRunLazyProviderChildSession | null = null;
+  class PendingRunLazyProviderChildSession extends TestAgentSession {
+    override async startTurn(prompt: AgentPromptInput): Promise<{ turnId: string }> {
+      startEntered.resolve();
+      await startGate.promise;
+      return await super.startTurn(prompt);
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded during pending start." },
+          },
+        },
+      ];
+    }
+  }
+  class PendingRunLazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new PendingRunLazyProviderChildSession(config);
+      return activeSession;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new PendingRunLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000122",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+  const run = manager.streamAgent(snapshot.id, "hold start");
+  const consume = (async () => {
+    for await (const _event of run) {
+      // Drain the test run.
+    }
+  })();
+  await startEntered.promise;
+
+  try {
+    await expect(
+      manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child"),
+    ).resolves.toMatchObject({
+      rows: [
+        expect.objectContaining({
+          item: { type: "assistant_message", text: "Loaded during pending start." },
+        }),
+      ],
+    });
+  } finally {
+    startGate.resolve();
+    await consume;
+  }
+});
+
+test("fetchProviderSubagentTimeline ingests lazy history while steer admission is pending", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-steer-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const steerEntered = deferred<void>();
+  const steerGate = deferred<void>();
+  let activeSession: SteerLazyProviderChildSession | null = null;
+  class SteerLazyProviderChildSession extends SteeringTestSession {
+    override async steerActiveTurn(): Promise<import("./agent-sdk-types.js").SteerResult> {
+      this.steerCount += 1;
+      steerEntered.resolve();
+      await steerGate.promise;
+      return { status: "accepted" };
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded during steer admission." },
+          },
+        },
+      ];
+    }
+  }
+  class SteerLazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new SteerLazyProviderChildSession(config);
+      return activeSession;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new SteerLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000123",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+  const run = manager.streamAgent(snapshot.id, "hold active turn");
+  const consume = (async () => {
+    for await (const _event of run) {
+      // Drain the test run.
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+  const steer = manager.steerAgentRun(snapshot.id, "hold steer");
+  await steerEntered.promise;
+
+  try {
+    await expect(
+      manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child"),
+    ).resolves.toMatchObject({
+      rows: [
+        expect.objectContaining({
+          item: { type: "assistant_message", text: "Loaded during steer admission." },
+        }),
+      ],
+    });
+  } finally {
+    steerGate.resolve();
+    await steer;
+    activeSession?.pushEvent({
+      type: "turn_completed",
+      provider: "codex",
+      turnId: "active-turn-1",
+    });
+    await consume;
+  }
 });
 
 test("hydrateTimelineFromProvider restores and broadcasts provider children from session history", async () => {
@@ -6933,9 +7742,9 @@ test("subscribe hides provider subagents of internal parents from global subscri
   expect(() => manager.getProviderSubagent(internalAgentId, "hidden-child")).toThrow(
     `Unknown agent '${internalAgentId}'`,
   );
-  expect(() => manager.fetchProviderSubagentTimeline(internalAgentId, "hidden-child")).toThrow(
-    `Unknown agent '${internalAgentId}'`,
-  );
+  await expect(
+    manager.fetchProviderSubagentTimeline(internalAgentId, "hidden-child"),
+  ).rejects.toThrow(`Unknown agent '${internalAgentId}'`);
   expect(manager.listProviderSubagentActivity()).toEqual([]);
 });
 

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -4294,20 +4294,15 @@ test("reloadAgentSession aborts a stuck provider history load and releases waiti
   await manager.flush();
 
   const stuckFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
-  const stuckFetchRejection = expect(stuckFetch).rejects.toThrow(
-    "Provider subagent history load aborted for reload",
-  );
+  const stuckFetchRejection = stuckFetch.catch((error: unknown) => error);
   await stuckLoadStarted.promise;
   const reload = manager.reloadAgentSession(snapshot.id);
   const waitingFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
 
-  await expect(
-    Promise.race([
-      reload.then(() => "reloaded"),
-      new Promise<"timed_out">((resolve) => setTimeout(() => resolve("timed_out"), 200)),
-    ]),
-  ).resolves.toBe("reloaded");
-  await stuckFetchRejection;
+  await reload;
+  await expect(stuckFetchRejection).resolves.toEqual(
+    expect.objectContaining({ message: "Provider subagent history load aborted for reload" }),
+  );
   await expect(waitingFetch).resolves.toMatchObject({
     rows: [
       expect.objectContaining({

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -689,6 +689,14 @@ export class AgentManager {
   private readonly providerSubagents = new ProviderSubagentStore();
   private readonly agentsAwaitingInitialSnapshotPersist = new Set<string>();
   private readonly sessionEventTails = new Map<string, Promise<void>>();
+  private readonly providerSubagentHistoryLoads = new Map<
+    string,
+    { session: AgentSession; promise: Promise<void>; abortController: AbortController }
+  >();
+  private readonly providerSubagentHistoryReloadBarriers = new Map<
+    string,
+    { promise: Promise<void>; release: () => void }
+  >();
   private readonly steerEventBarriers = new Map<string, SteerEventBarrier>();
   private readonly foregroundMutationTails = new Map<string, Promise<void>>();
   private readonly runs = new AgentRunState();
@@ -1152,11 +1160,52 @@ export class AgentManager {
     return this.providerSubagents.get(parentAgentId, subagentId);
   }
 
-  fetchProviderSubagentTimeline(
+  async fetchProviderSubagentTimeline(
     parentAgentId: string,
     subagentId: string,
     options?: AgentTimelineFetchOptions,
-  ): AgentTimelineFetchResult {
+  ): Promise<AgentTimelineFetchResult> {
+    for (;;) {
+      const reloadBarrier = this.providerSubagentHistoryReloadBarriers.get(parentAgentId);
+      if (!reloadBarrier) {
+        break;
+      }
+      await reloadBarrier.promise;
+    }
+    const agent = this.requirePublicAgent(parentAgentId);
+    const session = agent.session;
+    if (session?.loadProviderSubagentHistory) {
+      const key = `${parentAgentId}\0${subagentId}`;
+      const existingLoad = this.providerSubagentHistoryLoads.get(key);
+      if (existingLoad?.session === session) {
+        await existingLoad.promise;
+      } else {
+        const abortController = new AbortController();
+        const load = (async () => {
+          const events = await this.loadProviderSubagentHistoryWithAbort(
+            session,
+            subagentId,
+            abortController.signal,
+          );
+          const current = this.agents.get(parentAgentId);
+          if (!current || current.internal || current.session !== session) {
+            throw new Error("Agent session changed while loading provider subagent history");
+          }
+          for (const event of events) {
+            this.dispatchProviderSubagentEvent(current.id, event);
+          }
+        })();
+        const loadState = { session, promise: load, abortController };
+        this.providerSubagentHistoryLoads.set(key, loadState);
+        try {
+          await load;
+        } finally {
+          if (this.providerSubagentHistoryLoads.get(key) === loadState) {
+            this.providerSubagentHistoryLoads.delete(key);
+          }
+        }
+      }
+    }
     this.requirePublicAgent(parentAgentId);
     return this.providerSubagents.fetchTimeline(parentAgentId, subagentId, options);
   }
@@ -1371,8 +1420,143 @@ export class AgentManager {
     options?: { rehydrateFromDisk?: boolean },
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
-      this.reloadAgentSessionInternal(agentId, overrides, options),
+      this.withProviderSubagentHistoryReloadBarrier(agentId, () =>
+        this.reloadAgentSessionInternal(agentId, overrides, options),
+      ),
     );
+  }
+
+  private async withProviderSubagentHistoryReloadBarrier<T>(
+    agentId: string,
+    operation: () => Promise<T>,
+    options?: { abortReason?: string },
+  ): Promise<T> {
+    let barrier: { promise: Promise<void>; release: () => void };
+    for (;;) {
+      const existing = this.providerSubagentHistoryReloadBarriers.get(agentId);
+      if (existing) {
+        await existing.promise;
+        continue;
+      }
+      let release!: () => void;
+      const promise = new Promise<void>((resolveBarrier) => {
+        release = resolveBarrier;
+      });
+      barrier = { promise, release };
+      this.providerSubagentHistoryReloadBarriers.set(agentId, barrier);
+      break;
+    }
+    try {
+      if (options?.abortReason) {
+        await this.abortProviderSubagentHistoryLoads(agentId, options.abortReason);
+      } else {
+        await this.drainProviderSubagentHistoryLoads(agentId);
+      }
+      return await operation();
+    } finally {
+      if (this.providerSubagentHistoryReloadBarriers.get(agentId) === barrier) {
+        this.providerSubagentHistoryReloadBarriers.delete(agentId);
+      }
+      barrier.release();
+    }
+  }
+
+  private async drainProviderSubagentHistoryLoads(agentId: string): Promise<void> {
+    const keyPrefix = `${agentId}\0`;
+    for (;;) {
+      const loads = [...this.providerSubagentHistoryLoads.entries()]
+        .filter(([key]) => key.startsWith(keyPrefix))
+        .map(([, load]) => load);
+      if (loads.length === 0) {
+        return;
+      }
+      const settlement = Promise.allSettled(loads.map((load) => load.promise)).then(
+        () => undefined,
+      );
+      const promptSettlement = await this.waitWithTimeout({
+        operation: settlement,
+        timeoutMs: this.rescueTimeouts.reloadSessionCloseMs,
+      });
+      if (promptSettlement === "completed") {
+        continue;
+      }
+      for (const load of loads) {
+        load.abortController.abort(new Error("Provider subagent history load aborted for reload"));
+      }
+      const abortedSettlement = await this.waitWithTimeout({
+        operation: settlement,
+        timeoutMs: this.rescueTimeouts.reloadSessionCloseMs,
+      });
+      if (abortedSettlement === "timed_out") {
+        this.logger.warn(
+          { agentId, timeoutMs: this.rescueTimeouts.reloadSessionCloseMs },
+          "Timed out aborting provider subagent history loads during refresh",
+        );
+        return;
+      }
+    }
+  }
+
+  private async abortProviderSubagentHistoryLoads(agentId: string, reason: string): Promise<void> {
+    const keyPrefix = `${agentId}\0`;
+    const loads = [...this.providerSubagentHistoryLoads.entries()].filter(([key]) =>
+      key.startsWith(keyPrefix),
+    );
+    if (loads.length === 0) {
+      return;
+    }
+    for (const [, load] of loads) {
+      load.abortController.abort(new Error(reason));
+    }
+    const settlement = Promise.allSettled(loads.map(([, load]) => load.promise)).then(
+      () => undefined,
+    );
+    const result = await this.waitWithTimeout({
+      operation: settlement,
+      timeoutMs: this.rescueTimeouts.reloadSessionCloseMs,
+    });
+    if (result === "completed") {
+      return;
+    }
+    for (const [key, load] of loads) {
+      if (this.providerSubagentHistoryLoads.get(key) === load) {
+        this.providerSubagentHistoryLoads.delete(key);
+      }
+    }
+    this.logger.warn(
+      { agentId, timeoutMs: this.rescueTimeouts.reloadSessionCloseMs },
+      "Timed out aborting provider subagent history loads while closing agent",
+    );
+  }
+
+  private async loadProviderSubagentHistoryWithAbort(
+    session: AgentSession,
+    subagentId: string,
+    signal: AbortSignal,
+  ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+    if (signal.aborted) {
+      throw createAbortError(signal, "Provider subagent history load aborted");
+    }
+    const operation = session.loadProviderSubagentHistory!(subagentId, { signal });
+    return await new Promise((resolveLoad, rejectLoad) => {
+      const onAbort = () => {
+        signal.removeEventListener("abort", onAbort);
+        rejectLoad(createAbortError(signal, "Provider subagent history load aborted"));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      void operation.then(
+        (events) => {
+          signal.removeEventListener("abort", onAbort);
+          resolveLoad(events);
+          return undefined;
+        },
+        (error: unknown) => {
+          signal.removeEventListener("abort", onAbort);
+          rejectLoad(error);
+          return undefined;
+        },
+      );
+    });
   }
 
   private async reloadAgentSessionInternal(
@@ -1391,6 +1575,11 @@ export class AgentManager {
     const preservedLastUsage = existing.lastUsage;
     const preservedLastError = existing.lastError;
     const preservedAttention = existing.attention;
+    const preservedLoadedProviderSubagentHistoryIds = rehydrateFromDisk
+      ? []
+      : (existing.session.getLoadedProviderSubagentHistoryIds?.() ?? []).filter((subagentId) =>
+          Boolean(this.providerSubagents.get(agentId, subagentId)),
+        );
     const handle = existing.persistence;
     const provider = handle?.provider ?? existing.provider;
     const client = this.requireClient(provider);
@@ -1407,6 +1596,9 @@ export class AgentManager {
       ? await client.resumeSession(handle, providerLaunchConfig, launchContext)
       : await client.createSession(providerLaunchConfig, launchContext);
     await this.requireExternalMcpSupport(session, storedConfig);
+    if (preservedLoadedProviderSubagentHistoryIds.length > 0) {
+      session.seedLoadedProviderSubagentHistoryIds?.(preservedLoadedProviderSubagentHistoryIds);
+    }
 
     let handedToRegistration = false;
     try {
@@ -1510,7 +1702,11 @@ export class AgentManager {
       return existing;
     }
 
-    const close = this.closeAgentRuntime(agentId);
+    const close = this.withProviderSubagentHistoryReloadBarrier(
+      agentId,
+      () => this.closeAgentRuntime(agentId),
+      { abortReason: "Provider subagent history load aborted because agent closed" },
+    );
     this.inFlightAgentCloses.set(agentId, close);
     const clearClose = () => {
       if (this.inFlightAgentCloses.get(agentId) === close) {
@@ -3540,8 +3736,7 @@ export class AgentManager {
     event: AgentStreamEvent,
   ): Promise<void> {
     if (event.type === "provider_subagent") {
-      const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
-      this.dispatch({ type: "provider_subagent", event: update });
+      this.dispatchProviderSubagentEvent(agent.id, event);
       return;
     }
     const turnId = getAgentStreamEventTurnId(event);
@@ -3579,6 +3774,14 @@ export class AgentManager {
       },
       "agent.manager.notify_waiters",
     );
+  }
+
+  private dispatchProviderSubagentEvent(
+    parentAgentId: string,
+    event: Extract<AgentStreamEvent, { type: "provider_subagent" }>,
+  ): void {
+    const update = this.providerSubagents.apply(parentAgentId, event.provider, event.event);
+    this.dispatch({ type: "provider_subagent", event: update });
   }
 
   private async resolveInitialPersistedTitle(

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -661,6 +661,19 @@ export interface AgentSession {
   steerActiveTurn?(prompt: AgentPromptInput, options: SteerActiveTurnOptions): Promise<SteerResult>;
   subscribe(callback: (event: AgentStreamEvent) => void): () => void;
   streamHistory(): AsyncGenerator<AgentStreamEvent>;
+  /**
+   * Load one provider-owned subagent history on demand, if the provider persists it separately.
+   * Returned events have not been published through subscribe; the manager ingests them directly
+   * so an explicit history read cannot be delayed behind foreground-turn admission barriers.
+   */
+  loadProviderSubagentHistory?(
+    subagentId: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]>;
+  /** Snapshot provider-owned child histories already imported into the manager timeline. */
+  getLoadedProviderSubagentHistoryIds?(): readonly string[];
+  /** Preserve completed child hydration when replacing a session without replacing its timeline. */
+  seedLoadedProviderSubagentHistoryIds?(subagentIds: readonly string[]): void;
   getRuntimeInfo(): Promise<AgentRuntimeInfo>;
   getAvailableModes(): Promise<AgentMode[]>;
   getCurrentMode(): Promise<string | null>;

--- a/packages/server/src/server/agent/agent-timeline-store.test.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.test.ts
@@ -2,6 +2,78 @@ import { describe, expect, it } from "vitest";
 import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
 
 describe("InMemoryAgentTimelineStore", () => {
+  it("indexes tool lifecycle bounds by call id", () => {
+    const store = new InMemoryAgentTimelineStore();
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      nextSeq: 8,
+      rows: [
+        {
+          seq: 5,
+          timestamp: "2026-01-01T00:00:00.000Z",
+          turnId: "turn-a",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "running",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: null },
+          },
+        },
+        {
+          seq: 6,
+          timestamp: "2026-01-01T00:00:01.000Z",
+          turnId: "turn-b",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "running",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: null },
+          },
+        },
+        {
+          seq: 7,
+          timestamp: "2026-01-01T00:00:02.000Z",
+          turnId: "turn-a",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "completed",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: "/workspace" },
+          },
+        },
+      ],
+    });
+
+    const appended = store.append(
+      "agent-1",
+      {
+        type: "tool_call",
+        callId: "call-2",
+        name: "shell",
+        status: "running",
+        error: null,
+        detail: { type: "shell", command: "ls", output: null },
+      },
+      { turnId: "turn-a" },
+    );
+
+    expect(store.getToolCallSeqBounds("agent-1", "call-1")).toEqual({
+      minSeq: 5,
+      maxSeq: 7,
+    });
+    expect(appended.seq).toBe(8);
+    expect(store.getToolCallSeqBounds("agent-1", "call-2")).toEqual({
+      minSeq: 8,
+      maxSeq: 8,
+    });
+  });
+
   it("clamps an overshooting before cursor into the bounded tail window", () => {
     const store = new InMemoryAgentTimelineStore();
     store.initialize("agent-1", {

--- a/packages/server/src/server/agent/agent-timeline-store.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.ts
@@ -18,12 +18,33 @@ interface AgentTimelineState {
   epoch: string;
   rows: AgentTimelineRow[];
   nextSeq: number;
+  toolCallSeqBounds: Map<string, ToolCallSeqBounds>;
+}
+
+export interface ToolCallSeqBounds {
+  minSeq: number;
+  maxSeq: number;
 }
 
 const DEFAULT_TIMELINE_FETCH_LIMIT = 200;
 
 function cloneRow(row: AgentTimelineRow): AgentTimelineRow {
   return { ...row };
+}
+
+function indexToolCallRow(
+  boundsByCall: Map<string, ToolCallSeqBounds>,
+  row: AgentTimelineRow,
+): void {
+  if (row.item.type !== "tool_call") {
+    return;
+  }
+  const key = row.item.callId;
+  const previous = boundsByCall.get(key);
+  boundsByCall.set(key, {
+    minSeq: previous ? Math.min(previous.minSeq, row.seq) : row.seq,
+    maxSeq: previous ? Math.max(previous.maxSeq, row.seq) : row.seq,
+  });
 }
 
 interface FetchContext {
@@ -95,11 +116,9 @@ function fetchBefore(ctx: FetchContext): AgentTimelineFetchResult {
   const { state, direction, limit, selectAll, cursor, minSeq, window } = ctx;
   const beforeSeq = cursor?.seq ?? state.nextSeq;
   const endExclusive = state.rows.findIndex((row) => row.seq >= beforeSeq);
-  const boundedRows = endExclusive < 0 ? state.rows : state.rows.slice(0, endExclusive);
-  const selected =
-    selectAll || limit >= boundedRows.length
-      ? boundedRows
-      : boundedRows.slice(boundedRows.length - limit);
+  const boundedLength = endExclusive < 0 ? state.rows.length : endExclusive;
+  const startInclusive = selectAll ? 0 : Math.max(0, boundedLength - limit);
+  const selected = state.rows.slice(startInclusive, boundedLength);
   return {
     epoch: state.epoch,
     direction,
@@ -148,10 +167,15 @@ export class InMemoryAgentTimelineStore {
       ? options.rows.map(cloneRow)
       : this.buildRowsFromItems(options?.items ?? [], options?.nextSeq ?? 1, timestamp);
     const nextSeq = options?.nextSeq ?? (rows.length ? rows[rows.length - 1].seq + 1 : 1);
+    const toolCallSeqBounds = new Map<string, ToolCallSeqBounds>();
+    for (const row of rows) {
+      indexToolCallRow(toolCallSeqBounds, row);
+    }
     this.states.set(agentId, {
       epoch: options?.epoch ?? randomUUID(),
       rows,
       nextSeq,
+      toolCallSeqBounds,
     });
   }
 
@@ -198,6 +222,16 @@ export class InMemoryAgentTimelineStore {
 
   getEpoch(agentId: string): string {
     return this.requireState(agentId).epoch;
+  }
+
+  /**
+   * Tool projection stays anchored at the first row for a call while later lifecycle rows extend
+   * its canonical span. Bounded consumers use these indexed bounds to decide whether a page must
+   * grow without first cloning the complete timeline.
+   */
+  getToolCallSeqBounds(agentId: string, callId: string): ToolCallSeqBounds | null {
+    const bounds = this.requireState(agentId).toolCallSeqBounds.get(callId);
+    return bounds ? { ...bounds } : null;
   }
 
   fetch(agentId: string, options?: AgentTimelineFetchOptions): AgentTimelineFetchResult {
@@ -276,6 +310,7 @@ export class InMemoryAgentTimelineStore {
     };
     state.nextSeq += 1;
     state.rows.push(row);
+    indexToolCallRow(state.toolCallSeqBounds, row);
     return cloneRow(row);
   }
 

--- a/packages/server/src/server/agent/provider-subagents/store.test.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, test } from "vitest";
+import { InMemoryAgentTimelineStore } from "../agent-timeline-store.js";
+import type {
+  AgentTimelineFetchOptions,
+  AgentTimelineFetchResult,
+} from "../agent-timeline-store-types.js";
 import { ProviderSubagentStore } from "./store.js";
+
+class RecordingTimelineStore extends InMemoryAgentTimelineStore {
+  readonly fetches: Array<{
+    options: AgentTimelineFetchOptions | undefined;
+    result: AgentTimelineFetchResult;
+  }> = [];
+
+  override fetch(agentId: string, options?: AgentTimelineFetchOptions): AgentTimelineFetchResult {
+    const result = super.fetch(agentId, options);
+    this.fetches.push({ options, result });
+    return result;
+  }
+}
 
 describe("ProviderSubagentStore", () => {
   test("keeps provider children and their timelines scoped to the parent agent", () => {
@@ -102,5 +120,246 @@ describe("ProviderSubagentStore", () => {
     expect(page.rows[0]?.seq).toBe(1);
     expect(page.rows.at(-1)?.seq).toBe(101);
     expect(page.hasOlder).toBe(false);
+  });
+
+  test("fetches a bounded canonical tail for nonmergeable provider history", () => {
+    const timelines = new RecordingTimelineStore();
+    const subagents = new ProviderSubagentStore(timelines);
+    for (let index = 1; index <= 600; index += 1) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: { type: "user_message", text: `message ${index}` },
+      });
+    }
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: "tail",
+      limit: 100,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual(
+      Array.from({ length: 100 }, (_, index) => index + 501),
+    );
+    expect(page.hasOlder).toBe(true);
+    expect(
+      timelines.fetches.map(({ options, result }) => ({
+        direction: options?.direction,
+        limit: options?.limit,
+        rowCount: result.rows.length,
+      })),
+    ).toEqual([{ direction: "tail", limit: 100, rowCount: 100 }]);
+  });
+
+  test("does not scan older history for a tool lifecycle inside the projected page", () => {
+    const timelines = new RecordingTimelineStore();
+    const subagents = new ProviderSubagentStore(timelines);
+    for (let index = 1; index <= 194; index += 1) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: { type: "user_message", text: `message ${index}` },
+      });
+    }
+    for (const status of ["running", "completed"] as const) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: {
+          type: "tool_call",
+          callId: "call-1",
+          name: "shell",
+          status,
+          error: null,
+          detail: { type: "shell", command: "pwd", output: "/workspace" },
+        },
+      });
+    }
+    for (let index = 197; index <= 200; index += 1) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: { type: "user_message", text: `message ${index}` },
+      });
+    }
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: "tail",
+      limit: 10,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual(
+      Array.from({ length: 11 }, (_, index) => index + 190),
+    );
+    expect(
+      timelines.fetches.map(({ options, result }) => ({
+        direction: options?.direction,
+        limit: options?.limit,
+        rowCount: result.rows.length,
+      })),
+    ).toEqual([
+      { direction: "tail", limit: 10, rowCount: 10 },
+      { direction: "before", limit: 10, rowCount: 10 },
+    ]);
+  });
+
+  test("expands to the projected anchor of a tool update inside the canonical tail", () => {
+    const timelines = new RecordingTimelineStore();
+    const subagents = new ProviderSubagentStore(timelines);
+    for (let seq = 1; seq <= 600; seq += 1) {
+      const item =
+        seq === 1 || seq === 501
+          ? {
+              type: "tool_call" as const,
+              callId: "call-1",
+              name: "shell",
+              status: seq === 1 ? ("running" as const) : ("completed" as const),
+              error: null,
+              detail: { type: "shell" as const, command: "pwd", output: "/workspace" },
+            }
+          : { type: "user_message" as const, text: `message ${seq}` };
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item,
+      });
+    }
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: "tail",
+      limit: 100,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual(
+      Array.from({ length: 600 }, (_, index) => index + 1),
+    );
+    expect(page.hasOlder).toBe(false);
+    expect(
+      timelines.fetches.map(({ options, result }) => ({
+        limit: options?.limit,
+        rowCount: result.rows.length,
+      })),
+    ).toEqual([
+      { limit: 100, rowCount: 100 },
+      { limit: 100, rowCount: 100 },
+      { limit: 200, rowCount: 200 },
+      { limit: 200, rowCount: 200 },
+    ]);
+  });
+
+  test("preserves call-id projection behavior when a later turn reuses the call id", () => {
+    const timelines = new RecordingTimelineStore();
+    timelines.initialize("parent-a\0child-1", {
+      epoch: "epoch-1",
+      nextSeq: 6,
+      rows: [
+        {
+          seq: 1,
+          timestamp: "2026-01-01T00:00:00.000Z",
+          turnId: "turn-a",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "running",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: null },
+          },
+        },
+        {
+          seq: 2,
+          timestamp: "2026-01-01T00:00:01.000Z",
+          item: { type: "user_message", text: "between turns" },
+        },
+        {
+          seq: 3,
+          timestamp: "2026-01-01T00:00:02.000Z",
+          turnId: "turn-b",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "running",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: null },
+          },
+        },
+        {
+          seq: 4,
+          timestamp: "2026-01-01T00:00:03.000Z",
+          item: { type: "user_message", text: "work continues" },
+        },
+        {
+          seq: 5,
+          timestamp: "2026-01-01T00:00:04.000Z",
+          turnId: "turn-b",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "completed",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: "/workspace" },
+          },
+        },
+      ],
+    });
+    const subagents = new ProviderSubagentStore(timelines);
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: "tail",
+      limit: 1,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual([5]);
+  });
+
+  test.each([
+    {
+      direction: "before" as const,
+      cursorSeq: 103,
+      expectedHasOlder: true,
+      expectedHasNewer: true,
+    },
+    {
+      direction: "after" as const,
+      cursorSeq: 1,
+      expectedHasOlder: true,
+      expectedHasNewer: true,
+    },
+  ])("expands $direction pages to complete a projected item", (input) => {
+    const timelines = new RecordingTimelineStore();
+    const subagents = new ProviderSubagentStore(timelines);
+    subagents.apply("parent-a", "opencode", {
+      type: "timeline",
+      id: "child-1",
+      item: { type: "user_message", text: "before" },
+    });
+    for (let index = 0; index < 101; index += 1) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: { type: "assistant_message", text: String(index) },
+      });
+    }
+    subagents.apply("parent-a", "opencode", {
+      type: "timeline",
+      id: "child-1",
+      item: { type: "user_message", text: "after" },
+    });
+    const epoch = timelines.getEpoch("parent-a\0child-1");
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: input.direction,
+      cursor: { epoch, seq: input.cursorSeq },
+      limit: 1,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual(
+      Array.from({ length: 101 }, (_, index) => index + 2),
+    );
+    expect(page.hasOlder).toBe(input.expectedHasOlder);
+    expect(page.hasNewer).toBe(input.expectedHasNewer);
+    expect(timelines.fetches.every(({ options }) => options?.limit !== 0)).toBe(true);
   });
 });

--- a/packages/server/src/server/agent/provider-subagents/store.test.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.test.ts
@@ -311,7 +311,7 @@ describe("ProviderSubagentStore", () => {
       limit: 1,
     });
 
-    expect(page.rows.map((row) => row.seq)).toEqual([5]);
+    expect(page.rows.map((row) => row.seq)).toEqual([3, 4, 5]);
   });
 
   test.each([

--- a/packages/server/src/server/agent/provider-subagents/store.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.ts
@@ -73,9 +73,83 @@ function stickyField<T>(next: T | undefined, previous: T | null | undefined): T 
   return next === undefined ? (previous ?? null) : next;
 }
 
+export type ProviderSubagentTimelineStore = Pick<
+  InMemoryAgentTimelineStore,
+  "append" | "delete" | "fetch" | "getEpoch" | "getToolCallSeqBounds" | "has" | "initialize"
+>;
+
+const MAX_CANONICAL_PAGE_SIZE = 200;
+
+function initialCanonicalPageSize(projectedLimit: number): number {
+  if (projectedLimit === 0) {
+    return MAX_CANONICAL_PAGE_SIZE;
+  }
+  return Math.min(MAX_CANONICAL_PAGE_SIZE, Math.max(1, projectedLimit));
+}
+
+function expansionPageSize(accumulatedRows: number): number {
+  return Math.min(MAX_CANONICAL_PAGE_SIZE, Math.max(1, accumulatedRows));
+}
+
+function projectedSelectionNeedsMoreRows(input: {
+  direction: NonNullable<AgentTimelineFetchOptions["direction"]>;
+  limit: number;
+  timeline: AgentTimelineFetchResult;
+  rows: readonly AgentTimelineRow[];
+  selected: ReturnType<typeof selectTimelineWindowByProjectedLimit>;
+  getToolCallSeqBounds: (callId: string) => { minSeq: number; maxSeq: number } | null;
+}): "older" | "newer" | null {
+  const { direction, limit, timeline, rows, selected, getToolCallSeqBounds } = input;
+  const firstRow = rows[0];
+  const lastRow = rows.at(-1);
+  if (!firstRow || !lastRow) {
+    return null;
+  }
+
+  const expandToward = direction === "after" ? "newer" : "older";
+  const hasMore =
+    expandToward === "newer"
+      ? lastRow.seq < timeline.window.maxSeq
+      : firstRow.seq > timeline.window.minSeq;
+  if (!hasMore) {
+    return null;
+  }
+
+  if (limit === 0 || selected.projectedEntries.length < limit) {
+    return expandToward;
+  }
+
+  const hasToolCallRowsBeyondPage = selected.projectedEntries.some((entry) => {
+    if (entry.item.type !== "tool_call") {
+      return false;
+    }
+    const bounds = getToolCallSeqBounds(entry.item.callId);
+    if (!bounds) {
+      return false;
+    }
+    return expandToward === "newer" ? bounds.maxSeq > lastRow.seq : bounds.minSeq < firstRow.seq;
+  });
+  if (hasToolCallRowsBeyondPage) {
+    return expandToward;
+  }
+
+  const boundarySeq = expandToward === "newer" ? lastRow.seq : firstRow.seq;
+  const canMergeAcrossBoundary = selected.projectedEntries.some(
+    (entry) =>
+      entry.sourceSeqRanges.some(
+        (range) => boundarySeq >= range.startSeq && boundarySeq <= range.endSeq,
+      ) &&
+      (entry.item.type === "assistant_message" || entry.item.type === "reasoning"),
+  );
+  return canMergeAcrossBoundary ? expandToward : null;
+}
+
 export class ProviderSubagentStore {
   private readonly descriptors = new Map<string, ProviderSubagentDescriptor>();
-  private readonly timelines = new InMemoryAgentTimelineStore();
+
+  constructor(
+    private readonly timelines: ProviderSubagentTimelineStore = new InMemoryAgentTimelineStore(),
+  ) {}
 
   apply(
     parentAgentId: string,
@@ -149,27 +223,60 @@ export class ProviderSubagentStore {
   ): AgentTimelineFetchResult {
     const direction = options?.direction ?? "tail";
     const limit = options?.limit === undefined ? 200 : Math.max(0, Math.floor(options.limit));
-    const timeline = this.timelines.fetch(storeKey(parentAgentId, subagentId), {
+    const key = storeKey(parentAgentId, subagentId);
+    const timeline = this.timelines.fetch(key, {
       ...options,
-      limit: 0,
+      limit: initialCanonicalPageSize(limit),
     });
-    if (limit === 0 || timeline.rows.length === 0) {
+    if (timeline.rows.length === 0) {
       return timeline;
     }
-    const selected = selectTimelineWindowByProjectedLimit({
-      rows: timeline.rows,
-      direction: timeline.reset ? "tail" : direction,
+    const selectionDirection = timeline.reset ? "tail" : direction;
+    let rows = timeline.rows;
+    let selected = selectTimelineWindowByProjectedLimit({
+      rows,
+      direction: selectionDirection,
       limit,
     });
+    for (;;) {
+      const expandToward = projectedSelectionNeedsMoreRows({
+        direction: selectionDirection,
+        limit,
+        timeline,
+        rows,
+        selected,
+        getToolCallSeqBounds: (callId) => this.timelines.getToolCallSeqBounds(key, callId),
+      });
+      if (!expandToward) {
+        break;
+      }
+
+      const boundaryRow = expandToward === "older" ? rows[0] : rows.at(-1);
+      if (!boundaryRow) {
+        break;
+      }
+      const page = this.timelines.fetch(key, {
+        direction: expandToward === "older" ? "before" : "after",
+        cursor: { epoch: timeline.epoch, seq: boundaryRow.seq },
+        limit: expansionPageSize(rows.length),
+      });
+      if (page.rows.length === 0) {
+        break;
+      }
+      rows = expandToward === "older" ? [...page.rows, ...rows] : [...rows, ...page.rows];
+      selected = selectTimelineWindowByProjectedLimit({
+        rows,
+        direction: selectionDirection,
+        limit,
+      });
+    }
     const firstRow = selected.selectedRows[0];
     const lastRow = selected.selectedRows[selected.selectedRows.length - 1];
     return {
       ...timeline,
       rows: selected.selectedRows,
-      hasOlder:
-        timeline.hasOlder || (firstRow !== undefined && firstRow.seq > timeline.window.minSeq),
-      hasNewer:
-        timeline.hasNewer || (lastRow !== undefined && lastRow.seq < timeline.window.maxSeq),
+      hasOlder: firstRow ? firstRow.seq > timeline.window.minSeq : timeline.hasOlder,
+      hasNewer: lastRow ? lastRow.seq < timeline.window.maxSeq : timeline.hasNewer,
     };
   }
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -94,6 +94,7 @@ import {
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { asInternals as castInternals, createStub } from "../../test-utils/class-mocks.js";
 import { buildProviderRegistry } from "../provider-registry.js";
+import { ProviderSubagentStore } from "../provider-subagents/store.js";
 
 interface CollaborationModeRecord {
   name: string;
@@ -4292,6 +4293,1034 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("loads only root history and persisted child descriptors during resume", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [
+                        {
+                          type: "agentMessage",
+                          id: "child-message-history",
+                          text: "Child history must remain lazy.",
+                        },
+                      ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+
+    await asInternals(session).loadPersistedHistory();
+
+    const history: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      history.push(event);
+    }
+
+    expect(requestedThreadIds).toEqual(["test-thread"]);
+    expect(history).toContainEqual({
+      type: "provider_subagent",
+      provider: "codex",
+      event: expect.objectContaining({
+        type: "upsert",
+        id: "history-child-thread",
+      }),
+    });
+    expect(
+      history.some(
+        (event) => event.type === "provider_subagent" && event.event.type === "timeline",
+      ),
+    ).toBe(false);
+  });
+
+  test("loads one persisted child history only when that child is requested", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [
+                        {
+                          type: "agentMessage",
+                          id: "child-message-history",
+                          text: "Loaded on demand.",
+                        },
+                      ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing the lazy child load.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-child-thread")));
+
+    expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider_subagent",
+        provider: "codex",
+        event: {
+          type: "timeline",
+          id: "history-child-thread",
+          item: {
+            type: "assistant_message",
+            messageId: "child-message-history",
+            text: "Loaded on demand.",
+          },
+        },
+      }),
+    );
+  });
+
+  test("accepts a completed child hydration seed from a history-preserving reload", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before restoring the completed child hydration marker.
+    }
+    session.seedLoadedProviderSubagentHistoryIds(["history-child-thread"]);
+
+    expect(session.getLoadedProviderSubagentHistoryIds()).toEqual(["history-child-thread"]);
+    await expect(session.loadProviderSubagentHistory("history-child-thread")).resolves.toEqual([]);
+    expect(requestedThreadIds).toEqual(["test-thread"]);
+  });
+
+  test("shares one persisted child read across concurrent timeline requests", async () => {
+    const session = createSession();
+    const childRead = deferred<unknown>();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        if (threadId === "history-child-thread") {
+          return childRead.promise;
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+
+    const first = session.loadProviderSubagentHistory!("history-child-thread");
+    const second = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => {
+      expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+    });
+    childRead.resolve({
+      thread: {
+        turns: [
+          {
+            items: [
+              {
+                type: "agentMessage",
+                id: "child-message-history",
+                text: "Loaded once.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await Promise.all([first, second]);
+    await session.loadProviderSubagentHistory!("history-child-thread");
+
+    expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+  });
+
+  test("registers nested persisted child descriptors without reading descendants eagerly", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        const itemsByThreadId: Record<string, unknown[]> = {
+          "test-thread": [
+            {
+              type: "subAgentActivity",
+              id: "child-started-history",
+              kind: "started",
+              agentThreadId: "history-child-thread",
+              agentPath: "/root/history-child",
+            },
+          ],
+          "history-child-thread": [
+            {
+              type: "subAgentActivity",
+              id: "nested-started-history",
+              kind: "started",
+              agentThreadId: "history-grandchild-thread",
+              agentPath: "/root/history-child/history-grandchild",
+            },
+          ],
+          "history-grandchild-thread": [
+            {
+              type: "agentMessage",
+              id: "grandchild-message-history",
+              text: "Nested history loaded on demand.",
+            },
+          ],
+        };
+        return {
+          thread: { turns: [{ items: itemsByThreadId[threadId] ?? [] }] },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-child-thread")));
+
+    expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider_subagent",
+        provider: "codex",
+        event: expect.objectContaining({
+          type: "upsert",
+          id: "history-grandchild-thread",
+        }),
+      }),
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.type === "provider_subagent" &&
+          event.event.type === "timeline" &&
+          event.event.id === "history-grandchild-thread",
+      ),
+    ).toBe(false);
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-grandchild-thread")));
+
+    expect(requestedThreadIds).toEqual([
+      "test-thread",
+      "history-child-thread",
+      "history-grandchild-thread",
+    ]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider_subagent",
+        provider: "codex",
+        event: expect.objectContaining({
+          type: "timeline",
+          id: "history-grandchild-thread",
+          item: expect.objectContaining({
+            type: "assistant_message",
+            text: "Nested history loaded on demand.",
+          }),
+        }),
+      }),
+    );
+  });
+
+  test("orders persisted child history before concurrent live events and deduplicates replay", async () => {
+    const session = createSession();
+    const childRead = deferred<unknown>();
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "history-child-thread") {
+          return childRead.promise;
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const load = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => {
+      expect(session.client?.request).toHaveBeenCalledWith("thread/read", {
+        threadId: "history-child-thread",
+        includeTurns: true,
+      });
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "history-child-thread",
+      item: {
+        type: "userMessage",
+        id: "child-live-message",
+        content: [{ type: "text", text: "Concurrent child message." }],
+      },
+    });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-live-assistant",
+      delta: "First live fragment. ",
+    });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-live-assistant",
+      delta: "Second live fragment.",
+    });
+    expect(
+      events.filter(
+        (event) => event.type === "provider_subagent" && event.event.type === "timeline",
+      ),
+    ).toEqual([]);
+
+    childRead.resolve({
+      thread: {
+        turns: [
+          {
+            items: [
+              {
+                type: "agentMessage",
+                id: "child-persisted-message",
+                text: "Persisted history first.",
+              },
+              {
+                type: "userMessage",
+                id: "child-live-message",
+                content: [{ type: "text", text: "Concurrent child message." }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    events.push(...(await load));
+
+    expect(
+      events.flatMap((event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "timeline" &&
+        event.event.id === "history-child-thread"
+          ? [event.event.item]
+          : [],
+      ),
+    ).toEqual([
+      {
+        type: "assistant_message",
+        messageId: "child-persisted-message",
+        text: "Persisted history first.",
+      },
+      {
+        type: "user_message",
+        messageId: "child-live-message",
+        text: "Concurrent child message.",
+      },
+      {
+        type: "assistant_message",
+        messageId: "child-live-assistant",
+        text: "First live fragment. ",
+      },
+      {
+        type: "assistant_message",
+        messageId: "child-live-assistant",
+        text: "Second live fragment.",
+      },
+    ]);
+  });
+
+  test("buffers live events for a persisted child before its first history request", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [
+                        {
+                          type: "agentMessage",
+                          id: "child-persisted-message",
+                          text: "Older persisted history.",
+                        },
+                        {
+                          type: "userMessage",
+                          id: "child-live-before-request",
+                          content: [{ type: "text", text: "Live before first request." }],
+                        },
+                      ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "history-child-thread",
+      item: {
+        type: "userMessage",
+        id: "child-live-before-request",
+        content: [{ type: "text", text: "Live before first request." }],
+      },
+    });
+
+    expect(
+      events.filter(
+        (event) => event.type === "provider_subagent" && event.event.type === "timeline",
+      ),
+    ).toEqual([]);
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-child-thread")));
+
+    expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+    expect(
+      events.flatMap((event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "timeline" &&
+        event.event.id === "history-child-thread"
+          ? [event.event.item]
+          : [],
+      ),
+    ).toEqual([
+      {
+        type: "assistant_message",
+        messageId: "child-persisted-message",
+        text: "Older persisted history.",
+      },
+      {
+        type: "user_message",
+        messageId: "child-live-before-request",
+        text: "Live before first request.",
+      },
+    ]);
+  });
+
+  test("publishes persisted child running status before its history is requested", async () => {
+    const session = createSession();
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    const store = new ProviderSubagentStore();
+    for await (const event of session.streamHistory()) {
+      if (event.type === "provider_subagent") {
+        store.apply("parent-agent", event.provider, event.event);
+      }
+    }
+    expect(store.list("parent-agent")).toEqual([
+      expect.objectContaining({ id: "history-child-thread", status: "completed" }),
+    ]);
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+      if (event.type === "provider_subagent") {
+        store.apply("parent-agent", event.provider, event.event);
+      }
+    });
+
+    asInternals(session).handleNotification("turn/started", {
+      threadId: "history-child-thread",
+      turn: { id: "history-child-live-turn" },
+    });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider_subagent",
+        provider: "codex",
+        event: expect.objectContaining({
+          type: "upsert",
+          id: "history-child-thread",
+          status: "running",
+        }),
+      }),
+    );
+    expect(store.list("parent-agent")).toEqual([
+      expect.objectContaining({ id: "history-child-thread", status: "running" }),
+    ]);
+    expect(session.client.request).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not replay stale tool lifecycle rows over terminal persisted history", async () => {
+    const session = createSession();
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [
+                        {
+                          type: "commandExecution",
+                          id: "child-tool-call",
+                          status: "completed",
+                          command: "printf done",
+                          aggregatedOutput: "done",
+                          exitCode: 0,
+                        },
+                      ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain the persisted descriptor before buffering newer child activity.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/started", {
+      threadId: "history-child-thread",
+      item: {
+        type: "commandExecution",
+        id: "child-tool-call",
+        status: "inProgress",
+        command: "printf done",
+      },
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "history-child-thread",
+      item: {
+        type: "commandExecution",
+        id: "child-tool-call",
+        status: "completed",
+        command: "printf done",
+        aggregatedOutput: "done",
+        exitCode: 0,
+      },
+    });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-live-fragment",
+      delta: "Distinct live fragment.",
+    });
+
+    const loaded = await session.loadProviderSubagentHistory!("history-child-thread");
+    const loadedItems = loaded.flatMap((event) =>
+      event.event.type === "timeline" && event.event.id === "history-child-thread"
+        ? [event.event.item]
+        : [],
+    );
+
+    expect(
+      loadedItems.flatMap((item) =>
+        item.type === "tool_call" && item.callId === "child-tool-call" ? [item.status] : [],
+      ),
+    ).toEqual(["completed"]);
+    expect(loadedItems).toContainEqual({
+      type: "assistant_message",
+      messageId: "child-live-fragment",
+      text: "Distinct live fragment.",
+    });
+  });
+
+  test("replays live child events after a failed history read and allows retry", async () => {
+    const session = createSession();
+    const firstChildRead = deferred<unknown>();
+    let childReadCount = 0;
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "history-child-thread") {
+          childReadCount += 1;
+          if (childReadCount === 1) {
+            return firstChildRead.promise;
+          }
+          return {
+            thread: {
+              turns: [
+                {
+                  items: [
+                    {
+                      type: "agentMessage",
+                      id: "child-message-after-retry",
+                      text: "Retry succeeded.",
+                    },
+                    {
+                      type: "userMessage",
+                      id: "child-live-during-failure",
+                      content: [{ type: "text", text: "Do not lose this live event." }],
+                    },
+                  ],
+                },
+              ],
+            },
+          };
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const firstLoad = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => expect(childReadCount).toBe(1));
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "history-child-thread",
+      item: {
+        type: "userMessage",
+        id: "child-live-during-failure",
+        content: [{ type: "text", text: "Do not lose this live event." }],
+      },
+    });
+    firstChildRead.resolve(Promise.reject(new Error("history unavailable")));
+
+    await expect(firstLoad).rejects.toThrow("history unavailable");
+    expect(
+      events.flatMap((event) =>
+        event.type === "provider_subagent" && event.event.type === "timeline"
+          ? [event.event.item]
+          : [],
+      ),
+    ).toEqual([]);
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-child-thread")));
+
+    expect(childReadCount).toBe(2);
+    expect(
+      events.flatMap((event) =>
+        event.type === "provider_subagent" && event.event.type === "timeline"
+          ? [event.event.item]
+          : [],
+      ),
+    ).toEqual([
+      {
+        type: "assistant_message",
+        messageId: "child-message-after-retry",
+        text: "Retry succeeded.",
+      },
+      {
+        type: "user_message",
+        messageId: "child-live-during-failure",
+        text: "Do not lose this live event.",
+      },
+    ]);
+  });
+
+  test("aborts a stuck persisted child read and leaves it retryable", async () => {
+    const session = createSession();
+    let childReadCount = 0;
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "history-child-thread") {
+          childReadCount += 1;
+          if (childReadCount === 1) {
+            return await new Promise(() => undefined);
+          }
+          return {
+            thread: {
+              turns: [
+                {
+                  items: [
+                    {
+                      type: "agentMessage",
+                      id: "child-message-after-abort",
+                      text: "Retry after abort succeeded.",
+                    },
+                  ],
+                },
+              ],
+            },
+          };
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const abortController = new AbortController();
+    const firstLoad = session.loadProviderSubagentHistory!("history-child-thread", {
+      signal: abortController.signal,
+    });
+    await vi.waitFor(() => expect(childReadCount).toBe(1));
+
+    abortController.abort(new Error("reload canceled child history"));
+
+    await expect(firstLoad).rejects.toThrow("reload canceled child history");
+    await expect(
+      session.loadProviderSubagentHistory!("history-child-thread"),
+    ).resolves.toMatchObject([
+      {
+        event: {
+          type: "timeline",
+          id: "history-child-thread",
+          item: {
+            type: "assistant_message",
+            messageId: "child-message-after-abort",
+            text: "Retry after abort succeeded.",
+          },
+        },
+      },
+    ]);
+    expect(childReadCount).toBe(2);
+  });
+
+  test("discards a child read that resolves after persisted root history reloads", async () => {
+    const session = createSession();
+    const staleChildRead = deferred<unknown>();
+    let rootReadCount = 0;
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "history-child-thread") {
+          return staleChildRead.promise;
+        }
+        rootReadCount += 1;
+        const childThreadId = rootReadCount === 1 ? "history-child-thread" : "replacement-child";
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: `child-started-${rootReadCount}`,
+                    kind: "started",
+                    agentThreadId: childThreadId,
+                    agentPath: `/root/${childThreadId}`,
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain the first root generation.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const staleLoad = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => {
+      expect(session.client?.request).toHaveBeenCalledWith("thread/read", {
+        threadId: "history-child-thread",
+        includeTurns: true,
+      });
+    });
+    await asInternals(session).loadPersistedHistory();
+    staleChildRead.resolve({
+      thread: {
+        turns: [
+          {
+            items: [
+              {
+                type: "agentMessage",
+                id: "stale-child-message",
+                text: "Must not escape the old generation.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    await staleLoad;
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "provider_subagent" &&
+          event.event.type === "timeline" &&
+          event.event.id === "history-child-thread",
+      ),
+    ).toBe(false);
+  });
+
+  test("discards a child read that resolves after the session closes", async () => {
+    const session = createSession();
+    const staleChildRead = deferred<unknown>();
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        if ((params as { threadId?: string }).threadId === "history-child-thread") {
+          return staleChildRead.promise;
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+      notify: vi.fn(),
+      dispose: vi.fn(async () => undefined),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before starting the stale child read.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const staleLoad = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => {
+      expect(session.client?.request).toHaveBeenCalledWith("thread/read", {
+        threadId: "history-child-thread",
+        includeTurns: true,
+      });
+    });
+    await session.close();
+    staleChildRead.resolve({
+      thread: {
+        turns: [
+          {
+            items: [
+              {
+                type: "agentMessage",
+                id: "stale-child-message",
+                text: "Must not emit after close.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    await staleLoad;
+
+    expect(events).toEqual([]);
+  });
+
   test("loads mixed legacy and MultiAgentV2 sub-agent history", async () => {
     const session = createSession();
     session.client = {
@@ -4376,6 +5405,20 @@ describe("Codex app-server provider", () => {
       history.flatMap((event) =>
         event.type === "provider_subagent" && event.event.type === "timeline" ? [event.event] : [],
       ),
+    ).toEqual([]);
+    const liveEvents: AgentStreamEvent[] = [];
+    session.subscribe((event) => liveEvents.push(event));
+
+    const loadedEvents = await Promise.all([
+      session.loadProviderSubagentHistory!("legacy-child-thread"),
+      session.loadProviderSubagentHistory!("v2-child-thread"),
+    ]);
+    liveEvents.push(...loadedEvents.flat());
+
+    expect(
+      liveEvents.flatMap((event) =>
+        event.type === "provider_subagent" && event.event.type === "timeline" ? [event.event] : [],
+      ),
     ).toEqual([
       {
         type: "timeline",
@@ -4417,8 +5460,7 @@ describe("Codex app-server provider", () => {
       },
     ]);
 
-    const liveEvents: AgentStreamEvent[] = [];
-    session.subscribe((event) => liveEvents.push(event));
+    liveEvents.length = 0;
     asInternals(session).handleNotification("turn/started", {
       threadId: "v2-child-thread",
       turn: { id: "v2-child-turn-after-resume" },

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -138,6 +138,7 @@ type TurnTerminalEvent = Extract<
 const ONE_BY_ONE_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X1r0AAAAASUVORK5CYII=";
 const CODEX_PROVIDER = "codex";
+const MAX_SERIALIZED_PARENT_SUB_AGENT_SNAPSHOT_BYTES = 64_000;
 
 function createConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSessionConfig {
   return {
@@ -147,6 +148,13 @@ function createConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSession
     model: "gpt-5.4",
     ...overrides,
   };
+}
+
+function hasOnlyWellFormedCodePoints(text: string): boolean {
+  return Array.from(text).every((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return character.length > 1 || codePoint < 0xd800 || codePoint > 0xdfff;
+  });
 }
 
 function createSession(
@@ -2651,6 +2659,383 @@ describe("Codex app-server provider", () => {
       id: "child-thread-1",
       status: "completed",
     });
+  });
+
+  test("keeps parent sub-agent snapshots bounded while retaining canonical child activity", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-bounded-child",
+        kind: "started",
+        agentThreadId: "bounded-child-thread",
+        agentPath: "/root/bounded-child",
+      },
+    });
+    const childMessages = Array.from({ length: 20 }, (_, index) => {
+      const marker = index === 0 ? "oldest-marker" : `activity-${index}`;
+      const latestMarker = index === 19 ? " newest-marker" : "";
+      return `${String.fromCharCode(97 + index).repeat(16_000)} ${marker}${latestMarker}`;
+    });
+    for (const [index, text] of childMessages.entries()) {
+      asInternals(session).handleNotification("item/completed", {
+        threadId: "bounded-child-thread",
+        item: {
+          type: "agentMessage",
+          id: `bounded-child-message-${index}`,
+          text,
+        },
+      });
+    }
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "bounded-child-thread",
+      turn: { status: "completed" },
+    });
+
+    const parentSnapshots = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-bounded-child" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item]
+        : [],
+    );
+    expect(parentSnapshots.length).toBeGreaterThan(1);
+    expect(
+      parentSnapshots.every((item) => Buffer.byteLength(item.detail.log, "utf8") <= 32_000),
+    ).toBe(true);
+    const serializedParentBytes = parentSnapshots.reduce(
+      (total, item) => total + Buffer.byteLength(JSON.stringify(item), "utf8"),
+      0,
+    );
+    expect(serializedParentBytes).toBeLessThanOrEqual(parentSnapshots.length * 33_000);
+    expect(parentSnapshots.at(-1)).toMatchObject({ status: "completed" });
+    expect(parentSnapshots.at(-1)?.detail.log).not.toContain("oldest-marker");
+    expect(parentSnapshots.at(-1)?.detail.log).toContain("newest-marker");
+
+    const canonicalMessages = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "bounded-child-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalMessages).toEqual(childMessages);
+  });
+
+  test("bounds the root sub-agent prompt in the complete emitted snapshot", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    const prompt = `${"p".repeat(1_000_000)} newest-prompt-marker`;
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-large-prompt-child",
+        tool: "spawnAgent",
+        status: "inProgress",
+        prompt,
+        receiverThreadIds: [],
+        agentsStates: {},
+      },
+    });
+
+    const rootSnapshot = events.find(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "spawn-large-prompt-child",
+    );
+    if (rootSnapshot?.type !== "timeline" || rootSnapshot.item.type !== "tool_call") {
+      throw new Error("Expected root sub-agent snapshot");
+    }
+    expect(Buffer.byteLength(JSON.stringify(rootSnapshot.item), "utf8")).toBeLessThanOrEqual(
+      MAX_SERIALIZED_PARENT_SUB_AGENT_SNAPSHOT_BYTES,
+    );
+    expect(rootSnapshot.item.detail).toMatchObject({
+      type: "sub_agent",
+      description: expect.stringContaining("newest-prompt-marker"),
+    });
+  });
+
+  test("bounds the root sub-agent error in the complete emitted snapshot", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    const toJSON = vi.fn(() => ({ payload: "x".repeat(1_000_000) }));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-large-error-child",
+        tool: "spawnAgent",
+        status: "failed",
+        error: { toJSON },
+        prompt: "Fail safely.",
+        receiverThreadIds: [],
+        agentsStates: {},
+      },
+    });
+
+    const rootSnapshot = events.find(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "spawn-large-error-child",
+    );
+    if (rootSnapshot?.type !== "timeline" || rootSnapshot.item.type !== "tool_call") {
+      throw new Error("Expected failed root sub-agent snapshot");
+    }
+    const serialized = JSON.stringify(rootSnapshot.item);
+    expect(toJSON).not.toHaveBeenCalled();
+    expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(
+      MAX_SERIALIZED_PARENT_SUB_AGENT_SNAPSHOT_BYTES,
+    );
+    expect(rootSnapshot.item).toMatchObject({ status: "failed" });
+  });
+
+  test("keeps nested descendant snapshots bounded while retaining descendant history", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-bounded-root",
+        kind: "started",
+        agentThreadId: "bounded-root-thread",
+        agentPath: "/root/bounded-root",
+      },
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "bounded-root-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-bounded-descendant",
+        kind: "started",
+        agentThreadId: "bounded-descendant-thread",
+        agentPath: "/root/bounded-root/descendant",
+      },
+    });
+    const descendantMessages = Array.from({ length: 20 }, (_, index) => {
+      const marker = index === 0 ? "oldest-descendant-marker" : `descendant-${index}`;
+      const latestMarker = index === 19 ? " newest-descendant-marker" : "";
+      return `${String.fromCharCode(97 + index).repeat(16_000)} ${marker}${latestMarker}`;
+    });
+    for (const [index, text] of descendantMessages.entries()) {
+      asInternals(session).handleNotification("item/completed", {
+        threadId: "bounded-descendant-thread",
+        item: {
+          type: "agentMessage",
+          id: `bounded-descendant-message-${index}`,
+          text,
+        },
+      });
+    }
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "bounded-descendant-thread",
+      turn: { status: "completed" },
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "bounded-root-thread",
+      turn: { status: "completed" },
+    });
+
+    const rootSnapshots = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-bounded-root" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item]
+        : [],
+    );
+    const serializedRootBytes = rootSnapshots.reduce(
+      (total, item) => total + Buffer.byteLength(JSON.stringify(item), "utf8"),
+      0,
+    );
+    expect(serializedRootBytes).toBeLessThanOrEqual(rootSnapshots.length * 33_000);
+    expect(rootSnapshots.every((item) => Buffer.byteLength(item.detail.log, "utf8") <= 4_500)).toBe(
+      true,
+    );
+    expect(rootSnapshots.at(-1)).toMatchObject({ status: "completed" });
+    expect(rootSnapshots.at(-1)?.detail.log).not.toContain("oldest-descendant-marker");
+    expect(rootSnapshots.at(-1)?.detail.log).toContain("newest-descendant-marker");
+
+    const canonicalDescendantMessages = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "bounded-descendant-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalDescendantMessages).toEqual(descendantMessages);
+  });
+
+  test("builds the parent sub-agent preview from only the latest child activities", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-latest-child",
+        kind: "started",
+        agentThreadId: "latest-child-thread",
+        agentPath: "/root/latest-child",
+      },
+    });
+    const childMessages = Array.from({ length: 201 }, (_, index) =>
+      index === 0 ? "oldest-activity-marker" : `child activity ${index}`,
+    );
+    for (const [index, text] of childMessages.entries()) {
+      asInternals(session).handleNotification("item/completed", {
+        threadId: "latest-child-thread",
+        item: {
+          type: "agentMessage",
+          id: `latest-child-message-${index}`,
+          text,
+        },
+      });
+    }
+
+    const parentSnapshots = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-latest-child" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item]
+        : [],
+    );
+    expect(parentSnapshots.at(-1)?.detail.log).not.toContain("oldest-activity-marker");
+    expect(parentSnapshots.at(-1)?.detail.log).toContain("child activity 200");
+
+    const canonicalMessages = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "latest-child-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalMessages).toEqual(childMessages);
+  });
+
+  test("does not serialize unbounded non-sub-agent tool payloads for the parent preview", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-tool-preview-child",
+        kind: "started",
+        agentThreadId: "tool-preview-child-thread",
+        agentPath: "/root/tool-preview-child",
+      },
+    });
+    const toJSON = vi.fn(() => ({ payload: "x".repeat(1_000_000) }));
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "tool-preview-child-thread",
+      item: {
+        type: "mcpToolCall",
+        id: "large-child-tool",
+        status: "completed",
+        server: "example",
+        tool: "large_payload",
+        arguments: { toJSON },
+        result: null,
+      },
+    });
+
+    expect(toJSON).not.toHaveBeenCalled();
+    const parentSnapshot = events.findLast(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "spawn-tool-preview-child" &&
+        event.item.detail.type === "sub_agent",
+    );
+    expect(parentSnapshot?.item.detail.log).toContain("example.large_payload");
+
+    const canonicalToolCall = events.find(
+      (event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "timeline" &&
+        event.event.id === "tool-preview-child-thread" &&
+        event.event.item.type === "tool_call",
+    );
+    expect(canonicalToolCall?.event.item).toMatchObject({
+      type: "tool_call",
+      callId: "large-child-tool",
+      detail: { type: "unknown", input: { toJSON } },
+    });
+  });
+
+  test("bounds streamed multibyte child activity by UTF-8 bytes without splitting code points", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-multibyte-child",
+        kind: "started",
+        agentThreadId: "multibyte-child-thread",
+        agentPath: "/root/multibyte-child",
+      },
+    });
+    const deltas = Array.from({ length: 6 }, (_, index) =>
+      index === 5
+        ? `${"界".repeat(4_000)} 😀 newest-multibyte-marker`
+        : `${"界".repeat(4_000)} 😀 delta-${index}`,
+    );
+    for (const [index, delta] of deltas.entries()) {
+      asInternals(session).handleNotification("item/agentMessage/delta", {
+        threadId: "multibyte-child-thread",
+        itemId: `multibyte-child-message-${index}`,
+        delta,
+      });
+    }
+
+    const parentLogs = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-multibyte-child" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item.detail.log]
+        : [],
+    );
+    expect(parentLogs.length).toBeGreaterThan(1);
+    expect(parentLogs.every((log) => Buffer.byteLength(log, "utf8") <= 32_000)).toBe(true);
+    expect(parentLogs.every(hasOnlyWellFormedCodePoints)).toBe(true);
+    expect(parentLogs.at(-1)).toContain("😀 newest-multibyte-marker");
+
+    const canonicalDeltas = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "multibyte-child-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalDeltas).toEqual(deltas);
   });
 
   test("keeps a settled child completed until Codex starts another child turn", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4681,6 +4681,16 @@ describe("Codex app-server provider", () => {
       itemId: "child-live-assistant",
       delta: "Second live fragment.",
     });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-repeated-assistant",
+      delta: "Echo",
+    });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-repeated-assistant",
+      delta: "Echo",
+    });
     expect(
       events.filter(
         (event) => event.type === "provider_subagent" && event.event.type === "timeline",
@@ -4701,6 +4711,11 @@ describe("Codex app-server provider", () => {
                 type: "userMessage",
                 id: "child-live-message",
                 content: [{ type: "text", text: "Concurrent child message." }],
+              },
+              {
+                type: "agentMessage",
+                id: "child-repeated-assistant",
+                text: "Echo",
               },
             ],
           },
@@ -4730,6 +4745,11 @@ describe("Codex app-server provider", () => {
       },
       {
         type: "assistant_message",
+        messageId: "child-repeated-assistant",
+        text: "Echo",
+      },
+      {
+        type: "assistant_message",
         messageId: "child-live-assistant",
         text: "First live fragment. ",
       },
@@ -4737,6 +4757,11 @@ describe("Codex app-server provider", () => {
         type: "assistant_message",
         messageId: "child-live-assistant",
         text: "Second live fragment.",
+      },
+      {
+        type: "assistant_message",
+        messageId: "child-repeated-assistant",
+        text: "Echo",
       },
     ]);
   });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -729,11 +729,6 @@ function historicalProviderSubagentItemCoversLiveReplay(
   if (liveItem.type === "user_message") {
     return historicalItems.some((item) => item.type === "user_message");
   }
-  if (liveItem.type === "assistant_message") {
-    return historicalItems.some(
-      (item) => item.type === "assistant_message" && item.text.includes(liveItem.text),
-    );
-  }
   if (liveItem.type === "tool_call") {
     const historicalToolCalls = historicalItems.filter(
       (item): item is ToolCallTimelineItem =>
@@ -745,6 +740,117 @@ function historicalProviderSubagentItemCoversLiveReplay(
     );
   }
   return false;
+}
+
+function longestTextSuffixMatchingPrefix(text: string, prefix: string): number {
+  if (text.length === 0 || prefix.length === 0) {
+    return 0;
+  }
+  const fallback = Array.from({ length: prefix.length }, () => 0);
+  for (let index = 1, matched = 0; index < prefix.length; index += 1) {
+    while (matched > 0 && prefix[index] !== prefix[matched]) {
+      matched = fallback[matched - 1] ?? 0;
+    }
+    if (prefix[index] === prefix[matched]) {
+      matched += 1;
+    }
+    fallback[index] = matched;
+  }
+
+  let matched = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    while (matched > 0 && text[index] !== prefix[matched]) {
+      matched = fallback[matched - 1] ?? 0;
+    }
+    if (text[index] === prefix[matched]) {
+      matched += 1;
+    }
+    if (matched === prefix.length && index < text.length - 1) {
+      matched = fallback[matched - 1] ?? 0;
+    }
+  }
+  return matched;
+}
+
+function providerSubagentAssistantReplayCoverage(
+  historicalItemsByReplayIdentity: ReadonlyMap<string, readonly AgentTimelineItem[]>,
+  liveEvents: readonly BufferedProviderSubagentEvent[],
+): Map<string, number> {
+  const bufferedTextByReplayIdentity = new Map<string, string[]>();
+  for (const buffered of liveEvents) {
+    if (!buffered.replayIdentity || buffered.event.event.type !== "timeline") {
+      continue;
+    }
+    const item = buffered.event.event.item;
+    if (item.type !== "assistant_message") {
+      continue;
+    }
+    const text = bufferedTextByReplayIdentity.get(buffered.replayIdentity) ?? [];
+    text.push(item.text);
+    bufferedTextByReplayIdentity.set(buffered.replayIdentity, text);
+  }
+
+  const coverageByReplayIdentity = new Map<string, number>();
+  for (const [replayIdentity, chunks] of bufferedTextByReplayIdentity) {
+    const bufferedText = chunks.join("");
+    const historicalItems = historicalItemsByReplayIdentity.get(replayIdentity) ?? [];
+    let coverage = 0;
+    for (const item of historicalItems) {
+      if (item.type === "assistant_message") {
+        coverage = Math.max(coverage, longestTextSuffixMatchingPrefix(item.text, bufferedText));
+      }
+    }
+    if (coverage > 0) {
+      coverageByReplayIdentity.set(replayIdentity, coverage);
+    }
+  }
+  return coverageByReplayIdentity;
+}
+
+function reconcileProviderSubagentLiveEvents(
+  historicalItemsByReplayIdentity: ReadonlyMap<string, readonly AgentTimelineItem[]>,
+  liveEvents: readonly BufferedProviderSubagentEvent[],
+): ProviderSubagentStreamEvent[] {
+  const assistantReplayCoverageByIdentity = providerSubagentAssistantReplayCoverage(
+    historicalItemsByReplayIdentity,
+    liveEvents,
+  );
+  const reconciled: ProviderSubagentStreamEvent[] = [];
+  for (const buffered of liveEvents) {
+    let event = buffered.event;
+    if (
+      buffered.replayIdentity &&
+      event.event.type === "timeline" &&
+      event.event.item.type === "assistant_message"
+    ) {
+      const coverage = assistantReplayCoverageByIdentity.get(buffered.replayIdentity) ?? 0;
+      if (coverage >= event.event.item.text.length) {
+        assistantReplayCoverageByIdentity.set(
+          buffered.replayIdentity,
+          coverage - event.event.item.text.length,
+        );
+        continue;
+      }
+      if (coverage > 0) {
+        assistantReplayCoverageByIdentity.delete(buffered.replayIdentity);
+        event = {
+          ...event,
+          event: {
+            ...event.event,
+            item: { ...event.event.item, text: event.event.item.text.slice(coverage) },
+          },
+        };
+      }
+    }
+    const historicalItems = buffered.replayIdentity
+      ? historicalItemsByReplayIdentity.get(buffered.replayIdentity)
+      : undefined;
+    if (historicalItems && historicalProviderSubagentItemCoversLiveReplay(historicalItems, event)) {
+      continue;
+    }
+    reconciled.push(event);
+  }
+  return reconciled;
 }
 
 interface CodexThreadHistoryProjection {
@@ -4286,17 +4392,11 @@ export class CodexAppServerAgentSession implements AgentSession {
         routeState.route.toolCall.callId,
         routeState.generation,
       );
-      for (const buffered of liveEvents) {
-        const historicalItems = buffered.replayIdentity
-          ? historicalItemsByReplayIdentity.get(buffered.replayIdentity)
-          : undefined;
-        if (
-          historicalItems &&
-          historicalProviderSubagentItemCoversLiveReplay(historicalItems, buffered.event)
-        ) {
-          continue;
-        }
-        this.emitEvent(buffered.event);
+      for (const event of reconcileProviderSubagentLiveEvents(
+        historicalItemsByReplayIdentity,
+        liveEvents,
+      )) {
+        this.emitEvent(event);
       }
     } finally {
       this.collectingProviderSubagentHistoryEvents = null;

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -481,6 +481,7 @@ const DEFAULT_CODEX_MODE_ID = "auto";
 
 interface CodexAppServerClientLike {
   request(method: string, params?: unknown): Promise<unknown>;
+  requestWithSignal?(method: string, params: unknown, signal: AbortSignal): Promise<unknown>;
   forkThread?(params: CodexThreadForkParams): Promise<CodexThreadForkResponse>;
   rollbackThread?(params: CodexThreadRollbackParams): Promise<CodexThreadRollbackResponse>;
   notify(method: string, params?: unknown): void;
@@ -666,11 +667,84 @@ interface PersistedTimelineEntry {
   item: AgentTimelineItem;
   timestamp?: string;
   providerTurnId?: string;
+  sourceItemId?: string;
+  sourceItemOrdinal?: number;
 }
 
 interface PersistedSubAgentRoute {
   childThreadId: string;
   toolCall: ToolCallTimelineItem;
+}
+
+interface PersistedSubAgentRouteState {
+  route: PersistedSubAgentRoute;
+  parentCallId: string | null;
+  generation: number;
+}
+
+type ProviderSubagentStreamEvent = Extract<AgentStreamEvent, { type: "provider_subagent" }>;
+
+interface BufferedProviderSubagentEvent {
+  event: ProviderSubagentStreamEvent;
+  replayIdentity: string | null;
+}
+
+function providerSubagentTimelineReplayIdentity(
+  subagentId: string,
+  item: AgentTimelineItem,
+  sourceItemId: string | undefined,
+  sourceItemOrdinal = 0,
+): string | null {
+  if (item.type === "tool_call") {
+    return `${subagentId}\0${item.callId}\0tool_call`;
+  }
+  if (!sourceItemId) {
+    return null;
+  }
+  return `${subagentId}\0${sourceItemId}\0${sourceItemOrdinal}\0${item.type}`;
+}
+
+function providerSubagentEventReplayIdentity(event: ProviderSubagentStreamEvent): string | null {
+  if (event.event.type !== "timeline") {
+    return null;
+  }
+  const item = event.event.item;
+  let sourceItemId: string | undefined;
+  if (item.type === "user_message" || item.type === "assistant_message") {
+    sourceItemId = item.messageId;
+  } else if (item.type === "tool_call") {
+    sourceItemId = item.callId;
+  }
+  return providerSubagentTimelineReplayIdentity(event.event.id, item, sourceItemId);
+}
+
+function historicalProviderSubagentItemCoversLiveReplay(
+  historicalItems: readonly AgentTimelineItem[],
+  liveEvent: ProviderSubagentStreamEvent,
+): boolean {
+  if (liveEvent.event.type !== "timeline") {
+    return false;
+  }
+  const liveItem = liveEvent.event.item;
+  if (liveItem.type === "user_message") {
+    return historicalItems.some((item) => item.type === "user_message");
+  }
+  if (liveItem.type === "assistant_message") {
+    return historicalItems.some(
+      (item) => item.type === "assistant_message" && item.text.includes(liveItem.text),
+    );
+  }
+  if (liveItem.type === "tool_call") {
+    const historicalToolCalls = historicalItems.filter(
+      (item): item is ToolCallTimelineItem =>
+        item.type === "tool_call" && item.callId === liveItem.callId,
+    );
+    return (
+      historicalToolCalls.some((item) => isTerminalSubAgentStatus(item.status)) ||
+      historicalToolCalls.some((item) => item.status === liveItem.status)
+    );
+  }
+  return false;
 }
 
 interface CodexThreadHistoryProjection {
@@ -2217,6 +2291,9 @@ async function loadCodexThreadHistoryTimeline(params: {
           continue;
         }
       }
+      const itemRecord = toObjectRecord(item);
+      const sourceItemId = typeof itemRecord?.id === "string" ? itemRecord.id : undefined;
+      let sourceItemOrdinal = 0;
       for (const timelineItem of threadItemToTimelineEntries(item, { cwd: params.cwd })) {
         const timestamp =
           readCodexHistoryTimestamp(item) ?? readCodexTurnHistoryTimestamp(turn, timelineItem);
@@ -2230,7 +2307,10 @@ async function loadCodexThreadHistoryTimeline(params: {
           ...(timelineItem.type === "user_message" && typeof turn.id === "string"
             ? { providerTurnId: turn.id }
             : {}),
+          sourceItemId,
+          sourceItemOrdinal,
         });
+        sourceItemOrdinal += 1;
         for (const childThreadId of readCodexHistoricalSubAgentThreadIds(item)) {
           subAgentTimelineIndexByThreadId.set(childThreadId, timeline.length - 1);
         }
@@ -2248,10 +2328,45 @@ async function loadCodexThreadHistoryTimeline(params: {
   return { timeline, subAgentRoutes };
 }
 
-function readCodexThread(client: CodexAppServerClientLike, threadId: string): Promise<unknown> {
-  return client.request("thread/read", {
+function readCodexThread(
+  client: CodexAppServerClientLike,
+  threadId: string,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const params = {
     threadId,
     includeTurns: true,
+  };
+  if (signal && client.requestWithSignal) {
+    return client.requestWithSignal("thread/read", params, signal);
+  }
+  const operation = client.request("thread/read", {
+    ...params,
+  });
+  if (!signal) {
+    return operation;
+  }
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return new Promise((resolveRead, rejectRead) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      rejectRead(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void operation.then(
+      (thread) => {
+        signal.removeEventListener("abort", onAbort);
+        resolveRead(thread);
+        return undefined;
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        rejectRead(error);
+        return undefined;
+      },
+    );
   });
 }
 
@@ -3572,6 +3687,15 @@ export class CodexAppServerAgentSession implements AgentSession {
   private subAgentCallsByCallId = new Map<string, CodexSubAgentCallState>();
   private subAgentCallIdByChildThreadId = new Map<string, string>();
   private pendingSubAgentNotificationsByThreadId = new Map<string, ParsedCodexNotification[]>();
+  private persistedSubAgentRoutesByThreadId = new Map<string, PersistedSubAgentRouteState>();
+  private loadedPersistedSubAgentThreadIds = new Set<string>();
+  private persistedSubAgentHistoryLoads = new Map<string, Promise<ProviderSubagentStreamEvent[]>>();
+  private persistedSubAgentLiveEventsByThreadId = new Map<
+    string,
+    BufferedProviderSubagentEvent[]
+  >();
+  private collectingProviderSubagentHistoryEvents: ProviderSubagentStreamEvent[] | null = null;
+  private persistedHistoryGeneration = 0;
   private warnedUnknownNotificationMethods = new Set<string>();
   private warnedInvalidNotificationPayloads = new Set<string>();
   private warnedIncompleteEditToolCallIds = new Set<string>();
@@ -4002,6 +4126,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     if (!this.client || !this.currentThreadId) return;
     const client = this.client;
     const threadId = this.currentThreadId;
+    const generation = ++this.persistedHistoryGeneration;
 
     const history = await loadCodexThreadHistoryTimeline({
       threadId,
@@ -4010,14 +4135,21 @@ export class CodexAppServerAgentSession implements AgentSession {
         return readCodexThread(client, threadIdToRead);
       },
     });
+    if (generation !== this.persistedHistoryGeneration || this.closed) {
+      return;
+    }
     const { timeline, subAgentRoutes } = history;
     this.subAgentCallsByCallId.clear();
     this.subAgentCallIdByChildThreadId.clear();
     this.pendingSubAgentNotificationsByThreadId.clear();
+    this.persistedSubAgentRoutesByThreadId.clear();
+    this.loadedPersistedSubAgentThreadIds.clear();
+    this.persistedSubAgentHistoryLoads.clear();
+    this.persistedSubAgentLiveEventsByThreadId.clear();
     this.persistedProviderSubagentEvents = [];
     this.loadingPersistedHistory = true;
     try {
-      await this.loadPersistedSubAgentHistories(client, subAgentRoutes);
+      this.registerPersistedSubAgentRoutes(subAgentRoutes, null, generation);
     } finally {
       this.loadingPersistedHistory = false;
     }
@@ -4031,42 +4163,146 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.historyPending = timeline.length > 0;
   }
 
-  private async loadPersistedSubAgentHistories(
-    client: CodexAppServerClientLike,
-    rootRoutes: readonly PersistedSubAgentRoute[],
-  ): Promise<void> {
-    const queue = rootRoutes.map((route) => ({ route, parentCallId: null as string | null }));
-    const visitedThreadIds = new Set(this.currentThreadId ? [this.currentThreadId] : []);
-    while (queue.length > 0 && visitedThreadIds.size < 100) {
-      const next = queue.shift();
-      if (!next || visitedThreadIds.has(next.route.childThreadId)) {
+  private registerPersistedSubAgentRoutes(
+    routes: readonly PersistedSubAgentRoute[],
+    parentCallId: string | null,
+    generation: number,
+  ): void {
+    for (const route of routes) {
+      if (
+        route.childThreadId === this.currentThreadId ||
+        this.persistedSubAgentRoutesByThreadId.has(route.childThreadId) ||
+        this.persistedSubAgentRoutesByThreadId.size >= 99
+      ) {
         continue;
       }
-      visitedThreadIds.add(next.route.childThreadId);
-      this.registerSubAgentToolCall({
-        timelineItem: next.route.toolCall,
-        rawItem: { agentThreadId: next.route.childThreadId },
-        parentCallId: next.parentCallId,
+      this.persistedSubAgentRoutesByThreadId.set(route.childThreadId, {
+        route,
+        parentCallId,
+        generation,
       });
-      try {
-        const childHistory = await loadCodexThreadHistoryTimeline({
-          threadId: next.route.childThreadId,
-          cwd: this.config.cwd ?? null,
-          requestThread: (childThreadId) => readCodexThread(client, childThreadId),
-        });
-        for (const entry of childHistory.timeline) {
-          this.emitProviderSubagentTimeline(next.route.childThreadId, entry.item, entry.timestamp);
-        }
-        for (const route of childHistory.subAgentRoutes) {
-          queue.push({ route, parentCallId: next.route.toolCall.callId });
-        }
-      } catch (error) {
-        this.logger.trace(
-          { err: error, childThreadId: next.route.childThreadId },
-          "Failed to load persisted Codex child history",
-        );
+      this.registerSubAgentToolCall({
+        timelineItem: route.toolCall,
+        rawItem: { agentThreadId: route.childThreadId },
+        parentCallId,
+      });
+      this.persistedSubAgentLiveEventsByThreadId.set(route.childThreadId, []);
+    }
+  }
+
+  async loadProviderSubagentHistory(
+    subagentId: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<ProviderSubagentStreamEvent[]> {
+    if (this.loadedPersistedSubAgentThreadIds.has(subagentId)) {
+      return [];
+    }
+    const existingLoad = this.persistedSubAgentHistoryLoads.get(subagentId);
+    if (existingLoad) {
+      return await existingLoad;
+    }
+    const routeState = this.persistedSubAgentRoutesByThreadId.get(subagentId);
+    const client = this.client;
+    if (!routeState || !client || routeState.generation !== this.persistedHistoryGeneration) {
+      return [];
+    }
+
+    const load = this.loadPersistedSubAgentHistory(client, routeState, options?.signal);
+    this.persistedSubAgentHistoryLoads.set(subagentId, load);
+    try {
+      return await load;
+    } finally {
+      if (this.persistedSubAgentHistoryLoads.get(subagentId) === load) {
+        this.persistedSubAgentHistoryLoads.delete(subagentId);
       }
     }
+  }
+
+  getLoadedProviderSubagentHistoryIds(): readonly string[] {
+    return [...this.loadedPersistedSubAgentThreadIds];
+  }
+
+  seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+    for (const subagentId of subagentIds) {
+      this.loadedPersistedSubAgentThreadIds.add(subagentId);
+    }
+  }
+
+  private async loadPersistedSubAgentHistory(
+    client: CodexAppServerClientLike,
+    routeState: PersistedSubAgentRouteState,
+    signal?: AbortSignal,
+  ): Promise<ProviderSubagentStreamEvent[]> {
+    const childThreadId = routeState.route.childThreadId;
+    const liveEvents = this.persistedSubAgentLiveEventsByThreadId.get(childThreadId) ?? [];
+    this.persistedSubAgentLiveEventsByThreadId.set(childThreadId, liveEvents);
+    const childHistory = await loadCodexThreadHistoryTimeline({
+      threadId: childThreadId,
+      cwd: this.config.cwd ?? null,
+      requestThread: (threadId) => readCodexThread(client, threadId, signal),
+    });
+    if (
+      this.closed ||
+      this.client !== client ||
+      routeState.generation !== this.persistedHistoryGeneration ||
+      this.persistedSubAgentRoutesByThreadId.get(childThreadId) !== routeState
+    ) {
+      if (this.persistedSubAgentLiveEventsByThreadId.get(childThreadId) === liveEvents) {
+        this.persistedSubAgentLiveEventsByThreadId.delete(childThreadId);
+      }
+      return [];
+    }
+    this.persistedSubAgentLiveEventsByThreadId.delete(childThreadId);
+    const historicalItemsByReplayIdentity = new Map<string, AgentTimelineItem[]>();
+    const collectedEvents: ProviderSubagentStreamEvent[] = [];
+    this.collectingProviderSubagentHistoryEvents = collectedEvents;
+    try {
+      for (const entry of childHistory.timeline) {
+        const event: ProviderSubagentStreamEvent = {
+          type: "provider_subagent",
+          provider: CODEX_PROVIDER,
+          event: {
+            type: "timeline",
+            id: childThreadId,
+            item: entry.item,
+            ...(entry.timestamp ? { timestamp: entry.timestamp } : {}),
+          },
+        };
+        const replayIdentity = providerSubagentTimelineReplayIdentity(
+          childThreadId,
+          entry.item,
+          entry.sourceItemId,
+          entry.sourceItemOrdinal,
+        );
+        if (replayIdentity) {
+          const items = historicalItemsByReplayIdentity.get(replayIdentity) ?? [];
+          items.push(entry.item);
+          historicalItemsByReplayIdentity.set(replayIdentity, items);
+        }
+        this.emitEvent(event);
+      }
+      this.registerPersistedSubAgentRoutes(
+        childHistory.subAgentRoutes,
+        routeState.route.toolCall.callId,
+        routeState.generation,
+      );
+      for (const buffered of liveEvents) {
+        const historicalItems = buffered.replayIdentity
+          ? historicalItemsByReplayIdentity.get(buffered.replayIdentity)
+          : undefined;
+        if (
+          historicalItems &&
+          historicalProviderSubagentItemCoversLiveReplay(historicalItems, buffered.event)
+        ) {
+          continue;
+        }
+        this.emitEvent(buffered.event);
+      }
+    } finally {
+      this.collectingProviderSubagentHistoryEvents = null;
+    }
+    this.loadedPersistedSubAgentThreadIds.add(childThreadId);
+    return collectedEvents;
   }
 
   private async ensureThreadLoaded(
@@ -5005,8 +5241,13 @@ export class CodexAppServerAgentSession implements AgentSession {
 
   async close(): Promise<void> {
     this.closed = true;
+    this.persistedHistoryGeneration += 1;
     this.clearPendingPermissions();
     this.pendingSubAgentNotificationsByThreadId.clear();
+    this.persistedSubAgentRoutesByThreadId.clear();
+    this.loadedPersistedSubAgentThreadIds.clear();
+    this.persistedSubAgentHistoryLoads.clear();
+    this.persistedSubAgentLiveEventsByThreadId.clear();
     this.subscribers.clear();
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
@@ -5334,6 +5575,22 @@ export class CodexAppServerAgentSession implements AgentSession {
   }
 
   private emitEvent(event: AgentStreamEvent): void {
+    if (event.type === "provider_subagent") {
+      if (event.event.type === "timeline") {
+        const liveEvents = this.persistedSubAgentLiveEventsByThreadId.get(event.event.id);
+        if (liveEvents) {
+          liveEvents.push({
+            event,
+            replayIdentity: providerSubagentEventReplayIdentity(event),
+          });
+          return;
+        }
+      }
+      if (this.collectingProviderSubagentHistoryEvents) {
+        this.collectingProviderSubagentHistoryEvents.push(event);
+        return;
+      }
+    }
     if (this.loadingPersistedHistory && event.type === "provider_subagent") {
       this.persistedProviderSubagentEvents.push(event);
       return;

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -149,6 +149,13 @@ const CODEX_NON_ORIGINATING_APP_SERVER_CLIENT_INFO = {
 const ASSISTANT_MESSAGE_BOUNDARY_MARKDOWN = "\n\n---\n\n";
 const MAX_PENDING_SUB_AGENT_THREADS = 32;
 const MAX_PENDING_SUB_AGENT_NOTIFICATIONS_PER_THREAD = 128;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ITEMS = 200;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES = 4_000;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES = 256;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ACTIONS = 32;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ACTION_FIELD_BYTES = 256;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_BYTES = 32_000;
+const OMITTED_SUB_AGENT_ACTIVITY_PREFIX = "…\n";
 // COMPAT(codexLegacyCollabAgentToolCall): Codex <0.143 emits this shape. Added in
 // Paseo v0.1.105; remove after 2027-01-09 once the supported Codex floor is >=0.143.
 const CODEX_TOOL_THREAD_ITEM_TYPES = new Set([
@@ -207,6 +214,235 @@ function parseGoalSubcommand(args: string | undefined): GoalSubcommand {
 
 function formatOutOfBandStatusMessage(text: string): string {
   return `${text.replace(/\n+$/u, "")}\n\n`;
+}
+
+function utf8CodePointByteLength(codePoint: number): number {
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+function previousCodePointStart(text: string, end: number): number {
+  const lastIndex = end - 1;
+  const lastCodeUnit = text.charCodeAt(lastIndex);
+  if (lastCodeUnit >= 0xdc00 && lastCodeUnit <= 0xdfff && lastIndex > 0) {
+    const precedingCodeUnit = text.charCodeAt(lastIndex - 1);
+    if (precedingCodeUnit >= 0xd800 && precedingCodeUnit <= 0xdbff) {
+      return lastIndex - 1;
+    }
+  }
+  return lastIndex;
+}
+
+function utf8TailStart(text: string, maxBytes: number): number {
+  let start = text.length;
+  let retainedBytes = 0;
+  while (start > 0) {
+    const candidateStart = previousCodePointStart(text, start);
+    const codePoint = text.codePointAt(candidateStart);
+    if (codePoint === undefined) break;
+    const codePointBytes = utf8CodePointByteLength(codePoint);
+    if (retainedBytes + codePointBytes > maxBytes) break;
+    retainedBytes += codePointBytes;
+    start = candidateStart;
+  }
+  return start;
+}
+
+function tailSubAgentActivity(text: string, maxBytes: number): string {
+  const unprefixedStart = utf8TailStart(text, maxBytes);
+  if (unprefixedStart === 0) {
+    return text;
+  }
+  const prefixBytes = Buffer.byteLength(OMITTED_SUB_AGENT_ACTIVITY_PREFIX, "utf8");
+  if (maxBytes <= prefixBytes) {
+    return "";
+  }
+
+  const start = utf8TailStart(text, maxBytes - prefixBytes);
+  return `${OMITTED_SUB_AGENT_ACTIVITY_PREFIX}${text.slice(start)}`;
+}
+
+function boundedToolCallPreview(detail: ToolCallTimelineItem["detail"]): string | undefined {
+  switch (detail.type) {
+    case "shell":
+      return detail.command;
+    case "read":
+    case "edit":
+    case "write":
+      return detail.filePath;
+    case "search":
+      return detail.query;
+    case "fetch":
+      return detail.url;
+    case "worktree_setup":
+      return detail.branchName;
+    case "plain_text":
+      return detail.label ?? detail.text;
+    case "plan":
+      return detail.text;
+    case "unknown":
+      if (
+        typeof detail.input === "string" ||
+        typeof detail.input === "number" ||
+        typeof detail.input === "boolean" ||
+        typeof detail.input === "bigint"
+      ) {
+        return String(detail.input);
+      }
+      return undefined;
+    case "sub_agent":
+      return undefined;
+  }
+}
+
+function boundedToolCallPreviewName(item: ToolCallTimelineItem): string {
+  switch (item.detail.type) {
+    case "shell":
+      return "Shell";
+    case "read":
+      return "Read";
+    case "edit":
+      return "Edit";
+    case "write":
+      return "Write";
+    case "search":
+      return "Search";
+    case "fetch":
+      return "Fetch";
+    case "worktree_setup":
+      return "Worktree setup";
+    case "plan":
+      return "Plan";
+    case "sub_agent":
+    case "plain_text":
+    case "unknown":
+      return item.name;
+  }
+}
+
+function boundedToolCallError(item: ToolCallTimelineItem): unknown {
+  if (item.status !== "failed") return null;
+  return typeof item.error === "string"
+    ? tailSubAgentActivity(item.error, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES)
+    : "Tool call failed";
+}
+
+function buildBoundedToolCallPreview(
+  item: ToolCallTimelineItem,
+  subAgentLogBytes = MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES,
+): ToolCallTimelineItem {
+  const preview =
+    item.detail.type === "sub_agent" ? undefined : boundedToolCallPreview(item.detail);
+  const detail: ToolCallTimelineItem["detail"] =
+    item.detail.type === "sub_agent"
+      ? {
+          type: "sub_agent",
+          ...(item.detail.subAgentType
+            ? {
+                subAgentType: tailSubAgentActivity(
+                  item.detail.subAgentType,
+                  MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES,
+                ),
+              }
+            : {}),
+          ...(item.detail.description
+            ? {
+                description: tailSubAgentActivity(
+                  item.detail.description,
+                  MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES,
+                ),
+              }
+            : {}),
+          ...(item.detail.childSessionId
+            ? {
+                childSessionId: tailSubAgentActivity(
+                  item.detail.childSessionId,
+                  MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES,
+                ),
+              }
+            : {}),
+          log: tailSubAgentActivity(item.detail.log, subAgentLogBytes),
+          ...(item.detail.actions
+            ? {
+                actions: item.detail.actions
+                  .slice(-MAX_PARENT_SUB_AGENT_ACTIVITY_ACTIONS)
+                  .map((action) => {
+                    const boundedAction = {
+                      index: action.index,
+                      toolName: tailSubAgentActivity(
+                        action.toolName,
+                        MAX_PARENT_SUB_AGENT_ACTIVITY_ACTION_FIELD_BYTES,
+                      ),
+                    };
+                    if (!action.summary) return boundedAction;
+                    return {
+                      index: boundedAction.index,
+                      toolName: boundedAction.toolName,
+                      summary: tailSubAgentActivity(
+                        action.summary,
+                        MAX_PARENT_SUB_AGENT_ACTIVITY_ACTION_FIELD_BYTES,
+                      ),
+                    };
+                  }),
+              }
+            : {}),
+        }
+      : {
+          type: "plain_text",
+          ...(preview
+            ? {
+                label: tailSubAgentActivity(preview, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES),
+              }
+            : {}),
+        };
+  const base = {
+    type: "tool_call" as const,
+    callId: item.callId,
+    name: tailSubAgentActivity(
+      boundedToolCallPreviewName(item),
+      MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES,
+    ),
+    detail,
+  };
+  switch (item.status) {
+    case "running":
+    case "completed":
+    case "canceled":
+      return { ...base, status: item.status, error: null };
+    case "failed":
+      return { ...base, status: item.status, error: boundedToolCallError(item) };
+  }
+}
+
+function boundParentSubAgentActivityItem(item: AgentTimelineItem): AgentTimelineItem {
+  if (
+    item.type === "assistant_message" ||
+    item.type === "reasoning" ||
+    item.type === "user_message"
+  ) {
+    return {
+      ...item,
+      text: tailSubAgentActivity(item.text, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES),
+    };
+  }
+  if (item.type === "error") {
+    return {
+      ...item,
+      message: tailSubAgentActivity(item.message, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES),
+    };
+  }
+  if (item.type === "tool_call") {
+    return buildBoundedToolCallPreview(item);
+  }
+  return item;
+}
+
+function boundRootSubAgentTimelineItem(item: AgentTimelineItem): AgentTimelineItem {
+  return item.type === "tool_call" && item.detail.type === "sub_agent"
+    ? buildBoundedToolCallPreview(item, MAX_PARENT_SUB_AGENT_ACTIVITY_BYTES)
+    : item;
 }
 
 const CODEX_APP_SERVER_CAPABILITIES: AgentCapabilityFlags = {
@@ -5536,8 +5772,10 @@ export class CodexAppServerAgentSession implements AgentSession {
 
   private getSubAgentChildTimeline(state: CodexSubAgentCallState): AgentTimelineItem[] {
     return state.childItemOrder
+      .slice(-MAX_PARENT_SUB_AGENT_ACTIVITY_ITEMS)
       .map((itemId) => state.childItems.get(itemId))
-      .filter((item): item is AgentTimelineItem => Boolean(item));
+      .filter((item): item is AgentTimelineItem => Boolean(item))
+      .map(boundParentSubAgentActivityItem);
   }
 
   private emitSubAgentActivityUpdate(
@@ -5552,7 +5790,10 @@ export class CodexAppServerAgentSession implements AgentSession {
     const childTimeline = this.getSubAgentChildTimeline(state);
     const log =
       childTimeline.length > 0
-        ? curateAgentActivity(childTimeline, { labelAssistantMessages: true })
+        ? tailSubAgentActivity(
+            curateAgentActivity(childTimeline, { labelAssistantMessages: true }),
+            MAX_PARENT_SUB_AGENT_ACTIVITY_BYTES,
+          )
         : "";
     let resolvedStatus = status ?? state.toolCall.status;
     if (
@@ -5590,7 +5831,11 @@ export class CodexAppServerAgentSession implements AgentSession {
       this.emitSubAgentActivityUpdate(state.parentCallId);
       return;
     }
-    this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: nextToolCall });
+    this.emitEvent({
+      type: "timeline",
+      provider: CODEX_PROVIDER,
+      item: boundRootSubAgentTimelineItem(nextToolCall),
+    });
   }
 
   private emitProviderSubagentUpsert(
@@ -6298,7 +6543,11 @@ export class CodexAppServerAgentSession implements AgentSession {
       }
       this.warnOnIncompleteEditToolCall(timelineItem, "item_completed", parsed.item);
     }
-    this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: timelineItem });
+    this.emitEvent({
+      type: "timeline",
+      provider: CODEX_PROVIDER,
+      item: boundRootSubAgentTimelineItem(timelineItem),
+    });
     if (timelineItem.type === "assistant_message") {
       this.pendingAssistantMessageBoundary = true;
     }
@@ -6448,7 +6697,11 @@ export class CodexAppServerAgentSession implements AgentSession {
       return;
     }
     this.warnOnIncompleteEditToolCall(timelineItem, "item_started", parsed.item);
-    this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: timelineItem });
+    this.emitEvent({
+      type: "timeline",
+      provider: CODEX_PROVIDER,
+      item: boundRootSubAgentTimelineItem(timelineItem),
+    });
     if (itemId) {
       this.emittedItemStartedIds.add(itemId);
       this.pendingCommandOutputDeltas.delete(itemId);

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
@@ -22,6 +22,51 @@ describe("Codex app-server transport", () => {
     child.stdin.end();
   });
 
+  test("aborts a pending request, clears its timer, and ignores a late response", async () => {
+    const child = createCodexAppServerChildProcess();
+    const client = new CodexAppServerClient(child, createTestLogger());
+    const abortController = new AbortController();
+
+    const abortedRequest = client.requestWithSignal(
+      "thread/read",
+      { threadId: "child-thread" },
+      abortController.signal,
+    );
+    abortController.abort(new Error("history read canceled"));
+
+    await expect(abortedRequest).rejects.toThrow("history read canceled");
+    expect((client as unknown as { pending: Map<number, unknown> }).pending.size).toBe(0);
+
+    child.stdout.write('{"id":1,"result":{"thread":{"id":"too-late"}}}\n');
+    const nextRequest = client.request("model/list", {});
+    child.stdout.write('{"id":2,"result":{"data":[]}}\n');
+    await expect(nextRequest).resolves.toEqual({ data: [] });
+    child.stdout.end();
+    child.stderr.end();
+    child.stdin.end();
+  });
+
+  test("clears pending requests when termination follows disposal state", async () => {
+    const child = createCodexAppServerChildProcess();
+    const client = new CodexAppServerClient(child, createTestLogger());
+    const request = client.request("thread/read", { threadId: "child-thread" });
+    const rejection = expect(request).rejects.toThrow("process exited after disposal began");
+    const internals = client as unknown as {
+      disposed: boolean;
+      pending: Map<number, unknown>;
+      handleUnexpectedTermination(error: Error): void;
+    };
+
+    internals.disposed = true;
+    internals.handleUnexpectedTermination(new Error("process exited after disposal began"));
+
+    await rejection;
+    expect(internals.pending.size).toBe(0);
+    child.stdout.end();
+    child.stderr.end();
+    child.stdin.end();
+  });
+
   test.each([
     "item/commandExecution/requestApproval",
     "item/fileChange/requestApproval",

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.ts
@@ -31,6 +31,8 @@ interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
   timer: NodeJS.Timeout;
+  signal?: AbortSignal;
+  abortHandler?: () => void;
 }
 
 export class CodexAppServerRpcError extends Error {
@@ -224,8 +226,29 @@ export class CodexAppServerClient {
   }
 
   request(method: string, params?: unknown, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<unknown> {
+    return this.requestInternal(method, params, timeoutMs);
+  }
+
+  requestWithSignal(
+    method: string,
+    params: unknown,
+    signal: AbortSignal,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<unknown> {
+    return this.requestInternal(method, params, timeoutMs, signal);
+  }
+
+  private requestInternal(
+    method: string,
+    params: unknown,
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
     if (this.disposed) {
       return Promise.reject(new Error("Codex app-server client is closed"));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(this.createRequestAbortError(signal));
     }
     const id = this.nextId++;
     const payload: JsonRpcRequest = { id, method, params };
@@ -233,10 +256,21 @@ export class CodexAppServerClient {
     this.child.stdin.write(`${serialized}\n`);
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`Codex app-server request timed out for ${method}`));
+        this.takePendingRequest(id)?.reject(
+          new Error(`Codex app-server request timed out for ${method}`),
+        );
       }, timeoutMs);
-      this.pending.set(id, { resolve, reject, timer });
+      const pending: PendingRequest = { resolve, reject, timer, ...(signal ? { signal } : {}) };
+      if (signal) {
+        pending.abortHandler = () => {
+          this.takePendingRequest(id)?.reject(this.createRequestAbortError(signal));
+        };
+        signal.addEventListener("abort", pending.abortHandler, { once: true });
+      }
+      this.pending.set(id, pending);
+      if (signal?.aborted) {
+        pending.abortHandler?.();
+      }
     });
   }
 
@@ -257,10 +291,14 @@ export class CodexAppServerClient {
   }
 
   async dispose(): Promise<void> {
-    if (this.disposed) return;
+    if (this.disposed) {
+      this.rejectPendingRequests(new Error("Codex app-server client is closed"));
+      return;
+    }
     this.disposed = true;
     this.unexpectedTerminationHandler = null;
     this.rl.close();
+    this.rejectPendingRequests(new Error("Codex app-server client is closed"));
     try {
       this.child.stdin.end();
     } catch {
@@ -285,16 +323,13 @@ export class CodexAppServerClient {
   }
 
   private handleUnexpectedTermination(error: Error): void {
-    if (this.disposed) {
-      return;
-    }
+    const alreadyDisposed = this.disposed;
     this.disposed = true;
     this.rl.close();
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.reject(error);
+    this.rejectPendingRequests(error);
+    if (alreadyDisposed) {
+      return;
     }
-    this.pending.clear();
     const handler = this.unexpectedTerminationHandler;
     this.unexpectedTerminationHandler = null;
     if (!handler) {
@@ -304,6 +339,35 @@ export class CodexAppServerClient {
       handler(error);
     } catch (handlerError) {
       this.logger.warn({ err: handlerError }, "Codex app-server termination handler threw");
+    }
+  }
+
+  private createRequestAbortError(signal: AbortSignal): Error {
+    let message = "Codex app-server request aborted";
+    if (signal.reason instanceof Error) {
+      message = signal.reason.message;
+    } else if (typeof signal.reason === "string") {
+      message = signal.reason;
+    }
+    return Object.assign(new Error(message), { name: "AbortError" });
+  }
+
+  private takePendingRequest(id: number): PendingRequest | undefined {
+    const pending = this.pending.get(id);
+    if (!pending) {
+      return undefined;
+    }
+    this.pending.delete(id);
+    clearTimeout(pending.timer);
+    if (pending.signal && pending.abortHandler) {
+      pending.signal.removeEventListener("abort", pending.abortHandler);
+    }
+    return pending;
+  }
+
+  private rejectPendingRequests(error: Error): void {
+    for (const id of this.pending.keys()) {
+      this.takePendingRequest(id)?.reject(error);
     }
   }
 
@@ -336,10 +400,8 @@ export class CodexAppServerClient {
     if (isJsonRpcResponse(raw)) {
       const id = raw.id;
       if (raw.result !== undefined || raw.error) {
-        const pending = this.pending.get(id);
+        const pending = this.takePendingRequest(id);
         if (!pending) return;
-        clearTimeout(pending.timer);
-        this.pending.delete(id);
         if (raw.error) {
           pending.reject(
             new CodexAppServerRpcError(

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -7279,7 +7279,7 @@ export class Session {
       if (!descriptor) {
         throw new Error("Provider subagent not found");
       }
-      const timeline = this.agentManager.fetchProviderSubagentTimeline(
+      const timeline = await this.agentManager.fetchProviderSubagentTimeline(
         msg.parentAgentId,
         msg.subagentId,
         {


### PR DESCRIPTION
Refs #2300

Stacked on `dwaxe/bound-codex-subagent-snapshots`.

This makes provider-subagent history paged and lazy.

- select requested pages inside the provider-subagent store instead of materializing the full timeline
- restore child descriptors and relationships on resume without loading child bodies
- load child history on demand with single-flight, cancellation, and close/reload fencing

Regression coverage exercises paging, nested children, concurrent requests, cancellation, late responses, and transport cleanup.
