### PR TITLE
feat(server): add OMP ACP approval modes

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -79,11 +79,12 @@ The custom `omp-acp` provider is a thin ACP adapter for an OMP command configure
 `extends: "acp"`. It exposes OMP's `always-ask`, `write`, and `yolo` approval values as
 `Ask Every Time`, `Write Access`, and `Full Access`. The selected value is injected into
 the per-session `omp --approval-mode <value>` launch, including resumed sessions; a
-missing value defaults to `yolo` (`Full Access`). OMP does not expose an ACP request for
-changing this process setting, so changing it on a live session keeps the current mode and
-returns a restart notice. Provider preferences persist a new-session selection, while persisted
-agent config restores `modeId` when that session is resumed. Generic `extends: "acp"`
-providers retain their existing ACP modes and `Auto Accept` behavior.
+missing value defaults to `always-ask` (`Ask Every Time`) rather than inheriting the user's
+machine-level OMP preference. OMP does not expose an ACP request for changing this process
+setting, so changing it on a live session keeps the current mode and returns a restart notice.
+Provider preferences persist a new-session selection, while persisted agent config restores
+`modeId` when that session is resumed. Generic `extends: "acp"` providers retain their existing
+ACP modes and `Auto Accept` behavior.
 
 Pi RPC extension UI dialog requests (`select`, `input`, `editor`, `confirm`) are bridged into Paseo question permissions and answered with `extension_ui_response`. Pi extensions such as `ask_user` may chain dialogs: for example, a `select` can be followed by an optional-comment `input`. When an `ask_user` tool call declares `allowComment: true`, Paseo presents the selection and optional comment as one question permission, answers Pi's initial `select` immediately, then auto-answers the follow-up optional `input` with the comment the user already supplied (or an empty string). Preserve placeholders and optional/skip semantics for standalone optional inputs so the app can still distinguish "skip this optional input" from "cancel the whole dialog." Fire-and-forget extension UI requests such as notifications are intentionally ignored by the provider adapter unless Paseo grows first-class UI for them.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -75,6 +75,16 @@ OMP is a first-class built-in provider, disabled by default. Its launch contract
 
 OMP supports native Paseo host tools. The adapter registers the full caller-scoped Paseo tool catalog directly with OMP, matching providers such as Claude that expose the full catalog through MCP. Serialize every OMP host definition with `loadMode: "essential"` so `create_agent`, `send_agent_prompt`, `wait_for_agent`, and related tools remain direct calls; omitting the field makes OMP mount non-built-in names under `xd://` instead. OMP's provider-managed task subagents are surfaced as Paseo subagents through `child_session` imports; the parent keeps the subagents track while the child runtime stays owned by OMP. Custom OMP profiles should extend `omp`; other Pi-compatible forks can still extend `pi`, override `command`, and set `params.sessionDir` to their JSONL session directory.
 
+The custom `omp-acp` provider is a thin ACP adapter for an OMP command configured with
+`extends: "acp"`. It exposes OMP's `always-ask`, `write`, and `yolo` approval values as
+`Ask Every Time`, `Write Access`, and `Full Access`. The selected value is injected into
+the per-session `omp --approval-mode <value>` launch, including resumed sessions; a
+missing value defaults to `yolo` (`Full Access`). OMP does not expose an ACP request for
+changing this process setting, so changing it on a live session keeps the current mode and
+returns a restart notice. Provider preferences persist a new-session selection, while persisted
+agent config restores `modeId` when that session is resumed. Generic `extends: "acp"`
+providers retain their existing ACP modes and `Auto Accept` behavior.
+
 Pi RPC extension UI dialog requests (`select`, `input`, `editor`, `confirm`) are bridged into Paseo question permissions and answered with `extension_ui_response`. Pi extensions such as `ask_user` may chain dialogs: for example, a `select` can be followed by an optional-comment `input`. When an `ask_user` tool call declares `allowComment: true`, Paseo presents the selection and optional comment as one question permission, answers Pi's initial `select` immediately, then auto-answers the follow-up optional `input` with the comment the user already supplied (or an empty string). Preserve placeholders and optional/skip semantics for standalone optional inputs so the app can still distinguish "skip this optional input" from "cancel the whole dialog." Fire-and-forget extension UI requests such as notifications are intentionally ignored by the provider adapter unless Paseo grows first-class UI for them.
 
 OpenCode 1 keeps MCP and process environment outside the session boundary. Paseo shares one OpenCode server for ordinary agents and installs a daemon-owned plugin through `OPENCODE_CONFIG_CONTENT`. The plugin reads the exact agent environment and caller-scoped Paseo tool catalog from the daemon's private loopback bridge for each OpenCode session. Bridge context lives only in daemon memory and is removed when the Paseo session closes. The content-addressed plugin artifact contains no session data or secrets.

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -2244,6 +2244,60 @@ test("setAgentMode persists the selected mode across session reload", async () =
   expect(reloaded.currentModeId).toBe("full-access");
 });
 
