### PR TITLE
Add prompt deep links for new workspaces

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -573,6 +573,10 @@ sending a message. Use `paseo://h/<server-id>/agent/<agent-id>`, or run
 `paseo agent open <agent-id>`. The CLI reads the local daemon's server ID by
 default; pass `--server <server-id>` when targeting another server.
 
+Use `paseo://new?q=<encoded-prompt>` to open New workspace with a prompt.
+`https://paseo.sh/new?q=<encoded-prompt>` forwards to the same app link. The
+existing `/new` query parameters can be combined with either form.
+
 ## Agent state
 
 Agent data lives at:

--- a/packages/app/e2e/browser/new-workspace-deep-link.spec.ts
+++ b/packages/app/e2e/browser/new-workspace-deep-link.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "../support/fixtures";
+import { getServerId } from "../support/helpers/server-id";
+import { openNewWorkspacePromptDeepLink } from "../support/helpers/new-workspace";
+
+test("a new-workspace deep link preserves query context and prefills its prompt", async ({
+  page,
+}) => {
+  const serverId = getServerId();
+  const name = "TEst";
+  const prompt = "Fix auth & add # regression coverage\nThen run the focused tests.";
+
+  await openNewWorkspacePromptDeepLink(page, { serverId, name, prompt });
+  await expect(page.getByRole("textbox", { name: "Message agent..." })).toHaveValue(prompt, {
+    timeout: 30_000,
+  });
+});

--- a/packages/app/e2e/support/helpers/new-workspace.ts
+++ b/packages/app/e2e/support/helpers/new-workspace.ts
@@ -215,6 +215,23 @@ export async function openMissingProjectNewWorkspaceComposer(
   await expect(page).toHaveURL(/\/new\?.*projectId=/u, { timeout: 30_000 });
 }
 
