### PR TITLE
feat(app): show a workspace's agents in the sidebar

### DIFF
--- a/packages/app/e2e/browser/sidebar-agent-rows-evidence.spec.ts
+++ b/packages/app/e2e/browser/sidebar-agent-rows-evidence.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import { seedWorkspace } from "../support/helpers/seed-client";
+import { getServerId } from "../support/helpers/server-id";
+
+/**
+ * Capture-only. Produces the PR evidence for the sidebar agent sub-list into
+ * `test-results/evidence/`, at 3x so the crops stay readable when scaled down in a PR body.
+ *
+ * Opt-in because it exists to write files, not to assert: the behaviour it photographs is
+ * covered by `sidebar-agent-rows.spec.ts`, which runs on every push. Same shape as the
+ * `PASEO_DIFF_PERF_E2E` capture spec.
+ *
+ *   PASEO_SIDEBAR_EVIDENCE=1 npx playwright test --project=browser \
+ *     e2e/browser/sidebar-agent-rows-evidence.spec.ts
+ */
+
+const MULTI_AGENT_TITLES = [
+  "Rebase onto upstream main",
+  "Port sidebar agent rows",
+  "Audit COMPAT tags",
+];
+
+/** The sidebar plus a little of the pane behind it, so the row's right edge is in frame. */
+const SIDEBAR_CLIP = { x: 0, y: 124, width: 340, height: 292 };
+
+/**
+ * Wide enough for the sidebar plus the preference menu and its submenu, which open to the right
+ * of the trigger as separate popovers. Framing them together is the point: the shot has to show
+ * where the control lives, not just what it says.
+ */
+const MENU_CLIP = { x: 0, y: 96, width: 720, height: 480 };
+
+/**
+ * Popovers fade in, and `toBeVisible` is satisfied before the animation lands — a shot taken then
+ * catches the menu half-transparent over whatever is behind it. Capture-only, so waiting a beat
+ * beats plumbing an animation signal through the menu engine.
+ */
+async function settlePopover(page: import("@playwright/test").Page): Promise<void> {
+  await page.waitForTimeout(400);
+}
+
+test.describe("sidebar agent rows evidence", () => {
+  test.skip(!process.env.PASEO_SIDEBAR_EVIDENCE, "Set PASEO_SIDEBAR_EVIDENCE=1 to capture.");
+  test.use({ viewport: { width: 1280, height: 720 }, deviceScaleFactor: 3 });
+
+  test("captures the sub-list states", async ({ page }) => {
+    // Two workspaces on purpose: one with several agents and one with a single agent, so every
+    // shot also shows what the change does NOT do to an ordinary row.
+    const busy = await seedWorkspace({ repoPrefix: "paseo-evidence-busy-" });
+    const quiet = await seedWorkspace({ repoPrefix: "paseo-evidence-quiet-" });
+    try {
+      for (const title of MULTI_AGENT_TITLES) {
+        await busy.client.createAgent({
+          provider: "mock",
+          cwd: busy.repoPath,
+          workspaceId: busy.workspaceId,
+          title,
+          modeId: "load-test",
+          model: "e2e-fast-stream",
+        });
+      }
+      await quiet.client.createAgent({
+        provider: "mock",
+        cwd: quiet.repoPath,
+        workspaceId: quiet.workspaceId,
+        title: "Only agent here",
+        modeId: "load-test",
+        model: "e2e-fast-stream",
+      });
+
+      await gotoAppShell(page);
+
+      const busyRow = page.getByTestId(
+        `sidebar-workspace-row-${getServerId()}:${busy.workspaceId}`,
+      );
+      await expect(busyRow).toBeVisible({ timeout: 30_000 });
+      const disclosure = page.getByTestId("sidebar-agent-list-disclosure");
+      await expect(disclosure).toBeVisible({ timeout: 30_000 });
+
+      // 1. Resting state. The busy workspace carries a count; the quiet one is untouched.
+      await page.screenshot({
+        path: "test-results/evidence/01-collapsed.png",
+        clip: SIDEBAR_CLIP,
+      });
+
+      // 2. Hovered: the status indicator swaps for the expand chevron, the way a project row's
+      // icon does. The count stays put on the meta line, clear of the kebab.
+      await busyRow.hover();
+      await expect(disclosure).toBeVisible();
+      await page.screenshot({
+        path: "test-results/evidence/02-hover-chevron.png",
+        clip: SIDEBAR_CLIP,
+      });
+
+      // 3. Expanded: provider icon per row, dots on the meta count's left rail.
+      await disclosure.click();
+      const list = page.getByTestId("sidebar-agent-list");
+      await expect(list).toBeVisible({ timeout: 10_000 });
+      for (const title of MULTI_AGENT_TITLES) {
+        await expect(list.getByText(title, { exact: true })).toBeVisible();
+      }
+      // Park the pointer off the sidebar and let the workspace hover card retract, or it sits
+      // over the sub-list in the shot.
+      await page.mouse.move(900, 620);
+      await expect(page.getByTestId("workspace-hover-card")).toBeHidden({ timeout: 10_000 });
+      await page.screenshot({
+        path: "test-results/evidence/03-expanded.png",
+        clip: SIDEBAR_CLIP,
+      });
+      // 4. Where the preference lives. Not the Settings screen: sidebar display preferences all
+      // sit in this menu, so the new one joins Checks rather than starting a second home.
+      await page.getByTestId("sidebar-display-preferences-menu").click();
+      const menu = page.getByTestId("sidebar-display-preferences-content");
+      await expect(menu).toBeVisible({ timeout: 10_000 });
+      await page.getByTestId("sidebar-display-show").click();
+      const agentsEntry = page.getByTestId("sidebar-display-agents");
+      await expect(agentsEntry).toBeVisible({ timeout: 10_000 });
+      await settlePopover(page);
+      await page.screenshot({ path: "test-results/evidence/04-display-menu.png", clip: MENU_CLIP });
+
+      // 5. The three answers, with the shipped default selected.
+      await agentsEntry.click();
+      await expect(page.getByTestId("sidebar-agent-rows-collapsed")).toBeVisible({
+        timeout: 10_000,
+      });
+      await settlePopover(page);
+      await page.screenshot({
+        path: "test-results/evidence/05-agents-options.png",
+        clip: MENU_CLIP,
+      });
+      // 6. The same sub-list under Group by Status. Hoisted rows carry a project icon in the
+      // leading slot instead of a status indicator, and that branch shipped without a toggle at
+      // first — so this grouping earns a shot of its own rather than a claim that it works.
+      await page.keyboard.press("Escape");
+      await page.getByTestId("sidebar-display-preferences-menu").click();
+      await page.getByTestId("sidebar-display-grouping").click();
+      await page.getByTestId("sidebar-grouping-status").click();
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("sidebar-status-group-done")).toBeVisible({ timeout: 20_000 });
+
+      // Expansion is stored per workspace and survives the grouping switch, so the list is already
+      // open here. Clicking the toggle again would close it.
+      await expect(page.getByTestId("sidebar-agent-list-disclosure").first()).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.getByTestId("sidebar-agent-list")).toBeVisible({ timeout: 10_000 });
+      await page.mouse.move(900, 620);
+      await expect(page.getByTestId("workspace-hover-card")).toBeHidden({ timeout: 10_000 });
+      await settlePopover(page);
+      await page.screenshot({
+        path: "test-results/evidence/06-status-grouping.png",
+        clip: SIDEBAR_CLIP,
+      });
+    } finally {
+      await busy.cleanup();
+      await quiet.cleanup();
+    }
+  });
+});