+test("setAgentMode persists a restart-required mode while keeping the live mode", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-restart-mode-test-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+
+  class RestartModeSession extends TestAgentSession {
+    private configuredMode: string | null = "yolo";
+
+    override async getCurrentMode() {
+      return "yolo";
+    }
+
+    override async setMode(modeId: string) {
+      this.configuredMode = modeId;
+      return { type: "warning" as const, message: "Restart required" };
+    }
+
+    getConfiguredMode() {
+      return this.configuredMode;
+    }
+  }
+
+  class RestartModeClient extends TestAgentClient {
+    readonly session = new RestartModeSession({ provider: "codex", cwd: workdir });
+
+    override async createSession(): Promise<AgentSession> {
+      return this.session;
+    }
+  }
+
+  const client = new RestartModeClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000302",
+  });
+
+  const snapshot = await manager.createAgent(
+    { provider: "codex", cwd: workdir, modeId: "yolo" },
+    undefined,
+    { workspaceId: undefined },
+  );
+  await expect(manager.setAgentMode(snapshot.id, "write")).resolves.toEqual({
+    type: "warning",
+    message: "Restart required",
+  });
+
+  const updated = manager.getAgent(snapshot.id);
+  expect(updated?.currentModeId).toBe("yolo");
+  expect(updated?.config.modeId).toBe("write");
+  await storage.flush();
+  expect((await storage.get(snapshot.id))?.config?.modeId).toBe("write");
+});
+
 test("reloadAgentSession completes when the previous session close hangs", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-reload-close-timeout-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1704,7 +1704,7 @@ export class AgentManager {
     const notice = (await agent.session.setMode(modeId)) ?? null;
     await this.drainSessionEvents(agentId);
     const currentMode = (await agent.session.getCurrentMode()) ?? modeId;
-    agent.config.modeId = currentMode ?? undefined;
+    agent.config.modeId = agent.session.getConfiguredMode?.() ?? currentMode ?? undefined;
     agent.currentModeId = currentMode;
     // Update runtimeInfo to reflect the new mode
     if (agent.runtimeInfo) {

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -647,6 +647,8 @@ export interface AgentSession {
   getAvailableModes(): Promise<AgentMode[]>;
   getCurrentMode(): Promise<string | null>;
   setMode(modeId: string): Promise<void | AgentProviderNotice>;
+  /** Mode to persist when it intentionally differs from the live runtime mode. */
+  getConfiguredMode?(): string | null;
   getPendingPermissions(): AgentPermissionRequest[];
   respondToPermission(
     requestId: string,

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -679,6 +679,27 @@ test("built-in OMP override keeps the real OMP adapter enabled and launchable", 
   await session.close();
 });
 
+test("omp-acp custom providers expose OMP approval modes with Full Access by default", () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      "omp-acp": {
+        extends: "acp",
+        label: "OMP ACP",
+        command: ["omp", "--no-extensions", "acp"],
+      },
+    },
+  });
+
+  const definition = registry["omp-acp"];
+  expect(definition.defaultModeId).toBe("yolo");
+  expect(definition.modes.map((mode) => [mode.id, mode.label])).toEqual([
+    ["always-ask", "Ask Every Time"],
+    ["write", "Write Access"],
+    ["yolo", "Full Access"],
+  ]);
+  expect(definition.createClient(logger).provider).toBe("omp-acp");
+});
+
 test("new provider extending acp uses GenericACPAgentClient", () => {
   const registry = buildProviderRegistry(logger, {
     providerOverrides: {

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -679,7 +679,7 @@ test("built-in OMP override keeps the real OMP adapter enabled and launchable", 
   await session.close();
 });
 
-test("omp-acp custom providers expose OMP approval modes with Full Access by default", () => {
+test("omp-acp custom providers expose OMP approval modes with Ask Every Time by default", () => {
   const registry = buildProviderRegistry(logger, {
     providerOverrides: {
       "omp-acp": {
@@ -691,7 +691,7 @@ test("omp-acp custom providers expose OMP approval modes with Full Access by def
   });
 
   const definition = registry["omp-acp"];
-  expect(definition.defaultModeId).toBe("yolo");
+  expect(definition.defaultModeId).toBe("always-ask");
   expect(definition.modes.map((mode) => [mode.id, mode.label])).toEqual([
     ["always-ask", "Ask Every Time"],
     ["write", "Write Access"],

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -39,6 +39,11 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import {
+  OMP_ACP_DEFAULT_MODE_ID,
+  OMP_ACP_MODES,
+  OmpAcpAgentClient,
+} from "./providers/omp-acp-agent.js";
 import { KimiACPAgentClient } from "./providers/kimi-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
@@ -759,6 +764,7 @@ function addDerivedProviders(
     if (!override.extends) {
       throw new Error(`Custom provider '${providerId}' requires an extends value`);
     }
+    const isOmpAcpProvider = providerId === "omp-acp";
 
     if (override.extends === "acp") {
       if (!override.command || !isNonEmptyStringArray(override.command)) {
@@ -774,8 +780,8 @@ function addDerivedProviders(
             id: providerId,
             label: override.label ?? providerId,
             description: override.description ?? "Custom ACP provider",
-            defaultModeId: null,
-            modes: [],
+            defaultModeId: isOmpAcpProvider ? OMP_ACP_DEFAULT_MODE_ID : null,
+            modes: isOmpAcpProvider ? OMP_ACP_MODES : [],
           },
           override,
         ),
@@ -795,6 +801,9 @@ function addDerivedProviders(
             label: override.label ?? providerId,
             providerParams: override.params,
           };
+          if (isOmpAcpProvider) {
+            return new OmpAcpAgentClient(acpOptions);
+          }
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
           }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -75,6 +75,7 @@ import {
   type AgentPersistenceHandle,
   type AgentPromptContentBlock,
   type AgentPromptInput,
+  type AgentProviderNotice,
   type AgentRunOptions,
   type AgentRunResult,
   type AgentRuntimeInfo,
@@ -415,7 +416,9 @@ interface ACPAgentClientOptions {
   logger: Logger;
   runtimeSettings?: ProviderRuntimeSettings;
   defaultCommand: [string, ...string[]];
+  sessionLaunchTransformer?: ACPSessionLaunchTransformer;
   defaultModes?: AgentMode[];
+  includeAutoAcceptFeature?: boolean;
   catalogModelResolver?: ACPCatalogModelResolver;
   modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
@@ -446,7 +449,9 @@ interface ACPAgentSessionOptions {
   logger: Logger;
   runtimeSettings?: ProviderRuntimeSettings;
   defaultCommand: [string, ...string[]];
+  sessionLaunchTransformer?: ACPSessionLaunchTransformer;
   defaultModes: AgentMode[];
+  includeAutoAcceptFeature?: boolean;
   modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
   configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
@@ -518,6 +523,16 @@ interface PendingUserMessage {
 }
 
 export type SessionStateResponse = NewSessionResponse | LoadSessionResponse | ResumeSessionResponse;
+export interface ACPSessionLaunch {
+  command: string;
+  args: string[];
+  modeId?: string | null;
+}
+
+export type ACPSessionLaunchTransformer = (
+  config: AgentSessionConfig,
+  launch: ACPSessionLaunch,
+) => ACPSessionLaunch;
 
 interface TerminalExit {
   exitCode?: number | null;
@@ -592,6 +607,7 @@ export interface ACPProviderModeWriteResult {
   handled: boolean;
   currentModeId?: string;
   configOptions?: SessionConfigOption[];
+  notice?: AgentProviderNotice;
 }
 
 export interface ACPBeforeModeWriteResult {
@@ -792,13 +808,17 @@ function isACPCreateConfigUnattended(input: AgentCreateConfigUnattendedInput): b
 export class ACPAgentClient implements AgentClient {
   readonly provider: string;
   readonly capabilities: AgentCapabilityFlags;
-  readonly resolveCreateConfig = resolveACPCreateConfig;
-  readonly isCreateConfigUnattended = isACPCreateConfigUnattended;
+  readonly resolveCreateConfig: (
+    input: ResolveAgentCreateConfigInput,
+  ) => ResolveAgentCreateConfigResult;
+  readonly isCreateConfigUnattended: (input: AgentCreateConfigUnattendedInput) => boolean;
 
   protected readonly logger: Logger;
   protected readonly runtimeSettings?: ProviderRuntimeSettings;
   protected readonly defaultCommand: [string, ...string[]];
+  private readonly sessionLaunchTransformer?: ACPSessionLaunchTransformer;
   protected readonly defaultModes: AgentMode[];
+  private readonly includeAutoAcceptFeature: boolean;
   private readonly catalogModelResolver?: ACPCatalogModelResolver;
   private readonly modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   private readonly sessionResponseTransformer?: (
@@ -838,7 +858,15 @@ export class ACPAgentClient implements AgentClient {
     });
     this.runtimeSettings = options.runtimeSettings;
     this.defaultCommand = options.defaultCommand;
+    this.sessionLaunchTransformer = options.sessionLaunchTransformer;
     this.defaultModes = options.defaultModes ?? [];
+    this.includeAutoAcceptFeature = options.includeAutoAcceptFeature ?? true;
+    this.resolveCreateConfig = this.includeAutoAcceptFeature
+      ? resolveACPCreateConfig
+      : resolveDefaultAgentCreateConfig;
+    this.isCreateConfigUnattended = this.includeAutoAcceptFeature
+      ? isACPCreateConfigUnattended
+      : isDefaultAgentCreateConfigUnattended;
     this.catalogModelResolver = options.catalogModelResolver;
     this.modelTransformer = options.modelTransformer;
     this.sessionResponseTransformer = options.sessionResponseTransformer;
@@ -868,7 +896,9 @@ export class ACPAgentClient implements AgentClient {
         logger: this.logger,
         runtimeSettings: this.runtimeSettings,
         defaultCommand: this.defaultCommand,
+        sessionLaunchTransformer: this.sessionLaunchTransformer,
         defaultModes: this.defaultModes,
+        includeAutoAcceptFeature: this.includeAutoAcceptFeature,
         modelTransformer: this.modelTransformer,
         sessionResponseTransformer: this.sessionResponseTransformer,
         configOptionsTransformer: this.configOptionsTransformer,
@@ -918,7 +948,9 @@ export class ACPAgentClient implements AgentClient {
       logger: this.logger,
       runtimeSettings: this.runtimeSettings,
       defaultCommand: this.defaultCommand,
+      sessionLaunchTransformer: this.sessionLaunchTransformer,
       defaultModes: this.defaultModes,
+      includeAutoAcceptFeature: this.includeAutoAcceptFeature,
       modelTransformer: this.modelTransformer,
       sessionResponseTransformer: this.sessionResponseTransformer,
       configOptionsTransformer: this.configOptionsTransformer,
@@ -1023,9 +1055,9 @@ export class ACPAgentClient implements AgentClient {
   }
 
   async listFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {
-    const autoAcceptFeature = buildACPAutoAcceptFeature(config);
+    const baseFeatures = this.includeAutoAcceptFeature ? [buildACPAutoAcceptFeature(config)] : [];
     if (this.configFeatureOptions.length === 0) {
-      return [autoAcceptFeature];
+      return baseFeatures;
     }
 
     this.assertProvider(config);
@@ -1039,7 +1071,7 @@ export class ACPAgentClient implements AgentClient {
       );
       const transformed = this.transformSessionResponse(response);
       return [
-        autoAcceptFeature,
+        ...baseFeatures,
         ...deriveFeaturesFromACP(transformed.configOptions, this.configFeatureOptions),
       ];
     } finally {
@@ -1398,7 +1430,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly logger: Logger;
   private readonly runtimeSettings?: ProviderRuntimeSettings;
   private readonly defaultCommand: [string, ...string[]];
+  private readonly sessionLaunchTransformer?: ACPSessionLaunchTransformer;
   private readonly defaultModes: AgentMode[];
+  private readonly includeAutoAcceptFeature: boolean;
   protected readonly modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   private readonly sessionResponseTransformer?: (
     response: SessionStateResponse,
@@ -1439,6 +1473,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private agentCapabilities: ACPAgentCapabilities | null = null;
   private sessionId: string | null = null;
   private currentMode: string | null = null;
+  private configuredMode: string | null = null;
+  private launchModeId: string | null = null;
   private availableModes: AgentMode[];
   private currentModel: string | null = null;
   private availableModels: AvailableACPModel[] | null = null;
@@ -1468,7 +1504,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.logger = options.logger.child({ module: "agent", provider: options.provider });
     this.runtimeSettings = options.runtimeSettings;
     this.defaultCommand = options.defaultCommand;
+    this.sessionLaunchTransformer = options.sessionLaunchTransformer;
     this.defaultModes = options.defaultModes;
+    this.includeAutoAcceptFeature = options.includeAutoAcceptFeature ?? true;
     this.modelTransformer = options.modelTransformer;
     this.sessionResponseTransformer = options.sessionResponseTransformer;
     this.configOptionsTransformer = options.configOptionsTransformer;
@@ -1486,6 +1524,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.initialHandle = options.handle;
     this.config = { ...config, provider: options.provider };
     this.currentMode = config.modeId ?? null;
+    this.configuredMode = config.modeId ?? null;
     this.currentModel = config.model ?? null;
     this.thinkingOptionId = config.thinkingOptionId ?? null;
     this.currentTitle = config.title ?? null;
@@ -1690,9 +1729,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     return this.currentMode;
   }
 
+  getConfiguredMode(): string | null {
+    return this.configuredMode;
+  }
+
   get features(): AgentFeature[] {
     return [
-      buildACPAutoAcceptFeature(this.config),
+      ...(this.includeAutoAcceptFeature ? [buildACPAutoAcceptFeature(this.config)] : []),
       ...deriveFeaturesFromACP(this.configOptions, this.configFeatureOptions),
     ];
   }
@@ -1753,7 +1796,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     return this.cachedCommands;
   }
 
-  async setMode(modeId: string): Promise<void> {
+  async setMode(modeId: string): Promise<void | AgentProviderNotice> {
     if (!this.connection || !this.sessionId) {
       throw new Error("ACP session not initialized");
     }
@@ -1763,7 +1806,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       availableModes: this.availableModes,
       configOptions: this.configOptions,
     });
-    await this.setModeWithSelection({ modeId, selection });
+    return this.setModeWithSelection({ modeId, selection });
   }
 
   // Mode/model selection updates stay after ACP RPC success; this intentionally diverges from Zed's optimistic rollback path (acp.rs:3080-3104).
@@ -1773,7 +1816,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }: {
     modeId: string;
     selection: ACPModeSelection;
-  }): Promise<void> {
+  }): Promise<void | AgentProviderNotice> {
     if (!this.connection || !this.sessionId) {
       throw new Error("ACP session not initialized");
     }
@@ -1783,6 +1826,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       ? await this.providerModeWriter(context)
       : { handled: false };
     if (providerResult.handled) {
+      this.configuredMode = modeId;
+      this.config.modeId = modeId;
       this.currentMode = providerResult.currentModeId ?? modeId;
       if (providerResult.configOptions) {
         this.configOptions = this.transformConfigOptions(providerResult.configOptions);
@@ -1794,7 +1839,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         currentModeId: this.currentMode,
         availableModes: [...this.availableModes],
       });
-      return;
+      return providerResult.notice;
     }
 
     if (selection.hasAvailableModes) {
@@ -1834,6 +1879,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     if (selection.hasAvailableModes) {
       await this.connection.setSessionMode({ sessionId: this.sessionId, modeId });
+      this.configuredMode = modeId;
+      this.config.modeId = modeId;
       this.currentMode = modeId;
       this.pushEvent({
         type: "mode_changed",
@@ -1861,6 +1908,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       requestedValue: modeId,
       label: "mode",
     });
+    this.configuredMode = this.currentMode;
+    this.config.modeId = this.currentMode ?? undefined;
     this.availableModes = deriveModesFromACP(this.defaultModes, null, this.configOptions).modes;
     this.pushEvent({
       type: "mode_changed",
@@ -2034,7 +2083,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       throw new Error("ACP session not initialized");
     }
 
-    if (featureId === ACP_AUTO_ACCEPT_FEATURE_ID) {
+    if (featureId === ACP_AUTO_ACCEPT_FEATURE_ID && this.includeAutoAcceptFeature) {
       this.config.featureValues = {
         ...this.config.featureValues,
         [ACP_AUTO_ACCEPT_FEATURE_ID]: value === true,
@@ -2230,7 +2279,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
     const canAutoAccept =
-      isACPAutoAcceptEnabled(this.config) && !isACPChooserRequest(params.options);
+      this.includeAutoAcceptFeature &&
+      isACPAutoAcceptEnabled(this.config) &&
+      !isACPChooserRequest(params.options);
     if (canAutoAccept) {
       const allowOption = selectPermissionOption(params.options, { behavior: "allow" });
       if (allowOption) {
@@ -2479,9 +2530,17 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       throw new Error(`${this.provider} command '${this.defaultCommand[0]}' not found`);
     }
 
-    const command = prefix.command;
-    const args = [...prefix.args, ...this.defaultCommand.slice(1)];
-    const child = spawnProcess(command, args, {
+    const launch = this.sessionLaunchTransformer
+      ? this.sessionLaunchTransformer(this.config, {
+          command: prefix.command,
+          args: [...prefix.args, ...this.defaultCommand.slice(1)],
+        })
+      : {
+          command: prefix.command,
+          args: [...prefix.args, ...this.defaultCommand.slice(1)],
+        };
+    this.launchModeId = launch.modeId ?? null;
+    const child = spawnProcess(launch.command, launch.args, {
       cwd: this.config.cwd,
       ...createProviderEnvSpec({
         runtimeSettings: this.runtimeSettings,
@@ -2556,7 +2615,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     const modeInfo = deriveModesFromACP(this.defaultModes, transformed.modes, this.configOptions);
     this.availableModes = modeInfo.modes;
-    this.currentMode = modeInfo.currentModeId ?? this.currentMode;
+    this.currentMode =
+      this.launchModeId && this.availableModes.some((mode) => mode.id === this.launchModeId)
+        ? this.launchModeId
+        : (modeInfo.currentModeId ?? this.currentMode);
 
     this.availableModels = transformed.models?.availableModels ?? null;
     this.currentModel =
@@ -2663,7 +2725,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.fallbackAssistantMessageId = null;
         return [...pendingUserEvents, this.wrapTimeline(mapPlanToTimeline(update))];
       case "current_mode_update":
-        this.handleCurrentModeUpdate(update);
+        if (!this.handleCurrentModeUpdate(update)) {
+          return pendingUserEvents;
+        }
         return [
           ...pendingUserEvents,
           {
@@ -2789,8 +2853,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     return this.fallbackAssistantMessageId;
   }
 
-  private handleCurrentModeUpdate(update: CurrentModeUpdate): void {
-    this.currentMode = this.transformModeId(update.currentModeId);
+  private handleCurrentModeUpdate(update: CurrentModeUpdate): boolean {
+    const modeId = this.transformModeId(update.currentModeId);
+    if (modeId === null) {
+      return false;
+    }
+    this.currentMode = modeId;
+    return true;
   }
 
   private handleConfigOptionUpdate(update: ConfigOptionUpdate): AgentStreamEvent[] {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -1,15 +1,20 @@
 import type { Logger } from "pino";
 import { z } from "zod";
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 
-import type { AgentCapabilityFlags } from "../agent-sdk-types.js";
+import type { AgentCapabilityFlags, AgentMode } from "../agent-sdk-types.js";
 import { checkProviderLaunchAvailable, resolveProviderLaunch } from "../provider-launch-config.js";
 import {
   ACPAgentClient,
   type ACPCatalogModelResolver,
   type ACPClientCapabilityMeta,
   type ACPConfigFeatureOption,
+  type ACPProviderModeWriteResult,
+  type ACPProviderModeWriterContext,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type ACPSessionLaunchTransformer,
+  type SessionStateResponse,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -44,6 +49,15 @@ interface GenericACPAgentClientOptions {
   providerId?: string;
   label?: string;
   providerParams?: unknown;
+  defaultModes?: AgentMode[];
+  includeAutoAcceptFeature?: boolean;
+  sessionLaunchTransformer?: ACPSessionLaunchTransformer;
+  sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
+  configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
+  modeIdTransformer?: (modeId: string) => string | null;
+  providerModeWriter?: (
+    context: ACPProviderModeWriterContext,
+  ) => Promise<ACPProviderModeWriteResult>;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   diagnosticPhaseTimeoutMs?: number;
@@ -68,6 +82,13 @@ export class GenericACPAgentClient extends ACPAgentClient {
         env: options.env,
       },
       defaultCommand: options.command,
+      defaultModes: options.defaultModes,
+      includeAutoAcceptFeature: options.includeAutoAcceptFeature,
+      sessionLaunchTransformer: options.sessionLaunchTransformer,
+      sessionResponseTransformer: options.sessionResponseTransformer,
+      configOptionsTransformer: options.configOptionsTransformer,
+      modeIdTransformer: options.modeIdTransformer,
+      providerModeWriter: options.providerModeWriter,
       capabilities: buildGenericACPCapabilities(providerParams),
       waitForInitialCommands: options.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,

--- a/packages/server/src/server/agent/providers/omp-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp-acp-agent.test.ts
@@ -52,8 +52,8 @@ interface LiveOmpAcpSessionInternals {
 }
 
 describe("OMP ACP approval modes", () => {
-  test("exposes OMP approval values and defaults to Full Access", () => {
-    expect(OMP_ACP_DEFAULT_MODE_ID).toBe("yolo");
+  test("exposes OMP approval values and defaults to Ask Every Time", () => {
+    expect(OMP_ACP_DEFAULT_MODE_ID).toBe("always-ask");
     expect(OMP_ACP_MODES).toEqual([
       expect.objectContaining({
         id: "always-ask",
@@ -86,16 +86,16 @@ describe("OMP ACP approval modes", () => {
     },
   );
 
-  test("defaults to yolo and replaces an existing CLI override", () => {
+  test("defaults to always-ask and replaces an existing CLI override", () => {
     expect(
       buildOmpAcpSessionLaunch(baseConfig, {
         command: "omp",
-        args: ["--approval-mode=always-ask", "--no-extensions", "acp"],
+        args: ["--approval-mode=yolo", "--no-extensions", "acp"],
       }),
     ).toEqual({
       command: "omp",
-      args: ["--no-extensions", "--approval-mode", "yolo", "acp"],
-      modeId: "yolo",
+      args: ["--no-extensions", "--approval-mode", "always-ask", "acp"],
+      modeId: "always-ask",
     });
   });
 

--- a/packages/server/src/server/agent/providers/omp-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp-acp-agent.test.ts
@@ -1,0 +1,225 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { describe, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import { asInternals } from "../../test-utils/class-mocks.js";
+import type { AgentMode, AgentSessionConfig } from "../agent-sdk-types.js";
+import {
+  ACPAgentSession,
+  type ACPProviderModeWriterContext,
+  type SessionStateResponse,
+} from "./acp-agent.js";
+import {
+  OMP_ACP_DEFAULT_MODE_ID,
+  OMP_ACP_MODE_RESTART_NOTICE,
+  OMP_ACP_MODES,
+  OmpAcpAgentClient,
+  buildOmpAcpSessionLaunch,
+  transformOmpAcpConfigOptions,
+  transformOmpAcpSessionResponse,
+  writeOmpAcpProviderMode,
+} from "./omp-acp-agent.js";
+
+const baseConfig: AgentSessionConfig = {
+  provider: "omp-acp",
+  cwd: "/tmp/omp-acp-test",
+};
+
+function writerContext(
+  requestedModeId: string,
+  currentModeId: string | null,
+): ACPProviderModeWriterContext {
+  return {
+    connection: null as never,
+    sessionId: "session-1",
+    requestedModeId,
+    currentModeId,
+    selection: null as never,
+    configOptions: [],
+    logger: null as never,
+  };
+}
+
+interface LiveOmpAcpSessionInternals {
+  sessionId: string | null;
+  connection: {
+    setSessionMode: (input: { sessionId: string; modeId: string }) => Promise<void>;
+  };
+  availableModes: AgentMode[];
+  configOptions: SessionConfigOption[];
+  currentMode: string | null;
+  config: AgentSessionConfig;
+}
+
+describe("OMP ACP approval modes", () => {
+  test("exposes OMP approval values and defaults to Full Access", () => {
+    expect(OMP_ACP_DEFAULT_MODE_ID).toBe("yolo");
+    expect(OMP_ACP_MODES).toEqual([
+      expect.objectContaining({
+        id: "always-ask",
+        label: "Ask Every Time",
+        colorTier: "safe",
+      }),
+      expect.objectContaining({ id: "write", label: "Write Access", colorTier: "moderate" }),
+      expect.objectContaining({
+        id: "yolo",
+        label: "Full Access",
+        colorTier: "dangerous",
+        isUnattended: true,
+      }),
+    ]);
+  });
+
+  test.each(["always-ask", "write", "yolo"] as const)(
+    "passes the selected %s value to the OMP process",
+    (modeId) => {
+      expect(
+        buildOmpAcpSessionLaunch(
+          { ...baseConfig, modeId },
+          { command: "omp", args: ["--no-extensions", "acp"] },
+        ),
+      ).toEqual({
+        command: "omp",
+        args: ["--no-extensions", "--approval-mode", modeId, "acp"],
+        modeId,
+      });
+    },
+  );
+
+  test("defaults to yolo and replaces an existing CLI override", () => {
+    expect(
+      buildOmpAcpSessionLaunch(baseConfig, {
+        command: "omp",
+        args: ["--approval-mode=always-ask", "--no-extensions", "acp"],
+      }),
+    ).toEqual({
+      command: "omp",
+      args: ["--no-extensions", "--approval-mode", "yolo", "acp"],
+      modeId: "yolo",
+    });
+  });
+
+  test("uses the persisted modeId when a session is resumed", () => {
+    expect(
+      buildOmpAcpSessionLaunch(
+        { ...baseConfig, modeId: "write" },
+        { command: "omp", args: ["--no-extensions", "acp"] },
+      ),
+    ).toMatchObject({
+      args: ["--no-extensions", "--approval-mode", "write", "acp"],
+      modeId: "write",
+    });
+  });
+
+  test("hides OMP's unrelated ACP default and plan modes", () => {
+    const response: SessionStateResponse = {
+      sessionId: "session-1",
+      modes: {
+        availableModes: [
+          { id: "default", name: "Default" },
+          { id: "plan", name: "Plan" },
+        ],
+        currentModeId: "default",
+      },
+      configOptions: [
+        {
+          id: "mode",
+          name: "Mode",
+          category: "mode",
+          type: "select",
+          currentValue: "default",
+          options: [{ value: "default", name: "Default" }],
+        },
+      ],
+    };
+
+    expect(transformOmpAcpSessionResponse(response).modes).toBeNull();
+    expect(transformOmpAcpConfigOptions(response.configOptions ?? [])).toEqual([]);
+  });
+
+  test("does not expose the generic ACP Auto Accept feature", async () => {
+    const client = new OmpAcpAgentClient({
+      logger: createTestLogger(),
+      command: ["omp", "--no-extensions", "acp"],
+    });
+
+    await expect(client.listFeatures(baseConfig)).resolves.toEqual([]);
+
+    const session = new ACPAgentSession(baseConfig, {
+      provider: "omp-acp",
+      logger: createTestLogger(),
+      defaultCommand: ["omp", "--no-extensions", "acp"],
+      defaultModes: OMP_ACP_MODES,
+      includeAutoAcceptFeature: false,
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+    });
+    expect(session.features).toEqual([]);
+  });
+
+  test("keeps a live session's current mode and reports the restart boundary", async () => {
+    await expect(writeOmpAcpProviderMode(writerContext("write", "yolo"))).resolves.toEqual({
+      handled: true,
+      currentModeId: "yolo",
+      notice: OMP_ACP_MODE_RESTART_NOTICE,
+    });
+
+    await expect(writeOmpAcpProviderMode(writerContext("yolo", "yolo"))).resolves.toEqual({
+      handled: true,
+      currentModeId: "yolo",
+    });
+  });
+
+  test("routes live mode changes through the ACP notice boundary", async () => {
+    const session = new ACPAgentSession(
+      { ...baseConfig, modeId: "yolo" },
+      {
+        provider: "omp-acp",
+        logger: createTestLogger(),
+        defaultCommand: ["omp", "--no-extensions", "acp"],
+        defaultModes: OMP_ACP_MODES,
+        modeIdTransformer: () => null,
+        providerModeWriter: writeOmpAcpProviderMode,
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+      },
+    );
+    const setSessionMode = vi.fn(async () => undefined);
+    const internals = asInternals<LiveOmpAcpSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode };
+    internals.availableModes = OMP_ACP_MODES;
+    internals.configOptions = [];
+    internals.currentMode = "yolo";
+
+    await expect(session.setMode("write")).resolves.toEqual(OMP_ACP_MODE_RESTART_NOTICE);
+    expect(setSessionMode).not.toHaveBeenCalled();
+    await expect(session.getCurrentMode()).resolves.toBe("yolo");
+    expect(session.getConfiguredMode()).toBe("write");
+    expect(internals.config.modeId).toBe("write");
+  });
+
+  test("rejects unknown approval values", async () => {
+    expect(() =>
+      buildOmpAcpSessionLaunch(
+        { ...baseConfig, modeId: "plan" },
+        { command: "omp", args: ["acp"] },
+      ),
+    ).toThrow("Invalid OMP ACP approval mode 'plan'");
+    await expect(writeOmpAcpProviderMode(writerContext("plan", "yolo"))).rejects.toThrow(
+      "Invalid OMP ACP approval mode 'plan'",
+    );
+  });
+});

--- a/packages/server/src/server/agent/providers/omp-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/omp-acp-agent.ts
@@ -1,0 +1,145 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import type { AgentProviderModeDefinition } from "@getpaseo/protocol/provider-manifest";
+import type { Logger } from "pino";
+
+import type { AgentSessionConfig } from "../agent-sdk-types.js";
+import type {
+  ACPProviderModeWriterContext,
+  ACPProviderModeWriteResult,
+  ACPSessionLaunch,
+  SessionStateResponse,
+} from "./acp-agent.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+export const OMP_ACP_DEFAULT_MODE_ID = "yolo" as const;
+export const OMP_ACP_MODES: AgentProviderModeDefinition[] = [
+  {
+    id: "always-ask",
+    label: "Ask Every Time",
+    description: "Auto-approves read-only tools; asks before write and exec tools",
+    icon: "ShieldCheck",
+    colorTier: "safe",
+  },
+  {
+    id: "write",
+    label: "Write Access",
+    description: "Auto-approves read and write tools; asks before exec tools",
+    icon: "ShieldAlert",
+    colorTier: "moderate",
+  },
+  {
+    id: "yolo",
+    label: "Full Access",
+    description: "Auto-approves read, write, and exec tools",
+    icon: "ShieldOff",
+    colorTier: "dangerous",
+    isUnattended: true,
+  },
+];
+
+const OMP_ACP_MODE_IDS = new Set(OMP_ACP_MODES.map((mode) => mode.id));
+
+export const OMP_ACP_MODE_RESTART_NOTICE = {
+  type: "warning",
+  message: "Start or restart the OMP session to apply the approval mode",
+} as const;
+
+export function buildOmpAcpSessionLaunch(
+  config: AgentSessionConfig,
+  launch: ACPSessionLaunch,
+): ACPSessionLaunch {
+  const modeId = config.modeId ?? OMP_ACP_DEFAULT_MODE_ID;
+  if (!OMP_ACP_MODE_IDS.has(modeId)) {
+    throw new Error(`Invalid OMP ACP approval mode '${modeId}'`);
+  }
+
+  const argsWithoutApprovalMode: string[] = [];
+  for (let index = 0; index < launch.args.length; index += 1) {
+    const arg = launch.args[index];
+    if (arg === "--approval-mode") {
+      index += 1;
+      continue;
+    }
+    if (arg?.startsWith("--approval-mode=")) {
+      continue;
+    }
+    if (arg !== undefined) {
+      argsWithoutApprovalMode.push(arg);
+    }
+  }
+
+  const acpIndex = argsWithoutApprovalMode.indexOf("acp");
+  const insertAt = acpIndex >= 0 ? acpIndex : 0;
+  return {
+    command: launch.command,
+    args: [
+      ...argsWithoutApprovalMode.slice(0, insertAt),
+      "--approval-mode",
+      modeId,
+      ...argsWithoutApprovalMode.slice(insertAt),
+    ],
+    modeId,
+  };
+}
+
+export function transformOmpAcpSessionResponse(
+  response: SessionStateResponse,
+): SessionStateResponse {
+  // OMP's ACP mode picker controls its default/plan UI. Approval mode is a
+  // process setting, so this adapter exposes its own static modes instead.
+  return { ...response, modes: null };
+}
+
+export function transformOmpAcpConfigOptions(
+  configOptions: SessionConfigOption[],
+): SessionConfigOption[] {
+  return configOptions.filter((option) => option.category !== "mode" && option.id !== "mode");
+}
+
+export async function writeOmpAcpProviderMode(
+  context: ACPProviderModeWriterContext,
+): Promise<ACPProviderModeWriteResult> {
+  if (!OMP_ACP_MODE_IDS.has(context.requestedModeId)) {
+    throw new Error(`Invalid OMP ACP approval mode '${context.requestedModeId}'`);
+  }
+
+  const currentModeId = context.currentModeId ?? OMP_ACP_DEFAULT_MODE_ID;
+  if (currentModeId === context.requestedModeId) {
+    return { handled: true, currentModeId };
+  }
+
+  return {
+    handled: true,
+    currentModeId,
+    notice: OMP_ACP_MODE_RESTART_NOTICE,
+  };
+}
+
+interface OmpAcpAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+export class OmpAcpAgentClient extends GenericACPAgentClient {
+  constructor(options: OmpAcpAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId ?? "omp-acp",
+      label: options.label ?? "OMP ACP",
+      providerParams: options.providerParams,
+      defaultModes: OMP_ACP_MODES,
+      includeAutoAcceptFeature: false,
+      sessionLaunchTransformer: buildOmpAcpSessionLaunch,
+      sessionResponseTransformer: transformOmpAcpSessionResponse,
+      configOptionsTransformer: transformOmpAcpConfigOptions,
+      modeIdTransformer: () => null,
+      providerModeWriter: writeOmpAcpProviderMode,
+    });
+  }
+}

--- a/packages/server/src/server/agent/providers/omp-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/omp-acp-agent.ts
@@ -11,7 +11,7 @@ import type {
 } from "./acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
 
-export const OMP_ACP_DEFAULT_MODE_ID = "yolo" as const;
+export const OMP_ACP_DEFAULT_MODE_ID = "always-ask" as const;
 export const OMP_ACP_MODES: AgentProviderModeDefinition[] = [
   {
     id: "always-ask",


### PR DESCRIPTION
### Linked issue

N/A — this follows up on the reported OMP ACP workflow gap where the provider did not expose its approval modes in Paseo.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Custom ACP providers normally rely on runtime-advertised session modes. OMP instead selects its approval policy at process launch with `--approval-mode`, so an `omp-acp` provider had no way to expose or persist the three OMP policies in Paseo.

This adds an OMP-specific ACP adapter for the exact custom provider ID `omp-acp`. It exposes Ask Every Time, Write Access, and Full Access, defaults new configurations to the safe Ask Every Time policy (`always-ask`), and injects the configured policy when a session is launched or resumed. Since OMP cannot change this policy in a running process, the live session retains its actual mode and Paseo tells the user to restart the OMP session before a newly selected mode takes effect. Users who want unattended operation can explicitly select and persist Full Access (`yolo`) without making it the upstream default.

### Goals

- Expose the exact OMP approval-mode mapping:
  - `always-ask` → Ask Every Time
  - `write` → Write Access
  - `yolo` → Full Access
- Default `omp-acp` to `always-ask` / Ask Every Time.
- Keep Full Access available as an explicit persisted selection.
- Apply the configured mode to OMP session launch and resume, and persist it for the next process start.
- Keep configured mode separate from the live runtime mode when a restart is required.
- Avoid exposing the generic ACP Auto Accept mode for `omp-acp`.
- Keep generic ACP providers and the built-in `omp` provider unchanged.

### Non-goals

- Runtime approval-mode switching inside an already-running OMP process.
- Changing modes or defaults for generic ACP providers.
- Changing the built-in `omp` provider.
- Adding a new UI component; the existing provider-mode controls consume the new server metadata.

### QA

Tested on the Linux DevBox with Node.js 22.20.0.

- Installed the workspace successfully with `npm ci --workspaces --include-workspace-root` (2,694 packages, 0 vulnerabilities).
- Built server dependencies with `npm run build:server-deps`.
- Built the server with `npm run build --workspace=@getpaseo/server`.
- Ran the focused Vitest suite for `omp-acp-agent.test.ts`, `provider-registry.test.ts`, `acp-agent.test.ts`, `generic-acp-agent.test.ts`, and `agent-manager.test.ts`: 5 files and 330 tests passed.
- Ran `npm run typecheck --workspace=@getpaseo/server`.
- Ran the full workspace `npm run typecheck` for the original implementation.
- Ran ESLint against all changed TypeScript files: 0 warnings and 0 errors.
- Ran `npm run format:check:files -- <all changed files>`: all changed files passed.
- Ran `git diff --check`.
- The original implementation's pre-commit lint, format, and typecheck checks passed.

The automated tests cover mode metadata and the safe default selection, launch argument replacement, launch/resume behavior, exact provider-ID scoping, removal of duplicate Auto Accept, restart-required notices, and persistence of a newly configured mode while preserving the running session's actual mode.

No desktop or web visual QA was performed. This change adds no UI component; the visible controls are produced by Paseo's existing dynamic provider-mode UI. Maintainer edits are enabled on the fork.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [ ] `npm run lint` passes (all changed TypeScript files passed targeted ESLint; full-repository lint was not run)
- [ ] `npm run format` passes (all changed files passed `format:check:files`; full-repository format was not run)
- [x] QA evidence
- [x] Tests added or updated where it made sense