+export async function openNewWorkspacePromptDeepLink(
+  page: Page,
+  input: { serverId: string; name: string; prompt: string },
+): Promise<void> {
+  const query = new URLSearchParams({
+    serverId: input.serverId,
+    name: input.name,
+    q: input.prompt,
+  });
+  const route = `/new?${query.toString()}`;
+
+  await page.goto(route);
+  await expect(page).toHaveURL((url) => `${url.pathname}${url.search}${url.hash}` === route, {
+    timeout: 30_000,
+  });
+}
+
 export async function expectNewWorkspaceControlsEnabled(page: Page): Promise<void> {
   await expect(page.getByRole("button", { name: "Workspace project" })).toBeEnabled({
     timeout: 30_000,

--- a/packages/app/src/app/new.tsx
+++ b/packages/app/src/app/new.tsx
@@ -1,5 +1,6 @@
 import { useLocalSearchParams } from "expo-router";
 import { HostRouteBootstrapBoundary } from "@/components/host-route-bootstrap-boundary";
+import { resolveNewWorkspaceRouteParams } from "@/navigation/new-workspace-route-params";
 import { NewWorkspaceScreen } from "@/screens/new-workspace-screen";
 
 export default function NewWorkspaceRoute() {
@@ -9,18 +10,17 @@ export default function NewWorkspaceRoute() {
     name?: string;
     projectId?: string;
     draftId?: string;
+    q?: string;
   }>();
-  const serverId = typeof params.serverId === "string" ? params.serverId : "";
-  const sourceDirectory = typeof params.dir === "string" ? params.dir : undefined;
-  const displayName = typeof params.name === "string" ? params.name : undefined;
-  const projectId = typeof params.projectId === "string" ? params.projectId : undefined;
-  const draftId = typeof params.draftId === "string" ? params.draftId : undefined;
+  const { serverId, sourceDirectory, displayName, projectId, draftId, initialPrompt } =
+    resolveNewWorkspaceRouteParams(params);
   const screenKey = JSON.stringify([
     serverId,
     sourceDirectory ?? null,
     displayName ?? null,
     projectId ?? null,
     draftId ?? null,
+    initialPrompt ?? null,
   ]);
 
   return (
@@ -32,6 +32,7 @@ export default function NewWorkspaceRoute() {
         displayName={displayName}
         projectId={projectId}
         draftId={draftId}
+        initialPrompt={initialPrompt}
       />
     </HostRouteBootstrapBoundary>
   );

--- a/packages/app/src/navigation/new-workspace-route-params.test.ts
+++ b/packages/app/src/navigation/new-workspace-route-params.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveNewWorkspaceRouteParams } from "./new-workspace-route-params";
+
+describe("resolveNewWorkspaceRouteParams", () => {
+  it("reads a prompt from the query parameters", () => {
+    expect(
+      resolveNewWorkspaceRouteParams({
+        q: "Fix the bug & add tests",
+      }).initialPrompt,
+    ).toBe("Fix the bug & add tests");
+  });
+
+  it("preserves the supported query-string route context", () => {
+    expect(
+      resolveNewWorkspaceRouteParams({
+        serverId: "server-1",
+        dir: "/repo/project",
+        name: "Project",
+        projectId: "project-1",
+        draftId: "draft-1",
+        q: "Start here",
+      }),
+    ).toEqual({
+      serverId: "server-1",
+      sourceDirectory: "/repo/project",
+      displayName: "Project",
+      projectId: "project-1",
+      draftId: "draft-1",
+      initialPrompt: "Start here",
+    });
+  });
+
+  it("ignores repeated prompt parameters", () => {
+    expect(
+      resolveNewWorkspaceRouteParams({
+        q: ["first", "second"],
+      }).initialPrompt,
+    ).toBeUndefined();
+  });
+});

--- a/packages/app/src/navigation/new-workspace-route-params.ts
+++ b/packages/app/src/navigation/new-workspace-route-params.ts
@@ -1,0 +1,34 @@
+export interface NewWorkspaceRouteParams {
+  serverId?: string | string[];
+  dir?: string | string[];
+  name?: string | string[];
+  projectId?: string | string[];
+  draftId?: string | string[];
+  q?: string | string[];
+}
+
+export interface ResolvedNewWorkspaceRouteParams {
+  serverId: string;
+  sourceDirectory: string | undefined;
+  displayName: string | undefined;
+  projectId: string | undefined;
+  draftId: string | undefined;
+  initialPrompt: string | undefined;
+}
+
+function singleParam(value: string | string[] | undefined): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export function resolveNewWorkspaceRouteParams(
+  params: NewWorkspaceRouteParams,
+): ResolvedNewWorkspaceRouteParams {
+  return {
+    serverId: singleParam(params.serverId) ?? "",
+    sourceDirectory: singleParam(params.dir),
+    displayName: singleParam(params.name),
+    projectId: singleParam(params.projectId),
+    draftId: singleParam(params.draftId),
+    initialPrompt: singleParam(params.q),
+  };
+}

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -182,6 +182,21 @@ interface NewWorkspaceScreenProps {
   projectId?: string;
   displayName?: string;
   draftId?: string;
+  initialPrompt?: string;
+}
+
+function useSeedNewWorkspacePrompt(
+  chatDraft: ReturnType<typeof useAgentInputDraft>,
+  initialPrompt: string | undefined,
+): void {
+  const seededPromptRef = useRef(false);
+  useEffect(() => {
+    if (seededPromptRef.current || !chatDraft.isHydrated || initialPrompt === undefined) {
+      return;
+    }
+    seededPromptRef.current = true;
+    chatDraft.replaceText(initialPrompt);
+  }, [chatDraft, initialPrompt]);
 }
 
 // A terminal launch sends argv, not a message: there is nothing to attach and
@@ -1542,6 +1557,7 @@ export function NewWorkspaceScreen({
   projectId,
   displayName: displayNameProp,
   draftId,
+  initialPrompt,
 }: NewWorkspaceScreenProps) {
   const queryClient = useQueryClient();
   const { theme } = useUnistyles();
@@ -1613,7 +1629,7 @@ export function NewWorkspaceScreen({
     () => resolveLaunchTarget(manualLaunchTarget ?? formPreferences.launchTarget, terminalProfiles),
     [manualLaunchTarget, formPreferences.launchTarget, terminalProfiles],
   );
-  const [terminalPromptText, setTerminalPromptText] = useState("");
+  const [terminalPromptText, setTerminalPromptText] = useState(() => initialPrompt ?? "");
   const {
     isTerminalLaunch,
     selectedTerminalProfile,
@@ -1677,6 +1693,8 @@ export function NewWorkspaceScreen({
       initialSetup: forkDraftSetup?.setup,
     }),
   });
+  const clearChatDraft = chatDraft.clear;
+  useSeedNewWorkspacePrompt(chatDraft, initialPrompt);
   const composerState = chatDraft.composerState;
   const [pickerSelection, dispatchPickerSelection] = useReducer(
     reducePickerSelection,
@@ -2060,7 +2078,7 @@ export function NewWorkspaceScreen({
           forkDraftSetup,
           ensureWorkspace,
           serverId: selectedServerId,
-          clearDraft: chatDraft.clear,
+          clearDraft: clearChatDraft,
           draftId,
           supportsForgeSearch,
           labels: {
@@ -2078,7 +2096,7 @@ export function NewWorkspaceScreen({
     [
       composerState,
       draftId,
-      chatDraft.clear,
+      clearChatDraft,
       ensureWorkspace,
       forkDraftSetup,
       launchTarget,
@@ -2127,6 +2145,7 @@ export function NewWorkspaceScreen({
         sendTerminalInput: (terminalId, data) => {
           withConnectedClient().sendTerminalInput(terminalId, { type: "input", data });
         },
+        clearDraft: () => clearChatDraft("sent"),
         serverId: selectedServerId,
         navigate: (targetServerId, workspaceId, target) =>
           navigateToWorkspace({ serverId: targetServerId, workspaceId, target }),
@@ -2138,6 +2157,7 @@ export function NewWorkspaceScreen({
       toast.error(message);
     }
   }, [
+    clearChatDraft,
     ensureWorkspace,
     launchTarget,
     queryClient,

--- a/packages/app/src/screens/new-workspace-terminal.test.ts
+++ b/packages/app/src/screens/new-workspace-terminal.test.ts
@@ -17,6 +17,7 @@ describe("runCreateTerminalWorkspace", () => {
     const ensureWorkspace = vi.fn().mockResolvedValue(workspace);
     const createTerminal = vi.fn().mockResolvedValue({ terminalId: "term-1" });
     const sendTerminalInput = vi.fn();
+    const clearDraft = vi.fn();
     const { navigate, recorded } = createRecordingNavigate();
 
     await runCreateTerminalWorkspace({
@@ -27,6 +28,7 @@ describe("runCreateTerminalWorkspace", () => {
       ensureWorkspace,
       createTerminal,
       sendTerminalInput,
+      clearDraft,
       serverId: "server-abc",
       navigate,
     });
@@ -52,6 +54,7 @@ describe("runCreateTerminalWorkspace", () => {
         target: { kind: "terminal", terminalId: "term-1" },
       },
     ]);
+    expect(clearDraft).toHaveBeenCalledOnce();
   });
 
   it("drops a sentinel-only arg when the prompt is empty, so a bare command still launches", async () => {
@@ -69,6 +72,7 @@ describe("runCreateTerminalWorkspace", () => {
       ensureWorkspace,
       createTerminal,
       sendTerminalInput,
+      clearDraft: vi.fn(),
       serverId: "server-abc",
       navigate,
     });
@@ -97,6 +101,7 @@ describe("runCreateTerminalWorkspace", () => {
       ensureWorkspace,
       createTerminal,
       sendTerminalInput,
+      clearDraft: vi.fn(),
       serverId: "server-abc",
       navigate,
     });
@@ -132,6 +137,7 @@ describe("runCreateTerminalWorkspace", () => {
       ensureWorkspace,
       createTerminal,
       sendTerminalInput,
+      clearDraft: vi.fn(),
       serverId: "server-abc",
       navigate,
     });
@@ -155,6 +161,7 @@ describe("runCreateTerminalWorkspace", () => {
       ensureWorkspace,
       createTerminal,
       sendTerminalInput,
+      clearDraft: vi.fn(),
       serverId: "server-abc",
       navigate,
     });
@@ -183,6 +190,7 @@ describe("runCreateTerminalWorkspace", () => {
       ensureWorkspace,
       createTerminal,
       sendTerminalInput,
+      clearDraft: vi.fn(),
       serverId: "server-abc",
       navigate,
     });
@@ -212,6 +220,7 @@ describe("runCreateTerminalWorkspace", () => {
       ensureWorkspace,
       createTerminal,
       sendTerminalInput,
+      clearDraft: vi.fn(),
       serverId: "server-abc",
       navigate,
     });
@@ -234,6 +243,7 @@ describe("runCreateTerminalWorkspace", () => {
       ensureWorkspace,
       createTerminal,
       sendTerminalInput,
+      clearDraft: vi.fn(),
       serverId: "server-abc",
       navigate,
     });
@@ -243,5 +253,32 @@ describe("runCreateTerminalWorkspace", () => {
       workspaceId: "ws-1",
       name: undefined,
     });
+  });
+
+  it("keeps the draft when terminal creation fails", async () => {
+    const ensureWorkspace = vi
+      .fn()
+      .mockResolvedValue({ id: "ws-1", workspaceDirectory: "/repo/ws-1" });
+    const createTerminal = vi.fn().mockRejectedValue(new Error("terminal failed"));
+    const clearDraft = vi.fn();
+    const { navigate, recorded } = createRecordingNavigate();
+
+    await expect(
+      runCreateTerminalWorkspace({
+        cwd: "/repo",
+        prompt: "fix the bug",
+        profile: { command: "claude", args: ["{{{prompt}}}"] },
+        profileName: "Claude Code",
+        ensureWorkspace,
+        createTerminal,
+        sendTerminalInput: vi.fn(),
+        clearDraft,
+        serverId: "server-abc",
+        navigate,
+      }),
+    ).rejects.toThrow("terminal failed");
+
+    expect(clearDraft).not.toHaveBeenCalled();
+    expect(recorded).toEqual([]);
   });
 });

--- a/packages/app/src/screens/new-workspace-terminal.ts
+++ b/packages/app/src/screens/new-workspace-terminal.ts
@@ -33,6 +33,7 @@ export interface CreateTerminalWorkspaceInput {
   }) => Promise<CreatedTerminal>;
   /** Types text into a live terminal. Used for the shell path, where the typed command is a command, not argv. */
   sendTerminalInput: (terminalId: string, data: string) => void;
+  clearDraft: () => void;
   serverId: string;
   navigate: (serverId: string, workspaceId: string, target: WorkspaceTabTarget) => void;
 }
@@ -48,6 +49,7 @@ export async function runCreateTerminalWorkspace(
     ensureWorkspace,
     createTerminal,
     sendTerminalInput,
+    clearDraft,
     serverId,
     navigate,
   } = input;
@@ -81,6 +83,7 @@ export async function runCreateTerminalWorkspace(
     sendTerminalInput(createdTerminal.terminalId, `${trimmedPrompt}\r`);
   }
 
+  clearDraft();
   navigate(serverId, ensuredWorkspace.id, {
     kind: "terminal",
     terminalId: createdTerminal.terminalId,

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -106,6 +106,11 @@ import {
   type AgentDeepLinkTarget,
 } from "@getpaseo/protocol/agent-deep-link";
 import { AgentNavigationInbox, parseAgentDeepLinkFromArgv } from "./agent-navigation.js";
+import {
+  parseNewWorkspaceDeepLink,
+  parseNewWorkspaceDeepLinkFromArgv,
+  redactNewWorkspacePromptFromArgv,
+} from "./new-workspace-navigation.js";
 
 const DEV_SERVER_URL = process.env.EXPO_DEV_URL ?? "http://localhost:8081";
 const APP_SCHEME = "paseo";
@@ -354,6 +359,7 @@ let pendingOpenProjectPath = parseOpenProjectPathFromArgv({
   isDefaultApp: process.defaultApp,
 });
 let pendingAgentNavigation = parseAgentDeepLinkFromArgv(process.argv);
+let pendingNewWorkspaceRoute = parseNewWorkspaceDeepLinkFromArgv(process.argv);
 
 // Each window pulls its own pending open-project path on mount, keyed by
 // webContents id, so deep-linked windows (second-instance launches, the
@@ -362,7 +368,7 @@ let pendingAgentNavigation = parseAgentDeepLinkFromArgv(process.argv);
 let desktopWindowOwner: DesktopWindowOwner<AgentDeepLinkTarget>;
 
 if (PASEO_DEBUG) {
-  log.info("[open-project] argv:", process.argv);
+  log.info("[open-project] argv:", redactNewWorkspacePromptFromArgv(process.argv));
   log.info("[open-project] isDefaultApp:", process.defaultApp);
   log.info("[open-project] pendingOpenProjectPath:", pendingOpenProjectPath);
 }
@@ -852,8 +858,38 @@ function receiveAgentDeepLink(input: string): void {
   });
 }
 
+function receiveNewWorkspaceDeepLink(input: string): boolean {
+  const route = parseNewWorkspaceDeepLink(input);
+  if (!route) {
+    return false;
+  }
+
+  if (bootstrapIsComplete) {
+    void desktopWindowOwner
+      .openAdditional({ initialRoute: route })
+      .catch((error) => log.error("[window] failed to route new workspace link", error));
+    return true;
+  }
+
+  pendingNewWorkspaceRoute = route;
+  void bootstrapComplete.then(() => {
+    if (pendingNewWorkspaceRoute !== route) {
+      return undefined;
+    }
+    pendingNewWorkspaceRoute = null;
+    void desktopWindowOwner
+      .openAdditional({ initialRoute: route })
+      .catch((error) => log.error("[window] failed to route queued new workspace link", error));
+    return undefined;
+  });
+  return true;
+}
+
 app.on("open-url", (event, url) => {
   event.preventDefault();
+  if (receiveNewWorkspaceDeepLink(url)) {
+    return;
+  }
   receiveAgentDeepLink(url);
 });
 
@@ -870,6 +906,16 @@ function setupSingleInstanceLock(): boolean {
   }
 
   app.on("second-instance", (_event, commandLine) => {
+    const newWorkspaceRoute = parseNewWorkspaceDeepLinkFromArgv(commandLine);
+    if (newWorkspaceRoute) {
+      void bootstrapComplete
+        .then(() => desktopWindowOwner.openAdditional({ initialRoute: newWorkspaceRoute }))
+        .catch((error) =>
+          log.error("[window] failed to route second-instance new workspace link", error),
+        );
+      return;
+    }
+
     const agentTarget = parseAgentDeepLinkFromArgv(commandLine);
     if (agentTarget) {
       void bootstrapComplete
@@ -981,9 +1027,13 @@ async function bootstrap(): Promise<void> {
 
   // The first window of the session restores and persists saved geometry.
   const initialAgentNavigation = pendingAgentNavigation;
+  const initialNewWorkspaceRoute = pendingNewWorkspaceRoute;
   pendingAgentNavigation = null;
+  pendingNewWorkspaceRoute = null;
   await desktopWindowOwner.openPrimary({
-    initialRoute: initialAgentNavigation ? buildAgentDeepLinkRoute(initialAgentNavigation) : null,
+    initialRoute: initialAgentNavigation
+      ? buildAgentDeepLinkRoute(initialAgentNavigation)
+      : initialNewWorkspaceRoute,
     pendingProjectPath: pendingOpenProjectPath,
   });
   pendingOpenProjectPath = null;
@@ -999,6 +1049,12 @@ async function bootstrap(): Promise<void> {
     await desktopWindowOwner.openOrFocusAgent(target);
   }
 
+  if (pendingNewWorkspaceRoute) {
+    const route = pendingNewWorkspaceRoute;
+    pendingNewWorkspaceRoute = null;
+    await desktopWindowOwner.openAdditional({ initialRoute: route });
+  }
+
   app.on("activate", () => {
     void desktopWindowOwner.restoreWhenActivated().catch((error) => {
       console.error("Failed to restore a desktop window after activation", error);
@@ -1007,7 +1063,9 @@ async function bootstrap(): Promise<void> {
 }
 
 void runDesktopStartup({
-  hasPendingGuiLaunchRequest: Boolean(pendingOpenProjectPath || pendingAgentNavigation),
+  hasPendingGuiLaunchRequest: Boolean(
+    pendingOpenProjectPath || pendingAgentNavigation || pendingNewWorkspaceRoute,
+  ),
   runCliPassthroughIfRequested,
   inheritLoginShellEnv,
   bootstrapGui: bootstrap,

--- a/packages/desktop/src/new-workspace-navigation.test.ts
+++ b/packages/desktop/src/new-workspace-navigation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseNewWorkspaceDeepLink,
+  parseNewWorkspaceDeepLinkFromArgv,
+  redactNewWorkspacePromptFromArgv,
+} from "./new-workspace-navigation";
+
+describe("desktop new workspace navigation", () => {
+  it("routes prompt query parameters", () => {
+    expect(parseNewWorkspaceDeepLink("paseo://new?q=Fix%20it%20%26%20test%20it")).toBe(
+      "/new?q=Fix%20it%20%26%20test%20it",
+    );
+  });
+
+  it("preserves existing new-workspace query parameters", () => {
+    expect(
+      parseNewWorkspaceDeepLink(
+        "paseo://new?serverId=host-1&dir=%2Frepo&name=Repo&projectId=project-1&draftId=draft-1&q=Start",
+      ),
+    ).toBe(
+      "/new?serverId=host-1&dir=%2Frepo&name=Repo&projectId=project-1&draftId=draft-1&q=Start",
+    );
+  });
+
+  it("finds the deep link in desktop launch arguments", () => {
+    expect(
+      parseNewWorkspaceDeepLinkFromArgv([
+        "/Applications/Paseo.app/Contents/MacOS/Paseo",
+        "--no-sandbox",
+        "paseo://new?q=Start",
+      ]),
+    ).toBe("/new?q=Start");
+  });
+
+  it("rejects unrelated and nested custom-scheme URLs", () => {
+    for (const input of [
+      "https://paseo.sh/new?q=Start",
+      "paseo://settings",
+      "paseo://new/extra?q=Start",
+      "not a URL",
+    ]) {
+      expect(parseNewWorkspaceDeepLink(input)).toBeNull();
+    }
+  });
+
+  it("redacts prompt query parameters before launch arguments are logged", () => {
+    expect(
+      redactNewWorkspacePromptFromArgv([
+        "--no-sandbox",
+        "paseo://new?serverId=host-1&q=private%20prompt&source=integration",
+      ]),
+    ).toEqual(["--no-sandbox", "paseo://new?serverId=host-1&q=REDACTED&source=integration"]);
+  });
+});

--- a/packages/desktop/src/new-workspace-navigation.ts
+++ b/packages/desktop/src/new-workspace-navigation.ts
@@ -1,0 +1,46 @@
+const NEW_WORKSPACE_DEEP_LINK_HOST = "new";
+
+export function parseNewWorkspaceDeepLink(input: unknown): string | null {
+  if (typeof input !== "string" || !URL.canParse(input)) {
+    return null;
+  }
+
+  const url = new URL(input);
+  if (
+    url.protocol !== "paseo:" ||
+    url.hostname !== NEW_WORKSPACE_DEEP_LINK_HOST ||
+    url.username ||
+    url.password ||
+    url.port ||
+    (url.pathname !== "" && url.pathname !== "/")
+  ) {
+    return null;
+  }
+
+  return `/new${url.search}`;
+}
+
+export function parseNewWorkspaceDeepLinkFromArgv(argv: string[]): string | null {
+  for (const arg of argv) {
+    const route = parseNewWorkspaceDeepLink(arg);
+    if (route) {
+      return route;
+    }
+  }
+  return null;
+}
+
+export function redactNewWorkspacePromptFromArgv(argv: string[]): string[] {
+  return argv.map((arg) => {
+    if (!parseNewWorkspaceDeepLink(arg)) {
+      return arg;
+    }
+
+    const url = new URL(arg);
+    if (!url.searchParams.has("q")) {
+      return arg;
+    }
+    url.searchParams.set("q", "REDACTED");
+    return url.toString();
+  });
+}

--- a/packages/desktop/src/window/desktop-window-owner.test.ts
+++ b/packages/desktop/src/window/desktop-window-owner.test.ts
@@ -64,6 +64,14 @@ describe("desktop window owner", () => {
     expect(h.owner.takePendingProject(2)).toBe("/project/b");
   });
 
+  it("opens an additional window at an explicit route", async () => {
+    const h = harness();
+
+    await h.owner.openAdditional({ initialRoute: "/new?q=Start" });
+
+    expect(h.launches).toEqual([{ initialRoute: "/new?q=Start", restoreWindowState: false }]);
+  });
+
   it("focuses an existing window and delivers agent routing through its inbox", async () => {
     const h = harness();
     await h.owner.openPrimary();

--- a/packages/desktop/src/window/desktop-window-owner.ts
+++ b/packages/desktop/src/window/desktop-window-owner.ts
@@ -29,7 +29,10 @@ export interface DesktopWindowOwner<TAgentTarget> {
     initialRoute?: string | null;
     pendingProjectPath?: string | null;
   }): Promise<void>;
-  openAdditional(input?: { pendingProjectPath?: string | null }): Promise<void>;
+  openAdditional(input?: {
+    initialRoute?: string | null;
+    pendingProjectPath?: string | null;
+  }): Promise<void>;
   openOrFocusAgent(target: TAgentTarget): Promise<void>;
   restoreWhenActivated(): Promise<void>;
   takePendingProject(webContentsId: number): string | null;
@@ -63,7 +66,7 @@ export function createDesktopWindowOwner<TAgentTarget>(
       }),
     openAdditional: (input = {}) =>
       open({
-        initialRoute: null,
+        initialRoute: input.initialRoute ?? null,
         pendingProjectPath: input.pendingProjectPath ?? null,
         restoreWindowState: false,
       }),

--- a/packages/website/src/new-workspace-deep-link.test.ts
+++ b/packages/website/src/new-workspace-deep-link.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildNewWorkspaceDeepLink, createNewWorkspaceRedirect } from "./new-workspace-deep-link";
+
+describe("buildNewWorkspaceDeepLink", () => {
+  it("keeps the prompt in the query string", () => {
+    expect(buildNewWorkspaceDeepLink("/new?q=Fix%20it%20%26%20test%20it")).toBe(
+      "paseo://new?q=Fix%20it%20%26%20test%20it",
+    );
+  });
+
+  it("preserves supported query parameters alongside the prompt", () => {
+    expect(
+      buildNewWorkspaceDeepLink(
+        "/new?serverId=host-1&dir=%2Frepo&name=Repo&projectId=project-1&draftId=draft-1&q=Start",
+      ),
+    ).toBe(
+      "paseo://new?serverId=host-1&dir=%2Frepo&name=Repo&projectId=project-1&draftId=draft-1&q=Start",
+    );
+  });
+
+  it("returns a temporary redirect for website requests", () => {
+    const response = createNewWorkspaceRedirect(
+      "https://paseo.sh/new?serverId=host-1&dir=%2Frepo&q=Start%20here",
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Location")).toBe(
+      "paseo://new?serverId=host-1&dir=%2Frepo&q=Start%20here",
+    );
+  });
+});

--- a/packages/website/src/new-workspace-deep-link.ts
+++ b/packages/website/src/new-workspace-deep-link.ts
@@ -1,0 +1,11 @@
+export function buildNewWorkspaceDeepLink(input: string): string {
+  const source = new URL(input, "https://paseo.sh");
+  return `paseo://new${source.search}`;
+}
+
+export function createNewWorkspaceRedirect(input: string): Response {
+  return new Response(null, {
+    status: 307,
+    headers: { Location: buildNewWorkspaceDeepLink(input) },
+  });
+}

--- a/packages/website/src/routeTree.gen.ts
+++ b/packages/website/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as PiRouteImport } from "./routes/pi";
 import { Route as OpencodeRouteImport } from "./routes/opencode";
 import { Route as OmpRouteImport } from "./routes/omp";
 import { Route as NovaRouteImport } from "./routes/nova";
+import { Route as NewRouteImport } from "./routes/new";
 import { Route as MistralVibeRouteImport } from "./routes/mistral-vibe";
 import { Route as MinionCodeRouteImport } from "./routes/minion-code";
 import { Route as KimiRouteImport } from "./routes/kimi";
@@ -133,6 +134,11 @@ const OmpRoute = OmpRouteImport.update({
 const NovaRoute = NovaRouteImport.update({
   id: "/nova",
   path: "/nova",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const NewRoute = NewRouteImport.update({
+  id: "/new",
+  path: "/new",
   getParentRoute: () => rootRouteImport,
 } as any);
 const MistralVibeRoute = MistralVibeRouteImport.update({
@@ -410,6 +416,7 @@ export interface FileRoutesByFullPath {
   "/kimi": typeof KimiRoute;
   "/minion-code": typeof MinionCodeRoute;
   "/mistral-vibe": typeof MistralVibeRoute;
+  "/new": typeof NewRoute;
   "/nova": typeof NovaRoute;
   "/omp": typeof OmpRoute;
   "/opencode": typeof OpencodeRoute;
@@ -470,6 +477,7 @@ export interface FileRoutesByTo {
   "/kimi": typeof KimiRoute;
   "/minion-code": typeof MinionCodeRoute;
   "/mistral-vibe": typeof MistralVibeRoute;
+  "/new": typeof NewRoute;
   "/nova": typeof NovaRoute;
   "/omp": typeof OmpRoute;
   "/opencode": typeof OpencodeRoute;
@@ -533,6 +541,7 @@ export interface FileRoutesById {
   "/kimi": typeof KimiRoute;
   "/minion-code": typeof MinionCodeRoute;
   "/mistral-vibe": typeof MistralVibeRoute;
+  "/new": typeof NewRoute;
   "/nova": typeof NovaRoute;
   "/omp": typeof OmpRoute;
   "/opencode": typeof OpencodeRoute;
@@ -597,6 +606,7 @@ export interface FileRouteTypes {
     | "/kimi"
     | "/minion-code"
     | "/mistral-vibe"
+    | "/new"
     | "/nova"
     | "/omp"
     | "/opencode"
@@ -657,6 +667,7 @@ export interface FileRouteTypes {
     | "/kimi"
     | "/minion-code"
     | "/mistral-vibe"
+    | "/new"
     | "/nova"
     | "/omp"
     | "/opencode"
@@ -719,6 +730,7 @@ export interface FileRouteTypes {
     | "/kimi"
     | "/minion-code"
     | "/mistral-vibe"
+    | "/new"
     | "/nova"
     | "/omp"
     | "/opencode"
@@ -782,6 +794,7 @@ export interface RootRouteChildren {
   KimiRoute: typeof KimiRoute;
   MinionCodeRoute: typeof MinionCodeRoute;
   MistralVibeRoute: typeof MistralVibeRoute;
+  NewRoute: typeof NewRoute;
   NovaRoute: typeof NovaRoute;
   OmpRoute: typeof OmpRoute;
   OpencodeRoute: typeof OpencodeRoute;
@@ -895,6 +908,13 @@ declare module "@tanstack/react-router" {
       path: "/nova";
       fullPath: "/nova";
       preLoaderRoute: typeof NovaRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/new": {
+      id: "/new";
+      path: "/new";
+      fullPath: "/new";
+      preLoaderRoute: typeof NewRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/mistral-vibe": {
@@ -1290,6 +1310,7 @@ const rootRouteChildren: RootRouteChildren = {
   KimiRoute: KimiRoute,
   MinionCodeRoute: MinionCodeRoute,
   MistralVibeRoute: MistralVibeRoute,
+  NewRoute: NewRoute,
   NovaRoute: NovaRoute,
   OmpRoute: OmpRoute,
   OpencodeRoute: OpencodeRoute,

--- a/packages/website/src/routes/new.tsx
+++ b/packages/website/src/routes/new.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { createNewWorkspaceRedirect } from "~/new-workspace-deep-link";
+
+export const Route = createFileRoute("/new")({
+  server: {
+    handlers: {
+      GET: ({ request }) => createNewWorkspaceRedirect(request.url),
+    },
+  },
+});

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -45,6 +45,7 @@ function discoverAgentRoutes(): string[] {
     "download",
     "hub",
     "index",
+    "new",
     "sponsor",
     "privacy",
     "terms",


### PR DESCRIPTION
### Linked issue

Closes #<issue-number>

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

New-workspace links could select a host, project, directory, and draft, but users still had to copy and paste the task they wanted to start.

This change adds a `q` query parameter that prefills the new workspace composer without submitting it. Both `paseo://new?q=...` and `https://paseo.sh/new?q=...` are supported, allowing users to review or edit the prepared prompt before starting their workspace.

### Goals

- Accept an encoded prompt through the `/new` `q` query parameter.
- Support `q` in both `paseo://new` links and `https://paseo.sh/new` redirects.
- Preserve the existing `serverId`, `dir`, `name`, `projectId`, and `draftId` parameters.
- Prefill chat and terminal composers without automatically submitting the prompt.
- Handle desktop cold starts and links opened while Paseo is already running.
- Redact `q` from desktop launch-argument diagnostic logs.
- Add automated coverage for app routing, website redirects, and desktop window routing.

### Non-goals

- Automatically submit the prompt or start an agent.
- Support prompts in the URL fragment.
- Guarantee prompt confidentiality from HTTP servers, proxies, browser history, or request logs; `q` is an ordinary query parameter.
- Change the meaning of existing `/new` parameters.
- Add universal-link association or an app-install fallback.
- Change the new workspace screen’s visual design.
- Change the app/daemon protocol.

### QA

Requester verification:

- Manually confirmed that the resulting deep link works end to end.

Focused unit tests:

```text
npx vitest run \
  packages/app/src/navigation/new-workspace-route-params.test.ts \
  packages/desktop/src/new-workspace-navigation.test.ts \
  packages/desktop/src/window/desktop-window-owner.test.ts \
  packages/website/src/new-workspace-deep-link.test.ts \
  --bail=1

Test Files  4 passed (4)
Tests       15 passed (15)
```

Real-browser regression:

```text
npm run test:e2e --workspace=@getpaseo/app -- \
  e2e/browser/new-workspace-deep-link.spec.ts

✓ a new-workspace deep link preserves query context and prefills its prompt
1 passed (31.9s)
```

The Playwright test:

- Opens `/new` with `serverId`, `name=TEst`, and an encoded multiline `q`.
- Confirms all query parameters remain intact and the URL has no fragment.
- Confirms the message composer contains the decoded prompt.
- Uses an isolated daemon on a temporary port; port `6767` is explicitly blocked by the fixture.
- Stops both the isolated daemon and Metro after the test.

Website redirect verification:

```text
GET /new?name=TEst&q=Just%20testing

HTTP/1.1 307 Temporary Redirect
location: paseo://new?name=TEst&q=Just%20testing
```

Additional checks:

```text
npm run typecheck
Result: passed

npm run lint
Result: 0 warnings and 0 errors

npm run format
Result: passed

npm run format:check
Result: passed

npm run build --workspace=@getpaseo/website
Result: passed
```

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | No | Not manually tested |
| Android         | No | Not manually tested |
| Web             | Yes | Real Playwright composer flow and live website redirect tested |
| Desktop macOS   | Partial | Deep-link parsing and window routing covered by automated tests |
| Desktop Windows | Partial | Deep-link parsing and window routing covered by automated tests |
| Desktop Linux   | Partial | Deep-link parsing and window routing covered by automated tests |

No visual layout changes are intended; the browser test verifies the changed composer behavior directly.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense