### PR TITLE
fix(app): coalesce split resize previews by frame

### DIFF
--- a/packages/app/src/components/resize-handle-drag.test.ts
+++ b/packages/app/src/components/resize-handle-drag.test.ts
@@ -1,8 +1,60 @@
 import { describe, expect, it, vi } from "vitest";
 import { startResizeHandleDrag } from "@/components/resize-handle-drag";
 
+interface FakeFrameScheduler {
+  requestFrame(callback: () => void): number;
+  cancelFrame(frameId: number): void;
+  runNextFrame(): void;
+  runLastRequestedFrame(): void;
+  pendingFrameCount(): number;
+  canceledFrameIds(): number[];
+}
+
+function createFakeFrameScheduler(): FakeFrameScheduler {
+  const pendingFrames = new Map<number, () => void>();
+  const canceledFrameIds: number[] = [];
+  let lastRequestedFrame: (() => void) | null = null;
+  let nextFrameId = 1;
+
+  return {
+    requestFrame(callback) {
+      const frameId = nextFrameId;
+      nextFrameId += 1;
+      pendingFrames.set(frameId, callback);
+      lastRequestedFrame = callback;
+      return frameId;
+    },
+    cancelFrame(frameId) {
+      canceledFrameIds.push(frameId);
+      pendingFrames.delete(frameId);
+    },
+    runNextFrame() {
+      const nextFrame = pendingFrames.entries().next().value;
+      if (!nextFrame) {
+        throw new Error("Expected a pending resize preview frame");
+      }
+      const [frameId, callback] = nextFrame;
+      pendingFrames.delete(frameId);
+      callback();
+    },
+    runLastRequestedFrame() {
+      if (!lastRequestedFrame) {
+        throw new Error("Expected a requested resize preview frame");
+      }
+      lastRequestedFrame();
+    },
+    pendingFrameCount() {
+      return pendingFrames.size;
+    },
+    canceledFrameIds() {
+      return canceledFrameIds;
+    },
+  };
+}
+
 describe("startResizeHandleDrag", () => {
-  it("previews pointer frames and commits only the final size", () => {
+  it("previews multiple moves once per frame using the latest size", () => {
+    const frameScheduler = createFakeFrameScheduler();
     const preview = vi.fn();
     const commit = vi.fn();
     const drag = startResizeHandleDrag({
@@ -10,22 +62,51 @@ describe("startResizeHandleDrag", () => {
       index: 0,
       preview,
       commit,
+      frameScheduler,
     });
 
     drag.move(0.05);
     drag.move(0.1);
 
-    expect(preview).toHaveBeenCalledTimes(2);
-    expect(preview.mock.calls[0]?.[0][0]).toBeCloseTo(0.55, 10);
-    expect(preview.mock.calls[0]?.[0][1]).toBeCloseTo(0.45, 10);
-    expect(preview.mock.calls[1]?.[0][0]).toBeCloseTo(0.6, 10);
-    expect(preview.mock.calls[1]?.[0][1]).toBeCloseTo(0.4, 10);
+    expect(frameScheduler.pendingFrameCount()).toBe(1);
+    expect(preview).not.toHaveBeenCalled();
+
+    frameScheduler.runNextFrame();
+
+    expect(preview).toHaveBeenCalledOnce();
+    expect(preview.mock.calls[0]?.[0][0]).toBeCloseTo(0.6, 10);
+    expect(preview.mock.calls[0]?.[0][1]).toBeCloseTo(0.4, 10);
     expect(commit).not.toHaveBeenCalled();
+  });
+
+  it("finishes a queued frame with one synchronous preview and one commit", () => {
+    const frameScheduler = createFakeFrameScheduler();
+    const preview = vi.fn();
+    const commit = vi.fn();
+    const drag = startResizeHandleDrag({
+      sizes: [0.5, 0.5],
+      index: 0,
+      preview,
+      commit,
+      frameScheduler,
+    });
+
+    drag.move(0.05);
+    drag.move(0.1);
 
     drag.finish();
 
+    expect(frameScheduler.canceledFrameIds()).toEqual([1]);
+    expect(preview).toHaveBeenCalledOnce();
+    expect(preview.mock.calls[0]?.[0][0]).toBeCloseTo(0.6, 10);
+    expect(preview.mock.calls[0]?.[0][1]).toBeCloseTo(0.4, 10);
     expect(commit).toHaveBeenCalledOnce();
     expect(commit.mock.calls[0]?.[0][0]).toBeCloseTo(0.6, 10);
     expect(commit.mock.calls[0]?.[0][1]).toBeCloseTo(0.4, 10);
+
+    frameScheduler.runLastRequestedFrame();
+
+    expect(preview).toHaveBeenCalledOnce();
+    expect(commit).toHaveBeenCalledOnce();
   });
 });

--- a/packages/app/src/components/resize-handle-drag.ts
+++ b/packages/app/src/components/resize-handle-drag.ts
@@ -5,6 +5,12 @@ interface StartResizeHandleDragInput {
   index: number;
   preview: (sizes: number[]) => void;
   commit: (sizes: number[]) => void;
+  frameScheduler?: ResizeHandleDragFrameScheduler;
+}
+
+interface ResizeHandleDragFrameScheduler {
+  requestFrame: (callback: () => void) => number;
+  cancelFrame: (frameId: number) => void;
 }
 
 export interface ResizeHandleDrag {
@@ -12,21 +18,45 @@ export interface ResizeHandleDrag {
   finish: () => void;
 }
 
+const defaultFrameScheduler: ResizeHandleDragFrameScheduler = {
+  requestFrame: (callback) => requestAnimationFrame(callback),
+  cancelFrame: (frameId) => cancelAnimationFrame(frameId),
+};
+
 export function startResizeHandleDrag({
   sizes,
   index,
   preview,
   commit,
+  frameScheduler = defaultFrameScheduler,
 }: StartResizeHandleDragInput): ResizeHandleDrag {
   let pendingSizes: number[] | null = null;
+  let previewFrameId: number | null = null;
 
   return {
     move(deltaRatio) {
       pendingSizes = computeResizeHandleSizes({ sizes, index, deltaRatio });
-      preview(pendingSizes);
+      if (previewFrameId !== null) {
+        return;
+      }
+      const frameId = frameScheduler.requestFrame(() => {
+        if (previewFrameId !== frameId) {
+          return;
+        }
+        previewFrameId = null;
+        if (pendingSizes) {
+          preview(pendingSizes);
+        }
+      });
+      previewFrameId = frameId;
     },
     finish() {
       if (pendingSizes) {
+        if (previewFrameId !== null) {
+          frameScheduler.cancelFrame(previewFrameId);
+          previewFrameId = null;
+          preview(pendingSizes);
+        }
         commit(pendingSizes);
         pendingSizes = null;
       }


### PR DESCRIPTION
### Linked issue

Fixes #4163

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### What does this PR do

Coalesces split-pane resize previews to at most one update per animation frame while keeping only the latest pointer position.

If the pointer is released before the queued frame runs, the drag synchronously previews and commits the latest size, cancels the queued callback, and prevents a stale callback from repainting afterward.

The persisted resize behavior and pointer-up/pointer-cancel semantics are unchanged. This PR does not add Browser- or Terminal-specific resize behavior.

### Why

The desktop split handle currently previews every pointermove immediately. High-frequency pointer input can produce more resize work than the renderer can display, forcing pane contents—including browser webviews, terminals, and long conversations—to process intermediate layouts that will never be painted.

### Automated verification

Regression proof against the unchanged base commit `0c38749c`:

```text
Test Files  1 failed (1)
Tests       1 failed (2)
AssertionError: expected +0 to be 1
RED_EXIT=1
```

Final branch:

```text
Test Files  6 passed (6)
Tests       24 passed (24)
```

Commands run on Node 22.20.0:

```sh
npx vitest run packages/app/src/components/resize-handle-drag.test.ts packages/app/src/components/resize-handle-sizes.test.ts packages/app/src/components/sidebar-resize-handle-layout.test.ts packages/app/src/components/terminal-resize-debouncer.test.ts packages/app/src/terminal/native-renderer/terminal-input-resize-policy.test.ts packages/app/src/terminal/native-renderer/terminal-resize-policy.test.ts --bail=1
npm run lint -- packages/app/src/components/resize-handle-drag.test.ts packages/app/src/components/resize-handle-drag.ts
npm run format:check:files -- packages/app/src/components/resize-handle-drag.test.ts packages/app/src/components/resize-handle-drag.ts
npm run typecheck --workspace=@getpaseo/app
git diff HEAD^ --check
```

Results:

- 24/24 related resize tests passed.
- Changed-file lint: 0 warnings, 0 errors.
- Formatting check passed.
- `@getpaseo/app` typecheck passed after building the repository client declarations and applying the repository's existing dependency patches.
- Diff check passed.

### Platform QA

| Platform | Tested | Notes |
| --- | --- | --- |
| Desktop macOS | Not yet | Draft pending before/after interaction video on the reported environment. |
| Desktop Windows | No | Not available. |
| Desktop Linux | No | DevBox verification is headless only. |
| Web | No | Same helper is used, but no interaction capture yet. |
| iOS | No | Not available. |
| Android | No | Not available. |

### Risk surface

The change is limited to the split drag helper and its unit test. Browser, terminal, persisted layout, and pointer event handling are unchanged. The remaining risk is runtime frame pacing on Electron, which is why this is opened as a draft pending macOS interaction QA.

### Checklist

- [x] One focused change
- [x] Links the bug it fixes
- [x] Automated regression test with red/green evidence
- [x] Typecheck, lint, and formatting checks
- [ ] Before/after UI interaction video
- [ ] macOS Electron runtime QA