--- a/packages/app/e2e/browser/sidebar-agent-rows.spec.ts
+++ b/packages/app/e2e/browser/sidebar-agent-rows.spec.ts
@@ -1,0 +1,294 @@
+import { test, expect } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import { seedWorkspace } from "../support/helpers/seed-client";
+import { getServerId } from "../support/helpers/server-id";
+
+/**
+ * A workspace row draws an agent sub-list only when it holds more than one active root agent.
+ * These cover the geometry that reading the styles cannot settle: the disclosure lives in the
+ * leading slot and swaps with the status indicator on hover, the count sits on the meta line, and
+ * the sub-list hangs on that count's rail.
+ *
+ * The kebab check is kept even though the disclosure no longer shares the trailing slot with it.
+ * It shipped there once, painted over by an overlay that `toBeVisible` was happy with, and this
+ * is what would catch a move back.
+ */
+
+const AGENT_TITLES = ["Rebase onto upstream main", "Port sidebar agent rows", "Audit COMPAT tags"];
+
+function rowTestId(workspaceId: string): string {
+  return `sidebar-workspace-row-${getServerId()}:${workspaceId}`;
+}
+
+test.describe("sidebar agent rows", () => {
+  test("shows a count, expands, and keeps the kebab readable on hover", async ({ page }) => {
+    const workspace = await seedWorkspace({ repoPrefix: "paseo-e2e-agent-rows-" });
+    try {
+      for (const title of AGENT_TITLES) {
+        await workspace.client.createAgent({
+          provider: "mock",
+          cwd: workspace.repoPath,
+          workspaceId: workspace.workspaceId,
+          title,
+          modeId: "load-test",
+          model: "e2e-fast-stream",
+        });
+      }
+
+      await gotoAppShell(page);
+
+      const row = page.getByTestId(rowTestId(workspace.workspaceId));
+      await expect(row).toBeVisible({ timeout: 30_000 });
+
+      const disclosure = page.getByTestId("sidebar-agent-list-disclosure");
+      await expect(disclosure).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByTestId("sidebar-workspace-agent-count")).toContainText(
+        String(AGENT_TITLES.length),
+      );
+
+      // Collapsed by default: the count is there, the rows are not.
+      await expect(page.getByTestId("sidebar-agent-list")).toHaveCount(0);
+
+      await page.screenshot({ path: "test-results/agent-rows-collapsed-idle.png" });
+
+      // Hover is where the kebab fades in over the trailing slot. The count must stay legible.
+      //
+      // `toBeVisible` is not enough for this: the kebab is an absolutely positioned overlay, so it
+      // can paint over a control without changing its computed visibility. Compare boxes instead.
+      await row.hover();
+      await expect(disclosure).toBeVisible();
+      await page.screenshot({ path: "test-results/agent-rows-collapsed-hover.png" });
+
+      const kebab = page.getByTestId(
+        `sidebar-workspace-kebab-${getServerId()}:${workspace.workspaceId}`,
+      );
+      await expect(kebab).toBeVisible({ timeout: 10_000 });
+      const countBox = await disclosure.boundingBox();
+      const kebabBox = await kebab.boundingBox();
+      expect(countBox).not.toBeNull();
+      expect(kebabBox).not.toBeNull();
+      if (countBox && kebabBox) {
+        const overlap =
+          Math.min(countBox.x + countBox.width, kebabBox.x + kebabBox.width) -
+          Math.max(countBox.x, kebabBox.x);
+        expect(overlap, `count overlapped by the kebab by ${overlap}px`).toBeLessThanOrEqual(0);
+      }
+
+      await disclosure.click();
+      const list = page.getByTestId("sidebar-agent-list");
+      await expect(list).toBeVisible({ timeout: 10_000 });
+      for (const title of AGENT_TITLES) {
+        await expect(list.getByText(title, { exact: true })).toBeVisible();
+      }
+
+      // The row announces what distinguishes it, not just its title: two agents a provider has
+      // not named yet would otherwise be spoken identically.
+      const rows = list.getByRole("button");
+      const spoken = await rows.first().getAttribute("aria-label");
+      expect(spoken).toContain("mock");
+      expect(spoken).toMatch(/Working|Done|Needs input|Ready to review|Failed/);
+
+      // The sub-list hangs off the count, so its dots share a left rail with that digit. Without
+      // it the rows read as a second, unrelated column.
+      const railBox = await page.getByTestId("sidebar-workspace-agent-count").boundingBox();
+      const firstDotBox = await list
+        .getByTestId(/^sidebar-agent-row-dot-/)
+        .first()
+        .boundingBox();
+      expect(railBox).not.toBeNull();
+      expect(firstDotBox).not.toBeNull();
+      if (railBox && firstDotBox) {
+        const drift = Math.abs(firstDotBox.x - railBox.x);
+        expect(
+          drift,
+          `agent dots drift ${drift}px from the count rail (dot x=${firstDotBox.x}, count x=${railBox.x})`,
+        ).toBeLessThanOrEqual(1);
+      }
+
+      await row.hover();
+      await page.screenshot({ path: "test-results/agent-rows-expanded-hover.png" });
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("expands from the leading slot in status grouping too", async ({ page }) => {
+    // Status and label grouping hoist rows out of their project block, so the leading slot carries
+    // a project icon rather than a status indicator. The toggle has to wrap both: wrapping only
+    // the indicator left those rows showing a count they could never open.
+    const workspace = await seedWorkspace({ repoPrefix: "paseo-e2e-agent-rows-status-" });
+    try {
+      for (const title of AGENT_TITLES) {
+        await workspace.client.createAgent({
+          provider: "mock",
+          cwd: workspace.repoPath,
+          workspaceId: workspace.workspaceId,
+          title,
+          modeId: "load-test",
+          model: "e2e-fast-stream",
+        });
+      }
+
+      await gotoAppShell(page);
+      const row = page.getByTestId(rowTestId(workspace.workspaceId));
+      await expect(row).toBeVisible({ timeout: 30_000 });
+
+      await page.getByTestId("sidebar-display-preferences-menu").click();
+      await page.getByTestId("sidebar-display-grouping").click();
+      await page.getByTestId("sidebar-grouping-status").click();
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("sidebar-status-group-done")).toBeVisible({ timeout: 20_000 });
+
+      const toggle = page.getByTestId("sidebar-agent-list-disclosure").first();
+      await expect(toggle).toBeVisible({ timeout: 20_000 });
+
+      // Hover the row and wait for the chevron before clicking. The toggle's child swaps from the
+      // project icon to a narrower chevron on hover, so clicking mid-swap aims at the old box.
+      await row.hover();
+      await expect(toggle.locator("svg")).toBeVisible({ timeout: 8_000 });
+      await toggle.click();
+
+      const list = page.getByTestId("sidebar-agent-list");
+      await expect(list).toBeVisible({ timeout: 10_000 });
+      for (const title of AGENT_TITLES) {
+        await expect(list.getByText(title, { exact: true })).toBeVisible();
+      }
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("leaves the rest of the row navigating", async ({ page }) => {
+    // The toggle carries a generous hitSlop so touch can reach it. That slop must not reach the
+    // title: everything outside the leading slot still opens the workspace.
+    const workspace = await seedWorkspace({ repoPrefix: "paseo-e2e-agent-rows-nav-" });
+    try {
+      for (const title of AGENT_TITLES) {
+        await workspace.client.createAgent({
+          provider: "mock",
+          cwd: workspace.repoPath,
+          workspaceId: workspace.workspaceId,
+          title,
+          modeId: "load-test",
+          model: "e2e-fast-stream",
+        });
+      }
+
+      await gotoAppShell(page);
+      const row = page.getByTestId(rowTestId(workspace.workspaceId));
+      await expect(row).toBeVisible({ timeout: 30_000 });
+      const toggle = page.getByTestId("sidebar-agent-list-disclosure");
+      await expect(toggle).toBeVisible({ timeout: 30_000 });
+
+      // Press just right of the toggle's slop, where the title starts.
+      const toggleBox = await toggle.boundingBox();
+      const rowBox = await row.boundingBox();
+      expect(toggleBox).not.toBeNull();
+      expect(rowBox).not.toBeNull();
+      if (toggleBox && rowBox) {
+        await page.mouse.click(toggleBox.x + toggleBox.width + 16, rowBox.y + rowBox.height / 2);
+      }
+
+      await expect(page).toHaveURL(/\/workspace\//, { timeout: 30_000 });
+      await expect(page.getByTestId("sidebar-agent-list")).toHaveCount(0);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("holds the title rail when the leading slot swaps to a chevron", async ({ page }) => {
+    // The toggle shows a 16px status slot at rest and a 14px chevron on hover. If it sizes to its
+    // content, the title and meta line slide sideways as the pointer crosses the row.
+    const workspace = await seedWorkspace({ repoPrefix: "paseo-e2e-agent-rows-rail-" });
+    try {
+      for (const title of AGENT_TITLES) {
+        await workspace.client.createAgent({
+          provider: "mock",
+          cwd: workspace.repoPath,
+          workspaceId: workspace.workspaceId,
+          title,
+          modeId: "load-test",
+          model: "e2e-fast-stream",
+        });
+      }
+
+      await gotoAppShell(page);
+      const row = page.getByTestId(rowTestId(workspace.workspaceId));
+      await expect(row).toBeVisible({ timeout: 30_000 });
+      const count = page.getByTestId("sidebar-workspace-agent-count");
+      await expect(count).toBeVisible({ timeout: 30_000 });
+
+      const atRest = await count.boundingBox();
+      await row.hover();
+      const toggle = page.getByTestId("sidebar-agent-list-disclosure");
+      await expect(toggle.locator("svg")).toBeVisible({ timeout: 8_000 });
+      const hovered = await count.boundingBox();
+
+      expect(atRest).not.toBeNull();
+      expect(hovered).not.toBeNull();
+      if (atRest && hovered) {
+        const shift = Math.abs(hovered.x - atRest.x);
+        expect(shift, `row content shifted ${shift}px on hover`).toBeLessThanOrEqual(0.5);
+      }
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("opens the list from the meta-line count as well", async ({ page }) => {
+    // The leading toggle is a 6px dot with no hover on touch. The count is the same action on a
+    // target a thumb can find.
+    const workspace = await seedWorkspace({ repoPrefix: "paseo-e2e-agent-rows-count-" });
+    try {
+      for (const title of AGENT_TITLES) {
+        await workspace.client.createAgent({
+          provider: "mock",
+          cwd: workspace.repoPath,
+          workspaceId: workspace.workspaceId,
+          title,
+          modeId: "load-test",
+          model: "e2e-fast-stream",
+        });
+      }
+
+      await gotoAppShell(page);
+      await expect(page.getByTestId(rowTestId(workspace.workspaceId))).toBeVisible({
+        timeout: 30_000,
+      });
+      const count = page.getByTestId("sidebar-workspace-agent-count");
+      await expect(count).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByTestId("sidebar-agent-list")).toHaveCount(0);
+
+      await count.click();
+      await expect(page.getByTestId("sidebar-agent-list")).toBeVisible({ timeout: 10_000 });
+      // Same action as the leading toggle, so it closes again and never navigates.
+      await count.click();
+      await expect(page.getByTestId("sidebar-agent-list")).toHaveCount(0);
+      await expect(page).not.toHaveURL(/\/workspace\//);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("draws nothing for a workspace holding one agent", async ({ page }) => {
+    const workspace = await seedWorkspace({ repoPrefix: "paseo-e2e-agent-rows-single-" });
+    try {
+      await workspace.client.createAgent({
+        provider: "mock",
+        cwd: workspace.repoPath,
+        workspaceId: workspace.workspaceId,
+        title: "Only agent",
+        modeId: "load-test",
+        model: "e2e-fast-stream",
+      });
+
+      await gotoAppShell(page);
+      await expect(page.getByTestId(rowTestId(workspace.workspaceId))).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(page.getByTestId("sidebar-agent-list-disclosure")).toHaveCount(0);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+});

--- a/packages/app/src/appearance/apply.ts
+++ b/packages/app/src/appearance/apply.ts
@@ -36,6 +36,7 @@ function scaleFontSize(
 ): Theme["fontSize"] {
   const r = uiBaseSize / FONT_SIZE.base;
   return {
+    xs: Math.round(FONT_SIZE.xs * r),
     sm: Math.round(FONT_SIZE.sm * r),
     base: Math.round(FONT_SIZE.base * r),
     lg: Math.round(FONT_SIZE.lg * r),

--- a/packages/app/src/components/agent-status-dot.tsx
+++ b/packages/app/src/components/agent-status-dot.tsx
@@ -5,7 +5,7 @@ import {
   AGENT_LIFECYCLE_STATUSES,
   type AgentLifecycleStatus,
 } from "@getpaseo/protocol/agent-lifecycle";
-import { deriveSidebarStateBucket } from "@/utils/sidebar-agent-state";
+import { deriveSidebarStateBucket, type SidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { getStatusDotColor } from "@/utils/status-dot-color";
 import { STATUS_INDICATOR_FILLED_DOT_SIZE } from "@/utils/status-indicator-geometry";
 
@@ -22,8 +22,6 @@ export function AgentStatusDot({
   pendingPermissionCount?: number;
   showInactive?: boolean;
 }) {
-  const { theme } = useUnistyles();
-
   if (!status) {
     return null;
   }
@@ -37,6 +35,24 @@ export function AgentStatusDot({
     attentionReason: attentionReason ?? null,
     pendingPermissionCount: pendingPermissionCount ?? 0,
   });
+
+  return <AgentStateBucketDot bucket={bucket} showInactive={showInactive} />;
+}
+
+/**
+ * The same dot, for callers holding a bucket rather than raw agent fields — the sidebar's agent
+ * index buckets once for the whole list. Deriving inputs backwards from a bucket to feed
+ * `AgentStatusDot` would be a lossy inverse of `deriveSidebarStateBucket`, and two ways to reach
+ * one colour is one too many.
+ */
+export function AgentStateBucketDot({
+  bucket,
+  showInactive = false,
+}: {
+  bucket: SidebarStateBucket;
+  showInactive?: boolean;
+}) {
+  const { theme } = useUnistyles();
   const color = getStatusDotColor({ theme, bucket, showDoneAsInactive: showInactive });
 
   if (!color) {

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -99,6 +99,7 @@ import { useLongPressDragInteraction } from "@/components/sidebar/use-long-press
 import { PinnedSectionHeader } from "@/components/sidebar/pinned-section-header";
 import { SidebarGroupToggleRow } from "@/components/sidebar/sidebar-group-toggle-row";
 import { useLimitedSidebarGroup } from "@/components/sidebar/use-limited-sidebar-group";
+import { SidebarWorkspaceAgentRows } from "@/components/sidebar/workspace-agent-list";
 import {
   SidebarWorkspaceRowFrame,
   SidebarWorkspaceRowContent,
@@ -1189,6 +1190,7 @@ function WorkspaceRowInner({
                 />
               </SidebarWorkspaceRowContent>
             </SidebarWorkspaceContextMenu>
+            <SidebarWorkspaceAgentRows workspace={workspace} />
           </View>
         );
       }}

--- a/packages/app/src/components/sidebar/display-preferences/agent-rows.test.ts
+++ b/packages/app/src/components/sidebar/display-preferences/agent-rows.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SIDEBAR_AGENT_ROWS,
+  hasSidebarAgentRows,
+  parseSidebarAgentRows,
+} from "./agent-rows";
+
+describe("sidebar agent rows preference", () => {
+  it("accepts the three modes and rejects anything else", () => {
+    expect(parseSidebarAgentRows("collapsed")).toBe("collapsed");
+    expect(parseSidebarAgentRows("expanded")).toBe("expanded");
+    expect(parseSidebarAgentRows("none")).toBe("none");
+    expect(parseSidebarAgentRows("sometimes")).toBeNull();
+    expect(parseSidebarAgentRows(2)).toBeNull();
+    expect(parseSidebarAgentRows(undefined)).toBeNull();
+  });
+
+  it("defaults to collapsed", () => {
+    expect(DEFAULT_SIDEBAR_AGENT_ROWS).toBe("collapsed");
+  });
+
+  it("draws nothing for a workspace holding one agent", () => {
+    // The row already is that agent's row, so a lone child would restate its dot.
+    expect(hasSidebarAgentRows({ agentCount: 1, mode: "collapsed" })).toBe(false);
+    expect(hasSidebarAgentRows({ agentCount: 1, mode: "expanded" })).toBe(false);
+    expect(hasSidebarAgentRows({ agentCount: 0, mode: "expanded" })).toBe(false);
+  });
+
+  it("draws for two or more agents unless switched off", () => {
+    expect(hasSidebarAgentRows({ agentCount: 2, mode: "collapsed" })).toBe(true);
+    expect(hasSidebarAgentRows({ agentCount: 9, mode: "expanded" })).toBe(true);
+    expect(hasSidebarAgentRows({ agentCount: 9, mode: "none" })).toBe(false);
+  });
+});
+
+describe("blocked agents open their own list", () => {
+  // The default moves; the stored override still wins. Covered here rather than in the hook so
+  // the rule is readable without a React environment.
+  const expandedByDefault = (
+    mode: "collapsed" | "expanded" | "none",
+    statuses: readonly string[],
+  ) =>
+    mode === "expanded" ||
+    statuses.some((status) => status === "needs_input" || status === "failed");
+
+  it("opens for an agent that cannot proceed without you", () => {
+    expect(expandedByDefault("collapsed", ["running", "needs_input"])).toBe(true);
+    expect(expandedByDefault("collapsed", ["running", "failed"])).toBe(true);
+  });
+
+  it("stays shut for agents that are merely busy or finished", () => {
+    expect(expandedByDefault("collapsed", ["running", "running"])).toBe(false);
+    // `attention` is a finished turn. Rearranging the sidebar every time one ends would be noise.
+    expect(expandedByDefault("collapsed", ["attention", "done"])).toBe(false);
+  });
+});

--- a/packages/app/src/components/sidebar/display-preferences/agent-rows.ts
+++ b/packages/app/src/components/sidebar/display-preferences/agent-rows.ts
@@ -1,0 +1,44 @@
+/**
+ * Whether a workspace row can expand into the agents running inside it.
+ *
+ * Not one of the boolean row items, for the same reason CI is not: the middle answer is real.
+ * "collapsed" shows how many agents a workspace holds and lets you open the list; "expanded"
+ * keeps it open. A boolean would have to pick one and call the other off.
+ *
+ * The list is only ever drawn for a workspace holding more than one active root agent. A
+ * single-agent workspace row already is that agent's row — its dot, its status, and its click
+ * target all belong to that agent — so a lone child restating them is noise, not information.
+ * That rule lives in `hasSidebarAgentRows` rather than in either row renderer, so both list modes
+ * answer it the same way.
+ *
+ * Pure on purpose, like `row-items.ts` and `checks-display.ts`: `hooks/use-settings/storage.ts`
+ * validates the persisted value through `parseSidebarAgentRows` rather than growing its own copy
+ * of the value list.
+ */
+
+export const SIDEBAR_AGENT_ROWS_MODES = ["collapsed", "expanded", "none"] as const;
+
+export type SidebarAgentRows = (typeof SIDEBAR_AGENT_ROWS_MODES)[number];
+
+export const DEFAULT_SIDEBAR_AGENT_ROWS: SidebarAgentRows = "collapsed";
+
+/** How many active root agents a workspace needs before the sub-list earns its space. */
+export const SIDEBAR_AGENT_ROWS_MIN_COUNT = 2;
+
+/** Null for anything that isn't one of the three, so callers can tell "absent" from "chosen". */
+export function parseSidebarAgentRows(value: unknown): SidebarAgentRows | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  return (SIDEBAR_AGENT_ROWS_MODES as readonly string[]).includes(value)
+    ? (value as SidebarAgentRows)
+    : null;
+}
+
+/** Whether this workspace draws a disclosure and an agent sub-list at all. */
+export function hasSidebarAgentRows(input: {
+  agentCount: number;
+  mode: SidebarAgentRows;
+}): boolean {
+  return input.mode !== "none" && input.agentCount >= SIDEBAR_AGENT_ROWS_MIN_COUNT;
+}

--- a/packages/app/src/components/sidebar/display-preferences/menu.tsx
+++ b/packages/app/src/components/sidebar/display-preferences/menu.tsx
@@ -10,7 +10,10 @@ import { useTranslation } from "react-i18next";
 import { View, type PressableStateCallbackType } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import {
+  Bot,
   Captions,
+  ChevronDown,
+  ChevronRight,
   Circle,
   CircleCheck,
   CircleDashed,
@@ -52,6 +55,7 @@ import {
 } from "@/stores/sidebar-view-store";
 import { workspaceLabelKey, type WorkspaceLabelColor } from "@getpaseo/protocol/workspace-labels";
 import type { WorkspaceTitleSource } from "@/hooks/use-settings";
+import { SIDEBAR_AGENT_ROWS_MODES, type SidebarAgentRows } from "./agent-rows";
 import { SIDEBAR_CHECKS_DISPLAYS, type SidebarChecksDisplay } from "./checks-display";
 import { useSidebarDisplayPreferences, type SidebarTrailingChoice } from "./model";
 import { SIDEBAR_ROW_ITEMS, type SidebarRowItem } from "./row-items";
@@ -109,9 +113,17 @@ const ROW_ITEM_ICONS: Record<SidebarRowItem, OptionIcon> = {
 
 // These mark how much of the row an option spends, not what CI is, so they are the shapes each
 // answer produces: a glyph with words beside it, the glyph on its own, nothing.
+const ThemedBot = withUnistyles(Bot);
+
 const CHECKS_DISPLAY_ICONS: Record<SidebarChecksDisplay, OptionIcon> = {
   iconAndText: withUnistyles(Captions),
   icon: ThemedCircleCheck,
+  none: withUnistyles(EyeOff),
+};
+
+const AGENT_ROWS_ICONS: Record<SidebarAgentRows, OptionIcon> = {
+  collapsed: withUnistyles(ChevronRight),
+  expanded: withUnistyles(ChevronDown),
   none: withUnistyles(EyeOff),
 };
 
@@ -147,6 +159,12 @@ const CHECKS_DISPLAY_LABEL_KEYS: Record<SidebarChecksDisplay, string> = {
   iconAndText: "sidebar.display.checks.iconAndText",
   icon: "sidebar.display.checks.icon",
   none: "sidebar.display.checks.none",
+};
+
+const AGENT_ROWS_LABEL_KEYS: Record<SidebarAgentRows, string> = {
+  collapsed: "sidebar.display.agents.collapsed",
+  expanded: "sidebar.display.agents.expanded",
+  none: "sidebar.display.agents.none",
 };
 
 const TRAILING_LABEL_KEYS: Record<SidebarTrailingChoice, string> = {
@@ -223,6 +241,20 @@ export function SidebarDisplayPreferencesMenu(): ReactElement {
         id: "show",
         title: t("sidebar.display.show.label"),
         content: <ShowPage preferences={preferences} />,
+      },
+      {
+        id: "agents",
+        title: t("sidebar.display.show.agents"),
+        content: (
+          <OptionList
+            values={SIDEBAR_AGENT_ROWS_MODES}
+            icons={AGENT_ROWS_ICONS}
+            labelKeys={AGENT_ROWS_LABEL_KEYS}
+            selectedValue={preferences.agentRows}
+            onSelect={preferences.setAgentRows}
+            testIDPrefix="sidebar-agent-rows"
+          />
+        ),
       },
       {
         id: "checks",
@@ -565,6 +597,7 @@ function ShowPage({ preferences }: { preferences: Preferences }): ReactElement {
         />
       ))}
       <ChecksSubTrigger />
+      <AgentRowsSubTrigger />
       <MenuSeparator />
       {TRAILING_CHOICES.map((choice) => (
         <OptionItem
@@ -596,6 +629,23 @@ function ChecksSubTrigger(): ReactElement {
   return (
     <MenuSubTrigger id="checks" leading={leading} testID="sidebar-display-checks">
       {t("sidebar.display.show.checks")}
+    </MenuSubTrigger>
+  );
+}
+
+/**
+ * Same shape as `ChecksSubTrigger`, and for the same reason: three answers too long to sit on the
+ * row as a value.
+ */
+function AgentRowsSubTrigger(): ReactElement {
+  const { t } = useTranslation();
+  const leading = useMemo(
+    () => <ThemedBot size={OPTION_ICON_SIZE} uniProps={mutedIconMapping} />,
+    [],
+  );
+  return (
+    <MenuSubTrigger id="agents" leading={leading} testID="sidebar-display-agents">
+      {t("sidebar.display.show.agents")}
     </MenuSubTrigger>
   );
 }

--- a/packages/app/src/components/sidebar/display-preferences/model.ts
+++ b/packages/app/src/components/sidebar/display-preferences/model.ts
@@ -9,6 +9,7 @@ import {
   type SidebarGroupMode,
   type SidebarLabelFilter,
 } from "@/stores/sidebar-view-store";
+import { DEFAULT_SIDEBAR_AGENT_ROWS, type SidebarAgentRows } from "./agent-rows";
 import { DEFAULT_SIDEBAR_CHECKS_DISPLAY, type SidebarChecksDisplay } from "./checks-display";
 import { DEFAULT_SIDEBAR_ROW_ITEMS, type SidebarRowItem, type SidebarRowItems } from "./row-items";
 
@@ -24,6 +25,8 @@ export interface SidebarDisplayPreferences {
   toggleRowItem: (item: SidebarRowItem) => void;
   checksDisplay: SidebarChecksDisplay;
   setChecksDisplay: (display: SidebarChecksDisplay) => void;
+  agentRows: SidebarAgentRows;
+  setAgentRows: (mode: SidebarAgentRows) => void;
   trailing: SidebarWorkspaceTrailing;
   /** Picking the choice that is already showing clears the slot. */
   toggleTrailing: (choice: SidebarTrailingChoice) => void;
@@ -66,6 +69,7 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
       sidebarWorkspaceTrailing,
       sidebarRowItems,
       sidebarChecksDisplay,
+      sidebarAgentRows,
     },
     updateSettings,
   } = useAppSettings();
@@ -93,6 +97,13 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
     [updateSettings],
   );
 
+  const setAgentRows = useCallback(
+    (mode: SidebarAgentRows) => {
+      void updateSettings({ sidebarAgentRows: mode });
+    },
+    [updateSettings],
+  );
+
   const toggleTrailing = useCallback(
     (choice: SidebarTrailingChoice) => {
       void updateSettings({
@@ -112,6 +123,8 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
       toggleRowItem,
       checksDisplay: sidebarChecksDisplay,
       setChecksDisplay,
+      agentRows: sidebarAgentRows,
+      setAgentRows,
       trailing: sidebarWorkspaceTrailing,
       toggleTrailing,
       hostFilters,
@@ -133,6 +146,8 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
       toggleRowItem,
       sidebarChecksDisplay,
       setChecksDisplay,
+      sidebarAgentRows,
+      setAgentRows,
       sidebarWorkspaceTrailing,
       toggleTrailing,
       hostFilters,
@@ -178,4 +193,15 @@ export function useSidebarMetaPreferences(): {
     }),
     [sidebarRowItems, sidebarChecksDisplay],
   );
+}
+
+/**
+ * Just the agent-row mode, for the row renderers. Same reason as `useSidebarRowItems`: a row
+ * subscribes to the one preference it reads, not to the whole menu.
+ */
+export function useSidebarAgentRows(): SidebarAgentRows {
+  const {
+    settings: { sidebarAgentRows },
+  } = useAppSettings();
+  return sidebarAgentRows ?? DEFAULT_SIDEBAR_AGENT_ROWS;
 }

--- a/packages/app/src/components/sidebar/sidebar-labels.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-labels.test.ts
@@ -33,6 +33,7 @@ function workspace(
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    agents: [],
   };
 }
 

--- a/packages/app/src/components/sidebar/sidebar-project-filter.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-project-filter.test.ts
@@ -28,6 +28,7 @@ function workspace(workspaceId: string, projectViewKey: string): SidebarWorkspac
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    agents: [],
   };
 }
 

--- a/packages/app/src/components/sidebar/sidebar-projection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.test.ts
@@ -37,6 +37,7 @@ function makeWorkspace(
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    agents: [],
     labels,
   };
   return { placement, entry };

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -49,6 +49,7 @@ import type { ShortcutKey } from "@/utils/format-shortcut";
 import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import { useKeyboardActionHandler } from "@/hooks/use-keyboard-action-handler";
 import { useClearWorkspaceAttention } from "@/hooks/use-clear-workspace-attention";
+import { SidebarWorkspaceAgentRows } from "@/components/sidebar/workspace-agent-list";
 import {
   SidebarWorkspaceRowFrame,
   SidebarWorkspaceRowContent,
@@ -916,6 +917,7 @@ function StatusWorkspaceRowInnerContent({
                 ) : null}
               </SidebarWorkspaceRowContent>
             </SidebarWorkspaceContextMenu>
+            <SidebarWorkspaceAgentRows workspace={workspace} />
           </View>
         );
       }}

--- a/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
@@ -8,6 +8,10 @@ import {
   WorkspaceMetaRow,
   type WorkspaceServiceSummary,
 } from "@/components/sidebar/workspace-meta-row";
+import {
+  SidebarAgentListToggle,
+  useSidebarAgentListModel,
+} from "@/components/sidebar/workspace-agent-list";
 import { WorkspaceHoverCard } from "@/components/workspace-hover-card";
 import type { HostBadgeModel } from "@/hosts/appearance";
 import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
@@ -123,6 +127,10 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
     settings: { workspaceTitleSource },
   } = useAppSettings();
   const workspaceLabel = resolveSidebarWorkspacePrimaryLabel({ workspace, workspaceTitleSource });
+  // Built once and handed to both the leading toggle and the meta line's count, which are two
+  // affordances for one action. Letting each build its own would mean a second store subscription
+  // per row for an answer the row already has.
+  const agentListModel = useSidebarAgentListModel(workspace);
   // The workspace carries label names; their colors live in its host's catalog, so the row is
   // where the two meet — the meta line is handed finished definitions.
   const labels = useWorkspaceLabelDefinitions(workspace.serverId, workspace.labels);
@@ -138,24 +146,26 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
   return (
     <View style={styles.workspaceRowContent}>
       <View style={styles.workspaceRowMain}>
-        {leadingProjectName ? (
-          <ProjectStatusIndicator
-            iconDataUri={leadingProjectIconDataUri}
-            displayName={leadingProjectName}
-            projectViewKey={workspace.projectViewKey}
-            statusBucket={workspace.statusBucket}
-            backdrop={backdrop}
-            loading={isLoading}
-            testID={`sidebar-row-project-icon-${workspace.workspaceKey}`}
-          />
-        ) : (
-          <WorkspaceStatusIndicator
-            bucket={workspace.statusBucket}
-            workspaceKind={workspace.workspaceKind}
-            loading={isLoading}
-            reserveIdleSpace={reserveIdleStatusIndicatorSpace}
-          />
-        )}
+        <SidebarAgentListToggle model={agentListModel} isHovered={isHovered}>
+          {leadingProjectName ? (
+            <ProjectStatusIndicator
+              iconDataUri={leadingProjectIconDataUri}
+              displayName={leadingProjectName}
+              projectViewKey={workspace.projectViewKey}
+              statusBucket={workspace.statusBucket}
+              backdrop={backdrop}
+              loading={isLoading}
+              testID={`sidebar-row-project-icon-${workspace.workspaceKey}`}
+            />
+          ) : (
+            <WorkspaceStatusIndicator
+              bucket={workspace.statusBucket}
+              workspaceKind={workspace.workspaceKind}
+              loading={isLoading}
+              reserveIdleSpace={reserveIdleStatusIndicatorSpace}
+            />
+          )}
+        </SidebarAgentListToggle>
         <View style={styles.workspaceContentColumn}>
           <View style={styles.workspaceTitleRow}>
             <Text style={workspaceBranchTextStyle} numberOfLines={1}>
@@ -170,6 +180,9 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
             prHint={workspace.prHint}
             serviceSummary={serviceSummary}
             labels={labels}
+            agentCount={workspace.agents.length}
+            agentsExpanded={agentListModel.visible ? agentListModel.expanded : null}
+            onToggleAgents={agentListModel.toggle}
           />
         </View>
       </View>

--- a/packages/app/src/components/sidebar/workspace-agent-list.tsx
+++ b/packages/app/src/components/sidebar/workspace-agent-list.tsx
@@ -1,0 +1,325 @@
+import { memo, useCallback, useMemo, type ComponentType, type ReactNode } from "react";
+import { Pressable, Text, View, type GestureResponderEvent } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { ChevronDown, ChevronRight } from "lucide-react-native";
+import { useTranslation } from "react-i18next";
+import { AgentStateBucketDot } from "@/components/agent-status-dot";
+import { getProviderIcon, type ProviderIconComponent } from "@/components/provider-icons";
+import {
+  hasSidebarAgentRows,
+  type SidebarAgentRows,
+} from "@/components/sidebar/display-preferences/agent-rows";
+import { useSidebarAgentRows } from "@/components/sidebar/display-preferences/model";
+import { STATUS_BUCKET_LABELS } from "@/hooks/sidebar-status-view-model";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import { usePanelStore } from "@/stores/panel-store";
+import { useSidebarCollapsedSectionsStore } from "@/stores/sidebar-collapsed-sections-store";
+import { isAgentListExpanded } from "@/stores/sidebar-collapsed-sections-store/state";
+import type { Theme } from "@/styles/theme";
+import { STATUS_INDICATOR_FILLED_DOT_SIZE } from "@/utils/status-indicator-geometry";
+import type { WorkspaceAgentEntry } from "@/utils/workspace-agent-activity";
+import { navigateToAgent } from "@/utils/navigate-to-agent";
+
+/**
+ * The agents inside one workspace row.
+ *
+ * Only drawn for a workspace holding more than one active root agent — see `agent-rows.ts` for
+ * why. Both sidebar list modes mount this, so the rule and the layout live here rather than
+ * twice in two row renderers.
+ *
+ * Rows carry a dot and a title and nothing else. The workspace row above already answered branch,
+ * host, change request, and CI; repeating any of it per agent is what would make the sidebar
+ * unreadable.
+ */
+
+/**
+ * `withUnistyles` per icon, cached at module scope. The wrapper has to be a stable component type:
+ * building one during render would give the icon a new identity on every update and remount it.
+ *
+ * Keyed by the component `getProviderIcon` resolves to, not by the provider id. A provider id is
+ * an arbitrary string, so keying on it would keep a separate wrapper for every unrecognised
+ * provider ever rendered even though they all resolve to one fallback glyph. Keying on the
+ * resolved component collapses those to a single entry, and a WeakMap holds nothing the icon
+ * module has itself released.
+ */
+type ThemedProviderIcon = ComponentType<{
+  size: number;
+  uniProps: (theme: Theme) => { color: string };
+}>;
+
+const themedProviderIcons = new WeakMap<ProviderIconComponent, ThemedProviderIcon>();
+
+function getThemedProviderIcon(provider: string): ThemedProviderIcon {
+  const source = getProviderIcon(provider);
+  const cached = themedProviderIcons.get(source);
+  if (cached) return cached;
+  // `withUnistyles` supplies `color` from `uniProps`, which the source component still declares
+  // as required — hence the cast rather than a wider `ProviderIconProps`.
+  const themed = withUnistyles(source) as unknown as ThemedProviderIcon;
+  themedProviderIcons.set(source, themed);
+  return themed;
+}
+
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedChevronRight = withUnistyles(ChevronRight);
+const extraMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundExtraMuted });
+
+export interface SidebarAgentListModel {
+  agents: readonly WorkspaceAgentEntry[];
+  /** Whether this workspace draws a disclosure and a list at all. */
+  visible: boolean;
+  expanded: boolean;
+  toggle: () => void;
+}
+
+/**
+ * The three fields both pieces need. `SidebarWorkspaceEntry` satisfies it structurally, so callers
+ * pass the entry they already hold.
+ */
+export interface SidebarAgentListSource {
+  workspaceKey: string;
+  serverId: string;
+  agents: readonly WorkspaceAgentEntry[];
+}
+
+/**
+ * Statuses that open a workspace's list on their own. Deliberately the two an agent cannot leave
+ * without you — `attention` means finished, which is worth a dot but not worth rearranging the
+ * sidebar for every time a turn ends.
+ */
+function hasBlockedAgent(agents: readonly WorkspaceAgentEntry[]): boolean {
+  return agents.some((agent) => agent.status === "needs_input" || agent.status === "failed");
+}
+
+export function useSidebarAgentListModel(input: SidebarAgentListSource): SidebarAgentListModel {
+  const mode: SidebarAgentRows = useSidebarAgentRows();
+  // A blocked agent opens its list without being asked. This is the case the sub-list exists for,
+  // and it is the case where reaching the toggle is most awkward — a phone, one thumb, a 6px dot.
+  // It moves the default rather than forcing the state, so a workspace you collapsed stays
+  // collapsed: an override always wins.
+  const expandedByDefault = mode === "expanded" || hasBlockedAgent(input.agents);
+  // Select this workspace's answer, not the map it lives in. The store replaces the whole
+  // overrides map on every toggle, and this hook runs twice per row, so subscribing to the map
+  // would re-render every row in the sidebar each time one workspace expanded.
+  const expanded = useSidebarCollapsedSectionsStore((state) =>
+    isAgentListExpanded(state, input.workspaceKey, expandedByDefault),
+  );
+  const toggleAgentListExpanded = useSidebarCollapsedSectionsStore(
+    (state) => state.toggleAgentListExpanded,
+  );
+
+  const visible = hasSidebarAgentRows({ agentCount: input.agents.length, mode });
+
+  const toggle = useCallback(() => {
+    toggleAgentListExpanded(input.workspaceKey, expandedByDefault);
+  }, [toggleAgentListExpanded, input.workspaceKey, expandedByDefault]);
+
+  return useMemo(
+    () => ({ agents: input.agents, visible, expanded, toggle }),
+    [input.agents, visible, expanded, toggle],
+  );
+}
+
+/**
+ * The count and chevron that sit on the workspace row itself.
+ *
+ * Its own pressable rather than part of the row press: the row navigates to the workspace, and a
+ * disclosure that navigated as a side effect of being opened would be a trap.
+ */
+/**
+ * The row's leading slot: its status indicator at rest, an expand chevron while the row is
+ * hovered. Same shape as `ProjectLeadingVisual` — a project row swaps its icon for a chevron the
+ * same way, so a workspace row that expands says so in the same place.
+ *
+ * Unlike a project row it has to be its own press target. A project header's press already
+ * toggles collapse, so its chevron can be decoration; a workspace row's press navigates, so a
+ * chevron that inherited it would look like a disclosure and open the workspace instead.
+ *
+ * `hitSlop` is what makes it usable on touch, where there is no hover to reveal the chevron and
+ * the visible target is a 6px dot. The count on the meta line is the hint that there is anything
+ * to open.
+ */
+export const SidebarAgentListToggle = memo(function SidebarAgentListToggle({
+  model,
+  isHovered,
+  children,
+}: {
+  model: SidebarAgentListModel;
+  isHovered: boolean;
+  children: ReactNode;
+}) {
+  const { t } = useTranslation();
+  const accessibilityState = useMemo(() => ({ expanded: model.expanded }), [model.expanded]);
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      // The row beneath navigates. Without this, expanding also opens the workspace.
+      event.stopPropagation();
+      model.toggle();
+    },
+    [model],
+  );
+
+  // A workspace with nothing to expand keeps its plain leading slot: no press target, no chevron.
+  if (!model.visible) {
+    return children;
+  }
+
+  const Chevron = model.expanded ? ThemedChevronDown : ThemedChevronRight;
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={accessibilityState}
+      accessibilityLabel={t("sidebar.agentList.toggle", { count: model.agents.length })}
+      onPress={handlePress}
+      hitSlop={TOGGLE_HIT_SLOP}
+      style={styles.toggle}
+      testID="sidebar-agent-list-disclosure"
+    >
+      {isHovered ? <Chevron size={14} uniProps={extraMutedColorMapping} /> : children}
+    </Pressable>
+  );
+});
+
+export const SidebarWorkspaceAgentRows = memo(function SidebarWorkspaceAgentRows({
+  workspace,
+}: {
+  workspace: SidebarAgentListSource;
+}) {
+  const model = useSidebarAgentListModel(workspace);
+  if (!model.visible || !model.expanded) {
+    return null;
+  }
+  return (
+    <View style={styles.list} testID="sidebar-agent-list">
+      {model.agents.map((agent) => (
+        <SidebarAgentRow key={agent.agentId} serverId={workspace.serverId} agent={agent} />
+      ))}
+    </View>
+  );
+});
+
+const SidebarAgentRow = memo(function SidebarAgentRow({
+  serverId,
+  agent,
+}: {
+  serverId: string;
+  agent: WorkspaceAgentEntry;
+}) {
+  const { t } = useTranslation();
+  const label = agent.title || t("agentList.fallbackTitle");
+  // Two agents a provider has not named yet share one fallback title, so the visible text alone
+  // announces them identically. The row already draws what tells them apart — the provider mark
+  // and the status dot — and this is that, spoken. `STATUS_BUCKET_LABELS` is what the project
+  // row's leading visual already announces (`project-leading-visual.tsx:180`).
+  const accessibilityLabel = `${label}, ${agent.provider}, ${STATUS_BUCKET_LABELS[agent.status]}`;
+  // Which agent this is matters most in exactly the case that draws this list: a Claude and a
+  // Codex agent in one workspace are otherwise two identical rows. History rows already pair the
+  // provider icon with the title this way (`components/agent-list.tsx:285`).
+  const ProviderIcon = getThemedProviderIcon(agent.provider);
+
+  // A compact sidebar is an overlay covering the pane it navigates. A workspace row closes it on
+  // press (`left-sidebar.tsx` hands its rows `closeSidebar`); an agent row has to do the same, or
+  // the agent changes behind the sidebar and the tap looks like it did nothing.
+  const isCompact = useIsCompactFormFactor();
+  const showMobileAgent = usePanelStore((state) => state.showMobileAgent);
+  const handlePress = useCallback(() => {
+    navigateToAgent({ serverId, agentId: agent.agentId });
+    if (isCompact) {
+      showMobileAgent();
+    }
+  }, [serverId, agent.agentId, isCompact, showMobileAgent]);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={handlePress}
+      style={rowStyle}
+      testID={`sidebar-agent-row-${agent.agentId}`}
+    >
+      <View style={styles.rowDot} testID={`sidebar-agent-row-dot-${agent.agentId}`}>
+        <AgentStateBucketDot bucket={agent.status} showInactive />
+      </View>
+      <View style={styles.rowProviderIcon}>
+        <ProviderIcon size={PROVIDER_ICON_SIZE} uniProps={extraMutedColorMapping} />
+      </View>
+      <Text style={styles.rowLabel} numberOfLines={1}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+});
+
+const PROVIDER_ICON_SIZE = 12;
+
+/**
+ * The visible target is a 14x20 slot, well under the 44pt/48dp minimum, and on touch it is the
+ * only way to open the sub-list — a project row can be tapped anywhere because its press is free,
+ * while this row's press navigates.
+ *
+ * Asymmetric because the space is. Above and below is row padding and left is the sidebar's own
+ * gutter, so growing there costs nothing; right is the workspace title, so it stays put. Lands at
+ * roughly 34x44.
+ */
+const TOGGLE_HIT_SLOP = { top: 12, bottom: 12, left: 12, right: 8 };
+
+/**
+ * Left inset for the sub-list, set so an agent's status dot shares a left edge with the agent
+ * count on the meta line above it — which is itself on the workspace title's rail. The rows then
+ * hang under the workspace's text rather than starting a second column of their own.
+ *
+ * Not a spacing token: the rail is fixed by the geometry of the row above — its padding and its
+ * leading status indicator — which no token expresses. It was tuned against the hovered layout
+ * while the slot still narrowed on hover, so it read two pixels short until the slot was pinned.
+ * `e2e/browser/sidebar-agent-rows.spec.ts` measures both boxes and fails if they drift.
+ */
+const AGENT_LIST_RAIL_INSET = 24;
+
+const rowStyle = ({ pressed }: { pressed: boolean }) => [styles.row, pressed && styles.rowPressed];
+
+const styles = StyleSheet.create((theme) => ({
+  // Leading, next to the title, not trailing. The trailing slot is overlaid by the kebab and
+  // faded by a 48px scrim on hover (`ui/trailing-action-scrim.tsx`) — fine for a diff stat nobody
+  // clicks, wrong for a control you hover the row to reach. Leading also matches how project and
+  // status-group rows already say "this expands".
+  // Width is pinned to the resting slot (`workspaceStatusDot` is `iconSize.md`). Sizing to the
+  // content instead let the 14px chevron shrink the slot on hover, sliding the title and meta
+  // line two pixels left and back as the pointer crossed the row.
+  toggle: {
+    alignItems: "center",
+    justifyContent: "center",
+    width: theme.iconSize.md,
+    height: 20,
+    flexShrink: 0,
+  },
+  list: {
+    paddingLeft: AGENT_LIST_RAIL_INSET,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1.5],
+    height: 24,
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.sm,
+  },
+  rowPressed: {
+    backgroundColor: theme.colors.surface1,
+  },
+  // Sized to the dot itself, not padded around it: the wrapper's left edge is the rail, so any
+  // centering slack inside it would show up as drift against the count.
+  rowDot: {
+    width: STATUS_INDICATOR_FILLED_DOT_SIZE,
+    alignItems: "center",
+  },
+  rowProviderIcon: {
+    width: PROVIDER_ICON_SIZE,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  rowLabel: {
+    flex: 1,
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+}));

--- a/packages/app/src/components/sidebar/workspace-meta-row/index.tsx
+++ b/packages/app/src/components/sidebar/workspace-meta-row/index.tsx
@@ -1,8 +1,8 @@
-import { Fragment, useCallback, useState, type ReactNode } from "react";
+import { Fragment, useCallback, useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, Text, View, type GestureResponderEvent } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import { ExternalLink, Folder, GitBranch, Globe } from "lucide-react-native";
+import { Bot, ExternalLink, Folder, GitBranch, Globe } from "lucide-react-native";
 import {
   workspaceLabelKey,
   type WorkspaceLabelDefinition,
@@ -18,6 +18,7 @@ import type { Theme } from "@/styles/theme";
 import { PullRequestStateIcon } from "@/git/pull-request-state-icon";
 import { CheckIndicator } from "./check-indicator";
 import type { CheckSummary, CheckSummaryState } from "./check-summary";
+import { useSidebarAgentRows } from "@/components/sidebar/display-preferences/model";
 import { selectMetaRowItems, type MetaRowItem } from "./meta-items";
 import { workspaceServiceLabelKey, type WorkspaceServiceSummary } from "./service-summary";
 
@@ -36,6 +37,7 @@ const META_ICON_SIZE = HOST_BADGE_ICON_SIZE;
 
 const ThemedExternalLink = withUnistyles(ExternalLink);
 const ThemedFolder = withUnistyles(Folder);
+const ThemedBot = withUnistyles(Bot);
 const ThemedGitBranch = withUnistyles(GitBranch);
 const ThemedGlobe = withUnistyles(Globe);
 
@@ -67,6 +69,9 @@ export function WorkspaceMetaRow({
   prHint,
   serviceSummary,
   labels = EMPTY_LABELS,
+  agentCount,
+  agentsExpanded,
+  onToggleAgents,
 }: {
   currentBranch: string | null;
   projectName: string | null;
@@ -74,8 +79,13 @@ export function WorkspaceMetaRow({
   prHint: PrHint | null;
   serviceSummary: WorkspaceServiceSummary | null;
   labels?: readonly WorkspaceLabelDefinition[];
+  agentCount: number;
+  /** Expansion state of the sub-list, or null when this workspace draws none. */
+  agentsExpanded: boolean | null;
+  onToggleAgents: () => void;
 }) {
   const { rowItems, checksDisplay } = useSidebarMetaPreferences();
+  const agentRows = useSidebarAgentRows();
   const items = selectMetaRowItems({
     currentBranch,
     projectName,
@@ -85,6 +95,8 @@ export function WorkspaceMetaRow({
     labels,
     visible: rowItems,
     checksDisplay,
+    agentCount,
+    agentRows,
   });
 
   if (items.length === 0) return null;
@@ -94,7 +106,13 @@ export function WorkspaceMetaRow({
       {items.map((item, index) => (
         <Fragment key={item.kind}>
           {index > 0 ? <Text style={styles.separator}>·</Text> : null}
-          <MetaItemNode item={item} hostBadge={hostBadge} leading={index === 0} />
+          <MetaItemNode
+            item={item}
+            hostBadge={hostBadge}
+            leading={index === 0}
+            agentsExpanded={agentsExpanded}
+            onToggleAgents={onToggleAgents}
+          />
         </Fragment>
       ))}
     </View>
@@ -105,12 +123,19 @@ function MetaItemNode({
   item,
   hostBadge,
   leading,
+  agentsExpanded,
+  onToggleAgents,
 }: {
   item: MetaRowItem;
   hostBadge: HostBadgeModel | null;
   /** First on the line, so this item's ink sets the rail the title above it already uses. */
   leading: boolean;
+  agentsExpanded: boolean | null;
+  onToggleAgents: () => void;
 }): ReactNode {
+  if (item.kind === "agents") {
+    return <AgentsItem count={item.count} expanded={agentsExpanded} onToggle={onToggleAgents} />;
+  }
   if (item.kind === "branch") {
     return <IdentityItem kind="branch" name={item.name} />;
   }
@@ -131,6 +156,60 @@ function MetaItemNode({
   }
   return <ServiceItem summary={item.summary} />;
 }
+
+/**
+ * How many agents are working in this workspace, and the second way to open them.
+ *
+ * The leading slot is the primary control, but it is a 6px dot on touch with no hover to reveal
+ * its chevron. This is the same action on a target a thumb can find: it is already on the row,
+ * already says how many agents there are, and sits clear of both the kebab and the title.
+ *
+ * Two affordances for one action is fine — neither is ambiguous about what it does — and it is
+ * why this stays a count rather than growing a chevron of its own.
+ */
+function AgentsItem({
+  count,
+  expanded,
+  onToggle,
+}: {
+  count: number;
+  expanded: boolean | null;
+  onToggle: () => void;
+}) {
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      // The row beneath navigates.
+      event.stopPropagation();
+      onToggle();
+    },
+    [onToggle],
+  );
+  const accessibilityState = useMemo(
+    () => (expanded === null ? undefined : { expanded }),
+    [expanded],
+  );
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={accessibilityState}
+      onPress={handlePress}
+      hitSlop={AGENT_COUNT_HIT_SLOP}
+      style={styles.identityItem}
+      testID="sidebar-workspace-agent-count"
+    >
+      <View style={styles.identityIcon}>
+        <ThemedBot size={META_ICON_SIZE} uniProps={mutedMapping} />
+      </View>
+      <Text style={styles.identityText} numberOfLines={1}>
+        {count}
+      </Text>
+    </Pressable>
+  );
+}
+
+/** Vertical room is the meta line's own padding; horizontal would reach the next item. */
+const AGENT_COUNT_HIT_SLOP = { top: 10, bottom: 10, left: 6, right: 6 };
 
 function IdentityItem({ kind, name }: { kind: "branch" | "project"; name: string }) {
   const Icon = kind === "branch" ? ThemedGitBranch : ThemedFolder;

--- a/packages/app/src/components/sidebar/workspace-meta-row/meta-items.test.ts
+++ b/packages/app/src/components/sidebar/workspace-meta-row/meta-items.test.ts
@@ -26,6 +26,8 @@ function select(overrides: Partial<Parameters<typeof selectMetaRowItems>[0]> = {
     prHint: PR_HINT,
     serviceSummary: SERVICE,
     labels: LABELS,
+    agentCount: 0,
+    agentRows: "collapsed",
     visible: DEFAULT_SIDEBAR_ROW_ITEMS,
     checksDisplay: DEFAULT_SIDEBAR_CHECKS_DISPLAY,
     ...overrides,
@@ -141,5 +143,19 @@ describe("selectMetaRowItems", () => {
   it("keeps a change request whose forge reports no checks", () => {
     const items = select({ prHint: { ...PR_HINT, checksStatus: undefined } });
     expect(kinds(items)).toEqual(["host", "changeRequest", "services", "labels"]);
+  });
+
+  it("leads with the agent count, ahead of identity", () => {
+    const items = select({ agentCount: 3 });
+    expect(items[0]).toEqual({ kind: "agents", count: 3 });
+  });
+
+  it("omits the agent count wherever the sub-list is not drawn", () => {
+    // One agent draws no sub-list, so a count beside it would report something the row cannot open.
+    expect(select({ agentCount: 1 }).some((item) => item.kind === "agents")).toBe(false);
+    expect(select({ agentCount: 0 }).some((item) => item.kind === "agents")).toBe(false);
+    expect(
+      select({ agentCount: 5, agentRows: "none" }).some((item) => item.kind === "agents"),
+    ).toBe(false);
   });
 });

--- a/packages/app/src/components/sidebar/workspace-meta-row/meta-items.ts
+++ b/packages/app/src/components/sidebar/workspace-meta-row/meta-items.ts
@@ -1,21 +1,29 @@
 import type { WorkspaceLabelDefinition } from "@getpaseo/protocol/workspace-labels";
 import type { PrHint } from "@/git/pr-hint";
+import {
+  hasSidebarAgentRows,
+  type SidebarAgentRows,
+} from "@/components/sidebar/display-preferences/agent-rows";
 import type { SidebarChecksDisplay } from "@/components/sidebar/display-preferences/checks-display";
 import type { SidebarRowItems } from "@/components/sidebar/display-preferences/row-items";
 import { selectCheckSummary, type CheckSummary } from "./check-summary";
 import type { WorkspaceServiceSummary } from "./service-summary";
 
 /**
- * What ends up on the line under a workspace title, in the order it is read: where the
- * workspace lives, what change it belongs to, whether that change is passing, what it is
- * running, and what someone filed it under. Identity first, then the work, then the work's
- * state, then the labels a person put on it.
+ * What ends up on the line under a workspace title, in the order it is read: how many agents are
+ * working in it, where the workspace lives, what change it belongs to, whether that change is
+ * passing, what it is running, and what someone filed it under.
+ *
+ * The agent count leads, ahead of identity. Every other item describes the workspace — where it
+ * is, which change it carries, how that change is doing. The count is the only one about live
+ * work, and it is the reason you would open the row at all, so it is read first.
  *
  * Labels are one item rather than one per label: they are drawn as a run of chips with a single
  * separator in front of them, so the line reads as four peers however many labels a workspace
  * carries.
  */
 export type MetaRowItem =
+  | { kind: "agents"; count: number }
   | { kind: "branch"; name: string }
   | { kind: "project"; name: string }
   | { kind: "host" }
@@ -43,6 +51,9 @@ export function selectMetaRowItems(input: {
   labels: readonly WorkspaceLabelDefinition[];
   visible: SidebarRowItems;
   checksDisplay: SidebarChecksDisplay;
+  /** Active root agents in the workspace. Drawn only where the sub-list is, so the two agree. */
+  agentCount: number;
+  agentRows: SidebarAgentRows;
 }): MetaRowItem[] {
   const {
     currentBranch,
@@ -53,8 +64,14 @@ export function selectMetaRowItems(input: {
     labels,
     visible,
     checksDisplay,
+    agentCount,
+    agentRows,
   } = input;
   const items: MetaRowItem[] = [];
+
+  if (hasSidebarAgentRows({ agentCount, mode: agentRows })) {
+    items.push({ kind: "agents", count: agentCount });
+  }
 
   if (currentBranch && visible.branch) {
     items.push({ kind: "branch", name: currentBranch });

--- a/packages/app/src/hooks/sidebar-status-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-status-view-model.test.ts
@@ -33,6 +33,7 @@ function ws(
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    agents: [],
     workspaceKey: input.workspaceKey,
   };
 }

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -10,7 +10,7 @@ import type {
 import { projectDisplayNameFromProjectId } from "@/utils/project-display-name";
 import { aggregateSidebarStateBuckets } from "@/utils/sidebar-agent-state";
 import { shortenPath } from "@/utils/shorten-path";
-import type { WorkspaceAgentActivity } from "@/utils/workspace-agent-activity";
+import type { WorkspaceAgentActivity, WorkspaceAgentEntry } from "@/utils/workspace-agent-activity";
 import { resolveWorkspaceMapKeyByIdentity } from "@/utils/workspace-identity";
 
 const EMPTY_PROJECTS: SidebarProjectEntry[] = [];
@@ -52,6 +52,12 @@ export interface SidebarWorkspaceEntry extends SidebarStatusWorkspacePlacement {
   archiveUnpushedCommitCount: number | null;
   scripts: WorkspaceDescriptor["scripts"];
   hasRunningScripts: boolean;
+  /**
+   * Active root agents in this workspace, most recently active first. `statusBucket` above is this
+   * list's head once the workspace itself is `done`, so a row and its agent sub-list never
+   * disagree. Empty for a workspace whose agents are all archived.
+   */
+  agents: readonly WorkspaceAgentEntry[];
 }
 
 export interface SidebarProjectEntry {
@@ -152,6 +158,8 @@ export function createSidebarWorkspaceEntry(input: {
 }): SidebarWorkspaceEntry {
   const projectViewKey = input.projectViewKey ?? input.workspace.projectId;
   const effectiveStatus = deriveEffectiveWorkspaceStatus(input);
+  const agents =
+    input.workspaceAgentActivity?.get(input.workspace.id)?.agents ?? EMPTY_WORKSPACE_AGENTS;
   return {
     workspaceKey: `${input.serverId}:${input.workspace.id}`,
     serverId: input.serverId,
@@ -181,10 +189,12 @@ export function createSidebarWorkspaceEntry(input: {
     archiveUnpushedCommitCount: input.workspace.gitRuntime?.aheadOfOrigin ?? null,
     scripts: input.workspace.scripts,
     hasRunningScripts: input.workspace.scripts.some((script) => script.lifecycle === "running"),
+    agents,
   };
 }
 
 const EMPTY_WORKSPACE_LABELS: string[] = [];
+const EMPTY_WORKSPACE_AGENTS: readonly WorkspaceAgentEntry[] = [];
 
 function deriveEffectiveWorkspaceStatus(input: {
   serverId: string;

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -4,6 +4,10 @@ import type { QueryClient } from "@tanstack/react-query";
 import type { DesktopSettings } from "@/desktop/settings/desktop-settings";
 import type { AppLanguage } from "@/i18n/locales";
 import {
+  DEFAULT_SIDEBAR_AGENT_ROWS,
+  type SidebarAgentRows,
+} from "@/components/sidebar/display-preferences/agent-rows";
+import {
   DEFAULT_SIDEBAR_CHECKS_DISPLAY,
   type SidebarChecksDisplay,
 } from "@/components/sidebar/display-preferences/checks-display";
@@ -82,6 +86,7 @@ export interface AppSettings {
   sidebarWorkspaceTrailing: SidebarWorkspaceTrailing;
   sidebarRowItems: SidebarRowItems;
   sidebarChecksDisplay: SidebarChecksDisplay;
+  sidebarAgentRows: SidebarAgentRows;
   autoExpandReasoning: boolean;
   toolCallDetailLevel: ToolCallDetailLevel;
   chatOutlineEnabled: boolean;
@@ -130,6 +135,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   sidebarWorkspaceTrailing: "diff",
   sidebarRowItems: DEFAULT_SIDEBAR_ROW_ITEMS,
   sidebarChecksDisplay: DEFAULT_SIDEBAR_CHECKS_DISPLAY,
+  sidebarAgentRows: DEFAULT_SIDEBAR_AGENT_ROWS,
   autoExpandReasoning: false,
   toolCallDetailLevel: "detailed",
   chatOutlineEnabled: true,
@@ -218,6 +224,7 @@ const StoredAppSettingsSchema = z
       .enum(["iconAndText", "icon", "none"])
       .optional()
       .catch(DEFAULT_SIDEBAR_CHECKS_DISPLAY),
+    sidebarAgentRows: z.enum(["collapsed", "expanded", "none"]).catch(DEFAULT_SIDEBAR_AGENT_ROWS),
     autoExpandReasoning: z.boolean().catch(false),
     toolCallDetailLevel: z
       .enum(["overview", "detailed"])

--- a/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
+++ b/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
@@ -36,6 +36,7 @@ function workspace(projectKey: string, workspaceId: string): SidebarWorkspaceEnt
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    agents: [],
   };
 }
 

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1024,6 +1024,9 @@ export const ar: TranslationResources = {
     },
   },
   sidebar: {
+    agentList: {
+      toggle: "الوكلاء ({{count}})",
+    },
     display: {
       trigger: "تفضيلات العرض",
       heading: "العرض",
@@ -1039,6 +1042,7 @@ export const ar: TranslationResources = {
         branch: "اسم الفرع",
       },
       show: {
+        agents: "الوكلاء",
         label: "إظهار",
         branch: "الفرع",
         project: "المشروع",
@@ -1053,6 +1057,11 @@ export const ar: TranslationResources = {
       checks: {
         iconAndText: "أيقونة ونص",
         icon: "أيقونة فقط",
+        none: "مخفي",
+      },
+      agents: {
+        collapsed: "مطوي",
+        expanded: "موسّع",
         none: "مخفي",
       },
       hostFilter: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1033,6 +1033,9 @@ export const en = {
     },
   },
   sidebar: {
+    agentList: {
+      toggle: "Agents ({{count}})",
+    },
     display: {
       trigger: "Display preferences",
       heading: "Display",
@@ -1048,6 +1051,7 @@ export const en = {
         branch: "Branch name",
       },
       show: {
+        agents: "Agents",
         label: "Show",
         branch: "Branch",
         project: "Project",
@@ -1062,6 +1066,11 @@ export const en = {
       checks: {
         iconAndText: "Icon and text",
         icon: "Icon only",
+        none: "Hidden",
+      },
+      agents: {
+        collapsed: "Collapsed",
+        expanded: "Expanded",
         none: "Hidden",
       },
       hostFilter: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1058,6 +1058,9 @@ export const es: TranslationResources = {
     },
   },
   sidebar: {
+    agentList: {
+      toggle: "Agentes ({{count}})",
+    },
     display: {
       trigger: "Preferencias de visualización",
       heading: "Visualización",
@@ -1073,6 +1076,7 @@ export const es: TranslationResources = {
         branch: "Nombre de rama",
       },
       show: {
+        agents: "Agentes",
         label: "Mostrar",
         branch: "Rama",
         project: "Proyecto",
@@ -1087,6 +1091,11 @@ export const es: TranslationResources = {
       checks: {
         iconAndText: "Icono y texto",
         icon: "Solo icono",
+        none: "Oculto",
+      },
+      agents: {
+        collapsed: "Contraído",
+        expanded: "Expandido",
         none: "Oculto",
       },
       hostFilter: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1057,6 +1057,9 @@ export const fr: TranslationResources = {
     },
   },
   sidebar: {
+    agentList: {
+      toggle: "Agents ({{count}})",
+    },
     display: {
       trigger: "Préférences d'affichage",
       heading: "Affichage",
@@ -1072,6 +1075,7 @@ export const fr: TranslationResources = {
         branch: "Nom de branche",
       },
       show: {
+        agents: "Agents",
         label: "Afficher",
         branch: "Branche",
         project: "Projet",
@@ -1086,6 +1090,11 @@ export const fr: TranslationResources = {
       checks: {
         iconAndText: "Icône et texte",
         icon: "Icône seule",
+        none: "Masqué",
+      },
+      agents: {
+        collapsed: "Replié",
+        expanded: "Déplié",
         none: "Masqué",
       },
       hostFilter: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1035,6 +1035,9 @@ export const ja: TranslationResources = {
     },
   },
   sidebar: {
+    agentList: {
+      toggle: "エージェント ({{count}})",
+    },
     display: {
       trigger: "表示設定",
       heading: "表示",
@@ -1050,6 +1053,7 @@ export const ja: TranslationResources = {
         branch: "ブランチ名",
       },
       show: {
+        agents: "エージェント",
         label: "表示項目",
         branch: "ブランチ",
         project: "プロジェクト",
@@ -1064,6 +1068,11 @@ export const ja: TranslationResources = {
       checks: {
         iconAndText: "アイコンとテキスト",
         icon: "アイコンのみ",
+        none: "非表示",
+      },
+      agents: {
+        collapsed: "折りたたむ",
+        expanded: "展開",
         none: "非表示",
       },
       hostFilter: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1031,6 +1031,9 @@ export const ko: TranslationResources = {
     },
   },
   sidebar: {
+    agentList: {
+      toggle: "에이전트 ({{count}})",
+    },
     display: {
       trigger: "표시 설정",
       heading: "표시",
@@ -1046,6 +1049,7 @@ export const ko: TranslationResources = {
         branch: "브랜치 이름",
       },
       show: {
+        agents: "에이전트",
         label: "표시 항목",
         branch: "브랜치",
         project: "프로젝트",
@@ -1060,6 +1064,11 @@ export const ko: TranslationResources = {
       checks: {
         iconAndText: "아이콘 및 텍스트",
         icon: "아이콘만",
+        none: "숨김",
+      },
+      agents: {
+        collapsed: "접힘",
+        expanded: "펼침",
         none: "숨김",
       },
       hostFilter: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1049,6 +1049,9 @@ export const ptBR: TranslationResources = {
     },
   },
   sidebar: {
+    agentList: {
+      toggle: "Agentes ({{count}})",
+    },
     display: {
       trigger: "Preferências de exibição",
       heading: "Exibição",
@@ -1064,6 +1067,7 @@ export const ptBR: TranslationResources = {
         branch: "Nome da branch",
       },
       show: {
+        agents: "Agentes",
         label: "Mostrar",
         branch: "Branch",
         project: "Projeto",
@@ -1078,6 +1082,11 @@ export const ptBR: TranslationResources = {
       checks: {
         iconAndText: "Ícone e texto",
         icon: "Somente ícone",
+        none: "Oculto",
+      },
+      agents: {
+        collapsed: "Recolhido",
+        expanded: "Expandido",
         none: "Oculto",
       },
       hostFilter: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1039,6 +1039,9 @@ export const ru: TranslationResources = {
     },
   },
   sidebar: {
+    agentList: {
+      toggle: "Агенты ({{count}})",
+    },
     display: {
       trigger: "Настройки отображения",
       heading: "Отображение",
@@ -1054,6 +1057,7 @@ export const ru: TranslationResources = {
         branch: "Имя ветки",
       },
       show: {
+        agents: "Агенты",
         label: "Показывать",
         branch: "Ветка",
         project: "Проект",
@@ -1068,6 +1072,11 @@ export const ru: TranslationResources = {
       checks: {
         iconAndText: "Значок и текст",
         icon: "Только значок",
+        none: "Скрыто",
+      },
+      agents: {
+        collapsed: "Свёрнуто",
+        expanded: "Развёрнуто",
         none: "Скрыто",
       },
       hostFilter: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1016,6 +1016,9 @@ export const zhCN: TranslationResources = {
     },
   },
   sidebar: {
+    agentList: {
+      toggle: "Agents ({{count}})",
+    },
     display: {
       trigger: "显示偏好",
       heading: "显示",
@@ -1031,6 +1034,7 @@ export const zhCN: TranslationResources = {
         branch: "分支名称",
       },
       show: {
+        agents: "Agents",
         label: "显示",
         branch: "分支",
         project: "项目",
@@ -1045,6 +1049,11 @@ export const zhCN: TranslationResources = {
       checks: {
         iconAndText: "图标和文字",
         icon: "仅图标",
+        none: "隐藏",
+      },
+      agents: {
+        collapsed: "折叠",
+        expanded: "展开",
         none: "隐藏",
       },
       hostFilter: {

--- a/packages/app/src/screens/settings/host-appearance-section.tsx
+++ b/packages/app/src/screens/settings/host-appearance-section.tsx
@@ -215,6 +215,9 @@ function BadgeDisplayMenuItem({
  * the sidebar surface. The real component, never a restyled copy — a preview that can drift
  * from the thing it previews is worse than no preview.
  */
+/** The preview has no workspace behind it, so its count never draws and nothing can be toggled. */
+const noop = () => {};
+
 function BadgePreview({
   host,
   badgeDisplay,
@@ -247,6 +250,9 @@ function BadgePreview({
         hostBadge={hostBadge}
         prHint={null}
         serviceSummary={null}
+        agentCount={0}
+        agentsExpanded={null}
+        onToggleAgents={noop}
       />
     </View>
   );

--- a/packages/app/src/stores/sidebar-collapsed-sections-store/index.ts
+++ b/packages/app/src/stores/sidebar-collapsed-sections-store/index.ts
@@ -9,6 +9,7 @@ import {
   PersistedCollapsedProjectsSchema,
   serializeCollapsedProjects,
   setProjectCollapsed,
+  toggleAgentListExpanded,
   togglePinnedCollapsed,
   toggleProjectCollapsed,
   toggleWorkspaceGroupCollapsed,
@@ -19,6 +20,7 @@ interface SidebarCollapsedSectionsState extends CollapsedProjectsState {
   setProjectCollapsed: (projectKey: string, collapsed: boolean) => void;
   toggleWorkspaceGroupCollapsed: (workspaceGroupKey: string) => void;
   togglePinnedCollapsed: () => void;
+  toggleAgentListExpanded: (workspaceKey: string, expandedByDefault: boolean) => void;
 }
 
 export const useSidebarCollapsedSectionsStore = create<SidebarCollapsedSectionsState>()(
@@ -27,6 +29,7 @@ export const useSidebarCollapsedSectionsStore = create<SidebarCollapsedSectionsS
       collapsedProjectKeys: new Set(),
       collapsedWorkspaceGroupKeys: new Set(),
       collapsedPinned: false,
+      agentListOverrides: new Map(),
       toggleProjectCollapsed: (projectKey) =>
         set((state) => toggleProjectCollapsed(state, projectKey)),
       setProjectCollapsed: (projectKey, collapsed) =>
@@ -34,6 +37,8 @@ export const useSidebarCollapsedSectionsStore = create<SidebarCollapsedSectionsS
       toggleWorkspaceGroupCollapsed: (workspaceGroupKey) =>
         set((state) => toggleWorkspaceGroupCollapsed(state, workspaceGroupKey)),
       togglePinnedCollapsed: () => set((state) => togglePinnedCollapsed(state)),
+      toggleAgentListExpanded: (workspaceKey, expandedByDefault) =>
+        set((state) => toggleAgentListExpanded(state, workspaceKey, expandedByDefault)),
     }),
     {
       name: "sidebar-collapsed-sections",

--- a/packages/app/src/stores/sidebar-collapsed-sections-store/state.test.ts
+++ b/packages/app/src/stores/sidebar-collapsed-sections-store/state.test.ts
@@ -7,6 +7,8 @@ import {
   togglePinnedCollapsed,
   toggleProjectCollapsed,
   toggleWorkspaceGroupCollapsed,
+  isAgentListExpanded,
+  toggleAgentListExpanded,
 } from "@/stores/sidebar-collapsed-sections-store/state";
 
 function emptyState(): CollapsedProjectsState {
@@ -14,6 +16,7 @@ function emptyState(): CollapsedProjectsState {
     collapsedProjectKeys: new Set(),
     collapsedWorkspaceGroupKeys: new Set(),
     collapsedPinned: false,
+    agentListOverrides: new Map(),
   };
 }
 
@@ -35,12 +38,14 @@ describe("sidebar collapsed projects transitions", () => {
       collapsedProjectKeys: new Set(["project-a", "project-b"]),
       collapsedWorkspaceGroupKeys: new Set(["running"]),
       collapsedPinned: true,
+      agentListOverrides: new Map(),
     };
 
     expect(serializeCollapsedProjects(state)).toEqual({
       collapsedProjectKeys: ["project-a", "project-b"],
       collapsedWorkspaceGroupKeys: ["running"],
       collapsedPinned: true,
+      agentListOverrides: {},
     });
   });
 
@@ -70,5 +75,39 @@ describe("sidebar collapsed projects transitions", () => {
     expect(mergePersistedCollapsedProjects({ collapsedProjectKeys: [] }, currentState)).toBe(
       currentState,
     );
+  });
+});
+
+describe("sidebar agent list expansion", () => {
+  it("reads the display preference until a workspace is toggled", () => {
+    const state = emptyState();
+    expect(isAgentListExpanded(state, "host-a:ws-1", false)).toBe(false);
+    expect(isAgentListExpanded(state, "host-a:ws-1", true)).toBe(true);
+  });
+
+  it("stores an override only while it differs from the default", () => {
+    const expanded = toggleAgentListExpanded(emptyState(), "host-a:ws-1", false);
+    expect(isAgentListExpanded(expanded, "host-a:ws-1", false)).toBe(true);
+    expect(expanded.agentListOverrides.get("host-a:ws-1")).toBe(true);
+
+    // Back to the default: the override is dropped rather than pinned, so a later change to the
+    // display preference still reaches this workspace.
+    const collapsed = toggleAgentListExpanded(expanded, "host-a:ws-1", false);
+    expect(collapsed.agentListOverrides.has("host-a:ws-1")).toBe(false);
+    expect(isAgentListExpanded(collapsed, "host-a:ws-1", true)).toBe(true);
+  });
+
+  it("keeps overrides per workspace", () => {
+    const state = toggleAgentListExpanded(emptyState(), "host-a:ws-1", false);
+    expect(isAgentListExpanded(state, "host-a:ws-2", false)).toBe(false);
+  });
+
+  it("round-trips overrides through persistence", () => {
+    const state = toggleAgentListExpanded(emptyState(), "host-a:ws-1", false);
+    const restored = mergePersistedCollapsedProjects(
+      serializeCollapsedProjects(state),
+      emptyState(),
+    );
+    expect(isAgentListExpanded(restored, "host-a:ws-1", false)).toBe(true);
   });
 });

--- a/packages/app/src/stores/sidebar-collapsed-sections-store/state.ts
+++ b/packages/app/src/stores/sidebar-collapsed-sections-store/state.ts
@@ -4,6 +4,14 @@ export interface CollapsedProjectsState {
   collapsedProjectKeys: Set<string>;
   collapsedWorkspaceGroupKeys: Set<string>;
   collapsedPinned: boolean;
+  /**
+   * Per-workspace overrides for the agent sub-list, keyed by `${serverId}:${workspaceId}`.
+   *
+   * An override rather than a set of collapsed keys, because this is the one section whose
+   * default flips with a preference: `sidebarAgentRows` is "collapsed" or "expanded". A bare set
+   * would silently invert every stored row the moment the user changed that preference.
+   */
+  agentListOverrides: Map<string, boolean>;
 }
 
 export interface PersistedCollapsedProjects {
@@ -11,6 +19,7 @@ export interface PersistedCollapsedProjects {
   collapsedWorkspaceGroupKeys?: string[];
   collapsedStatusGroupKeys?: string[];
   collapsedPinned?: boolean;
+  agentListOverrides?: Record<string, boolean>;
 }
 
 export const PersistedCollapsedProjectsSchema: z.ZodType<PersistedCollapsedProjects> =
@@ -20,6 +29,7 @@ export const PersistedCollapsedProjectsSchema: z.ZodType<PersistedCollapsedProje
     // COMPAT(sidebarWorkspaceGroupCollapse): added in v0.4.0, remove after 2027-02-14.
     collapsedStatusGroupKeys: z.array(z.string()).optional(),
     collapsedPinned: z.boolean().optional(),
+    agentListOverrides: z.record(z.string(), z.boolean()).optional(),
   });
 
 export function togglePinnedCollapsed(state: CollapsedProjectsState): CollapsedProjectsState {
@@ -52,6 +62,34 @@ export function toggleWorkspaceGroupCollapsed(
   return { ...state, collapsedWorkspaceGroupKeys: next };
 }
 
+/**
+ * Flip one workspace's agent sub-list. `expandedByDefault` comes from the display preference, so
+ * a toggle back to the default drops the override instead of pinning the value the user already
+ * had — otherwise changing the preference would leave stale rows behind.
+ */
+export function toggleAgentListExpanded(
+  state: CollapsedProjectsState,
+  workspaceKey: string,
+  expandedByDefault: boolean,
+): CollapsedProjectsState {
+  const current = state.agentListOverrides.get(workspaceKey) ?? expandedByDefault;
+  const next = new Map(state.agentListOverrides);
+  if (!current === expandedByDefault) {
+    next.delete(workspaceKey);
+  } else {
+    next.set(workspaceKey, !current);
+  }
+  return { ...state, agentListOverrides: next };
+}
+
+export function isAgentListExpanded(
+  state: Pick<CollapsedProjectsState, "agentListOverrides">,
+  workspaceKey: string,
+  expandedByDefault: boolean,
+): boolean {
+  return state.agentListOverrides.get(workspaceKey) ?? expandedByDefault;
+}
+
 export function setProjectCollapsed(
   state: CollapsedProjectsState,
   projectKey: string,
@@ -70,11 +108,13 @@ export function serializeCollapsedProjects(state: CollapsedProjectsState): {
   collapsedProjectKeys: string[];
   collapsedWorkspaceGroupKeys: string[];
   collapsedPinned: boolean;
+  agentListOverrides: Record<string, boolean>;
 } {
   return {
     collapsedProjectKeys: Array.from(state.collapsedProjectKeys),
     collapsedWorkspaceGroupKeys: Array.from(state.collapsedWorkspaceGroupKeys),
     collapsedPinned: state.collapsedPinned,
+    agentListOverrides: Object.fromEntries(state.agentListOverrides),
   };
 }
 
@@ -96,10 +136,14 @@ export function mergePersistedCollapsedProjects<S extends CollapsedProjectsState
       Array.from(current.collapsedWorkspaceGroupKeys),
   );
   const restoredPinned = persisted.collapsedPinned ?? current.collapsedPinned;
+  const restoredAgentListOverrides = persisted.agentListOverrides
+    ? new Map(Object.entries(persisted.agentListOverrides))
+    : current.agentListOverrides;
   if (
     areSetsEqual(current.collapsedProjectKeys, restoredProjects) &&
     areSetsEqual(current.collapsedWorkspaceGroupKeys, restoredWorkspaceGroups) &&
-    current.collapsedPinned === restoredPinned
+    current.collapsedPinned === restoredPinned &&
+    areOverridesEqual(current.agentListOverrides, restoredAgentListOverrides)
   ) {
     return current;
   }
@@ -108,7 +152,20 @@ export function mergePersistedCollapsedProjects<S extends CollapsedProjectsState
     collapsedProjectKeys: restoredProjects,
     collapsedWorkspaceGroupKeys: restoredWorkspaceGroups,
     collapsedPinned: restoredPinned,
+    agentListOverrides: restoredAgentListOverrides,
   };
+}
+
+function areOverridesEqual(left: Map<string, boolean>, right: Map<string, boolean>): boolean {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const [key, value] of left) {
+    if (right.get(key) !== value) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function deserializeCollapsedKeys(value: string[]): Set<string> {

--- a/packages/app/src/styles/theme.test.ts
+++ b/packages/app/src/styles/theme.test.ts
@@ -13,6 +13,7 @@ describe("Typography scale", () => {
     expect(FONT_SIZE).toEqual({
       code: 12,
       content: 15,
+      xs: 11,
       sm: 12,
       base: 14,
       lg: 16,

--- a/packages/app/src/styles/theme.ts
+++ b/packages/app/src/styles/theme.ts
@@ -561,6 +561,10 @@ export const SPACING = {
 export const FONT_SIZE = {
   code: 12,
   content: 15,
+  // One step below `sm`, for text that is deliberately subordinate to what it sits with —
+  // a row it hangs under, or the group heading it labels. Not for body text: `sm` is the
+  // floor for anything a user reads on its own.
+  xs: 11,
   sm: 12,
   base: 14,
   lg: 16,

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -31,6 +31,7 @@ function workspace(overrides: Partial<SidebarWorkspaceEntry> = {}): SidebarWorks
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    agents: [],
     statusEnteredAt: null,
     ...overrides,
     archivingAt: overrides.archivingAt ?? null,

--- a/packages/app/src/utils/sidebar-shortcuts.test.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.test.ts
@@ -42,6 +42,7 @@ function workspace(input: {
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    agents: [],
   };
 }
 

--- a/packages/app/src/utils/workspace-agent-activity.test.ts
+++ b/packages/app/src/utils/workspace-agent-activity.test.ts
@@ -13,6 +13,7 @@ function agent(input: {
   pendingPermissionCount?: number;
   archivedAt?: string | null;
   parentAgentId?: string | null;
+  title?: string | null;
 }): Agent {
   return {
     serverId: "host-a",
@@ -42,7 +43,7 @@ function agent(input: {
       input: {},
     })),
     persistence: null,
-    title: null,
+    title: input.title ?? null,
     cwd: "/repo",
     workspaceId: input.workspaceId,
     model: null,
@@ -99,6 +100,22 @@ describe("workspace agent activity index", () => {
             agentId: "permission",
             status: "needs_input",
             enteredAt: new Date("2026-06-01T10:01:00.000Z"),
+            agents: [
+              {
+                agentId: "permission",
+                title: null,
+                provider: "codex",
+                status: "needs_input",
+                enteredAt: new Date("2026-06-01T10:01:00.000Z"),
+              },
+              {
+                agentId: "older",
+                title: null,
+                provider: "codex",
+                status: "running",
+                enteredAt: new Date("2026-06-01T10:00:00.000Z"),
+              },
+            ],
           },
         ],
         [
@@ -107,6 +124,15 @@ describe("workspace agent activity index", () => {
             agentId: "attention",
             status: "attention",
             enteredAt: new Date("2026-06-01T10:02:00.000Z"),
+            agents: [
+              {
+                agentId: "attention",
+                title: null,
+                provider: "codex",
+                status: "attention",
+                enteredAt: new Date("2026-06-01T10:02:00.000Z"),
+              },
+            ],
           },
         ],
       ]),
@@ -153,6 +179,15 @@ describe("workspace agent activity index", () => {
       agentId: "root",
       status: "running",
       enteredAt: new Date("2026-06-01T10:00:00.000Z"),
+      agents: [
+        {
+          agentId: "root",
+          title: null,
+          provider: "codex",
+          status: "running",
+          enteredAt: new Date("2026-06-01T10:00:00.000Z"),
+        },
+      ],
     });
   });
 
@@ -188,6 +223,15 @@ describe("workspace agent activity index", () => {
             agentId: "parent",
             status: "done",
             enteredAt: new Date("2026-06-01T10:00:00.000Z"),
+            agents: [
+              {
+                agentId: "parent",
+                title: null,
+                provider: "codex",
+                status: "done",
+                enteredAt: new Date("2026-06-01T10:00:00.000Z"),
+              },
+            ],
           },
         ],
         [
@@ -196,6 +240,15 @@ describe("workspace agent activity index", () => {
             agentId: "child",
             status: "running",
             enteredAt: new Date("2026-06-01T10:03:00.000Z"),
+            agents: [
+              {
+                agentId: "child",
+                title: null,
+                provider: "codex",
+                status: "running",
+                enteredAt: new Date("2026-06-01T10:03:00.000Z"),
+              },
+            ],
           },
         ],
       ]),
@@ -272,6 +325,248 @@ describe("workspace agent activity index", () => {
       agentId: "root",
       status: "needs_input",
       enteredAt: new Date("2026-06-01T10:05:00.000Z"),
+      agents: [
+        {
+          agentId: "root",
+          title: null,
+          provider: "codex",
+          status: "needs_input",
+          enteredAt: new Date("2026-06-01T10:05:00.000Z"),
+        },
+      ],
     });
+  });
+  it("lists every active root agent in a workspace, most recently active first", () => {
+    const index = buildWorkspaceAgentActivityIndex(
+      new Map([
+        [
+          "middle",
+          agent({
+            id: "middle",
+            workspaceId: "workspace-a",
+            status: "running",
+            updatedAt: "2026-06-01T10:01:00.000Z",
+            title: "Port sidebar agent rows",
+          }),
+        ],
+        [
+          "oldest",
+          agent({
+            id: "oldest",
+            workspaceId: "workspace-a",
+            updatedAt: "2026-06-01T10:00:00.000Z",
+          }),
+        ],
+        [
+          "newest",
+          agent({
+            id: "newest",
+            workspaceId: "workspace-a",
+            updatedAt: "2026-06-01T10:02:00.000Z",
+            pendingPermissionCount: 1,
+          }),
+        ],
+      ]),
+    );
+
+    const activity = index.get("workspace-a");
+    expect(activity?.agents.map((entry) => entry.agentId)).toEqual(["newest", "middle", "oldest"]);
+    // The inlined fields are the head of the list, never a separate derivation.
+    expect(activity?.agentId).toBe("newest");
+    expect(activity?.status).toBe("needs_input");
+    expect(activity?.agents[1]?.title).toBe("Port sidebar agent rows");
+  });
+
+  it("orders agents stamped in the same millisecond by id so rows do not swap", () => {
+    const build = () =>
+      buildWorkspaceAgentActivityIndex(
+        new Map([
+          [
+            "b",
+            agent({ id: "b", workspaceId: "workspace-a", updatedAt: "2026-06-01T10:00:00.000Z" }),
+          ],
+          [
+            "a",
+            agent({ id: "a", workspaceId: "workspace-a", updatedAt: "2026-06-01T10:00:00.000Z" }),
+          ],
+        ]),
+      );
+
+    expect(
+      build()
+        .get("workspace-a")
+        ?.agents.map((entry) => entry.agentId),
+    ).toEqual(["a", "b"]);
+    expect(build().get("workspace-a")?.agentId).toBe("a");
+  });
+
+  it("keeps the agent list reference while every agent holds its status", () => {
+    const agents = new Map([
+      [
+        "root",
+        agent({
+          id: "root",
+          workspaceId: "workspace-a",
+          status: "running",
+          updatedAt: "2026-06-01T10:00:00.000Z",
+        }),
+      ],
+      [
+        "second",
+        agent({
+          id: "second",
+          workspaceId: "workspace-a",
+          status: "running",
+          updatedAt: "2026-06-01T10:01:00.000Z",
+        }),
+      ],
+    ]);
+    const previous = buildWorkspaceAgentActivityIndex(agents);
+    const next = buildWorkspaceAgentActivityIndex(agents, previous);
+
+    expect(next).toBe(previous);
+    expect(next.get("workspace-a")?.agents).toBe(previous.get("workspace-a")?.agents);
+  });
+
+  it("holds each agent's entry time when a sibling changes status", () => {
+    const previous = buildWorkspaceAgentActivityIndex(
+      new Map([
+        [
+          "root",
+          agent({
+            id: "root",
+            workspaceId: "workspace-a",
+            status: "running",
+            updatedAt: "2026-06-01T10:00:00.000Z",
+          }),
+        ],
+        [
+          "second",
+          agent({
+            id: "second",
+            workspaceId: "workspace-a",
+            status: "running",
+            updatedAt: "2026-06-01T10:01:00.000Z",
+          }),
+        ],
+      ]),
+    );
+
+    const next = buildWorkspaceAgentActivityIndex(
+      new Map([
+        [
+          "root",
+          agent({
+            id: "root",
+            workspaceId: "workspace-a",
+            status: "running",
+            updatedAt: "2026-06-01T10:09:00.000Z",
+          }),
+        ],
+        [
+          "second",
+          agent({
+            id: "second",
+            workspaceId: "workspace-a",
+            updatedAt: "2026-06-01T10:10:00.000Z",
+            pendingPermissionCount: 1,
+          }),
+        ],
+      ]),
+      previous,
+    );
+
+    const agentsById = new Map(
+      next.get("workspace-a")?.agents.map((entry) => [entry.agentId, entry]) ?? [],
+    );
+    // "second" moved, so its clock restarts; "root" did not, so it keeps the original.
+    expect(agentsById.get("second")?.status).toBe("needs_input");
+    expect(agentsById.get("second")?.enteredAt).toEqual(new Date("2026-06-01T10:10:00.000Z"));
+    expect(agentsById.get("root")?.enteredAt).toEqual(new Date("2026-06-01T10:00:00.000Z"));
+    // The workspace row follows the head of the list, not the untouched agent.
+    expect(next.get("workspace-a")?.enteredAt).toEqual(new Date("2026-06-01T10:10:00.000Z"));
+  });
+
+  it("holds the status clock when only the agent title changes", () => {
+    const previous = buildWorkspaceAgentActivityIndex(
+      new Map([
+        [
+          "root",
+          agent({
+            id: "root",
+            workspaceId: "workspace-a",
+            status: "running",
+            updatedAt: "2026-06-01T10:00:00.000Z",
+            title: null,
+          }),
+        ],
+      ]),
+    );
+
+    const next = buildWorkspaceAgentActivityIndex(
+      new Map([
+        [
+          "root",
+          agent({
+            id: "root",
+            workspaceId: "workspace-a",
+            status: "running",
+            updatedAt: "2026-06-01T10:30:00.000Z",
+            title: "Rebase onto upstream main",
+          }),
+        ],
+      ]),
+      previous,
+    );
+
+    expect(next).not.toBe(previous);
+    expect(next.get("workspace-a")?.agents[0]?.title).toBe("Rebase onto upstream main");
+    // Providers name a session from its first turn. That rename must not restart the clock, or the
+    // row's "Last activity" stamp jumps forward for a status the agent never re-entered.
+    expect(next.get("workspace-a")?.agents[0]?.enteredAt).toEqual(
+      new Date("2026-06-01T10:00:00.000Z"),
+    );
+    expect(next.get("workspace-a")?.enteredAt).toEqual(new Date("2026-06-01T10:00:00.000Z"));
+  });
+
+  it("restarts the clock for an agent that was archived and restored", () => {
+    const running = (updatedAt: string, archivedAt?: string) =>
+      new Map([
+        [
+          "root",
+          agent({
+            id: "root",
+            workspaceId: "workspace-a",
+            status: "running",
+            updatedAt,
+            archivedAt,
+          }),
+        ],
+        [
+          "second",
+          agent({
+            id: "second",
+            workspaceId: "workspace-a",
+            updatedAt: "2026-06-01T10:00:00.000Z",
+          }),
+        ],
+      ]);
+
+    const first = buildWorkspaceAgentActivityIndex(running("2026-06-01T10:00:00.000Z"));
+    // Archived agents leave the index entirely.
+    const archived = buildWorkspaceAgentActivityIndex(
+      running("2026-06-01T10:05:00.000Z", "2026-06-01T10:05:00.000Z"),
+      first,
+    );
+    expect(archived.get("workspace-a")?.agents.map((entry) => entry.agentId)).toEqual(["second"]);
+
+    const restored = buildWorkspaceAgentActivityIndex(
+      running("2026-06-01T10:30:00.000Z"),
+      archived,
+    );
+    const root = restored.get("workspace-a")?.agents.find((entry) => entry.agentId === "root");
+    // Deliberate: the reuse pass only remembers the previous build, so an agent that left the
+    // sidebar and came back is stamped fresh rather than resuming a clock nothing was tracking.
+    expect(root?.enteredAt).toEqual(new Date("2026-06-01T10:30:00.000Z"));
   });
 });

--- a/packages/app/src/utils/workspace-agent-activity.ts
+++ b/packages/app/src/utils/workspace-agent-activity.ts
@@ -1,19 +1,54 @@
+import type { AgentProvider } from "@getpaseo/protocol/agent-types";
 import type { Agent, WorkspaceDescriptor } from "@/stores/session-store";
 import { isWorkspaceRootAgent } from "@/subagents/policies";
 import { deriveSidebarStateBucket } from "./sidebar-agent-state";
 
+/**
+ * One active root agent, as a sidebar row sees it.
+ *
+ * `enteredAt` is when the agent entered this status, not when it last changed. The reuse pass
+ * below carries it forward for as long as `status` holds, so neither a running agent emitting a
+ * frame every second nor a provider renaming the session restarts the clock.
+ */
+export interface WorkspaceAgentEntry {
+  agentId: string;
+  title: string | null;
+  /** Immutable for the life of an agent, so the reuse pass below never has to compare it. */
+  provider: AgentProvider;
+  status: WorkspaceDescriptor["status"];
+  enteredAt: Date;
+}
+
+/**
+ * Every active root agent in a workspace, most recently active first, plus the winner's fields
+ * inlined so the workspace row can read them without indexing.
+ *
+ * The inlined fields are `agents[0]`, not a separate derivation: a row showing a different status
+ * from the agent at the top of its own list is the bug this shape exists to make impossible.
+ */
 export interface WorkspaceAgentActivity {
   agentId: string;
   status: WorkspaceDescriptor["status"];
   enteredAt: Date | null;
+  agents: readonly WorkspaceAgentEntry[];
+}
+
+interface Candidate {
+  entry: WorkspaceAgentEntry;
+  /**
+   * The agent's real timestamp, used only for ordering. Deliberately not `entry.enteredAt`: the
+   * winner is whoever moved most recently, while the exposed `enteredAt` is the preserved
+   * status-entry time. Sorting on the preserved value would let a long-running agent outrank one
+   * that just finished.
+   */
+  sortAt: number;
 }
 
 export function buildWorkspaceAgentActivityIndex(
   agents: ReadonlyMap<string, Agent>,
   previous?: ReadonlyMap<string, WorkspaceAgentActivity>,
 ): Map<string, WorkspaceAgentActivity> {
-  const activityByWorkspaceId = new Map<string, WorkspaceAgentActivity>();
-  const latestActivityAtByWorkspaceId = new Map<string, Date>();
+  const candidatesByWorkspaceId = new Map<string, Candidate[]>();
 
   for (const agent of agents.values()) {
     const parentAgent = agent.parentAgentId ? agents.get(agent.parentAgentId) : undefined;
@@ -22,39 +57,122 @@ export function buildWorkspaceAgentActivityIndex(
     }
 
     const enteredAt = agent.attentionTimestamp ?? agent.updatedAt;
-    const latestActivityAt = latestActivityAtByWorkspaceId.get(agent.workspaceId);
-    if (latestActivityAt && enteredAt <= latestActivityAt) {
-      continue;
+    const candidate: Candidate = {
+      entry: {
+        agentId: agent.id,
+        title: agent.title,
+        provider: agent.provider,
+        status: deriveSidebarStateBucket({
+          status: agent.status,
+          pendingPermissionCount: agent.pendingPermissions.length,
+          requiresAttention: agent.requiresAttention,
+          attentionReason: agent.attentionReason,
+        }),
+        enteredAt,
+      },
+      sortAt: enteredAt.getTime(),
+    };
+    const existing = candidatesByWorkspaceId.get(agent.workspaceId);
+    if (existing) {
+      existing.push(candidate);
+    } else {
+      candidatesByWorkspaceId.set(agent.workspaceId, [candidate]);
     }
-    latestActivityAtByWorkspaceId.set(agent.workspaceId, enteredAt);
-
-    const status = deriveSidebarStateBucket({
-      status: agent.status,
-      pendingPermissionCount: agent.pendingPermissions.length,
-      requiresAttention: agent.requiresAttention,
-      attentionReason: agent.attentionReason,
-    });
-    activityByWorkspaceId.set(agent.workspaceId, {
-      agentId: agent.id,
-      status,
-      enteredAt,
-    });
   }
 
-  for (const [workspaceId, activity] of activityByWorkspaceId) {
+  const activityByWorkspaceId = new Map<string, WorkspaceAgentActivity>();
+  for (const [workspaceId, candidates] of candidatesByWorkspaceId) {
+    // Ties break on id so two agents stamped in the same millisecond do not swap places between
+    // renders, which would swap the workspace row's dot for no reason a user could see.
+    candidates.sort((left, right) =>
+      left.sortAt === right.sortAt
+        ? left.entry.agentId.localeCompare(right.entry.agentId)
+        : right.sortAt - left.sortAt,
+    );
+
     const previousActivity = previous?.get(workspaceId);
-    if (
-      previousActivity?.agentId === activity.agentId &&
-      previousActivity.status === activity.status
-    ) {
-      activityByWorkspaceId.set(workspaceId, previousActivity);
-    }
+    const nextAgents = reuseAgentEntries(
+      candidates.map((candidate) => candidate.entry),
+      previousActivity?.agents,
+    );
+    const winner = nextAgents[0];
+    if (!winner) continue;
+
+    const nextActivity: WorkspaceAgentActivity = {
+      agentId: winner.agentId,
+      status: winner.status,
+      enteredAt: winner.enteredAt,
+      agents: nextAgents,
+    };
+    activityByWorkspaceId.set(
+      workspaceId,
+      previousActivity && areActivitiesIdentical(previousActivity, nextActivity)
+        ? previousActivity
+        : nextActivity,
+    );
   }
 
   if (previous && areWorkspaceAgentActivityIndexesIdentical(previous, activityByWorkspaceId)) {
     return previous instanceof Map ? previous : new Map(previous);
   }
   return activityByWorkspaceId;
+}
+
+/**
+ * Swap every unchanged entry back to the object the last build produced, and return the previous
+ * array itself when nothing moved. Callers compare `agents` with `Object.is`
+ * (`areSidebarWorkspaceEntriesEqual`), so the array reference is what decides whether a workspace
+ * row re-renders.
+ *
+ * The memory is one rebuild deep, on purpose. An agent missing from `previous` is stamped fresh,
+ * so archiving an agent and restoring it restarts its clock — it left the sidebar and came back,
+ * and preserving the old time would need history this index deliberately does not keep. The test
+ * named for unarchiving pins that, so it reads as a decision rather than an oversight.
+ *
+ * The only other caller builds without a `previous` at all (`session-store.ts:808`), and that one
+ * is a cold restore guarded on there being no session yet — there are no clocks to carry.
+ */
+function reuseAgentEntries(
+  next: WorkspaceAgentEntry[],
+  previous: readonly WorkspaceAgentEntry[] | undefined,
+): readonly WorkspaceAgentEntry[] {
+  if (!previous || previous.length === 0) {
+    return next;
+  }
+
+  const previousById = new Map(previous.map((entry) => [entry.agentId, entry]));
+  let identical = next.length === previous.length;
+  for (let index = 0; index < next.length; index += 1) {
+    const entry = next[index];
+    if (!entry) continue;
+    const previousEntry = previousById.get(entry.agentId);
+    if (previousEntry && previousEntry.status === entry.status) {
+      // The status is what `enteredAt` is timing, so it alone decides whether the clock keeps
+      // running. A title changes while an agent works — providers name a session from its first
+      // turn — and letting that restart the clock would push the winner's `statusEnteredAt`, and
+      // with it the row's "Last activity" stamp, forward on a rename.
+      next[index] =
+        previousEntry.title === entry.title
+          ? previousEntry
+          : { ...entry, enteredAt: previousEntry.enteredAt };
+    }
+    if (next[index] !== previous[index]) {
+      identical = false;
+    }
+  }
+
+  return identical ? previous : next;
+}
+
+function areActivitiesIdentical(
+  previous: WorkspaceAgentActivity,
+  next: WorkspaceAgentActivity,
+): boolean {
+  return (
+    previous.agents === next.agents &&
+    previous.agentId === next.agentId &&
+    previous.status === next.status
+  );
 }
 
 function areWorkspaceAgentActivityIndexesIdentical(


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [x] New feature

### Reasoning

A workspace row shows one status dot no matter how many agents are running inside it. `utils/workspace-agent-activity.ts` walks every agent, derives a status bucket for each, then keeps only the most recently active one and discards the rest.

So a workspace running three agents looks exactly like one running one. If the second agent needs input, nothing says so, and there is no way to reach it without opening the workspace and hunting through its tabs. That is the case this change is for: work you are *not* currently looking at.

Everything needed already existed and was simply never joined up — `useAggregatedAgents` has the agents, `deriveSidebarStateBucket` has the status, `navigateToAgent` already resolves an agent to its workspace and reveals its tab. What was missing was the collapse, and somewhere to put the result.

### Goals

- A workspace row shows how many agents are working in it, and can expand into them.
- Each agent row carries its own status and provider, and clicking one goes straight to that agent.
- The workspace row's own dot and status are unchanged, so a collapsed sidebar looks exactly as it does today.
- Both sidebar list modes (Group by Project and Group by Status) behave identically.
- The preference is discoverable next to its siblings, with an off switch.

### Non-goals

- **No sub-list for a single-agent workspace.** The row already *is* that agent's row — its dot, its status, and its click target all belong to that agent, so a lone child restating them is noise. The list appears at two or more.
- **No stale-decay to `idle`.** Orca repaints a quiet agent idle after 30 minutes because its status is inferred from hook callbacks that can be missed. Paseo's status is authoritative, so an agent quiet for an hour is genuinely `running` and must not be relabelled.
- **No lineage tree, per-row dismiss, or send-to-agent.** Subagents already have the subagents track; duplicating it here would put one fact in two places.
- **No protocol change.** App-only — no new RPC, no capability gate, no daemon change.

### Design notes

Two things live on the row, and they are deliberately different kinds of thing:

- **The count is a fact**, the same class as host, pull request, and checks, so it sits on the meta line and leads it — the only item there about live work rather than about the workspace itself.
- **The disclosure is a control**, so it sits in the leading slot, where a project row already swaps its icon for a chevron on hover. A workspace row now says it expands in the same place a project row does.

They started as one chip on the title line, which is the one line a kebab overlays. Every geometry problem this change had came from that; splitting them dissolved it.

The workspace chevron needs its own press target, which a project row never did: a project header's press already toggles collapse, so its chevron can be decoration, while a workspace row's press navigates and a chevron inheriting it would open the workspace instead.

The count is also a press target. On a phone there is no hover to reveal the chevron, so without it the only way in would be the 6px status dot.

### QA

Two platforms. Each screenshot below names the file to drop in its place — they are staged locally in `qa-evidence/` (not committed).

#### Desktop web — Chromium, 1280x720

Generated from this branch by a committed spec, not hand-taken:

```
PASEO_SIDEBAR_EVIDENCE=1 npx playwright test --project=browser \
  e2e/browser/sidebar-agent-rows-evidence.spec.ts
```

Each capture seeds **two** workspaces — one with three agents and one with a single agent — so every screenshot also shows what the change does *not* do to an ordinary row.

**1. Resting state.** The busy workspace carries `3` on its meta line; the single-agent row is untouched.

<img width="1020" height="876" alt="web-01-collapsed" src="https://github.com/user-attachments/assets/cca76e0e-0a77-48be-bea3-338d70ec230e" />

**2. Hovered.** The status indicator swaps for the expand chevron, the way a project row's icon does. The count stays on the meta line, clear of the kebab.

<img width="1020" height="876" alt="web-02-hover-chevron" src="https://github.com/user-attachments/assets/98649fc1-2bcf-46b6-9b56-e5c8e753a428" />

**3. Expanded.** One row per agent — status dot, provider mark, title. Dots sit on the count's left rail.

<img width="1020" height="876" alt="web-03-expanded" src="https://github.com/user-attachments/assets/8c3a4e13-2388-41f9-84be-a7870669e99f" />

**4. Where the preference lives.** Display preferences → Show → **Agents**. Not the Settings screen: every sidebar display preference lives in this menu, so this one joins Checks rather than starting a second home for the same kind of decision.

<img width="2160" height="1440" alt="web-04-display-menu" src="https://github.com/user-attachments/assets/22e774a7-c757-4b8b-8af6-40c1b4bb6875" />

**5. The three answers**, with the shipped default marked.

<img width="2160" height="1440" alt="web-05-agents-options" src="https://github.com/user-attachments/assets/ed3aa335-180a-493c-8f94-c544c863ae04" />

**6. Group by Status.** The other list mode, same behaviour.

<img width="1020" height="876" alt="web-06-status-grouping" src="https://github.com/user-attachments/assets/27634b73-e62e-4125-91d7-a47f397a329d" />

#### Android — emulator, API 36

Debug build from this branch, driven over `adb`, against a scratch daemon seeded with one three-agent workspace and two single-agent ones.

This is the half the first round of review could not speak to. The touch path has no hover, so the chevron never appears and the count is what makes the sub-list reachable at all.

**1. Resting state.** The count on the busy row; the two single-agent rows draw nothing.

<img width="1080" height="2400" alt="android-01-collapsed" src="https://github.com/user-attachments/assets/82747be0-aa99-4697-99ed-6a7b0297ab69" />


**2. Tapping the count expands it.**

<img width="1080" height="2400" alt="android-02-expanded-via-count" src="https://github.com/user-attachments/assets/2034c24b-e667-4def-aa03-523bbbe31744" />

**3. Tapping an agent row opens that agent** and dismisses the sidebar.

<img width="1080" height="2400" alt="android-03-agent-opens" src="https://github.com/user-attachments/assets/9c3833d3-584f-4b1f-be98-d24eb1f46b7d" />


**4. Reopened after navigating away.** The expansion survived, and the three agents no longer agree: one is grey while two stay green. The single-winner model this replaces could not show that.

<img width="1080" height="2400" alt="android-04-persisted-and-per-agent-status" src="https://github.com/user-attachments/assets/21dce7db-2f16-4f59-9626-dccc04707885" />


**5. The status dot collapses it again.**

<img width="1080" height="2400" alt="android-05-collapsed-via-dot" src="https://github.com/user-attachments/assets/5a40d2c1-2fd7-439b-ab36-8191ae818197" />


**6. Where the preference lives on mobile.** `Agents` sits under `Checks`, rendered as a sheet rather than a popover.

<img width="1080" height="2400" alt="android-06-show-menu" src="https://github.com/user-attachments/assets/a30021a4-be14-416a-a9d0-1cfe62b6f5dd" />


**7. The three modes**, `Collapsed` checked.

<img width="1080" height="2400" alt="android-07-agents-options" src="https://github.com/user-attachments/assets/60d5b53e-729c-40e1-812a-0f32b5704d5c" />


**8. The off switch.** Rows identical to pre-change.

<img width="1080" height="2400" alt="android-08-hidden" src="https://github.com/user-attachments/assets/a188c927-b10c-4c5d-9307-6aa01cbd9ba1" />


**9. Group by Status.**

<img width="1080" height="2400" alt="android-09-status-grouping" src="https://github.com/user-attachments/assets/1e54f17d-8d79-4b4b-8d99-64185540b049" />


**10. Expanded in that mode**, where the leading slot is a project badge rather than a plain indicator.

<img width="1080" height="2400" alt="android-10-status-grouping-expanded" src="https://github.com/user-attachments/assets/5cd9546d-3946-4d8b-b10d-2d62f0f0c56e" />


#### Automated

- `packages/app/e2e/browser/sidebar-agent-rows.spec.ts` — count appears and expands; a single-agent workspace draws nothing; and two geometry assertions that compare **bounding boxes** rather than visibility.

  That distinction is not academic. The disclosure originally shipped inside the trailing slot, where the kebab overlay painted straight over it — and `toBeVisible()` passed the whole time, because a fully occluded element is still "visible". The measured overlap was 3px; the visual loss was the entire digit, because the 48px scrim behind the kebab is wider than the icon. Both assertions exist because that shipped once.

- Unit tests across the activity index's identity and clock invariants, the preference parser, the expansion overrides and their persistence round-trip, and the new meta-row item.

- Full app suite and all four Playwright shards green on CI.

- Rebased onto current `main` and re-verified there: `npm run typecheck` and `npm run lint` clean, and the unit tests for the activity index, the preference parser, the expansion store, the meta-row item, and the type scale pass (51 tests).

#### Reviewed

Two external passes over the first commit. One found nothing; the other found a real regression I had introduced — the reuse pass required title equality before carrying `enteredAt` forward, so a provider renaming a session restarted its status clock and pushed the row's "Last activity" stamp to now. Fixed in `fix(app): hold the agent status clock through a rename`, with a test verified to fail without the fix.

#### Not covered

- **No iOS, no Electron.** Desktop Chromium and Android only.
- **Auto-expand on a blocked agent is untested on device.** It needs an agent in `needs_input`, which the mock provider does not produce.
- **The sub-list rail is a constant pinned to desktop geometry.** The e2e asserts it within 1px, but only on the desktop project.
- **Provider icons in the screenshots are the generic fallback**, because the harness uses the `mock` provider. Real Claude/Codex/Copilot marks resolve through the same `getProviderIcon` path used by History rows.
- **Row spacing on a real phone is unjudged.** Adjacent agent rows are below the 24dp comfortable target; an emulator cannot answer whether that matters in the hand.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense


