### PR TITLE
Prevent repository fsmonitor commands from running in the daemon

### DIFF
--- a/packages/server/src/server/session/daemon/diagnostics.ts
+++ b/packages/server/src/server/session/daemon/diagnostics.ts
@@ -227,7 +227,7 @@ async function collectProviderEntries(
 
 async function collectToolEntries(): Promise<DiagnosticEntry[]> {
   const [git, gh] = await Promise.all([
-    checkTool("git", ["--version"]),
+    checkTool("git", ["-c", "core.fsmonitor=false", "--version"]),
     checkTool("gh", ["--version"]),
   ]);
   return [

--- a/packages/server/src/utils/checkout-git-batching.test.ts
+++ b/packages/server/src/utils/checkout-git-batching.test.ts
@@ -16,10 +16,10 @@ vi.mock("child_process", async () => {
       const [command, commandArgs] = args;
       if (command === "git" && Array.isArray(commandArgs)) {
         const normalizedArgs = commandArgs.map((arg) => String(arg));
-        // `runGitCommand` always prepends `-c core.quotepath=false`; skip it to
-        // find the actual git subcommand.
+        // `runGitCommand` always prepends its two config overrides; skip them
+        // to find the actual git subcommand.
         const subcommandIndex =
-          normalizedArgs[0] === "-c" && normalizedArgs[1] === "core.quotepath=false" ? 2 : 0;
+          normalizedArgs[0] === "-c" && normalizedArgs[1] === "core.quotepath=false" ? 4 : 0;
         const isTrackedTextDiff =
           normalizedArgs[subcommandIndex] === "diff" &&
           normalizedArgs.includes("HEAD") &&

--- a/packages/server/src/utils/run-git-command.posix.test.ts
+++ b/packages/server/src/utils/run-git-command.posix.test.ts
@@ -1,0 +1,51 @@
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runGitCommand } from "./run-git-command.js";
+
+const tempDirs: string[] = [];
+
+function makeTempRepo(): string {
+  const repo = mkdtempSync(path.join(tmpdir(), "paseo-git-fsmonitor-"));
+  tempDirs.push(repo);
+  return repo;
+}
+
+async function configureFsmonitor(repo: string): Promise<string> {
+  const hookPath = path.join(repo, "fsmonitor-hook.sh");
+  const markerPath = `${hookPath}.marker`;
+  writeFileSync(hookPath, "#!/bin/sh\n: > \"$0.marker\"\nprintf '1\\n'\n");
+  chmodSync(hookPath, 0o755);
+  await runGitCommand(["config", "core.fsmonitor", hookPath], { cwd: repo });
+  return markerPath;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+});
+
+describe("runGitCommand fsmonitor isolation", () => {
+  it("does not execute a repository-configured fsmonitor command", async () => {
+    const repo = makeTempRepo();
+    await runGitCommand(["init"], { cwd: repo });
+    const markerPath = await configureFsmonitor(repo);
+
+    await runGitCommand(["status", "--porcelain"], { cwd: repo });
+
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  it("overrides core.fsmonitor for commands other than status", async () => {
+    const repo = makeTempRepo();
+    await runGitCommand(["init"], { cwd: repo });
+    await configureFsmonitor(repo);
+
+    const result = await runGitCommand(["config", "--get", "core.fsmonitor"], { cwd: repo });
+
+    expect(result.stdout.trim()).toBe("false");
+  });
+});

--- a/packages/server/src/utils/run-git-command.ts
+++ b/packages/server/src/utils/run-git-command.ts
@@ -377,12 +377,17 @@ function runGitCommandWithProvenance(
       try {
         // `core.quotepath=false` makes git emit raw UTF-8 paths instead of
         // octal-escaping non-ASCII bytes (e.g. `测试文件.txt` vs `"\346\265\213..."`).
-        child = spawnProcess("git", ["-c", "core.quotepath=false", ...args], {
-          cwd: options.cwd,
-          envOverlay,
-          shell: false,
-          stdio: ["ignore", "pipe", "pipe"],
-        });
+        // `core.fsmonitor=false` prevents repository config from launching a command.
+        child = spawnProcess(
+          "git",
+          ["-c", "core.quotepath=false", "-c", "core.fsmonitor=false", ...args],
+          {
+            cwd: options.cwd,
+            envOverlay,
+            shell: false,
+            stdio: ["ignore", "pipe", "pipe"],
+          },
+        );
         spawnGitCommandTrace(commandTrace, child.pid);
       } catch (error) {
         rejectSpawnFailure(error);


### PR DESCRIPTION
### Linked issue

None — reported `core.fsmonitor` RCE.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Repository-controlled `core.fsmonitor` can launch a command when the daemon refreshes Git state. Opening or reconciling a malicious checkout can therefore execute code as the daemon user. This PR unconditionally passes `-c core.fsmonitor=false` on daemon-owned Git invocations before repository config is considered.

### Goals

- Disable external and built-in fsmonitor behavior for every daemon-owned Git command.
- Apply the override before Paseo needs to trust or inspect a repository.
- Prove the boundary with a real temporary repository and executable fsmonitor command.

### Non-goals

- Change Git commands launched by agents or user terminals.
- Neutralize other Git configuration keys such as hooks, filters, diff drivers, or SSH commands.

### QA

- Before the fix, `npx vitest run packages/server/src/utils/run-git-command.posix.test.ts --bail=1` failed because `git status --porcelain` created the marker file. The non-status `git config --get core.fsmonitor` case separately failed because it returned the configured command path instead of `false`.
- After the fix, the same file passes 2/2 tests against real Git.
- `npx vitest run packages/server/src/utils/checkout-git-batching.test.ts --bail=1` passes 1/1.
- `npm run typecheck`, `npm run lint`, and `npm run format` pass.

### Risk surface

The main Git primitive now prepends one additional command-line config override. The only production Git spawn found outside that primitive is the daemon diagnostics `git --version` probe; it receives the override directly.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense