### PR TITLE
Keep agents running when closing image previews

### DIFF
--- a/packages/app/e2e/browser/agent-tab-image-stability.spec.ts
+++ b/packages/app/e2e/browser/agent-tab-image-stability.spec.ts
@@ -14,6 +14,7 @@ import {
   switchAwayAndBackWithoutImageInstability,
   userPagesUntilAssistantImageRenders,
 } from "../support/helpers/assistant-images";
+import { expectAgentReadyToInterrupt } from "../support/helpers/agent-stream";
 import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
 
 const test = base.extend<{ imageWorkspace: SeededWorkspace }>({
@@ -84,8 +85,15 @@ test("opens a timeline image in a zoomable lightbox", async ({
     .poll(async () => Math.round((await transformedContent.boundingBox())?.width ?? 0))
     .toBe(Math.round(initialBox!.width));
 
-  await canvas.click({ position: { x: 4, y: 4 } });
+  await workspace.client.sendAgentMessage(
+    imageAgent.id,
+    "Stay running while the assistant image lightbox is closed.",
+  );
+  await expectAgentReadyToInterrupt(page);
+
+  await page.keyboard.press("Escape");
   await expect(lightboxImage).toHaveCount(0);
+  await expectAgentReadyToInterrupt(page);
 });
 
 test("reloading a timeline anchors near-tail assistant image growth", async ({

--- a/packages/app/src/components/attachment-lightbox.test.tsx
+++ b/packages/app/src/components/attachment-lightbox.test.tsx
@@ -136,6 +136,8 @@ let container: HTMLElement | null = null;
 
 beforeEach(() => {
   const dom = new JSDOM("<!doctype html><html><body></body></html>");
+  dom.window.requestAnimationFrame = vi.fn(() => 1);
+  dom.window.cancelAnimationFrame = vi.fn();
   vi.stubGlobal("React", React);
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   vi.stubGlobal("window", dom.window);

--- a/packages/app/src/components/attachment-lightbox.tsx
+++ b/packages/app/src/components/attachment-lightbox.tsx
@@ -12,6 +12,7 @@ import { SPACING } from "@/styles/theme";
 import { WindowChromeRootRegion } from "@/utils/desktop-window";
 import { ZoomableImage } from "@/components/zoomable-viewport/image";
 import type { ViewportSize } from "@/components/zoomable-viewport/geometry";
+import { useGlobalWebOverlayLayer, useWebOverlayRegistration } from "@/lib/overlay-root";
 
 export type ImageLightboxSource =
   | { type: "attachment"; metadata: AttachmentMetadata }
@@ -33,23 +34,27 @@ export function AttachmentLightbox({ source, onClose }: AttachmentLightboxProps)
   const url = source?.type === "uri" ? source.uri : attachmentUrl;
   const contentSize = source?.type === "uri" ? source.contentSize : undefined;
   const [errored, setErrored] = useState(false);
+  const modalLayer = useGlobalWebOverlayLayer("modal", isWeb && source !== null);
 
   useEffect(() => {
     setErrored(false);
   }, [metadata?.id, url]);
 
-  useEffect(() => {
-    if (!isWeb || !source) return;
-    function handleKeydown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    }
-    window.addEventListener("keydown", handleKeydown);
-    return () => {
-      window.removeEventListener("keydown", handleKeydown);
-    };
-  }, [onClose, source]);
+  const handleWebOverlayKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return false;
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+      return true;
+    },
+    [onClose],
+  );
+  const setWebOverlayScope = useWebOverlayRegistration({
+    active: isWeb && source !== null,
+    layer: modalLayer,
+    onKeyDown: handleWebOverlayKeyDown,
+  });
 
   const contentLayerStyle = useMemo(
     () => [
@@ -87,7 +92,7 @@ export function AttachmentLightbox({ source, onClose }: AttachmentLightboxProps)
     <Modal transparent animationType="fade" statusBarTranslucent visible onRequestClose={onClose}>
       <ModalRoot style={styles.root}>
         <WindowChromeRootRegion corners="both">
-          <View style={styles.root}>
+          <View ref={setWebOverlayScope} style={styles.root}>
             <Pressable
               testID="attachment-lightbox-backdrop"
               accessibilityRole="button"


### PR DESCRIPTION
### Linked issue

Refs #1705

Related: #2639 addresses the broader class of Escape-dismissible surfaces. This PR is limited to the shared image lightbox path confirmed in the issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Closing a zoomed assistant-message image with Escape also interrupted the active agent. Composer attachments use the same viewer and were exposed to the same event leak.

The lightbox handled Escape with an independent window listener, after the global shortcut dispatcher had already routed the key to agent interruption. Registering the shared lightbox with the established web overlay owner gives the visible modal first refusal while preserving normal Escape-to-interrupt behavior when no overlay owns the key.

### Goals

- Escape closes assistant-message and attachment image previews without interrupting the active agent.
- The shared lightbox owns dismissal through the existing overlay boundary.
- Escape continues to interrupt an agent when no overlay owns it.
- Native modal dismissal and image zoom gestures remain unchanged.

### Non-goals

- Changing the agent interrupt shortcut.
- Redesigning image preview controls or gestures.
- Addressing Escape ownership for non-lightbox surfaces covered by the broader related issue.

### QA

Confirmed the existing assistant-image Playwright flow was red before the fix: the image closed, then the final Stop agent assertion failed because Escape interrupted the stream.

Confirmed after the fix:

- `npm run test:e2e --workspace=@getpaseo/app -- agent-tab-image-stability.spec.ts --grep "opens a timeline image in a zoomable lightbox"` — 1 passed; the image closed and the same agent remained running.
- `npm run test:e2e --workspace=@getpaseo/app -- composer-attachments.spec.ts --grep "image lightbox opens on pill click and closes on Escape"` — 1 passed.
- `npx vitest run packages/app/src/components/attachment-lightbox.test.tsx --bail=1` — 7 passed.
- `npm run typecheck` — passed.
- `npm run lint -- packages/app/src/components/attachment-lightbox.tsx packages/app/src/components/attachment-lightbox.test.tsx packages/app/e2e/browser/agent-tab-image-stability.spec.ts` — 0 warnings and 0 errors.
- `npm run format` — passed.

Tested in headless Chromium against an isolated real Paseo daemon with a streaming mock agent. Native platforms were not manually tested; the overlay registration is web-only and `Modal.onRequestClose` remains unchanged.

### Risk surface

The web lightbox now participates in overlay focus ownership and restoration. Review should concentrate on Escape dismissal, toolbar focus, and nested web overlays. Native behavior is outside the changed path.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense