### PR TITLE
Restore daemon restart from Linux desktop-installed CLI

### DIFF
--- a/packages/desktop/src/integrations/cli-install/path.test.ts
+++ b/packages/desktop/src/integrations/cli-install/path.test.ts
@@ -25,6 +25,17 @@ describe("cli-install-path", () => {
     ).toBe("/home/user/Applications/Paseo.AppImage");
   });
 
+  it("uses the bundled shim for packaged linux installs outside an AppImage", () => {
+    expect(
+      resolveCliInstallSourcePath({
+        platform: "linux",
+        isPackaged: true,
+        executablePath: "/opt/Paseo/Paseo",
+        shimPath: "/opt/Paseo/resources/bin/paseo",
+      }),
+    ).toBe("/opt/Paseo/resources/bin/paseo");
+  });
+
   it("falls back to the shim on windows and in development", () => {
     expect(
       resolveCliInstallSourcePath({

--- a/packages/desktop/src/integrations/cli-install/path.ts
+++ b/packages/desktop/src/integrations/cli-install/path.ts
@@ -22,6 +22,7 @@ export function resolveCliInstallSourcePath(input: {
     if (appImagePath) {
       return appImagePath;
     }
+    return input.shimPath;
   }
 
   return input.executablePath;


### PR DESCRIPTION
Linux desktop installations outside AppImage now link the installed CLI to the bundled CLI shim. This restores daemon lifecycle commands such as `paseo restart` for `.deb`, RPM, and tarball installs while preserving the stable AppImage link behavior.

### Linked issue

Closes #4184

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The CLI install source resolver fell through to the Electron executable for packaged Linux when `APPIMAGE` was absent. The Electron executable does not provide the shim passthrough environment needed for daemon restart. All Linux package targets already ship `resources/bin/paseo`, so non-AppImage installs should link that shim; AppImage installs must continue linking the original AppImage path because its mounted resources path is temporary.

### Goals

- Make the desktop-installed CLI use the bundled shim for packaged non-AppImage Linux installs.
- Preserve the existing stable AppImage symlink behavior.
- Lock the `.deb` layout regression with an automated test.

### Non-goals

- Change CLI installation behavior on macOS or Windows.
- Change daemon lifecycle implementation.
- Change package contents or target configuration.

### QA

Failing-first regression evidence from the pre-fix run: the added non-AppImage Linux case expected `/opt/Paseo/resources/bin/paseo` and received `/opt/Paseo/Paseo`. After the fix:

```console
$ npx vitest run packages/desktop/src/integrations/cli-install/path.test.ts --bail=1
Test Files  1 passed (1)
Tests       4 passed (4)
```

```console
$ npm run typecheck
# all workspace typechecks completed successfully
$ npm run lint
Found 0 warnings and 0 errors.
$ npm run format
Finished on 4217 files.
```

Built and inspected a real x64 Debian package:

```console
$ npm run build:desktop -- --publish never --linux deb --x64
building target=deb arch=x64 file=release/Paseo-0.7.2-amd64.deb

$ dpkg-deb -x packages/desktop/release/Paseo-0.7.2-amd64.deb /tmp/paseo-4184-deb-inspect
$ stat -c "%A %n" /tmp/paseo-4184-deb-inspect/opt/Paseo/Paseo /tmp/paseo-4184-deb-inspect/opt/Paseo/resources/bin/paseo
-rwxr-xr-x .../opt/Paseo/Paseo
-rwxrwxr-x .../opt/Paseo/resources/bin/paseo

$ ln -s .../opt/Paseo/resources/bin/paseo .../paseo
$ .../paseo --version
0.7.2
```

The package-level smoke confirms the `.deb` contains the shim at the runtime-resolved path and that a symlink through it executes the packaged CLI. I did not run `restart` against the extracted package because this host has active Paseo daemon sessions and daemon lifecycle must not be disturbed.

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Not affected |
| Android | No | Not affected |
| Web | No | Not affected |
| Desktop macOS | No | Resolver behavior unchanged; automated test remains green |
| Desktop Windows | No | Resolver behavior unchanged; automated test remains green |
| Desktop Linux | Yes | Unit regression plus real x64 `.deb` build, extraction, packaged shim presence, and CLI execution |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense