### PR TITLE
fix(server): bound agent timeline history

### DIFF
--- a/docs/timeline-sync.md
+++ b/docs/timeline-sync.md
@@ -14,10 +14,11 @@ The invariants are:
 > agent establishes the daemon's current tail in one bounded request, with older history reachable
 > through backward pagination.
 
-Tool output is bounded before it enters either delivery path. Canonical shell tool output is sliced
-to 64 KiB, and the same bounded item is used for runtime timeline rows and live stream events.
-Provider history hydration applies the same rule so reopening an agent cannot restore an oversized
-tool payload.
+Timeline items are bounded before they enter either delivery path. An item's encoded JSON is limited
+to 128 KiB; oversized text carries a visible truncation notice, while other oversized item shapes
+retain their discriminant and lifecycle state with summarized detail. Canonical shell tool output
+is also sliced to 64 KiB. The same bounded item is used for runtime rows, live stream events, and
+provider history hydration, so reopening an agent cannot restore an oversized payload.
 
 ## Presence is not delivery
 

--- a/packages/app/src/hooks/use-agent-initialization.test.ts
+++ b/packages/app/src/hooks/use-agent-initialization.test.ts
@@ -111,6 +111,32 @@ describe("ensureAgentIsInitialized", () => {
     expect(getInitDeferred(getInitKey(serverId, agentId))?.requestDirection).toBe("tail");
   });
 
+  it("rejects initialization when the bounded projected timeline response is an error", async () => {
+    const client = new FakeDaemonClient();
+    const runtime = new FakeTimelineRuntime();
+    const failure = new Error(
+      "Projected timeline lifecycle exceeds the bounded legacy history window",
+    );
+    runtime.fetchAgentTimeline = async () => {
+      throw failure;
+    };
+    useSessionStore.getState().initializeSession(serverId, client as never);
+
+    const initialization = ensureAgentIsInitialized({
+      serverId,
+      agentId,
+      client: client as never,
+      runtime,
+      setAgentInitializing: bindSetAgentInitializing(),
+    });
+
+    await expect(initialization).rejects.toBe(failure);
+    expect(getInitDeferred(getInitKey(serverId, agentId))).toBeUndefined();
+    expect(useSessionStore.getState().sessions[serverId]?.initializingAgents.get(agentId)).toBe(
+      false,
+    );
+  });
+
   it("requests a bounded projected tail after restoring painted replica items", () => {
     const client = new FakeDaemonClient();
     const runtime = new FakeTimelineRuntime();

--- a/packages/app/src/hooks/use-load-older-agent-history.test.ts
+++ b/packages/app/src/hooks/use-load-older-agent-history.test.ts
@@ -158,10 +158,14 @@ describe("loadOlderAgentHistory", () => {
     expect(started).toBe(true);
   });
 
-  it("shows a panel toast, warns, and clears in-flight on failure", async () => {
-    const error = new Error("network");
+  it("preserves retryability after a bounded projected-history failure", async () => {
+    const error = new Error(
+      "Projected timeline lifecycle exceeds the bounded legacy history window",
+    );
+    let attempts = 0;
     const client = createClient(async () => {
-      throw error;
+      attempts += 1;
+      if (attempts === 1) throw error;
     });
     const inFlight = createInFlight();
     const toast = createToast();
@@ -188,5 +192,19 @@ describe("loadOlderAgentHistory", () => {
       ["[Timeline] failed to load older agent history", agentId, error],
     ]);
     expect(inFlight.values).toEqual([false, true, false]);
+
+    await expect(
+      loadOlderAgentHistory(agentId, {
+        client,
+        cursor: someCursor,
+        hasOlder: true,
+        isLoadingOlder: false,
+        setInFlight: inFlight.setInFlight,
+        toast,
+        logger,
+      }),
+    ).resolves.toBe(true);
+    expect(client.calls).toHaveLength(2);
+    expect(inFlight.values).toEqual([false, true, false, true, false]);
   });
 });

--- a/packages/app/src/timeline/replica.test.ts
+++ b/packages/app/src/timeline/replica.test.ts
@@ -352,6 +352,45 @@ describe("viewed timeline persistence", () => {
     owner.dispose();
   });
 
+  it("preserves the prior authoritative timeline when a projected fetch returns an error", () => {
+    useSessionStore.getState().initializeSession(SERVER_ID, null);
+    applySynced(AGENT_ID, 8);
+    const commits: CachedTimeline[] = [];
+    const owner = createOwner({
+      readTimeline: async () => undefined,
+      commitTimeline: (_serverId, _agentId, timeline) => commits.push(timeline),
+    });
+    const before = selectAgentTimelineState(
+      useSessionStore.getState().sessions[SERVER_ID],
+      AGENT_ID,
+    );
+
+    owner.applyTimelineResponse({
+      requestId: "bounded-projection-error",
+      agentId: AGENT_ID,
+      agent: null,
+      direction: "before",
+      projection: "projected",
+      reset: false,
+      epoch: "",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 0 },
+      startCursor: null,
+      endCursor: null,
+      entries: [],
+      error: "Projected timeline lifecycle exceeds the bounded legacy history window",
+      hasNewer: false,
+      hasOlder: false,
+      staleCursor: false,
+      gap: false,
+    });
+
+    expect(
+      selectAgentTimelineState(useSessionStore.getState().sessions[SERVER_ID], AGENT_ID),
+    ).toEqual(before);
+    expect(commits).toEqual([]);
+    owner.dispose();
+  });
+
   it("persists demanded agents independently", () => {
     useSessionStore.getState().initializeSession(SERVER_ID, null);
     const keys: string[] = [];

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -3779,7 +3779,7 @@ test("importProviderSession imports the selected session without listing and pub
   expect(manager.listProviderSubagents(imported.id)).toEqual([
     expect.objectContaining({ id: "thread-child", title: "Imported child", status: "completed" }),
   ]);
-  expect(manager.fetchProviderSubagentTimeline(imported.id, "thread-child").rows).toEqual([
+  expect((await manager.fetchProviderSubagentTimeline(imported.id, "thread-child")).rows).toEqual([
     expect.objectContaining({ item: { type: "assistant_message", text: "Child result" } }),
   ]);
   expect(events).toHaveLength(3);
@@ -4046,6 +4046,815 @@ test("reloadAgentSession terminalizes running provider children when preserving 
   expect(manager.listProviderSubagents(snapshot.id)).toEqual([
     expect.objectContaining({ id: "running-child", status: "canceled" }),
   ]);
+});
+
+test("fetchProviderSubagentTimeline single-flights lazy provider history and ingests it once", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-history-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const loadGate = deferred<void>();
+  let activeSession: LazyProviderChildSession | null = null;
+  class LazyProviderChildSession extends TestAgentSession {
+    loadCalls = 0;
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      this.loadCalls += 1;
+      await loadGate.promise;
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded lazily." },
+          },
+        },
+      ];
+    }
+  }
+  class LazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new LazyProviderChildSession(config);
+      return activeSession;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new LazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000120",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const firstTimeline = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  const secondTimeline = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  await vi.waitFor(() => expect(activeSession?.loadCalls).toBe(1));
+  loadGate.resolve();
+
+  const timelines = await Promise.all([firstTimeline, secondTimeline]);
+  for (const timeline of timelines) {
+    expect(timeline).toMatchObject({
+      rows: [
+        expect.objectContaining({ item: { type: "assistant_message", text: "Loaded lazily." } }),
+      ],
+    });
+  }
+  expect(timelines[0]?.rows).toHaveLength(1);
+});
+
+test("reloadAgentSession preserves completed lazy provider history without replaying it", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-hot-reload-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const sessions: ReloadableLazyProviderChildSession[] = [];
+  class ReloadableLazyProviderChildSession extends TestAgentSession {
+    readonly loadedSubagentIds = new Set<string>();
+    loadCalls = 0;
+
+    getLoadedProviderSubagentHistoryIds(): readonly string[] {
+      return [...this.loadedSubagentIds];
+    }
+
+    seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+      for (const subagentId of subagentIds) {
+        this.loadedSubagentIds.add(subagentId);
+      }
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      if (this.loadedSubagentIds.has(subagentId)) {
+        return [];
+      }
+      this.loadCalls += 1;
+      this.loadedSubagentIds.add(subagentId);
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded once across reloads." },
+          },
+        },
+      ];
+    }
+  }
+  class ReloadableLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): AgentSession {
+      const session = new ReloadableLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new ReloadableLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000124",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const beforeReload = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  expect(beforeReload.rows).toHaveLength(1);
+  expect(sessions[0]?.loadCalls).toBe(1);
+
+  await manager.reloadAgentSession(snapshot.id);
+  const afterReload = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(0);
+  expect(afterReload.rows).toEqual(beforeReload.rows);
+});
+
+test("reloadAgentSession preserves a lazy provider history load that finishes during replacement", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-reload-race-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const childLoadStarted = deferred<void>();
+  const childLoadGate = deferred<void>();
+  const resumeStarted = deferred<void>();
+  const resumeGate = deferred<void>();
+  const sessions: RacingReloadLazyProviderChildSession[] = [];
+  class RacingReloadLazyProviderChildSession extends TestAgentSession {
+    readonly loadedSubagentIds = new Set<string>();
+    loadCalls = 0;
+
+    getLoadedProviderSubagentHistoryIds(): readonly string[] {
+      return [...this.loadedSubagentIds];
+    }
+
+    seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+      for (const subagentId of subagentIds) {
+        this.loadedSubagentIds.add(subagentId);
+      }
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      if (this.loadedSubagentIds.has(subagentId)) {
+        return [];
+      }
+      this.loadCalls += 1;
+      if (sessions[0] === this) {
+        childLoadStarted.resolve();
+        await childLoadGate.promise;
+      }
+      this.loadedSubagentIds.add(subagentId);
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded while reload waits." },
+          },
+        },
+      ];
+    }
+  }
+  class RacingReloadLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): RacingReloadLazyProviderChildSession {
+      const session = new RacingReloadLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      resumeStarted.resolve();
+      await resumeGate.promise;
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new RacingReloadLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000126",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const childFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  await childLoadStarted.promise;
+  const reload = manager.reloadAgentSession(snapshot.id);
+  childLoadGate.resolve();
+  const loadedDuringReload = await childFetch;
+  await resumeStarted.promise;
+  resumeGate.resolve();
+  await reload;
+
+  const afterReload = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(0);
+  expect(afterReload.rows).toEqual(loadedDuringReload.rows);
+  expect(afterReload.rows).toHaveLength(1);
+});
+
+test("reloadAgentSession atomically admits a provider history fetch started in the same turn", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-admission-race-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const childLoadStarted = deferred<void>();
+  const childLoadGate = deferred<void>();
+  const resumeStarted = deferred<void>();
+  const resumeGate = deferred<void>();
+  const sessions: AdmissionRaceLazyProviderChildSession[] = [];
+  class AdmissionRaceLazyProviderChildSession extends TestAgentSession {
+    readonly loadedSubagentIds = new Set<string>();
+    loadCalls = 0;
+
+    getLoadedProviderSubagentHistoryIds(): readonly string[] {
+      return [...this.loadedSubagentIds];
+    }
+
+    seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+      for (const subagentId of subagentIds) {
+        this.loadedSubagentIds.add(subagentId);
+      }
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      if (this.loadedSubagentIds.has(subagentId)) {
+        return [];
+      }
+      this.loadCalls += 1;
+      if (sessions[0] === this) {
+        childLoadStarted.resolve();
+        await childLoadGate.promise;
+      }
+      this.loadedSubagentIds.add(subagentId);
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Admitted before reload." },
+          },
+        },
+      ];
+    }
+  }
+  class AdmissionRaceLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): AdmissionRaceLazyProviderChildSession {
+      const session = new AdmissionRaceLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      resumeStarted.resolve();
+      await resumeGate.promise;
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new AdmissionRaceLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000127",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const childFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  const reload = manager.reloadAgentSession(snapshot.id);
+  await childLoadStarted.promise;
+  childLoadGate.resolve();
+  const admittedTimeline = await childFetch;
+  await resumeStarted.promise;
+  resumeGate.resolve();
+  await reload;
+
+  const afterReload = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(0);
+  expect(afterReload.rows).toEqual(admittedTimeline.rows);
+  expect(afterReload.rows).toHaveLength(1);
+});
+
+test("reloadAgentSession aborts a stuck provider history load and releases waiting fetches", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-stuck-reload-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const stuckLoadStarted = deferred<void>();
+  const sessions: StuckReloadLazyProviderChildSession[] = [];
+  class StuckReloadLazyProviderChildSession extends TestAgentSession {
+    loadCalls = 0;
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      this.loadCalls += 1;
+      if (sessions[0] === this) {
+        stuckLoadStarted.resolve();
+        return await new Promise(() => undefined);
+      }
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Retried on the replacement session." },
+          },
+        },
+      ];
+    }
+  }
+  class StuckReloadLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): StuckReloadLazyProviderChildSession {
+      const session = new StuckReloadLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new StuckReloadLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000128",
+    rescueTimeouts: { reloadSessionCloseMs: 10 },
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const stuckFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  const stuckFetchRejection = expect(stuckFetch).rejects.toThrow(
+    "Provider subagent history load aborted for reload",
+  );
+  await stuckLoadStarted.promise;
+  const reload = manager.reloadAgentSession(snapshot.id);
+  const waitingFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  await expect(
+    Promise.race([
+      reload.then(() => "reloaded"),
+      new Promise<"timed_out">((resolve) => setTimeout(() => resolve("timed_out"), 200)),
+    ]),
+  ).resolves.toBe("reloaded");
+  await stuckFetchRejection;
+  await expect(waitingFetch).resolves.toMatchObject({
+    rows: [
+      expect.objectContaining({
+        item: { type: "assistant_message", text: "Retried on the replacement session." },
+      }),
+    ],
+  });
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(1);
+});
+
+test("closeAgent aborts and removes a stuck provider history load", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-stuck-close-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const stuckLoadStarted = deferred<void>();
+  let activeSession: StuckCloseLazyProviderChildSession | null = null;
+  class StuckCloseLazyProviderChildSession extends TestAgentSession {
+    override async loadProviderSubagentHistory(): Promise<
+      Extract<AgentStreamEvent, { type: "provider_subagent" }>[]
+    > {
+      stuckLoadStarted.resolve();
+      return await new Promise(() => undefined);
+    }
+  }
+  class StuckCloseLazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new StuckCloseLazyProviderChildSession(config);
+      return activeSession;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new StuckCloseLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000129",
+    rescueTimeouts: { reloadSessionCloseMs: 10 },
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const stuckFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  const stuckFetchRejection = expect(stuckFetch).rejects.toThrow(
+    "Provider subagent history load aborted because agent closed",
+  );
+  await stuckLoadStarted.promise;
+
+  await manager.closeAgent(snapshot.id);
+
+  expect(
+    (
+      manager as unknown as {
+        providerSubagentHistoryLoads: Map<string, unknown>;
+      }
+    ).providerSubagentHistoryLoads.size,
+  ).toBe(0);
+  await stuckFetchRejection;
+});
+
+test("reloadAgentSession rehydrates lazy provider history when requested", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-rehydrate-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const sessions: RehydratingLazyProviderChildSession[] = [];
+  class RehydratingLazyProviderChildSession extends TestAgentSession {
+    readonly loadedSubagentIds = new Set<string>();
+    loadCalls = 0;
+
+    getLoadedProviderSubagentHistoryIds(): readonly string[] {
+      return [...this.loadedSubagentIds];
+    }
+
+    seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+      for (const subagentId of subagentIds) {
+        this.loadedSubagentIds.add(subagentId);
+      }
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      if (this.loadedSubagentIds.has(subagentId)) {
+        return [];
+      }
+      this.loadCalls += 1;
+      this.loadedSubagentIds.add(subagentId);
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Reloaded from disk." },
+          },
+        },
+      ];
+    }
+  }
+  class RehydratingLazyProviderChildClient extends TestAgentClient {
+    private create(config: AgentSessionConfig): AgentSession {
+      const session = new RehydratingLazyProviderChildSession(config);
+      sessions.push(session);
+      return session;
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return this.create(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return this.create({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new RehydratingLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000125",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  sessions[0]?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+  await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  await manager.reloadAgentSession(snapshot.id, undefined, { rehydrateFromDisk: true });
+  const rehydrated = await manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+
+  expect(sessions).toHaveLength(2);
+  expect(sessions[1]?.loadCalls).toBe(1);
+  expect(rehydrated.rows).toMatchObject([
+    { item: { type: "assistant_message", text: "Reloaded from disk." } },
+  ]);
+  expect(rehydrated.rows).toHaveLength(1);
+});
+
+test("reloadAgentSession waits for an in-flight provider history load before replacing it", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-reload-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const loadStarted = deferred<void>();
+  const loadGate = deferred<void>();
+  let activeSession: ReloadingLazyProviderChildSession | null = null;
+  class ReloadingLazyProviderChildSession extends TestAgentSession {
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      loadStarted.resolve();
+      await loadGate.promise;
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded by the replaced session." },
+          },
+        },
+      ];
+    }
+  }
+  class ReloadingLazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new ReloadingLazyProviderChildSession(config);
+      return activeSession;
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new TestAgentSession({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new ReloadingLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000121",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+
+  const timelinePromise = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
+  await loadStarted.promise;
+  let reloadSettled = false;
+  const reload = manager.reloadAgentSession(snapshot.id).finally(() => {
+    reloadSettled = true;
+  });
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  expect(reloadSettled).toBe(false);
+  loadGate.resolve();
+
+  await expect(timelinePromise).resolves.toMatchObject({
+    rows: [
+      expect.objectContaining({
+        item: { type: "assistant_message", text: "Loaded by the replaced session." },
+      }),
+    ],
+  });
+  await reload;
+});
+
+test("fetchProviderSubagentTimeline ingests lazy history while a turn is pending", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-pending-run-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const startEntered = deferred<void>();
+  const startGate = deferred<void>();
+  let activeSession: PendingRunLazyProviderChildSession | null = null;
+  class PendingRunLazyProviderChildSession extends TestAgentSession {
+    override async startTurn(prompt: AgentPromptInput): Promise<{ turnId: string }> {
+      startEntered.resolve();
+      await startGate.promise;
+      return await super.startTurn(prompt);
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded during pending start." },
+          },
+        },
+      ];
+    }
+  }
+  class PendingRunLazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new PendingRunLazyProviderChildSession(config);
+      return activeSession;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new PendingRunLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000122",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+  const run = manager.streamAgent(snapshot.id, "hold start");
+  const consume = (async () => {
+    for await (const _event of run) {
+      // Drain the test run.
+    }
+  })();
+  await startEntered.promise;
+
+  try {
+    await expect(
+      manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child"),
+    ).resolves.toMatchObject({
+      rows: [
+        expect.objectContaining({
+          item: { type: "assistant_message", text: "Loaded during pending start." },
+        }),
+      ],
+    });
+  } finally {
+    startGate.resolve();
+    await consume;
+  }
+});
+
+test("fetchProviderSubagentTimeline ingests lazy history while steer admission is pending", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-lazy-steer-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const steerEntered = deferred<void>();
+  const steerGate = deferred<void>();
+  let activeSession: SteerLazyProviderChildSession | null = null;
+  class SteerLazyProviderChildSession extends SteeringTestSession {
+    override async steerActiveTurn(): Promise<import("./agent-sdk-types.js").SteerResult> {
+      this.steerCount += 1;
+      steerEntered.resolve();
+      await steerGate.promise;
+      return { status: "accepted" };
+    }
+
+    override async loadProviderSubagentHistory(
+      subagentId: string,
+    ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+      return [
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "timeline",
+            id: subagentId,
+            item: { type: "assistant_message", text: "Loaded during steer admission." },
+          },
+        },
+      ];
+    }
+  }
+  class SteerLazyProviderChildClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new SteerLazyProviderChildSession(config);
+      return activeSession;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new SteerLazyProviderChildClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000123",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  activeSession?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "lazy-child", title: "Lazy child", status: "completed" },
+  });
+  await manager.flush();
+  const run = manager.streamAgent(snapshot.id, "hold active turn");
+  const consume = (async () => {
+    for await (const _event of run) {
+      // Drain the test run.
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+  const steer = manager.steerAgentRun(snapshot.id, "hold steer");
+  await steerEntered.promise;
+
+  try {
+    await expect(
+      manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child"),
+    ).resolves.toMatchObject({
+      rows: [
+        expect.objectContaining({
+          item: { type: "assistant_message", text: "Loaded during steer admission." },
+        }),
+      ],
+    });
+  } finally {
+    steerGate.resolve();
+    await steer;
+    activeSession?.pushEvent({
+      type: "turn_completed",
+      provider: "codex",
+      turnId: "active-turn-1",
+    });
+    await consume;
+  }
 });
 
 test("hydrateTimelineFromProvider restores and broadcasts provider children from session history", async () => {
@@ -7101,9 +7910,9 @@ test("subscribe hides provider subagents of internal parents from global subscri
   expect(() => manager.getProviderSubagent(internalAgentId, "hidden-child")).toThrow(
     `Unknown agent '${internalAgentId}'`,
   );
-  expect(() => manager.fetchProviderSubagentTimeline(internalAgentId, "hidden-child")).toThrow(
-    `Unknown agent '${internalAgentId}'`,
-  );
+  await expect(
+    manager.fetchProviderSubagentTimeline(internalAgentId, "hidden-child"),
+  ).rejects.toThrow(`Unknown agent '${internalAgentId}'`);
   expect(manager.listProviderSubagentActivity()).toEqual([]);
 });
 

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -4462,20 +4462,15 @@ test("reloadAgentSession aborts a stuck provider history load and releases waiti
   await manager.flush();
 
   const stuckFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
-  const stuckFetchRejection = expect(stuckFetch).rejects.toThrow(
-    "Provider subagent history load aborted for reload",
-  );
+  const stuckFetchRejection = stuckFetch.catch((error: unknown) => error);
   await stuckLoadStarted.promise;
   const reload = manager.reloadAgentSession(snapshot.id);
   const waitingFetch = manager.fetchProviderSubagentTimeline(snapshot.id, "lazy-child");
 
-  await expect(
-    Promise.race([
-      reload.then(() => "reloaded"),
-      new Promise<"timed_out">((resolve) => setTimeout(() => resolve("timed_out"), 200)),
-    ]),
-  ).resolves.toBe("reloaded");
-  await stuckFetchRejection;
+  await reload;
+  await expect(stuckFetchRejection).resolves.toEqual(
+    expect.objectContaining({ message: "Provider subagent history load aborted for reload" }),
+  );
   await expect(waitingFetch).resolves.toMatchObject({
     rows: [
       expect.objectContaining({

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -6195,6 +6195,44 @@ test("bounds the live root timeline while paging 600 durable rows in both direct
   }
 }, 30_000);
 
+test("bounds oversized assistant messages before writing the disposable timeline cache", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bounded-root-message-"));
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    durableTimelineStore: new SegmentedFileAgentTimelineStore(join(workdir, "timeline-cache")),
+    boundedTimeline: { hot: { maxRows: 4, maxBytes: 8 * 1024 * 1024 } },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000606",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+
+    await expect(
+      manager.appendTimelineItem(snapshot.id, {
+        type: "assistant_message",
+        text: "x".repeat(250 * 1024),
+      }),
+    ).resolves.toEqual({ seq: 1, epoch: expect.any(String) });
+    await manager.flush();
+
+    const timeline = await manager.fetchTimelinePage(snapshot.id, {
+      direction: "tail",
+      limit: 10,
+    });
+    expect(timeline.rows).toHaveLength(1);
+    expect(timeline.rows[0]?.item).toMatchObject({
+      type: "assistant_message",
+      text: expect.stringMatching(/\[truncated to fit timeline storage\]$/),
+    });
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("force hydration clears the disposable cache before provider history repopulates it", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bounded-provider-replay-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./agent-manager.js";
 import { AgentStorage } from "./agent-storage.js";
 import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
+import { SegmentedFileAgentTimelineStore } from "./segmented-file-agent-timeline-store.js";
 import { toAgentPayload } from "./agent-projections.js";
 import { projectTimelineRows } from "./timeline-projection.js";
 import { getOpenAgentTabLabel, PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
@@ -3794,6 +3795,48 @@ test("importProviderSession imports the selected session without listing and pub
   expect((await storage.get(imported.id))?.title).toBe("Trace provider imports");
 });
 
+test("failed registration discards a partially admitted explicit bounded timeline seed", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-seed-rollback-"));
+  const durable = new RecordingTimelineStore();
+  const manager = new AgentManager({
+    clients: {},
+    durableTimelineStore: durable,
+    boundedTimeline: { hot: { maxRows: 1, maxBytes: 10_000 } },
+    logger,
+  });
+  const failure = new Error("snapshot persistence failed");
+  const agentId = randomUUID();
+  const internals = manager as unknown as {
+    persistSnapshot: (...args: unknown[]) => Promise<void>;
+    registerSession: (
+      session: AgentSession,
+      config: AgentSessionConfig,
+      agentId: string,
+      options: { timelineRows: AgentTimelineRow[] },
+    ) => Promise<ManagedAgent>;
+    boundedTimeline: { has(agentId: string): boolean };
+    timelineStore: InMemoryAgentTimelineStore;
+  };
+  vi.spyOn(internals, "persistSnapshot").mockRejectedValue(failure);
+  const session = new TestAgentSession({ provider: "codex", cwd: workdir });
+
+  await expect(
+    internals.registerSession(session, { provider: "codex", cwd: workdir }, agentId, {
+      timelineRows: [
+        {
+          seq: 1,
+          timestamp: "2026-01-02T00:00:00.000Z",
+          item: { type: "user_message", text: "seed" },
+        },
+      ],
+    }),
+  ).rejects.toBe(failure);
+
+  await expect(durable.getCommittedRows(agentId)).resolves.toEqual([]);
+  expect(internals.boundedTimeline.has(agentId)).toBe(false);
+  expect(internals.timelineStore.has(agentId)).toBe(false);
+});
+
 test("reloadAgentSession passes daemon launch env through the provider launch context", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-reload-context-"));
   const storagePath = join(workdir, "agents");
@@ -6090,6 +6133,431 @@ test("does not trim committed history", async () => {
   expect(fetched.rows).toHaveLength(3);
   expect(fetched.window.minSeq).toBe(1);
   expect(fetched.window.maxSeq).toBe(3);
+});
+
+test("bounds the live root timeline while paging 600 durable rows in both directions", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bounded-root-timeline-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const durable = new SegmentedFileAgentTimelineStore(join(workdir, "timeline-cache"), {
+    maxRowsPerSegment: 8,
+  });
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    durableTimelineStore: durable,
+    boundedTimeline: {
+      hot: { maxRows: 4, maxBytes: 10_000 },
+      buffer: { maxBatchRows: 16, maxPendingRows: 32, maxPendingBytes: 100_000 },
+    },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000600",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    for (let seq = 1; seq <= 600; seq += 1) {
+      await manager.appendTimelineItem(snapshot.id, {
+        type: "user_message",
+        text: `row-${seq}`,
+      });
+    }
+    await manager.flush();
+
+    expect(manager.getTimeline(snapshot.id)).toHaveLength(4);
+    const tail = await manager.fetchTimelinePage(snapshot.id, { direction: "tail", limit: 10 });
+    expect(tail.rows.map(({ seq }) => seq)).toEqual([
+      591, 592, 593, 594, 595, 596, 597, 598, 599, 600,
+    ]);
+    const before = await manager.fetchTimelinePage(snapshot.id, {
+      direction: "before",
+      cursor: { epoch: tail.epoch, seq: 591 },
+      limit: 2,
+    });
+    expect(before.rows.map(({ seq }) => seq)).toEqual([589, 590]);
+    const after = await manager.fetchTimelinePage(snapshot.id, {
+      direction: "after",
+      cursor: { epoch: tail.epoch, seq: 590 },
+      limit: 2,
+    });
+    expect(after.rows.map(({ seq }) => seq)).toEqual([591, 592]);
+    expect(manager.getMetricsSnapshot().timelineCache).toMatchObject({
+      residentRows: 4,
+      residentBytes: expect.any(Number),
+      pendingRows: 0,
+      pendingBytes: 0,
+      backpressuredAgents: 0,
+      failedAgents: 0,
+    });
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}, 30_000);
+
+test("force hydration clears the disposable cache before provider history repopulates it", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bounded-provider-replay-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const durable = new SegmentedFileAgentTimelineStore(join(workdir, "timeline-cache"));
+
+  class ProviderHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      for (let seq = 1; seq <= 6; seq += 1) {
+        yield {
+          type: "timeline",
+          provider: this.provider,
+          item: { type: "assistant_message", text: `provider-${seq}` },
+        };
+      }
+    }
+  }
+
+  class ProviderHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new ProviderHistorySession(config);
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new ProviderHistoryClient() },
+    registry: storage,
+    durableTimelineStore: durable,
+    boundedTimeline: { hot: { maxRows: 2, maxBytes: 10_000 } },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000601",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await manager.appendTimelineItem(snapshot.id, {
+      type: "assistant_message",
+      text: "discard this stale cache row",
+    });
+    await manager.flush();
+
+    await manager.hydrateTimelineFromProvider(snapshot.id, { force: true });
+    await manager.flush();
+
+    const replayed = await manager.fetchTimelinePage(snapshot.id, {
+      direction: "tail",
+      limit: 10,
+    });
+    expect(replayed.rows.map(({ item }) => item)).toEqual(
+      Array.from({ length: 6 }, (_, index) => ({
+        type: "assistant_message",
+        text: `provider-${index + 1}`,
+      })),
+    );
+    expect(manager.getTimeline(snapshot.id)).toHaveLength(2);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("surfaces bounded timeline durability failure while retaining the pending live row", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bounded-durable-failure-"));
+  const durable = new SegmentedFileAgentTimelineStore(join(workdir, "timeline-cache"));
+  const failure = new Error("timeline cache write failed");
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    durableTimelineStore: durable,
+    boundedTimeline: {
+      durableSink: {
+        bulkInsert: async () => {
+          throw failure;
+        },
+        updateCommittedRow: async () => {
+          throw failure;
+        },
+      },
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000602",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await manager.appendTimelineItem(snapshot.id, {
+      type: "assistant_message",
+      text: "keep pending",
+    });
+
+    await expect(manager.flush()).rejects.toBe(failure);
+    expect(manager.getTimeline(snapshot.id)).toEqual([
+      { type: "assistant_message", text: "keep pending" },
+    ]);
+    expect(manager.getTimelineCacheMetrics(snapshot.id)).toMatchObject({
+      hot: { retainedRows: 1, pinnedRows: 1, pendingRows: 1 },
+      durabilityError: failure,
+    });
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("archive completes when the disposable timeline cache write failed", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bounded-archive-failure-"));
+  const failure = new Error("timeline cache write failed");
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    durableTimelineStore: new SegmentedFileAgentTimelineStore(join(workdir, "timeline-cache")),
+    boundedTimeline: {
+      durableSink: {
+        bulkInsert: async () => {
+          throw failure;
+        },
+        updateCommittedRow: async () => {
+          throw failure;
+        },
+      },
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000603",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await manager.appendTimelineItem(snapshot.id, {
+      type: "assistant_message",
+      text: "provider remains authoritative",
+    });
+    await expect(manager.archiveAgent(snapshot.id)).resolves.toMatchObject({
+      archivedAt: expect.any(String),
+    });
+    expect(manager.getAgent(snapshot.id)).toBeNull();
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("close completes after a coalesced timeline row latches a disposable cache failure", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bounded-close-coalescer-failure-"));
+  const failure = new Error("timeline cache write failed");
+  const session = new TestAgentSession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: {
+      codex: new (class extends TestAgentClient {
+        override async createSession(): Promise<AgentSession> {
+          return session;
+        }
+      })(),
+    },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    durableTimelineStore: new SegmentedFileAgentTimelineStore(join(workdir, "timeline-cache")),
+    boundedTimeline: {
+      durableSink: {
+        bulkInsert: async () => {
+          throw failure;
+        },
+        updateCommittedRow: async () => {
+          throw failure;
+        },
+      },
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000604",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    session.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "assistant_message", text: "coalesced cache failure" },
+    });
+    await expect(manager.flush()).rejects.toBe(failure);
+    expect(manager.getAgent(snapshot.id)).not.toBeNull();
+    session.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "assistant_message", text: "queued after cache failure" },
+    });
+
+    await expect(manager.closeAgent(snapshot.id)).resolves.toBeUndefined();
+    expect(manager.getAgent(snapshot.id)).toBeNull();
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("a latched coalescer cache failure does not swallow a terminal event", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bounded-terminal-cache-failure-"));
+  const failure = new Error("timeline cache write failed");
+  const session = new TestAgentSession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: {
+      codex: new (class extends TestAgentClient {
+        override async createSession(): Promise<AgentSession> {
+          return session;
+        }
+      })(),
+    },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    durableTimelineStore: new SegmentedFileAgentTimelineStore(join(workdir, "timeline-cache")),
+    boundedTimeline: {
+      durableSink: {
+        bulkInsert: async () => {
+          throw failure;
+        },
+        updateCommittedRow: async () => {
+          throw failure;
+        },
+      },
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000605",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    session.pushEvent({ type: "turn_started", provider: "codex", turnId: "turn-cache-failure" });
+    await waitForAgentLifecycle(manager, snapshot.id, "running");
+    session.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      turnId: "turn-cache-failure",
+      item: { type: "assistant_message", text: "fails cache" },
+    });
+    await expect(manager.flush()).rejects.toBe(failure);
+    session.pushEvent({
+      type: "turn_completed",
+      provider: "codex",
+      turnId: "turn-cache-failure",
+    });
+
+    await expect(waitForAgentLifecycle(manager, snapshot.id, "idle")).resolves.toBeUndefined();
+    expect(manager.getAgent(snapshot.id)?.lastError).toBeUndefined();
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("turn_failed settles the foreground run after system-error timeline persistence fails", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bounded-turn-failed-cache-"));
+  const cacheFailure = new Error("timeline cache write failed");
+  const cacheFailureObserved = deferred<void>();
+
+  class CacheFailingTurnSession extends TestAgentSession {
+    override async startTurn(): Promise<{ turnId: string }> {
+      const turnId = "turn-cache-failed";
+      setTimeout(() => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+      }, 0);
+      return { turnId };
+    }
+  }
+
+  const session = new CacheFailingTurnSession({ provider: "codex", cwd: workdir });
+  let writes = 0;
+  const manager = new AgentManager({
+    clients: {
+      codex: new (class extends TestAgentClient {
+        override async createSession(): Promise<AgentSession> {
+          return session;
+        }
+      })(),
+    },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    durableTimelineStore: new SegmentedFileAgentTimelineStore(join(workdir, "timeline-cache")),
+    boundedTimeline: {
+      durableSink: {
+        bulkInsert: async () => {
+          writes += 1;
+          if (writes > 1) {
+            cacheFailureObserved.resolve();
+            throw cacheFailure;
+          }
+        },
+        updateCommittedRow: async () => undefined,
+      },
+      hot: { maxRows: 4, maxBytes: 10_000 },
+      buffer: { maxBatchRows: 1 },
+    },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000606",
+  });
+
+  try {
+    const agent = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const run = manager.runAgent(agent.id, "hello", { clientMessageId: "client-cache-failed" });
+    await waitForAgentLifecycle(manager, agent.id, "running");
+    await vi.waitFor(() => {
+      expect(manager.getTimelineCacheMetrics(agent.id)?.hot).toMatchObject({
+        pinnedRows: 1,
+        pendingRows: 0,
+      });
+    });
+    await manager.flush();
+    await manager.appendTimelineItem(agent.id, {
+      type: "assistant_message",
+      text: "cache this",
+    });
+    await expect(manager.flush()).rejects.toBe(cacheFailure);
+    await cacheFailureObserved.promise;
+    session.pushEvent({
+      type: "permission_requested",
+      provider: session.provider,
+      turnId: "turn-cache-failed",
+      request: {
+        id: "permission-cache-failed",
+        provider: session.provider,
+        kind: "tool",
+        name: "Read file",
+      },
+    });
+    await vi.waitFor(() => {
+      expect(manager.getAgent(agent.id)?.pendingPermissions.size).toBe(1);
+    });
+    expect(manager.getTimelineCacheMetrics(agent.id)?.hot).toMatchObject({
+      pinnedRows: 2,
+      pendingRows: 1,
+    });
+    session.pushEvent({
+      type: "turn_failed",
+      provider: session.provider,
+      turnId: "turn-cache-failed",
+      error: "provider turn failed",
+    });
+
+    await expect(
+      Promise.race([
+        run,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("foreground run did not settle")), 1_000),
+        ),
+      ]),
+    ).rejects.toThrow("provider turn failed");
+    expect(manager.getAgent(agent.id)).toMatchObject({
+      lifecycle: "error",
+      activeTurnId: null,
+      lastError: "provider turn failed",
+    });
+    expect(manager.getAgent(agent.id)?.pendingPermissions.size).toBe(0);
+    expect(manager.getTimelineCacheMetrics(agent.id)?.hot).toMatchObject({
+      pinnedRows: 1,
+      pendingRows: 1,
+    });
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("hydrateTimeline preserves assistant chunk, reasoning, and tool timeline history", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -693,6 +693,14 @@ export class AgentManager {
   private readonly providerSubagents = new ProviderSubagentStore();
   private readonly agentsAwaitingInitialSnapshotPersist = new Set<string>();
   private readonly sessionEventTails = new Map<string, Promise<void>>();
+  private readonly providerSubagentHistoryLoads = new Map<
+    string,
+    { session: AgentSession; promise: Promise<void>; abortController: AbortController }
+  >();
+  private readonly providerSubagentHistoryReloadBarriers = new Map<
+    string,
+    { promise: Promise<void>; release: () => void }
+  >();
   private readonly steerEventBarriers = new Map<string, SteerEventBarrier>();
   private readonly foregroundMutationTails = new Map<string, Promise<void>>();
   private readonly runs = new AgentRunState();
@@ -1165,11 +1173,52 @@ export class AgentManager {
     return this.providerSubagents.get(parentAgentId, subagentId);
   }
 
-  fetchProviderSubagentTimeline(
+  async fetchProviderSubagentTimeline(
     parentAgentId: string,
     subagentId: string,
     options?: AgentTimelineFetchOptions,
-  ): AgentTimelineFetchResult {
+  ): Promise<AgentTimelineFetchResult> {
+    for (;;) {
+      const reloadBarrier = this.providerSubagentHistoryReloadBarriers.get(parentAgentId);
+      if (!reloadBarrier) {
+        break;
+      }
+      await reloadBarrier.promise;
+    }
+    const agent = this.requirePublicAgent(parentAgentId);
+    const session = agent.session;
+    if (session?.loadProviderSubagentHistory) {
+      const key = `${parentAgentId}\0${subagentId}`;
+      const existingLoad = this.providerSubagentHistoryLoads.get(key);
+      if (existingLoad?.session === session) {
+        await existingLoad.promise;
+      } else {
+        const abortController = new AbortController();
+        const load = (async () => {
+          const events = await this.loadProviderSubagentHistoryWithAbort(
+            session,
+            subagentId,
+            abortController.signal,
+          );
+          const current = this.agents.get(parentAgentId);
+          if (!current || current.internal || current.session !== session) {
+            throw new Error("Agent session changed while loading provider subagent history");
+          }
+          for (const event of events) {
+            this.dispatchProviderSubagentEvent(current.id, event);
+          }
+        })();
+        const loadState = { session, promise: load, abortController };
+        this.providerSubagentHistoryLoads.set(key, loadState);
+        try {
+          await load;
+        } finally {
+          if (this.providerSubagentHistoryLoads.get(key) === loadState) {
+            this.providerSubagentHistoryLoads.delete(key);
+          }
+        }
+      }
+    }
     this.requirePublicAgent(parentAgentId);
     return this.providerSubagents.fetchTimeline(parentAgentId, subagentId, options);
   }
@@ -1398,8 +1447,143 @@ export class AgentManager {
     options?: { rehydrateFromDisk?: boolean },
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
-      this.reloadAgentSessionInternal(agentId, overrides, options),
+      this.withProviderSubagentHistoryReloadBarrier(agentId, () =>
+        this.reloadAgentSessionInternal(agentId, overrides, options),
+      ),
     );
+  }
+
+  private async withProviderSubagentHistoryReloadBarrier<T>(
+    agentId: string,
+    operation: () => Promise<T>,
+    options?: { abortReason?: string },
+  ): Promise<T> {
+    let barrier: { promise: Promise<void>; release: () => void };
+    for (;;) {
+      const existing = this.providerSubagentHistoryReloadBarriers.get(agentId);
+      if (existing) {
+        await existing.promise;
+        continue;
+      }
+      let release!: () => void;
+      const promise = new Promise<void>((resolveBarrier) => {
+        release = resolveBarrier;
+      });
+      barrier = { promise, release };
+      this.providerSubagentHistoryReloadBarriers.set(agentId, barrier);
+      break;
+    }
+    try {
+      if (options?.abortReason) {
+        await this.abortProviderSubagentHistoryLoads(agentId, options.abortReason);
+      } else {
+        await this.drainProviderSubagentHistoryLoads(agentId);
+      }
+      return await operation();
+    } finally {
+      if (this.providerSubagentHistoryReloadBarriers.get(agentId) === barrier) {
+        this.providerSubagentHistoryReloadBarriers.delete(agentId);
+      }
+      barrier.release();
+    }
+  }
+
+  private async drainProviderSubagentHistoryLoads(agentId: string): Promise<void> {
+    const keyPrefix = `${agentId}\0`;
+    for (;;) {
+      const loads = [...this.providerSubagentHistoryLoads.entries()]
+        .filter(([key]) => key.startsWith(keyPrefix))
+        .map(([, load]) => load);
+      if (loads.length === 0) {
+        return;
+      }
+      const settlement = Promise.allSettled(loads.map((load) => load.promise)).then(
+        () => undefined,
+      );
+      const promptSettlement = await this.waitWithTimeout({
+        operation: settlement,
+        timeoutMs: this.rescueTimeouts.reloadSessionCloseMs,
+      });
+      if (promptSettlement === "completed") {
+        continue;
+      }
+      for (const load of loads) {
+        load.abortController.abort(new Error("Provider subagent history load aborted for reload"));
+      }
+      const abortedSettlement = await this.waitWithTimeout({
+        operation: settlement,
+        timeoutMs: this.rescueTimeouts.reloadSessionCloseMs,
+      });
+      if (abortedSettlement === "timed_out") {
+        this.logger.warn(
+          { agentId, timeoutMs: this.rescueTimeouts.reloadSessionCloseMs },
+          "Timed out aborting provider subagent history loads during refresh",
+        );
+        return;
+      }
+    }
+  }
+
+  private async abortProviderSubagentHistoryLoads(agentId: string, reason: string): Promise<void> {
+    const keyPrefix = `${agentId}\0`;
+    const loads = [...this.providerSubagentHistoryLoads.entries()].filter(([key]) =>
+      key.startsWith(keyPrefix),
+    );
+    if (loads.length === 0) {
+      return;
+    }
+    for (const [, load] of loads) {
+      load.abortController.abort(new Error(reason));
+    }
+    const settlement = Promise.allSettled(loads.map(([, load]) => load.promise)).then(
+      () => undefined,
+    );
+    const result = await this.waitWithTimeout({
+      operation: settlement,
+      timeoutMs: this.rescueTimeouts.reloadSessionCloseMs,
+    });
+    if (result === "completed") {
+      return;
+    }
+    for (const [key, load] of loads) {
+      if (this.providerSubagentHistoryLoads.get(key) === load) {
+        this.providerSubagentHistoryLoads.delete(key);
+      }
+    }
+    this.logger.warn(
+      { agentId, timeoutMs: this.rescueTimeouts.reloadSessionCloseMs },
+      "Timed out aborting provider subagent history loads while closing agent",
+    );
+  }
+
+  private async loadProviderSubagentHistoryWithAbort(
+    session: AgentSession,
+    subagentId: string,
+    signal: AbortSignal,
+  ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]> {
+    if (signal.aborted) {
+      throw createAbortError(signal, "Provider subagent history load aborted");
+    }
+    const operation = session.loadProviderSubagentHistory!(subagentId, { signal });
+    return await new Promise((resolveLoad, rejectLoad) => {
+      const onAbort = () => {
+        signal.removeEventListener("abort", onAbort);
+        rejectLoad(createAbortError(signal, "Provider subagent history load aborted"));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      void operation.then(
+        (events) => {
+          signal.removeEventListener("abort", onAbort);
+          resolveLoad(events);
+          return undefined;
+        },
+        (error: unknown) => {
+          signal.removeEventListener("abort", onAbort);
+          rejectLoad(error);
+          return undefined;
+        },
+      );
+    });
   }
 
   private async reloadAgentSessionInternal(
@@ -1418,6 +1602,11 @@ export class AgentManager {
     const preservedLastUsage = existing.lastUsage;
     const preservedLastError = existing.lastError;
     const preservedAttention = existing.attention;
+    const preservedLoadedProviderSubagentHistoryIds = rehydrateFromDisk
+      ? []
+      : (existing.session.getLoadedProviderSubagentHistoryIds?.() ?? []).filter((subagentId) =>
+          Boolean(this.providerSubagents.get(agentId, subagentId)),
+        );
     const handle = existing.persistence;
     const provider = handle?.provider ?? existing.provider;
     const client = this.requireClient(provider);
@@ -1449,6 +1638,9 @@ export class AgentManager {
         ? await client.resumeSession(handle, providerLaunchConfig, launchContext)
         : await client.createSession(providerLaunchConfig, launchContext);
       await this.requireExternalMcpSupport(session, storedConfig);
+      if (preservedLoadedProviderSubagentHistoryIds.length > 0) {
+        session.seedLoadedProviderSubagentHistoryIds?.(preservedLoadedProviderSubagentHistoryIds);
+      }
 
       this.assertAcceptingAgentRegistrations();
 
@@ -1558,7 +1750,11 @@ export class AgentManager {
       return existing;
     }
 
-    const close = this.closeAgentRuntime(agentId);
+    const close = this.withProviderSubagentHistoryReloadBarrier(
+      agentId,
+      () => this.closeAgentRuntime(agentId),
+      { abortReason: "Provider subagent history load aborted because agent closed" },
+    );
     this.inFlightAgentCloses.set(agentId, close);
     const clearClose = () => {
       if (this.inFlightAgentCloses.get(agentId) === close) {
@@ -3589,8 +3785,7 @@ export class AgentManager {
     event: AgentStreamEvent,
   ): Promise<void> {
     if (event.type === "provider_subagent") {
-      const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
-      this.dispatch({ type: "provider_subagent", event: update });
+      this.dispatchProviderSubagentEvent(agent.id, event);
       return;
     }
     const turnId = getAgentStreamEventTurnId(event);
@@ -3628,6 +3823,14 @@ export class AgentManager {
       },
       "agent.manager.notify_waiters",
     );
+  }
+
+  private dispatchProviderSubagentEvent(
+    parentAgentId: string,
+    event: Extract<AgentStreamEvent, { type: "provider_subagent" }>,
+  ): void {
+    const update = this.providerSubagents.apply(parentAgentId, event.provider, event.event);
+    this.dispatch({ type: "provider_subagent", event: update });
   }
 
   private async resolveInitialPersistedTitle(

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -63,6 +63,11 @@ import type {
   AgentTimelineStore,
 } from "./agent-timeline-store-types.js";
 import {
+  BoundedAgentTimelineRuntime,
+  type BoundedAgentTimelineRuntimeOptions,
+} from "./bounded-agent-timeline-runtime.js";
+import { TimelineDurableBufferBackpressureError } from "./ordered-agent-timeline-durable-buffer.js";
+import {
   AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
   AgentStreamCoalescer,
 } from "./agent-stream-coalescer.js";
@@ -293,6 +298,7 @@ export interface AgentManagerOptions {
   onAgentAttention?: AgentAttentionCallback;
   onWorkspaceStateMayHaveChanged?: (params: { cwd: string }) => void;
   durableTimelineStore?: AgentTimelineStore;
+  boundedTimeline?: Omit<BoundedAgentTimelineRuntimeOptions, "onHotChanged">;
   terminalManager?: TerminalManager | null;
   mcpBaseUrl?: string;
   mcpAuthToken?: string;
@@ -307,6 +313,24 @@ export interface AgentManagerOptions {
     expectedTurnId: string;
   }) => Promise<void>;
   logger: Logger;
+}
+
+function createBoundedTimelineRuntime(
+  durableStore: AgentTimelineStore | undefined,
+  options: Omit<BoundedAgentTimelineRuntimeOptions, "onHotChanged"> | undefined,
+  hotStore: InMemoryAgentTimelineStore,
+): BoundedAgentTimelineRuntime | undefined {
+  if (!durableStore || !options) return undefined;
+  return new BoundedAgentTimelineRuntime(durableStore, {
+    ...options,
+    onHotChanged: (agentId, snapshot) => {
+      hotStore.initialize(agentId, {
+        epoch: snapshot.epoch,
+        rows: snapshot.rows,
+        nextSeq: snapshot.logicalWindow.nextSeq,
+      });
+    },
+  });
 }
 
 export type ActiveTurnSteerDispatchResult =
@@ -457,6 +481,14 @@ export interface AgentMetricsSnapshot {
   timelineStats: {
     totalItems: number;
     maxItemsPerAgent: number;
+  };
+  timelineCache?: {
+    residentRows: number;
+    residentBytes: number;
+    pendingRows: number;
+    pendingBytes: number;
+    backpressuredAgents: number;
+    failedAgents: number;
   };
 }
 
@@ -708,11 +740,14 @@ export class AgentManager {
   private readonly idFactory: () => string;
   private readonly registry?: AgentStorage;
   private readonly durableTimelineStore?: AgentTimelineStore;
+  private readonly boundedTimeline?: BoundedAgentTimelineRuntime;
   private readonly previousStatuses = new Map<string, AgentLifecycleStatus>();
   private readonly backgroundTasks = new Set<Promise<void>>();
   private readonly agentRegistrationTasks = new Set<Promise<void>>();
   private readonly inFlightAgentCloses = new Map<string, Promise<void>>();
   private readonly lifecycleMutationTails = new Map<string, Promise<void>>();
+  private readonly outOfBandTasks = new Map<string, Set<Promise<void>>>();
+  private readonly closingAgentIds = new Set<string>();
   private readonly agentStreamCoalescer: AgentStreamCoalescer;
   private mcpBaseUrl: string | null;
   private readonly mcpAuthToken: string | null;
@@ -735,6 +770,11 @@ export class AgentManager {
     this.idFactory = options?.idFactory ?? (() => randomUUID());
     this.registry = options?.registry;
     this.durableTimelineStore = options?.durableTimelineStore;
+    this.boundedTimeline = createBoundedTimelineRuntime(
+      this.durableTimelineStore,
+      options.boundedTimeline,
+      this.timelineStore,
+    );
     this.onAgentAttention = options?.onAgentAttention;
     this.onWorkspaceStateMayHaveChanged = options?.onWorkspaceStateMayHaveChanged;
     this.mcpBaseUrl = options?.mcpBaseUrl ?? null;
@@ -753,9 +793,17 @@ export class AgentManager {
     this.agentStreamCoalescer = new AgentStreamCoalescer({
       windowMs: options.agentStreamCoalesceWindowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
       timers: { setTimeout, clearTimeout },
-      onFlush: ({ agentId, item, provider, turnId }) => {
-        const event = this.recordAndDispatchTimelineItem(agentId, item, provider, turnId);
+      onFlush: async ({ agentId, item, provider, turnId }) => {
+        const event = await this.recordAndDispatchTimelineItemAsync(
+          agentId,
+          item,
+          provider,
+          turnId,
+        );
         this.notifyForegroundTurnWaiters(agentId, event);
+      },
+      onError: (agentId, error) => {
+        this.logger.error({ err: error, agentId }, "Timeline coalescer flush failed");
       },
     });
     this.updateProviderRegistry({
@@ -873,6 +921,7 @@ export class AgentManager {
         totalItems,
         maxItemsPerAgent,
       },
+      ...(this.boundedTimeline ? { timelineCache: this.boundedTimeline.aggregateMetrics() } : {}),
     };
   }
 
@@ -1138,6 +1187,9 @@ export class AgentManager {
 
   async getTimelineRows(id: string): Promise<AgentTimelineRow[]> {
     this.requireAgent(id);
+    if (this.boundedTimeline) {
+      return await this.boundedTimeline.getRows(id);
+    }
     if (this.durableTimelineStore) {
       return await this.durableTimelineStore.getCommittedRows(id);
     }
@@ -1147,6 +1199,20 @@ export class AgentManager {
   fetchTimeline(id: string, options?: AgentTimelineFetchOptions): AgentTimelineFetchResult {
     this.requireAgent(id);
     return this.timelineStore.fetch(id, options);
+  }
+
+  async fetchTimelinePage(
+    id: string,
+    options?: AgentTimelineFetchOptions,
+  ): Promise<AgentTimelineFetchResult> {
+    this.requireAgent(id);
+    if (this.boundedTimeline) return await this.boundedTimeline.fetch(id, options);
+    return this.timelineStore.fetch(id, options);
+  }
+
+  getTimelineCacheMetrics(id: string) {
+    this.requireAgent(id);
+    return this.boundedTimeline?.metrics(id) ?? null;
   }
 
   listProviderSubagents(parentAgentId: string): ProviderSubagentDescriptor[] {
@@ -1645,7 +1711,7 @@ export class AgentManager {
       this.assertAcceptingAgentRegistrations();
 
       this.cancelRunningProviderSubagents(agentId);
-      const closedExisting = this.prepareAgentForClosure(existing, "agent reloaded");
+      const closedExisting = await this.prepareAgentForClosure(existing, "agent reloaded");
       replacedExisting = true;
       try {
         await this.persistSnapshot(closedExisting);
@@ -1656,6 +1722,7 @@ export class AgentManager {
       if (rehydrateFromDisk) {
         // Wipe the in-memory timeline so registerSession mints a new epoch and
         // hydrateTimelineFromProvider re-streams the freshly read provider history.
+        await this.deleteCommittedTimeline(agentId);
         this.timelineStore.delete(agentId);
         for (const event of this.providerSubagents.deleteParent(agentId)) {
           this.dispatch({ type: "provider_subagent", event });
@@ -1749,6 +1816,12 @@ export class AgentManager {
     if (existing) {
       return existing;
     }
+    this.closingAgentIds.add(agentId);
+    const activeAgent = this.agents.get(agentId);
+    if (activeAgent?.unsubscribeSession) {
+      activeAgent.unsubscribeSession();
+      activeAgent.unsubscribeSession = null;
+    }
 
     const close = this.withProviderSubagentHistoryReloadBarrier(
       agentId,
@@ -1760,6 +1833,7 @@ export class AgentManager {
       if (this.inFlightAgentCloses.get(agentId) === close) {
         this.inFlightAgentCloses.delete(agentId);
       }
+      this.closingAgentIds.delete(agentId);
     };
     void close.then(clearClose, clearClose);
     return close;
@@ -1781,7 +1855,7 @@ export class AgentManager {
     );
     await this.drainSessionEvents(agentId);
     this.cancelRunningProviderSubagents(agentId);
-    const closedAgent = this.prepareAgentForClosure(agent, "agent closed");
+    const closedAgent = await this.prepareAgentForClosure(agent, "agent closed");
     let closeError: unknown;
     try {
       await agent.session.close();
@@ -1796,6 +1870,13 @@ export class AgentManager {
       persistError = error;
     }
     this.emitClosedAgent(closedAgent, { persist: false });
+    let timelineReleaseError: unknown;
+    try {
+      await this.boundedTimeline?.release(agentId);
+    } catch (error) {
+      timelineReleaseError = error;
+    }
+    this.timelineStore.delete(agentId);
     this.logger.trace(
       {
         agentId,
@@ -1810,6 +1891,12 @@ export class AgentManager {
     }
     if (persistError !== undefined) {
       throw persistError;
+    }
+    if (timelineReleaseError !== undefined) {
+      this.logger.warn(
+        { err: timelineReleaseError, agentId },
+        "Discarded failed disposable timeline cache during agent close",
+      );
     }
   }
 
@@ -2350,33 +2437,51 @@ export class AgentManager {
    * broadcast like normal timeline events.
    */
   tryRunOutOfBand(agentId: string, prompt: AgentPromptInput, options?: AgentRunOptions): boolean {
+    if (this.closingAgentIds.has(agentId)) throw new Error(`Agent ${agentId} is closing`);
     const agent = this.requireSessionAgent(agentId);
     const handler = agent.session.tryHandleOutOfBand?.(prompt);
     if (!handler) {
       return false;
     }
-    if (options?.clientMessageId) {
-      this.recordSubmittedPrompt(agent, prompt, options.clientMessageId);
-      this.emitState(agent);
-    }
-    const dispatch = (event: AgentStreamEvent): void => {
-      // Persist timeline items so they show up in fetchAgentTimeline; broadcast
-      // for live subscribers. Other event types are broadcast only.
-      if (event.type === "timeline") {
-        this.touchUpdatedAt(agent);
-        const row = this.recordTimeline(agent.id, event.item);
-        this.dispatchStream(agent.id, event, {
-          seq: row.seq,
-          epoch: this.timelineStore.getEpoch(agent.id),
-          timestamp: row.timestamp,
+    const task = (async () => {
+      if (options?.clientMessageId) {
+        await this.recordSubmittedPrompt(agent, prompt, options.clientMessageId, {
+          mutable: false,
         });
-        return;
+        this.emitState(agent);
       }
-      this.dispatchStream(agent.id, event, { timestamp: new Date().toISOString() });
-    };
-    void (async () => {
+      let dispatchTail = Promise.resolve();
+      const dispatch = (event: AgentStreamEvent): void => {
+        if (event.type === "timeline") {
+          try {
+            this.touchUpdatedAt(agent);
+            const row = this.tryRecordTimelineNow(agent.id, event.item);
+            this.dispatchStream(agent.id, event, {
+              seq: row.seq,
+              epoch: this.timelineStore.getEpoch(agent.id),
+              timestamp: row.timestamp,
+            });
+            return;
+          } catch (error) {
+            if (!(error instanceof TimelineDurableBufferBackpressureError)) throw error;
+            dispatchTail = dispatchTail.then(async () => {
+              await error.whenWritable;
+              const row = await this.recordTimelineAsync(agent.id, event.item);
+              this.dispatchStream(agent.id, event, {
+                seq: row.seq,
+                epoch: this.timelineStore.getEpoch(agent.id),
+                timestamp: row.timestamp,
+              });
+              return undefined;
+            });
+            return;
+          }
+        }
+        this.dispatchStream(agent.id, event, { timestamp: new Date().toISOString() });
+      };
       try {
         await handler.run({ emit: dispatch });
+        await dispatchTail;
       } catch (error) {
         const text = error instanceof Error ? error.message : "Out-of-band command failed";
         dispatch({
@@ -2384,8 +2489,21 @@ export class AgentManager {
           provider: agent.provider,
           item: { type: "assistant_message", text: `[Error] ${text}` },
         });
+        await dispatchTail;
       }
     })();
+    let agentTasks = this.outOfBandTasks.get(agentId);
+    if (!agentTasks) {
+      agentTasks = new Set();
+      this.outOfBandTasks.set(agentId, agentTasks);
+    }
+    agentTasks.add(task);
+    const clearOutOfBandTask = () => {
+      agentTasks!.delete(task);
+      if (agentTasks!.size === 0) this.outOfBandTasks.delete(agentId);
+    };
+    void task.then(clearOutOfBandTask, clearOutOfBandTask);
+    this.trackBackgroundTask(task);
     return true;
   }
 
@@ -2393,10 +2511,11 @@ export class AgentManager {
     agentId: string,
     item: AgentTimelineItem,
   ): Promise<{ seq: number; epoch: string }> {
+    this.assertTimelineIngressOpen(agentId);
     const agent = this.requireAgent(agentId);
     item = limitAgentTimelineItemContent(item);
     this.touchUpdatedAt(agent);
-    const row = this.recordTimeline(agentId, item);
+    const row = await this.recordTimelineAsync(agentId, item);
     this.dispatchStream(
       agentId,
       {
@@ -2461,6 +2580,7 @@ export class AgentManager {
     prompt: AgentPromptInput,
     options?: AgentRunOptions,
   ): AsyncGenerator<AgentStreamEvent> {
+    this.assertTimelineIngressOpen(agentId);
     const existingAgent = this.requireSessionAgent(agentId);
     this.logger.trace(
       {
@@ -2534,7 +2654,7 @@ export class AgentManager {
           )
         : undefined;
       if (options?.clientMessageId) {
-        this.recordSubmittedPrompt(agent, prompt, options.clientMessageId, {
+        await this.recordSubmittedPrompt(agent, prompt, options.clientMessageId, {
           messageId: options.clientMessageId,
           turnId,
           providerMessageId:
@@ -2690,6 +2810,7 @@ export class AgentManager {
     prompt: AgentPromptInput,
     options?: AgentSteerOptions,
   ): Promise<SteerResult> {
+    this.assertTimelineIngressOpen(agentId);
     const agent = this.requireSessionAgent(agentId);
     const expectedTurnId = agent.activeForegroundTurnId ?? agent.activeTurnId;
     if (!expectedTurnId || !agent.session.steerActiveTurn) {
@@ -2718,6 +2839,7 @@ export class AgentManager {
     prompt: AgentPromptInput,
     options?: AgentSteerOptions,
   ): Promise<ActiveTurnSteerDispatchResult> {
+    this.assertTimelineIngressOpen(agentId);
     const agent = this.requireSessionAgent(agentId);
     const expectedTurnId = agent.activeForegroundTurnId ?? agent.activeTurnId;
     if (!expectedTurnId) {
@@ -2772,7 +2894,7 @@ export class AgentManager {
   ): Promise<T> {
     return this.runForegroundMutation(agent.id, async () => {
       await this.drainSessionEvents(agent.id);
-      this.agentStreamCoalescer.flushFor(agent.id);
+      await this.agentStreamCoalescer.flushFor(agent.id);
       this.assertSteerAdmissionOwnsTurn(agent, expectedTurnId);
       const barrier: SteerEventBarrier = { events: [] };
       this.steerEventBarriers.set(agent.id, barrier);
@@ -2840,7 +2962,7 @@ export class AgentManager {
     if (!clientMessageId) {
       return;
     }
-    this.recordSubmittedPrompt(agent, prompt, clientMessageId, {
+    await this.recordSubmittedPrompt(agent, prompt, clientMessageId, {
       messageId: clientMessageId,
       turnId: expectedTurnId,
     });
@@ -3125,14 +3247,12 @@ export class AgentManager {
 
   async rewind(agentId: string, messageId: string, mode: RewindMode): Promise<void> {
     const agent = this.requireSessionAgent(agentId);
-    const submittedRow = this.timelineStore
-      .getRows(agentId)
-      .find(
-        (row) =>
-          row.item.type === "user_message" &&
-          row.item.messageId === messageId &&
-          row.item.clientMessageId === messageId,
-      );
+    const submittedRow = (await this.getTimelineRows(agentId)).find(
+      (row) =>
+        row.item.type === "user_message" &&
+        row.item.messageId === messageId &&
+        row.item.clientMessageId === messageId,
+    );
     if (submittedRow && !submittedRow.providerMessageId) {
       throw new Error("Cannot rewind before the provider acknowledges the submitted prompt");
     }
@@ -3184,6 +3304,10 @@ export class AgentManager {
   }
 
   async deleteCommittedTimeline(agentId: string): Promise<void> {
+    if (this.boundedTimeline) {
+      await this.boundedTimeline.discardAndDelete(agentId);
+      return;
+    }
     await this.durableTimelineStore?.deleteAgent(agentId);
   }
 
@@ -3231,6 +3355,9 @@ export class AgentManager {
   }
 
   private async getLastAssistantMessageFromStores(agentId: string): Promise<string | null> {
+    if (this.boundedTimeline) {
+      return await this.boundedTimeline.getLastAssistantMessage(agentId);
+    }
     const liveTimeline = this.timelineStore.getItems(agentId);
     const liveSegment = this.getLastAssistantMessageSegmentFromTimeline(liveTimeline);
     if (!this.durableTimelineStore) {
@@ -3251,6 +3378,7 @@ export class AgentManager {
   }
 
   private async getLastItemFromStores(agentId: string): Promise<AgentTimelineItem | null> {
+    if (this.boundedTimeline) return await this.boundedTimeline.getLastItem(agentId);
     const lastLiveItem = this.timelineStore.getLastItem(agentId);
     return lastLiveItem ?? (await this.durableTimelineStore?.getLastItem(agentId)) ?? null;
   }
@@ -3440,6 +3568,8 @@ export class AgentManager {
     },
   ): Promise<ManagedAgent> {
     let registered = false;
+    let explicitBoundedSeedStarted = false;
+    let resolvedAgentIdForCleanup: string | undefined;
     try {
       this.assertAcceptingAgentRegistrations();
       const resolvedAgentId = validateAgentId(agentId, "registerSession");
@@ -3453,6 +3583,11 @@ export class AgentManager {
       );
 
       const now = new Date();
+      resolvedAgentIdForCleanup = resolvedAgentId;
+      explicitBoundedSeedStarted = Boolean(
+        this.boundedTimeline &&
+        ((options?.timelineRows?.length ?? 0) > 0 || (options?.timeline?.length ?? 0) > 0),
+      );
       const { durableTimelineHasRows } = await this.initializeAgentTimelineForRegister({
         agentId: resolvedAgentId,
         now,
@@ -3493,17 +3628,52 @@ export class AgentManager {
       this.subscribeToSession(managed);
       return { ...managed };
     } catch (error) {
-      if (!registered) {
-        await this.closeUnregisteredSession(session);
-      }
+      await this.cleanupFailedRegistration({
+        session,
+        registered,
+        explicitBoundedSeedStarted,
+        agentId: resolvedAgentIdForCleanup,
+      });
       throw error;
     }
+  }
+
+  private async cleanupFailedRegistration(input: {
+    session: AgentSession;
+    registered: boolean;
+    explicitBoundedSeedStarted: boolean;
+    agentId: string | undefined;
+  }): Promise<void> {
+    if (!input.explicitBoundedSeedStarted || !input.agentId) {
+      if (!input.registered) await this.closeUnregisteredSession(input.session);
+      return;
+    }
+    if (input.registered) {
+      this.agents.delete(input.agentId);
+      this.previousStatuses.delete(input.agentId);
+    }
+    if (this.boundedTimeline?.has(input.agentId)) {
+      try {
+        await this.boundedTimeline.discardAndDelete(input.agentId);
+        this.timelineStore.delete(input.agentId);
+      } catch (error) {
+        this.logger.warn(
+          { err: error, agentId: input.agentId },
+          "Failed to discard an incomplete explicit timeline seed",
+        );
+      }
+    }
+    await this.closeUnregisteredSession(input.session);
   }
 
   private assertAcceptingAgentRegistrations(): void {
     if (!this.acceptingAgentRegistrations) {
       throw new AgentManagerShuttingDownError();
     }
+  }
+
+  private assertTimelineIngressOpen(agentId: string): void {
+    if (this.closingAgentIds.has(agentId)) throw new Error(`Agent ${agentId} is closing`);
   }
 
   private assertAgentRegistrationActive(agent: ActiveManagedAgent): void {
@@ -3551,6 +3721,9 @@ export class AgentManager {
     const { agentId, now, options } = params;
     const timelineAlreadyPrimed = this.timelineStore.has(agentId);
     const explicitTimelineSeed = buildExplicitTimelineSeedForRegister(now, options);
+    if (this.boundedTimeline) {
+      return await this.initializeBoundedTimelineForRegister(agentId, now, explicitTimelineSeed);
+    }
     const shouldSeedFromDurable =
       !explicitTimelineSeed && !this.timelineStore.has(agentId) && this.durableTimelineStore;
     const durableTimelineSeed = shouldSeedFromDurable
@@ -3567,6 +3740,32 @@ export class AgentManager {
       this.enqueueDurableTimelineBulkInsert(agentId, options.timelineRows);
     }
     return { durableTimelineHasRows };
+  }
+
+  private async initializeBoundedTimelineForRegister(
+    agentId: string,
+    now: Date,
+    seed: SeedAgentTimelineOptions | null,
+  ): Promise<{ durableTimelineHasRows: boolean }> {
+    const runtime = this.boundedTimeline!;
+    if (!runtime.has(agentId)) await runtime.initialize(agentId);
+    if (seed) {
+      const rowCount = seed.rows?.length ?? seed.items?.length ?? 0;
+      const expectedNextSeq = (seed.rows?.at(-1)?.seq ?? rowCount) + 1;
+      if (seed.nextSeq !== undefined && seed.nextSeq !== expectedNextSeq) {
+        throw new Error("Explicit bounded timeline seed must be contiguous");
+      }
+      if (seed.rows) {
+        for (const row of seed.rows) await runtime.appendWhenWritable(agentId, row);
+      } else {
+        const timestamp = seed.timestamp ?? now.toISOString();
+        for (const [index, item] of (seed.items ?? []).entries()) {
+          await runtime.appendWhenWritable(agentId, { seq: index + 1, timestamp, item });
+        }
+      }
+    }
+    const window = await runtime.fetch(agentId, { direction: "tail", limit: 1 });
+    return { durableTimelineHasRows: window.window.nextSeq > 1 };
   }
 
   private buildManagedAgentForRegister(params: {
@@ -3644,17 +3843,27 @@ export class AgentManager {
     };
   }
 
-  private prepareAgentForClosure(
+  private async prepareAgentForClosure(
     agent: LiveManagedAgent,
     cancelReason: string,
-  ): ManagedAgentClosed {
-    this.agentStreamCoalescer.flushAndDiscard(agent.id);
-    this.agents.delete(agent.id);
-    this.previousStatuses.delete(agent.id);
+  ): Promise<ManagedAgentClosed> {
     if (agent.unsubscribeSession) {
       agent.unsubscribeSession();
       agent.unsubscribeSession = null;
     }
+    const outOfBandTasks = this.outOfBandTasks.get(agent.id);
+    if (outOfBandTasks) await Promise.allSettled(outOfBandTasks);
+    try {
+      await this.agentStreamCoalescer.flushAndDiscard(agent.id);
+    } catch (error) {
+      this.agentStreamCoalescer.discard(agent.id);
+      this.logger.warn(
+        { err: error, agentId: agent.id },
+        "Discarded coalesced timeline rows after disposable cache failure during agent close",
+      );
+    }
+    this.agents.delete(agent.id);
+    this.previousStatuses.delete(agent.id);
     this.runs.cancelWaiters(agent, (turnId) => ({
       type: "turn_canceled",
       provider: agent.provider,
@@ -3967,10 +4176,14 @@ export class AgentManager {
       }
     }
 
-    this.agentStreamCoalescer.flushAndDiscard(agent.id);
+    await this.agentStreamCoalescer.flushAndDiscard(agent.id);
     await this.deleteCommittedTimeline(agent.id);
-    this.timelineStore.delete(agent.id);
-    this.timelineStore.initialize(agent.id, { timestamp: new Date().toISOString() });
+    if (this.boundedTimeline) {
+      await this.boundedTimeline.initialize(agent.id);
+    } else {
+      this.timelineStore.delete(agent.id);
+      this.timelineStore.initialize(agent.id, { timestamp: new Date().toISOString() });
+    }
     agent.historyPrimed = true;
 
     for (const event of this.providerSubagents.deleteParent(agent.id)) {
@@ -3985,7 +4198,7 @@ export class AgentManager {
       }
     }
     for (const event of historyEvents) {
-      const row = this.recordTimeline(
+      const row = await this.recordTimelineAsync(
         agent.id,
         event.item,
         event.timestamp ? { timestamp: event.timestamp } : undefined,
@@ -4032,7 +4245,7 @@ export class AgentManager {
         if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
           continue;
         }
-        const row = this.recordTimeline(
+        const row = await this.recordTimelineAsync(
           agent.id,
           event.item,
           event.timestamp ? { timestamp: event.timestamp } : undefined,
@@ -4114,11 +4327,22 @@ export class AgentManager {
     // Only update timestamp for live events, not history replay
     if (!options?.fromHistory) {
       this.touchUpdatedAt(agent);
-      if (this.agentStreamCoalescer.handle(agent.id, event)) {
-        this.traceCoalescerBuffered(agent, event, eventTurnId);
-        return false;
+      try {
+        if (await this.agentStreamCoalescer.handleAsync(agent.id, event)) {
+          this.traceCoalescerBuffered(agent, event, eventTurnId);
+          return false;
+        }
+        await this.agentStreamCoalescer.flushFor(agent.id);
+      } catch (error) {
+        if (!isTurnTerminalEvent(event)) throw error;
+        // The transcript cache is disposable. A latched cache write failure must not swallow the
+        // provider's authoritative terminal event or leave foreground waiters unsettled.
+        this.agentStreamCoalescer.discard(agent.id);
+        this.logger.error(
+          { err: error, agentId: agent.id, turnId: eventTurnId },
+          "Timeline cache flush failed before terminal event",
+        );
       }
-      this.agentStreamCoalescer.flushFor(agent.id);
     }
 
     let terminalDisposition: ActiveTurnTerminalDisposition = "untracked";
@@ -4141,8 +4365,14 @@ export class AgentManager {
       terminalDisposition,
       flags,
     });
-    if (dispatchPromise) {
-      await dispatchPromise;
+    try {
+      if (dispatchPromise) await dispatchPromise;
+    } catch (error) {
+      if (!isTurnTerminalEvent(event)) throw error;
+      this.logger.error(
+        { err: error, agentId: agent.id, turnId: eventTurnId, eventType: event.type },
+        "Timeline cache mutation failed while handling terminal event",
+      );
     }
 
     if (!options?.fromHistory) {
@@ -4347,7 +4577,7 @@ export class AgentManager {
     if (
       event.item.type === "user_message" &&
       event.item.clientMessageId &&
-      this.reconcileSubmittedPromptEcho(agent, event.item, event.turnId)
+      (await this.reconcileSubmittedPromptEcho(agent, event.item, event.turnId))
     ) {
       flags.shouldDispatchEvent = false;
       flags.shouldNotifyWaiters = false;
@@ -4355,7 +4585,7 @@ export class AgentManager {
     }
 
     if (options?.fromHistory) {
-      this.recordTimeline(
+      await this.recordTimelineAsync(
         agent.id,
         event.item,
         event.timestamp ? { timestamp: event.timestamp } : undefined,
@@ -4365,7 +4595,12 @@ export class AgentManager {
       return;
     }
 
-    this.recordAndDispatchTimelineItem(agent.id, event.item, event.provider, event.turnId);
+    await this.recordAndDispatchTimelineItemAsync(
+      agent.id,
+      event.item,
+      event.provider,
+      event.turnId,
+    );
     if (event.item.type === "user_message") {
       agent.lastUserMessageAt = new Date();
       this.emitState(agent);
@@ -4394,6 +4629,7 @@ export class AgentManager {
       "agent.manager.turn.completed",
     );
     if (terminalDisposition === "stale") return;
+    this.boundedTimeline?.unpinMutableRows(agent.id, eventTurnId);
     if (event.usage) {
       agent.lastUsage = { ...agent.lastUsage, ...event.usage };
     }
@@ -4442,13 +4678,17 @@ export class AgentManager {
       agent.lifecycle = "error";
     }
     agent.lastError = event.error;
-    await this.appendSystemErrorTimelineMessage(
-      agent,
-      event.provider,
-      this.formatTurnFailedMessage(event),
-      options,
-    );
-    this.resolvePendingPermissionsForAgent(agent, event.provider, options, "Turn failed");
+    try {
+      await this.appendSystemErrorTimelineMessage(
+        agent,
+        event.provider,
+        this.formatTurnFailedMessage(event),
+        options,
+      );
+    } finally {
+      this.boundedTimeline?.unpinMutableRows(agent.id, eventTurnId);
+      this.resolvePendingPermissionsForAgent(agent, event.provider, options, "Turn failed");
+    }
     if (!isForegroundEvent && !agent.activeForegroundTurnId) {
       this.emitState(agent);
     }
@@ -4480,6 +4720,7 @@ export class AgentManager {
       "agent.manager.turn.canceled",
     );
     if (terminalDisposition === "stale") return;
+    this.boundedTimeline?.unpinMutableRows(agent.id, eventTurnId);
     if (!isForegroundEvent && !agent.activeForegroundTurnId && !agent.pendingReplacement) {
       agent.lifecycle = "idle";
     }
@@ -4573,14 +4814,14 @@ export class AgentManager {
     }
   }
 
-  private recordAndDispatchTimelineItem(
+  private async recordAndDispatchTimelineItemAsync(
     agentId: string,
     item: AgentTimelineItem,
     provider: AgentProvider,
     turnId?: string,
-    options?: { providerMessageId?: string },
-  ): AgentStreamEvent {
-    const row = this.recordTimeline(agentId, item, { ...options, turnId });
+    options?: { providerMessageId?: string; mutable?: boolean },
+  ): Promise<AgentStreamEvent> {
+    const row = await this.recordTimelineAsync(agentId, item, { ...options, turnId });
     const event: AgentStreamEvent = {
       type: "timeline",
       item,
@@ -4592,7 +4833,6 @@ export class AgentManager {
       epoch: this.timelineStore.getEpoch(agentId),
       timestamp: row.timestamp,
     });
-
     if (
       item.type === "tool_call" &&
       item.status === "completed" &&
@@ -4600,20 +4840,22 @@ export class AgentManager {
       commandMayHaveChangedExternalState(item.detail.command)
     ) {
       const agent = this.agents.get(agentId);
-      if (agent) {
-        this.onWorkspaceStateMayHaveChanged?.({ cwd: agent.cwd });
-      }
+      if (agent) this.onWorkspaceStateMayHaveChanged?.({ cwd: agent.cwd });
     }
-
     return event;
   }
 
-  private recordSubmittedPrompt(
+  private async recordSubmittedPrompt(
     agent: ActiveManagedAgent,
     prompt: AgentPromptInput,
     clientMessageId: string,
-    options?: { messageId?: string; providerMessageId?: string; turnId?: string },
-  ): void {
+    options?: {
+      messageId?: string;
+      providerMessageId?: string;
+      turnId?: string;
+      mutable?: boolean;
+    },
+  ): Promise<void> {
     if (this.timelineStore.getSubmittedUserMessage(agent.id, clientMessageId)) {
       return;
     }
@@ -4625,19 +4867,22 @@ export class AgentManager {
       clientMessageId,
       ...(options?.messageId ? { messageId: options.messageId } : {}),
     };
-    this.recordAndDispatchTimelineItem(agent.id, item, agent.provider, options?.turnId, options);
+    await this.recordAndDispatchTimelineItemAsync(agent.id, item, agent.provider, options?.turnId, {
+      ...options,
+      mutable: options?.mutable ?? options?.providerMessageId === undefined,
+    });
   }
 
-  private reconcileSubmittedPromptEcho(
+  private async reconcileSubmittedPromptEcho(
     agent: ActiveManagedAgent,
     item: Extract<AgentTimelineItem, { type: "user_message" }>,
     turnId?: string,
-  ): AgentTimelineRow | null {
+  ): Promise<AgentTimelineRow | null> {
     const { clientMessageId, messageId } = item;
     if (!clientMessageId) return null;
     let existing = this.timelineStore.getSubmittedUserMessage(agent.id, clientMessageId);
     if (!existing) {
-      this.recordSubmittedPrompt(agent, item.text, clientMessageId, {
+      await this.recordSubmittedPrompt(agent, item.text, clientMessageId, {
         messageId: clientMessageId,
         ...(messageId ? { providerMessageId: messageId } : {}),
         ...(turnId ? { turnId } : {}),
@@ -4646,12 +4891,20 @@ export class AgentManager {
     }
     if (!existing || existing.item.type !== "user_message") return null;
     if (messageId) {
-      const enriched = this.timelineStore.enrichSubmittedUserMessage(
-        agent.id,
-        clientMessageId,
-        messageId,
-      );
-      if (enriched) this.enqueueDurableTimelineUpdate(agent.id, enriched);
+      if (this.boundedTimeline) {
+        await this.boundedTimeline.updateWhenWritable(
+          agent.id,
+          { ...existing, providerMessageId: messageId },
+          { mutable: false },
+        );
+      } else {
+        const enriched = this.timelineStore.enrichSubmittedUserMessage(
+          agent.id,
+          clientMessageId,
+          messageId,
+        );
+        if (enriched) this.enqueueDurableTimelineUpdate(agent.id, enriched);
+      }
     }
     return existing;
   }
@@ -4678,7 +4931,7 @@ export class AgentManager {
     }
 
     const item: AgentTimelineItem = { type: "assistant_message", text };
-    const row = this.recordTimeline(agent.id, item);
+    const row = await this.recordTimelineAsync(agent.id, item);
     this.dispatchStream(
       agent.id,
       {
@@ -4710,16 +4963,45 @@ export class AgentManager {
     return parts.join("\n\n");
   }
 
-  private recordTimeline(
+  private async recordTimelineAsync(
     agentId: string,
     item: AgentTimelineItem,
     options?: {
       timestamp?: string;
       providerMessageId?: string;
       turnId?: string;
+      mutable?: boolean;
+    },
+  ): Promise<AgentTimelineRow> {
+    item = limitAgentTimelineItemContent(item);
+    if (this.boundedTimeline) {
+      return await this.boundedTimeline.appendItemWhenWritable(agentId, item, {
+        ...options,
+        mutable: options?.mutable ?? false,
+      });
+    }
+    const row = this.timelineStore.append(agentId, item, options);
+    this.enqueueDurableTimelineAppend(agentId, row);
+    return row;
+  }
+
+  private tryRecordTimelineNow(
+    agentId: string,
+    item: AgentTimelineItem,
+    options?: {
+      timestamp?: string;
+      providerMessageId?: string;
+      turnId?: string;
+      mutable?: boolean;
     },
   ): AgentTimelineRow {
     item = limitAgentTimelineItemContent(item);
+    if (this.boundedTimeline) {
+      return this.boundedTimeline.appendItem(agentId, item, {
+        ...options,
+        mutable: options?.mutable ?? false,
+      });
+    }
     const row = this.timelineStore.append(agentId, item, options);
     this.enqueueDurableTimelineAppend(agentId, row);
     return row;
@@ -4808,6 +5090,7 @@ export class AgentManager {
   }
 
   private enqueueDurableTimelineAppend(agentId: string, row: AgentTimelineRow): void {
+    if (this.boundedTimeline) return;
     if (!this.durableTimelineStore) {
       return;
     }
@@ -4824,7 +5107,7 @@ export class AgentManager {
     agentId: string,
     rows: readonly AgentTimelineRow[],
   ): void {
-    if (!this.durableTimelineStore || rows.length === 0) {
+    if (this.boundedTimeline || !this.durableTimelineStore || rows.length === 0) {
       return;
     }
     const task = this.durableTimelineStore.bulkInsert(agentId, rows).catch((err) => {
@@ -4837,6 +5120,7 @@ export class AgentManager {
   }
 
   private enqueueDurableTimelineUpdate(agentId: string, row: AgentTimelineRow): void {
+    if (this.boundedTimeline) return;
     if (!this.durableTimelineStore) return;
     const task = this.durableTimelineStore.updateCommittedRow(agentId, row).catch((err) => {
       this.logger.error(
@@ -4884,7 +5168,7 @@ export class AgentManager {
   }
 
   private async flushTasks(options: { includeAgentRegistrations: boolean }): Promise<void> {
-    this.agentStreamCoalescer.flushAll();
+    await this.agentStreamCoalescer.flushAll();
     // Drain tasks, including tasks spawned while awaiting.
     while (
       this.backgroundTasks.size > 0 ||
@@ -4895,6 +5179,7 @@ export class AgentManager {
         : [...this.backgroundTasks];
       await Promise.allSettled(pending);
     }
+    await this.boundedTimeline?.flushAll();
   }
 
   private broadcastAgentAttention(

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -667,6 +667,19 @@ export interface AgentSession {
   steerActiveTurn?(prompt: AgentPromptInput, options: SteerActiveTurnOptions): Promise<SteerResult>;
   subscribe(callback: (event: AgentStreamEvent) => void): () => void;
   streamHistory(): AsyncGenerator<AgentStreamEvent>;
+  /**
+   * Load one provider-owned subagent history on demand, if the provider persists it separately.
+   * Returned events have not been published through subscribe; the manager ingests them directly
+   * so an explicit history read cannot be delayed behind foreground-turn admission barriers.
+   */
+  loadProviderSubagentHistory?(
+    subagentId: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<Extract<AgentStreamEvent, { type: "provider_subagent" }>[]>;
+  /** Snapshot provider-owned child histories already imported into the manager timeline. */
+  getLoadedProviderSubagentHistoryIds?(): readonly string[];
+  /** Preserve completed child hydration when replacing a session without replacing its timeline. */
+  seedLoadedProviderSubagentHistoryIds?(subagentIds: readonly string[]): void;
   getRuntimeInfo(): Promise<AgentRuntimeInfo>;
   getAvailableModes(): Promise<AgentMode[]>;
   getCurrentMode(): Promise<string | null>;

--- a/packages/server/src/server/agent/agent-stream-coalescer.test.ts
+++ b/packages/server/src/server/agent/agent-stream-coalescer.test.ts
@@ -524,6 +524,52 @@ describe("AgentStreamCoalescer", () => {
     ]);
   });
 
+  test("retains later chunks while an asynchronous flush is backpressured", async () => {
+    const flushes: string[] = [];
+    const releaseFirst = Promise.withResolvers<void>();
+    let first = true;
+    const coalescer = new AgentStreamCoalescer({
+      timers: { setTimeout, clearTimeout },
+      onFlush: async ({ item }) => {
+        if (first) {
+          first = false;
+          await releaseFirst.promise;
+        }
+        if (item.type === "assistant_message") flushes.push(item.text);
+      },
+    });
+
+    coalescer.handle("agent-1", assistant("first"));
+    coalescer.handle("agent-1", assistant("second"));
+    const flush = coalescer.flushFor("agent-1");
+    await Promise.resolve();
+    expect(flushes).toEqual([]);
+
+    releaseFirst.resolve();
+    await flush;
+    expect(flushes).toEqual(["first", "second"]);
+  });
+
+  test("latches a permanent flush failure without scheduling timer retries", async () => {
+    const failure = new Error("durable cache failed");
+    let attempts = 0;
+    const coalescer = new AgentStreamCoalescer({
+      windowMs: 10,
+      timers: { setTimeout, clearTimeout },
+      onFlush: async () => {
+        attempts += 1;
+        throw failure;
+      },
+    });
+
+    await expect(coalescer.handleAsync("agent-1", assistant("failed"))).rejects.toBe(failure);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(attempts).toBe(1);
+    await expect(coalescer.flushFor("agent-1")).rejects.toBe(failure);
+    await expect(coalescer.flushAll()).rejects.toBe(failure);
+    expect(attempts).toBe(1);
+  });
+
   test("manual flush prevents late duplicate output after timers advance", async () => {
     const { coalescer, flushes } = createHarness();
 

--- a/packages/server/src/server/agent/agent-stream-coalescer.ts
+++ b/packages/server/src/server/agent/agent-stream-coalescer.ts
@@ -26,7 +26,8 @@ export interface AgentStreamCoalescerOptions {
   windowMs?: number;
   timers: AgentStreamCoalescerTimers;
   now?: () => number;
-  onFlush: (payload: AgentStreamCoalescerFlush) => void;
+  onFlush: (payload: AgentStreamCoalescerFlush) => void | Promise<void>;
+  onError?: (agentId: string, error: unknown) => void;
 }
 
 interface PendingTextEntry {
@@ -51,7 +52,8 @@ interface PendingAgentStreamBuffer {
   entries: PendingAgentStreamEntry[];
   toolCallEntryIndexes: Map<string, number>;
   timer: ReturnType<typeof setTimeout> | null;
-  flushing: boolean;
+  flushing: Promise<void> | null;
+  failure: unknown;
   lastFlushAt: number | null;
 }
 
@@ -87,16 +89,27 @@ function isSameTextStream(previous: PendingTextEntry, next: PendingTextEntry): b
 
 export class AgentStreamCoalescer {
   private readonly buffers = new Map<string, PendingAgentStreamBuffer>();
-  private readonly onFlush: (payload: AgentStreamCoalescerFlush) => void;
+  private readonly onFlush: (payload: AgentStreamCoalescerFlush) => void | Promise<void>;
   private readonly timers: AgentStreamCoalescerTimers;
   private readonly windowMs: number;
   private readonly now: () => number;
+  private readonly onError?: AgentStreamCoalescerOptions["onError"];
 
   constructor(options: AgentStreamCoalescerOptions) {
     this.windowMs = options.windowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS;
     this.timers = options.timers;
     this.now = options.now ?? Date.now;
     this.onFlush = options.onFlush;
+    this.onError = options.onError;
+  }
+
+  async handleAsync(agentId: string, event: AgentStreamEvent): Promise<boolean> {
+    const activeFlush = this.buffers.get(agentId)?.flushing;
+    if (activeFlush) await activeFlush;
+    const handled = this.handle(agentId, event);
+    const startedFlush = this.buffers.get(agentId)?.flushing;
+    if (startedFlush) await startedFlush;
+    return handled;
   }
 
   handle(agentId: string, event: AgentStreamEvent): boolean {
@@ -109,6 +122,7 @@ export class AgentStreamCoalescer {
     }
 
     const buffer = this.getOrCreateBuffer(agentId);
+    if (buffer.failure !== undefined) throw buffer.failure;
     this.appendToBuffer(buffer, event);
 
     if (isTerminalToolCall(event.item)) {
@@ -133,18 +147,27 @@ export class AgentStreamCoalescer {
     return true;
   }
 
-  flushFor(agentId: string): void {
-    this.flushBuffer(agentId);
-  }
-
-  flushAll(): void {
-    for (const agentId of Array.from(this.buffers.keys())) {
-      this.flushBuffer(agentId);
+  async flushFor(agentId: string): Promise<void> {
+    while (true) {
+      const buffer = this.buffers.get(agentId);
+      if (!buffer || (!buffer.flushing && buffer.entries.length === 0)) return;
+      if (buffer.failure !== undefined) throw buffer.failure;
+      await this.flushBuffer(agentId);
     }
   }
 
-  flushAndDiscard(agentId: string): void {
-    this.flushBuffer(agentId);
+  async flushAll(): Promise<void> {
+    await Promise.all(
+      Array.from(this.buffers.keys()).map(async (agentId) => await this.flushFor(agentId)),
+    );
+  }
+
+  async flushAndDiscard(agentId: string): Promise<void> {
+    await this.flushFor(agentId);
+    this.discard(agentId);
+  }
+
+  discard(agentId: string): void {
     const buffer = this.buffers.get(agentId);
     if (buffer) {
       this.clearTimer(buffer);
@@ -163,7 +186,8 @@ export class AgentStreamCoalescer {
       entries: [],
       toolCallEntryIndexes: new Map(),
       timer: null,
-      flushing: false,
+      flushing: null,
+      failure: undefined,
       lastFlushAt: null,
     };
     this.buffers.set(agentId, buffer);
@@ -201,7 +225,9 @@ export class AgentStreamCoalescer {
 
   private scheduleFlush(buffer: PendingAgentStreamBuffer): void {
     const timer = this.timers.setTimeout(() => {
-      this.flushBuffer(buffer.agentId, buffer);
+      void this.flushBuffer(buffer.agentId, buffer).catch((error: unknown) => {
+        this.onError?.(buffer.agentId, error);
+      });
     }, this.windowMs);
     timer.unref?.();
     buffer.timer = timer;
@@ -215,47 +241,82 @@ export class AgentStreamCoalescer {
     buffer.timer = null;
   }
 
-  private flushBuffer(agentId: string, expectedBuffer?: PendingAgentStreamBuffer): void {
+  private flushBuffer(agentId: string, expectedBuffer?: PendingAgentStreamBuffer): Promise<void> {
     const buffer = this.buffers.get(agentId);
     if (!buffer) {
-      return;
+      return Promise.resolve();
     }
     if (expectedBuffer && buffer !== expectedBuffer) {
-      return;
+      return Promise.resolve();
     }
-    if (buffer.flushing) {
-      return;
-    }
+    if (buffer.flushing) return buffer.flushing;
 
     this.clearTimer(buffer);
     if (buffer.entries.length === 0) {
-      return;
+      return Promise.resolve();
     }
 
-    const entries = buffer.entries;
+    const entries = this.collapseEntries(buffer.entries);
     buffer.entries = [];
     buffer.toolCallEntryIndexes.clear();
-    buffer.flushing = true;
     buffer.lastFlushAt = this.now();
-
-    try {
-      for (const entry of this.collapseEntries(entries)) {
-        this.onFlush({
-          agentId,
-          item:
-            entry.kind === "text"
-              ? {
-                  ...entry.item,
-                  text: entry.text,
-                }
-              : entry.item,
-          provider: entry.provider,
-          ...(entry.turnId !== undefined ? { turnId: entry.turnId } : {}),
-        });
+    const finish = () => {
+      buffer.flushing = null;
+      if (buffer.failure === undefined && buffer.entries.length > 0 && !buffer.timer) {
+        this.scheduleFlush(buffer);
       }
-    } finally {
-      buffer.flushing = false;
+    };
+    const restore = (start: number) => {
+      buffer.entries = [...entries.slice(start), ...buffer.entries];
+      this.rebuildToolCallIndexes(buffer);
+    };
+    const payload = (entry: PendingAgentStreamEntry): AgentStreamCoalescerFlush => ({
+      agentId,
+      item:
+        entry.kind === "text"
+          ? {
+              ...entry.item,
+              text: entry.text,
+            }
+          : entry.item,
+      provider: entry.provider,
+      ...(entry.turnId !== undefined ? { turnId: entry.turnId } : {}),
+    });
+    for (let index = 0; index < entries.length; index += 1) {
+      let completion: void | Promise<void>;
+      try {
+        completion = this.onFlush(payload(entries[index]!));
+      } catch (error) {
+        restore(index);
+        buffer.failure = error;
+        finish();
+        return Promise.reject(error);
+      }
+      if (!completion) continue;
+      buffer.flushing = (async () => {
+        let pendingIndex = index;
+        try {
+          await completion;
+          for (pendingIndex = index + 1; pendingIndex < entries.length; pendingIndex += 1) {
+            await this.onFlush(payload(entries[pendingIndex]!));
+          }
+        } catch (error) {
+          restore(pendingIndex);
+          buffer.failure = error;
+          throw error;
+        }
+      })().finally(finish);
+      return buffer.flushing;
     }
+    finish();
+    return Promise.resolve();
+  }
+
+  private rebuildToolCallIndexes(buffer: PendingAgentStreamBuffer): void {
+    buffer.toolCallEntryIndexes.clear();
+    buffer.entries.forEach((entry, index) => {
+      if (entry.kind === "tool_call") buffer.toolCallEntryIndexes.set(entry.item.callId, index);
+    });
   }
 
   private collapseEntries(entries: PendingAgentStreamEntry[]): PendingAgentStreamEntry[] {

--- a/packages/server/src/server/agent/agent-timeline-content.test.ts
+++ b/packages/server/src/server/agent/agent-timeline-content.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 
-import { limitAgentTimelineItemContent } from "./agent-timeline-content.js";
+import type { AgentTimelineItem } from "./agent-sdk-types.js";
+import {
+  AGENT_TIMELINE_ITEM_MAX_BYTES,
+  limitAgentTimelineItemContent,
+} from "./agent-timeline-content.js";
 
 describe("agent timeline content", () => {
   test("limits terminal input to the tool-call content budget", () => {
@@ -31,5 +35,41 @@ describe("agent timeline content", () => {
         icon: "square_terminal",
       },
     });
+  });
+
+  test("bounds every timeline item shape without changing its discriminant", () => {
+    const oversizedText = "🦀".repeat(128 * 1024);
+    const items: AgentTimelineItem[] = [
+      { type: "user_message", text: oversizedText, messageId: "user-1" },
+      { type: "assistant_message", text: oversizedText, messageId: "assistant-1" },
+      { type: "reasoning", text: oversizedText },
+      { type: "error", message: oversizedText },
+      { type: "todo", items: [{ id: "task-1", text: oversizedText, completed: false }] },
+      {
+        type: "tool_call",
+        callId: "call-1",
+        name: "read",
+        status: "completed",
+        error: null,
+        detail: { type: "read", filePath: "/tmp/example", content: oversizedText },
+      },
+      { type: "compaction", status: "completed", providerPayload: oversizedText },
+      {
+        type: "plugin",
+        id: "plugin-item-1",
+        pluginId: "example",
+        kind: "result",
+        version: 1,
+        data: { content: oversizedText },
+      },
+    ];
+
+    for (const item of items) {
+      const limited = limitAgentTimelineItemContent(item);
+      expect(limited.type).toBe(item.type);
+      expect(Buffer.byteLength(JSON.stringify(limited), "utf8")).toBeLessThanOrEqual(
+        AGENT_TIMELINE_ITEM_MAX_BYTES,
+      );
+    }
   });
 });

--- a/packages/server/src/server/agent/agent-timeline-content.test.ts
+++ b/packages/server/src/server/agent/agent-timeline-content.test.ts
@@ -44,6 +44,7 @@ describe("agent timeline content", () => {
       { type: "assistant_message", text: oversizedText, messageId: "assistant-1" },
       { type: "reasoning", text: oversizedText },
       { type: "error", message: oversizedText },
+      { type: "notification", level: "warning", message: oversizedText },
       { type: "todo", items: [{ id: "task-1", text: oversizedText, completed: false }] },
       {
         type: "tool_call",

--- a/packages/server/src/server/agent/agent-timeline-content.ts
+++ b/packages/server/src/server/agent/agent-timeline-content.ts
@@ -169,6 +169,12 @@ function summarizeOversizedTimelineItem(item: AgentTimelineItem): AgentTimelineI
       return { type: item.type, text: truncateUtf8(item.text, TIMELINE_TEXT_MAX_BYTES) };
     case "error":
       return { type: item.type, message: truncateUtf8(item.message, TIMELINE_TEXT_MAX_BYTES) };
+    case "notification":
+      return {
+        type: item.type,
+        level: item.level,
+        message: truncateUtf8(item.message, TIMELINE_TEXT_MAX_BYTES),
+      };
     case "todo":
       return {
         type: item.type,
@@ -206,6 +212,8 @@ function minimalTimelineItem(item: AgentTimelineItem): AgentTimelineItem {
       return { type: item.type, text: notice };
     case "error":
       return { type: item.type, message: notice };
+    case "notification":
+      return { type: item.type, level: item.level, message: notice };
     case "todo":
       return { type: item.type, items: [] };
     case "tool_call":

--- a/packages/server/src/server/agent/agent-timeline-content.ts
+++ b/packages/server/src/server/agent/agent-timeline-content.ts
@@ -1,12 +1,19 @@
-import type { AgentTimelineItem } from "./agent-sdk-types.js";
+import type { AgentTaskItem, AgentTimelineItem, ToolCallTimelineItem } from "./agent-sdk-types.js";
 import type { JsonValue } from "@getpaseo/protocol/agent-types";
 
 const TOOL_CALL_CONTENT_MAX_LENGTH = 64 * 1024;
+const TIMELINE_TEXT_MAX_BYTES = 64 * 1024;
+const TIMELINE_IDENTIFIER_MAX_BYTES = 4 * 1024;
+const TIMELINE_TASK_TEXT_MAX_BYTES = 512;
+const TIMELINE_TASK_IDENTIFIER_MAX_BYTES = 256;
+const TIMELINE_TASK_LIMIT = 8;
+const TIMELINE_TRUNCATION_NOTICE = "\n\n[truncated to fit timeline storage]";
+export const AGENT_TIMELINE_ITEM_MAX_BYTES = 128 * 1024;
 export const PLUGIN_TIMELINE_DATA_MAX_BYTES = 64 * 1024;
 
 export function assertPluginTimelineDataSize(data: JsonValue): void {
-  const serializedBytes = Buffer.byteLength(JSON.stringify(data), "utf8");
-  if (serializedBytes > PLUGIN_TIMELINE_DATA_MAX_BYTES) {
+  const dataBytes = Buffer.byteLength(JSON.stringify(data), "utf8");
+  if (dataBytes > PLUGIN_TIMELINE_DATA_MAX_BYTES) {
     throw new Error(`Plugin timeline item data exceeds ${PLUGIN_TIMELINE_DATA_MAX_BYTES} bytes`);
   }
 }
@@ -51,24 +58,201 @@ function limitPlainText(item: AgentTimelineItem): AgentTimelineItem {
   };
 }
 
+function serializedBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function truncateUtf8(text: string, maxBytes: number, suffix = TIMELINE_TRUNCATION_NOTICE): string {
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) {
+    return text;
+  }
+  const suffixBytes = Buffer.byteLength(suffix, "utf8");
+  const contentBudget = Math.max(0, maxBytes - suffixBytes);
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const candidate = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(text.slice(0, candidate), "utf8") <= contentBudget) {
+      low = candidate;
+    } else {
+      high = candidate - 1;
+    }
+  }
+  if (
+    low > 0 &&
+    low < text.length &&
+    /[\uD800-\uDBFF]/.test(text[low - 1] ?? "") &&
+    /[\uDC00-\uDFFF]/.test(text[low] ?? "")
+  ) {
+    low -= 1;
+  }
+  return `${text.slice(0, low)}${suffix}`;
+}
+
+function truncateIdentifier(value: string): string {
+  return truncateUtf8(value, TIMELINE_IDENTIFIER_MAX_BYTES, "");
+}
+
+function rebuildOversizedToolCall(
+  item: ToolCallTimelineItem,
+  options: { callId: string; name: string; label?: string },
+): ToolCallTimelineItem {
+  const base = {
+    type: "tool_call" as const,
+    callId: options.callId,
+    name: options.name,
+    detail: {
+      type: "plain_text" as const,
+      ...(options.label ? { label: options.label } : {}),
+      text: TIMELINE_TRUNCATION_NOTICE.trim(),
+    },
+  };
+  switch (item.status) {
+    case "running":
+      return { ...base, status: item.status, error: null };
+    case "completed":
+      return { ...base, status: item.status, error: null };
+    case "failed":
+      return {
+        ...base,
+        status: item.status,
+        error: { message: TIMELINE_TRUNCATION_NOTICE.trim() },
+      };
+    case "canceled":
+      return { ...base, status: item.status, error: null };
+  }
+}
+
+function summarizeOversizedToolCall(item: ToolCallTimelineItem): ToolCallTimelineItem {
+  return rebuildOversizedToolCall(item, {
+    callId: truncateIdentifier(item.callId),
+    name: truncateIdentifier(item.name),
+    label: truncateIdentifier(item.name),
+  });
+}
+
+function summarizeTimelineTask(task: AgentTaskItem): AgentTaskItem {
+  const summarized: AgentTaskItem = {
+    text: truncateUtf8(task.text, TIMELINE_TASK_TEXT_MAX_BYTES),
+    completed: task.completed,
+  };
+  if (task.id) {
+    summarized.id = truncateUtf8(task.id, TIMELINE_TASK_IDENTIFIER_MAX_BYTES, "");
+  }
+  if (task.status) {
+    summarized.status = task.status;
+  }
+  if (task.activeForm) {
+    summarized.activeForm = truncateUtf8(task.activeForm, TIMELINE_TASK_IDENTIFIER_MAX_BYTES, "");
+  }
+  return summarized;
+}
+
+function summarizeOversizedTimelineItem(item: AgentTimelineItem): AgentTimelineItem {
+  switch (item.type) {
+    case "user_message":
+      return {
+        type: item.type,
+        text: truncateUtf8(item.text, TIMELINE_TEXT_MAX_BYTES),
+        ...(item.messageId ? { messageId: truncateIdentifier(item.messageId) } : {}),
+        ...(item.clientMessageId
+          ? { clientMessageId: truncateIdentifier(item.clientMessageId) }
+          : {}),
+      };
+    case "assistant_message":
+      return {
+        type: item.type,
+        text: truncateUtf8(item.text, TIMELINE_TEXT_MAX_BYTES),
+        ...(item.messageId ? { messageId: truncateIdentifier(item.messageId) } : {}),
+      };
+    case "reasoning":
+      return { type: item.type, text: truncateUtf8(item.text, TIMELINE_TEXT_MAX_BYTES) };
+    case "error":
+      return { type: item.type, message: truncateUtf8(item.message, TIMELINE_TEXT_MAX_BYTES) };
+    case "todo":
+      return {
+        type: item.type,
+        items: item.items.slice(0, TIMELINE_TASK_LIMIT).map(summarizeTimelineTask),
+      };
+    case "tool_call":
+      return summarizeOversizedToolCall(item);
+    case "compaction":
+      return {
+        type: item.type,
+        status: item.status,
+        ...(item.trigger ? { trigger: item.trigger } : {}),
+        ...(item.preTokens === undefined ? {} : { preTokens: item.preTokens }),
+      };
+    case "plugin":
+      return {
+        type: item.type,
+        id: truncateIdentifier(item.id),
+        pluginId: truncateIdentifier(item.pluginId),
+        kind: truncateIdentifier(item.kind),
+        version: item.version,
+        data: { truncated: true },
+      };
+  }
+}
+
+function minimalTimelineItem(item: AgentTimelineItem): AgentTimelineItem {
+  const notice = TIMELINE_TRUNCATION_NOTICE.trim();
+  switch (item.type) {
+    case "user_message":
+      return { type: item.type, text: notice };
+    case "assistant_message":
+      return { type: item.type, text: notice };
+    case "reasoning":
+      return { type: item.type, text: notice };
+    case "error":
+      return { type: item.type, message: notice };
+    case "todo":
+      return { type: item.type, items: [] };
+    case "tool_call":
+      return rebuildOversizedToolCall(item, {
+        callId: "oversized-tool-call",
+        name: "tool",
+      });
+    case "compaction":
+      return { type: item.type, status: item.status };
+    case "plugin":
+      return {
+        type: item.type,
+        id: "oversized-plugin-item",
+        pluginId: "unknown",
+        kind: "truncated",
+        version: item.version,
+        data: { truncated: true },
+      };
+  }
+}
+
+function limitAgentTimelineItemSize(item: AgentTimelineItem): AgentTimelineItem {
+  if (serializedBytes(item) <= AGENT_TIMELINE_ITEM_MAX_BYTES) {
+    return item;
+  }
+  const summarized = summarizeOversizedTimelineItem(item);
+  return serializedBytes(summarized) <= AGENT_TIMELINE_ITEM_MAX_BYTES
+    ? summarized
+    : minimalTimelineItem(item);
+}
+
 export function limitAgentTimelineItemContent(item: AgentTimelineItem): AgentTimelineItem {
   item = limitFailedShellError(item);
   item = limitPlainText(item);
   if (
-    item.type !== "tool_call" ||
-    item.detail.type !== "shell" ||
-    typeof item.detail.output !== "string"
+    item.type === "tool_call" &&
+    item.detail.type === "shell" &&
+    typeof item.detail.output === "string" &&
+    item.detail.output.length > TOOL_CALL_CONTENT_MAX_LENGTH
   ) {
-    return item;
+    item = {
+      ...item,
+      detail: {
+        ...item.detail,
+        output: item.detail.output.slice(0, TOOL_CALL_CONTENT_MAX_LENGTH),
+      },
+    };
   }
-  if (item.detail.output.length <= TOOL_CALL_CONTENT_MAX_LENGTH) {
-    return item;
-  }
-  return {
-    ...item,
-    detail: {
-      ...item.detail,
-      output: item.detail.output.slice(0, TOOL_CALL_CONTENT_MAX_LENGTH),
-    },
-  };
+  return limitAgentTimelineItemSize(item);
 }

--- a/packages/server/src/server/agent/agent-timeline-store.test.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.test.ts
@@ -2,6 +2,78 @@ import { describe, expect, it } from "vitest";
 import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
 
 describe("InMemoryAgentTimelineStore", () => {
+  it("indexes tool lifecycle bounds by call id", () => {
+    const store = new InMemoryAgentTimelineStore();
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      nextSeq: 8,
+      rows: [
+        {
+          seq: 5,
+          timestamp: "2026-01-01T00:00:00.000Z",
+          turnId: "turn-a",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "running",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: null },
+          },
+        },
+        {
+          seq: 6,
+          timestamp: "2026-01-01T00:00:01.000Z",
+          turnId: "turn-b",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "running",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: null },
+          },
+        },
+        {
+          seq: 7,
+          timestamp: "2026-01-01T00:00:02.000Z",
+          turnId: "turn-a",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "completed",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: "/workspace" },
+          },
+        },
+      ],
+    });
+
+    const appended = store.append(
+      "agent-1",
+      {
+        type: "tool_call",
+        callId: "call-2",
+        name: "shell",
+        status: "running",
+        error: null,
+        detail: { type: "shell", command: "ls", output: null },
+      },
+      { turnId: "turn-a" },
+    );
+
+    expect(store.getToolCallSeqBounds("agent-1", "call-1")).toEqual({
+      minSeq: 5,
+      maxSeq: 7,
+    });
+    expect(appended.seq).toBe(8);
+    expect(store.getToolCallSeqBounds("agent-1", "call-2")).toEqual({
+      minSeq: 8,
+      maxSeq: 8,
+    });
+  });
+
   it("clamps an overshooting before cursor into the bounded tail window", () => {
     const store = new InMemoryAgentTimelineStore();
     store.initialize("agent-1", {

--- a/packages/server/src/server/agent/agent-timeline-store.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.ts
@@ -18,12 +18,33 @@ interface AgentTimelineState {
   epoch: string;
   rows: AgentTimelineRow[];
   nextSeq: number;
+  toolCallSeqBounds: Map<string, ToolCallSeqBounds>;
+}
+
+export interface ToolCallSeqBounds {
+  minSeq: number;
+  maxSeq: number;
 }
 
 const DEFAULT_TIMELINE_FETCH_LIMIT = 200;
 
 function cloneRow(row: AgentTimelineRow): AgentTimelineRow {
   return { ...row };
+}
+
+function indexToolCallRow(
+  boundsByCall: Map<string, ToolCallSeqBounds>,
+  row: AgentTimelineRow,
+): void {
+  if (row.item.type !== "tool_call") {
+    return;
+  }
+  const key = row.item.callId;
+  const previous = boundsByCall.get(key);
+  boundsByCall.set(key, {
+    minSeq: previous ? Math.min(previous.minSeq, row.seq) : row.seq,
+    maxSeq: previous ? Math.max(previous.maxSeq, row.seq) : row.seq,
+  });
 }
 
 interface FetchContext {
@@ -95,11 +116,9 @@ function fetchBefore(ctx: FetchContext): AgentTimelineFetchResult {
   const { state, direction, limit, selectAll, cursor, minSeq, window } = ctx;
   const beforeSeq = cursor?.seq ?? state.nextSeq;
   const endExclusive = state.rows.findIndex((row) => row.seq >= beforeSeq);
-  const boundedRows = endExclusive < 0 ? state.rows : state.rows.slice(0, endExclusive);
-  const selected =
-    selectAll || limit >= boundedRows.length
-      ? boundedRows
-      : boundedRows.slice(boundedRows.length - limit);
+  const boundedLength = endExclusive < 0 ? state.rows.length : endExclusive;
+  const startInclusive = selectAll ? 0 : Math.max(0, boundedLength - limit);
+  const selected = state.rows.slice(startInclusive, boundedLength);
   return {
     epoch: state.epoch,
     direction,
@@ -148,10 +167,15 @@ export class InMemoryAgentTimelineStore {
       ? options.rows.map(cloneRow)
       : this.buildRowsFromItems(options?.items ?? [], options?.nextSeq ?? 1, timestamp);
     const nextSeq = options?.nextSeq ?? (rows.length ? rows[rows.length - 1].seq + 1 : 1);
+    const toolCallSeqBounds = new Map<string, ToolCallSeqBounds>();
+    for (const row of rows) {
+      indexToolCallRow(toolCallSeqBounds, row);
+    }
     this.states.set(agentId, {
       epoch: options?.epoch ?? randomUUID(),
       rows,
       nextSeq,
+      toolCallSeqBounds,
     });
   }
 
@@ -198,6 +222,16 @@ export class InMemoryAgentTimelineStore {
 
   getEpoch(agentId: string): string {
     return this.requireState(agentId).epoch;
+  }
+
+  /**
+   * Tool projection stays anchored at the first row for a call while later lifecycle rows extend
+   * its canonical span. Bounded consumers use these indexed bounds to decide whether a page must
+   * grow without first cloning the complete timeline.
+   */
+  getToolCallSeqBounds(agentId: string, callId: string): ToolCallSeqBounds | null {
+    const bounds = this.requireState(agentId).toolCallSeqBounds.get(callId);
+    return bounds ? { ...bounds } : null;
   }
 
   fetch(agentId: string, options?: AgentTimelineFetchOptions): AgentTimelineFetchResult {
@@ -276,6 +310,7 @@ export class InMemoryAgentTimelineStore {
     };
     state.nextSeq += 1;
     state.rows.push(row);
+    indexToolCallRow(state.toolCallSeqBounds, row);
     return cloneRow(row);
   }
 

--- a/packages/server/src/server/agent/bounded-agent-timeline-hot-store.test.ts
+++ b/packages/server/src/server/agent/bounded-agent-timeline-hot-store.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+
+import { BoundedAgentTimelineHotStore } from "./bounded-agent-timeline-hot-store.js";
+
+describe("BoundedAgentTimelineHotStore", () => {
+  it("bounds retained rows and UTF-8 bytes without shrinking the logical timeline window", () => {
+    const store = new BoundedAgentTimelineHotStore({ maxRows: 2, maxBytes: 10_000 });
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+
+    store.append("agent-1", row(1, `one-é${"x".repeat(80)}`), { durable: true });
+    store.append("agent-1", row(2, `two-é${"x".repeat(80)}`), { durable: true });
+    store.append("agent-1", row(3, `three-é${"x".repeat(80)}`), { durable: true });
+
+    expect(store.snapshot("agent-1")).toEqual({
+      epoch: "epoch-1",
+      logicalWindow: { minSeq: 1, maxSeq: 3, nextSeq: 4 },
+      retainedWindow: { minSeq: 2, maxSeq: 3 },
+      encodedBytes: expect.any(Number),
+      rows: [row(2, `two-é${"x".repeat(80)}`), row(3, `three-é${"x".repeat(80)}`)],
+    });
+    expect(store.snapshot("agent-1").encodedBytes).toBeLessThanOrEqual(10_000);
+  });
+
+  it("uses encoded UTF-8 bytes for its independent byte bound", () => {
+    const first = row(1, "😀".repeat(30));
+    const second = row(2, "😀".repeat(30));
+    const oneRowBytes = Buffer.byteLength(JSON.stringify(first), "utf8");
+    const store = new BoundedAgentTimelineHotStore({
+      maxRows: 10,
+      maxBytes: oneRowBytes * 2 - 1,
+    });
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+
+    store.append("agent-1", first, { durable: true });
+    store.append("agent-1", second, { durable: true });
+
+    expect(store.snapshot("agent-1").rows).toEqual([second]);
+    expect(store.snapshot("agent-1").encodedBytes).toBe(oneRowBytes);
+  });
+
+  it("keeps the newest row even when that row alone exceeds both bounds", () => {
+    const oversized = row(1, "😀".repeat(100));
+    const store = new BoundedAgentTimelineHotStore({ maxRows: 1, maxBytes: 1 });
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+
+    store.append("agent-1", oversized, { durable: true });
+
+    expect(store.snapshot("agent-1").rows).toEqual([oversized]);
+    expect(store.snapshot("agent-1").encodedBytes).toBeGreaterThan(1);
+  });
+
+  it("pins unacknowledged and mutable rows until durability and completion precede eviction", () => {
+    const store = new BoundedAgentTimelineHotStore({ maxRows: 1, maxBytes: 10_000 });
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+    const pending = store.append("agent-1", row(1, "pending"));
+    store.append("agent-1", row(2, "durable"), { durable: true });
+
+    expect(store.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([1, 2]);
+    store.acknowledgeDurable("agent-1", pending);
+    expect(store.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([2]);
+
+    store.append("agent-1", row(3, "incomplete"), { durable: true, mutable: true });
+    store.append("agent-1", row(4, "later"), { durable: true });
+    expect(store.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([3, 4]);
+    const completed = store.update("agent-1", row(3, "complete"), { mutable: false });
+    expect(store.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([3, 4]);
+    store.acknowledgeDurable("agent-1", completed);
+    expect(store.snapshot("agent-1").rows).toEqual([row(4, "later")]);
+  });
+
+  it("keeps pinned rows plus only a bounded newest eligible tail", () => {
+    const store = new BoundedAgentTimelineHotStore({ maxRows: 3, maxBytes: 10_000 });
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+    store.append("agent-1", row(1, "pinned"), { durable: true, mutable: true });
+    for (let seq = 2; seq <= 6; seq += 1) {
+      store.append("agent-1", row(seq, `eligible-${seq}`), { durable: true });
+    }
+
+    expect(store.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([1, 5, 6]);
+  });
+
+  it("sparsely evicts eligible rows around a pin to meet the encoded-byte bound", () => {
+    const pinned = row(1, "pinned");
+    const newest = row(6, "eligible");
+    const maxBytes =
+      Buffer.byteLength(JSON.stringify(pinned), "utf8") +
+      Buffer.byteLength(JSON.stringify(newest), "utf8") * 2;
+    const store = new BoundedAgentTimelineHotStore({ maxRows: 100, maxBytes });
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+    store.append("agent-1", pinned, { durable: true, mutable: true });
+    for (let seq = 2; seq <= 6; seq += 1) {
+      store.append("agent-1", row(seq, "eligible"), { durable: true });
+    }
+
+    expect(store.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([1, 5, 6]);
+    expect(store.snapshot("agent-1").encodedBytes).toBeLessThanOrEqual(maxBytes);
+  });
+
+  it("requires an exact current revision before acknowledging an updated row", () => {
+    const store = new BoundedAgentTimelineHotStore({ maxRows: 1, maxBytes: 10_000 });
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+    const inserted = store.append("agent-1", row(1, "insert"));
+    store.append("agent-1", row(2, "newest"), { durable: true });
+    const updated = store.update("agent-1", row(1, "updated"));
+
+    expect(store.acknowledgeDurable("agent-1", inserted)).toBe(false);
+    expect(store.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([1, 2]);
+    expect(store.acknowledgeDurable("agent-1", updated)).toBe(true);
+    expect(store.snapshot("agent-1").rows).toEqual([row(2, "newest")]);
+  });
+
+  it("initializes the complete logical durable window even when no rows are hot", () => {
+    const store = new BoundedAgentTimelineHotStore({ maxRows: 2, maxBytes: 1_000 });
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 10, maxSeq: 99, nextSeq: 100 },
+    });
+
+    expect(store.snapshot("agent-1")).toMatchObject({
+      logicalWindow: { minSeq: 10, maxSeq: 99, nextSeq: 100 },
+      retainedWindow: { minSeq: 0, maxSeq: 0 },
+      rows: [],
+    });
+  });
+
+  it("reports recent and pinned/pending retention, then releases agent lifecycle state", () => {
+    const store = new BoundedAgentTimelineHotStore({ maxRows: 4, maxBytes: 10_000 });
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+    store.append("agent-1", row(1, "recent"), { durable: true });
+    store.append("agent-1", row(2, "pending"));
+    store.append("agent-1", row(3, "mutable"), { durable: true, mutable: true });
+
+    expect(store.metrics("agent-1")).toMatchObject({
+      retainedRows: 3,
+      recentRows: 1,
+      pinnedRows: 2,
+      pendingRows: 1,
+    });
+    expect(store.metrics("agent-1").retainedBytes).toBe(
+      store.metrics("agent-1").recentBytes + store.metrics("agent-1").pinnedBytes,
+    );
+    store.deleteAgent("agent-1");
+    expect(store.has("agent-1")).toBe(false);
+
+    store.initialize("agent-2", {
+      epoch: "epoch-2",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+    store.clear();
+    expect(store.has("agent-2")).toBe(false);
+  });
+
+  it("rejects a non-contiguous initialized logical window", () => {
+    const store = new BoundedAgentTimelineHotStore({ maxRows: 2, maxBytes: 1_000 });
+
+    expect(() =>
+      store.initialize("agent-1", {
+        epoch: "epoch-1",
+        window: { minSeq: 10, maxSeq: 99, nextSeq: 101 },
+      }),
+    ).toThrow("Invalid logical timeline window");
+  });
+});
+
+function row(seq: number, text: string) {
+  return {
+    seq,
+    timestamp: "2026-08-31T12:00:00.000Z",
+    item: { type: "user_message" as const, text },
+  };
+}

--- a/packages/server/src/server/agent/bounded-agent-timeline-hot-store.ts
+++ b/packages/server/src/server/agent/bounded-agent-timeline-hot-store.ts
@@ -8,6 +8,7 @@ export interface BoundedAgentTimelineHotStoreOptions {
 export interface HotTimelineInitializeOptions {
   epoch: string;
   window: AgentTimelineWindow;
+  rows?: readonly AgentTimelineRow[];
 }
 
 export interface HotTimelineRowOptions {
@@ -48,6 +49,7 @@ interface HotRow {
 }
 
 interface HotState {
+  version: number;
   epoch: string;
   logicalMinSeq: number;
   logicalMaxSeq: number;
@@ -75,15 +77,40 @@ export class BoundedAgentTimelineHotStore {
       throw new Error("epoch must be a non-empty string");
     }
     validateWindow(options.window);
-    this.states.set(agentId, {
+    const rows = (options.rows ?? []).map((row, index, source): HotRow => {
+      if (
+        row.seq < options.window.minSeq ||
+        row.seq > options.window.maxSeq ||
+        (index > 0 && row.seq !== source[index - 1]!.seq + 1)
+      ) {
+        throw new Error(
+          "Initial hot timeline rows must be an ordered suffix of the logical window",
+        );
+      }
+      const cloned = cloneRow(row);
+      return {
+        row: cloned,
+        bytes: encodedRowBytes(cloned),
+        durable: true,
+        mutable: false,
+        revision: index + 1,
+      };
+    });
+    if (rows.length > 0 && rows.at(-1)!.row.seq !== options.window.maxSeq) {
+      throw new Error("Initial hot timeline rows must end at the logical window maximum");
+    }
+    const state: HotState = {
+      version: 0,
       epoch: options.epoch,
       logicalMinSeq: options.window.minSeq,
       logicalMaxSeq: options.window.maxSeq,
       nextSeq: options.window.nextSeq,
-      encodedBytes: 0,
-      rows: [],
-      nextRevision: 1,
-    });
+      encodedBytes: rows.reduce((total, row) => total + row.bytes, 0),
+      rows,
+      nextRevision: rows.length + 1,
+    };
+    this.evict(state);
+    this.states.set(agentId, state);
   }
 
   append(
@@ -110,6 +137,7 @@ export class BoundedAgentTimelineHotStore {
     state.rows.push(entry);
     state.encodedBytes += entry.bytes;
     this.evict(state);
+    state.version += 1;
     return { seq: row.seq, revision: entry.revision };
   }
 
@@ -119,6 +147,7 @@ export class BoundedAgentTimelineHotStore {
     if (!entry || entry.revision !== revision.revision) return false;
     entry.durable = true;
     this.evict(state);
+    state.version += 1;
     return true;
   }
 
@@ -140,11 +169,21 @@ export class BoundedAgentTimelineHotStore {
     entry.revision = state.nextRevision;
     state.nextRevision += 1;
     this.evict(state);
+    state.version += 1;
     return { seq: row.seq, revision: entry.revision };
   }
 
   snapshot(agentId: string): HotTimelineSnapshot {
     const state = this.requireState(agentId);
+    return this.snapshotState(state);
+  }
+
+  versionedSnapshot(agentId: string): { version: number; snapshot: HotTimelineSnapshot } {
+    const state = this.requireState(agentId);
+    return { version: state.version, snapshot: this.snapshotState(state) };
+  }
+
+  private snapshotState(state: HotState): HotTimelineSnapshot {
     return {
       epoch: state.epoch,
       logicalWindow: {
@@ -159,6 +198,34 @@ export class BoundedAgentTimelineHotStore {
       encodedBytes: state.encodedBytes,
       rows: state.rows.map(({ row }) => cloneRow(row)),
     };
+  }
+
+  getRow(agentId: string, seq: number): AgentTimelineRow | null {
+    const entry = this.requireState(agentId).rows.find((candidate) => candidate.row.seq === seq);
+    return entry ? cloneRow(entry.row) : null;
+  }
+
+  getVersion(agentId: string): number {
+    return this.requireState(agentId).version;
+  }
+
+  getPendingRows(agentId: string): AgentTimelineRow[] {
+    return this.requireState(agentId)
+      .rows.filter(({ durable }) => !durable)
+      .map(({ row }) => cloneRow(row));
+  }
+
+  unpinMutableRows(agentId: string, turnId: string | undefined): void {
+    const state = this.requireState(agentId);
+    let changed = false;
+    for (const entry of state.rows) {
+      if (entry.row.turnId === turnId && entry.mutable) {
+        entry.mutable = false;
+        changed = true;
+      }
+    }
+    this.evict(state);
+    if (changed) state.version += 1;
   }
 
   metrics(agentId: string): HotTimelineMetrics {

--- a/packages/server/src/server/agent/bounded-agent-timeline-hot-store.ts
+++ b/packages/server/src/server/agent/bounded-agent-timeline-hot-store.ts
@@ -1,0 +1,254 @@
+import type { AgentTimelineRow, AgentTimelineWindow } from "./agent-timeline-store-types.js";
+
+export interface BoundedAgentTimelineHotStoreOptions {
+  maxRows: number;
+  maxBytes: number;
+}
+
+export interface HotTimelineInitializeOptions {
+  epoch: string;
+  window: AgentTimelineWindow;
+}
+
+export interface HotTimelineRowOptions {
+  durable?: boolean;
+  mutable?: boolean;
+}
+
+export interface HotTimelineSnapshot {
+  epoch: string;
+  logicalWindow: AgentTimelineWindow;
+  retainedWindow: Pick<AgentTimelineWindow, "minSeq" | "maxSeq">;
+  encodedBytes: number;
+  rows: AgentTimelineRow[];
+}
+
+export interface HotTimelineRevision {
+  seq: number;
+  revision: number;
+}
+
+export interface HotTimelineMetrics {
+  retainedRows: number;
+  retainedBytes: number;
+  recentRows: number;
+  recentBytes: number;
+  pinnedRows: number;
+  pinnedBytes: number;
+  pendingRows: number;
+  pendingBytes: number;
+}
+
+interface HotRow {
+  row: AgentTimelineRow;
+  bytes: number;
+  durable: boolean;
+  mutable: boolean;
+  revision: number;
+}
+
+interface HotState {
+  epoch: string;
+  logicalMinSeq: number;
+  logicalMaxSeq: number;
+  nextSeq: number;
+  encodedBytes: number;
+  rows: HotRow[];
+  nextRevision: number;
+}
+
+/**
+ * Bounded process-local timeline window. The durable store owns evicted prefixes; this window may
+ * overlap it with acknowledged rows and may extend it with a pinned unacknowledged/mutable tail.
+ * Later integration must merge by sequence, preferring the hot copy for overlapping mutable rows.
+ */
+export class BoundedAgentTimelineHotStore {
+  private readonly states = new Map<string, HotState>();
+
+  constructor(private readonly options: BoundedAgentTimelineHotStoreOptions) {
+    validatePositiveInteger(options.maxRows, "maxRows");
+    validatePositiveInteger(options.maxBytes, "maxBytes");
+  }
+
+  initialize(agentId: string, options: HotTimelineInitializeOptions): void {
+    if (typeof options.epoch !== "string" || options.epoch.length === 0) {
+      throw new Error("epoch must be a non-empty string");
+    }
+    validateWindow(options.window);
+    this.states.set(agentId, {
+      epoch: options.epoch,
+      logicalMinSeq: options.window.minSeq,
+      logicalMaxSeq: options.window.maxSeq,
+      nextSeq: options.window.nextSeq,
+      encodedBytes: 0,
+      rows: [],
+      nextRevision: 1,
+    });
+  }
+
+  append(
+    agentId: string,
+    row: AgentTimelineRow,
+    options?: HotTimelineRowOptions,
+  ): HotTimelineRevision {
+    const state = this.requireState(agentId);
+    if (row.seq !== state.nextSeq) {
+      throw new Error(`Expected timeline sequence ${state.nextSeq}, received ${row.seq}`);
+    }
+    const cloned = cloneRow(row);
+    const entry: HotRow = {
+      row: cloned,
+      bytes: encodedRowBytes(cloned),
+      durable: options?.durable ?? false,
+      mutable: options?.mutable ?? false,
+      revision: state.nextRevision,
+    };
+    state.nextRevision += 1;
+    if (state.logicalMinSeq === 0) state.logicalMinSeq = row.seq;
+    state.logicalMaxSeq = row.seq;
+    state.nextSeq = row.seq + 1;
+    state.rows.push(entry);
+    state.encodedBytes += entry.bytes;
+    this.evict(state);
+    return { seq: row.seq, revision: entry.revision };
+  }
+
+  acknowledgeDurable(agentId: string, revision: HotTimelineRevision): boolean {
+    const state = this.requireState(agentId);
+    const entry = state.rows.find(({ row }) => row.seq === revision.seq);
+    if (!entry || entry.revision !== revision.revision) return false;
+    entry.durable = true;
+    this.evict(state);
+    return true;
+  }
+
+  update(
+    agentId: string,
+    row: AgentTimelineRow,
+    options?: HotTimelineRowOptions,
+  ): HotTimelineRevision {
+    const state = this.requireState(agentId);
+    const entry = state.rows.find((candidate) => candidate.row.seq === row.seq);
+    if (!entry) throw new Error(`Cannot update missing hot timeline sequence ${row.seq}`);
+    const cloned = cloneRow(row);
+    const bytes = encodedRowBytes(cloned);
+    state.encodedBytes += bytes - entry.bytes;
+    entry.row = cloned;
+    entry.bytes = bytes;
+    entry.durable = options?.durable ?? false;
+    if (options?.mutable !== undefined) entry.mutable = options.mutable;
+    entry.revision = state.nextRevision;
+    state.nextRevision += 1;
+    this.evict(state);
+    return { seq: row.seq, revision: entry.revision };
+  }
+
+  snapshot(agentId: string): HotTimelineSnapshot {
+    const state = this.requireState(agentId);
+    return {
+      epoch: state.epoch,
+      logicalWindow: {
+        minSeq: state.logicalMinSeq,
+        maxSeq: state.logicalMaxSeq,
+        nextSeq: state.nextSeq,
+      },
+      retainedWindow: {
+        minSeq: state.rows[0]?.row.seq ?? 0,
+        maxSeq: state.rows.at(-1)?.row.seq ?? 0,
+      },
+      encodedBytes: state.encodedBytes,
+      rows: state.rows.map(({ row }) => cloneRow(row)),
+    };
+  }
+
+  metrics(agentId: string): HotTimelineMetrics {
+    const state = this.requireState(agentId);
+    const result: HotTimelineMetrics = {
+      retainedRows: state.rows.length,
+      retainedBytes: state.encodedBytes,
+      recentRows: 0,
+      recentBytes: 0,
+      pinnedRows: 0,
+      pinnedBytes: 0,
+      pendingRows: 0,
+      pendingBytes: 0,
+    };
+    for (const entry of state.rows) {
+      if (entry.durable && !entry.mutable) {
+        result.recentRows += 1;
+        result.recentBytes += entry.bytes;
+      } else {
+        result.pinnedRows += 1;
+        result.pinnedBytes += entry.bytes;
+      }
+      if (!entry.durable) {
+        result.pendingRows += 1;
+        result.pendingBytes += entry.bytes;
+      }
+    }
+    return result;
+  }
+
+  has(agentId: string): boolean {
+    return this.states.has(agentId);
+  }
+
+  deleteAgent(agentId: string): void {
+    this.states.delete(agentId);
+  }
+
+  clear(): void {
+    this.states.clear();
+  }
+
+  private evict(state: HotState): void {
+    while (
+      state.rows.length > 1 &&
+      (state.rows.length > this.options.maxRows || state.encodedBytes > this.options.maxBytes)
+    ) {
+      const evictableIndex = state.rows.findIndex(
+        (entry, index) => index < state.rows.length - 1 && entry.durable && !entry.mutable,
+      );
+      if (evictableIndex < 0) return;
+      const [evicted] = state.rows.splice(evictableIndex, 1);
+      state.encodedBytes -= evicted!.bytes;
+    }
+  }
+
+  private requireState(agentId: string): HotState {
+    const state = this.states.get(agentId);
+    if (!state) throw new Error(`Timeline hot store is not initialized for agent '${agentId}'`);
+    return state;
+  }
+}
+
+function encodedRowBytes(row: AgentTimelineRow): number {
+  return Buffer.byteLength(JSON.stringify(row), "utf8");
+}
+
+function cloneRow(row: AgentTimelineRow): AgentTimelineRow {
+  return { ...row, item: structuredClone(row.item) };
+}
+
+function validatePositiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+}
+
+function validateWindow(window: AgentTimelineWindow): void {
+  if (
+    !Number.isSafeInteger(window.minSeq) ||
+    window.minSeq < 0 ||
+    !Number.isSafeInteger(window.maxSeq) ||
+    window.maxSeq < 0 ||
+    !Number.isSafeInteger(window.nextSeq) ||
+    window.nextSeq < 1 ||
+    (window.minSeq === 0 && window.maxSeq !== 0) ||
+    (window.minSeq === 0 && window.nextSeq !== 1) ||
+    (window.minSeq > 0 && window.minSeq > window.maxSeq) ||
+    (window.minSeq > 0 && window.nextSeq !== window.maxSeq + 1)
+  ) {
+    throw new Error("Invalid logical timeline window");
+  }
+}

--- a/packages/server/src/server/agent/bounded-agent-timeline-runtime.test.ts
+++ b/packages/server/src/server/agent/bounded-agent-timeline-runtime.test.ts
@@ -1,0 +1,834 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AgentTimelineRow } from "./agent-timeline-store-types.js";
+import { BoundedAgentTimelineRuntime } from "./bounded-agent-timeline-runtime.js";
+import { SegmentedFileAgentTimelineStore } from "./segmented-file-agent-timeline-store.js";
+import type { TimelineDurableSink } from "./ordered-agent-timeline-durable-buffer.js";
+import { TimelineDurableBufferBackpressureError } from "./ordered-agent-timeline-durable-buffer.js";
+import { projectTimelineRows } from "./timeline-projection.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await rm(directory, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("BoundedAgentTimelineRuntime", () => {
+  it("rejects a durable row limit above the hot byte ceiling", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-row-ceiling-"));
+    temporaryDirectories.push(directory);
+
+    expect(
+      () =>
+        new BoundedAgentTimelineRuntime(new SegmentedFileAgentTimelineStore(directory), {
+          hot: { maxRows: 1, maxBytes: 100 },
+          buffer: { maxBatchBytes: 200, maxPendingBytes: 200, maxRowBytes: 101 },
+        }),
+    ).toThrow("maxRowBytes must not exceed the hot timeline maxBytes");
+  });
+
+  it("derives the default row limit from every configured byte ceiling", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-row-default-"));
+    temporaryDirectories.push(directory);
+
+    expect(
+      () =>
+        new BoundedAgentTimelineRuntime(new SegmentedFileAgentTimelineStore(directory), {
+          hot: { maxRows: 1, maxBytes: 300 },
+          buffer: { maxBatchBytes: 200, maxPendingBytes: 100 },
+        }),
+    ).not.toThrow();
+  });
+
+  it("pages a durable prefix while exposing a pending hot tail exactly once", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory, { maxRowsPerSegment: 1 });
+    const writeStarted = deferred<void>();
+    const releaseWrite = deferred<void>();
+    let holdFirstWrite = true;
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId, rows) => {
+        if (holdFirstWrite) {
+          holdFirstWrite = false;
+          writeStarted.resolve();
+          await releaseWrite.promise;
+        }
+        await durable.bulkInsert(agentId, rows);
+      },
+      updateCommittedRow: async (agentId, row) => {
+        await durable.updateCommittedRow(agentId, row);
+      },
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: sink,
+      hot: { maxRows: 2, maxBytes: 10_000 },
+      buffer: { maxPendingRows: 3, maxPendingBytes: 10_000, maxBatchRows: 2 },
+    });
+    await runtime.initialize("agent-1");
+
+    runtime.append("agent-1", assistantRow(1));
+    runtime.append("agent-1", assistantRow(2));
+    runtime.append("agent-1", assistantRow(3));
+    await writeStarted.promise;
+
+    await expect(runtime.fetch("agent-1", { direction: "tail", limit: 3 })).resolves.toMatchObject({
+      window: { minSeq: 1, maxSeq: 3, nextSeq: 4 },
+      rows: [assistantRow(1), assistantRow(2), assistantRow(3)],
+    });
+    expect(runtime.metrics("agent-1").hot.pendingRows).toBe(3);
+
+    releaseWrite.resolve();
+    await runtime.flush("agent-1");
+    expect(runtime.metrics("agent-1").hot.retainedRows).toBeLessThanOrEqual(2);
+
+    const tail = await runtime.fetch("agent-1", { direction: "tail", limit: 2 });
+    expect(tail.rows).toEqual([assistantRow(2), assistantRow(3)]);
+    const older = await runtime.fetch("agent-1", {
+      direction: "before",
+      cursor: { epoch: tail.epoch, seq: 2 },
+      limit: 1,
+    });
+    expect(older.rows).toEqual([assistantRow(1)]);
+  });
+
+  it("retries a fetch when a committed row is evicted from hot after the durable snapshot", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-fetch-race-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory, { maxRowsPerSegment: 1 });
+    const rowTwoWriteStarted = deferred<void>();
+    const releaseRowTwoWrite = deferred<void>();
+    const rowThreeWriteStarted = deferred<void>();
+    const releaseRowThreeWrite = deferred<void>();
+    const durableFetchCaptured = deferred<void>();
+    const releaseDurableFetch = deferred<void>();
+    let write = 0;
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId, rows) => {
+        write += 1;
+        if (write === 1) {
+          rowTwoWriteStarted.resolve();
+          await releaseRowTwoWrite.promise;
+        } else if (write === 2) {
+          rowThreeWriteStarted.resolve();
+          await releaseRowThreeWrite.promise;
+        }
+        await durable.bulkInsert(agentId, rows);
+      },
+      updateCommittedRow: async (agentId, row) => {
+        await durable.updateCommittedRow(agentId, row);
+      },
+    };
+    await durable.bulkInsert("agent-1", [assistantRow(1)]);
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: sink,
+      hot: { maxRows: 1, maxBytes: 10_000 },
+      buffer: { maxPendingRows: 2, maxPendingBytes: 10_000, maxBatchRows: 1 },
+    });
+    await runtime.initialize("agent-1");
+
+    runtime.append("agent-1", assistantRow(2));
+    runtime.append("agent-1", assistantRow(3));
+    await rowTwoWriteStarted.promise;
+
+    const originalFetch = durable.fetchCommitted.bind(durable);
+    let intercept = true;
+    durable.fetchCommitted = async (...args) => {
+      const result = await originalFetch(...args);
+      if (intercept) {
+        intercept = false;
+        durableFetchCaptured.resolve();
+        await releaseDurableFetch.promise;
+      }
+      return result;
+    };
+    const fetching = runtime.fetch("agent-1", { direction: "tail", limit: 3 });
+    await durableFetchCaptured.promise;
+
+    releaseRowTwoWrite.resolve();
+    await rowThreeWriteStarted.promise;
+    expect(runtime.getHotRows("agent-1").map(({ seq }) => seq)).toEqual([3]);
+    releaseDurableFetch.resolve();
+
+    await expect(fetching).resolves.toMatchObject({
+      rows: [assistantRow(1), assistantRow(2), assistantRow(3)],
+    });
+    releaseRowThreeWrite.resolve();
+    await runtime.flush("agent-1");
+  });
+
+  it("rejects an in-flight read when its runtime generation is replaced", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-read-generation-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    await durable.bulkInsert("agent-1", [assistantRow(1, "old")]);
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+    const originalFetch = durable.fetchCommitted.bind(durable);
+    const oldReadCaptured = deferred<void>();
+    const releaseOldRead = deferred<void>();
+    let hold = true;
+    durable.fetchCommitted = async (...args) => {
+      const result = await originalFetch(...args);
+      if (hold) {
+        hold = false;
+        oldReadCaptured.resolve();
+        await releaseOldRead.promise;
+      }
+      return result;
+    };
+
+    const oldRead = runtime.fetch("agent-1", { direction: "tail", limit: 1 });
+    await oldReadCaptured.promise;
+    await runtime.discardAndDelete("agent-1");
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1, "new"));
+    await runtime.flush("agent-1");
+    releaseOldRead.resolve();
+
+    await expect(oldRead).rejects.toThrow("Timeline runtime generation changed");
+    await expect(runtime.fetch("agent-1", { direction: "tail", limit: 1 })).resolves.toMatchObject({
+      rows: [assistantRow(1, "new")],
+    });
+  });
+
+  it("does not resume a backpressured writer into a replacement generation", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-write-generation-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const writeStarted = deferred<void>();
+    const releaseWrite = deferred<void>();
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: {
+        bulkInsert: async (agentId, rows) => {
+          writeStarted.resolve();
+          await releaseWrite.promise;
+          await durable.bulkInsert(agentId, rows);
+        },
+        updateCommittedRow: async (agentId, row) => await durable.updateCommittedRow(agentId, row),
+      },
+      hot: { maxRows: 1, maxBytes: 10_000 },
+      buffer: { maxPendingRows: 1, maxPendingBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1, "old"));
+    await writeStarted.promise;
+    const blocked = runtime.appendWhenWritable("agent-1", assistantRow(2, "must not replay"));
+    const blockedResult = blocked.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    const deleting = runtime.discardAndDelete("agent-1");
+    releaseWrite.resolve();
+    await deleting;
+    await runtime.initialize("agent-1");
+
+    await expect(blockedResult).resolves.toMatchObject({
+      message: expect.stringMatching(/generation changed|not accepting writes/),
+    });
+    await expect(runtime.fetch("agent-1", { direction: "tail", limit: 10 })).resolves.toMatchObject(
+      {
+        rows: [],
+      },
+    );
+  });
+
+  it("retries a fetch when an updated overlap commits and is evicted after the durable snapshot", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-update-race-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory, { maxRowsPerSegment: 1 });
+    await durable.bulkInsert("agent-1", [assistantRow(1, "old")]);
+    const updateStarted = deferred<void>();
+    const releaseUpdate = deferred<void>();
+    const rowTwoWriteStarted = deferred<void>();
+    const releaseRowTwoWrite = deferred<void>();
+    const durableFetchCaptured = deferred<void>();
+    const releaseDurableFetch = deferred<void>();
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId, rows) => {
+        rowTwoWriteStarted.resolve();
+        await releaseRowTwoWrite.promise;
+        await durable.bulkInsert(agentId, rows);
+      },
+      updateCommittedRow: async (agentId, row) => {
+        updateStarted.resolve();
+        await releaseUpdate.promise;
+        await durable.updateCommittedRow(agentId, row);
+      },
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: sink,
+      hot: { maxRows: 1, maxBytes: 10_000 },
+      buffer: { maxPendingRows: 2, maxPendingBytes: 10_000, maxBatchRows: 1 },
+    });
+    await runtime.initialize("agent-1");
+    runtime.update("agent-1", assistantRow(1, "new"));
+    runtime.append("agent-1", assistantRow(2));
+    await updateStarted.promise;
+
+    const originalFetch = durable.fetchCommitted.bind(durable);
+    let intercept = true;
+    durable.fetchCommitted = async (...args) => {
+      const result = await originalFetch(...args);
+      if (intercept) {
+        intercept = false;
+        durableFetchCaptured.resolve();
+        await releaseDurableFetch.promise;
+      }
+      return result;
+    };
+    const fetching = runtime.fetch("agent-1", { direction: "tail", limit: 2 });
+    await durableFetchCaptured.promise;
+
+    releaseUpdate.resolve();
+    await rowTwoWriteStarted.promise;
+    expect(runtime.getHotRows("agent-1").map(({ seq }) => seq)).toEqual([2]);
+    releaseDurableFetch.resolve();
+
+    await expect(fetching).resolves.toMatchObject({
+      rows: [assistantRow(1, "new"), assistantRow(2)],
+    });
+    releaseRowTwoWrite.resolve();
+    await runtime.flush("agent-1");
+  });
+
+  it("serializes a backpressured retry without reordering timeline sequences", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-order-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const writeStarted = deferred<void>();
+    const releaseWrite = deferred<void>();
+    const writes: number[][] = [];
+    let holdFirstWrite = true;
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId, rows) => {
+        writes.push(rows.map(({ seq }) => seq));
+        if (holdFirstWrite) {
+          holdFirstWrite = false;
+          writeStarted.resolve();
+          await releaseWrite.promise;
+        }
+        await durable.bulkInsert(agentId, rows);
+      },
+      updateCommittedRow: async (agentId, row) => {
+        await durable.updateCommittedRow(agentId, row);
+      },
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: sink,
+      hot: { maxRows: 2, maxBytes: 10_000 },
+      buffer: { maxPendingRows: 1, maxPendingBytes: 10_000, maxBatchRows: 1 },
+    });
+    await runtime.initialize("agent-1");
+
+    runtime.append("agent-1", assistantRow(1));
+    let backpressure: TimelineDurableBufferBackpressureError | undefined;
+    try {
+      runtime.append("agent-1", assistantRow(2));
+    } catch (error) {
+      expect(error).toBeInstanceOf(TimelineDurableBufferBackpressureError);
+      backpressure = error as TimelineDurableBufferBackpressureError;
+    }
+    await writeStarted.promise;
+    expect(runtime.metrics("agent-1").buffer).toMatchObject({
+      pendingRows: 1,
+      writableSignals: 1,
+    });
+
+    releaseWrite.resolve();
+    await backpressure!.whenWritable;
+    runtime.append("agent-1", assistantRow(2));
+    await runtime.flush("agent-1");
+    runtime.append("agent-1", assistantRow(3));
+    await runtime.flush("agent-1");
+    expect(writes).toEqual([[1], [2], [3]]);
+  });
+
+  it("rejects a burst before retaining rows beyond the durable buffer admission bound", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-burst-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const writeStarted = deferred<void>();
+    const releaseWrite = deferred<void>();
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId, rows) => {
+        writeStarted.resolve();
+        await releaseWrite.promise;
+        await durable.bulkInsert(agentId, rows);
+      },
+      updateCommittedRow: async (agentId, row) => {
+        await durable.updateCommittedRow(agentId, row);
+      },
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: sink,
+      hot: { maxRows: 2, maxBytes: 1_000 },
+      buffer: { maxPendingRows: 2, maxPendingBytes: 1_000, maxBatchRows: 1 },
+    });
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1, "x".repeat(200)));
+    runtime.append("agent-1", assistantRow(2, "x".repeat(200)));
+    await writeStarted.promise;
+
+    let backpressure: TimelineDurableBufferBackpressureError | undefined;
+    for (let attempt = 0; attempt < 2_000; attempt += 1) {
+      try {
+        runtime.append("agent-1", assistantRow(3, "x".repeat(200)));
+      } catch (error) {
+        expect(error).toBeInstanceOf(TimelineDurableBufferBackpressureError);
+        backpressure = error as TimelineDurableBufferBackpressureError;
+      }
+    }
+    expect(runtime.metrics("agent-1")).toMatchObject({
+      hot: { retainedRows: 2, pendingRows: 2 },
+      buffer: { pendingRows: 2, writableSignals: 1 },
+    });
+
+    releaseWrite.resolve();
+    await backpressure!.whenWritable;
+    runtime.append("agent-1", assistantRow(3, "x".repeat(200)));
+    await runtime.flush("agent-1");
+    await expect(durable.getCommittedRows("agent-1")).resolves.toEqual([
+      assistantRow(1, "x".repeat(200)),
+      assistantRow(2, "x".repeat(200)),
+      assistantRow(3, "x".repeat(200)),
+    ]);
+  });
+
+  it("keeps a failed durable row pinned and exposes the persistence failure", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-failure-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const failure = new Error("durable cache unavailable");
+    const sink: TimelineDurableSink = {
+      bulkInsert: async () => {
+        throw failure;
+      },
+      updateCommittedRow: async () => {
+        throw failure;
+      },
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: sink,
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+
+    runtime.append("agent-1", assistantRow(1));
+
+    await expect(runtime.flush("agent-1")).rejects.toBe(failure);
+    expect(runtime.metrics("agent-1")).toMatchObject({
+      hot: { retainedRows: 1, pinnedRows: 1, pendingRows: 1 },
+      durabilityError: failure,
+    });
+  });
+
+  it("rejects flush promptly when a failed durable prefix has an admitted suffix", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-prefix-failure-"));
+    temporaryDirectories.push(directory);
+    const failure = new Error("durable prefix failed");
+    const runtime = new BoundedAgentTimelineRuntime(
+      new SegmentedFileAgentTimelineStore(directory),
+      {
+        durableSink: {
+          bulkInsert: async () => {
+            throw failure;
+          },
+          updateCommittedRow: async () => {
+            throw failure;
+          },
+        },
+        hot: { maxRows: 2, maxBytes: 10_000 },
+        buffer: { maxPendingRows: 2, maxPendingBytes: 10_000, maxBatchRows: 1 },
+      },
+    );
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1));
+    runtime.append("agent-1", assistantRow(2));
+
+    await expect(
+      Promise.race([
+        runtime.flush("agent-1"),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("flush timed out")), 100)),
+      ]),
+    ).rejects.toBe(failure);
+  });
+
+  it("fences an active writer before deleting hot and durable agent state", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-delete-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const writeStarted = deferred<void>();
+    const releaseWrite = deferred<void>();
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId, rows) => {
+        writeStarted.resolve();
+        await releaseWrite.promise;
+        await durable.bulkInsert(agentId, rows);
+      },
+      updateCommittedRow: async (agentId, row) => {
+        await durable.updateCommittedRow(agentId, row);
+      },
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: sink,
+      hot: { maxRows: 2, maxBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1));
+    await writeStarted.promise;
+
+    let deleted = false;
+    const deletion = runtime.discardAndDelete("agent-1").then(() => {
+      deleted = true;
+      return undefined;
+    });
+    await Promise.resolve();
+    expect(deleted).toBe(false);
+    releaseWrite.resolve();
+    await deletion;
+
+    expect(runtime.has("agent-1")).toBe(false);
+    await expect(durable.getCommittedRows("agent-1")).resolves.toEqual([]);
+  });
+
+  it("drains and releases resident state without deleting the durable cache", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-release-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const writeStarted = deferred<void>();
+    const releaseWrite = deferred<void>();
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId, rows) => {
+        writeStarted.resolve();
+        await releaseWrite.promise;
+        await durable.bulkInsert(agentId, rows);
+      },
+      updateCommittedRow: async (agentId, row) => {
+        await durable.updateCommittedRow(agentId, row);
+      },
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: sink,
+      hot: { maxRows: 2, maxBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1));
+    await writeStarted.promise;
+
+    let released = false;
+    const release = runtime.release("agent-1").then(() => {
+      released = true;
+      return undefined;
+    });
+    await Promise.resolve();
+    expect(released).toBe(false);
+    expect(() => runtime.append("agent-1", assistantRow(2))).toThrow(
+      "Timeline runtime is not accepting writes",
+    );
+    releaseWrite.resolve();
+    await release;
+
+    expect(runtime.has("agent-1")).toBe(false);
+    await expect(durable.getCommittedRows("agent-1")).resolves.toEqual([assistantRow(1)]);
+
+    await runtime.initialize("agent-1");
+    expect(runtime.getHotItems("agent-1")).toEqual([{ type: "assistant_message", text: "row-1" }]);
+    expect(runtime.metrics("agent-1").hot).toMatchObject({
+      retainedRows: 1,
+      recentRows: 1,
+      pendingRows: 0,
+    });
+  });
+
+  it("invalidates the disposable durable cache when release observes a failed write", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-failed-release-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const failure = new Error("second cache write failed");
+    let writes = 0;
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: {
+        bulkInsert: async (agentId, rows) => {
+          writes += 1;
+          if (writes > 1) throw failure;
+          await durable.bulkInsert(agentId, rows);
+        },
+        updateCommittedRow: async (agentId, row) => await durable.updateCommittedRow(agentId, row),
+      },
+      hot: { maxRows: 1, maxBytes: 10_000 },
+      buffer: { maxBatchRows: 1 },
+    });
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1));
+    await runtime.flush("agent-1");
+    runtime.append("agent-1", assistantRow(2));
+    await expect(runtime.flush("agent-1")).rejects.toBe(failure);
+
+    await expect(runtime.release("agent-1")).rejects.toBe(failure);
+    await expect(durable.getCommittedRows("agent-1")).resolves.toEqual([]);
+  });
+
+  it("allows discard-and-delete to retry after durable deletion fails", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-delete-retry-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const originalDelete = durable.deleteAgent.bind(durable);
+    const failure = new Error("delete failed");
+    let failDelete = true;
+    durable.deleteAgent = async (agentId) => {
+      if (failDelete) throw failure;
+      await originalDelete(agentId);
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+
+    await expect(runtime.discardAndDelete("agent-1")).rejects.toBe(failure);
+    expect(runtime.aggregateMetrics().failedAgents).toBe(1);
+    failDelete = false;
+    await expect(runtime.discardAndDelete("agent-1")).resolves.toBeUndefined();
+    expect(runtime.has("agent-1")).toBe(false);
+  });
+
+  it("keeps a failed cache invalidation fenced until deletion can be retried", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-release-retry-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const originalDelete = durable.deleteAgent.bind(durable);
+    const writeFailure = new Error("cache write failed");
+    const deleteFailure = new Error("cache delete failed");
+    let failDelete = true;
+    durable.deleteAgent = async (agentId) => {
+      if (failDelete) throw deleteFailure;
+      await originalDelete(agentId);
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: {
+        bulkInsert: async () => {
+          throw writeFailure;
+        },
+        updateCommittedRow: async () => undefined,
+      },
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1));
+    await expect(runtime.release("agent-1")).rejects.toBeInstanceOf(AggregateError);
+
+    await expect(runtime.initialize("agent-1")).rejects.toThrow(
+      "Timeline runtime cache deletion must be retried",
+    );
+    expect(runtime.has("agent-1")).toBe(false);
+
+    failDelete = false;
+    await runtime.discardAndDelete("agent-1");
+    await runtime.initialize("agent-1");
+    expect(runtime.getHotRows("agent-1")).toEqual([]);
+  });
+
+  it("single-flights concurrent initialization and does not retain release tombstones", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-init-fence-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const originalFetch = durable.fetchCommitted.bind(durable);
+    const fetchStarted = deferred<void>();
+    const releaseFetch = deferred<void>();
+    let fetches = 0;
+    durable.fetchCommitted = async (...args) => {
+      fetches += 1;
+      fetchStarted.resolve();
+      await releaseFetch.promise;
+      return await originalFetch(...args);
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    });
+    const first = runtime.initialize("agent-1");
+    await fetchStarted.promise;
+    const second = runtime.initialize("agent-1");
+    releaseFetch.resolve();
+    await Promise.all([first, second]);
+    expect(fetches).toBe(1);
+    await runtime.release("agent-1");
+    expect((runtime as unknown as { lifecycle: Map<string, unknown> }).lifecycle.size).toBe(0);
+  });
+
+  it("projects adjacent assistant rows across the durable and hot overlap boundary", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-projection-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory, { maxRowsPerSegment: 1 });
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1, "first "));
+    runtime.append("agent-1", assistantRow(2, "second"));
+    await runtime.flush("agent-1");
+
+    const timeline = await runtime.fetch("agent-1", { direction: "tail", limit: 2 });
+    expect(runtime.metrics("agent-1").hot.retainedRows).toBe(1);
+    expect(timeline.rows.map(({ seq }) => seq)).toEqual([1, 2]);
+    expect(projectTimelineRows({ rows: timeline.rows, mode: "projected" })).toMatchObject([
+      {
+        seqStart: 1,
+        seqEnd: 2,
+        item: { type: "assistant_message", text: "first second" },
+      },
+    ]);
+    await expect(runtime.getLastAssistantMessage("agent-1")).resolves.toBe("first second");
+    await expect(runtime.getLastItem("agent-1")).resolves.toEqual({
+      type: "assistant_message",
+      text: "second",
+    });
+  });
+
+  it("preserves store navigation flags for empty pages beyond either edge", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-empty-pages-"));
+    temporaryDirectories.push(directory);
+    const runtime = new BoundedAgentTimelineRuntime(
+      new SegmentedFileAgentTimelineStore(directory),
+      { hot: { maxRows: 1, maxBytes: 10_000 } },
+    );
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1));
+    runtime.append("agent-1", assistantRow(2));
+    await runtime.flush("agent-1");
+    const epoch = runtime.getEpoch("agent-1");
+
+    await expect(
+      runtime.fetch("agent-1", {
+        direction: "after",
+        cursor: { epoch, seq: 2 },
+        limit: 1,
+      }),
+    ).resolves.toMatchObject({ rows: [], hasOlder: true, hasNewer: false });
+    await expect(
+      runtime.fetch("agent-1", {
+        direction: "before",
+        cursor: { epoch, seq: 1 },
+        limit: 1,
+      }),
+    ).resolves.toMatchObject({ rows: [], hasOlder: false, hasNewer: true });
+  });
+
+  it("prefers an unacknowledged hot update at the durable maximum sequence", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-hot-update-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const updateStarted = deferred<void>();
+    const releaseUpdate = deferred<void>();
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId, rows) => {
+        await durable.bulkInsert(agentId, rows);
+      },
+      updateCommittedRow: async (agentId, row) => {
+        updateStarted.resolve();
+        await releaseUpdate.promise;
+        await durable.updateCommittedRow(agentId, row);
+      },
+    };
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      durableSink: sink,
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+    runtime.append("agent-1", assistantRow(1, "old"));
+    await runtime.flush("agent-1");
+    runtime.update("agent-1", assistantRow(1, "new"));
+    await updateStarted.promise;
+
+    await expect(runtime.getLastItem("agent-1")).resolves.toEqual({
+      type: "assistant_message",
+      text: "new",
+    });
+    await expect(runtime.getLastAssistantMessage("agent-1")).resolves.toBe("new");
+
+    releaseUpdate.resolve();
+    await runtime.flush("agent-1");
+  });
+
+  it("pins a mutable submitted row through eviction pressure until enrichment is durable", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-mutable-"));
+    temporaryDirectories.push(directory);
+    const durable = new SegmentedFileAgentTimelineStore(directory);
+    const runtime = new BoundedAgentTimelineRuntime(durable, {
+      hot: { maxRows: 1, maxBytes: 10_000 },
+    });
+    await runtime.initialize("agent-1");
+    const submitted: AgentTimelineRow = {
+      seq: 1,
+      timestamp: "2026-08-31T12:00:00.000Z",
+      item: { type: "user_message", text: "prompt", clientMessageId: "client-1" },
+    };
+    runtime.append("agent-1", submitted, { mutable: true });
+    await runtime.flush("agent-1");
+    runtime.append("agent-1", assistantRow(2));
+    await runtime.flush("agent-1");
+    expect(runtime.getHotRows("agent-1").map(({ seq }) => seq)).toEqual([1, 2]);
+
+    runtime.update(
+      "agent-1",
+      { ...submitted, providerMessageId: "provider-1" },
+      { mutable: false },
+    );
+    await runtime.flush("agent-1");
+    const rows = await runtime.fetch("agent-1", { direction: "tail", limit: 2 });
+    expect(rows.rows).toEqual([{ ...submitted, providerMessageId: "provider-1" }, assistantRow(2)]);
+  });
+
+  it("unpins submitted rows without provider echoes after their terminal boundary", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-bounded-runtime-unpin-"));
+    temporaryDirectories.push(directory);
+    const runtime = new BoundedAgentTimelineRuntime(
+      new SegmentedFileAgentTimelineStore(directory),
+      { hot: { maxRows: 1, maxBytes: 10_000 } },
+    );
+    await runtime.initialize("agent-1");
+    runtime.append(
+      "agent-1",
+      {
+        seq: 1,
+        timestamp: "2026-08-31T12:00:00.000Z",
+        item: { type: "user_message", text: "failed prompt", clientMessageId: "client-1" },
+      },
+      { mutable: true },
+    );
+    await runtime.flush("agent-1");
+    runtime.unpinMutableRows("agent-1", undefined);
+    runtime.append("agent-1", assistantRow(2));
+    await runtime.flush("agent-1");
+
+    expect(runtime.getHotRows("agent-1").map(({ seq }) => seq)).toEqual([2]);
+  });
+});
+
+function assistantRow(seq: number, text = `row-${seq}`): AgentTimelineRow {
+  return {
+    seq,
+    timestamp: "2026-08-31T12:00:00.000Z",
+    item: { type: "assistant_message", text },
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value?: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value?: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve as (value?: T | PromiseLike<T>) => void;
+  });
+  return { promise, resolve };
+}

--- a/packages/server/src/server/agent/bounded-agent-timeline-runtime.ts
+++ b/packages/server/src/server/agent/bounded-agent-timeline-runtime.ts
@@ -1,0 +1,615 @@
+import type { AgentTimelineItem } from "./agent-sdk-types.js";
+import type {
+  AgentTimelineFetchOptions,
+  AgentTimelineFetchResult,
+  AgentTimelineRow,
+  AgentTimelineStore,
+} from "./agent-timeline-store-types.js";
+import {
+  BoundedAgentTimelineHotStore,
+  type BoundedAgentTimelineHotStoreOptions,
+  type HotTimelineMetrics,
+  type HotTimelineRowOptions,
+  type HotTimelineRevision,
+  type HotTimelineSnapshot,
+} from "./bounded-agent-timeline-hot-store.js";
+import {
+  OrderedAgentTimelineDurableBuffer,
+  DEFAULT_TIMELINE_DURABLE_MAX_ROW_BYTES,
+  TimelineDurableBufferBackpressureError,
+  type OrderedAgentTimelineDurableBufferOptions,
+  type TimelineDurableBufferMetrics,
+  type TimelineDurableSink,
+} from "./ordered-agent-timeline-durable-buffer.js";
+
+const DEFAULT_FETCH_LIMIT = 200;
+
+export interface BoundedAgentTimelineRuntimeOptions {
+  hot: BoundedAgentTimelineHotStoreOptions;
+  buffer?: OrderedAgentTimelineDurableBufferOptions;
+  durableSink?: TimelineDurableSink;
+  onHotChanged?: (agentId: string, snapshot: HotTimelineSnapshot) => void;
+}
+
+export interface BoundedAgentTimelineRuntimeMetrics {
+  hot: HotTimelineMetrics;
+  buffer: TimelineDurableBufferMetrics;
+  durabilityError: unknown;
+}
+
+export interface BoundedAgentTimelineRuntimeAggregateMetrics {
+  residentRows: number;
+  residentBytes: number;
+  pendingRows: number;
+  pendingBytes: number;
+  backpressuredAgents: number;
+  failedAgents: number;
+}
+
+interface MutationState {
+  completions: Set<Promise<void>>;
+}
+
+type RuntimeLifecycle = "initializing" | "active" | "releasing" | "delete_failed";
+
+/**
+ * Root-agent timeline cache. Provider history remains authoritative; the segmented store is a
+ * disposable paging cache, while the hot store owns the synchronous live tail and pending rows.
+ */
+export class BoundedAgentTimelineRuntime {
+  private readonly hot: BoundedAgentTimelineHotStore;
+  private readonly buffer: OrderedAgentTimelineDurableBuffer;
+  private readonly onHotChanged?: BoundedAgentTimelineRuntimeOptions["onHotChanged"];
+  private readonly mutations = new Map<string, MutationState>();
+  private readonly durabilityErrors = new Map<string, unknown>();
+  private readonly agentIds = new Set<string>();
+  private readonly lifecycle = new Map<string, RuntimeLifecycle>();
+  private readonly generationTokens = new Map<string, object>();
+  private readonly initializations = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly durable: AgentTimelineStore,
+    options: BoundedAgentTimelineRuntimeOptions,
+  ) {
+    this.hot = new BoundedAgentTimelineHotStore(options.hot);
+    this.onHotChanged = options.onHotChanged;
+    const callerOnDurable = options.buffer?.onDurable;
+    const maxBatchBytes = options.buffer?.maxBatchBytes ?? Number.POSITIVE_INFINITY;
+    const maxPendingBytes = options.buffer?.maxPendingBytes ?? Number.POSITIVE_INFINITY;
+    const maxRowBytes =
+      options.buffer?.maxRowBytes ??
+      Math.min(
+        DEFAULT_TIMELINE_DURABLE_MAX_ROW_BYTES,
+        options.hot.maxBytes,
+        maxBatchBytes,
+        maxPendingBytes,
+      );
+    if (maxRowBytes > options.hot.maxBytes) {
+      throw new Error("maxRowBytes must not exceed the hot timeline maxBytes");
+    }
+    this.buffer = new OrderedAgentTimelineDurableBuffer(options.durableSink ?? durable, {
+      ...options.buffer,
+      maxRowBytes,
+      onDurable: (acknowledgement) => {
+        for (const revision of acknowledgement.revisions) {
+          if (revision) this.hot.acknowledgeDurable(acknowledgement.agentId, revision);
+        }
+        this.publishHotChanged(acknowledgement.agentId);
+        callerOnDurable?.(acknowledgement);
+      },
+    });
+  }
+
+  initialize(agentId: string): Promise<void> {
+    const existing = this.initializations.get(agentId);
+    if (existing) return existing;
+    const lifecycle = this.lifecycle.get(agentId);
+    if (lifecycle === "active") return Promise.resolve();
+    if (lifecycle === "initializing") {
+      return Promise.reject(new Error(`Timeline runtime is still initializing agent '${agentId}'`));
+    }
+    if (lifecycle === "releasing") {
+      return Promise.reject(new Error(`Timeline runtime is still releasing agent '${agentId}'`));
+    }
+    if (lifecycle === "delete_failed") {
+      return Promise.reject(
+        new Error(`Timeline runtime cache deletion must be retried for agent '${agentId}'`),
+      );
+    }
+    this.lifecycle.set(agentId, "initializing");
+    this.generationTokens.set(agentId, {});
+    const initialization = this.initializeOnce(agentId)
+      .catch((error: unknown) => {
+        if (this.lifecycle.get(agentId) === "initializing") this.clearResidentState(agentId);
+        throw error;
+      })
+      .finally(() => {
+        if (this.initializations.get(agentId) === initialization) {
+          this.initializations.delete(agentId);
+        }
+      });
+    this.initializations.set(agentId, initialization);
+    return initialization;
+  }
+
+  private async initializeOnce(agentId: string): Promise<void> {
+    const durable = await this.durable.fetchCommitted(agentId, { direction: "tail" });
+    this.hot.initialize(agentId, {
+      epoch: durable.epoch,
+      window: durable.window,
+      rows: durable.rows,
+    });
+    this.agentIds.add(agentId);
+    this.lifecycle.set(agentId, "active");
+    this.durabilityErrors.delete(agentId);
+    this.publishHotChanged(agentId);
+  }
+
+  has(agentId: string): boolean {
+    return this.lifecycle.get(agentId) === "active" && this.hot.has(agentId);
+  }
+
+  append(
+    agentId: string,
+    row: AgentTimelineRow,
+    options?: HotTimelineRowOptions,
+  ): HotTimelineRevision {
+    this.assertActive(agentId);
+    const reservation = this.buffer.reserveInsertOrThrow(agentId, row);
+    try {
+      const revision = this.hot.append(agentId, row, options);
+      this.publishHotChanged(agentId);
+      this.observeCompletion(agentId, reservation.commit(revision));
+      return revision;
+    } catch (error) {
+      reservation.cancel();
+      throw error;
+    }
+  }
+
+  appendItem(
+    agentId: string,
+    item: AgentTimelineItem,
+    options?: {
+      timestamp?: string;
+      providerMessageId?: string;
+      turnId?: string;
+      mutable?: boolean;
+    },
+  ): AgentTimelineRow {
+    const nextSeq = this.hot.snapshot(agentId).logicalWindow.nextSeq;
+    const row: AgentTimelineRow = {
+      seq: nextSeq,
+      timestamp: options?.timestamp ?? new Date().toISOString(),
+      item: structuredClone(item),
+      ...(options?.providerMessageId ? { providerMessageId: options.providerMessageId } : {}),
+      ...(options?.turnId ? { turnId: options.turnId } : {}),
+    };
+    this.append(agentId, row, { mutable: options?.mutable });
+    return row;
+  }
+
+  async appendWhenWritable(
+    agentId: string,
+    row: AgentTimelineRow,
+    options?: HotTimelineRowOptions,
+  ): Promise<HotTimelineRevision> {
+    const generation = this.requireGeneration(agentId);
+    while (true) {
+      try {
+        return this.append(agentId, row, options);
+      } catch (error) {
+        if (!(error instanceof TimelineDurableBufferBackpressureError)) throw error;
+        await error.whenWritable;
+        this.assertGeneration(agentId, generation);
+      }
+    }
+  }
+
+  async appendItemWhenWritable(
+    agentId: string,
+    item: AgentTimelineItem,
+    options?: {
+      timestamp?: string;
+      providerMessageId?: string;
+      turnId?: string;
+      mutable?: boolean;
+    },
+  ): Promise<AgentTimelineRow> {
+    const timestamp = options?.timestamp ?? new Date().toISOString();
+    const generation = this.requireGeneration(agentId);
+    while (true) {
+      try {
+        return this.appendItem(agentId, item, { ...options, timestamp });
+      } catch (error) {
+        if (!(error instanceof TimelineDurableBufferBackpressureError)) throw error;
+        await error.whenWritable;
+        this.assertGeneration(agentId, generation);
+      }
+    }
+  }
+
+  update(
+    agentId: string,
+    row: AgentTimelineRow,
+    options?: HotTimelineRowOptions,
+  ): HotTimelineRevision {
+    this.assertActive(agentId);
+    const reservation = this.buffer.reserveUpdateOrThrow(agentId, row);
+    try {
+      const revision = this.hot.update(agentId, row, options);
+      this.publishHotChanged(agentId);
+      this.observeCompletion(agentId, reservation.commit(revision));
+      return revision;
+    } catch (error) {
+      reservation.cancel();
+      throw error;
+    }
+  }
+
+  async updateWhenWritable(
+    agentId: string,
+    row: AgentTimelineRow,
+    options?: HotTimelineRowOptions,
+  ): Promise<HotTimelineRevision> {
+    const generation = this.requireGeneration(agentId);
+    while (true) {
+      try {
+        return this.update(agentId, row, options);
+      } catch (error) {
+        if (!(error instanceof TimelineDurableBufferBackpressureError)) throw error;
+        await error.whenWritable;
+        this.assertGeneration(agentId, generation);
+      }
+    }
+  }
+
+  getHotRows(agentId: string): AgentTimelineRow[] {
+    return this.hot.snapshot(agentId).rows;
+  }
+
+  getHotItems(agentId: string): AgentTimelineItem[] {
+    return this.getHotRows(agentId).map(({ item }) => item);
+  }
+
+  getEpoch(agentId: string): string {
+    return this.hot.snapshot(agentId).epoch;
+  }
+
+  getLastHotItem(agentId: string): AgentTimelineItem | null {
+    return this.getHotRows(agentId).at(-1)?.item ?? null;
+  }
+
+  metrics(agentId: string): BoundedAgentTimelineRuntimeMetrics {
+    return {
+      hot: this.hot.metrics(agentId),
+      buffer: this.buffer.metrics(agentId),
+      durabilityError: this.durabilityErrors.get(agentId) ?? null,
+    };
+  }
+
+  aggregateMetrics(): BoundedAgentTimelineRuntimeAggregateMetrics {
+    let residentRows = 0;
+    let residentBytes = 0;
+    for (const agentId of this.agentIds) {
+      const metrics = this.hot.metrics(agentId);
+      residentRows += metrics.retainedRows;
+      residentBytes += metrics.retainedBytes;
+    }
+    const buffer = this.buffer.metrics();
+    const failedRuntimeAgentIds = new Set(this.durabilityErrors.keys());
+    for (const [agentId, lifecycle] of this.lifecycle) {
+      if (lifecycle === "delete_failed") failedRuntimeAgentIds.add(agentId);
+    }
+    return {
+      residentRows,
+      residentBytes,
+      pendingRows: buffer.pendingRows,
+      pendingBytes: buffer.pendingBytes,
+      backpressuredAgents: buffer.writableSignals,
+      failedAgents: Math.max(buffer.failedAgents, failedRuntimeAgentIds.size),
+    };
+  }
+
+  async fetch(
+    agentId: string,
+    options?: AgentTimelineFetchOptions,
+  ): Promise<AgentTimelineFetchResult> {
+    const generation = this.requireGeneration(agentId);
+    while (true) {
+      const direction = options?.direction ?? "tail";
+      const limit = normalizeLimit(options?.limit);
+      const cursor = options?.cursor;
+      const { version: initialHotVersion, snapshot: initialHot } =
+        this.hot.versionedSnapshot(agentId);
+      const expandedLimit = limit === 0 ? 0 : limit + initialHot.rows.length;
+      let durable = await this.durable.fetchCommitted(agentId, {
+        direction,
+        ...(direction !== "tail" && cursor ? { cursor } : {}),
+        limit: expandedLimit,
+      });
+      this.assertGeneration(agentId, generation);
+      const hot = this.hot.snapshot(agentId);
+      const { staleCursor, gap } = classifyCursor(hot, direction, cursor);
+      const reset = staleCursor || gap;
+      const effectiveDirection = reset ? "tail" : direction;
+      if (reset && direction !== "tail") {
+        durable = await this.durable.fetchCommitted(agentId, {
+          direction: "tail",
+          limit: limit === 0 ? 0 : limit + hot.rows.length,
+        });
+        this.assertGeneration(agentId, generation);
+      }
+      if (this.hot.getVersion(agentId) !== initialHotVersion) continue;
+      const rowsBySeq = new Map(durable.rows.map((row) => [row.seq, cloneRow(row)]));
+      for (const row of hot.rows) rowsBySeq.set(row.seq, cloneRow(row));
+      const candidates = [...rowsBySeq.values()].sort((left, right) => left.seq - right.seq);
+      const selected = selectRows(candidates, effectiveDirection, cursor?.seq, limit);
+      const firstSeq = selected[0]?.seq;
+      const lastSeq = selected.at(-1)?.seq;
+      const navigation = mergedNavigationFlags(
+        hot,
+        effectiveDirection,
+        cursor?.seq,
+        firstSeq,
+        lastSeq,
+      );
+      return {
+        epoch: hot.epoch,
+        direction,
+        reset,
+        staleCursor,
+        gap,
+        window: hot.logicalWindow,
+        ...navigation,
+        rows: selected,
+      };
+    }
+  }
+
+  async getRows(agentId: string): Promise<AgentTimelineRow[]> {
+    return (await this.fetch(agentId, { direction: "tail", limit: 0 })).rows;
+  }
+
+  async getLastItem(agentId: string): Promise<AgentTimelineItem | null> {
+    const generation = this.requireGeneration(agentId);
+    const hot = this.hot.snapshot(agentId).rows.at(-1);
+    const durableSeq = await this.durable.getLatestCommittedSeq(agentId);
+    this.assertGeneration(agentId, generation);
+    if (hot && hot.seq >= durableSeq) return structuredClone(hot.item);
+    const item = await this.durable.getLastItem(agentId);
+    this.assertGeneration(agentId, generation);
+    return item;
+  }
+
+  async getLastAssistantMessage(agentId: string): Promise<string | null> {
+    const generation = this.requireGeneration(agentId);
+    while (true) {
+      const durableSeq = await this.durable.getLatestCommittedSeq(agentId);
+      this.assertGeneration(agentId, generation);
+      const pendingRows = this.hot.getPendingRows(agentId).filter(({ seq }) => seq >= durableSeq);
+      const segment = trailingAssistantSegment(pendingRows.map(({ item }) => item));
+      let result: string | null;
+      if (!segment) {
+        result = await this.durable.getLastAssistantMessage(agentId);
+      } else if (!segment.startsAtBeginning || pendingRows[0]?.seq === durableSeq) {
+        result = segment.text;
+      } else {
+        const durableLast = await this.durable.getLastItem(agentId);
+        const durableMessage =
+          durableLast?.type === "assistant_message"
+            ? await this.durable.getLastAssistantMessage(agentId)
+            : null;
+        result = durableMessage ? `${durableMessage}${segment.text}` : segment.text;
+      }
+      const latestSeq = await this.durable.getLatestCommittedSeq(agentId);
+      this.assertGeneration(agentId, generation);
+      if (latestSeq === durableSeq) return result;
+    }
+  }
+
+  async flush(agentId: string): Promise<void> {
+    const state = this.mutations.get(agentId);
+    if (state) await Promise.all(state.completions);
+    await this.buffer.flush(agentId);
+    const error = this.durabilityErrors.get(agentId);
+    if (error) throw error;
+  }
+
+  async flushAll(): Promise<void> {
+    await Promise.all([...this.agentIds].map(async (agentId) => await this.flush(agentId)));
+  }
+
+  async discardAndDelete(agentId: string): Promise<void> {
+    this.beginDelete(agentId);
+    try {
+      await this.buffer.discard(agentId);
+      await this.durable.deleteAgent(agentId);
+      await this.buffer.reset(agentId);
+      this.clearResidentState(agentId);
+    } catch (error) {
+      this.lifecycle.set(agentId, "delete_failed");
+      throw error;
+    }
+  }
+
+  async release(agentId: string): Promise<void> {
+    this.beginRelease(agentId);
+    let failure: unknown;
+    try {
+      await this.flush(agentId);
+    } catch (error) {
+      failure = error;
+      await this.buffer.discard(agentId);
+      await this.buffer.reset(agentId);
+      try {
+        await this.durable.deleteAgent(agentId);
+      } catch (deleteError) {
+        this.lifecycle.set(agentId, "delete_failed");
+        failure = new AggregateError(
+          [error, deleteError],
+          `Failed to flush and invalidate timeline cache for agent '${agentId}'`,
+        );
+      }
+    }
+    if (this.lifecycle.get(agentId) !== "delete_failed") this.clearResidentState(agentId);
+    if (failure !== undefined) throw failure;
+  }
+
+  async discardResident(agentId: string): Promise<void> {
+    this.beginRelease(agentId);
+    await this.buffer.discard(agentId);
+    await this.buffer.reset(agentId);
+    this.clearResidentState(agentId);
+  }
+
+  unpinMutableRows(agentId: string, turnId: string | undefined): void {
+    this.assertActive(agentId);
+    this.hot.unpinMutableRows(agentId, turnId);
+    this.publishHotChanged(agentId);
+  }
+
+  private beginRelease(agentId: string): void {
+    this.assertActive(agentId);
+    this.lifecycle.set(agentId, "releasing");
+    this.generationTokens.delete(agentId);
+  }
+
+  private beginDelete(agentId: string): void {
+    const lifecycle = this.lifecycle.get(agentId);
+    if (lifecycle !== undefined && lifecycle !== "active" && lifecycle !== "delete_failed") {
+      throw new Error(`Timeline runtime is not accepting deletion for agent '${agentId}'`);
+    }
+    this.lifecycle.set(agentId, "releasing");
+    this.generationTokens.delete(agentId);
+  }
+
+  private clearResidentState(agentId: string): void {
+    this.mutations.delete(agentId);
+    this.durabilityErrors.delete(agentId);
+    this.hot.deleteAgent(agentId);
+    this.agentIds.delete(agentId);
+    this.lifecycle.delete(agentId);
+    this.generationTokens.delete(agentId);
+  }
+
+  private assertActive(agentId: string): void {
+    if (this.lifecycle.get(agentId) !== "active") {
+      throw new Error(`Timeline runtime is not accepting writes for agent '${agentId}'`);
+    }
+  }
+
+  private requireGeneration(agentId: string): object {
+    this.assertActive(agentId);
+    return this.generationTokens.get(agentId)!;
+  }
+
+  private assertGeneration(agentId: string, generation: object): void {
+    if (this.generationTokens.get(agentId) !== generation) {
+      throw new Error(`Timeline runtime generation changed for agent '${agentId}'`);
+    }
+    this.assertActive(agentId);
+  }
+
+  private observeCompletion(agentId: string, completion: Promise<void>): void {
+    let state = this.mutations.get(agentId);
+    if (!state) {
+      state = { completions: new Set() };
+      this.mutations.set(agentId, state);
+    }
+    const observed = completion
+      .catch((error: unknown) => {
+        this.durabilityErrors.set(agentId, error);
+      })
+      .finally(() => {
+        state!.completions.delete(observed);
+        if (state!.completions.size === 0) this.mutations.delete(agentId);
+      });
+    state.completions.add(observed);
+  }
+
+  private publishHotChanged(agentId: string): void {
+    this.onHotChanged?.(agentId, this.hot.snapshot(agentId));
+  }
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  return limit === undefined ? DEFAULT_FETCH_LIMIT : Math.max(0, Math.floor(limit));
+}
+
+function selectRows(
+  rows: readonly AgentTimelineRow[],
+  direction: "tail" | "before" | "after",
+  cursorSeq: number | undefined,
+  limit: number,
+): AgentTimelineRow[] {
+  let candidates = [...rows];
+  if (direction === "before" && cursorSeq !== undefined) {
+    candidates = rows.filter(({ seq }) => seq < cursorSeq);
+  } else if (direction === "after" && cursorSeq !== undefined) {
+    candidates = rows.filter(({ seq }) => seq > cursorSeq);
+  }
+  let selected = candidates;
+  if (limit > 0 && candidates.length > limit) {
+    selected = direction === "after" ? candidates.slice(0, limit) : candidates.slice(-limit);
+  }
+  return selected.map(cloneRow);
+}
+
+function classifyCursor(
+  hot: HotTimelineSnapshot,
+  direction: AgentTimelineFetchOptions["direction"],
+  cursor: AgentTimelineFetchOptions["cursor"],
+): { staleCursor: boolean; gap: boolean } {
+  const staleCursor = cursor !== undefined && cursor.epoch !== hot.epoch;
+  const gap =
+    !staleCursor &&
+    direction === "after" &&
+    cursor !== undefined &&
+    hot.logicalWindow.minSeq > 0 &&
+    cursor.seq < hot.logicalWindow.minSeq - 1;
+  return { staleCursor, gap };
+}
+
+function cloneRow(row: AgentTimelineRow): AgentTimelineRow {
+  return { ...row, item: structuredClone(row.item) };
+}
+
+function mergedNavigationFlags(
+  hot: HotTimelineSnapshot,
+  direction: "tail" | "before" | "after",
+  cursorSeq: number | undefined,
+  firstSeq: number | undefined,
+  lastSeq: number | undefined,
+): { hasOlder: boolean; hasNewer: boolean } {
+  return {
+    hasOlder:
+      firstSeq !== undefined
+        ? firstSeq > hot.logicalWindow.minSeq
+        : direction === "after" &&
+          (cursorSeq ?? 0) >= hot.logicalWindow.minSeq &&
+          hot.logicalWindow.maxSeq > 0,
+    hasNewer:
+      lastSeq !== undefined
+        ? lastSeq < hot.logicalWindow.maxSeq
+        : direction === "before" &&
+          (cursorSeq ?? hot.logicalWindow.nextSeq) <= hot.logicalWindow.maxSeq,
+  };
+}
+
+function trailingAssistantSegment(
+  items: readonly AgentTimelineItem[],
+): { text: string; startsAtBeginning: boolean } | null {
+  const chunks: string[] = [];
+  let startsAtBeginning = false;
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index]!;
+    if (item.type !== "assistant_message") {
+      if (chunks.length > 0) break;
+      continue;
+    }
+    chunks.push(item.text);
+    startsAtBeginning = index === 0;
+  }
+  return chunks.length > 0 ? { text: chunks.toReversed().join(""), startsAtBeginning } : null;
+}

--- a/packages/server/src/server/agent/ordered-agent-timeline-durable-buffer.test.ts
+++ b/packages/server/src/server/agent/ordered-agent-timeline-durable-buffer.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentTimelineRow } from "./agent-timeline-store-types.js";
+import { BoundedAgentTimelineHotStore } from "./bounded-agent-timeline-hot-store.js";
+import {
+  OrderedAgentTimelineDurableBuffer,
+  TimelineDurableBufferBackpressureError,
+  type TimelineDurableSink,
+} from "./ordered-agent-timeline-durable-buffer.js";
+
+describe("OrderedAgentTimelineDurableBuffer", () => {
+  it("batches inserts in sequence per agent while allowing agents to drain independently", async () => {
+    const writes: Array<{ agentId: string; seqs: number[] }> = [];
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId, rows) => {
+        writes.push({ agentId, seqs: rows.map(({ seq }) => seq) });
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink, { maxBatchRows: 8 });
+
+    await Promise.all([
+      buffer.insert("agent-a", row(1)),
+      buffer.insert("agent-a", row(2)),
+      buffer.insert("agent-b", row(7)),
+    ]);
+
+    expect(writes).toEqual(
+      expect.arrayContaining([
+        { agentId: "agent-a", seqs: [1, 2] },
+        { agentId: "agent-b", seqs: [7] },
+      ]),
+    );
+    expect(writes).toHaveLength(2);
+  });
+
+  it("does not serialize another agent behind a held durable batch", async () => {
+    const releaseAgentA = deferred<void>();
+    const agentAStarted = deferred<void>();
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (agentId) => {
+        if (agentId !== "agent-a") return;
+        agentAStarted.resolve();
+        await releaseAgentA.promise;
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink);
+
+    const agentA = buffer.insert("agent-a", row(1));
+    await agentAStarted.promise;
+    await expect(buffer.insert("agent-b", row(1))).resolves.toBeUndefined();
+    releaseAgentA.resolve();
+    await agentA;
+  });
+
+  it("acknowledges durability only after the sink succeeds, before hot eviction", async () => {
+    const durableWrite = deferred<void>();
+    const writeStarted = deferred<void>();
+    const hot = new BoundedAgentTimelineHotStore({ maxRows: 1, maxBytes: 10_000 });
+    hot.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+    const revision = hot.append("agent-1", row(1));
+    hot.append("agent-1", row(2), { durable: true });
+    const sink: TimelineDurableSink = {
+      bulkInsert: async () => {
+        writeStarted.resolve();
+        await durableWrite.promise;
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink, {
+      onDurable: ({ agentId, revisions }) => {
+        for (const durableRevision of revisions) {
+          if (durableRevision) hot.acknowledgeDurable(agentId, durableRevision);
+        }
+      },
+    });
+
+    const completion = buffer.insert("agent-1", row(1), revision);
+    await writeStarted.promise;
+    expect(hot.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([1, 2]);
+    durableWrite.resolve();
+    await completion;
+    expect(hot.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([2]);
+  });
+
+  it("does not let an old insert acknowledgement evict a newer pending update", async () => {
+    const durableWrite = deferred<void>();
+    const writeStarted = deferred<void>();
+    const hot = new BoundedAgentTimelineHotStore({ maxRows: 1, maxBytes: 10_000 });
+    hot.initialize("agent-1", {
+      epoch: "epoch-1",
+      window: { minSeq: 0, maxSeq: 0, nextSeq: 1 },
+    });
+    const insertedRevision = hot.append("agent-1", row(1));
+    hot.append("agent-1", row(2), { durable: true });
+    let holdInsert = true;
+    const sink: TimelineDurableSink = {
+      bulkInsert: async () => {
+        if (!holdInsert) return;
+        writeStarted.resolve();
+        await durableWrite.promise;
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink, {
+      onDurable: ({ agentId, revisions }) => {
+        for (const revision of revisions) {
+          if (revision) hot.acknowledgeDurable(agentId, revision);
+        }
+      },
+    });
+    const inserted = buffer.insert("agent-1", row(1), insertedRevision);
+    await writeStarted.promise;
+    const updatedRow = { ...row(1), item: { type: "user_message" as const, text: "updated" } };
+    const updatedRevision = hot.update("agent-1", updatedRow);
+
+    holdInsert = false;
+    durableWrite.resolve();
+    await inserted;
+    expect(hot.snapshot("agent-1").rows.map(({ seq }) => seq)).toEqual([1, 2]);
+
+    await buffer.update("agent-1", updatedRow, updatedRevision);
+    expect(hot.snapshot("agent-1").rows).toEqual([row(2)]);
+  });
+
+  it("fails a sequence prefix without writing any later operation", async () => {
+    const writes: number[][] = [];
+    const failure = new Error("durable unavailable");
+    let failWrites = true;
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (_agentId, rows) => {
+        writes.push(rows.map(({ seq }) => seq));
+        if (failWrites) throw failure;
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink, { maxBatchRows: 2 });
+
+    const results = await Promise.allSettled([
+      buffer.insert("agent-1", row(1)),
+      buffer.insert("agent-1", row(2)),
+      buffer.insert("agent-1", row(3)),
+    ]);
+
+    expect(writes).toEqual([[1, 2]]);
+    expect(results).toEqual([
+      { status: "rejected", reason: failure },
+      { status: "rejected", reason: failure },
+      { status: "rejected", reason: failure },
+    ]);
+    await expect(buffer.insert("agent-1", row(4))).rejects.toBe(failure);
+    expect(writes).toEqual([[1, 2]]);
+
+    await buffer.reset("agent-1");
+    failWrites = false;
+    await Promise.all([
+      buffer.insert("agent-1", row(1)),
+      buffer.insert("agent-1", row(2)),
+      buffer.insert("agent-1", row(3)),
+    ]);
+    expect(writes).toEqual([[1, 2], [1, 2], [3]]);
+  });
+
+  it("waits for an insert before writing an update for the same row", async () => {
+    const insertWrite = deferred<void>();
+    const insertStarted = deferred<void>();
+    const writes: string[] = [];
+    const sink: TimelineDurableSink = {
+      bulkInsert: async () => {
+        writes.push("insert-started");
+        insertStarted.resolve();
+        await insertWrite.promise;
+        writes.push("insert-finished");
+      },
+      updateCommittedRow: async () => {
+        writes.push("update");
+      },
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink);
+
+    const inserted = buffer.insert("agent-1", row(1));
+    const updated = buffer.update("agent-1", {
+      ...row(1),
+      item: { type: "user_message", text: "updated" },
+    });
+    await insertStarted.promise;
+    expect(writes).toEqual(["insert-started"]);
+    insertWrite.resolve();
+    await Promise.all([inserted, updated]);
+    expect(writes).toEqual(["insert-started", "insert-finished", "update"]);
+  });
+
+  it("invalidates an in-flight completion when an agent buffer is discarded", async () => {
+    const durableWrite = deferred<void>();
+    const writeStarted = deferred<void>();
+    let acknowledgements = 0;
+    const sink: TimelineDurableSink = {
+      bulkInsert: async () => {
+        writeStarted.resolve();
+        await durableWrite.promise;
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink, {
+      onDurable: () => {
+        acknowledgements += 1;
+      },
+    });
+    const completion = buffer.insert("agent-1", row(1));
+    const observed = completion.then(
+      () => "fulfilled" as const,
+      (error: unknown) => error,
+    );
+    await writeStarted.promise;
+
+    const discarded = buffer.discard("agent-1");
+    let discardFinished = false;
+    void discarded.then(() => {
+      discardFinished = true;
+      return undefined;
+    });
+    await expect(buffer.insert("agent-1", row(2))).rejects.toMatchObject({
+      name: "TimelineDurableBufferDiscardedError",
+    });
+    expect(discardFinished).toBe(false);
+    durableWrite.resolve();
+    await discarded;
+
+    await expect(observed).resolves.toMatchObject({
+      name: "TimelineDurableBufferDiscardedError",
+    });
+    expect(acknowledgements).toBe(0);
+    await buffer.reset("agent-1");
+    await expect(buffer.insert("agent-1", row(1))).resolves.toBeUndefined();
+  });
+
+  it("splits batches by encoded bytes while allowing one oversized row", async () => {
+    const writes: number[][] = [];
+    const first = textRow(1, "😀".repeat(40));
+    const second = textRow(2, "😀".repeat(40));
+    const huge = textRow(3, "😀".repeat(400));
+    const maxBatchBytes = Buffer.byteLength(JSON.stringify(first), "utf8") * 2 - 1;
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (_agentId, rows) => {
+        writes.push(rows.map(({ seq }) => seq));
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink, {
+      maxBatchRows: 10,
+      maxBatchBytes,
+    });
+
+    await Promise.all([
+      buffer.insert("agent-1", first),
+      buffer.insert("agent-1", second),
+      buffer.insert("agent-1", huge),
+    ]);
+
+    expect(writes).toEqual([[1], [2], [3]]);
+  });
+
+  it.each([
+    { name: "row", maxPendingRows: 2, maxPendingBytes: 100_000, expectedPending: 2 },
+    {
+      name: "byte",
+      maxPendingRows: 10,
+      maxPendingBytes: Buffer.byteLength(JSON.stringify(row(1)), "utf8") * 2 - 1,
+      expectedPending: 1,
+    },
+  ])("backpressures producers at the pending $name high-water mark", async (limits) => {
+    const durableWrite = deferred<void>();
+    const writeStarted = deferred<void>();
+    const sink: TimelineDurableSink = {
+      bulkInsert: async () => {
+        writeStarted.resolve();
+        await durableWrite.promise;
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink, {
+      maxPendingRows: limits.maxPendingRows,
+      maxPendingBytes: limits.maxPendingBytes,
+      maxBatchRows: 10,
+    });
+    const writes = Array.from({ length: limits.expectedPending }, (_, index) =>
+      buffer.insert("agent-1", row(index + 1)),
+    );
+    const rejected = await buffer.insert("agent-1", row(limits.expectedPending + 1)).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    await writeStarted.promise;
+
+    expect(buffer.metrics()).toMatchObject({
+      agents: 1,
+      pendingRows: limits.expectedPending,
+      writableSignals: 1,
+    });
+    expect(rejected).toBeInstanceOf(TimelineDurableBufferBackpressureError);
+    const flushed = buffer.flushAll();
+    durableWrite.resolve();
+    await Promise.all(writes);
+    await flushed;
+    await (rejected as TimelineDurableBufferBackpressureError).whenWritable;
+    await buffer.insert("agent-1", row(limits.expectedPending + 1));
+    expect(buffer.metrics()).toEqual({
+      agents: 0,
+      pendingRows: 0,
+      pendingBytes: 0,
+      writableSignals: 0,
+      failedAgents: 0,
+      discardedAgents: 0,
+      acknowledgementFailures: 0,
+    });
+  });
+
+  it("reports acknowledgement failure separately and continues durable writes", async () => {
+    const writes: number[][] = [];
+    const acknowledgementFailure = new Error("hot acknowledgement failed");
+    let failAcknowledgement = true;
+    const sink: TimelineDurableSink = {
+      bulkInsert: async (_agentId, rows) => {
+        writes.push(rows.map(({ seq }) => seq));
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink, {
+      onDurable: () => {
+        if (!failAcknowledgement) return;
+        failAcknowledgement = false;
+        throw acknowledgementFailure;
+      },
+    });
+
+    await expect(buffer.insert("agent-1", row(1))).rejects.toBe(acknowledgementFailure);
+    await expect(buffer.insert("agent-1", row(2))).resolves.toBeUndefined();
+
+    expect(writes).toEqual([[1], [2]]);
+    expect(buffer.metrics()).toMatchObject({
+      agents: 0,
+      failedAgents: 0,
+      acknowledgementFailures: 1,
+    });
+  });
+
+  it("hard-bounds admitted work and coalesces backpressure and flush waiters", async () => {
+    const durableWrite = deferred<void>();
+    const writeStarted = deferred<void>();
+    const sink: TimelineDurableSink = {
+      bulkInsert: async () => {
+        writeStarted.resolve();
+        await durableWrite.promise;
+      },
+      updateCommittedRow: async () => undefined,
+    };
+    const buffer = new OrderedAgentTimelineDurableBuffer(sink, {
+      maxPendingRows: 2,
+      maxPendingBytes: 100_000,
+      maxBatchRows: 2,
+    });
+    const accepted = [buffer.insert("agent-1", row(1)), buffer.insert("agent-1", row(2))];
+    await writeStarted.promise;
+    const excess = Array.from({ length: 1_000 }, (_, index) =>
+      captureError(buffer.insert("agent-1", row(index + 3))),
+    );
+    const firstFlush = buffer.flush("agent-1");
+    const secondFlush = buffer.flush("agent-1");
+    try {
+      expect(firstFlush).toBe(secondFlush);
+      expect(buffer.metrics()).toMatchObject({
+        agents: 1,
+        pendingRows: 2,
+        writableSignals: 1,
+      });
+    } finally {
+      durableWrite.resolve();
+    }
+    const errors = await Promise.all(excess);
+    await Promise.all(accepted);
+    await firstFlush;
+    expect(errors).toHaveLength(1_000);
+    expect(errors.every((error) => error instanceof TimelineDurableBufferBackpressureError)).toBe(
+      true,
+    );
+    const writableSignals = errors.map(
+      (error) => (error as TimelineDurableBufferBackpressureError).whenWritable,
+    );
+    expect(new Set(writableSignals)).toHaveLength(1);
+    await writableSignals[0];
+    await expect(buffer.insert("agent-1", row(3))).resolves.toBeUndefined();
+  });
+});
+
+function row(seq: number): AgentTimelineRow {
+  return {
+    seq,
+    timestamp: "2026-08-31T12:00:00.000Z",
+    item: { type: "user_message", text: `row-${seq}` },
+  };
+}
+
+function textRow(seq: number, text: string): AgentTimelineRow {
+  return { ...row(seq), item: { type: "user_message", text } };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+async function captureError(promise: Promise<void>): Promise<unknown> {
+  try {
+    await promise;
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}

--- a/packages/server/src/server/agent/ordered-agent-timeline-durable-buffer.test.ts
+++ b/packages/server/src/server/agent/ordered-agent-timeline-durable-buffer.test.ts
@@ -238,7 +238,27 @@ describe("OrderedAgentTimelineDurableBuffer", () => {
     await expect(buffer.insert("agent-1", row(1))).resolves.toBeUndefined();
   });
 
-  it("splits batches by encoded bytes while allowing one oversized row", async () => {
+  it("does not reopen a discarded buffer when an abandoned reservation is canceled", async () => {
+    const buffer = new OrderedAgentTimelineDurableBuffer({
+      bulkInsert: async () => undefined,
+      updateCommittedRow: async () => undefined,
+    });
+    const reservation = buffer.reserveInsertOrThrow("agent-1", row(1));
+    await buffer.discard("agent-1");
+
+    reservation.cancel();
+
+    expect(buffer.metrics("agent-1")).toMatchObject({
+      pendingRows: 0,
+      pendingBytes: 0,
+      discardedAgents: 1,
+    });
+    await expect(buffer.insert("agent-1", row(2))).rejects.toMatchObject({
+      name: "TimelineDurableBufferDiscardedError",
+    });
+  });
+
+  it("splits batches by encoded bytes without admitting a row larger than the durable limit", async () => {
     const writes: number[][] = [];
     const first = textRow(1, "😀".repeat(40));
     const second = textRow(2, "😀".repeat(40));
@@ -253,15 +273,105 @@ describe("OrderedAgentTimelineDurableBuffer", () => {
     const buffer = new OrderedAgentTimelineDurableBuffer(sink, {
       maxBatchRows: 10,
       maxBatchBytes,
+      maxRowBytes: Buffer.byteLength(JSON.stringify(second), "utf8"),
     });
 
-    await Promise.all([
-      buffer.insert("agent-1", first),
-      buffer.insert("agent-1", second),
-      buffer.insert("agent-1", huge),
-    ]);
+    await Promise.all([buffer.insert("agent-1", first), buffer.insert("agent-1", second)]);
+    await expect(buffer.insert("agent-1", huge)).rejects.toMatchObject({
+      name: "TimelineDurableRowTooLargeError",
+    });
 
-    expect(writes).toEqual([[1], [2], [3]]);
+    expect(writes).toEqual([[1], [2]]);
+    expect(buffer.metrics()).toMatchObject({ agents: 0, pendingRows: 0, pendingBytes: 0 });
+  });
+
+  it("rejects a row limit that exceeds either pending or batch byte budgets", () => {
+    const sink: TimelineDurableSink = {
+      bulkInsert: async () => undefined,
+      updateCommittedRow: async () => undefined,
+    };
+
+    expect(
+      () =>
+        new OrderedAgentTimelineDurableBuffer(sink, {
+          maxBatchBytes: 100,
+          maxPendingBytes: 200,
+          maxRowBytes: 101,
+        }),
+    ).toThrow("maxRowBytes must not exceed maxBatchBytes or maxPendingBytes");
+    expect(
+      () =>
+        new OrderedAgentTimelineDurableBuffer(sink, {
+          maxBatchBytes: 200,
+          maxPendingBytes: 100,
+          maxRowBytes: 101,
+        }),
+    ).toThrow("maxRowBytes must not exceed maxBatchBytes or maxPendingBytes");
+  });
+
+  it("schedules a ready follower when an unready head reservation is canceled", async () => {
+    const writes: number[][] = [];
+    const buffer = new OrderedAgentTimelineDurableBuffer({
+      bulkInsert: async (_agentId, rows) => writes.push(rows.map(({ seq }) => seq)),
+      updateCommittedRow: async () => undefined,
+    });
+    const head = buffer.reserveInsertOrThrow("agent-1", row(1));
+    const follower = buffer.reserveInsertOrThrow("agent-1", row(2));
+    const completed = follower.commit();
+    const flushed = buffer.flush("agent-1");
+
+    head.cancel();
+    await expect(Promise.all([completed, flushed])).resolves.toEqual([undefined, undefined]);
+    expect(writes).toEqual([[2]]);
+  });
+
+  it("waits for every reservation readiness before writing a later batch", async () => {
+    const writes: number[][] = [];
+    const firstWrite = deferred<void>();
+    const firstStarted = deferred<void>();
+    const buffer = new OrderedAgentTimelineDurableBuffer(
+      {
+        bulkInsert: async (_agentId, rows) => {
+          writes.push(rows.map(({ seq }) => seq));
+          if (rows[0]?.seq === 1) {
+            firstStarted.resolve();
+            await firstWrite.promise;
+          }
+        },
+        updateCommittedRow: async () => undefined,
+      },
+      { maxBatchRows: 1 },
+    );
+    const first = buffer.reserveInsertOrThrow("agent-1", row(1));
+    const held = buffer.reserveInsertOrThrow("agent-1", row(2));
+    const follower = buffer.reserveInsertOrThrow("agent-1", row(3));
+    const firstCompletion = first.commit();
+    const followerCompletion = follower.commit();
+    await firstStarted.promise;
+    firstWrite.resolve();
+    await firstCompletion;
+    await Promise.resolve();
+    expect(writes).toEqual([[1]]);
+
+    held.cancel();
+    await followerCompletion;
+    expect(writes).toEqual([[1], [3]]);
+  });
+
+  it("reports per-agent pending metrics without including another agent", async () => {
+    const release = deferred<void>();
+    const buffer = new OrderedAgentTimelineDurableBuffer({
+      bulkInsert: async () => await release.promise,
+      updateCommittedRow: async () => undefined,
+    });
+    const first = buffer.insert("agent-a", row(1));
+    const second = buffer.insert("agent-b", row(1));
+    await Promise.resolve();
+
+    expect(buffer.metrics("agent-a")).toMatchObject({ agents: 1, pendingRows: 1 });
+    expect(buffer.metrics("agent-b")).toMatchObject({ agents: 1, pendingRows: 1 });
+    release.resolve();
+    await Promise.all([first, second]);
   });
 
   it.each([
@@ -346,6 +456,8 @@ describe("OrderedAgentTimelineDurableBuffer", () => {
       failedAgents: 0,
       acknowledgementFailures: 1,
     });
+    expect(buffer.metrics("agent-1").acknowledgementFailures).toBe(0);
+    expect(buffer.metrics("agent-2").acknowledgementFailures).toBe(0);
   });
 
   it("hard-bounds admitted work and coalesces backpressure and flush waiters", async () => {

--- a/packages/server/src/server/agent/ordered-agent-timeline-durable-buffer.ts
+++ b/packages/server/src/server/agent/ordered-agent-timeline-durable-buffer.ts
@@ -28,6 +28,7 @@ export interface OrderedAgentTimelineDurableBufferOptions {
   maxBatchBytes?: number;
   maxPendingRows?: number;
   maxPendingBytes?: number;
+  maxRowBytes?: number;
   onDurable?: (acknowledgement: TimelineDurableAcknowledgement) => void;
 }
 
@@ -37,8 +38,14 @@ interface PendingOperation {
   revision: HotTimelineRevision | undefined;
   bytes: number;
   settled: boolean;
+  ready: boolean;
   resolve(): void;
   reject(error: unknown): void;
+}
+
+export interface TimelineDurableBufferReservation {
+  commit(revision?: HotTimelineRevision): Promise<void>;
+  cancel(): void;
 }
 
 interface Deferred<T> {
@@ -65,6 +72,7 @@ const DEFAULT_MAX_BATCH_ROWS = 64;
 const DEFAULT_MAX_BATCH_BYTES = 256 * 1024;
 const DEFAULT_MAX_PENDING_ROWS = 512;
 const DEFAULT_MAX_PENDING_BYTES = 2 * 1024 * 1024;
+export const DEFAULT_TIMELINE_DURABLE_MAX_ROW_BYTES = 240 * 1024;
 
 export class TimelineDurableBufferDiscardedError extends Error {
   constructor(agentId: string) {
@@ -80,6 +88,17 @@ export class TimelineDurableBufferBackpressureError extends Error {
   ) {
     super(`Timeline durable buffer is full for agent '${agentId}'; retry when writable`);
     this.name = "TimelineDurableBufferBackpressureError";
+  }
+}
+
+export class TimelineDurableRowTooLargeError extends Error {
+  constructor(
+    agentId: string,
+    readonly bytes: number,
+    readonly maxBytes: number,
+  ) {
+    super(`Timeline row for agent '${agentId}' is ${bytes} bytes; maximum is ${maxBytes}`);
+    this.name = "TimelineDurableRowTooLargeError";
   }
 }
 
@@ -104,6 +123,7 @@ export class OrderedAgentTimelineDurableBuffer {
   private readonly maxBatchBytes: number;
   private readonly maxPendingRows: number;
   private readonly maxPendingBytes: number;
+  private readonly maxRowBytes: number;
   private readonly onDurable?: (acknowledgement: TimelineDurableAcknowledgement) => void;
   private acknowledgementFailures = 0;
 
@@ -115,19 +135,58 @@ export class OrderedAgentTimelineDurableBuffer {
     this.maxBatchBytes = options?.maxBatchBytes ?? DEFAULT_MAX_BATCH_BYTES;
     this.maxPendingRows = options?.maxPendingRows ?? DEFAULT_MAX_PENDING_ROWS;
     this.maxPendingBytes = options?.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
+    this.maxRowBytes =
+      options?.maxRowBytes ??
+      Math.min(DEFAULT_TIMELINE_DURABLE_MAX_ROW_BYTES, this.maxBatchBytes, this.maxPendingBytes);
     this.onDurable = options?.onDurable;
     validatePositiveInteger(this.maxBatchRows, "maxBatchRows");
     validatePositiveInteger(this.maxBatchBytes, "maxBatchBytes");
     validatePositiveInteger(this.maxPendingRows, "maxPendingRows");
     validatePositiveInteger(this.maxPendingBytes, "maxPendingBytes");
+    validatePositiveInteger(this.maxRowBytes, "maxRowBytes");
+    if (this.maxRowBytes > this.maxBatchBytes || this.maxRowBytes > this.maxPendingBytes) {
+      throw new Error("maxRowBytes must not exceed maxBatchBytes or maxPendingBytes");
+    }
   }
 
   insert(agentId: string, row: AgentTimelineRow, revision?: HotTimelineRevision): Promise<void> {
-    return this.enqueue(agentId, "insert", row, revision);
+    try {
+      return this.insertOrThrow(agentId, row, revision);
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   update(agentId: string, row: AgentTimelineRow, revision?: HotTimelineRevision): Promise<void> {
-    return this.enqueue(agentId, "update", row, revision);
+    try {
+      return this.updateOrThrow(agentId, row, revision);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  insertOrThrow(
+    agentId: string,
+    row: AgentTimelineRow,
+    revision?: HotTimelineRevision,
+  ): Promise<void> {
+    return this.enqueueOrThrow(agentId, "insert", row, revision);
+  }
+
+  reserveInsertOrThrow(agentId: string, row: AgentTimelineRow): TimelineDurableBufferReservation {
+    return this.reserveOrThrow(agentId, "insert", row);
+  }
+
+  reserveUpdateOrThrow(agentId: string, row: AgentTimelineRow): TimelineDurableBufferReservation {
+    return this.reserveOrThrow(agentId, "update", row);
+  }
+
+  updateOrThrow(
+    agentId: string,
+    row: AgentTimelineRow,
+    revision?: HotTimelineRevision,
+  ): Promise<void> {
+    return this.enqueueOrThrow(agentId, "update", row, revision);
   }
 
   async discard(agentId: string): Promise<void> {
@@ -173,7 +232,7 @@ export class OrderedAgentTimelineDurableBuffer {
     await Promise.all([...this.states.keys()].map(async (agentId) => await this.flush(agentId)));
   }
 
-  metrics(): TimelineDurableBufferMetrics {
+  metrics(agentId?: string): TimelineDurableBufferMetrics {
     const result: TimelineDurableBufferMetrics = {
       agents: this.states.size,
       pendingRows: 0,
@@ -181,51 +240,101 @@ export class OrderedAgentTimelineDurableBuffer {
       writableSignals: 0,
       failedAgents: 0,
       discardedAgents: 0,
-      acknowledgementFailures: this.acknowledgementFailures,
+      // Acknowledgement failures are an aggregate process counter. Per-agent state is removed
+      // once its durable queue drains, so attributing the aggregate to any queried agent would
+      // make unrelated agents appear unhealthy.
+      acknowledgementFailures: agentId === undefined ? this.acknowledgementFailures : 0,
     };
-    for (const state of this.states.values()) {
+    const states =
+      agentId === undefined
+        ? this.states.values()
+        : [this.states.get(agentId)].filter(
+            (state): state is AgentBufferState => state !== undefined,
+          );
+    for (const state of states) {
       result.pendingRows += state.pendingRows;
       result.pendingBytes += state.pendingBytes;
       if (state.writableSignal) result.writableSignals += 1;
       if (state.status === "failed") result.failedAgents += 1;
       if (state.status === "discarded") result.discardedAgents += 1;
     }
+    if (agentId !== undefined) result.agents = this.states.has(agentId) ? 1 : 0;
     return result;
   }
 
-  private enqueue(
+  private enqueueOrThrow(
     agentId: string,
     kind: PendingOperation["kind"],
     row: AgentTimelineRow,
     revision: HotTimelineRevision | undefined,
   ): Promise<void> {
-    const state = this.state(agentId);
-    if (state.status === "failed") return Promise.reject(state.failure);
-    if (state.status === "discarded") {
-      return Promise.reject(new TimelineDurableBufferDiscardedError(agentId));
-    }
+    const reservation = this.reserveOrThrow(agentId, kind, row);
+    return reservation.commit(revision!);
+  }
+
+  private reserveOrThrow(
+    agentId: string,
+    kind: PendingOperation["kind"],
+    row: AgentTimelineRow,
+  ): TimelineDurableBufferReservation {
     const bytes = encodedRowBytes(row);
+    if (bytes > this.maxRowBytes) {
+      throw new TimelineDurableRowTooLargeError(agentId, bytes, this.maxRowBytes);
+    }
+    const state = this.state(agentId);
+    if (state.status === "failed") throw state.failure;
+    if (state.status === "discarded") {
+      throw new TimelineDurableBufferDiscardedError(agentId);
+    }
     if (!this.canAdmit(state, bytes)) {
       state.writableSignal ??= promiseWithResolvers<void>();
-      return Promise.reject(
-        new TimelineDurableBufferBackpressureError(agentId, state.writableSignal.promise),
-      );
+      throw new TimelineDurableBufferBackpressureError(agentId, state.writableSignal.promise);
     }
     const deferred = promiseWithResolvers<void>();
+    // Reservations may be invalidated before commit exposes their completion to a caller.
+    // Observe that hidden rejection while preserving rejection for a later committed promise.
+    void deferred.promise.catch(() => undefined);
     const cloned = cloneRow(row);
-    state.queue.push({
+    const operation: PendingOperation = {
       kind,
       row: cloned,
-      revision,
+      revision: undefined,
       bytes,
       settled: false,
+      ready: false,
       resolve: () => deferred.resolve(),
       reject: deferred.reject,
-    });
+    };
+    state.queue.push(operation);
     state.pendingRows += 1;
     state.pendingBytes += bytes;
-    this.schedule(agentId, state);
-    return deferred.promise;
+    let finalized = false;
+    return {
+      commit: (revision) => {
+        if (finalized) throw new Error("Timeline durable reservation was already finalized");
+        finalized = true;
+        operation.revision = revision;
+        operation.ready = true;
+        this.schedule(agentId, state);
+        return deferred.promise;
+      },
+      cancel: () => {
+        if (finalized) return;
+        finalized = true;
+        const index = state.queue.indexOf(operation);
+        if (index < 0) return;
+        state.queue.splice(index, 1);
+        state.pendingRows -= 1;
+        state.pendingBytes -= bytes;
+        settleResolved(operation);
+        this.resolveWritableSignal(state);
+        this.schedule(agentId, state);
+        if (state.status === "healthy" && isIdle(state)) {
+          this.settleFlushWaiter(state);
+          if (this.states.get(agentId) === state) this.states.delete(agentId);
+        }
+      },
+    };
   }
 
   private state(agentId: string): AgentBufferState {
@@ -250,7 +359,8 @@ export class OrderedAgentTimelineDurableBuffer {
   }
 
   private schedule(agentId: string, state: AgentBufferState): void {
-    if (state.queue.length === 0 || state.running || state.scheduled) return;
+    if (state.queue.length === 0 || !state.queue[0]!.ready || state.running || state.scheduled)
+      return;
     state.scheduled = true;
     queueMicrotask(() => {
       state.scheduled = false;
@@ -262,7 +372,7 @@ export class OrderedAgentTimelineDurableBuffer {
     if (state.running || this.states.get(agentId) !== state || state.status !== "healthy") return;
     state.running = true;
     try {
-      while (state.queue.length > 0 && state.status === "healthy") {
+      while (state.queue[0]?.ready && state.status === "healthy") {
         state.active = this.takeBatch(state.queue);
         try {
           await this.write(agentId, state.active);
@@ -329,7 +439,7 @@ export class OrderedAgentTimelineDurableBuffer {
     let bytes = 0;
     while (count < queue.length && count < this.maxBatchRows) {
       const operation = queue[count]!;
-      if (operation.kind !== "insert") break;
+      if (operation.kind !== "insert" || !operation.ready) break;
       if (count > 0 && bytes + operation.bytes > this.maxBatchBytes) break;
       bytes += operation.bytes;
       count += 1;

--- a/packages/server/src/server/agent/ordered-agent-timeline-durable-buffer.ts
+++ b/packages/server/src/server/agent/ordered-agent-timeline-durable-buffer.ts
@@ -1,0 +1,435 @@
+import type { AgentTimelineRow } from "./agent-timeline-store-types.js";
+import type { HotTimelineRevision } from "./bounded-agent-timeline-hot-store.js";
+
+export interface TimelineDurableSink {
+  bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void>;
+  updateCommittedRow(agentId: string, row: AgentTimelineRow): Promise<void>;
+}
+
+export interface TimelineDurableAcknowledgement {
+  agentId: string;
+  kind: "insert" | "update";
+  rows: AgentTimelineRow[];
+  revisions: Array<HotTimelineRevision | undefined>;
+}
+
+export interface TimelineDurableBufferMetrics {
+  agents: number;
+  pendingRows: number;
+  pendingBytes: number;
+  writableSignals: number;
+  failedAgents: number;
+  discardedAgents: number;
+  acknowledgementFailures: number;
+}
+
+export interface OrderedAgentTimelineDurableBufferOptions {
+  maxBatchRows?: number;
+  maxBatchBytes?: number;
+  maxPendingRows?: number;
+  maxPendingBytes?: number;
+  onDurable?: (acknowledgement: TimelineDurableAcknowledgement) => void;
+}
+
+interface PendingOperation {
+  kind: "insert" | "update";
+  row: AgentTimelineRow;
+  revision: HotTimelineRevision | undefined;
+  bytes: number;
+  settled: boolean;
+  resolve(): void;
+  reject(error: unknown): void;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+  reject(error: unknown): void;
+}
+
+interface AgentBufferState {
+  status: "healthy" | "failed" | "discarded";
+  failure: unknown;
+  queue: PendingOperation[];
+  active: PendingOperation[];
+  pendingRows: number;
+  pendingBytes: number;
+  running: boolean;
+  scheduled: boolean;
+  flushWaiter: Deferred<void> | undefined;
+  idleWaiter: Deferred<void> | undefined;
+  writableSignal: Deferred<void> | undefined;
+}
+
+const DEFAULT_MAX_BATCH_ROWS = 64;
+const DEFAULT_MAX_BATCH_BYTES = 256 * 1024;
+const DEFAULT_MAX_PENDING_ROWS = 512;
+const DEFAULT_MAX_PENDING_BYTES = 2 * 1024 * 1024;
+
+export class TimelineDurableBufferDiscardedError extends Error {
+  constructor(agentId: string) {
+    super(`Timeline durable buffer was discarded for agent '${agentId}'`);
+    this.name = "TimelineDurableBufferDiscardedError";
+  }
+}
+
+export class TimelineDurableBufferBackpressureError extends Error {
+  constructor(
+    agentId: string,
+    readonly whenWritable: Promise<void>,
+  ) {
+    super(`Timeline durable buffer is full for agent '${agentId}'; retry when writable`);
+    this.name = "TimelineDurableBufferBackpressureError";
+  }
+}
+
+/**
+ * Orders disposable-cache writes per agent with bounded admitted work. A sink success is the
+ * durability boundary; revision-specific acknowledgements run only afterward, so an old insert
+ * completion cannot evict a newer hot update. The durable store owns evicted prefixes. Hot rows
+ * may overlap durable rows and win by sequence while their exact revision remains mutable.
+ *
+ * Admission is fail-fast: callers receive one coalesced `whenWritable` signal before an excess
+ * row is cloned or retained, and must retry that row after the signal resolves. Producers must
+ * serialize that retry to preserve their authoritative sequence order.
+ *
+ * A sink failure fails that agent's complete queued prefix and blocks later writes until `reset`;
+ * callers replay authoritative provider rows in order after resetting. `discard` rejects local
+ * completions and waits for an active sink write to settle. Callers must await it before deleting
+ * durable state, then call `reset` before recreating the agent, preventing post-delete resurrection.
+ */
+export class OrderedAgentTimelineDurableBuffer {
+  private readonly states = new Map<string, AgentBufferState>();
+  private readonly maxBatchRows: number;
+  private readonly maxBatchBytes: number;
+  private readonly maxPendingRows: number;
+  private readonly maxPendingBytes: number;
+  private readonly onDurable?: (acknowledgement: TimelineDurableAcknowledgement) => void;
+  private acknowledgementFailures = 0;
+
+  constructor(
+    private readonly sink: TimelineDurableSink,
+    options?: OrderedAgentTimelineDurableBufferOptions,
+  ) {
+    this.maxBatchRows = options?.maxBatchRows ?? DEFAULT_MAX_BATCH_ROWS;
+    this.maxBatchBytes = options?.maxBatchBytes ?? DEFAULT_MAX_BATCH_BYTES;
+    this.maxPendingRows = options?.maxPendingRows ?? DEFAULT_MAX_PENDING_ROWS;
+    this.maxPendingBytes = options?.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
+    this.onDurable = options?.onDurable;
+    validatePositiveInteger(this.maxBatchRows, "maxBatchRows");
+    validatePositiveInteger(this.maxBatchBytes, "maxBatchBytes");
+    validatePositiveInteger(this.maxPendingRows, "maxPendingRows");
+    validatePositiveInteger(this.maxPendingBytes, "maxPendingBytes");
+  }
+
+  insert(agentId: string, row: AgentTimelineRow, revision?: HotTimelineRevision): Promise<void> {
+    return this.enqueue(agentId, "insert", row, revision);
+  }
+
+  update(agentId: string, row: AgentTimelineRow, revision?: HotTimelineRevision): Promise<void> {
+    return this.enqueue(agentId, "update", row, revision);
+  }
+
+  async discard(agentId: string): Promise<void> {
+    const state = this.states.get(agentId);
+    if (!state) return;
+    state.status = "discarded";
+    const error = new TimelineDurableBufferDiscardedError(agentId);
+    for (const operation of [...state.active, ...state.queue]) {
+      settleRejected(operation, error);
+    }
+    state.pendingRows = state.active.length;
+    state.pendingBytes = totalBytes(state.active);
+    state.queue = [];
+    this.resolveWritableSignal(state);
+    this.settleFlushWaiter(state, error);
+    if (state.running) await this.waitForIdleState(state);
+  }
+
+  async reset(agentId: string): Promise<void> {
+    const state = this.states.get(agentId);
+    if (!state) return;
+    if (state.status === "healthy") {
+      throw new Error(`Cannot reset a healthy timeline buffer for agent '${agentId}'`);
+    }
+    if (state.running) await this.waitForIdleState(state);
+    this.states.delete(agentId);
+  }
+
+  flush(agentId: string): Promise<void> {
+    const state = this.states.get(agentId);
+    if (!state) return Promise.resolve();
+    if (state.status === "failed") return Promise.reject(state.failure);
+    if (state.status === "discarded") {
+      return Promise.reject(new TimelineDurableBufferDiscardedError(agentId));
+    }
+    if (isIdle(state)) return Promise.resolve();
+    state.flushWaiter ??= promiseWithResolvers<void>();
+    this.schedule(agentId, state);
+    return state.flushWaiter.promise;
+  }
+
+  async flushAll(): Promise<void> {
+    await Promise.all([...this.states.keys()].map(async (agentId) => await this.flush(agentId)));
+  }
+
+  metrics(): TimelineDurableBufferMetrics {
+    const result: TimelineDurableBufferMetrics = {
+      agents: this.states.size,
+      pendingRows: 0,
+      pendingBytes: 0,
+      writableSignals: 0,
+      failedAgents: 0,
+      discardedAgents: 0,
+      acknowledgementFailures: this.acknowledgementFailures,
+    };
+    for (const state of this.states.values()) {
+      result.pendingRows += state.pendingRows;
+      result.pendingBytes += state.pendingBytes;
+      if (state.writableSignal) result.writableSignals += 1;
+      if (state.status === "failed") result.failedAgents += 1;
+      if (state.status === "discarded") result.discardedAgents += 1;
+    }
+    return result;
+  }
+
+  private enqueue(
+    agentId: string,
+    kind: PendingOperation["kind"],
+    row: AgentTimelineRow,
+    revision: HotTimelineRevision | undefined,
+  ): Promise<void> {
+    const state = this.state(agentId);
+    if (state.status === "failed") return Promise.reject(state.failure);
+    if (state.status === "discarded") {
+      return Promise.reject(new TimelineDurableBufferDiscardedError(agentId));
+    }
+    const bytes = encodedRowBytes(row);
+    if (!this.canAdmit(state, bytes)) {
+      state.writableSignal ??= promiseWithResolvers<void>();
+      return Promise.reject(
+        new TimelineDurableBufferBackpressureError(agentId, state.writableSignal.promise),
+      );
+    }
+    const deferred = promiseWithResolvers<void>();
+    const cloned = cloneRow(row);
+    state.queue.push({
+      kind,
+      row: cloned,
+      revision,
+      bytes,
+      settled: false,
+      resolve: () => deferred.resolve(),
+      reject: deferred.reject,
+    });
+    state.pendingRows += 1;
+    state.pendingBytes += bytes;
+    this.schedule(agentId, state);
+    return deferred.promise;
+  }
+
+  private state(agentId: string): AgentBufferState {
+    let state = this.states.get(agentId);
+    if (!state) {
+      state = {
+        status: "healthy",
+        failure: undefined,
+        queue: [],
+        active: [],
+        pendingRows: 0,
+        pendingBytes: 0,
+        running: false,
+        scheduled: false,
+        flushWaiter: undefined,
+        idleWaiter: undefined,
+        writableSignal: undefined,
+      };
+      this.states.set(agentId, state);
+    }
+    return state;
+  }
+
+  private schedule(agentId: string, state: AgentBufferState): void {
+    if (state.queue.length === 0 || state.running || state.scheduled) return;
+    state.scheduled = true;
+    queueMicrotask(() => {
+      state.scheduled = false;
+      void this.drain(agentId, state);
+    });
+  }
+
+  private async drain(agentId: string, state: AgentBufferState): Promise<void> {
+    if (state.running || this.states.get(agentId) !== state || state.status !== "healthy") return;
+    state.running = true;
+    try {
+      while (state.queue.length > 0 && state.status === "healthy") {
+        state.active = this.takeBatch(state.queue);
+        try {
+          await this.write(agentId, state.active);
+        } catch (error) {
+          if (state.status !== "healthy") {
+            state.pendingRows -= state.active.length;
+            state.pendingBytes -= totalBytes(state.active);
+            state.active = [];
+            return;
+          }
+          state.failure = error;
+          state.status = "failed";
+          for (const operation of [...state.active, ...state.queue]) {
+            settleRejected(operation, error);
+          }
+          state.active = [];
+          state.queue = [];
+          state.pendingRows = 0;
+          state.pendingBytes = 0;
+          this.resolveWritableSignal(state);
+          this.settleFlushWaiter(state, error);
+          return;
+        }
+        if (state.status !== "healthy") {
+          state.pendingRows -= state.active.length;
+          state.pendingBytes -= totalBytes(state.active);
+          state.active = [];
+          return;
+        }
+        const completed = state.active;
+        state.active = [];
+        state.pendingRows -= completed.length;
+        state.pendingBytes -= totalBytes(completed);
+        this.resolveWritableSignal(state);
+        try {
+          this.onDurable?.({
+            agentId,
+            kind: completed[0]!.kind,
+            rows: completed.map(({ row }) => cloneRow(row)),
+            revisions: completed.map(({ revision }) => revision),
+          });
+          for (const operation of completed) settleResolved(operation);
+        } catch (error) {
+          this.acknowledgementFailures += 1;
+          for (const operation of completed) settleRejected(operation, error);
+        }
+      }
+    } finally {
+      state.running = false;
+      if (state.status === "healthy") {
+        this.schedule(agentId, state);
+        if (isIdle(state)) {
+          this.settleFlushWaiter(state);
+          if (this.states.get(agentId) === state) this.states.delete(agentId);
+        }
+      }
+      if (isIdle(state)) this.settleIdleWaiter(state);
+    }
+  }
+
+  private takeBatch(queue: PendingOperation[]): PendingOperation[] {
+    if (queue[0]!.kind === "update") return queue.splice(0, 1);
+    let count = 0;
+    let bytes = 0;
+    while (count < queue.length && count < this.maxBatchRows) {
+      const operation = queue[count]!;
+      if (operation.kind !== "insert") break;
+      if (count > 0 && bytes + operation.bytes > this.maxBatchBytes) break;
+      bytes += operation.bytes;
+      count += 1;
+    }
+    return queue.splice(0, count);
+  }
+
+  private async write(agentId: string, operations: PendingOperation[]): Promise<void> {
+    const first = operations[0]!;
+    if (first.kind === "insert") {
+      await this.sink.bulkInsert(
+        agentId,
+        operations.map(({ row }) => cloneRow(row)),
+      );
+      return;
+    }
+    await this.sink.updateCommittedRow(agentId, cloneRow(first.row));
+  }
+
+  private async waitForIdleState(state: AgentBufferState): Promise<void> {
+    if (!state.running) return;
+    state.idleWaiter ??= promiseWithResolvers<void>();
+    await state.idleWaiter.promise;
+  }
+
+  private settleFlushWaiter(state: AgentBufferState, error?: unknown): void {
+    const waiter = state.flushWaiter;
+    state.flushWaiter = undefined;
+    if (!waiter) return;
+    if (error === undefined) waiter.resolve(undefined);
+    else waiter.reject(error);
+  }
+
+  private settleIdleWaiter(state: AgentBufferState): void {
+    const waiter = state.idleWaiter;
+    state.idleWaiter = undefined;
+    waiter?.resolve(undefined);
+  }
+
+  private resolveWritableSignal(state: AgentBufferState): void {
+    const signal = state.writableSignal;
+    state.writableSignal = undefined;
+    signal?.resolve(undefined);
+  }
+
+  private canAdmit(state: AgentBufferState, bytes: number): boolean {
+    return (
+      state.pendingRows === 0 ||
+      (state.pendingRows + 1 <= this.maxPendingRows &&
+        state.pendingBytes + bytes <= this.maxPendingBytes)
+    );
+  }
+}
+
+function isIdle(state: AgentBufferState): boolean {
+  return (
+    !state.running && !state.scheduled && state.active.length === 0 && state.queue.length === 0
+  );
+}
+
+function totalBytes(operations: readonly PendingOperation[]): number {
+  return operations.reduce((total, operation) => total + operation.bytes, 0);
+}
+
+function encodedRowBytes(row: AgentTimelineRow): number {
+  return Buffer.byteLength(JSON.stringify(row), "utf8");
+}
+
+function settleResolved(operation: PendingOperation): void {
+  if (operation.settled) return;
+  operation.settled = true;
+  operation.resolve();
+}
+
+function settleRejected(operation: PendingOperation, error: unknown): void {
+  if (operation.settled) return;
+  operation.settled = true;
+  operation.reject(error);
+}
+
+function cloneRow(row: AgentTimelineRow): AgentTimelineRow {
+  return { ...row, item: structuredClone(row.item) };
+}
+
+function validatePositiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+}
+
+function promiseWithResolvers<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}

--- a/packages/server/src/server/agent/provider-subagents/store.test.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, test } from "vitest";
+import { InMemoryAgentTimelineStore } from "../agent-timeline-store.js";
+import type {
+  AgentTimelineFetchOptions,
+  AgentTimelineFetchResult,
+} from "../agent-timeline-store-types.js";
 import { ProviderSubagentStore } from "./store.js";
+
+class RecordingTimelineStore extends InMemoryAgentTimelineStore {
+  readonly fetches: Array<{
+    options: AgentTimelineFetchOptions | undefined;
+    result: AgentTimelineFetchResult;
+  }> = [];
+
+  override fetch(agentId: string, options?: AgentTimelineFetchOptions): AgentTimelineFetchResult {
+    const result = super.fetch(agentId, options);
+    this.fetches.push({ options, result });
+    return result;
+  }
+}
 
 describe("ProviderSubagentStore", () => {
   test("keeps provider children and their timelines scoped to the parent agent", () => {
@@ -102,5 +120,246 @@ describe("ProviderSubagentStore", () => {
     expect(page.rows[0]?.seq).toBe(1);
     expect(page.rows.at(-1)?.seq).toBe(101);
     expect(page.hasOlder).toBe(false);
+  });
+
+  test("fetches a bounded canonical tail for nonmergeable provider history", () => {
+    const timelines = new RecordingTimelineStore();
+    const subagents = new ProviderSubagentStore(timelines);
+    for (let index = 1; index <= 600; index += 1) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: { type: "user_message", text: `message ${index}` },
+      });
+    }
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: "tail",
+      limit: 100,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual(
+      Array.from({ length: 100 }, (_, index) => index + 501),
+    );
+    expect(page.hasOlder).toBe(true);
+    expect(
+      timelines.fetches.map(({ options, result }) => ({
+        direction: options?.direction,
+        limit: options?.limit,
+        rowCount: result.rows.length,
+      })),
+    ).toEqual([{ direction: "tail", limit: 100, rowCount: 100 }]);
+  });
+
+  test("does not scan older history for a tool lifecycle inside the projected page", () => {
+    const timelines = new RecordingTimelineStore();
+    const subagents = new ProviderSubagentStore(timelines);
+    for (let index = 1; index <= 194; index += 1) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: { type: "user_message", text: `message ${index}` },
+      });
+    }
+    for (const status of ["running", "completed"] as const) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: {
+          type: "tool_call",
+          callId: "call-1",
+          name: "shell",
+          status,
+          error: null,
+          detail: { type: "shell", command: "pwd", output: "/workspace" },
+        },
+      });
+    }
+    for (let index = 197; index <= 200; index += 1) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: { type: "user_message", text: `message ${index}` },
+      });
+    }
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: "tail",
+      limit: 10,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual(
+      Array.from({ length: 11 }, (_, index) => index + 190),
+    );
+    expect(
+      timelines.fetches.map(({ options, result }) => ({
+        direction: options?.direction,
+        limit: options?.limit,
+        rowCount: result.rows.length,
+      })),
+    ).toEqual([
+      { direction: "tail", limit: 10, rowCount: 10 },
+      { direction: "before", limit: 10, rowCount: 10 },
+    ]);
+  });
+
+  test("expands to the projected anchor of a tool update inside the canonical tail", () => {
+    const timelines = new RecordingTimelineStore();
+    const subagents = new ProviderSubagentStore(timelines);
+    for (let seq = 1; seq <= 600; seq += 1) {
+      const item =
+        seq === 1 || seq === 501
+          ? {
+              type: "tool_call" as const,
+              callId: "call-1",
+              name: "shell",
+              status: seq === 1 ? ("running" as const) : ("completed" as const),
+              error: null,
+              detail: { type: "shell" as const, command: "pwd", output: "/workspace" },
+            }
+          : { type: "user_message" as const, text: `message ${seq}` };
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item,
+      });
+    }
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: "tail",
+      limit: 100,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual(
+      Array.from({ length: 600 }, (_, index) => index + 1),
+    );
+    expect(page.hasOlder).toBe(false);
+    expect(
+      timelines.fetches.map(({ options, result }) => ({
+        limit: options?.limit,
+        rowCount: result.rows.length,
+      })),
+    ).toEqual([
+      { limit: 100, rowCount: 100 },
+      { limit: 100, rowCount: 100 },
+      { limit: 200, rowCount: 200 },
+      { limit: 200, rowCount: 200 },
+    ]);
+  });
+
+  test("preserves call-id projection behavior when a later turn reuses the call id", () => {
+    const timelines = new RecordingTimelineStore();
+    timelines.initialize("parent-a\0child-1", {
+      epoch: "epoch-1",
+      nextSeq: 6,
+      rows: [
+        {
+          seq: 1,
+          timestamp: "2026-01-01T00:00:00.000Z",
+          turnId: "turn-a",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "running",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: null },
+          },
+        },
+        {
+          seq: 2,
+          timestamp: "2026-01-01T00:00:01.000Z",
+          item: { type: "user_message", text: "between turns" },
+        },
+        {
+          seq: 3,
+          timestamp: "2026-01-01T00:00:02.000Z",
+          turnId: "turn-b",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "running",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: null },
+          },
+        },
+        {
+          seq: 4,
+          timestamp: "2026-01-01T00:00:03.000Z",
+          item: { type: "user_message", text: "work continues" },
+        },
+        {
+          seq: 5,
+          timestamp: "2026-01-01T00:00:04.000Z",
+          turnId: "turn-b",
+          item: {
+            type: "tool_call",
+            callId: "call-1",
+            name: "shell",
+            status: "completed",
+            error: null,
+            detail: { type: "shell", command: "pwd", output: "/workspace" },
+          },
+        },
+      ],
+    });
+    const subagents = new ProviderSubagentStore(timelines);
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: "tail",
+      limit: 1,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual([5]);
+  });
+
+  test.each([
+    {
+      direction: "before" as const,
+      cursorSeq: 103,
+      expectedHasOlder: true,
+      expectedHasNewer: true,
+    },
+    {
+      direction: "after" as const,
+      cursorSeq: 1,
+      expectedHasOlder: true,
+      expectedHasNewer: true,
+    },
+  ])("expands $direction pages to complete a projected item", (input) => {
+    const timelines = new RecordingTimelineStore();
+    const subagents = new ProviderSubagentStore(timelines);
+    subagents.apply("parent-a", "opencode", {
+      type: "timeline",
+      id: "child-1",
+      item: { type: "user_message", text: "before" },
+    });
+    for (let index = 0; index < 101; index += 1) {
+      subagents.apply("parent-a", "opencode", {
+        type: "timeline",
+        id: "child-1",
+        item: { type: "assistant_message", text: String(index) },
+      });
+    }
+    subagents.apply("parent-a", "opencode", {
+      type: "timeline",
+      id: "child-1",
+      item: { type: "user_message", text: "after" },
+    });
+    const epoch = timelines.getEpoch("parent-a\0child-1");
+
+    const page = subagents.fetchTimeline("parent-a", "child-1", {
+      direction: input.direction,
+      cursor: { epoch, seq: input.cursorSeq },
+      limit: 1,
+    });
+
+    expect(page.rows.map((row) => row.seq)).toEqual(
+      Array.from({ length: 101 }, (_, index) => index + 2),
+    );
+    expect(page.hasOlder).toBe(input.expectedHasOlder);
+    expect(page.hasNewer).toBe(input.expectedHasNewer);
+    expect(timelines.fetches.every(({ options }) => options?.limit !== 0)).toBe(true);
   });
 });

--- a/packages/server/src/server/agent/provider-subagents/store.test.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.test.ts
@@ -311,7 +311,7 @@ describe("ProviderSubagentStore", () => {
       limit: 1,
     });
 
-    expect(page.rows.map((row) => row.seq)).toEqual([5]);
+    expect(page.rows.map((row) => row.seq)).toEqual([3, 4, 5]);
   });
 
   test.each([

--- a/packages/server/src/server/agent/provider-subagents/store.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.ts
@@ -76,9 +76,83 @@ function stickyField<T>(next: T | undefined, previous: T | null | undefined): T 
   return next === undefined ? (previous ?? null) : next;
 }
 
+export type ProviderSubagentTimelineStore = Pick<
+  InMemoryAgentTimelineStore,
+  "append" | "delete" | "fetch" | "getEpoch" | "getToolCallSeqBounds" | "has" | "initialize"
+>;
+
+const MAX_CANONICAL_PAGE_SIZE = 200;
+
+function initialCanonicalPageSize(projectedLimit: number): number {
+  if (projectedLimit === 0) {
+    return MAX_CANONICAL_PAGE_SIZE;
+  }
+  return Math.min(MAX_CANONICAL_PAGE_SIZE, Math.max(1, projectedLimit));
+}
+
+function expansionPageSize(accumulatedRows: number): number {
+  return Math.min(MAX_CANONICAL_PAGE_SIZE, Math.max(1, accumulatedRows));
+}
+
+function projectedSelectionNeedsMoreRows(input: {
+  direction: NonNullable<AgentTimelineFetchOptions["direction"]>;
+  limit: number;
+  timeline: AgentTimelineFetchResult;
+  rows: readonly AgentTimelineRow[];
+  selected: ReturnType<typeof selectTimelineWindowByProjectedLimit>;
+  getToolCallSeqBounds: (callId: string) => { minSeq: number; maxSeq: number } | null;
+}): "older" | "newer" | null {
+  const { direction, limit, timeline, rows, selected, getToolCallSeqBounds } = input;
+  const firstRow = rows[0];
+  const lastRow = rows.at(-1);
+  if (!firstRow || !lastRow) {
+    return null;
+  }
+
+  const expandToward = direction === "after" ? "newer" : "older";
+  const hasMore =
+    expandToward === "newer"
+      ? lastRow.seq < timeline.window.maxSeq
+      : firstRow.seq > timeline.window.minSeq;
+  if (!hasMore) {
+    return null;
+  }
+
+  if (limit === 0 || selected.projectedEntries.length < limit) {
+    return expandToward;
+  }
+
+  const hasToolCallRowsBeyondPage = selected.projectedEntries.some((entry) => {
+    if (entry.item.type !== "tool_call") {
+      return false;
+    }
+    const bounds = getToolCallSeqBounds(entry.item.callId);
+    if (!bounds) {
+      return false;
+    }
+    return expandToward === "newer" ? bounds.maxSeq > lastRow.seq : bounds.minSeq < firstRow.seq;
+  });
+  if (hasToolCallRowsBeyondPage) {
+    return expandToward;
+  }
+
+  const boundarySeq = expandToward === "newer" ? lastRow.seq : firstRow.seq;
+  const canMergeAcrossBoundary = selected.projectedEntries.some(
+    (entry) =>
+      entry.sourceSeqRanges.some(
+        (range) => boundarySeq >= range.startSeq && boundarySeq <= range.endSeq,
+      ) &&
+      (entry.item.type === "assistant_message" || entry.item.type === "reasoning"),
+  );
+  return canMergeAcrossBoundary ? expandToward : null;
+}
+
 export class ProviderSubagentStore {
   private readonly descriptors = new Map<string, ProviderSubagentDescriptor>();
-  private readonly timelines = new InMemoryAgentTimelineStore();
+
+  constructor(
+    private readonly timelines: ProviderSubagentTimelineStore = new InMemoryAgentTimelineStore(),
+  ) {}
 
   apply(
     parentAgentId: string,
@@ -153,27 +227,60 @@ export class ProviderSubagentStore {
   ): AgentTimelineFetchResult {
     const direction = options?.direction ?? "tail";
     const limit = options?.limit === undefined ? 200 : Math.max(0, Math.floor(options.limit));
-    const timeline = this.timelines.fetch(storeKey(parentAgentId, subagentId), {
+    const key = storeKey(parentAgentId, subagentId);
+    const timeline = this.timelines.fetch(key, {
       ...options,
-      limit: 0,
+      limit: initialCanonicalPageSize(limit),
     });
-    if (limit === 0 || timeline.rows.length === 0) {
+    if (timeline.rows.length === 0) {
       return timeline;
     }
-    const selected = selectTimelineWindowByProjectedLimit({
-      rows: timeline.rows,
-      direction: timeline.reset ? "tail" : direction,
+    const selectionDirection = timeline.reset ? "tail" : direction;
+    let rows = timeline.rows;
+    let selected = selectTimelineWindowByProjectedLimit({
+      rows,
+      direction: selectionDirection,
       limit,
     });
+    for (;;) {
+      const expandToward = projectedSelectionNeedsMoreRows({
+        direction: selectionDirection,
+        limit,
+        timeline,
+        rows,
+        selected,
+        getToolCallSeqBounds: (callId) => this.timelines.getToolCallSeqBounds(key, callId),
+      });
+      if (!expandToward) {
+        break;
+      }
+
+      const boundaryRow = expandToward === "older" ? rows[0] : rows.at(-1);
+      if (!boundaryRow) {
+        break;
+      }
+      const page = this.timelines.fetch(key, {
+        direction: expandToward === "older" ? "before" : "after",
+        cursor: { epoch: timeline.epoch, seq: boundaryRow.seq },
+        limit: expansionPageSize(rows.length),
+      });
+      if (page.rows.length === 0) {
+        break;
+      }
+      rows = expandToward === "older" ? [...page.rows, ...rows] : [...rows, ...page.rows];
+      selected = selectTimelineWindowByProjectedLimit({
+        rows,
+        direction: selectionDirection,
+        limit,
+      });
+    }
     const firstRow = selected.selectedRows[0];
     const lastRow = selected.selectedRows[selected.selectedRows.length - 1];
     return {
       ...timeline,
       rows: selected.selectedRows,
-      hasOlder:
-        timeline.hasOlder || (firstRow !== undefined && firstRow.seq > timeline.window.minSeq),
-      hasNewer:
-        timeline.hasNewer || (lastRow !== undefined && lastRow.seq < timeline.window.maxSeq),
+      hasOlder: firstRow ? firstRow.seq > timeline.window.minSeq : timeline.hasOlder,
+      hasNewer: lastRow ? lastRow.seq < timeline.window.maxSeq : timeline.hasNewer,
     };
   }
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -94,6 +94,7 @@ import {
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { asInternals as castInternals, createStub } from "../../test-utils/class-mocks.js";
 import { buildProviderRegistry } from "../provider-registry.js";
+import { ProviderSubagentStore } from "../provider-subagents/store.js";
 
 interface CollaborationModeRecord {
   name: string;
@@ -4372,6 +4373,1034 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("loads only root history and persisted child descriptors during resume", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [
+                        {
+                          type: "agentMessage",
+                          id: "child-message-history",
+                          text: "Child history must remain lazy.",
+                        },
+                      ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+
+    await asInternals(session).loadPersistedHistory();
+
+    const history: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      history.push(event);
+    }
+
+    expect(requestedThreadIds).toEqual(["test-thread"]);
+    expect(history).toContainEqual({
+      type: "provider_subagent",
+      provider: "codex",
+      event: expect.objectContaining({
+        type: "upsert",
+        id: "history-child-thread",
+      }),
+    });
+    expect(
+      history.some(
+        (event) => event.type === "provider_subagent" && event.event.type === "timeline",
+      ),
+    ).toBe(false);
+  });
+
+  test("loads one persisted child history only when that child is requested", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [
+                        {
+                          type: "agentMessage",
+                          id: "child-message-history",
+                          text: "Loaded on demand.",
+                        },
+                      ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing the lazy child load.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-child-thread")));
+
+    expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider_subagent",
+        provider: "codex",
+        event: {
+          type: "timeline",
+          id: "history-child-thread",
+          item: {
+            type: "assistant_message",
+            messageId: "child-message-history",
+            text: "Loaded on demand.",
+          },
+        },
+      }),
+    );
+  });
+
+  test("accepts a completed child hydration seed from a history-preserving reload", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before restoring the completed child hydration marker.
+    }
+    session.seedLoadedProviderSubagentHistoryIds(["history-child-thread"]);
+
+    expect(session.getLoadedProviderSubagentHistoryIds()).toEqual(["history-child-thread"]);
+    await expect(session.loadProviderSubagentHistory("history-child-thread")).resolves.toEqual([]);
+    expect(requestedThreadIds).toEqual(["test-thread"]);
+  });
+
+  test("shares one persisted child read across concurrent timeline requests", async () => {
+    const session = createSession();
+    const childRead = deferred<unknown>();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        if (threadId === "history-child-thread") {
+          return childRead.promise;
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+
+    const first = session.loadProviderSubagentHistory!("history-child-thread");
+    const second = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => {
+      expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+    });
+    childRead.resolve({
+      thread: {
+        turns: [
+          {
+            items: [
+              {
+                type: "agentMessage",
+                id: "child-message-history",
+                text: "Loaded once.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await Promise.all([first, second]);
+    await session.loadProviderSubagentHistory!("history-child-thread");
+
+    expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+  });
+
+  test("registers nested persisted child descriptors without reading descendants eagerly", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        const itemsByThreadId: Record<string, unknown[]> = {
+          "test-thread": [
+            {
+              type: "subAgentActivity",
+              id: "child-started-history",
+              kind: "started",
+              agentThreadId: "history-child-thread",
+              agentPath: "/root/history-child",
+            },
+          ],
+          "history-child-thread": [
+            {
+              type: "subAgentActivity",
+              id: "nested-started-history",
+              kind: "started",
+              agentThreadId: "history-grandchild-thread",
+              agentPath: "/root/history-child/history-grandchild",
+            },
+          ],
+          "history-grandchild-thread": [
+            {
+              type: "agentMessage",
+              id: "grandchild-message-history",
+              text: "Nested history loaded on demand.",
+            },
+          ],
+        };
+        return {
+          thread: { turns: [{ items: itemsByThreadId[threadId] ?? [] }] },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-child-thread")));
+
+    expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider_subagent",
+        provider: "codex",
+        event: expect.objectContaining({
+          type: "upsert",
+          id: "history-grandchild-thread",
+        }),
+      }),
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.type === "provider_subagent" &&
+          event.event.type === "timeline" &&
+          event.event.id === "history-grandchild-thread",
+      ),
+    ).toBe(false);
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-grandchild-thread")));
+
+    expect(requestedThreadIds).toEqual([
+      "test-thread",
+      "history-child-thread",
+      "history-grandchild-thread",
+    ]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider_subagent",
+        provider: "codex",
+        event: expect.objectContaining({
+          type: "timeline",
+          id: "history-grandchild-thread",
+          item: expect.objectContaining({
+            type: "assistant_message",
+            text: "Nested history loaded on demand.",
+          }),
+        }),
+      }),
+    );
+  });
+
+  test("orders persisted child history before concurrent live events and deduplicates replay", async () => {
+    const session = createSession();
+    const childRead = deferred<unknown>();
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "history-child-thread") {
+          return childRead.promise;
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const load = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => {
+      expect(session.client?.request).toHaveBeenCalledWith("thread/read", {
+        threadId: "history-child-thread",
+        includeTurns: true,
+      });
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "history-child-thread",
+      item: {
+        type: "userMessage",
+        id: "child-live-message",
+        content: [{ type: "text", text: "Concurrent child message." }],
+      },
+    });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-live-assistant",
+      delta: "First live fragment. ",
+    });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-live-assistant",
+      delta: "Second live fragment.",
+    });
+    expect(
+      events.filter(
+        (event) => event.type === "provider_subagent" && event.event.type === "timeline",
+      ),
+    ).toEqual([]);
+
+    childRead.resolve({
+      thread: {
+        turns: [
+          {
+            items: [
+              {
+                type: "agentMessage",
+                id: "child-persisted-message",
+                text: "Persisted history first.",
+              },
+              {
+                type: "userMessage",
+                id: "child-live-message",
+                content: [{ type: "text", text: "Concurrent child message." }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    events.push(...(await load));
+
+    expect(
+      events.flatMap((event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "timeline" &&
+        event.event.id === "history-child-thread"
+          ? [event.event.item]
+          : [],
+      ),
+    ).toEqual([
+      {
+        type: "assistant_message",
+        messageId: "child-persisted-message",
+        text: "Persisted history first.",
+      },
+      {
+        type: "user_message",
+        messageId: "child-live-message",
+        text: "Concurrent child message.",
+      },
+      {
+        type: "assistant_message",
+        messageId: "child-live-assistant",
+        text: "First live fragment. ",
+      },
+      {
+        type: "assistant_message",
+        messageId: "child-live-assistant",
+        text: "Second live fragment.",
+      },
+    ]);
+  });
+
+  test("buffers live events for a persisted child before its first history request", async () => {
+    const session = createSession();
+    const requestedThreadIds: string[] = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId ?? "";
+        requestedThreadIds.push(threadId);
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [
+                        {
+                          type: "agentMessage",
+                          id: "child-persisted-message",
+                          text: "Older persisted history.",
+                        },
+                        {
+                          type: "userMessage",
+                          id: "child-live-before-request",
+                          content: [{ type: "text", text: "Live before first request." }],
+                        },
+                      ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "history-child-thread",
+      item: {
+        type: "userMessage",
+        id: "child-live-before-request",
+        content: [{ type: "text", text: "Live before first request." }],
+      },
+    });
+
+    expect(
+      events.filter(
+        (event) => event.type === "provider_subagent" && event.event.type === "timeline",
+      ),
+    ).toEqual([]);
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-child-thread")));
+
+    expect(requestedThreadIds).toEqual(["test-thread", "history-child-thread"]);
+    expect(
+      events.flatMap((event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "timeline" &&
+        event.event.id === "history-child-thread"
+          ? [event.event.item]
+          : [],
+      ),
+    ).toEqual([
+      {
+        type: "assistant_message",
+        messageId: "child-persisted-message",
+        text: "Older persisted history.",
+      },
+      {
+        type: "user_message",
+        messageId: "child-live-before-request",
+        text: "Live before first request.",
+      },
+    ]);
+  });
+
+  test("publishes persisted child running status before its history is requested", async () => {
+    const session = createSession();
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    const store = new ProviderSubagentStore();
+    for await (const event of session.streamHistory()) {
+      if (event.type === "provider_subagent") {
+        store.apply("parent-agent", event.provider, event.event);
+      }
+    }
+    expect(store.list("parent-agent")).toEqual([
+      expect.objectContaining({ id: "history-child-thread", status: "completed" }),
+    ]);
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+      if (event.type === "provider_subagent") {
+        store.apply("parent-agent", event.provider, event.event);
+      }
+    });
+
+    asInternals(session).handleNotification("turn/started", {
+      threadId: "history-child-thread",
+      turn: { id: "history-child-live-turn" },
+    });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider_subagent",
+        provider: "codex",
+        event: expect.objectContaining({
+          type: "upsert",
+          id: "history-child-thread",
+          status: "running",
+        }),
+      }),
+    );
+    expect(store.list("parent-agent")).toEqual([
+      expect.objectContaining({ id: "history-child-thread", status: "running" }),
+    ]);
+    expect(session.client.request).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not replay stale tool lifecycle rows over terminal persisted history", async () => {
+    const session = createSession();
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        return {
+          thread: {
+            turns: [
+              {
+                items:
+                  threadId === "test-thread"
+                    ? [
+                        {
+                          type: "subAgentActivity",
+                          id: "child-started-history",
+                          kind: "started",
+                          agentThreadId: "history-child-thread",
+                          agentPath: "/root/history-child",
+                        },
+                      ]
+                    : [
+                        {
+                          type: "commandExecution",
+                          id: "child-tool-call",
+                          status: "completed",
+                          command: "printf done",
+                          aggregatedOutput: "done",
+                          exitCode: 0,
+                        },
+                      ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain the persisted descriptor before buffering newer child activity.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/started", {
+      threadId: "history-child-thread",
+      item: {
+        type: "commandExecution",
+        id: "child-tool-call",
+        status: "inProgress",
+        command: "printf done",
+      },
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "history-child-thread",
+      item: {
+        type: "commandExecution",
+        id: "child-tool-call",
+        status: "completed",
+        command: "printf done",
+        aggregatedOutput: "done",
+        exitCode: 0,
+      },
+    });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-live-fragment",
+      delta: "Distinct live fragment.",
+    });
+
+    const loaded = await session.loadProviderSubagentHistory!("history-child-thread");
+    const loadedItems = loaded.flatMap((event) =>
+      event.event.type === "timeline" && event.event.id === "history-child-thread"
+        ? [event.event.item]
+        : [],
+    );
+
+    expect(
+      loadedItems.flatMap((item) =>
+        item.type === "tool_call" && item.callId === "child-tool-call" ? [item.status] : [],
+      ),
+    ).toEqual(["completed"]);
+    expect(loadedItems).toContainEqual({
+      type: "assistant_message",
+      messageId: "child-live-fragment",
+      text: "Distinct live fragment.",
+    });
+  });
+
+  test("replays live child events after a failed history read and allows retry", async () => {
+    const session = createSession();
+    const firstChildRead = deferred<unknown>();
+    let childReadCount = 0;
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "history-child-thread") {
+          childReadCount += 1;
+          if (childReadCount === 1) {
+            return firstChildRead.promise;
+          }
+          return {
+            thread: {
+              turns: [
+                {
+                  items: [
+                    {
+                      type: "agentMessage",
+                      id: "child-message-after-retry",
+                      text: "Retry succeeded.",
+                    },
+                    {
+                      type: "userMessage",
+                      id: "child-live-during-failure",
+                      content: [{ type: "text", text: "Do not lose this live event." }],
+                    },
+                  ],
+                },
+              ],
+            },
+          };
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const firstLoad = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => expect(childReadCount).toBe(1));
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "history-child-thread",
+      item: {
+        type: "userMessage",
+        id: "child-live-during-failure",
+        content: [{ type: "text", text: "Do not lose this live event." }],
+      },
+    });
+    firstChildRead.resolve(Promise.reject(new Error("history unavailable")));
+
+    await expect(firstLoad).rejects.toThrow("history unavailable");
+    expect(
+      events.flatMap((event) =>
+        event.type === "provider_subagent" && event.event.type === "timeline"
+          ? [event.event.item]
+          : [],
+      ),
+    ).toEqual([]);
+
+    events.push(...(await session.loadProviderSubagentHistory!("history-child-thread")));
+
+    expect(childReadCount).toBe(2);
+    expect(
+      events.flatMap((event) =>
+        event.type === "provider_subagent" && event.event.type === "timeline"
+          ? [event.event.item]
+          : [],
+      ),
+    ).toEqual([
+      {
+        type: "assistant_message",
+        messageId: "child-message-after-retry",
+        text: "Retry succeeded.",
+      },
+      {
+        type: "user_message",
+        messageId: "child-live-during-failure",
+        text: "Do not lose this live event.",
+      },
+    ]);
+  });
+
+  test("aborts a stuck persisted child read and leaves it retryable", async () => {
+    const session = createSession();
+    let childReadCount = 0;
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "history-child-thread") {
+          childReadCount += 1;
+          if (childReadCount === 1) {
+            return await new Promise(() => undefined);
+          }
+          return {
+            thread: {
+              turns: [
+                {
+                  items: [
+                    {
+                      type: "agentMessage",
+                      id: "child-message-after-abort",
+                      text: "Retry after abort succeeded.",
+                    },
+                  ],
+                },
+              ],
+            },
+          };
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before observing lazy child events.
+    }
+    const abortController = new AbortController();
+    const firstLoad = session.loadProviderSubagentHistory!("history-child-thread", {
+      signal: abortController.signal,
+    });
+    await vi.waitFor(() => expect(childReadCount).toBe(1));
+
+    abortController.abort(new Error("reload canceled child history"));
+
+    await expect(firstLoad).rejects.toThrow("reload canceled child history");
+    await expect(
+      session.loadProviderSubagentHistory!("history-child-thread"),
+    ).resolves.toMatchObject([
+      {
+        event: {
+          type: "timeline",
+          id: "history-child-thread",
+          item: {
+            type: "assistant_message",
+            messageId: "child-message-after-abort",
+            text: "Retry after abort succeeded.",
+          },
+        },
+      },
+    ]);
+    expect(childReadCount).toBe(2);
+  });
+
+  test("discards a child read that resolves after persisted root history reloads", async () => {
+    const session = createSession();
+    const staleChildRead = deferred<unknown>();
+    let rootReadCount = 0;
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "history-child-thread") {
+          return staleChildRead.promise;
+        }
+        rootReadCount += 1;
+        const childThreadId = rootReadCount === 1 ? "history-child-thread" : "replacement-child";
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: `child-started-${rootReadCount}`,
+                    kind: "started",
+                    agentThreadId: childThreadId,
+                    agentPath: `/root/${childThreadId}`,
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain the first root generation.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const staleLoad = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => {
+      expect(session.client?.request).toHaveBeenCalledWith("thread/read", {
+        threadId: "history-child-thread",
+        includeTurns: true,
+      });
+    });
+    await asInternals(session).loadPersistedHistory();
+    staleChildRead.resolve({
+      thread: {
+        turns: [
+          {
+            items: [
+              {
+                type: "agentMessage",
+                id: "stale-child-message",
+                text: "Must not escape the old generation.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    await staleLoad;
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "provider_subagent" &&
+          event.event.type === "timeline" &&
+          event.event.id === "history-child-thread",
+      ),
+    ).toBe(false);
+  });
+
+  test("discards a child read that resolves after the session closes", async () => {
+    const session = createSession();
+    const staleChildRead = deferred<unknown>();
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        if ((params as { threadId?: string }).threadId === "history-child-thread") {
+          return staleChildRead.promise;
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "subAgentActivity",
+                    id: "child-started-history",
+                    kind: "started",
+                    agentThreadId: "history-child-thread",
+                    agentPath: "/root/history-child",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+      notify: vi.fn(),
+      dispose: vi.fn(async () => undefined),
+    };
+    await asInternals(session).loadPersistedHistory();
+    for await (const _event of session.streamHistory()) {
+      // Drain root history before starting the stale child read.
+    }
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const staleLoad = session.loadProviderSubagentHistory!("history-child-thread");
+    await vi.waitFor(() => {
+      expect(session.client?.request).toHaveBeenCalledWith("thread/read", {
+        threadId: "history-child-thread",
+        includeTurns: true,
+      });
+    });
+    await session.close();
+    staleChildRead.resolve({
+      thread: {
+        turns: [
+          {
+            items: [
+              {
+                type: "agentMessage",
+                id: "stale-child-message",
+                text: "Must not emit after close.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    await staleLoad;
+
+    expect(events).toEqual([]);
+  });
+
   test("loads mixed legacy and MultiAgentV2 sub-agent history", async () => {
     const session = createSession();
     session.client = {
@@ -4456,6 +5485,20 @@ describe("Codex app-server provider", () => {
       history.flatMap((event) =>
         event.type === "provider_subagent" && event.event.type === "timeline" ? [event.event] : [],
       ),
+    ).toEqual([]);
+    const liveEvents: AgentStreamEvent[] = [];
+    session.subscribe((event) => liveEvents.push(event));
+
+    const loadedEvents = await Promise.all([
+      session.loadProviderSubagentHistory!("legacy-child-thread"),
+      session.loadProviderSubagentHistory!("v2-child-thread"),
+    ]);
+    liveEvents.push(...loadedEvents.flat());
+
+    expect(
+      liveEvents.flatMap((event) =>
+        event.type === "provider_subagent" && event.event.type === "timeline" ? [event.event] : [],
+      ),
     ).toEqual([
       {
         type: "timeline",
@@ -4497,8 +5540,7 @@ describe("Codex app-server provider", () => {
       },
     ]);
 
-    const liveEvents: AgentStreamEvent[] = [];
-    session.subscribe((event) => liveEvents.push(event));
+    liveEvents.length = 0;
     asInternals(session).handleNotification("turn/started", {
       threadId: "v2-child-thread",
       turn: { id: "v2-child-turn-after-resume" },

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -138,6 +138,7 @@ type TurnTerminalEvent = Extract<
 const ONE_BY_ONE_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X1r0AAAAASUVORK5CYII=";
 const CODEX_PROVIDER = "codex";
+const MAX_SERIALIZED_PARENT_SUB_AGENT_SNAPSHOT_BYTES = 64_000;
 
 function createConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSessionConfig {
   return {
@@ -147,6 +148,13 @@ function createConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSession
     model: "gpt-5.4",
     ...overrides,
   };
+}
+
+function hasOnlyWellFormedCodePoints(text: string): boolean {
+  return Array.from(text).every((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return character.length > 1 || codePoint < 0xd800 || codePoint > 0xdfff;
+  });
 }
 
 function createSession(
@@ -2651,6 +2659,383 @@ describe("Codex app-server provider", () => {
       id: "child-thread-1",
       status: "completed",
     });
+  });
+
+  test("keeps parent sub-agent snapshots bounded while retaining canonical child activity", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-bounded-child",
+        kind: "started",
+        agentThreadId: "bounded-child-thread",
+        agentPath: "/root/bounded-child",
+      },
+    });
+    const childMessages = Array.from({ length: 20 }, (_, index) => {
+      const marker = index === 0 ? "oldest-marker" : `activity-${index}`;
+      const latestMarker = index === 19 ? " newest-marker" : "";
+      return `${String.fromCharCode(97 + index).repeat(16_000)} ${marker}${latestMarker}`;
+    });
+    for (const [index, text] of childMessages.entries()) {
+      asInternals(session).handleNotification("item/completed", {
+        threadId: "bounded-child-thread",
+        item: {
+          type: "agentMessage",
+          id: `bounded-child-message-${index}`,
+          text,
+        },
+      });
+    }
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "bounded-child-thread",
+      turn: { status: "completed" },
+    });
+
+    const parentSnapshots = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-bounded-child" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item]
+        : [],
+    );
+    expect(parentSnapshots.length).toBeGreaterThan(1);
+    expect(
+      parentSnapshots.every((item) => Buffer.byteLength(item.detail.log, "utf8") <= 32_000),
+    ).toBe(true);
+    const serializedParentBytes = parentSnapshots.reduce(
+      (total, item) => total + Buffer.byteLength(JSON.stringify(item), "utf8"),
+      0,
+    );
+    expect(serializedParentBytes).toBeLessThanOrEqual(parentSnapshots.length * 33_000);
+    expect(parentSnapshots.at(-1)).toMatchObject({ status: "completed" });
+    expect(parentSnapshots.at(-1)?.detail.log).not.toContain("oldest-marker");
+    expect(parentSnapshots.at(-1)?.detail.log).toContain("newest-marker");
+
+    const canonicalMessages = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "bounded-child-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalMessages).toEqual(childMessages);
+  });
+
+  test("bounds the root sub-agent prompt in the complete emitted snapshot", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    const prompt = `${"p".repeat(1_000_000)} newest-prompt-marker`;
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-large-prompt-child",
+        tool: "spawnAgent",
+        status: "inProgress",
+        prompt,
+        receiverThreadIds: [],
+        agentsStates: {},
+      },
+    });
+
+    const rootSnapshot = events.find(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "spawn-large-prompt-child",
+    );
+    if (rootSnapshot?.type !== "timeline" || rootSnapshot.item.type !== "tool_call") {
+      throw new Error("Expected root sub-agent snapshot");
+    }
+    expect(Buffer.byteLength(JSON.stringify(rootSnapshot.item), "utf8")).toBeLessThanOrEqual(
+      MAX_SERIALIZED_PARENT_SUB_AGENT_SNAPSHOT_BYTES,
+    );
+    expect(rootSnapshot.item.detail).toMatchObject({
+      type: "sub_agent",
+      description: expect.stringContaining("newest-prompt-marker"),
+    });
+  });
+
+  test("bounds the root sub-agent error in the complete emitted snapshot", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    const toJSON = vi.fn(() => ({ payload: "x".repeat(1_000_000) }));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-large-error-child",
+        tool: "spawnAgent",
+        status: "failed",
+        error: { toJSON },
+        prompt: "Fail safely.",
+        receiverThreadIds: [],
+        agentsStates: {},
+      },
+    });
+
+    const rootSnapshot = events.find(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "spawn-large-error-child",
+    );
+    if (rootSnapshot?.type !== "timeline" || rootSnapshot.item.type !== "tool_call") {
+      throw new Error("Expected failed root sub-agent snapshot");
+    }
+    const serialized = JSON.stringify(rootSnapshot.item);
+    expect(toJSON).not.toHaveBeenCalled();
+    expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(
+      MAX_SERIALIZED_PARENT_SUB_AGENT_SNAPSHOT_BYTES,
+    );
+    expect(rootSnapshot.item).toMatchObject({ status: "failed" });
+  });
+
+  test("keeps nested descendant snapshots bounded while retaining descendant history", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-bounded-root",
+        kind: "started",
+        agentThreadId: "bounded-root-thread",
+        agentPath: "/root/bounded-root",
+      },
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "bounded-root-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-bounded-descendant",
+        kind: "started",
+        agentThreadId: "bounded-descendant-thread",
+        agentPath: "/root/bounded-root/descendant",
+      },
+    });
+    const descendantMessages = Array.from({ length: 20 }, (_, index) => {
+      const marker = index === 0 ? "oldest-descendant-marker" : `descendant-${index}`;
+      const latestMarker = index === 19 ? " newest-descendant-marker" : "";
+      return `${String.fromCharCode(97 + index).repeat(16_000)} ${marker}${latestMarker}`;
+    });
+    for (const [index, text] of descendantMessages.entries()) {
+      asInternals(session).handleNotification("item/completed", {
+        threadId: "bounded-descendant-thread",
+        item: {
+          type: "agentMessage",
+          id: `bounded-descendant-message-${index}`,
+          text,
+        },
+      });
+    }
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "bounded-descendant-thread",
+      turn: { status: "completed" },
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "bounded-root-thread",
+      turn: { status: "completed" },
+    });
+
+    const rootSnapshots = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-bounded-root" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item]
+        : [],
+    );
+    const serializedRootBytes = rootSnapshots.reduce(
+      (total, item) => total + Buffer.byteLength(JSON.stringify(item), "utf8"),
+      0,
+    );
+    expect(serializedRootBytes).toBeLessThanOrEqual(rootSnapshots.length * 33_000);
+    expect(rootSnapshots.every((item) => Buffer.byteLength(item.detail.log, "utf8") <= 4_500)).toBe(
+      true,
+    );
+    expect(rootSnapshots.at(-1)).toMatchObject({ status: "completed" });
+    expect(rootSnapshots.at(-1)?.detail.log).not.toContain("oldest-descendant-marker");
+    expect(rootSnapshots.at(-1)?.detail.log).toContain("newest-descendant-marker");
+
+    const canonicalDescendantMessages = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "bounded-descendant-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalDescendantMessages).toEqual(descendantMessages);
+  });
+
+  test("builds the parent sub-agent preview from only the latest child activities", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-latest-child",
+        kind: "started",
+        agentThreadId: "latest-child-thread",
+        agentPath: "/root/latest-child",
+      },
+    });
+    const childMessages = Array.from({ length: 201 }, (_, index) =>
+      index === 0 ? "oldest-activity-marker" : `child activity ${index}`,
+    );
+    for (const [index, text] of childMessages.entries()) {
+      asInternals(session).handleNotification("item/completed", {
+        threadId: "latest-child-thread",
+        item: {
+          type: "agentMessage",
+          id: `latest-child-message-${index}`,
+          text,
+        },
+      });
+    }
+
+    const parentSnapshots = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-latest-child" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item]
+        : [],
+    );
+    expect(parentSnapshots.at(-1)?.detail.log).not.toContain("oldest-activity-marker");
+    expect(parentSnapshots.at(-1)?.detail.log).toContain("child activity 200");
+
+    const canonicalMessages = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "latest-child-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalMessages).toEqual(childMessages);
+  });
+
+  test("does not serialize unbounded non-sub-agent tool payloads for the parent preview", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-tool-preview-child",
+        kind: "started",
+        agentThreadId: "tool-preview-child-thread",
+        agentPath: "/root/tool-preview-child",
+      },
+    });
+    const toJSON = vi.fn(() => ({ payload: "x".repeat(1_000_000) }));
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "tool-preview-child-thread",
+      item: {
+        type: "mcpToolCall",
+        id: "large-child-tool",
+        status: "completed",
+        server: "example",
+        tool: "large_payload",
+        arguments: { toJSON },
+        result: null,
+      },
+    });
+
+    expect(toJSON).not.toHaveBeenCalled();
+    const parentSnapshot = events.findLast(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "spawn-tool-preview-child" &&
+        event.item.detail.type === "sub_agent",
+    );
+    expect(parentSnapshot?.item.detail.log).toContain("example.large_payload");
+
+    const canonicalToolCall = events.find(
+      (event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "timeline" &&
+        event.event.id === "tool-preview-child-thread" &&
+        event.event.item.type === "tool_call",
+    );
+    expect(canonicalToolCall?.event.item).toMatchObject({
+      type: "tool_call",
+      callId: "large-child-tool",
+      detail: { type: "unknown", input: { toJSON } },
+    });
+  });
+
+  test("bounds streamed multibyte child activity by UTF-8 bytes without splitting code points", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-multibyte-child",
+        kind: "started",
+        agentThreadId: "multibyte-child-thread",
+        agentPath: "/root/multibyte-child",
+      },
+    });
+    const deltas = Array.from({ length: 6 }, (_, index) =>
+      index === 5
+        ? `${"界".repeat(4_000)} 😀 newest-multibyte-marker`
+        : `${"界".repeat(4_000)} 😀 delta-${index}`,
+    );
+    for (const [index, delta] of deltas.entries()) {
+      asInternals(session).handleNotification("item/agentMessage/delta", {
+        threadId: "multibyte-child-thread",
+        itemId: `multibyte-child-message-${index}`,
+        delta,
+      });
+    }
+
+    const parentLogs = events.flatMap((event) =>
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.callId === "spawn-multibyte-child" &&
+      event.item.detail.type === "sub_agent"
+        ? [event.item.detail.log]
+        : [],
+    );
+    expect(parentLogs.length).toBeGreaterThan(1);
+    expect(parentLogs.every((log) => Buffer.byteLength(log, "utf8") <= 32_000)).toBe(true);
+    expect(parentLogs.every(hasOnlyWellFormedCodePoints)).toBe(true);
+    expect(parentLogs.at(-1)).toContain("😀 newest-multibyte-marker");
+
+    const canonicalDeltas = events.flatMap((event) =>
+      event.type === "provider_subagent" &&
+      event.event.type === "timeline" &&
+      event.event.id === "multibyte-child-thread" &&
+      event.event.item.type === "assistant_message"
+        ? [event.event.item.text]
+        : [],
+    );
+    expect(canonicalDeltas).toEqual(deltas);
   });
 
   test("keeps a settled child completed until Codex starts another child turn", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4761,6 +4761,16 @@ describe("Codex app-server provider", () => {
       itemId: "child-live-assistant",
       delta: "Second live fragment.",
     });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-repeated-assistant",
+      delta: "Echo",
+    });
+    asInternals(session).handleNotification("item/agentMessage/delta", {
+      threadId: "history-child-thread",
+      itemId: "child-repeated-assistant",
+      delta: "Echo",
+    });
     expect(
       events.filter(
         (event) => event.type === "provider_subagent" && event.event.type === "timeline",
@@ -4781,6 +4791,11 @@ describe("Codex app-server provider", () => {
                 type: "userMessage",
                 id: "child-live-message",
                 content: [{ type: "text", text: "Concurrent child message." }],
+              },
+              {
+                type: "agentMessage",
+                id: "child-repeated-assistant",
+                text: "Echo",
               },
             ],
           },
@@ -4810,6 +4825,11 @@ describe("Codex app-server provider", () => {
       },
       {
         type: "assistant_message",
+        messageId: "child-repeated-assistant",
+        text: "Echo",
+      },
+      {
+        type: "assistant_message",
         messageId: "child-live-assistant",
         text: "First live fragment. ",
       },
@@ -4817,6 +4837,11 @@ describe("Codex app-server provider", () => {
         type: "assistant_message",
         messageId: "child-live-assistant",
         text: "Second live fragment.",
+      },
+      {
+        type: "assistant_message",
+        messageId: "child-repeated-assistant",
+        text: "Echo",
       },
     ]);
   });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -5673,6 +5673,13 @@ describe("Codex app-server provider", () => {
     );
     expect(upserts).toEqual([
       expect.objectContaining({ id: "persisted-child", parentSubagentId: null }),
+    ]);
+
+    const childHistory = await session.loadProviderSubagentHistory("persisted-child");
+    const nestedUpserts = childHistory.flatMap((event) =>
+      event.event.type === "upsert" ? [event.event] : [],
+    );
+    expect(nestedUpserts).toEqual([
       expect.objectContaining({
         id: "persisted-grandchild",
         parentSubagentId: "persisted-child",

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -149,6 +149,13 @@ const CODEX_NON_ORIGINATING_APP_SERVER_CLIENT_INFO = {
 const ASSISTANT_MESSAGE_BOUNDARY_MARKDOWN = "\n\n---\n\n";
 const MAX_PENDING_SUB_AGENT_THREADS = 32;
 const MAX_PENDING_SUB_AGENT_NOTIFICATIONS_PER_THREAD = 128;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ITEMS = 200;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES = 4_000;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES = 256;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ACTIONS = 32;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_ACTION_FIELD_BYTES = 256;
+const MAX_PARENT_SUB_AGENT_ACTIVITY_BYTES = 32_000;
+const OMITTED_SUB_AGENT_ACTIVITY_PREFIX = "…\n";
 // COMPAT(codexLegacyCollabAgentToolCall): Codex <0.143 emits this shape. Added in
 // Paseo v0.1.105; remove after 2027-01-09 once the supported Codex floor is >=0.143.
 const CODEX_TOOL_THREAD_ITEM_TYPES = new Set([
@@ -207,6 +214,235 @@ function parseGoalSubcommand(args: string | undefined): GoalSubcommand {
 
 function formatOutOfBandStatusMessage(text: string): string {
   return `${text.replace(/\n+$/u, "")}\n\n`;
+}
+
+function utf8CodePointByteLength(codePoint: number): number {
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+function previousCodePointStart(text: string, end: number): number {
+  const lastIndex = end - 1;
+  const lastCodeUnit = text.charCodeAt(lastIndex);
+  if (lastCodeUnit >= 0xdc00 && lastCodeUnit <= 0xdfff && lastIndex > 0) {
+    const precedingCodeUnit = text.charCodeAt(lastIndex - 1);
+    if (precedingCodeUnit >= 0xd800 && precedingCodeUnit <= 0xdbff) {
+      return lastIndex - 1;
+    }
+  }
+  return lastIndex;
+}
+
+function utf8TailStart(text: string, maxBytes: number): number {
+  let start = text.length;
+  let retainedBytes = 0;
+  while (start > 0) {
+    const candidateStart = previousCodePointStart(text, start);
+    const codePoint = text.codePointAt(candidateStart);
+    if (codePoint === undefined) break;
+    const codePointBytes = utf8CodePointByteLength(codePoint);
+    if (retainedBytes + codePointBytes > maxBytes) break;
+    retainedBytes += codePointBytes;
+    start = candidateStart;
+  }
+  return start;
+}
+
+function tailSubAgentActivity(text: string, maxBytes: number): string {
+  const unprefixedStart = utf8TailStart(text, maxBytes);
+  if (unprefixedStart === 0) {
+    return text;
+  }
+  const prefixBytes = Buffer.byteLength(OMITTED_SUB_AGENT_ACTIVITY_PREFIX, "utf8");
+  if (maxBytes <= prefixBytes) {
+    return "";
+  }
+
+  const start = utf8TailStart(text, maxBytes - prefixBytes);
+  return `${OMITTED_SUB_AGENT_ACTIVITY_PREFIX}${text.slice(start)}`;
+}
+
+function boundedToolCallPreview(detail: ToolCallTimelineItem["detail"]): string | undefined {
+  switch (detail.type) {
+    case "shell":
+      return detail.command;
+    case "read":
+    case "edit":
+    case "write":
+      return detail.filePath;
+    case "search":
+      return detail.query;
+    case "fetch":
+      return detail.url;
+    case "worktree_setup":
+      return detail.branchName;
+    case "plain_text":
+      return detail.label ?? detail.text;
+    case "plan":
+      return detail.text;
+    case "unknown":
+      if (
+        typeof detail.input === "string" ||
+        typeof detail.input === "number" ||
+        typeof detail.input === "boolean" ||
+        typeof detail.input === "bigint"
+      ) {
+        return String(detail.input);
+      }
+      return undefined;
+    case "sub_agent":
+      return undefined;
+  }
+}
+
+function boundedToolCallPreviewName(item: ToolCallTimelineItem): string {
+  switch (item.detail.type) {
+    case "shell":
+      return "Shell";
+    case "read":
+      return "Read";
+    case "edit":
+      return "Edit";
+    case "write":
+      return "Write";
+    case "search":
+      return "Search";
+    case "fetch":
+      return "Fetch";
+    case "worktree_setup":
+      return "Worktree setup";
+    case "plan":
+      return "Plan";
+    case "sub_agent":
+    case "plain_text":
+    case "unknown":
+      return item.name;
+  }
+}
+
+function boundedToolCallError(item: ToolCallTimelineItem): unknown {
+  if (item.status !== "failed") return null;
+  return typeof item.error === "string"
+    ? tailSubAgentActivity(item.error, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES)
+    : "Tool call failed";
+}
+
+function buildBoundedToolCallPreview(
+  item: ToolCallTimelineItem,
+  subAgentLogBytes = MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES,
+): ToolCallTimelineItem {
+  const preview =
+    item.detail.type === "sub_agent" ? undefined : boundedToolCallPreview(item.detail);
+  const detail: ToolCallTimelineItem["detail"] =
+    item.detail.type === "sub_agent"
+      ? {
+          type: "sub_agent",
+          ...(item.detail.subAgentType
+            ? {
+                subAgentType: tailSubAgentActivity(
+                  item.detail.subAgentType,
+                  MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES,
+                ),
+              }
+            : {}),
+          ...(item.detail.description
+            ? {
+                description: tailSubAgentActivity(
+                  item.detail.description,
+                  MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES,
+                ),
+              }
+            : {}),
+          ...(item.detail.childSessionId
+            ? {
+                childSessionId: tailSubAgentActivity(
+                  item.detail.childSessionId,
+                  MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES,
+                ),
+              }
+            : {}),
+          log: tailSubAgentActivity(item.detail.log, subAgentLogBytes),
+          ...(item.detail.actions
+            ? {
+                actions: item.detail.actions
+                  .slice(-MAX_PARENT_SUB_AGENT_ACTIVITY_ACTIONS)
+                  .map((action) => {
+                    const boundedAction = {
+                      index: action.index,
+                      toolName: tailSubAgentActivity(
+                        action.toolName,
+                        MAX_PARENT_SUB_AGENT_ACTIVITY_ACTION_FIELD_BYTES,
+                      ),
+                    };
+                    if (!action.summary) return boundedAction;
+                    return {
+                      index: boundedAction.index,
+                      toolName: boundedAction.toolName,
+                      summary: tailSubAgentActivity(
+                        action.summary,
+                        MAX_PARENT_SUB_AGENT_ACTIVITY_ACTION_FIELD_BYTES,
+                      ),
+                    };
+                  }),
+              }
+            : {}),
+        }
+      : {
+          type: "plain_text",
+          ...(preview
+            ? {
+                label: tailSubAgentActivity(preview, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES),
+              }
+            : {}),
+        };
+  const base = {
+    type: "tool_call" as const,
+    callId: item.callId,
+    name: tailSubAgentActivity(
+      boundedToolCallPreviewName(item),
+      MAX_PARENT_SUB_AGENT_ACTIVITY_TOOL_NAME_BYTES,
+    ),
+    detail,
+  };
+  switch (item.status) {
+    case "running":
+    case "completed":
+    case "canceled":
+      return { ...base, status: item.status, error: null };
+    case "failed":
+      return { ...base, status: item.status, error: boundedToolCallError(item) };
+  }
+}
+
+function boundParentSubAgentActivityItem(item: AgentTimelineItem): AgentTimelineItem {
+  if (
+    item.type === "assistant_message" ||
+    item.type === "reasoning" ||
+    item.type === "user_message"
+  ) {
+    return {
+      ...item,
+      text: tailSubAgentActivity(item.text, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES),
+    };
+  }
+  if (item.type === "error") {
+    return {
+      ...item,
+      message: tailSubAgentActivity(item.message, MAX_PARENT_SUB_AGENT_ACTIVITY_ITEM_BYTES),
+    };
+  }
+  if (item.type === "tool_call") {
+    return buildBoundedToolCallPreview(item);
+  }
+  return item;
+}
+
+function boundRootSubAgentTimelineItem(item: AgentTimelineItem): AgentTimelineItem {
+  return item.type === "tool_call" && item.detail.type === "sub_agent"
+    ? buildBoundedToolCallPreview(item, MAX_PARENT_SUB_AGENT_ACTIVITY_BYTES)
+    : item;
 }
 
 const CODEX_APP_SERVER_CAPABILITIES: AgentCapabilityFlags = {
@@ -5564,8 +5800,10 @@ export class CodexAppServerAgentSession implements AgentSession {
 
   private getSubAgentChildTimeline(state: CodexSubAgentCallState): AgentTimelineItem[] {
     return state.childItemOrder
+      .slice(-MAX_PARENT_SUB_AGENT_ACTIVITY_ITEMS)
       .map((itemId) => state.childItems.get(itemId))
-      .filter((item): item is AgentTimelineItem => Boolean(item));
+      .filter((item): item is AgentTimelineItem => Boolean(item))
+      .map(boundParentSubAgentActivityItem);
   }
 
   private emitSubAgentActivityUpdate(
@@ -5580,7 +5818,10 @@ export class CodexAppServerAgentSession implements AgentSession {
     const childTimeline = this.getSubAgentChildTimeline(state);
     const log =
       childTimeline.length > 0
-        ? curateAgentActivity(childTimeline, { labelAssistantMessages: true })
+        ? tailSubAgentActivity(
+            curateAgentActivity(childTimeline, { labelAssistantMessages: true }),
+            MAX_PARENT_SUB_AGENT_ACTIVITY_BYTES,
+          )
         : "";
     let resolvedStatus = status ?? state.toolCall.status;
     if (
@@ -5618,7 +5859,11 @@ export class CodexAppServerAgentSession implements AgentSession {
       this.emitSubAgentActivityUpdate(state.parentCallId);
       return;
     }
-    this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: nextToolCall });
+    this.emitEvent({
+      type: "timeline",
+      provider: CODEX_PROVIDER,
+      item: boundRootSubAgentTimelineItem(nextToolCall),
+    });
   }
 
   private emitProviderSubagentUpsert(
@@ -6328,7 +6573,11 @@ export class CodexAppServerAgentSession implements AgentSession {
       }
       this.warnOnIncompleteEditToolCall(timelineItem, "item_completed", parsed.item);
     }
-    this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: timelineItem });
+    this.emitEvent({
+      type: "timeline",
+      provider: CODEX_PROVIDER,
+      item: boundRootSubAgentTimelineItem(timelineItem),
+    });
     if (timelineItem.type === "assistant_message") {
       this.pendingAssistantMessageBoundary = true;
     }
@@ -6479,7 +6728,11 @@ export class CodexAppServerAgentSession implements AgentSession {
       return;
     }
     this.warnOnIncompleteEditToolCall(timelineItem, "item_started", parsed.item);
-    this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: timelineItem });
+    this.emitEvent({
+      type: "timeline",
+      provider: CODEX_PROVIDER,
+      item: boundRootSubAgentTimelineItem(timelineItem),
+    });
     if (itemId) {
       this.emittedItemStartedIds.add(itemId);
       this.pendingCommandOutputDeltas.delete(itemId);

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -730,11 +730,6 @@ function historicalProviderSubagentItemCoversLiveReplay(
   if (liveItem.type === "user_message") {
     return historicalItems.some((item) => item.type === "user_message");
   }
-  if (liveItem.type === "assistant_message") {
-    return historicalItems.some(
-      (item) => item.type === "assistant_message" && item.text.includes(liveItem.text),
-    );
-  }
   if (liveItem.type === "tool_call") {
     const historicalToolCalls = historicalItems.filter(
       (item): item is ToolCallTimelineItem =>
@@ -746,6 +741,117 @@ function historicalProviderSubagentItemCoversLiveReplay(
     );
   }
   return false;
+}
+
+function longestTextSuffixMatchingPrefix(text: string, prefix: string): number {
+  if (text.length === 0 || prefix.length === 0) {
+    return 0;
+  }
+  const fallback = Array.from({ length: prefix.length }, () => 0);
+  for (let index = 1, matched = 0; index < prefix.length; index += 1) {
+    while (matched > 0 && prefix[index] !== prefix[matched]) {
+      matched = fallback[matched - 1] ?? 0;
+    }
+    if (prefix[index] === prefix[matched]) {
+      matched += 1;
+    }
+    fallback[index] = matched;
+  }
+
+  let matched = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    while (matched > 0 && text[index] !== prefix[matched]) {
+      matched = fallback[matched - 1] ?? 0;
+    }
+    if (text[index] === prefix[matched]) {
+      matched += 1;
+    }
+    if (matched === prefix.length && index < text.length - 1) {
+      matched = fallback[matched - 1] ?? 0;
+    }
+  }
+  return matched;
+}
+
+function providerSubagentAssistantReplayCoverage(
+  historicalItemsByReplayIdentity: ReadonlyMap<string, readonly AgentTimelineItem[]>,
+  liveEvents: readonly BufferedProviderSubagentEvent[],
+): Map<string, number> {
+  const bufferedTextByReplayIdentity = new Map<string, string[]>();
+  for (const buffered of liveEvents) {
+    if (!buffered.replayIdentity || buffered.event.event.type !== "timeline") {
+      continue;
+    }
+    const item = buffered.event.event.item;
+    if (item.type !== "assistant_message") {
+      continue;
+    }
+    const text = bufferedTextByReplayIdentity.get(buffered.replayIdentity) ?? [];
+    text.push(item.text);
+    bufferedTextByReplayIdentity.set(buffered.replayIdentity, text);
+  }
+
+  const coverageByReplayIdentity = new Map<string, number>();
+  for (const [replayIdentity, chunks] of bufferedTextByReplayIdentity) {
+    const bufferedText = chunks.join("");
+    const historicalItems = historicalItemsByReplayIdentity.get(replayIdentity) ?? [];
+    let coverage = 0;
+    for (const item of historicalItems) {
+      if (item.type === "assistant_message") {
+        coverage = Math.max(coverage, longestTextSuffixMatchingPrefix(item.text, bufferedText));
+      }
+    }
+    if (coverage > 0) {
+      coverageByReplayIdentity.set(replayIdentity, coverage);
+    }
+  }
+  return coverageByReplayIdentity;
+}
+
+function reconcileProviderSubagentLiveEvents(
+  historicalItemsByReplayIdentity: ReadonlyMap<string, readonly AgentTimelineItem[]>,
+  liveEvents: readonly BufferedProviderSubagentEvent[],
+): ProviderSubagentStreamEvent[] {
+  const assistantReplayCoverageByIdentity = providerSubagentAssistantReplayCoverage(
+    historicalItemsByReplayIdentity,
+    liveEvents,
+  );
+  const reconciled: ProviderSubagentStreamEvent[] = [];
+  for (const buffered of liveEvents) {
+    let event = buffered.event;
+    if (
+      buffered.replayIdentity &&
+      event.event.type === "timeline" &&
+      event.event.item.type === "assistant_message"
+    ) {
+      const coverage = assistantReplayCoverageByIdentity.get(buffered.replayIdentity) ?? 0;
+      if (coverage >= event.event.item.text.length) {
+        assistantReplayCoverageByIdentity.set(
+          buffered.replayIdentity,
+          coverage - event.event.item.text.length,
+        );
+        continue;
+      }
+      if (coverage > 0) {
+        assistantReplayCoverageByIdentity.delete(buffered.replayIdentity);
+        event = {
+          ...event,
+          event: {
+            ...event.event,
+            item: { ...event.event.item, text: event.event.item.text.slice(coverage) },
+          },
+        };
+      }
+    }
+    const historicalItems = buffered.replayIdentity
+      ? historicalItemsByReplayIdentity.get(buffered.replayIdentity)
+      : undefined;
+    if (historicalItems && historicalProviderSubagentItemCoversLiveReplay(historicalItems, event)) {
+      continue;
+    }
+    reconciled.push(event);
+  }
+  return reconciled;
 }
 
 interface CodexThreadHistoryProjection {
@@ -4303,17 +4409,11 @@ export class CodexAppServerAgentSession implements AgentSession {
         childThreadId,
         routeState.generation,
       );
-      for (const buffered of liveEvents) {
-        const historicalItems = buffered.replayIdentity
-          ? historicalItemsByReplayIdentity.get(buffered.replayIdentity)
-          : undefined;
-        if (
-          historicalItems &&
-          historicalProviderSubagentItemCoversLiveReplay(historicalItems, buffered.event)
-        ) {
-          continue;
-        }
-        this.emitEvent(buffered.event);
+      for (const event of reconcileProviderSubagentLiveEvents(
+        historicalItemsByReplayIdentity,
+        liveEvents,
+      )) {
+        this.emitEvent(event);
       }
     } finally {
       this.collectingProviderSubagentHistoryEvents = null;

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -481,6 +481,7 @@ const DEFAULT_CODEX_MODE_ID = "auto";
 
 interface CodexAppServerClientLike {
   request(method: string, params?: unknown): Promise<unknown>;
+  requestWithSignal?(method: string, params: unknown, signal: AbortSignal): Promise<unknown>;
   forkThread?(params: CodexThreadForkParams): Promise<CodexThreadForkResponse>;
   rollbackThread?(params: CodexThreadRollbackParams): Promise<CodexThreadRollbackResponse>;
   notify(method: string, params?: unknown): void;
@@ -666,11 +667,85 @@ interface PersistedTimelineEntry {
   item: AgentTimelineItem;
   timestamp?: string;
   providerTurnId?: string;
+  sourceItemId?: string;
+  sourceItemOrdinal?: number;
 }
 
 interface PersistedSubAgentRoute {
   childThreadId: string;
   toolCall: ToolCallTimelineItem;
+}
+
+interface PersistedSubAgentRouteState {
+  route: PersistedSubAgentRoute;
+  parentCallId: string | null;
+  parentSubagentId: string | null;
+  generation: number;
+}
+
+type ProviderSubagentStreamEvent = Extract<AgentStreamEvent, { type: "provider_subagent" }>;
+
+interface BufferedProviderSubagentEvent {
+  event: ProviderSubagentStreamEvent;
+  replayIdentity: string | null;
+}
+
+function providerSubagentTimelineReplayIdentity(
+  subagentId: string,
+  item: AgentTimelineItem,
+  sourceItemId: string | undefined,
+  sourceItemOrdinal = 0,
+): string | null {
+  if (item.type === "tool_call") {
+    return `${subagentId}\0${item.callId}\0tool_call`;
+  }
+  if (!sourceItemId) {
+    return null;
+  }
+  return `${subagentId}\0${sourceItemId}\0${sourceItemOrdinal}\0${item.type}`;
+}
+
+function providerSubagentEventReplayIdentity(event: ProviderSubagentStreamEvent): string | null {
+  if (event.event.type !== "timeline") {
+    return null;
+  }
+  const item = event.event.item;
+  let sourceItemId: string | undefined;
+  if (item.type === "user_message" || item.type === "assistant_message") {
+    sourceItemId = item.messageId;
+  } else if (item.type === "tool_call") {
+    sourceItemId = item.callId;
+  }
+  return providerSubagentTimelineReplayIdentity(event.event.id, item, sourceItemId);
+}
+
+function historicalProviderSubagentItemCoversLiveReplay(
+  historicalItems: readonly AgentTimelineItem[],
+  liveEvent: ProviderSubagentStreamEvent,
+): boolean {
+  if (liveEvent.event.type !== "timeline") {
+    return false;
+  }
+  const liveItem = liveEvent.event.item;
+  if (liveItem.type === "user_message") {
+    return historicalItems.some((item) => item.type === "user_message");
+  }
+  if (liveItem.type === "assistant_message") {
+    return historicalItems.some(
+      (item) => item.type === "assistant_message" && item.text.includes(liveItem.text),
+    );
+  }
+  if (liveItem.type === "tool_call") {
+    const historicalToolCalls = historicalItems.filter(
+      (item): item is ToolCallTimelineItem =>
+        item.type === "tool_call" && item.callId === liveItem.callId,
+    );
+    return (
+      historicalToolCalls.some((item) => isTerminalSubAgentStatus(item.status)) ||
+      historicalToolCalls.some((item) => item.status === liveItem.status)
+    );
+  }
+  return false;
 }
 
 interface CodexThreadHistoryProjection {
@@ -2221,6 +2296,9 @@ async function loadCodexThreadHistoryTimeline(params: {
           continue;
         }
       }
+      const itemRecord = toObjectRecord(item);
+      const sourceItemId = typeof itemRecord?.id === "string" ? itemRecord.id : undefined;
+      let sourceItemOrdinal = 0;
       for (const timelineItem of threadItemToTimelineEntries(item, { cwd: params.cwd })) {
         const timestamp =
           readCodexHistoryTimestamp(item) ?? readCodexTurnHistoryTimestamp(turn, timelineItem);
@@ -2234,7 +2312,10 @@ async function loadCodexThreadHistoryTimeline(params: {
           ...(timelineItem.type === "user_message" && typeof turn.id === "string"
             ? { providerTurnId: turn.id }
             : {}),
+          sourceItemId,
+          sourceItemOrdinal,
         });
+        sourceItemOrdinal += 1;
         for (const childThreadId of readCodexHistoricalSubAgentThreadIds(item)) {
           subAgentTimelineIndexByThreadId.set(childThreadId, timeline.length - 1);
         }
@@ -2252,10 +2333,45 @@ async function loadCodexThreadHistoryTimeline(params: {
   return { timeline, subAgentRoutes };
 }
 
-function readCodexThread(client: CodexAppServerClientLike, threadId: string): Promise<unknown> {
-  return client.request("thread/read", {
+function readCodexThread(
+  client: CodexAppServerClientLike,
+  threadId: string,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const params = {
     threadId,
     includeTurns: true,
+  };
+  if (signal && client.requestWithSignal) {
+    return client.requestWithSignal("thread/read", params, signal);
+  }
+  const operation = client.request("thread/read", {
+    ...params,
+  });
+  if (!signal) {
+    return operation;
+  }
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return new Promise((resolveRead, rejectRead) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      rejectRead(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void operation.then(
+      (thread) => {
+        signal.removeEventListener("abort", onAbort);
+        resolveRead(thread);
+        return undefined;
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        rejectRead(error);
+        return undefined;
+      },
+    );
   });
 }
 
@@ -3584,6 +3700,15 @@ export class CodexAppServerAgentSession implements AgentSession {
   private subAgentCallsByCallId = new Map<string, CodexSubAgentCallState>();
   private subAgentCallIdByChildThreadId = new Map<string, string>();
   private pendingSubAgentNotificationsByThreadId = new Map<string, ParsedCodexNotification[]>();
+  private persistedSubAgentRoutesByThreadId = new Map<string, PersistedSubAgentRouteState>();
+  private loadedPersistedSubAgentThreadIds = new Set<string>();
+  private persistedSubAgentHistoryLoads = new Map<string, Promise<ProviderSubagentStreamEvent[]>>();
+  private persistedSubAgentLiveEventsByThreadId = new Map<
+    string,
+    BufferedProviderSubagentEvent[]
+  >();
+  private collectingProviderSubagentHistoryEvents: ProviderSubagentStreamEvent[] | null = null;
+  private persistedHistoryGeneration = 0;
   private warnedUnknownNotificationMethods = new Set<string>();
   private warnedInvalidNotificationPayloads = new Set<string>();
   private warnedIncompleteEditToolCallIds = new Set<string>();
@@ -4014,6 +4139,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     if (!this.client || !this.currentThreadId) return;
     const client = this.client;
     const threadId = this.currentThreadId;
+    const generation = ++this.persistedHistoryGeneration;
 
     const history = await loadCodexThreadHistoryTimeline({
       threadId,
@@ -4022,14 +4148,21 @@ export class CodexAppServerAgentSession implements AgentSession {
         return readCodexThread(client, threadIdToRead);
       },
     });
+    if (generation !== this.persistedHistoryGeneration || this.closed) {
+      return;
+    }
     const { timeline, subAgentRoutes } = history;
     this.subAgentCallsByCallId.clear();
     this.subAgentCallIdByChildThreadId.clear();
     this.pendingSubAgentNotificationsByThreadId.clear();
+    this.persistedSubAgentRoutesByThreadId.clear();
+    this.loadedPersistedSubAgentThreadIds.clear();
+    this.persistedSubAgentHistoryLoads.clear();
+    this.persistedSubAgentLiveEventsByThreadId.clear();
     this.persistedProviderSubagentEvents = [];
     this.loadingPersistedHistory = true;
     try {
-      await this.loadPersistedSubAgentHistories(client, subAgentRoutes);
+      this.registerPersistedSubAgentRoutes(subAgentRoutes, null, null, generation);
     } finally {
       this.loadingPersistedHistory = false;
     }
@@ -4043,51 +4176,150 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.historyPending = timeline.length > 0;
   }
 
-  private async loadPersistedSubAgentHistories(
-    client: CodexAppServerClientLike,
-    rootRoutes: readonly PersistedSubAgentRoute[],
-  ): Promise<void> {
-    const queue = rootRoutes.map((route) => ({
-      route,
-      parentCallId: null as string | null,
-      parentSubagentId: null as string | null,
-    }));
-    const visitedThreadIds = new Set(this.currentThreadId ? [this.currentThreadId] : []);
-    while (queue.length > 0 && visitedThreadIds.size < 100) {
-      const next = queue.shift();
-      if (!next || visitedThreadIds.has(next.route.childThreadId)) {
+  private registerPersistedSubAgentRoutes(
+    routes: readonly PersistedSubAgentRoute[],
+    parentCallId: string | null,
+    parentSubagentId: string | null,
+    generation: number,
+  ): void {
+    for (const route of routes) {
+      if (
+        route.childThreadId === this.currentThreadId ||
+        this.persistedSubAgentRoutesByThreadId.has(route.childThreadId) ||
+        this.persistedSubAgentRoutesByThreadId.size >= 99
+      ) {
         continue;
       }
-      visitedThreadIds.add(next.route.childThreadId);
-      this.registerSubAgentToolCall({
-        timelineItem: next.route.toolCall,
-        rawItem: { agentThreadId: next.route.childThreadId },
-        parentCallId: next.parentCallId,
-        parentSubagentId: next.parentSubagentId,
+      this.persistedSubAgentRoutesByThreadId.set(route.childThreadId, {
+        route,
+        parentCallId,
+        parentSubagentId,
+        generation,
       });
-      try {
-        const childHistory = await loadCodexThreadHistoryTimeline({
-          threadId: next.route.childThreadId,
-          cwd: this.config.cwd ?? null,
-          requestThread: (childThreadId) => readCodexThread(client, childThreadId),
-        });
-        for (const entry of childHistory.timeline) {
-          this.emitProviderSubagentTimeline(next.route.childThreadId, entry.item, entry.timestamp);
-        }
-        for (const route of childHistory.subAgentRoutes) {
-          queue.push({
-            route,
-            parentCallId: next.route.toolCall.callId,
-            parentSubagentId: next.route.childThreadId,
-          });
-        }
-      } catch (error) {
-        this.logger.trace(
-          { err: error, childThreadId: next.route.childThreadId },
-          "Failed to load persisted Codex child history",
-        );
+      this.registerSubAgentToolCall({
+        timelineItem: route.toolCall,
+        rawItem: { agentThreadId: route.childThreadId },
+        parentCallId,
+        parentSubagentId,
+      });
+      this.persistedSubAgentLiveEventsByThreadId.set(route.childThreadId, []);
+    }
+  }
+
+  async loadProviderSubagentHistory(
+    subagentId: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<ProviderSubagentStreamEvent[]> {
+    if (this.loadedPersistedSubAgentThreadIds.has(subagentId)) {
+      return [];
+    }
+    const existingLoad = this.persistedSubAgentHistoryLoads.get(subagentId);
+    if (existingLoad) {
+      return await existingLoad;
+    }
+    const routeState = this.persistedSubAgentRoutesByThreadId.get(subagentId);
+    const client = this.client;
+    if (!routeState || !client || routeState.generation !== this.persistedHistoryGeneration) {
+      return [];
+    }
+
+    const load = this.loadPersistedSubAgentHistory(client, routeState, options?.signal);
+    this.persistedSubAgentHistoryLoads.set(subagentId, load);
+    try {
+      return await load;
+    } finally {
+      if (this.persistedSubAgentHistoryLoads.get(subagentId) === load) {
+        this.persistedSubAgentHistoryLoads.delete(subagentId);
       }
     }
+  }
+
+  getLoadedProviderSubagentHistoryIds(): readonly string[] {
+    return [...this.loadedPersistedSubAgentThreadIds];
+  }
+
+  seedLoadedProviderSubagentHistoryIds(subagentIds: readonly string[]): void {
+    for (const subagentId of subagentIds) {
+      this.loadedPersistedSubAgentThreadIds.add(subagentId);
+    }
+  }
+
+  private async loadPersistedSubAgentHistory(
+    client: CodexAppServerClientLike,
+    routeState: PersistedSubAgentRouteState,
+    signal?: AbortSignal,
+  ): Promise<ProviderSubagentStreamEvent[]> {
+    const childThreadId = routeState.route.childThreadId;
+    const liveEvents = this.persistedSubAgentLiveEventsByThreadId.get(childThreadId) ?? [];
+    this.persistedSubAgentLiveEventsByThreadId.set(childThreadId, liveEvents);
+    const childHistory = await loadCodexThreadHistoryTimeline({
+      threadId: childThreadId,
+      cwd: this.config.cwd ?? null,
+      requestThread: (threadId) => readCodexThread(client, threadId, signal),
+    });
+    if (
+      this.closed ||
+      this.client !== client ||
+      routeState.generation !== this.persistedHistoryGeneration ||
+      this.persistedSubAgentRoutesByThreadId.get(childThreadId) !== routeState
+    ) {
+      if (this.persistedSubAgentLiveEventsByThreadId.get(childThreadId) === liveEvents) {
+        this.persistedSubAgentLiveEventsByThreadId.delete(childThreadId);
+      }
+      return [];
+    }
+    this.persistedSubAgentLiveEventsByThreadId.delete(childThreadId);
+    const historicalItemsByReplayIdentity = new Map<string, AgentTimelineItem[]>();
+    const collectedEvents: ProviderSubagentStreamEvent[] = [];
+    this.collectingProviderSubagentHistoryEvents = collectedEvents;
+    try {
+      for (const entry of childHistory.timeline) {
+        const event: ProviderSubagentStreamEvent = {
+          type: "provider_subagent",
+          provider: CODEX_PROVIDER,
+          event: {
+            type: "timeline",
+            id: childThreadId,
+            item: entry.item,
+            ...(entry.timestamp ? { timestamp: entry.timestamp } : {}),
+          },
+        };
+        const replayIdentity = providerSubagentTimelineReplayIdentity(
+          childThreadId,
+          entry.item,
+          entry.sourceItemId,
+          entry.sourceItemOrdinal,
+        );
+        if (replayIdentity) {
+          const items = historicalItemsByReplayIdentity.get(replayIdentity) ?? [];
+          items.push(entry.item);
+          historicalItemsByReplayIdentity.set(replayIdentity, items);
+        }
+        this.emitEvent(event);
+      }
+      this.registerPersistedSubAgentRoutes(
+        childHistory.subAgentRoutes,
+        routeState.route.toolCall.callId,
+        childThreadId,
+        routeState.generation,
+      );
+      for (const buffered of liveEvents) {
+        const historicalItems = buffered.replayIdentity
+          ? historicalItemsByReplayIdentity.get(buffered.replayIdentity)
+          : undefined;
+        if (
+          historicalItems &&
+          historicalProviderSubagentItemCoversLiveReplay(historicalItems, buffered.event)
+        ) {
+          continue;
+        }
+        this.emitEvent(buffered.event);
+      }
+    } finally {
+      this.collectingProviderSubagentHistoryEvents = null;
+    }
+    this.loadedPersistedSubAgentThreadIds.add(childThreadId);
+    return collectedEvents;
   }
 
   private async ensureThreadLoaded(
@@ -5026,8 +5258,13 @@ export class CodexAppServerAgentSession implements AgentSession {
 
   async close(): Promise<void> {
     this.closed = true;
+    this.persistedHistoryGeneration += 1;
     this.clearPendingPermissions();
     this.pendingSubAgentNotificationsByThreadId.clear();
+    this.persistedSubAgentRoutesByThreadId.clear();
+    this.loadedPersistedSubAgentThreadIds.clear();
+    this.persistedSubAgentHistoryLoads.clear();
+    this.persistedSubAgentLiveEventsByThreadId.clear();
     this.subscribers.clear();
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
@@ -5355,6 +5592,22 @@ export class CodexAppServerAgentSession implements AgentSession {
   }
 
   private emitEvent(event: AgentStreamEvent): void {
+    if (event.type === "provider_subagent") {
+      if (event.event.type === "timeline") {
+        const liveEvents = this.persistedSubAgentLiveEventsByThreadId.get(event.event.id);
+        if (liveEvents) {
+          liveEvents.push({
+            event,
+            replayIdentity: providerSubagentEventReplayIdentity(event),
+          });
+          return;
+        }
+      }
+      if (this.collectingProviderSubagentHistoryEvents) {
+        this.collectingProviderSubagentHistoryEvents.push(event);
+        return;
+      }
+    }
     if (this.loadingPersistedHistory && event.type === "provider_subagent") {
       this.persistedProviderSubagentEvents.push(event);
       return;

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
@@ -32,6 +32,51 @@ describe("Codex app-server transport", () => {
     await expect(request).rejects.toThrow("Codex app-server client is closed");
   });
 
+  test("aborts a pending request, clears its timer, and ignores a late response", async () => {
+    const child = createCodexAppServerChildProcess();
+    const client = new CodexAppServerClient(child, createTestLogger());
+    const abortController = new AbortController();
+
+    const abortedRequest = client.requestWithSignal(
+      "thread/read",
+      { threadId: "child-thread" },
+      abortController.signal,
+    );
+    abortController.abort(new Error("history read canceled"));
+
+    await expect(abortedRequest).rejects.toThrow("history read canceled");
+    expect((client as unknown as { pending: Map<number, unknown> }).pending.size).toBe(0);
+
+    child.stdout.write('{"id":1,"result":{"thread":{"id":"too-late"}}}\n');
+    const nextRequest = client.request("model/list", {});
+    child.stdout.write('{"id":2,"result":{"data":[]}}\n');
+    await expect(nextRequest).resolves.toEqual({ data: [] });
+    child.stdout.end();
+    child.stderr.end();
+    child.stdin.end();
+  });
+
+  test("clears pending requests when termination follows disposal state", async () => {
+    const child = createCodexAppServerChildProcess();
+    const client = new CodexAppServerClient(child, createTestLogger());
+    const request = client.request("thread/read", { threadId: "child-thread" });
+    const rejection = expect(request).rejects.toThrow("process exited after disposal began");
+    const internals = client as unknown as {
+      disposed: boolean;
+      pending: Map<number, unknown>;
+      handleUnexpectedTermination(error: Error): void;
+    };
+
+    internals.disposed = true;
+    internals.handleUnexpectedTermination(new Error("process exited after disposal began"));
+
+    await rejection;
+    expect(internals.pending.size).toBe(0);
+    child.stdout.end();
+    child.stderr.end();
+    child.stdin.end();
+  });
+
   test.each([
     "item/commandExecution/requestApproval",
     "item/fileChange/requestApproval",

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.ts
@@ -31,6 +31,8 @@ interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
   timer: NodeJS.Timeout;
+  signal?: AbortSignal;
+  abortHandler?: () => void;
 }
 
 export class CodexAppServerRpcError extends Error {
@@ -224,8 +226,29 @@ export class CodexAppServerClient {
   }
 
   request(method: string, params?: unknown, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<unknown> {
+    return this.requestInternal(method, params, timeoutMs);
+  }
+
+  requestWithSignal(
+    method: string,
+    params: unknown,
+    signal: AbortSignal,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<unknown> {
+    return this.requestInternal(method, params, timeoutMs, signal);
+  }
+
+  private requestInternal(
+    method: string,
+    params: unknown,
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
     if (this.disposed) {
       return Promise.reject(new Error("Codex app-server client is closed"));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(this.createRequestAbortError(signal));
     }
     const id = this.nextId++;
     const payload: JsonRpcRequest = { id, method, params };
@@ -233,10 +256,21 @@ export class CodexAppServerClient {
     this.child.stdin.write(`${serialized}\n`);
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`Codex app-server request timed out for ${method}`));
+        this.takePendingRequest(id)?.reject(
+          new Error(`Codex app-server request timed out for ${method}`),
+        );
       }, timeoutMs);
-      this.pending.set(id, { resolve, reject, timer });
+      const pending: PendingRequest = { resolve, reject, timer, ...(signal ? { signal } : {}) };
+      if (signal) {
+        pending.abortHandler = () => {
+          this.takePendingRequest(id)?.reject(this.createRequestAbortError(signal));
+        };
+        signal.addEventListener("abort", pending.abortHandler, { once: true });
+      }
+      this.pending.set(id, pending);
+      if (signal?.aborted) {
+        pending.abortHandler?.();
+      }
     });
   }
 
@@ -257,11 +291,14 @@ export class CodexAppServerClient {
   }
 
   async dispose(): Promise<void> {
-    if (this.disposed) return;
+    if (this.disposed) {
+      this.rejectPendingRequests(new Error("Codex app-server client is closed"));
+      return;
+    }
     this.disposed = true;
     this.unexpectedTerminationHandler = null;
     this.rl.close();
-    this.rejectPending(new Error("Codex app-server client is closed"));
+    this.rejectPendingRequests(new Error("Codex app-server client is closed"));
     try {
       this.child.stdin.end();
     } catch {
@@ -286,12 +323,13 @@ export class CodexAppServerClient {
   }
 
   private handleUnexpectedTermination(error: Error): void {
-    if (this.disposed) {
-      return;
-    }
+    const alreadyDisposed = this.disposed;
     this.disposed = true;
     this.rl.close();
-    this.rejectPending(error);
+    this.rejectPendingRequests(error);
+    if (alreadyDisposed) {
+      return;
+    }
     const handler = this.unexpectedTerminationHandler;
     this.unexpectedTerminationHandler = null;
     if (!handler) {
@@ -304,12 +342,33 @@ export class CodexAppServerClient {
     }
   }
 
-  private rejectPending(error: Error): void {
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.reject(error);
+  private createRequestAbortError(signal: AbortSignal): Error {
+    let message = "Codex app-server request aborted";
+    if (signal.reason instanceof Error) {
+      message = signal.reason.message;
+    } else if (typeof signal.reason === "string") {
+      message = signal.reason;
     }
-    this.pending.clear();
+    return Object.assign(new Error(message), { name: "AbortError" });
+  }
+
+  private takePendingRequest(id: number): PendingRequest | undefined {
+    const pending = this.pending.get(id);
+    if (!pending) {
+      return undefined;
+    }
+    this.pending.delete(id);
+    clearTimeout(pending.timer);
+    if (pending.signal && pending.abortHandler) {
+      pending.signal.removeEventListener("abort", pending.abortHandler);
+    }
+    return pending;
+  }
+
+  private rejectPendingRequests(error: Error): void {
+    for (const id of this.pending.keys()) {
+      this.takePendingRequest(id)?.reject(error);
+    }
   }
 
   private writeJsonRpcResponse(response: JsonRpcResponse): void {
@@ -341,10 +400,8 @@ export class CodexAppServerClient {
     if (isJsonRpcResponse(raw)) {
       const id = raw.id;
       if (raw.result !== undefined || raw.error) {
-        const pending = this.pending.get(id);
+        const pending = this.takePendingRequest(id);
         if (!pending) return;
-        clearTimeout(pending.timer);
-        this.pending.delete(id);
         if (raw.error) {
           pending.reject(
             new CodexAppServerRpcError(

--- a/packages/server/src/server/agent/segmented-file-agent-timeline-store.test.ts
+++ b/packages/server/src/server/agent/segmented-file-agent-timeline-store.test.ts
@@ -1,0 +1,680 @@
+import { copyFile, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { writeFileAtomic } from "../atomic-file.js";
+import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
+import { SegmentedFileAgentTimelineStore } from "./segmented-file-agent-timeline-store.js";
+
+const directories: string[] = [];
+
+async function storeDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "paseo-segmented-timeline-"));
+  directories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+describe("SegmentedFileAgentTimelineStore", () => {
+  it("matches in-memory fetch semantics across directions, cursors, and limits", async () => {
+    const durable = new SegmentedFileAgentTimelineStore(await storeDirectory(), {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+    });
+    const rows = Array.from({ length: 5 }, (_, index) => ({
+      seq: index + 3,
+      timestamp: "2026-08-31T12:00:00.000Z",
+      item: { type: "user_message" as const, text: `row-${index + 3}` },
+    }));
+    await durable.bulkInsert("agent-1", rows);
+    const epoch = (await durable.fetchCommitted("agent-1")).epoch;
+    const memory = new InMemoryAgentTimelineStore();
+    memory.initialize("agent-1", { rows, epoch, nextSeq: 8 });
+    const options = [
+      undefined,
+      { direction: "tail" as const, limit: 0 },
+      { direction: "before" as const, cursor: { epoch, seq: 6 }, limit: 2 },
+      { direction: "before" as const, cursor: { epoch, seq: 3 }, limit: 2 },
+      { direction: "after" as const, cursor: { epoch, seq: 4 }, limit: 2 },
+      { direction: "after" as const, cursor: { epoch, seq: 7 }, limit: 2 },
+      { direction: "after" as const, cursor: { epoch, seq: 0 }, limit: 2 },
+      { direction: "before" as const, cursor: { epoch: "stale", seq: 6 }, limit: 2 },
+      { direction: "after" as const, cursor: { epoch: "stale", seq: 6 }, limit: 0 },
+    ];
+    for (const option of options) {
+      await expect(durable.fetchCommitted("agent-1", option)).resolves.toEqual(
+        memory.fetch("agent-1", option),
+      );
+    }
+  });
+
+  it("pages across bounded segments after rebuilding the disposable cache", async () => {
+    const directory = await storeDirectory();
+    const store = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+    });
+
+    for (const text of ["one", "two", "three", "four", "five"]) {
+      await store.appendCommitted("agent-1", { type: "user_message", text });
+    }
+
+    const tail = await store.fetchCommitted("agent-1", { direction: "tail", limit: 2 });
+    const reopened = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+    });
+    const older = await reopened.fetchCommitted("agent-1", {
+      direction: "before",
+      cursor: { epoch: tail.epoch, seq: tail.rows[0]!.seq },
+      limit: 3,
+    });
+
+    expect(tail).toMatchObject({
+      epoch: expect.any(String),
+      window: { minSeq: 1, maxSeq: 5, nextSeq: 6 },
+      hasOlder: true,
+      hasNewer: false,
+      rows: [
+        { seq: 4, item: { type: "user_message", text: "four" } },
+        { seq: 5, item: { type: "user_message", text: "five" } },
+      ],
+    });
+    expect(older).toMatchObject({
+      epoch: tail.epoch,
+      direction: "before",
+      reset: false,
+      staleCursor: false,
+      gap: false,
+      window: { minSeq: 1, maxSeq: 5, nextSeq: 6 },
+      hasOlder: false,
+      hasNewer: true,
+      rows: [
+        { seq: 1, item: { type: "user_message", text: "one" } },
+        { seq: 2, item: { type: "user_message", text: "two" } },
+        { seq: 3, item: { type: "user_message", text: "three" } },
+      ],
+    });
+  });
+
+  it("keeps duplicate canonical rows idempotent and rejects sequence conflicts", async () => {
+    const directory = await storeDirectory();
+    const row = {
+      seq: 7,
+      timestamp: "2026-08-31T12:00:00.000Z",
+      item: { type: "user_message" as const, text: "canonical" },
+      turnId: "turn-1",
+      providerMessageId: "provider-1",
+    };
+    const store = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+    });
+
+    await store.bulkInsert("agent-1", [row]);
+    await store.bulkInsert("agent-1", [row]);
+
+    await expect(
+      store.bulkInsert("agent-1", [{ ...row, item: { ...row.item, text: "conflict" } }]),
+    ).rejects.toThrow("Conflicting timeline row sequence 7");
+    await expect(
+      new SegmentedFileAgentTimelineStore(directory).getCommittedRows("agent-1"),
+    ).resolves.toEqual([row]);
+  });
+
+  it("deletes one agent cache without disturbing another", async () => {
+    const directory = await storeDirectory();
+    const store = new SegmentedFileAgentTimelineStore(directory);
+    await store.appendCommitted("agent-a", { type: "user_message", text: "remove" });
+    await store.appendCommitted("agent-b", { type: "user_message", text: "preserve" });
+
+    await store.deleteAgent("agent-a");
+
+    const reopened = new SegmentedFileAgentTimelineStore(directory);
+    await expect(reopened.getCommittedRows("agent-a")).resolves.toEqual([]);
+    await expect(reopened.getCommittedRows("agent-b")).resolves.toEqual([
+      expect.objectContaining({ seq: 1, item: { type: "user_message", text: "preserve" } }),
+    ]);
+  });
+
+  it("updates an existing canonical row and rejects a missing sequence", async () => {
+    const directory = await storeDirectory();
+    const store = new SegmentedFileAgentTimelineStore(directory);
+    await store.bulkInsert("agent-1", [
+      {
+        seq: 3,
+        timestamp: "2026-08-31T12:00:00.000Z",
+        item: { type: "assistant_message", text: "before" },
+      },
+    ]);
+    const replacement = {
+      seq: 3,
+      timestamp: "2026-08-31T12:00:01.000Z",
+      item: { type: "assistant_message" as const, text: "after" },
+      turnId: "turn-1",
+      providerMessageId: "provider-1",
+    };
+
+    await store.updateCommittedRow("agent-1", replacement);
+
+    await expect(
+      new SegmentedFileAgentTimelineStore(directory).getCommittedRows("agent-1"),
+    ).resolves.toEqual([replacement]);
+    await expect(store.updateCommittedRow("agent-1", { ...replacement, seq: 4 })).rejects.toThrow(
+      "Cannot update missing timeline row sequence 4",
+    );
+  });
+
+  it("reads the latest item and assistant message across segment boundaries", async () => {
+    const store = new SegmentedFileAgentTimelineStore(await storeDirectory(), {
+      maxRowsPerSegment: 1,
+      maxBytesPerSegment: 4_096,
+    });
+    await store.appendCommitted("agent-1", { type: "user_message", text: "question" });
+    await store.appendCommitted("agent-1", { type: "assistant_message", text: "part one" });
+    await store.appendCommitted("agent-1", { type: "assistant_message", text: " + part two" });
+
+    await expect(store.getLatestCommittedSeq("agent-1")).resolves.toBe(3);
+    await expect(store.getLastItem("agent-1")).resolves.toEqual({
+      type: "assistant_message",
+      text: " + part two",
+    });
+    await expect(store.getLastAssistantMessage("agent-1")).resolves.toBe("part one + part two");
+  });
+
+  it("rewrites only bounded files and removes superseded segment generations", async () => {
+    const directory = await storeDirectory();
+    const maxBytesPerSegment = 512;
+    const writes: Array<{ file: string; bytes: number }> = [];
+    const store = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment,
+      writeFileAtomic: async (filePath, data) => {
+        writes.push({ file: path.basename(filePath), bytes: Buffer.byteLength(data) });
+        await writeFileAtomic(filePath, data);
+      },
+    });
+
+    for (let index = 1; index <= 10; index += 1) {
+      await store.appendCommitted("agent-1", {
+        type: "user_message",
+        text: `row-${index}-${"x".repeat(40)}`,
+      });
+    }
+
+    const reopened = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment,
+    });
+    await reopened.getCommittedRows("agent-1");
+    await reopened.collectGarbage("agent-1");
+
+    const agentDirectory = path.join(
+      directory,
+      `agent-${Buffer.from("agent-1", "utf8").toString("base64url")}`,
+    );
+    const files = await readdir(agentDirectory);
+    const segmentFiles = files.filter((file) => file.startsWith("segment-"));
+    const segmentBytes = await Promise.all(
+      segmentFiles.map(async (file) =>
+        Buffer.byteLength(await readFile(path.join(agentDirectory, file))),
+      ),
+    );
+
+    expect(segmentFiles).toHaveLength(5);
+    expect(Math.max(...segmentBytes)).toBeLessThanOrEqual(maxBytesPerSegment);
+    expect(
+      Math.max(
+        ...writes.filter(({ file }) => file.startsWith("segment-")).map(({ bytes }) => bytes),
+      ),
+    ).toBeLessThanOrEqual(maxBytesPerSegment);
+    expect(
+      Math.max(...writes.filter(({ file }) => file === "manifest.json").map(({ bytes }) => bytes)),
+    ).toBeLessThan(512);
+    expect(
+      Buffer.byteLength(await readFile(path.join(agentDirectory, "manifest.json"))),
+    ).toBeLessThan(512);
+  });
+
+  it("reads only the segments touched by tail, before, and after pages", async () => {
+    const directory = await storeDirectory();
+    const writer = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+    });
+    for (let index = 1; index <= 100; index += 1) {
+      await writer.appendCommitted("agent-1", {
+        type: "user_message",
+        text: `row-${index}`,
+      });
+    }
+
+    let segmentReads = 0;
+    const store = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+      onSegmentRead: (filePath) => {
+        if (path.basename(filePath).startsWith("segment-")) segmentReads += 1;
+      },
+    });
+
+    const tail = await store.fetchCommitted("agent-1", { direction: "tail", limit: 2 });
+    expect(tail.rows.map((row) => row.seq)).toEqual([99, 100]);
+    expect(segmentReads).toBe(1);
+
+    segmentReads = 0;
+    const before = await store.fetchCommitted("agent-1", {
+      direction: "before",
+      cursor: { epoch: tail.epoch, seq: 99 },
+      limit: 2,
+    });
+    expect(before.rows.map((row) => row.seq)).toEqual([97, 98]);
+    expect(segmentReads).toBe(1);
+
+    segmentReads = 0;
+    const after = await store.fetchCommitted("agent-1", {
+      direction: "after",
+      cursor: { epoch: tail.epoch, seq: 98 },
+      limit: 2,
+    });
+    expect(after.rows.map((row) => row.seq)).toEqual([99, 100]);
+    expect(segmentReads).toBe(1);
+
+    segmentReads = 0;
+    const farAfter = await store.fetchCommitted("agent-1", {
+      direction: "after",
+      cursor: { epoch: tail.epoch, seq: 2 },
+      limit: 2,
+    });
+    expect(farAfter.rows.map((row) => row.seq)).toEqual([3, 4]);
+    expect(segmentReads).toBe(1);
+
+    segmentReads = 0;
+    const pageOne = await store.fetchCommitted("agent-1", {
+      direction: "before",
+      cursor: { epoch: tail.epoch, seq: 51 },
+      limit: 2,
+    });
+    const pageTwo = await store.fetchCommitted("agent-1", {
+      direction: "before",
+      cursor: { epoch: tail.epoch, seq: pageOne.rows[0]!.seq },
+      limit: 2,
+    });
+    expect(pageOne.rows.map((row) => row.seq)).toEqual([49, 50]);
+    expect(pageTwo.rows.map((row) => row.seq)).toEqual([47, 48]);
+    expect(segmentReads).toBe(2);
+  });
+
+  it("updates only the bounded segment containing a canonical row", async () => {
+    const directory = await storeDirectory();
+    const writer = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+    });
+    for (let index = 1; index <= 6; index += 1) {
+      await writer.appendCommitted("agent-1", {
+        type: "assistant_message",
+        text: `before-${index}`,
+      });
+    }
+
+    const writes: string[] = [];
+    const store = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+      writeFileAtomic: async (filePath, data) => {
+        writes.push(path.basename(filePath));
+        await writeFileAtomic(filePath, data);
+      },
+    });
+    const row = (await store.getCommittedRows("agent-1"))[0]!;
+
+    await store.updateCommittedRow("agent-1", {
+      ...row,
+      item: { type: "assistant_message", text: "after-1" },
+    });
+
+    expect(writes.filter((file) => file.startsWith("segment-"))).toHaveLength(1);
+    expect(writes.filter((file) => file === "manifest.json")).toHaveLength(1);
+    await expect(
+      new SegmentedFileAgentTimelineStore(directory).getCommittedRows("agent-1"),
+    ).resolves.toEqual([
+      expect.objectContaining({ seq: 1, item: { type: "assistant_message", text: "after-1" } }),
+      ...Array.from({ length: 5 }, (_, index) =>
+        expect.objectContaining({
+          seq: index + 2,
+          item: { type: "assistant_message", text: `before-${index + 2}` },
+        }),
+      ),
+    ]);
+  });
+
+  it("keeps the last manifest visible after failed publication and cleans the orphan on recovery", async () => {
+    const directory = await storeDirectory();
+    let failManifest = false;
+    const store = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+      writeFileAtomic: async (filePath, data) => {
+        if (path.basename(filePath) === "manifest.json" && failManifest) {
+          failManifest = false;
+          throw new Error("manifest unavailable");
+        }
+        await writeFileAtomic(filePath, data);
+      },
+    });
+    await store.appendCommitted("agent-1", { type: "user_message", text: "committed" });
+
+    failManifest = true;
+    await expect(
+      store.appendCommitted("agent-1", { type: "user_message", text: "not committed" }),
+    ).rejects.toThrow("manifest unavailable");
+    await expect(
+      new SegmentedFileAgentTimelineStore(directory).getCommittedRows("agent-1"),
+    ).resolves.toEqual([
+      expect.objectContaining({ seq: 1, item: { type: "user_message", text: "committed" } }),
+    ]);
+
+    await expect(
+      store.appendCommitted("agent-1", { type: "user_message", text: "recovered" }),
+    ).resolves.toMatchObject({ seq: 2 });
+    const agentDirectory = path.join(
+      directory,
+      `agent-${Buffer.from("agent-1", "utf8").toString("base64url")}`,
+    );
+    const recovered = new SegmentedFileAgentTimelineStore(directory);
+    await recovered.getCommittedRows("agent-1");
+    await recovered.collectGarbage("agent-1");
+    expect(
+      (await readdir(agentDirectory)).filter((file) => file.startsWith("segment-")),
+    ).toHaveLength(1);
+    await expect(
+      new SegmentedFileAgentTimelineStore(directory).getCommittedRows("agent-1"),
+    ).resolves.toEqual([
+      expect.objectContaining({ seq: 1, item: { type: "user_message", text: "committed" } }),
+      expect.objectContaining({ seq: 2, item: { type: "user_message", text: "recovered" } }),
+    ]);
+  });
+
+  it("does not serialize agent B behind a held agent A publication", async () => {
+    const directory = await storeDirectory();
+    let releaseAgentA!: () => void;
+    let markAgentAStarted!: () => void;
+    const agentAStarted = new Promise<void>((resolve) => {
+      markAgentAStarted = resolve;
+    });
+    const holdAgentA = new Promise<void>((resolve) => {
+      releaseAgentA = resolve;
+    });
+    const store = new SegmentedFileAgentTimelineStore(directory, {
+      writeFileAtomic: async (filePath, data) => {
+        const agentDirectory = path.basename(path.dirname(filePath));
+        if (agentDirectory === `agent-${Buffer.from("agent-a").toString("base64url")}`) {
+          markAgentAStarted();
+          await holdAgentA;
+        }
+        await writeFileAtomic(filePath, data);
+      },
+    });
+
+    const appendAgentA = store.appendCommitted("agent-a", {
+      type: "user_message",
+      text: "held",
+    });
+    await agentAStarted;
+    await expect(
+      store.appendCommitted("agent-b", { type: "user_message", text: "independent" }),
+    ).resolves.toMatchObject({ seq: 1 });
+    releaseAgentA();
+    await expect(appendAgentA).resolves.toMatchObject({ seq: 1 });
+  });
+
+  it("keeps repeated single-row bulk inserts bounded as history grows", async () => {
+    const directory = await storeDirectory();
+    let segmentReads = 0;
+    const writes: string[] = [];
+    const store = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+      onSegmentRead: (filePath) => {
+        if (path.basename(filePath).startsWith("segment-")) segmentReads += 1;
+      },
+      writeFileAtomic: async (filePath, data) => {
+        writes.push(path.basename(filePath));
+        await writeFileAtomic(filePath, data);
+      },
+    });
+
+    for (let seq = 1; seq <= 40; seq += 1) {
+      segmentReads = 0;
+      writes.length = 0;
+      await store.bulkInsert("agent-1", [
+        {
+          seq,
+          timestamp: `2026-08-31T12:00:${String(seq).padStart(2, "0")}.000Z`,
+          item: { type: "user_message", text: `row-${seq}` },
+        },
+      ]);
+      expect(segmentReads).toBeLessThanOrEqual(1);
+      expect(writes.filter((file) => file.startsWith("segment-"))).toHaveLength(1);
+      expect(writes.filter((file) => file === "manifest.json")).toHaveLength(1);
+    }
+  });
+
+  it("keeps a published segment available to an in-flight reader", async () => {
+    const directory = await storeDirectory();
+    const writer = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+    });
+    await writer.appendCommitted("agent-1", { type: "user_message", text: "one" });
+
+    let releaseRead!: () => void;
+    let markReadStarted!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    const heldRead = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    let held = false;
+    const reader = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+      beforeSegmentRead: async () => {
+        if (held) return;
+        held = true;
+        markReadStarted();
+        await heldRead;
+      },
+    });
+
+    const read = reader.fetchCommitted("agent-1", { direction: "tail", limit: 1 });
+    await readStarted;
+    await writer.appendCommitted("agent-1", { type: "user_message", text: "two" });
+    await new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+    }).getCommittedRows("agent-1");
+    releaseRead();
+
+    await expect(read).resolves.toMatchObject({
+      rows: [{ seq: 1, item: { type: "user_message", text: "one" } }],
+    });
+  });
+
+  it("removes unreachable lower generations during explicit garbage collection", async () => {
+    const directory = await storeDirectory();
+    const writer = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 2,
+      maxBytesPerSegment: 4_096,
+    });
+    await writer.appendCommitted("agent-1", { type: "user_message", text: "one" });
+    await writer.appendCommitted("agent-1", { type: "user_message", text: "two" });
+    const agentDirectory = path.join(
+      directory,
+      `agent-${Buffer.from("agent-1", "utf8").toString("base64url")}`,
+    );
+    await writer.collectGarbage("agent-1");
+    const activeSegment = (await readdir(agentDirectory)).find((file) =>
+      file.startsWith("segment-"),
+    )!;
+    await copyFile(
+      path.join(agentDirectory, activeSegment),
+      path.join(agentDirectory, "segment-1-unreachable.json"),
+    );
+    expect(
+      (await readdir(agentDirectory)).filter((file) => file.startsWith("segment-")),
+    ).toHaveLength(2);
+
+    const reopened = new SegmentedFileAgentTimelineStore(directory);
+    await reopened.getCommittedRows("agent-1");
+    await reopened.collectGarbage("agent-1");
+
+    expect(
+      (await readdir(agentDirectory)).filter((file) => file.startsWith("segment-")),
+    ).toHaveLength(1);
+  });
+
+  it.each(["same instance", "cross instance"] as const)(
+    "keeps unpublished generation files while %s garbage collection contends",
+    async (collectorKind) => {
+      const directory = await storeDirectory();
+      const manifestHeld = deferred();
+      const releaseManifest = deferred();
+      const lockContended = deferred();
+      let holdNextManifest = false;
+      const writer = new SegmentedFileAgentTimelineStore(directory, {
+        maxRowsPerSegment: 2,
+        maxBytesPerSegment: 4_096,
+        onMutationLockContention: () => lockContended.resolve(),
+        writeFileAtomic: async (filePath, data) => {
+          if (path.basename(filePath) === "manifest.json" && holdNextManifest) {
+            holdNextManifest = false;
+            manifestHeld.resolve();
+            await releaseManifest.promise;
+          }
+          await writeFileAtomic(filePath, data);
+        },
+      });
+      await writer.appendCommitted("agent-1", { type: "user_message", text: "one" });
+      holdNextManifest = true;
+      const append = writer.appendCommitted("agent-1", { type: "user_message", text: "two" });
+      await manifestHeld.promise;
+      const agentDirectory = path.join(
+        directory,
+        `agent-${Buffer.from("agent-1", "utf8").toString("base64url")}`,
+      );
+      const pendingFiles = (await readdir(agentDirectory)).filter(
+        (file) => file.startsWith("segment-2-") || file.startsWith("catalog-"),
+      );
+      const collector =
+        collectorKind === "same instance"
+          ? writer
+          : new SegmentedFileAgentTimelineStore(directory, {
+              onMutationLockContention: () => lockContended.resolve(),
+            });
+      const garbageCollection = collector.collectGarbage("agent-1");
+      await lockContended.promise;
+
+      expect(pendingFiles).not.toHaveLength(0);
+      await expect(readExistingFiles(agentDirectory, pendingFiles)).resolves.toEqual(pendingFiles);
+
+      releaseManifest.resolve();
+      await append;
+      await garbageCollection;
+      await expect(collector.getCommittedRows("agent-1")).resolves.toEqual([
+        expect.objectContaining({ seq: 1, item: { type: "user_message", text: "one" } }),
+        expect.objectContaining({ seq: 2, item: { type: "user_message", text: "two" } }),
+      ]);
+    },
+  );
+
+  it("fails closed when a cataloged segment is missing", async () => {
+    const missingDirectory = await storeDirectory();
+    const missingWriter = new SegmentedFileAgentTimelineStore(missingDirectory);
+    await missingWriter.appendCommitted("agent-1", { type: "user_message", text: "one" });
+    const missingAgentDirectory = path.join(
+      missingDirectory,
+      `agent-${Buffer.from("agent-1", "utf8").toString("base64url")}`,
+    );
+    await missingWriter.collectGarbage("agent-1");
+    const missingSegment = (await readdir(missingAgentDirectory)).find((file) =>
+      file.startsWith("segment-"),
+    )!;
+    await rm(path.join(missingAgentDirectory, missingSegment));
+    await expect(
+      new SegmentedFileAgentTimelineStore(missingDirectory).getCommittedRows("agent-1"),
+    ).rejects.toThrow("Corrupt timeline cache: missing segment");
+  });
+
+  it("reads backward only until the last assistant-message boundary", async () => {
+    const directory = await storeDirectory();
+    const writer = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 1,
+      maxBytesPerSegment: 4_096,
+    });
+    for (let seq = 1; seq <= 98; seq += 1) {
+      await writer.appendCommitted("agent-1", { type: "user_message", text: `row-${seq}` });
+    }
+    await writer.appendCommitted("agent-1", { type: "assistant_message", text: "part one" });
+    await writer.appendCommitted("agent-1", { type: "assistant_message", text: " + part two" });
+
+    let segmentReads = 0;
+    const reader = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 1,
+      maxBytesPerSegment: 4_096,
+      onSegmentRead: (filePath) => {
+        if (path.basename(filePath).startsWith("segment-")) segmentReads += 1;
+      },
+    });
+    await expect(reader.getLastAssistantMessage("agent-1")).resolves.toBe("part one + part two");
+    expect(segmentReads).toBe(2);
+  });
+
+  it("uses assistant summary metadata across a long non-assistant tail", async () => {
+    const directory = await storeDirectory();
+    const writer = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 1,
+      maxBytesPerSegment: 4_096,
+    });
+    await writer.appendCommitted("agent-1", { type: "assistant_message", text: "answer" });
+    for (let seq = 2; seq <= 100; seq += 1) {
+      await writer.appendCommitted("agent-1", { type: "user_message", text: `tail-${seq}` });
+    }
+    for (let seq = 1; seq <= 100; seq += 1) {
+      await writer.appendCommitted("agent-2", { type: "user_message", text: `row-${seq}` });
+    }
+    let segmentReads = 0;
+    const reader = new SegmentedFileAgentTimelineStore(directory, {
+      maxRowsPerSegment: 1,
+      maxBytesPerSegment: 4_096,
+      onSegmentRead: () => {
+        segmentReads += 1;
+      },
+    });
+
+    await expect(reader.getLastAssistantMessage("agent-1")).resolves.toBe("answer");
+    expect(segmentReads).toBe(1);
+    segmentReads = 0;
+    await expect(reader.getLastAssistantMessage("agent-2")).resolves.toBeNull();
+    expect(segmentReads).toBe(0);
+  });
+});
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+async function readExistingFiles(directory: string, files: string[]): Promise<string[]> {
+  await Promise.all(files.map(async (file) => await readFile(path.join(directory, file), "utf8")));
+  return files;
+}

--- a/packages/server/src/server/agent/segmented-file-agent-timeline-store.ts
+++ b/packages/server/src/server/agent/segmented-file-agent-timeline-store.ts
@@ -1,0 +1,538 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import { writeFileAtomic } from "../atomic-file.js";
+import type { AgentTimelineItem } from "./agent-sdk-types.js";
+import type {
+  AgentTimelineFetchOptions,
+  AgentTimelineFetchResult,
+  AgentTimelineRow,
+  AgentTimelineStore,
+} from "./agent-timeline-store-types.js";
+import { PagedTimelineCatalog } from "./timeline-cache/paged-catalog.js";
+import type { CatalogPageRef } from "./timeline-cache/paged-catalog.js";
+import { buildRowSegment, encodeRowSegment, readRowSegment } from "./timeline-cache/row-segment.js";
+import type { RowSegment, SegmentDescriptor } from "./timeline-cache/row-segment.js";
+import { TimelineSnapshotManager } from "./timeline-cache/snapshot.js";
+import type { TimelineManifest } from "./timeline-cache/snapshot.js";
+
+const DEFAULT_MAX_ROWS = 256;
+const DEFAULT_MAX_SEGMENT_BYTES = 256 * 1024;
+const DEFAULT_CATALOG_FANOUT = 64;
+const DEFAULT_MAX_PAGE_BYTES = 64 * 1024;
+const DEFAULT_MAX_MANIFEST_BYTES = 64 * 1024;
+const CATALOG_BATCH = 16;
+
+export interface SegmentedFileAgentTimelineStoreOptions {
+  maxRowsPerSegment?: number;
+  maxBytesPerSegment?: number;
+  catalogFanout?: number;
+  maxCatalogPageBytes?: number;
+  maxManifestBytes?: number;
+  onCatalogPageRead?: (filePath: string) => void;
+  onSegmentRead?: (filePath: string) => void;
+  onSegmentWrite?: (filePath: string, bytes: number) => void;
+  onManifestWrite?: (bytes: number) => void;
+  beforeSegmentRead?: (filePath: string) => Promise<void>;
+  onMutationLockContention?: () => void;
+  writeFileAtomic?: (filePath: string, data: string) => Promise<void>;
+}
+
+interface AgentContext {
+  directory: string;
+  catalog: PagedTimelineCatalog;
+  snapshots: TimelineSnapshotManager;
+}
+
+function cloneRow(row: AgentTimelineRow): AgentTimelineRow {
+  return { ...row, item: structuredClone(row.item) };
+}
+
+function fetchLimit(options?: AgentTimelineFetchOptions): number {
+  return options?.limit === undefined ? 200 : Math.max(0, Math.floor(options.limit));
+}
+
+/** Regenerable, bounded-I/O cache. Provider history remains authoritative. */
+export class SegmentedFileAgentTimelineStore implements AgentTimelineStore {
+  private readonly maxRows: number;
+  private readonly maxSegmentBytes: number;
+  private readonly contexts = new Map<string, AgentContext>();
+  private readonly mutationTails = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly directory: string,
+    private readonly options?: SegmentedFileAgentTimelineStoreOptions,
+  ) {
+    this.maxRows = options?.maxRowsPerSegment ?? DEFAULT_MAX_ROWS;
+    this.maxSegmentBytes = options?.maxBytesPerSegment ?? DEFAULT_MAX_SEGMENT_BYTES;
+    if (!Number.isSafeInteger(this.maxRows) || this.maxRows < 1) {
+      throw new Error("maxRowsPerSegment must be a positive safe integer");
+    }
+    if (!Number.isSafeInteger(this.maxSegmentBytes) || this.maxSegmentBytes < 1) {
+      throw new Error("maxBytesPerSegment must be a positive safe integer");
+    }
+  }
+
+  async appendCommitted(
+    agentId: string,
+    item: AgentTimelineItem,
+    options?: { timestamp?: string; turnId?: string },
+  ): Promise<AgentTimelineRow> {
+    return await this.mutate(agentId, async () => {
+      const context = this.context(agentId);
+      const lease = await context.snapshots.load();
+      try {
+        const row: AgentTimelineRow = {
+          seq: lease.manifest.nextSeq,
+          timestamp: options?.timestamp ?? new Date().toISOString(),
+          item: structuredClone(item),
+          ...(options?.turnId ? { turnId: options.turnId } : {}),
+        };
+        await this.appendRow(context, lease.manifest, row);
+        return cloneRow(row);
+      } finally {
+        lease.release();
+      }
+    });
+  }
+
+  async fetchCommitted(
+    agentId: string,
+    options?: AgentTimelineFetchOptions,
+  ): Promise<AgentTimelineFetchResult> {
+    const context = this.context(agentId);
+    const lease = await context.snapshots.load();
+    try {
+      const manifest = lease.manifest;
+      const direction = options?.direction ?? "tail";
+      const limit = fetchLimit(options);
+      const cursor = options?.cursor;
+      const { rows, staleCursor, gap } = await this.selectFetchRows(
+        context,
+        manifest,
+        direction,
+        cursor,
+        limit,
+      );
+      const reset = staleCursor || gap;
+      const { hasOlder, hasNewer } = fetchNavigationFlags(
+        manifest,
+        direction,
+        cursor?.seq,
+        rows,
+        reset,
+      );
+      return {
+        epoch: manifest.epoch,
+        direction,
+        reset,
+        staleCursor,
+        gap,
+        window: {
+          minSeq: manifest.minSeq,
+          maxSeq: manifest.maxSeq,
+          nextSeq: manifest.nextSeq,
+        },
+        hasOlder,
+        hasNewer,
+        rows,
+      };
+    } finally {
+      lease.release();
+    }
+  }
+
+  async getCommittedRows(agentId: string): Promise<AgentTimelineRow[]> {
+    const context = this.context(agentId);
+    const lease = await context.snapshots.load();
+    try {
+      if (!lease.manifest.root) return [];
+      const rows: AgentTimelineRow[] = [];
+      let cursor = lease.manifest.minSeq - 1;
+      while (cursor < lease.manifest.maxSeq) {
+        const descriptors = await context.catalog.after(lease.manifest.root, cursor, CATALOG_BATCH);
+        if (descriptors.length === 0) break;
+        for (const descriptor of descriptors) {
+          rows.push(...(await this.readSegment(context, descriptor)).rows.map(cloneRow));
+        }
+        cursor = descriptors.at(-1)!.maxSeq;
+      }
+      return rows;
+    } finally {
+      lease.release();
+    }
+  }
+
+  async getLatestCommittedSeq(agentId: string): Promise<number> {
+    const lease = await this.context(agentId).snapshots.load();
+    try {
+      return lease.manifest.maxSeq;
+    } finally {
+      lease.release();
+    }
+  }
+
+  async getLastItem(agentId: string): Promise<AgentTimelineItem | null> {
+    const context = this.context(agentId);
+    const lease = await context.snapshots.load();
+    try {
+      if (!lease.manifest.root) return null;
+      const descriptor = (
+        await context.catalog.before(lease.manifest.root, lease.manifest.nextSeq, 1)
+      )[0]!;
+      return structuredClone((await this.readSegment(context, descriptor)).rows.at(-1)!.item);
+    } finally {
+      lease.release();
+    }
+  }
+
+  async getLastAssistantMessage(agentId: string): Promise<string | null> {
+    const context = this.context(agentId);
+    const lease = await context.snapshots.load();
+    try {
+      const root = lease.manifest.root;
+      const address = root?.summary.lastAssistantRun;
+      if (!address || !root) return null;
+      const chunks: string[] = [];
+      let cursor = address.startSeq - 1;
+      while (cursor < address.endSeq) {
+        const descriptors = await context.catalog.after(root, cursor, CATALOG_BATCH);
+        if (descriptors.length === 0) throw new Error("Assistant address is absent from catalog");
+        for (const descriptor of descriptors) {
+          const segment = await this.readSegment(context, descriptor);
+          chunks.push(...assistantChunks(segment, address));
+          cursor = descriptor.maxSeq;
+          if (cursor >= address.endSeq) break;
+        }
+      }
+      return chunks.join("");
+    } finally {
+      lease.release();
+    }
+  }
+
+  async bulkInsert(agentId: string, candidates: readonly AgentTimelineRow[]): Promise<void> {
+    // Each row is independently published. Multi-row calls are not atomic by design because this
+    // is a regenerable cache; provider history remains the transaction authority.
+    await this.mutate(agentId, async () => {
+      for (const candidate of candidates) await this.insertCandidate(agentId, cloneRow(candidate));
+    });
+  }
+
+  async updateCommittedRow(agentId: string, row: AgentTimelineRow): Promise<void> {
+    await this.mutate(agentId, async () => {
+      const context = this.context(agentId);
+      const lease = await context.snapshots.load();
+      try {
+        const existing = await context.catalog.find(lease.manifest.root, row.seq);
+        if (!existing) throw new Error(`Cannot update missing timeline row sequence ${row.seq}`);
+        const segment = await this.readSegment(context, existing);
+        const index = segment.rows.findIndex((candidate) => candidate.seq === row.seq);
+        if (index < 0) throw new Error(`Cannot update missing timeline row sequence ${row.seq}`);
+        const replacement = buildRowSegment(segment.rows.with(index, cloneRow(row)));
+        await this.publishRoot(context, lease.manifest, async () => {
+          const descriptor = await this.writeSegment(
+            context,
+            lease.manifest.generation + 1,
+            replacement,
+          );
+          return await context.catalog.replace(lease.manifest.root, row.seq, descriptor);
+        });
+      } finally {
+        lease.release();
+      }
+    });
+  }
+
+  async deleteAgent(agentId: string): Promise<void> {
+    await this.mutate(agentId, async () => {
+      await this.context(agentId).snapshots.deleteCache();
+      this.contexts.delete(agentId);
+    });
+  }
+
+  async collectGarbage(agentId: string): Promise<void> {
+    // Explicit maintenance keeps first access bounded; GC walks the complete manifest-owned tree.
+    await this.context(agentId).snapshots.collectGarbage();
+  }
+
+  private async selectFetchRows(
+    context: AgentContext,
+    manifest: TimelineManifest,
+    direction: NonNullable<AgentTimelineFetchOptions["direction"]>,
+    cursor: AgentTimelineFetchOptions["cursor"],
+    requestedLimit: number,
+  ): Promise<{ rows: AgentTimelineRow[]; staleCursor: boolean; gap: boolean }> {
+    const limit =
+      requestedLimit === 0 ? Math.max(0, manifest.maxSeq - manifest.minSeq + 1) : requestedLimit;
+    const staleCursor = cursor?.epoch !== undefined && cursor.epoch !== manifest.epoch;
+    const gap =
+      !staleCursor &&
+      direction === "after" &&
+      cursor !== undefined &&
+      manifest.root !== null &&
+      cursor.seq < manifest.minSeq - 1;
+    if (staleCursor || gap) {
+      const rows = manifest.root
+        ? await this.rowsBefore(context, manifest.root, manifest.nextSeq, limit)
+        : [];
+      return { rows, staleCursor, gap };
+    }
+    if (!manifest.root) return { rows: [], staleCursor: false, gap: false };
+    if (direction === "tail") {
+      return {
+        rows: await this.rowsBefore(context, manifest.root, manifest.nextSeq, limit),
+        staleCursor: false,
+        gap: false,
+      };
+    }
+    const rows =
+      direction === "before"
+        ? await this.rowsBefore(context, manifest.root, cursor?.seq ?? manifest.nextSeq, limit)
+        : await this.rowsAfter(context, manifest.root, cursor?.seq ?? 0, limit);
+    return { rows, staleCursor: false, gap: false };
+  }
+
+  private async insertCandidate(agentId: string, row: AgentTimelineRow): Promise<void> {
+    const context = this.context(agentId);
+    const lease = await context.snapshots.load();
+    try {
+      const descriptor = await context.catalog.find(lease.manifest.root, row.seq);
+      if (descriptor) {
+        const existing = (await this.readSegment(context, descriptor)).rows.find(
+          (candidate) => candidate.seq === row.seq,
+        );
+        if (!existing || !isDeepStrictEqual(existing, row)) {
+          throw new Error(`Conflicting timeline row sequence ${row.seq}`);
+        }
+        return;
+      }
+      if (lease.manifest.root && row.seq !== lease.manifest.nextSeq) {
+        throw new Error("Timeline inserts must append in increasing sequence order");
+      }
+      await this.appendRow(context, lease.manifest, row);
+    } finally {
+      lease.release();
+    }
+  }
+
+  private async appendRow(
+    context: AgentContext,
+    manifest: TimelineManifest,
+    row: AgentTimelineRow,
+  ): Promise<void> {
+    await this.publishRoot(context, manifest, async () => {
+      const last = manifest.root
+        ? (await context.catalog.before(manifest.root, manifest.nextSeq, 1))[0]!
+        : null;
+      if (last) {
+        const current = await this.readSegment(context, last);
+        const extended = buildRowSegment([...current.rows, cloneRow(row)]);
+        const fits =
+          extended.rows.length <= this.maxRows &&
+          Buffer.byteLength(JSON.stringify(extended)) <= this.maxSegmentBytes;
+        if (fits) {
+          const descriptor = await this.writeSegment(context, manifest.generation + 1, extended);
+          return await context.catalog.replace(manifest.root, last.minSeq, descriptor);
+        }
+        const descriptor = await this.writeSegment(
+          context,
+          manifest.generation + 1,
+          buildRowSegment([row]),
+        );
+        return await context.catalog.append(manifest.root, descriptor);
+      }
+      const descriptor = await this.writeSegment(
+        context,
+        manifest.generation + 1,
+        buildRowSegment([row]),
+      );
+      return await context.catalog.append(null, descriptor);
+    });
+  }
+
+  private async publishRoot(
+    context: AgentContext,
+    manifest: TimelineManifest,
+    buildRoot: () => Promise<CatalogPageRef>,
+  ): Promise<void> {
+    const next = await context.snapshots.publish(manifest, async () => {
+      const root = await buildRoot();
+      return {
+        epoch: manifest.epoch,
+        nextSeq: root.maxSeq + 1,
+        minSeq: root.minSeq,
+        maxSeq: root.maxSeq,
+        root,
+      };
+    });
+    this.options?.onManifestWrite?.(Buffer.byteLength(JSON.stringify(next)));
+  }
+
+  private async rowsBefore(
+    context: AgentContext,
+    root: CatalogPageRef,
+    beforeSeq: number,
+    limit: number,
+  ): Promise<AgentTimelineRow[]> {
+    let cursor = beforeSeq;
+    const chunks: AgentTimelineRow[][] = [];
+    let count = 0;
+    while (count < limit) {
+      const descriptor = (await context.catalog.before(root, cursor, 1))[0];
+      if (!descriptor) break;
+      const rows = (await this.readSegment(context, descriptor)).rows
+        .filter((row) => row.seq < beforeSeq)
+        .map(cloneRow);
+      if (rows.length > 0) {
+        chunks.push(rows);
+        count += rows.length;
+      }
+      cursor = descriptor.minSeq;
+    }
+    return chunks.toReversed().flat().slice(-limit);
+  }
+
+  private async rowsAfter(
+    context: AgentContext,
+    root: CatalogPageRef,
+    afterSeq: number,
+    limit: number,
+  ): Promise<AgentTimelineRow[]> {
+    const rows: AgentTimelineRow[] = [];
+    let cursor = afterSeq;
+    while (rows.length < limit) {
+      const descriptor = (await context.catalog.after(root, cursor, 1))[0];
+      if (!descriptor) break;
+      rows.push(
+        ...(await this.readSegment(context, descriptor)).rows
+          .filter((row) => row.seq > afterSeq)
+          .map(cloneRow),
+      );
+      cursor = descriptor.maxSeq;
+    }
+    return rows.slice(0, limit);
+  }
+
+  private async readSegment(
+    context: AgentContext,
+    descriptor: SegmentDescriptor,
+  ): Promise<RowSegment> {
+    const filePath = path.join(context.directory, descriptor.file);
+    this.options?.onSegmentRead?.(filePath);
+    await this.options?.beforeSegmentRead?.(filePath);
+    let segment: RowSegment;
+    try {
+      segment = await readRowSegment(filePath, this.maxSegmentBytes);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new Error(`Corrupt timeline cache: missing segment '${descriptor.file}'`, {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+    if (
+      segment.summary.minSeq !== descriptor.minSeq ||
+      segment.summary.maxSeq !== descriptor.maxSeq ||
+      !isDeepStrictEqual(segment.summary, descriptor.summary)
+    ) {
+      throw new Error("Timeline segment does not match its catalog descriptor");
+    }
+    return segment;
+  }
+
+  private async writeSegment(
+    context: AgentContext,
+    generation: number,
+    segment: RowSegment,
+  ): Promise<SegmentDescriptor> {
+    if (segment.rows.length > this.maxRows) throw new Error("Timeline segment exceeds row limit");
+    const text = encodeRowSegment(segment, this.maxSegmentBytes);
+    const file = `segment-${generation}-${randomUUID()}.json`;
+    const filePath = path.join(context.directory, file);
+    await (this.options?.writeFileAtomic ?? writeFileAtomic)(filePath, text);
+    this.options?.onSegmentWrite?.(filePath, Buffer.byteLength(text));
+    return {
+      file,
+      generation,
+      minSeq: segment.summary.minSeq,
+      maxSeq: segment.summary.maxSeq,
+      summary: segment.summary,
+    };
+  }
+
+  private context(agentId: string): AgentContext {
+    const cached = this.contexts.get(agentId);
+    if (cached) return cached;
+    const directory = this.agentDirectory(agentId);
+    const catalog = new PagedTimelineCatalog(directory, {
+      fanout: this.options?.catalogFanout ?? DEFAULT_CATALOG_FANOUT,
+      maxPageBytes: this.options?.maxCatalogPageBytes ?? DEFAULT_MAX_PAGE_BYTES,
+      onPageRead: this.options?.onCatalogPageRead,
+      writeFileAtomic: this.options?.writeFileAtomic,
+    });
+    const context = {
+      directory,
+      catalog,
+      snapshots: new TimelineSnapshotManager(directory, catalog, {
+        maxManifestBytes: this.options?.maxManifestBytes ?? DEFAULT_MAX_MANIFEST_BYTES,
+        writeFileAtomic: this.options?.writeFileAtomic,
+        mutationLock: { onContention: this.options?.onMutationLockContention },
+      }),
+    };
+    this.contexts.set(agentId, context);
+    return context;
+  }
+
+  private async mutate<T>(agentId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.mutationTails.get(agentId) ?? Promise.resolve();
+    const result = previous.catch(() => undefined).then(operation);
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.mutationTails.set(agentId, tail);
+    void tail.finally(() => {
+      if (this.mutationTails.get(agentId) === tail) this.mutationTails.delete(agentId);
+    });
+    return await result;
+  }
+
+  private agentDirectory(agentId: string): string {
+    return path.join(this.directory, `agent-${Buffer.from(agentId, "utf8").toString("base64url")}`);
+  }
+}
+
+function assistantChunks(
+  segment: RowSegment,
+  address: { startSeq: number; endSeq: number },
+): string[] {
+  return segment.rows
+    .filter((row) => address.startSeq <= row.seq && row.seq <= address.endSeq)
+    .map((row) => {
+      if (row.item.type !== "assistant_message") {
+        throw new Error("Assistant address contains a non-assistant row");
+      }
+      return row.item.text;
+    });
+}
+
+function fetchNavigationFlags(
+  manifest: TimelineManifest,
+  direction: NonNullable<AgentTimelineFetchOptions["direction"]>,
+  cursorSeq: number | undefined,
+  rows: readonly AgentTimelineRow[],
+  reset: boolean,
+): { hasOlder: boolean; hasNewer: boolean } {
+  let hasOlder = rows.length > 0 && rows[0]!.seq > manifest.minSeq;
+  let hasNewer = false;
+  if (!reset && direction === "after") {
+    if (rows.length === 0) hasOlder = (cursorSeq ?? 0) >= manifest.minSeq && manifest.root !== null;
+    hasNewer = rows.length > 0 && rows.at(-1)!.seq < manifest.maxSeq;
+  } else if (!reset && direction === "before") {
+    hasNewer = manifest.root !== null && (cursorSeq ?? manifest.nextSeq) <= manifest.maxSeq;
+  }
+  return { hasOlder, hasNewer };
+}

--- a/packages/server/src/server/agent/timeline-cache/cache-validation.ts
+++ b/packages/server/src/server/agent/timeline-cache/cache-validation.ts
@@ -1,0 +1,89 @@
+import type { CatalogPageRef } from "./paged-catalog.js";
+import type { SegmentDescriptor, TimelineSummary } from "./row-segment.js";
+
+const CATALOG_FILE = /^catalog-[0-9a-f-]{36}\.json$/;
+const SEGMENT_FILE = /^segment-([0-9]+)-[0-9a-f-]{36}\.json$/;
+
+export function validateCatalogRef(value: unknown): asserts value is CatalogPageRef {
+  if (!value || typeof value !== "object") throw new Error("Invalid catalog reference");
+  const ref = value as Partial<CatalogPageRef>;
+  if (
+    typeof ref.file !== "string" ||
+    !CATALOG_FILE.test(ref.file) ||
+    !positive(ref.minSeq) ||
+    !positive(ref.maxSeq) ||
+    ref.minSeq > ref.maxSeq
+  ) {
+    throw new Error("Invalid catalog reference");
+  }
+  validateSummary(ref.summary);
+  if (ref.summary.minSeq !== ref.minSeq || ref.summary.maxSeq !== ref.maxSeq) {
+    throw new Error("Catalog reference summary mismatch");
+  }
+}
+
+export function validateDescriptor(value: unknown): asserts value is SegmentDescriptor {
+  if (!value || typeof value !== "object") throw new Error("Invalid segment descriptor");
+  const descriptor = value as Partial<SegmentDescriptor>;
+  const match = typeof descriptor.file === "string" ? SEGMENT_FILE.exec(descriptor.file) : null;
+  if (
+    !match ||
+    !positive(descriptor.generation) ||
+    Number(match[1]) !== descriptor.generation ||
+    !positive(descriptor.minSeq) ||
+    !positive(descriptor.maxSeq) ||
+    descriptor.minSeq > descriptor.maxSeq
+  ) {
+    throw new Error("Invalid segment descriptor");
+  }
+  validateSummary(descriptor.summary);
+  if (
+    descriptor.summary.minSeq !== descriptor.minSeq ||
+    descriptor.summary.maxSeq !== descriptor.maxSeq
+  ) {
+    throw new Error("Segment descriptor summary mismatch");
+  }
+}
+
+export function validateSummary(value: unknown): asserts value is TimelineSummary {
+  if (!value || typeof value !== "object") throw new Error("Invalid timeline summary");
+  const summary = value as Partial<TimelineSummary>;
+  if (
+    !positive(summary.minSeq) ||
+    !positive(summary.maxSeq) ||
+    summary.minSeq > summary.maxSeq ||
+    typeof summary.firstItemType !== "string" ||
+    typeof summary.lastItemType !== "string"
+  ) {
+    throw new Error("Invalid timeline summary");
+  }
+  const trailing = summary.trailingAssistantStartSeq;
+  if (!(trailing === null || inRange(trailing, summary.minSeq, summary.maxSeq))) {
+    throw new Error("Invalid trailing assistant address");
+  }
+  const run = summary.lastAssistantRun;
+  if (
+    run !== null &&
+    (!run ||
+      !inRange(run.startSeq, summary.minSeq, summary.maxSeq) ||
+      !inRange(run.endSeq, run.startSeq, summary.maxSeq))
+  ) {
+    throw new Error("Invalid assistant run address");
+  }
+}
+
+export function validateOrderedRanges(values: readonly { minSeq: number; maxSeq: number }[]): void {
+  for (let index = 1; index < values.length; index += 1) {
+    if (values[index - 1]!.maxSeq >= values[index]!.minSeq) {
+      throw new Error("Catalog ranges overlap or are out of order");
+    }
+  }
+}
+
+function positive(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+function inRange(value: unknown, min: number, max: number): value is number {
+  return positive(value) && min <= value && value <= max;
+}

--- a/packages/server/src/server/agent/timeline-cache/file-mutation-lock.test.ts
+++ b/packages/server/src/server/agent/timeline-cache/file-mutation-lock.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, readFile, readdir, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { withTimelineMutationLock } from "./file-mutation-lock.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+describe("withTimelineMutationLock", () => {
+  it("fails closed instead of stealing an existing lock", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-timeline-lock-"));
+    directories.push(directory);
+    const first = deferred<void>();
+    const firstAcquired = deferred<void>();
+
+    const owner = withTimelineMutationLock(
+      directory,
+      async () => {
+        firstAcquired.resolve();
+        await first.promise;
+      },
+      { createToken: () => "current-owner" },
+    );
+    await firstAcquired.promise;
+    await expect(
+      withTimelineMutationLock(directory, async () => undefined, {
+        retries: 1,
+        retryMs: 0,
+        createToken: () => "contending-owner",
+      }),
+    ).rejects.toThrow("Timed out acquiring timeline mutation lock");
+
+    first.resolve();
+    await owner;
+    await expect(
+      withTimelineMutationLock(directory, async () => "acquired", {
+        retries: 1,
+        retryMs: 0,
+        createToken: () => "next-owner",
+      }),
+    ).resolves.toBe("acquired");
+  });
+
+  it("does not let an old owner release an adversarial replacement lock", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-timeline-lock-"));
+    directories.push(directory);
+    const releaseOwner = deferred<void>();
+    const ownerAcquired = deferred<void>();
+    const lockPath = path.join(directory, ".timeline-write.lock");
+    const owner = withTimelineMutationLock(
+      directory,
+      async () => {
+        ownerAcquired.resolve();
+        await releaseOwner.promise;
+      },
+      { createToken: () => "original-owner" },
+    );
+    await ownerAcquired.promise;
+    await unlink(lockPath);
+    const replacement = { token: "replacement-owner", pid: process.pid, createdAt: Date.now() };
+    await writeFile(lockPath, JSON.stringify(replacement), { flag: "wx" });
+
+    releaseOwner.resolve();
+    await owner;
+
+    await expect(readFile(lockPath, "utf8")).resolves.toBe(JSON.stringify(replacement));
+  });
+
+  it("rejects unsafe owner tokens before constructing a cache pathname", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-timeline-lock-"));
+    directories.push(directory);
+
+    await expect(
+      withTimelineMutationLock(directory, async () => undefined, {
+        createToken: () => "../escape",
+      }),
+    ).rejects.toThrow("Invalid timeline mutation lock token");
+    await expect(readdir(directory)).resolves.toEqual([]);
+  });
+});
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}

--- a/packages/server/src/server/agent/timeline-cache/file-mutation-lock.ts
+++ b/packages/server/src/server/agent/timeline-cache/file-mutation-lock.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from "node:crypto";
+import { link, readFile, stat, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_RETRIES = 200;
+const DEFAULT_RETRY_MS = 5;
+const MAX_LOCK_BYTES = 512;
+const SAFE_TOKEN = /^[A-Za-z0-9_-]{1,128}$/;
+
+interface LockOwner {
+  token: string;
+  pid: number;
+  createdAt: number;
+}
+
+export interface TimelineMutationLockOptions {
+  retries?: number;
+  retryMs?: number;
+  createToken?: () => string;
+  onContention?: () => void;
+}
+
+/**
+ * Serializes timeline cache mutations without stealing an existing lock. A lock left by a crashed
+ * process is recovered only by explicitly deleting/resetting the disposable cache while no store
+ * is active; runtime ownership cannot safely infer that another process is dead.
+ */
+export async function withTimelineMutationLock<T>(
+  directory: string,
+  operation: () => Promise<T>,
+  options?: TimelineMutationLockOptions,
+): Promise<T> {
+  const retries = options?.retries ?? DEFAULT_RETRIES;
+  const retryMs = options?.retryMs ?? DEFAULT_RETRY_MS;
+  validatePositiveInteger(retries, "retries");
+  validateNonnegativeInteger(retryMs, "retryMs");
+
+  const lockPath = path.join(directory, ".timeline-write.lock");
+  const token = options?.createToken?.() ?? randomUUID();
+  if (!SAFE_TOKEN.test(token)) throw new Error("Invalid timeline mutation lock token");
+  const owner: LockOwner = {
+    token,
+    pid: process.pid,
+    createdAt: Date.now(),
+  };
+  const ownerPath = path.join(directory, `.timeline-write-lock-${owner.token}.tmp`);
+  await writeFile(ownerPath, JSON.stringify(owner), { flag: "wx" });
+  try {
+    for (let attempt = 0; attempt < retries; attempt += 1) {
+      try {
+        await link(ownerPath, lockPath);
+        const identity = await stat(ownerPath);
+        try {
+          return await operation();
+        } finally {
+          await releaseIfOwner(lockPath, owner.token, identity.dev, identity.ino);
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        options?.onContention?.();
+        await readOwner(lockPath);
+        if (retryMs > 0) await new Promise((resolve) => setTimeout(resolve, retryMs));
+      }
+    }
+    throw new Error("Timed out acquiring timeline mutation lock");
+  } finally {
+    await unlink(ownerPath).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") throw error;
+    });
+  }
+}
+
+async function releaseIfOwner(
+  lockPath: string,
+  token: string,
+  expectedDevice: number,
+  expectedInode: number,
+): Promise<void> {
+  const lockStat = await stat(lockPath).catch(() => null);
+  if (lockStat?.dev !== expectedDevice || lockStat.ino !== expectedInode) return;
+  if ((await readOwner(lockPath))?.token !== token) return;
+  await unlink(lockPath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== "ENOENT") throw error;
+  });
+}
+
+async function readOwner(lockPath: string): Promise<LockOwner | null> {
+  let lockStat;
+  try {
+    lockStat = await stat(lockPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  if (!lockStat.isFile() || lockStat.size > MAX_LOCK_BYTES) {
+    throw new Error("Invalid timeline mutation lock");
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(await readFile(lockPath, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new Error("Invalid timeline mutation lock", { cause: error });
+  }
+  if (!value || typeof value !== "object") throw new Error("Invalid timeline mutation lock");
+  const owner = value as Partial<LockOwner>;
+  if (
+    typeof owner.token !== "string" ||
+    !SAFE_TOKEN.test(owner.token) ||
+    !Number.isSafeInteger(owner.pid) ||
+    owner.pid! < 0 ||
+    !Number.isSafeInteger(owner.createdAt) ||
+    owner.createdAt! < 0
+  ) {
+    throw new Error("Invalid timeline mutation lock");
+  }
+  return owner as LockOwner;
+}
+
+function validatePositiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+}
+
+function validateNonnegativeInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a nonnegative safe integer`);
+  }
+}

--- a/packages/server/src/server/agent/timeline-cache/paged-catalog.test.ts
+++ b/packages/server/src/server/agent/timeline-cache/paged-catalog.test.ts
@@ -1,0 +1,139 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PagedTimelineCatalog } from "./paged-catalog.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+describe("PagedTimelineCatalog", () => {
+  it("copy-on-write appends and locates far ranges through bounded fanout pages", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-catalog-"));
+    directories.push(directory);
+    let pageReads = 0;
+    const catalog = new PagedTimelineCatalog(directory, {
+      fanout: 3,
+      maxPageBytes: 2_048,
+      onPageRead: () => {
+        pageReads += 1;
+      },
+    });
+    let root = null;
+    for (let seq = 1; seq <= 100; seq += 1) root = await catalog.append(root, descriptor(seq));
+
+    pageReads = 0;
+    await expect(catalog.find(root, 2)).resolves.toMatchObject({ minSeq: 2, maxSeq: 2 });
+    expect(pageReads).toBeLessThanOrEqual(6);
+    pageReads = 0;
+    await expect(catalog.find(root, 99)).resolves.toMatchObject({ minSeq: 99, maxSeq: 99 });
+    expect(pageReads).toBeLessThanOrEqual(6);
+  });
+
+  it("pages before and after a far cursor without reading unrelated catalog branches", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-catalog-"));
+    directories.push(directory);
+    let pageReads = 0;
+    const catalog = new PagedTimelineCatalog(directory, {
+      fanout: 3,
+      maxPageBytes: 2_048,
+      onPageRead: () => {
+        pageReads += 1;
+      },
+    });
+    let root = null;
+    for (let seq = 1; seq <= 100; seq += 1) root = await catalog.append(root, descriptor(seq));
+
+    pageReads = 0;
+    await expect(catalog.before(root, 51, 2)).resolves.toMatchObject([
+      { minSeq: 49 },
+      { minSeq: 50 },
+    ]);
+    expect(pageReads).toBeLessThanOrEqual(7);
+    pageReads = 0;
+    await expect(catalog.after(root, 50, 2)).resolves.toMatchObject([
+      { minSeq: 51 },
+      { minSeq: 52 },
+    ]);
+    expect(pageReads).toBeLessThanOrEqual(7);
+  });
+
+  it("replaces one descriptor with copy-on-write pages", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-catalog-"));
+    directories.push(directory);
+    const catalog = new PagedTimelineCatalog(directory, { fanout: 3, maxPageBytes: 2_048 });
+    let root = null;
+    for (let seq = 1; seq <= 12; seq += 1) root = await catalog.append(root, descriptor(seq));
+    const replacement = {
+      ...descriptor(6),
+      file: "segment-20-ffffffff-0000-4000-8000-000000000000.json",
+      generation: 20,
+    };
+
+    const replaced = await catalog.replace(root, 6, replacement);
+
+    await expect(catalog.find(replaced, 6)).resolves.toEqual(replacement);
+    await expect(catalog.find(root, 6)).resolves.toEqual(descriptor(6));
+  });
+
+  it("rejects path escapes, cycles, and excessive depth before opening descendants", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-catalog-"));
+    directories.push(directory);
+    const summary = descriptor(1).summary;
+    const escaped = { file: "../escape.json", minSeq: 1, maxSeq: 1, summary };
+    await expect(new PagedTimelineCatalog(directory).find(escaped, 1)).rejects.toThrow(
+      "Invalid catalog reference",
+    );
+
+    const cycleFile = "catalog-00000000-0000-4000-8000-000000000001.json";
+    const cycleRef = { file: cycleFile, minSeq: 1, maxSeq: 1, summary };
+    await writeFile(
+      path.join(directory, cycleFile),
+      JSON.stringify({ version: 1, kind: "internal", children: [cycleRef] }),
+    );
+    await expect(new PagedTimelineCatalog(directory).find(cycleRef, 1)).rejects.toThrow(
+      "Catalog page cycle detected",
+    );
+
+    const files = [2, 3, 4].map(
+      (suffix) => `catalog-00000000-0000-4000-8000-${String(suffix).padStart(12, "0")}.json`,
+    );
+    const refs = files.map((file) => ({ file, minSeq: 1, maxSeq: 1, summary }));
+    await writeFile(
+      path.join(directory, files[2]!),
+      JSON.stringify({ version: 1, kind: "leaf", entries: [descriptor(1)] }),
+    );
+    await writeFile(
+      path.join(directory, files[1]!),
+      JSON.stringify({ version: 1, kind: "internal", children: [refs[2]] }),
+    );
+    await writeFile(
+      path.join(directory, files[0]!),
+      JSON.stringify({ version: 1, kind: "internal", children: [refs[1]] }),
+    );
+    await expect(
+      new PagedTimelineCatalog(directory, { maxTraversalDepth: 2 }).find(refs[0]!, 1),
+    ).rejects.toThrow("Catalog traversal depth exceeded");
+  });
+});
+
+function descriptor(seq: number) {
+  return {
+    file: `segment-${seq}-${String(seq).padStart(8, "0")}-0000-4000-8000-000000000000.json`,
+    generation: seq,
+    minSeq: seq,
+    maxSeq: seq,
+    summary: {
+      minSeq: seq,
+      maxSeq: seq,
+      firstItemType: "user_message",
+      lastItemType: "user_message",
+      trailingAssistantStartSeq: null,
+      lastAssistantRun: null,
+    },
+  };
+}

--- a/packages/server/src/server/agent/timeline-cache/paged-catalog.ts
+++ b/packages/server/src/server/agent/timeline-cache/paged-catalog.ts
@@ -1,0 +1,353 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import { writeFileAtomic } from "../../atomic-file.js";
+import {
+  validateCatalogRef,
+  validateDescriptor,
+  validateOrderedRanges,
+} from "./cache-validation.js";
+import type { SegmentDescriptor, TimelineSummary } from "./row-segment.js";
+import { combineTimelineSummaries } from "./row-segment.js";
+import { readJsonFileCapped } from "./safe-json-file.js";
+
+export interface CatalogPageRef {
+  file: string;
+  minSeq: number;
+  maxSeq: number;
+  summary: TimelineSummary;
+}
+
+interface LeafPage {
+  version: 1;
+  kind: "leaf";
+  entries: SegmentDescriptor[];
+}
+
+interface InternalPage {
+  version: 1;
+  kind: "internal";
+  children: CatalogPageRef[];
+}
+
+type CatalogPage = LeafPage | InternalPage;
+
+export interface PagedTimelineCatalogOptions {
+  fanout?: number;
+  maxPageBytes?: number;
+  onPageRead?: (filePath: string) => void;
+  writeFileAtomic?: (filePath: string, data: string) => Promise<void>;
+  maxTraversalDepth?: number;
+}
+
+export interface CatalogReachability {
+  pageFiles: Set<string>;
+  segments: SegmentDescriptor[];
+}
+
+const DEFAULT_FANOUT = 64;
+const DEFAULT_MAX_PAGE_BYTES = 64 * 1024;
+const DEFAULT_MAX_TRAVERSAL_DEPTH = 32;
+
+export class PagedTimelineCatalog {
+  private readonly fanout: number;
+  private readonly maxPageBytes: number;
+  private readonly onPageRead?: (filePath: string) => void;
+  private readonly writeAtomic: (filePath: string, data: string) => Promise<void>;
+  private readonly maxTraversalDepth: number;
+
+  constructor(
+    private readonly directory: string,
+    options?: PagedTimelineCatalogOptions,
+  ) {
+    this.fanout = options?.fanout ?? DEFAULT_FANOUT;
+    this.maxPageBytes = options?.maxPageBytes ?? DEFAULT_MAX_PAGE_BYTES;
+    this.onPageRead = options?.onPageRead;
+    this.writeAtomic = options?.writeFileAtomic ?? writeFileAtomic;
+    this.maxTraversalDepth = options?.maxTraversalDepth ?? DEFAULT_MAX_TRAVERSAL_DEPTH;
+    if (!Number.isSafeInteger(this.fanout) || this.fanout < 2) {
+      throw new Error("fanout must be a safe integer of at least 2");
+    }
+    if (!Number.isSafeInteger(this.maxPageBytes) || this.maxPageBytes < 1) {
+      throw new Error("maxPageBytes must be a positive safe integer");
+    }
+    if (!Number.isSafeInteger(this.maxTraversalDepth) || this.maxTraversalDepth < 1) {
+      throw new Error("maxTraversalDepth must be a positive safe integer");
+    }
+  }
+
+  async append(
+    root: CatalogPageRef | null,
+    descriptor: SegmentDescriptor,
+  ): Promise<CatalogPageRef> {
+    validateDescriptor(descriptor);
+    if (!root) return await this.writePage({ version: 1, kind: "leaf", entries: [descriptor] });
+    validateCatalogRef(root);
+    if (root.maxSeq >= descriptor.minSeq) {
+      throw new Error("Catalog append ranges must be strictly increasing");
+    }
+    const replacements = await this.appendToPage(root, descriptor);
+    if (replacements.length === 1) return replacements[0]!;
+    return await this.writePage({ version: 1, kind: "internal", children: replacements });
+  }
+
+  async find(root: CatalogPageRef | null, seq: number): Promise<SegmentDescriptor | null> {
+    let current = root;
+    const visited = new Set<string>();
+    let depth = 0;
+    while (current) {
+      validateCatalogRef(current);
+      if (visited.has(current.file)) throw new Error("Catalog page cycle detected");
+      if (depth >= this.maxTraversalDepth) throw new Error("Catalog traversal depth exceeded");
+      visited.add(current.file);
+      depth += 1;
+      if (seq < current.minSeq || seq > current.maxSeq) return null;
+      const page = await this.readPage(current);
+      if (page.kind === "leaf") {
+        return page.entries.find((entry) => entry.minSeq <= seq && seq <= entry.maxSeq) ?? null;
+      }
+      current = binaryFindRange(page.children, seq);
+    }
+    return null;
+  }
+
+  async before(
+    root: CatalogPageRef | null,
+    beforeSeq: number,
+    limit: number,
+  ): Promise<SegmentDescriptor[]> {
+    if (!root || limit <= 0) return [];
+    const descending: SegmentDescriptor[] = [];
+    await this.collectBefore(root, beforeSeq, limit, descending);
+    return descending.toReversed();
+  }
+
+  async after(
+    root: CatalogPageRef | null,
+    afterSeq: number,
+    limit: number,
+  ): Promise<SegmentDescriptor[]> {
+    if (!root || limit <= 0) return [];
+    const ascending: SegmentDescriptor[] = [];
+    await this.collectAfter(root, afterSeq, limit, ascending);
+    return ascending;
+  }
+
+  async collectReachable(root: CatalogPageRef | null): Promise<CatalogReachability> {
+    const result: CatalogReachability = { pageFiles: new Set(), segments: [] };
+    if (root) await this.collectReachablePage(root, result);
+    return result;
+  }
+
+  async replace(
+    root: CatalogPageRef | null,
+    seq: number,
+    descriptor: SegmentDescriptor,
+  ): Promise<CatalogPageRef> {
+    validateDescriptor(descriptor);
+    if (!root) throw new Error(`Cannot replace missing catalog sequence ${seq}`);
+    if (descriptor.minSeq > seq || descriptor.maxSeq < seq) {
+      throw new Error("Replacement descriptor does not contain the target sequence");
+    }
+    return await this.replaceInPage(root, seq, descriptor);
+  }
+
+  private async replaceInPage(
+    ref: CatalogPageRef,
+    seq: number,
+    descriptor: SegmentDescriptor,
+  ): Promise<CatalogPageRef> {
+    const page = await this.readPage(ref);
+    if (page.kind === "leaf") {
+      const index = page.entries.findIndex((entry) => entry.minSeq <= seq && seq <= entry.maxSeq);
+      if (index < 0) throw new Error(`Cannot replace missing catalog sequence ${seq}`);
+      const entries = page.entries.with(index, descriptor);
+      return await this.writePage({ version: 1, kind: "leaf", entries });
+    }
+    const index = page.children.findIndex((child) => child.minSeq <= seq && seq <= child.maxSeq);
+    if (index < 0) throw new Error(`Cannot replace missing catalog sequence ${seq}`);
+    const replacement = await this.replaceInPage(page.children[index]!, seq, descriptor);
+    const children = page.children.with(index, replacement);
+    return await this.writePage({ version: 1, kind: "internal", children });
+  }
+
+  private async collectReachablePage(
+    ref: CatalogPageRef,
+    result: CatalogReachability,
+    depth = 0,
+  ): Promise<void> {
+    validateCatalogRef(ref);
+    if (result.pageFiles.has(ref.file)) throw new Error("Catalog page cycle detected");
+    if (depth >= this.maxTraversalDepth) throw new Error("Catalog traversal depth exceeded");
+    result.pageFiles.add(ref.file);
+    const page = await this.readPage(ref);
+    if (page.kind === "leaf") {
+      result.segments.push(...page.entries);
+      return;
+    }
+    for (const child of page.children) await this.collectReachablePage(child, result, depth + 1);
+  }
+
+  private async collectBefore(
+    ref: CatalogPageRef,
+    beforeSeq: number,
+    limit: number,
+    output: SegmentDescriptor[],
+    depth = 0,
+  ): Promise<void> {
+    if (ref.minSeq >= beforeSeq || output.length >= limit) return;
+    if (depth >= this.maxTraversalDepth) throw new Error("Catalog traversal depth exceeded");
+    const page = await this.readPage(ref);
+    const values = page.kind === "leaf" ? page.entries : page.children;
+    for (let index = values.length - 1; index >= 0 && output.length < limit; index -= 1) {
+      const value = values[index]!;
+      if (value.minSeq >= beforeSeq) continue;
+      if (page.kind === "leaf") output.push(value as SegmentDescriptor);
+      else await this.collectBefore(value as CatalogPageRef, beforeSeq, limit, output, depth + 1);
+    }
+  }
+
+  private async collectAfter(
+    ref: CatalogPageRef,
+    afterSeq: number,
+    limit: number,
+    output: SegmentDescriptor[],
+    depth = 0,
+  ): Promise<void> {
+    if (ref.maxSeq <= afterSeq || output.length >= limit) return;
+    if (depth >= this.maxTraversalDepth) throw new Error("Catalog traversal depth exceeded");
+    const page = await this.readPage(ref);
+    const values = page.kind === "leaf" ? page.entries : page.children;
+    for (const value of values) {
+      if (output.length >= limit) return;
+      if (value.maxSeq <= afterSeq) continue;
+      if (page.kind === "leaf") output.push(value as SegmentDescriptor);
+      else await this.collectAfter(value as CatalogPageRef, afterSeq, limit, output, depth + 1);
+    }
+  }
+
+  private async appendToPage(
+    ref: CatalogPageRef,
+    descriptor: SegmentDescriptor,
+  ): Promise<CatalogPageRef[]> {
+    const page = await this.readPage(ref);
+    if (page.kind === "leaf") {
+      return await this.writeSplitPages("leaf", [...page.entries, descriptor]);
+    }
+    const replacements = await this.appendToPage(page.children.at(-1)!, descriptor);
+    return await this.writeSplitPages("internal", [...page.children.slice(0, -1), ...replacements]);
+  }
+
+  private async writeSplitPages(
+    kind: "leaf",
+    values: SegmentDescriptor[],
+  ): Promise<CatalogPageRef[]>;
+  private async writeSplitPages(
+    kind: "internal",
+    values: CatalogPageRef[],
+  ): Promise<CatalogPageRef[]>;
+  private async writeSplitPages(
+    kind: "leaf" | "internal",
+    values: SegmentDescriptor[] | CatalogPageRef[],
+  ): Promise<CatalogPageRef[]> {
+    if (values.length <= this.fanout) {
+      return [
+        await this.writePage(
+          kind === "leaf"
+            ? { version: 1, kind, entries: values as SegmentDescriptor[] }
+            : { version: 1, kind, children: values as CatalogPageRef[] },
+        ),
+      ];
+    }
+    const middle = Math.ceil(values.length / 2);
+    const left = values.slice(0, middle);
+    const right = values.slice(middle);
+    return await Promise.all([
+      this.writePage(
+        kind === "leaf"
+          ? { version: 1, kind, entries: left as SegmentDescriptor[] }
+          : { version: 1, kind, children: left as CatalogPageRef[] },
+      ),
+      this.writePage(
+        kind === "leaf"
+          ? { version: 1, kind, entries: right as SegmentDescriptor[] }
+          : { version: 1, kind, children: right as CatalogPageRef[] },
+      ),
+    ]);
+  }
+
+  private async writePage(page: CatalogPage): Promise<CatalogPageRef> {
+    validatePage(page, this.fanout);
+    const summary = summarizePage(page);
+    const text = JSON.stringify(page);
+    if (Buffer.byteLength(text) > this.maxPageBytes) {
+      throw new Error(`Catalog page exceeds the ${this.maxPageBytes}-byte limit`);
+    }
+    const file = `catalog-${randomUUID()}.json`;
+    await this.writeAtomic(path.join(this.directory, file), text);
+    return { file, minSeq: summary.minSeq, maxSeq: summary.maxSeq, summary };
+  }
+
+  private async readPage(ref: CatalogPageRef): Promise<CatalogPage> {
+    validateCatalogRef(ref);
+    const filePath = path.join(this.directory, ref.file);
+    this.onPageRead?.(filePath);
+    const page = validatePage(await readJsonFileCapped(filePath, this.maxPageBytes), this.fanout);
+    const summary = summarizePage(page);
+    if (
+      summary.minSeq !== ref.minSeq ||
+      summary.maxSeq !== ref.maxSeq ||
+      JSON.stringify(summary) !== JSON.stringify(ref.summary)
+    ) {
+      throw new Error("Catalog page contents do not match their reference");
+    }
+    return page;
+  }
+}
+
+function summarizePage(page: CatalogPage): TimelineSummary {
+  const values = page.kind === "leaf" ? page.entries : page.children;
+  if (values.length === 0) throw new Error("Catalog pages must not be empty");
+  return values
+    .slice(1)
+    .reduce(
+      (summary, value) => combineTimelineSummaries(summary, value.summary),
+      values[0]!.summary,
+    );
+}
+
+function validatePage(value: unknown, fanout: number): CatalogPage {
+  if (!value || typeof value !== "object") throw new Error("Invalid catalog page");
+  const candidate = value as {
+    version?: unknown;
+    kind?: unknown;
+    entries?: unknown;
+    children?: unknown;
+  };
+  if (candidate.version !== 1 || (candidate.kind !== "leaf" && candidate.kind !== "internal")) {
+    throw new Error("Invalid catalog page");
+  }
+  const values = candidate.kind === "leaf" ? candidate.entries : candidate.children;
+  if (!Array.isArray(values) || values.length < 1 || values.length > fanout) {
+    throw new Error("Invalid catalog page fanout");
+  }
+  for (const entry of values) {
+    if (candidate.kind === "leaf") validateDescriptor(entry);
+    else validateCatalogRef(entry);
+  }
+  validateOrderedRanges(values as Array<{ minSeq: number; maxSeq: number }>);
+  return candidate as CatalogPage;
+}
+
+function binaryFindRange(values: readonly CatalogPageRef[], seq: number): CatalogPageRef | null {
+  let low = 0;
+  let high = values.length - 1;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const value = values[middle]!;
+    if (seq < value.minSeq) high = middle - 1;
+    else if (seq > value.maxSeq) low = middle + 1;
+    else return value;
+  }
+  return null;
+}

--- a/packages/server/src/server/agent/timeline-cache/row-segment.test.ts
+++ b/packages/server/src/server/agent/timeline-cache/row-segment.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRowSegment,
+  combineTimelineSummaries,
+  encodeRowSegment,
+  readRowSegment,
+} from "./row-segment.js";
+
+describe("row segments", () => {
+  it("records an address for the latest assistant run without scanning older rows", () => {
+    const left = buildRowSegment([
+      row(1, "user_message", "question"),
+      row(2, "assistant_message", "part one"),
+    ]);
+    const right = buildRowSegment([
+      row(3, "assistant_message", "part two"),
+      row(4, "user_message", "tool result"),
+    ]);
+
+    expect(combineTimelineSummaries(left.summary, right.summary)).toEqual({
+      minSeq: 1,
+      maxSeq: 4,
+      firstItemType: "user_message",
+      lastItemType: "user_message",
+      trailingAssistantStartSeq: null,
+      lastAssistantRun: { startSeq: 2, endSeq: 3 },
+    });
+  });
+
+  it("enforces the encoded segment limit on write and before read allocation", async () => {
+    const segment = buildRowSegment([row(1, "user_message", "x".repeat(256))]);
+    expect(() => encodeRowSegment(segment, 64)).toThrow("segment exceeds the 64-byte limit");
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-row-segment-"));
+    const file = path.join(directory, "segment.json");
+    await writeFile(file, JSON.stringify(segment));
+    await expect(readRowSegment(file, 64)).rejects.toThrow("JSON file exceeds the 64-byte limit");
+    await rm(directory, { recursive: true });
+  });
+});
+
+function row(seq: number, type: "user_message" | "assistant_message", text: string) {
+  return { seq, timestamp: "2026-08-31T12:00:00.000Z", item: { type, text } };
+}

--- a/packages/server/src/server/agent/timeline-cache/row-segment.ts
+++ b/packages/server/src/server/agent/timeline-cache/row-segment.ts
@@ -1,0 +1,142 @@
+import type { AgentTimelineRow } from "../agent-timeline-store-types.js";
+import { AgentTimelineItemPayloadSchema } from "@getpaseo/protocol/messages";
+import { z } from "zod";
+
+import { readJsonFileCapped } from "./safe-json-file.js";
+
+export interface AssistantRunAddress {
+  startSeq: number;
+  endSeq: number;
+}
+
+export interface TimelineSummary {
+  minSeq: number;
+  maxSeq: number;
+  firstItemType: string;
+  lastItemType: string;
+  trailingAssistantStartSeq: number | null;
+  lastAssistantRun: AssistantRunAddress | null;
+}
+
+export interface RowSegment {
+  version: 1;
+  rows: AgentTimelineRow[];
+  summary: TimelineSummary;
+}
+
+export interface SegmentDescriptor {
+  file: string;
+  generation: number;
+  minSeq: number;
+  maxSeq: number;
+  summary: TimelineSummary;
+}
+
+const TimelineSummarySchema = z.object({
+  minSeq: z.number().int().positive(),
+  maxSeq: z.number().int().positive(),
+  firstItemType: z.string(),
+  lastItemType: z.string(),
+  trailingAssistantStartSeq: z.number().int().positive().nullable(),
+  lastAssistantRun: z
+    .object({ startSeq: z.number().int().positive(), endSeq: z.number().int().positive() })
+    .nullable(),
+});
+const RowSegmentSchema: z.ZodType<RowSegment> = z.object({
+  version: z.literal(1),
+  rows: z
+    .array(
+      z.object({
+        seq: z.number().int().positive(),
+        timestamp: z.string(),
+        item: AgentTimelineItemPayloadSchema,
+        turnId: z.string().optional(),
+        providerMessageId: z.string().optional(),
+      }),
+    )
+    .min(1),
+  summary: TimelineSummarySchema,
+});
+
+export function buildRowSegment(rows: readonly AgentTimelineRow[]): RowSegment {
+  if (rows.length === 0) throw new Error("Timeline segment must contain at least one row");
+  let previousSeq = 0;
+  let currentAssistantStart: number | null = null;
+  let lastAssistantRun: AssistantRunAddress | null = null;
+  for (const row of rows) {
+    if (row.seq <= previousSeq) {
+      throw new Error("Timeline rows must have strictly increasing sequence numbers");
+    }
+    previousSeq = row.seq;
+    if (row.item.type === "assistant_message") {
+      currentAssistantStart ??= row.seq;
+      lastAssistantRun = { startSeq: currentAssistantStart, endSeq: row.seq };
+    } else {
+      currentAssistantStart = null;
+    }
+  }
+  return {
+    version: 1,
+    rows: rows.map((row) => ({ ...row, item: structuredClone(row.item) })),
+    summary: {
+      minSeq: rows[0]!.seq,
+      maxSeq: rows.at(-1)!.seq,
+      firstItemType: rows[0]!.item.type,
+      lastItemType: rows.at(-1)!.item.type,
+      trailingAssistantStartSeq: currentAssistantStart,
+      lastAssistantRun,
+    },
+  };
+}
+
+export function combineTimelineSummaries(
+  left: TimelineSummary,
+  right: TimelineSummary,
+): TimelineSummary {
+  if (left.maxSeq >= right.minSeq) throw new Error("Timeline summary ranges must not overlap");
+  let lastAssistantRun = right.lastAssistantRun ?? left.lastAssistantRun;
+  if (
+    right.lastAssistantRun?.startSeq === right.minSeq &&
+    right.firstItemType === "assistant_message" &&
+    left.trailingAssistantStartSeq !== null
+  ) {
+    lastAssistantRun = {
+      startSeq: left.trailingAssistantStartSeq,
+      endSeq: right.lastAssistantRun.endSeq,
+    };
+  }
+  let trailingAssistantStartSeq = right.trailingAssistantStartSeq;
+  if (trailingAssistantStartSeq === right.minSeq && left.trailingAssistantStartSeq !== null) {
+    trailingAssistantStartSeq = left.trailingAssistantStartSeq;
+  }
+  return {
+    minSeq: left.minSeq,
+    maxSeq: right.maxSeq,
+    firstItemType: left.firstItemType,
+    lastItemType: right.lastItemType,
+    trailingAssistantStartSeq,
+    lastAssistantRun,
+  };
+}
+
+export function encodeRowSegment(segment: RowSegment, maxBytes: number): string {
+  const parsed = validateRowSegment(segment);
+  const text = JSON.stringify(parsed);
+  if (Buffer.byteLength(text) > maxBytes) {
+    throw new Error(`Timeline segment exceeds the ${maxBytes}-byte limit`);
+  }
+  return text;
+}
+
+export async function readRowSegment(filePath: string, maxBytes: number): Promise<RowSegment> {
+  return validateRowSegment(await readJsonFileCapped(filePath, maxBytes));
+}
+
+function validateRowSegment(value: unknown): RowSegment {
+  const segment = RowSegmentSchema.parse(value);
+  const rebuilt = buildRowSegment(segment.rows);
+  if (JSON.stringify(rebuilt.summary) !== JSON.stringify(segment.summary)) {
+    throw new Error("Timeline segment summary does not match its rows");
+  }
+  return segment;
+}

--- a/packages/server/src/server/agent/timeline-cache/safe-json-file.test.ts
+++ b/packages/server/src/server/agent/timeline-cache/safe-json-file.test.ts
@@ -1,0 +1,28 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readJsonFileCapped } from "./safe-json-file.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+describe("readJsonFileCapped", () => {
+  it("parses a bounded file and rejects an oversized file before reading its contents", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-safe-json-"));
+    directories.push(directory);
+    const bounded = path.join(directory, "bounded.json");
+    const oversized = path.join(directory, "oversized.json");
+    await writeFile(bounded, JSON.stringify({ version: 1, value: "ok" }));
+    await writeFile(oversized, JSON.stringify({ value: "x".repeat(256) }));
+
+    await expect(readJsonFileCapped(bounded, 128)).resolves.toEqual({ version: 1, value: "ok" });
+    await expect(readJsonFileCapped(oversized, 64)).rejects.toThrow(
+      "JSON file exceeds the 64-byte limit",
+    );
+  });
+});

--- a/packages/server/src/server/agent/timeline-cache/safe-json-file.ts
+++ b/packages/server/src/server/agent/timeline-cache/safe-json-file.ts
@@ -1,0 +1,29 @@
+import { open } from "node:fs/promises";
+
+export async function readJsonFileCapped(filePath: string, maxBytes: number): Promise<unknown> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new Error("maxBytes must be a positive safe integer");
+  }
+  const handle = await open(filePath, "r");
+  try {
+    const before = await handle.stat();
+    if (!before.isFile()) throw new Error(`JSON path is not a regular file: '${filePath}'`);
+    if (before.size > maxBytes) {
+      throw new Error(`JSON file exceeds the ${maxBytes}-byte limit: '${filePath}'`);
+    }
+    const buffer = Buffer.allocUnsafe(before.size);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+      if (bytesRead === 0) throw new Error(`JSON file changed while being read: '${filePath}'`);
+      offset += bytesRead;
+    }
+    const after = await handle.stat();
+    if (after.size !== before.size || after.mtimeMs !== before.mtimeMs) {
+      throw new Error(`JSON file changed while being read: '${filePath}'`);
+    }
+    return JSON.parse(buffer.toString("utf8"));
+  } finally {
+    await handle.close();
+  }
+}

--- a/packages/server/src/server/agent/timeline-cache/snapshot.test.ts
+++ b/packages/server/src/server/agent/timeline-cache/snapshot.test.ts
@@ -1,0 +1,200 @@
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PagedTimelineCatalog } from "./paged-catalog.js";
+import { TimelineSnapshotManager } from "./snapshot.js";
+import type { TimelineManifestFields } from "./snapshot.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+describe("TimelineSnapshotManager", () => {
+  it("reopens the manifest-owned root after publication and collects only unreachable files", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-snapshot-"));
+    directories.push(directory);
+    const catalog = new PagedTimelineCatalog(directory, { fanout: 2, maxPageBytes: 2_048 });
+    const manager = new TimelineSnapshotManager(directory, catalog, { maxManifestBytes: 2_048 });
+    const firstRoot = await catalog.append(null, descriptor(1));
+    await publish(manager, manifestFields(firstRoot, 1));
+    const secondRoot = await catalog.append(firstRoot, descriptor(2));
+    await publish(manager, manifestFields(secondRoot, 2));
+
+    const reopened = new TimelineSnapshotManager(directory, catalog, { maxManifestBytes: 2_048 });
+    const lease = await reopened.load();
+    expect(lease.manifest).toMatchObject({ generation: 2, maxSeq: 2, root: secondRoot });
+    lease.release();
+    expect(
+      (await readdir(directory)).filter((file) => file.startsWith("catalog-")),
+    ).not.toHaveLength(1);
+
+    await reopened.collectGarbage();
+
+    const reachable = await catalog.collectReachable(secondRoot);
+    expect((await readdir(directory)).filter((file) => file.startsWith("catalog-"))).toHaveLength(
+      reachable.pageFiles.size,
+    );
+  });
+
+  it("retries a load when publication changes generation before its snapshot lease", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-snapshot-"));
+    directories.push(directory);
+    const catalog = new PagedTimelineCatalog(directory, { fanout: 2, maxPageBytes: 2_048 });
+    const writer = new TimelineSnapshotManager(directory, catalog, { maxManifestBytes: 2_048 });
+    const firstRoot = await catalog.append(null, descriptor(1));
+    await publish(writer, manifestFields(firstRoot, 1));
+    let releaseFirstRead!: () => void;
+    let markFirstRead!: () => void;
+    const firstRead = new Promise<void>((resolve) => {
+      markFirstRead = resolve;
+    });
+    const holdFirstRead = new Promise<void>((resolve) => {
+      releaseFirstRead = resolve;
+    });
+    let reads = 0;
+    const loader = new TimelineSnapshotManager(directory, catalog, {
+      maxManifestBytes: 2_048,
+      afterManifestRead: async () => {
+        reads += 1;
+        if (reads !== 1) return;
+        markFirstRead();
+        await holdFirstRead;
+      },
+    });
+
+    const loading = loader.load();
+    await firstRead;
+    const secondRoot = await catalog.append(firstRoot, descriptor(2));
+    await publish(writer, manifestFields(secondRoot, 2));
+    await writer.collectGarbage();
+    releaseFirstRead();
+
+    const loaded = await loading;
+    expect(loaded.manifest).toMatchObject({ generation: 2, root: secondRoot });
+    expect(reads).toBeGreaterThanOrEqual(3);
+    loaded.release();
+  });
+
+  it("allows only one cross-instance publisher from the same generation", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-snapshot-"));
+    directories.push(directory);
+    const catalog = new PagedTimelineCatalog(directory, { fanout: 2, maxPageBytes: 2_048 });
+    const first = new TimelineSnapshotManager(directory, catalog, { maxManifestBytes: 2_048 });
+    const second = new TimelineSnapshotManager(directory, catalog, { maxManifestBytes: 2_048 });
+    const root = await catalog.append(null, descriptor(1));
+    await publish(first, manifestFields(root, 1));
+    const left = await catalog.append(root, descriptor(2));
+    const right = await catalog.append(root, {
+      ...descriptor(2),
+      file: "segment-2-ffffffff-0000-4000-8000-000000000000.json",
+    });
+
+    const firstExpected = await first.load();
+    const secondExpected = await second.load();
+    const results = await Promise.allSettled([
+      first.publish(firstExpected.manifest, async () => manifestFields(left, 2)),
+      second.publish(secondExpected.manifest, async () => manifestFields(right, 2)),
+    ]);
+    firstExpected.release();
+    secondExpected.release();
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const loaded = await first.load();
+    expect([left.file, right.file]).toContain(loaded.manifest.root?.file);
+    loaded.release();
+  });
+
+  it.each(["epoch", "root"] as const)(
+    "rejects a same-generation %s mismatch before building unpublished files",
+    async (changedField) => {
+      const directory = await mkdtemp(path.join(tmpdir(), "paseo-snapshot-"));
+      directories.push(directory);
+      const catalog = new PagedTimelineCatalog(directory, { fanout: 2, maxPageBytes: 2_048 });
+      const manager = new TimelineSnapshotManager(directory, catalog, { maxManifestBytes: 2_048 });
+      const root = await catalog.append(null, descriptor(1));
+      await publish(manager, manifestFields(root, 1));
+      const expected = await manager.load();
+      const replacementRoot = await catalog.append(root, descriptor(2));
+      const replacement =
+        changedField === "epoch"
+          ? { ...expected.manifest, epoch: "replacement-epoch" }
+          : {
+              ...expected.manifest,
+              nextSeq: 3,
+              maxSeq: 2,
+              root: replacementRoot,
+            };
+      await writeFile(path.join(directory, "manifest.json"), JSON.stringify(replacement));
+      let built = false;
+
+      await expect(
+        manager.publish(expected.manifest, async () => {
+          built = true;
+          return manifestFields(replacementRoot, 2);
+        }),
+      ).rejects.toThrow("Timeline snapshot changed");
+      expect(built).toBe(false);
+      expected.release();
+    },
+  );
+
+  it("rejects an escaping manifest root before catalog path resolution", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-snapshot-"));
+    directories.push(directory);
+    const summary = descriptor(1).summary;
+    await writeFile(
+      path.join(directory, "manifest.json"),
+      JSON.stringify({
+        version: 1,
+        generation: 1,
+        epoch: "epoch-1",
+        nextSeq: 2,
+        minSeq: 1,
+        maxSeq: 1,
+        root: { file: "../escape.json", minSeq: 1, maxSeq: 1, summary },
+      }),
+    );
+    const catalog = new PagedTimelineCatalog(directory);
+    await expect(new TimelineSnapshotManager(directory, catalog).load()).rejects.toThrow(
+      "Invalid catalog reference",
+    );
+  });
+});
+
+function manifestFields(root: Awaited<ReturnType<PagedTimelineCatalog["append"]>>, maxSeq: number) {
+  return { epoch: "epoch-1", nextSeq: maxSeq + 1, minSeq: 1, maxSeq, root };
+}
+
+function descriptor(seq: number) {
+  return {
+    file: `segment-${seq}-${String(seq).padStart(8, "0")}-0000-4000-8000-000000000000.json`,
+    generation: seq,
+    minSeq: seq,
+    maxSeq: seq,
+    summary: {
+      minSeq: seq,
+      maxSeq: seq,
+      firstItemType: "user_message",
+      lastItemType: "user_message",
+      trailingAssistantStartSeq: null,
+      lastAssistantRun: null,
+    },
+  };
+}
+
+async function publish(
+  manager: TimelineSnapshotManager,
+  fields: TimelineManifestFields,
+): Promise<void> {
+  const lease = await manager.load();
+  try {
+    await manager.publish(lease.manifest, async () => fields);
+  } finally {
+    lease.release();
+  }
+}

--- a/packages/server/src/server/agent/timeline-cache/snapshot.ts
+++ b/packages/server/src/server/agent/timeline-cache/snapshot.ts
@@ -1,0 +1,246 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { writeFileAtomic } from "../../atomic-file.js";
+import { validateCatalogRef } from "./cache-validation.js";
+import { withTimelineMutationLock } from "./file-mutation-lock.js";
+import type { TimelineMutationLockOptions } from "./file-mutation-lock.js";
+import type { CatalogPageRef } from "./paged-catalog.js";
+import { PagedTimelineCatalog } from "./paged-catalog.js";
+import { readJsonFileCapped } from "./safe-json-file.js";
+
+export interface TimelineManifest {
+  version: 1;
+  generation: number;
+  epoch: string;
+  nextSeq: number;
+  minSeq: number;
+  maxSeq: number;
+  root: CatalogPageRef | null;
+}
+
+export type TimelineManifestFields = Omit<TimelineManifest, "version" | "generation">;
+
+export interface TimelineSnapshotLease {
+  manifest: TimelineManifest;
+  release(): void;
+}
+
+export interface TimelineSnapshotManagerOptions {
+  maxManifestBytes?: number;
+  afterManifestRead?: (manifest: TimelineManifest) => Promise<void>;
+  writeFileAtomic?: (filePath: string, data: string) => Promise<void>;
+  mutationLock?: TimelineMutationLockOptions;
+}
+
+interface ActiveGeneration {
+  count: number;
+  root: CatalogPageRef | null;
+}
+
+const activeGenerations = new Map<string, Map<number, ActiveGeneration>>();
+const DEFAULT_MAX_MANIFEST_BYTES = 64 * 1024;
+
+export class TimelineSnapshotManager {
+  private readonly maxManifestBytes: number;
+  private readonly afterManifestRead?: (manifest: TimelineManifest) => Promise<void>;
+  private readonly writeAtomic: (filePath: string, data: string) => Promise<void>;
+  private readonly mutationLock?: TimelineMutationLockOptions;
+  private readonly emptyEpoch = randomUUID();
+
+  constructor(
+    private readonly directory: string,
+    private readonly catalog: PagedTimelineCatalog,
+    options?: TimelineSnapshotManagerOptions,
+  ) {
+    this.maxManifestBytes = options?.maxManifestBytes ?? DEFAULT_MAX_MANIFEST_BYTES;
+    this.afterManifestRead = options?.afterManifestRead;
+    this.writeAtomic = options?.writeFileAtomic ?? writeFileAtomic;
+    this.mutationLock = options?.mutationLock;
+    if (!Number.isSafeInteger(this.maxManifestBytes) || this.maxManifestBytes < 1) {
+      throw new Error("maxManifestBytes must be a positive safe integer");
+    }
+  }
+
+  async load(): Promise<TimelineSnapshotLease> {
+    for (;;) {
+      const first = await this.readManifest();
+      const release = this.acquire(first);
+      const second = await this.readManifest();
+      if (sameSnapshotIdentity(first, second)) {
+        return { manifest: first, release };
+      }
+      release();
+    }
+  }
+
+  async publish(
+    expected: TimelineManifest,
+    build: () => Promise<TimelineManifestFields>,
+  ): Promise<TimelineManifest> {
+    await fs.mkdir(this.directory, { recursive: true });
+    return await withTimelineMutationLock(
+      this.directory,
+      async () => {
+        const current = await this.readManifest();
+        if (!sameSnapshotIdentity(current, expected)) {
+          throw new Error(
+            `Timeline snapshot changed from generation ${expected.generation} to ${current.generation}`,
+          );
+        }
+        const fields = await build();
+        const manifest = validateManifest({
+          version: 1,
+          generation: expected.generation + 1,
+          ...fields,
+        });
+        const text = JSON.stringify(manifest);
+        if (Buffer.byteLength(text) > this.maxManifestBytes) {
+          throw new Error(`Timeline manifest exceeds the ${this.maxManifestBytes}-byte limit`);
+        }
+        await this.writeAtomic(this.manifestPath(), text);
+        return manifest;
+      },
+      this.mutationLock,
+    );
+  }
+
+  async collectGarbage(): Promise<void> {
+    await fs.mkdir(this.directory, { recursive: true });
+    await withTimelineMutationLock(
+      this.directory,
+      async () => {
+        const current = await this.load();
+        try {
+          const roots = new Map<string, CatalogPageRef>();
+          if (current.manifest.root) roots.set(current.manifest.root.file, current.manifest.root);
+          for (const active of activeGenerations.get(this.directory)?.values() ?? []) {
+            if (active.root) roots.set(active.root.file, active.root);
+          }
+          const pageFiles = new Set<string>();
+          const segmentFiles = new Set<string>();
+          for (const root of roots.values()) {
+            const reachable = await this.catalog.collectReachable(root);
+            for (const file of reachable.pageFiles) pageFiles.add(file);
+            for (const segment of reachable.segments) segmentFiles.add(segment.file);
+          }
+          const files = await fs.readdir(this.directory).catch(() => [] as string[]);
+          await Promise.all(
+            files
+              .filter(
+                (file) =>
+                  (file.startsWith("catalog-") && !pageFiles.has(file)) ||
+                  (file.startsWith("segment-") && !segmentFiles.has(file)),
+              )
+              .map(async (file) => await fs.rm(path.join(this.directory, file), { force: true })),
+          );
+        } finally {
+          current.release();
+        }
+      },
+      this.mutationLock,
+    );
+  }
+
+  async deleteCache(): Promise<void> {
+    await fs.mkdir(this.directory, { recursive: true });
+    await withTimelineMutationLock(
+      this.directory,
+      async () => await fs.rm(this.directory, { recursive: true, force: true }),
+      this.mutationLock,
+    );
+  }
+
+  private async readManifest(): Promise<TimelineManifest> {
+    let manifest: TimelineManifest;
+    try {
+      manifest = validateManifest(
+        await readJsonFileCapped(this.manifestPath(), this.maxManifestBytes),
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        manifest = {
+          version: 1,
+          generation: 0,
+          epoch: this.emptyEpoch,
+          nextSeq: 1,
+          minSeq: 0,
+          maxSeq: 0,
+          root: null,
+        };
+      } else throw error;
+    }
+    await this.afterManifestRead?.(manifest);
+    return manifest;
+  }
+
+  private acquire(manifest: TimelineManifest): () => void {
+    let generations = activeGenerations.get(this.directory);
+    if (!generations) {
+      generations = new Map();
+      activeGenerations.set(this.directory, generations);
+    }
+    const active = generations.get(manifest.generation);
+    if (active && active.root?.file !== manifest.root?.file) {
+      throw new Error("Timeline generation points to conflicting catalog roots");
+    }
+    generations.set(manifest.generation, {
+      count: (active?.count ?? 0) + 1,
+      root: manifest.root,
+    });
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const current = generations!.get(manifest.generation);
+      if (!current || current.count === 1) generations!.delete(manifest.generation);
+      else generations!.set(manifest.generation, { ...current, count: current.count - 1 });
+      if (generations!.size === 0) activeGenerations.delete(this.directory);
+    };
+  }
+
+  private manifestPath(): string {
+    return path.join(this.directory, "manifest.json");
+  }
+}
+
+function validateManifest(value: unknown): TimelineManifest {
+  if (!value || typeof value !== "object") throw new Error("Invalid timeline manifest");
+  const manifest = value as Partial<TimelineManifest>;
+  if (
+    manifest.version !== 1 ||
+    !isNonnegativeSafeInteger(manifest.generation) ||
+    typeof manifest.epoch !== "string" ||
+    !isNonnegativeSafeInteger(manifest.nextSeq) ||
+    !isNonnegativeSafeInteger(manifest.minSeq) ||
+    !isNonnegativeSafeInteger(manifest.maxSeq) ||
+    !(manifest.root === null || typeof manifest.root === "object")
+  ) {
+    throw new Error("Invalid timeline manifest");
+  }
+  if (manifest.root) validateCatalogRef(manifest.root);
+  if (
+    (manifest.root === null &&
+      (manifest.minSeq !== 0 || manifest.maxSeq !== 0 || manifest.nextSeq !== 1)) ||
+    (manifest.root !== null &&
+      (manifest.root.minSeq !== manifest.minSeq ||
+        manifest.root.maxSeq !== manifest.maxSeq ||
+        manifest.nextSeq! <= manifest.maxSeq!))
+  ) {
+    throw new Error("Timeline manifest does not match its catalog root");
+  }
+  return manifest as TimelineManifest;
+}
+
+function sameSnapshotIdentity(left: TimelineManifest, right: TimelineManifest): boolean {
+  return (
+    left.generation === right.generation &&
+    left.epoch === right.epoch &&
+    left.root?.file === right.root?.file
+  );
+}
+
+function isNonnegativeSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}

--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -6,7 +6,12 @@ import pino from "pino";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 
-import { createPaseoDaemon, parseListenString, type PaseoDaemonConfig } from "./bootstrap.js";
+import {
+  clearDisposableAgentTimelineCache,
+  createPaseoDaemon,
+  parseListenString,
+  type PaseoDaemonConfig,
+} from "./bootstrap.js";
 import { loadConfig } from "./config.js";
 import { AgentManagerShuttingDownError } from "./agent/agent-manager.js";
 import { hashDaemonPassword } from "./auth.js";
@@ -53,6 +58,15 @@ describe("paseo daemon bootstrap", () => {
     vi.restoreAllMocks();
   });
 
+  test("fails startup cache preparation closed when stale cache removal fails", async () => {
+    const failure = new Error("timeline cache is busy");
+    await expect(
+      clearDisposableAgentTimelineCache("/tmp/paseo/agent-timeline-cache", async () => {
+        throw failure;
+      }),
+    ).rejects.toBe(failure);
+  });
+
   test("starts and serves health endpoint", async () => {
     const daemonHandle = await createTestPaseoDaemon({
       openai: { stt: { apiKey: "test-openai-api-key" }, tts: { apiKey: "test-openai-api-key" } },
@@ -79,17 +93,23 @@ describe("paseo daemon bootstrap", () => {
     }
   });
 
-  test("keeps timeline activity in memory and removes obsolete timeline files at startup", async () => {
+  test("clears stale timeline caches and writes the versioned disposable cache", async () => {
     const paseoHomeRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-timeline-cleanup-"));
     const paseoHome = path.join(paseoHomeRoot, ".paseo");
     const obsoleteTimelineDirectory = path.join(paseoHome, "agent-timelines");
+    const staleTimelineCache = path.join(paseoHome, "agent-timeline-cache", "v1");
     const agentCwd = await mkdtemp(path.join(os.tmpdir(), "paseo-timeline-agent-"));
     await mkdir(obsoleteTimelineDirectory, { recursive: true });
     await writeFile(path.join(obsoleteTimelineDirectory, "obsolete.json"), "{}\n", "utf-8");
+    await mkdir(staleTimelineCache, { recursive: true });
+    await writeFile(path.join(staleTimelineCache, "stale.json"), "{}\n", "utf-8");
 
     const daemonHandle = await createTestPaseoDaemon({ paseoHomeRoot, cleanup: false });
     try {
       await expect(access(obsoleteTimelineDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(access(path.join(staleTimelineCache, "stale.json"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
 
       const agent = await daemonHandle.daemon.agentManager.createAgent(
         { provider: "codex", cwd: agentCwd },
@@ -103,6 +123,7 @@ describe("paseo daemon bootstrap", () => {
       await daemonHandle.daemon.agentManager.flush();
 
       await expect(access(obsoleteTimelineDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(access(staleTimelineCache)).resolves.toBeUndefined();
     } finally {
       await daemonHandle.close();
       await Promise.all([
@@ -112,7 +133,7 @@ describe("paseo daemon bootstrap", () => {
     }
   });
 
-  test("does not create a timeline directory for live timeline activity", async () => {
+  test("does not restore the obsolete whole-document timeline directory", async () => {
     const paseoHomeRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-timeline-memory-"));
     const agentCwd = await mkdtemp(path.join(os.tmpdir(), "paseo-timeline-agent-"));
     const daemonHandle = await createTestPaseoDaemon({ paseoHomeRoot, cleanup: false });

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -130,6 +130,7 @@ import type { RequestedSpeechProviders } from "./speech/speech-types.js";
 import { createSpeechService } from "./speech/speech-runtime.js";
 import { AgentManager } from "./agent/agent-manager.js";
 import { AgentStorage } from "./agent/agent-storage.js";
+import { SegmentedFileAgentTimelineStore } from "./agent/segmented-file-agent-timeline-store.js";
 import { attachAgentStoragePersistence } from "./persistence-hooks.js";
 import { createAgentMcpServer } from "./agent/mcp-server.js";
 import {
@@ -147,6 +148,15 @@ import {
 } from "./workspace-registry.js";
 import { CheckoutDiffManager } from "./checkout-diff-manager.js";
 import { ScheduleService } from "./schedule/service.js";
+
+type RecursiveRemove = (target: string, options: { recursive: true; force: true }) => Promise<void>;
+
+export async function clearDisposableAgentTimelineCache(
+  cacheRoot: string,
+  remove: RecursiveRemove = rm,
+): Promise<void> {
+  await remove(cacheRoot, { recursive: true, force: true });
+}
 import { DaemonConfigStore, type MutableDaemonConfig } from "./daemon-config-store.js";
 import { createOrchestrationSkills } from "./orchestration-skills/index.js";
 import { resolveConfigFromPersisted, type CliConfigOverrides } from "./config.js";
@@ -578,6 +588,13 @@ export async function createPaseoDaemon(
       "Failed to remove obsolete agent timeline data",
     );
   });
+  const timelineCacheRoot = path.join(config.paseoHome, "agent-timeline-cache");
+  // Provider history is authoritative. Clearing every daemon start is the crash-completeness
+  // boundary for this disposable cache: a partially published prior process is never reused.
+  await clearDisposableAgentTimelineCache(timelineCacheRoot);
+  const durableTimelineStore = new SegmentedFileAgentTimelineStore(
+    path.join(timelineCacheRoot, "v1"),
+  );
   const bootstrapStart = performance.now();
   const elapsed = () => `${(performance.now() - bootstrapStart).toFixed(0)}ms`;
   const daemonVersion = config.daemonVersion ?? resolveDaemonVersion(import.meta.url);
@@ -913,6 +930,10 @@ export async function createPaseoDaemon(
     clients: initialAgentManagerState.clients,
     providerDefinitions: initialAgentManagerState.providerDefinitions,
     registry: agentStorage,
+    durableTimelineStore,
+    boundedTimeline: {
+      hot: { maxRows: 512, maxBytes: 8 * 1024 * 1024 },
+    },
     appendSystemPrompt: config.appendSystemPrompt,
     onWorkspaceStateMayHaveChanged: ({ cwd }) => {
       workspaceGitService.onWorkspaceStateMayHaveChanged(cwd);

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -129,6 +129,7 @@ import {
   type AgentPermissionResponse,
   type AgentRunOptions,
   type AgentSessionConfig,
+  type AgentTimelineItem,
 } from "./agent/agent-sdk-types.js";
 import type { StoredAgentRecord } from "./agent/agent-storage.js";
 import type { AgentStorage } from "./agent/agent-storage.js";
@@ -7041,8 +7042,7 @@ export class Session {
       timeline: input.controlTimeline,
       pageLimit: input.pageLimit,
     })
-      ? (input.fullTimeline ??
-        this.agentManager.fetchTimeline(input.agentId, { direction: "tail", limit: 0 }))
+      ? (input.fullTimeline ?? input.controlTimeline)
       : input.controlTimeline;
     const page = selectProjectedTimelinePage({
       rows: selectedTimeline.rows,
@@ -7079,6 +7079,91 @@ export class Session {
     return this.selectProjectedTimelineProjection(input);
   }
 
+  private async expandProjectedTimelineWindow(input: {
+    agentId: string;
+    control: AgentTimelineFetchResult;
+    direction: AgentTimelineFetchDirection;
+    pageLimit: number;
+  }): Promise<AgentTimelineFetchResult> {
+    // Legacy provider history has no turn identity to prove a lifecycle boundary. Keep paging
+    // bounded; if no user boundary is visible, the response remains an honest partial window.
+    const maxLegacyToolExpansionPages = 4;
+    const rowsBySeq = new Map(input.control.rows.map((row) => [row.seq, row]));
+    let hasOlder = input.control.hasOlder;
+    let hasNewer = input.control.hasNewer;
+    let legacyToolExpansionPages = 0;
+    const pageSize = Math.max(50, Math.min(200, input.pageLimit || 200));
+    const expandOlderTextBoundary = isTextProjectionBoundary(input.control.rows[0]);
+    const expandNewerTextBoundary = isTextProjectionBoundary(input.control.rows.at(-1));
+
+    while (true) {
+      const rows = [...rowsBySeq.values()].sort((left, right) => left.seq - right.seq);
+      const first = rows[0];
+      const last = rows.at(-1);
+      if (!first || !last) break;
+      const { needOlder, needNewer } = projectedTimelineExpansionNeeds({
+        rows,
+        hasOlder,
+        hasNewer,
+        direction: input.direction,
+        pageLimit: input.pageLimit,
+        expandOlderTextBoundary,
+        expandNewerTextBoundary,
+        allowLegacyToolExpansion: legacyToolExpansionPages < maxLegacyToolExpansionPages,
+      });
+      if (!needOlder && !needNewer) break;
+
+      let added = false;
+      if (needOlder) {
+        const older = await this.agentManager.fetchTimelinePage(input.agentId, {
+          direction: "before",
+          cursor: { epoch: input.control.epoch, seq: first.seq },
+          limit: pageSize,
+        });
+        hasOlder = older.hasOlder;
+        if (containsLegacyToolRows(rows)) {
+          legacyToolExpansionPages += 1;
+        }
+        for (const row of older.rows) {
+          added = !rowsBySeq.has(row.seq) || added;
+          rowsBySeq.set(row.seq, row);
+        }
+      }
+      if (needNewer) {
+        const newer = await this.agentManager.fetchTimelinePage(input.agentId, {
+          direction: "after",
+          cursor: { epoch: input.control.epoch, seq: last.seq },
+          limit: pageSize,
+        });
+        hasNewer = newer.hasNewer;
+        for (const row of newer.rows) {
+          added = !rowsBySeq.has(row.seq) || added;
+          rowsBySeq.set(row.seq, row);
+        }
+      }
+      if (!added) break;
+    }
+
+    const rows = [...rowsBySeq.values()].sort((left, right) => left.seq - right.seq);
+    const exceedsLegacyProjectionBound =
+      hasOlder &&
+      rows.some(
+        (row) =>
+          isToolCallRow(row) &&
+          row.turnId === undefined &&
+          !hasVisibleToolCallStartBoundary(rows, row),
+      );
+    if (exceedsLegacyProjectionBound) {
+      throw new Error("Projected timeline lifecycle exceeds the bounded legacy history window");
+    }
+    return {
+      ...input.control,
+      hasOlder,
+      hasNewer,
+      rows,
+    };
+  }
+
   private async handleFetchAgentTimelineRequest(
     msg: Extract<SessionInboundMessage, { type: "fetch_agent_timeline_request" }>,
     source?: object,
@@ -7086,7 +7171,7 @@ export class Session {
     const direction: AgentTimelineFetchDirection = msg.direction ?? (msg.cursor ? "after" : "tail");
     const projection: TimelineProjectionMode = msg.projection ?? "projected";
     const requestedLimit = msg.limit;
-    const pageLimit = requestedLimit ?? (direction === "after" ? 0 : 200);
+    const pageLimit = requestedLimit ?? 200;
     const cursor: AgentTimelineCursor | undefined = msg.cursor
       ? {
           epoch: msg.cursor.epoch,
@@ -7102,11 +7187,25 @@ export class Session {
       });
       const agentPayload = await this.buildAgentPayload(snapshot);
 
-      const fetchedControlTimeline = this.agentManager.fetchTimeline(msg.agentId, {
+      const fetchedControlTimeline = await this.agentManager.fetchTimelinePage(msg.agentId, {
         direction,
         cursor,
         limit: pageLimit,
       });
+      const fullTimeline =
+        projection === "projected" &&
+        pageLimit > 0 &&
+        this.shouldUseFullTimelineForProjectedPage({
+          timeline: fetchedControlTimeline,
+          pageLimit,
+        })
+          ? await this.expandProjectedTimelineWindow({
+              agentId: msg.agentId,
+              control: fetchedControlTimeline,
+              direction,
+              pageLimit,
+            })
+          : undefined;
       const selectedTimeline = this.selectTimelineProjection({
         agentId: msg.agentId,
         projection,
@@ -7114,6 +7213,7 @@ export class Session {
         direction,
         ...(cursor ? { cursor } : {}),
         pageLimit,
+        ...(fullTimeline ? { fullTimeline } : {}),
       });
       const startCursor =
         selectedTimeline.startSeq !== null
@@ -7389,10 +7489,11 @@ export class Session {
         logger: this.sessionLogger,
       });
       const agentPayload = await this.buildAgentPayload(snapshot);
-      const timeline = this.agentManager.fetchTimeline(msg.agentId, {
-        direction: "tail",
-        limit: 0,
-      });
+      const rows = await this.agentManager.getTimelineRows(msg.agentId);
+      const timeline = {
+        epoch: this.agentManager.fetchTimeline(msg.agentId, { direction: "tail", limit: 1 }).epoch,
+        rows,
+      };
       const forkContext = buildAgentForkContextAttachment({
         rows: timeline.rows,
         cursorBoundary: msg.boundaryCursor
@@ -7749,6 +7850,100 @@ export class Session {
     this.workspaceGitObserver.dispose();
     this.workspaceFilesSession.dispose();
   }
+}
+
+function projectedTimelineExpansionNeeds(input: {
+  rows: AgentTimelineFetchResult["rows"];
+  hasOlder: boolean;
+  hasNewer: boolean;
+  direction: AgentTimelineFetchDirection;
+  pageLimit: number;
+  expandOlderTextBoundary: boolean;
+  expandNewerTextBoundary: boolean;
+  allowLegacyToolExpansion: boolean;
+}): { needOlder: boolean; needNewer: boolean } {
+  const first = input.rows[0]!;
+  const last = input.rows.at(-1)!;
+  const toolRows = input.rows.filter(
+    (row): row is typeof row & { item: Extract<AgentTimelineItem, { type: "tool_call" }> } =>
+      row.item.type === "tool_call",
+  );
+  const needsOlderTool = toolRows.some(
+    (row) =>
+      (row.turnId !== undefined || input.allowLegacyToolExpansion) &&
+      !hasVisibleToolCallStartBoundary(input.rows, row),
+  );
+  const needsNewerTool = toolRows.some(
+    ({ item, turnId }) =>
+      !toolRows.some(
+        (candidate) =>
+          candidate.item.callId === item.callId &&
+          candidate.turnId === turnId &&
+          candidate.item.status !== "running",
+      ),
+  );
+  const projectedCount = projectTimelineRows({ rows: input.rows, mode: "projected" }).length;
+  return {
+    needOlder:
+      input.hasOlder &&
+      (needsOlderTool ||
+        (input.expandOlderTextBoundary &&
+          (first.item.type === "assistant_message" || first.item.type === "reasoning")) ||
+        (input.direction !== "after" && projectedCount < input.pageLimit)),
+    needNewer:
+      input.hasNewer &&
+      (needsNewerTool ||
+        (input.expandNewerTextBoundary &&
+          (last.item.type === "assistant_message" || last.item.type === "reasoning")) ||
+        (input.direction === "after" && projectedCount < input.pageLimit)),
+  };
+}
+
+function containsLegacyToolRows(rows: AgentTimelineFetchResult["rows"]): boolean {
+  return rows.some((row) => row.item.type === "tool_call" && row.turnId === undefined);
+}
+
+function isToolCallRow(
+  row: AgentTimelineFetchResult["rows"][number],
+): row is AgentTimelineFetchResult["rows"][number] & {
+  item: Extract<AgentTimelineItem, { type: "tool_call" }>;
+} {
+  return row.item.type === "tool_call";
+}
+
+function isTextProjectionBoundary(row: AgentTimelineFetchResult["rows"][number] | undefined) {
+  return row?.item.type === "assistant_message" || row?.item.type === "reasoning";
+}
+
+function hasVisibleToolCallStartBoundary(
+  rows: AgentTimelineFetchResult["rows"],
+  toolRow: AgentTimelineFetchResult["rows"][number] & {
+    item: Extract<AgentTimelineItem, { type: "tool_call" }>;
+  },
+): boolean {
+  const firstCallIndex = rows.findIndex(
+    (candidate) =>
+      candidate.item.type === "tool_call" &&
+      candidate.item.callId === toolRow.item.callId &&
+      candidate.turnId === toolRow.turnId,
+  );
+  if (firstCallIndex < 0) return false;
+  const preceding = rows.slice(0, firstCallIndex);
+  if (toolRow.turnId === undefined) {
+    const hasRunningRow = rows.some(
+      (candidate) =>
+        candidate.item.type === "tool_call" &&
+        candidate.item.callId === toolRow.item.callId &&
+        candidate.turnId === undefined &&
+        candidate.item.status === "running",
+    );
+    return hasRunningRow && preceding.some(({ item }) => item.type === "user_message");
+  }
+  return preceding.some(
+    (candidate) =>
+      (candidate.item.type === "user_message" && candidate.turnId === toolRow.turnId) ||
+      (candidate.turnId !== undefined && candidate.turnId !== toolRow.turnId),
+  );
 }
 
 interface CloneRepositoryInput {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -7315,7 +7315,7 @@ export class Session {
       if (!descriptor) {
         throw new Error("Provider subagent not found");
       }
-      const timeline = this.agentManager.fetchProviderSubagentTimeline(
+      const timeline = await this.agentManager.fetchProviderSubagentTimeline(
         msg.parentAgentId,
         msg.subagentId,
         {

--- a/packages/server/src/server/session/daemon/diagnostics.ts
+++ b/packages/server/src/server/session/daemon/diagnostics.ts
@@ -47,6 +47,14 @@ interface DiagnosticAgentRuntimeMetrics {
     totalItems: number;
     maxItemsPerAgent: number;
   };
+  timelineCache?: {
+    residentRows: number;
+    residentBytes: number;
+    pendingRows: number;
+    pendingBytes: number;
+    backpressuredAgents: number;
+    failedAgents: number;
+  };
 }
 
 export type DaemonWebSocketRuntimeDiagnosticSnapshot = WebSocketRuntimeDiagnosticSnapshot<
@@ -336,6 +344,21 @@ function collectWebSocketRuntimeEntries(options: DaemonDiagnosticsOptions): Diag
         `maxPerAgent=${formatNumberMetric(agents.timelineStats?.maxItemsPerAgent)}`,
       ].join(", "),
     },
+    ...(agents.timelineCache
+      ? [
+          {
+            label: "Agent timeline cache",
+            value: [
+              `residentRows=${formatNumberMetric(agents.timelineCache.residentRows)}`,
+              `residentBytes=${formatNumberMetric(agents.timelineCache.residentBytes)}`,
+              `pendingRows=${formatNumberMetric(agents.timelineCache.pendingRows)}`,
+              `pendingBytes=${formatNumberMetric(agents.timelineCache.pendingBytes)}`,
+              `backpressuredAgents=${formatNumberMetric(agents.timelineCache.backpressuredAgents)}`,
+              `failedAgents=${formatNumberMetric(agents.timelineCache.failedAgents)}`,
+            ].join(", "),
+          },
+        ]
+      : []),
   ];
 }
 

--- a/packages/server/src/server/wire-compat.test.ts
+++ b/packages/server/src/server/wire-compat.test.ts
@@ -54,6 +54,7 @@ interface SessionInternals {
 
 class InMemoryAgentManager {
   private readonly timeline = new InMemoryAgentTimelineStore();
+  readonly fetchOptions: AgentTimelineFetchOptions[] = [];
 
   constructor(rows: AgentTimelineRow[]) {
     this.timeline.initialize("agent-1", {
@@ -108,6 +109,11 @@ class InMemoryAgentManager {
   }
 
   fetchTimeline(_agentId: string, options?: AgentTimelineFetchOptions) {
+    return this.timeline.fetch("agent-1", options);
+  }
+
+  async fetchTimelinePage(_agentId: string, options?: AgentTimelineFetchOptions) {
+    this.fetchOptions.push(options ?? {});
     return this.timeline.fetch("agent-1", options);
   }
 
@@ -181,6 +187,7 @@ class InMemoryWorktreeWorkflow {
 }
 
 function createSessionForWireCompatTest(options?: {
+  agentManager?: InMemoryAgentManager;
   clientCapabilities?: Record<string, unknown> | null;
   directorySync?: DirectorySyncService;
   messages?: SessionOutboundMessage[];
@@ -214,9 +221,8 @@ function createSessionForWireCompatTest(options?: {
     downloadTokenStore: {} as SessionOptions["downloadTokenStore"],
     pushNotifications: {} as SessionOptions["pushNotifications"],
     paseoHome: "/tmp/paseo-home",
-    agentManager: new InMemoryAgentManager(
-      options?.rows ?? rows,
-    ) as unknown as SessionOptions["agentManager"],
+    agentManager: (options?.agentManager ??
+      new InMemoryAgentManager(options?.rows ?? rows)) as unknown as SessionOptions["agentManager"],
     agentStorage: new EmptyAgentStorage() as unknown as SessionOptions["agentStorage"],
     projectRegistry: new EmptyProjectRegistry() as unknown as SessionOptions["projectRegistry"],
     workspaceRegistry:
@@ -277,6 +283,7 @@ function createSessionForWireCompatTest(options?: {
 }
 
 async function emitTimelineResponse(options?: {
+  agentManager?: InMemoryAgentManager;
   clientCapabilities?: Record<string, unknown> | null;
   rows?: AgentTimelineRow[];
   request?: Partial<
@@ -285,6 +292,7 @@ async function emitTimelineResponse(options?: {
 }): Promise<Extract<SessionOutboundMessage, { type: "fetch_agent_timeline_response" }>> {
   const messages: SessionOutboundMessage[] = [];
   const session = createSessionForWireCompatTest({
+    agentManager: options?.agentManager,
     clientCapabilities: options?.clientCapabilities,
     rows: options?.rows,
     messages,
@@ -444,6 +452,229 @@ describe("wire compatibility", () => {
     expect(LegacyFetchAgentTimelineResponseMessageSchema.parse(response).payload.entries).toEqual(
       expect.arrayContaining([expect.not.objectContaining({ turnId: expect.anything() })]),
     );
+  });
+
+  test("pages backward across a long pre-cursor tool lifecycle without an unbounded fetch", async () => {
+    const rows: AgentTimelineRow[] = [
+      {
+        seq: 1,
+        timestamp: "2026-05-02T00:00:00.000Z",
+        turnId: "turn-1",
+        item: {
+          type: "tool_call",
+          callId: "call-1",
+          name: "shell",
+          status: "running",
+          detail: { type: "shell", command: "long command" },
+        },
+      },
+      ...Array.from(
+        { length: 448 },
+        (_, index): AgentTimelineRow => ({
+          seq: index + 2,
+          timestamp: "2026-05-02T00:00:01.000Z",
+          item: { type: "user_message", text: `filler-${index}` },
+        }),
+      ),
+      {
+        seq: 450,
+        timestamp: "2026-05-02T00:00:02.000Z",
+        turnId: "turn-1",
+        item: {
+          type: "tool_call",
+          callId: "call-1",
+          name: "shell",
+          status: "completed",
+          detail: { type: "shell", command: "long command", exitCode: 0 },
+        },
+      },
+    ];
+    const agentManager = new InMemoryAgentManager(rows);
+    const response = await emitTimelineResponse({
+      agentManager,
+      request: {
+        direction: "after",
+        cursor: { epoch: "epoch-1", seq: 449 },
+        limit: 1,
+      },
+    });
+
+    expect(response.payload.entries).toEqual([
+      expect.objectContaining({
+        seqStart: 1,
+        seqEnd: 450,
+        item: expect.objectContaining({ type: "tool_call", callId: "call-1", status: "completed" }),
+      }),
+    ]);
+    expect(agentManager.fetchOptions.length).toBeGreaterThan(2);
+    expect(agentManager.fetchOptions.every(({ limit }) => limit !== 0)).toBe(true);
+  });
+
+  test("stops paging at the turn boundary for a recent complete tool lifecycle", async () => {
+    const olderRows = Array.from(
+      { length: 600 },
+      (_, index): AgentTimelineRow => ({
+        seq: index + 1,
+        timestamp: "2026-05-02T00:00:00.000Z",
+        turnId: "turn-old",
+        item: { type: "assistant_message", text: `older-${index}` },
+      }),
+    );
+    const rows: AgentTimelineRow[] = [
+      ...olderRows,
+      {
+        seq: 601,
+        timestamp: "2026-05-02T00:01:00.000Z",
+        turnId: "turn-recent",
+        item: { type: "user_message", text: "run it", clientMessageId: "message-recent" },
+      },
+      {
+        seq: 602,
+        timestamp: "2026-05-02T00:01:01.000Z",
+        turnId: "turn-recent",
+        item: {
+          type: "tool_call",
+          callId: "call-recent",
+          name: "shell",
+          status: "running",
+          detail: { type: "shell", command: "true" },
+        },
+      },
+      {
+        seq: 603,
+        timestamp: "2026-05-02T00:01:02.000Z",
+        turnId: "turn-recent",
+        item: {
+          type: "tool_call",
+          callId: "call-recent",
+          name: "shell",
+          status: "completed",
+          detail: { type: "shell", command: "true", exitCode: 0 },
+        },
+      },
+    ];
+    const agentManager = new InMemoryAgentManager(rows);
+    const response = await emitTimelineResponse({
+      agentManager,
+      request: { direction: "tail", limit: 1 },
+    });
+
+    expect(response.payload.entries).toEqual([
+      expect.objectContaining({
+        seqStart: 602,
+        seqEnd: 603,
+        item: expect.objectContaining({
+          type: "tool_call",
+          callId: "call-recent",
+          status: "completed",
+        }),
+      }),
+    ]);
+    expect(agentManager.fetchOptions).toHaveLength(2);
+    expect(agentManager.fetchOptions.every(({ limit }) => limit !== 0)).toBe(true);
+  });
+
+  test("stops paging at a legacy user boundary for a recent complete tool lifecycle", async () => {
+    const rows: AgentTimelineRow[] = [
+      ...Array.from(
+        { length: 600 },
+        (_, index): AgentTimelineRow => ({
+          seq: index + 1,
+          timestamp: "2026-05-02T00:00:00.000Z",
+          item: { type: "assistant_message", text: `older-${index}` },
+        }),
+      ),
+      {
+        seq: 601,
+        timestamp: "2026-05-02T00:01:00.000Z",
+        item: { type: "user_message", text: "run it", clientMessageId: "legacy-message" },
+      },
+      {
+        seq: 602,
+        timestamp: "2026-05-02T00:01:01.000Z",
+        item: {
+          type: "tool_call",
+          callId: "legacy-call",
+          name: "shell",
+          status: "running",
+          detail: { type: "shell", command: "true" },
+        },
+      },
+      {
+        seq: 603,
+        timestamp: "2026-05-02T00:01:02.000Z",
+        item: {
+          type: "tool_call",
+          callId: "legacy-call",
+          name: "shell",
+          status: "completed",
+          detail: { type: "shell", command: "true", exitCode: 0 },
+        },
+      },
+    ];
+    const agentManager = new InMemoryAgentManager(rows);
+    const response = await emitTimelineResponse({
+      agentManager,
+      request: { direction: "tail", limit: 1 },
+    });
+
+    expect(response.payload.entries).toEqual([
+      expect.objectContaining({
+        seqStart: 602,
+        seqEnd: 603,
+        collapsed: expect.arrayContaining(["tool_lifecycle"]),
+      }),
+    ]);
+    expect(agentManager.fetchOptions).toHaveLength(2);
+  });
+
+  test("bounds legacy tool expansion and reports a partial lifecycle when no boundary is visible", async () => {
+    const rows: AgentTimelineRow[] = [
+      {
+        seq: 1,
+        timestamp: "2026-05-02T00:00:00.000Z",
+        item: {
+          type: "tool_call",
+          callId: "legacy-long-call",
+          name: "shell",
+          status: "running",
+          detail: { type: "shell", command: "long command" },
+        },
+      },
+      ...Array.from(
+        { length: 1_998 },
+        (_, index): AgentTimelineRow => ({
+          seq: index + 2,
+          timestamp: "2026-05-02T00:00:01.000Z",
+          item: { type: "assistant_message", text: `legacy-filler-${index}` },
+        }),
+      ),
+      {
+        seq: 2_000,
+        timestamp: "2026-05-02T00:01:00.000Z",
+        item: {
+          type: "tool_call",
+          callId: "legacy-long-call",
+          name: "shell",
+          status: "completed",
+          detail: { type: "shell", command: "long command", exitCode: 0 },
+        },
+      },
+    ];
+    const agentManager = new InMemoryAgentManager(rows);
+    const response = await emitTimelineResponse({
+      agentManager,
+      request: { direction: "tail", limit: 1 },
+    });
+
+    expect(response.payload).toMatchObject({
+      entries: [],
+      startCursor: null,
+      endCursor: null,
+      error: "Projected timeline lifecycle exceeds the bounded legacy history window",
+    });
+    expect(agentManager.fetchOptions).toHaveLength(5);
+    expect(agentManager.fetchOptions.every(({ limit }) => limit !== 0)).toBe(true);
   });
 
   test("legacy worktree request shape normalizes to the same internal input as the new shape", async () => {


### PR DESCRIPTION
Refs #2300

Bounds daemon memory used by long-running root and Codex provider-subagent histories.

- bounds parent subagent previews while retaining canonical child activity
- restores child descriptors without loading their bodies and pages child history on demand
- keeps a bounded hot root tail and pages older committed rows from a segmented disposable cache
- enforces row, batch, pending, and resident byte limits, including oversized timeline items
- fences reload, delete, and close operations across cache generations
- exposes timeline retention metrics

Provider history remains authoritative, and daemon startup clears the disposable cache fail-closed.
