### PR TITLE
Keep Mermaid diagrams stable through streaming and reloads

### DIFF
--- a/packages/app/e2e/browser/mermaid-streaming.spec.ts
+++ b/packages/app/e2e/browser/mermaid-streaming.spec.ts
@@ -35,6 +35,7 @@ test("keeps a Mermaid diagram rendered while its message streams, completes, and
   page,
 }) => {
   test.setTimeout(120_000);
+  let diagramTurnCompleted!: Promise<void>;
 
   const agent = await seedMockAgentWorkspace({
     repoPrefix: "mermaid-streaming-",
@@ -48,15 +49,16 @@ test("keeps a Mermaid diagram rendered while its message streams, completes, and
     await test.step("Open the conversation and request a diagram", async () => {
       await openAgentRoute(page, agent);
       await requestDiagram(agent);
+      diagramTurnCompleted = waitForDiagramTurnToComplete(agent);
     });
 
     await test.step("The diagram renders and stays rendered while tokens arrive", async () => {
       await expectDiagramWithLabels(page, ["Start", "Middle"]);
-      await expectDiagramRemainsRenderedWhileStreaming(page);
+      await expectDiagramRemainsRenderedWhileStreaming(page, diagramTurnCompleted);
     });
 
     await test.step("The completed diagram shows the final streamed content", async () => {
-      await waitForDiagramTurnToComplete(agent);
+      await diagramTurnCompleted;
       await expectCompletedDiagram(page, ["Start", "Done", "Release"]);
     });
 

--- a/packages/app/e2e/support/helpers/diagram.ts
+++ b/packages/app/e2e/support/helpers/diagram.ts
@@ -25,13 +25,16 @@ export async function expectDiagramWithLabels(
   }
 }
 
-export async function expectDiagramRemainsRenderedWhileStreaming(page: Page): Promise<void> {
-  const { diagram, svg } = renderedDiagram(page);
-  const samples = 80;
-  for (let sample = 0; sample < samples; sample += 1) {
-    await expect(diagram).toBeVisible({ timeout: 100 });
-    await expect(svg).toBeVisible({ timeout: 500 });
-    await page.waitForTimeout(25);
+export async function expectDiagramRemainsRenderedWhileStreaming(
+  page: Page,
+  completion: Promise<void>,
+): Promise<void> {
+  const diagram = page.getByRole("img", { name: DIAGRAM_NAME }).last();
+  const completed = completion.then(() => true);
+  for (;;) {
+    expect(await diagram.isVisible()).toBe(true);
+    const didComplete = await Promise.race([completed, page.waitForTimeout(16).then(() => false)]);
+    if (didComplete) return completion;
   }
 }
 

--- a/packages/app/src/timeline/replica.test.ts
+++ b/packages/app/src/timeline/replica.test.ts
@@ -115,6 +115,64 @@ describe("viewed timeline persistence", () => {
     owner.dispose();
   });
 
+  it("reconciles an overlapping projected message against its cached cursor", async () => {
+    useSessionStore.getState().initializeSession(SERVER_ID, null);
+    const partial = "```mermaid\nflowchart LR\n  Start --> Mid";
+    const complete = `${partial}dle\n  Middle --> Done\n\`\`\``;
+    const owner = createOwner({
+      readTimeline: async () => ({
+        agentId: AGENT_ID,
+        items: [item("cached", partial, 4)],
+        range: { epoch: "epoch-1", startSeq: 1, endSeq: 4 },
+        hasOlder: false,
+      }),
+      commitTimeline: () => undefined,
+    });
+
+    owner.replaceVisibleAgentIds("test", [AGENT_ID]);
+    await expect
+      .poll(() =>
+        selectAgentTimelineState(useSessionStore.getState().sessions[SERVER_ID], AGENT_ID),
+      )
+      .toMatchObject({ status: "painted" });
+
+    owner.applyTimelineResponse({
+      requestId: "page-after-cache",
+      agentId: AGENT_ID,
+      agent: null,
+      direction: "after",
+      projection: "projected",
+      reset: false,
+      epoch: "epoch-1",
+      window: { minSeq: 1, maxSeq: 5, nextSeq: 6 },
+      startCursor: { epoch: "epoch-1", seq: 5 },
+      endCursor: { epoch: "epoch-1", seq: 5 },
+      entries: [
+        {
+          provider: "mock",
+          item: { type: "assistant_message", text: complete },
+          timestamp: "2026-08-26T10:00:00.000Z",
+          seqStart: 2,
+          seqEnd: 5,
+          sourceSeqRanges: [{ startSeq: 2, endSeq: 5 }],
+          collapsed: ["assistant_merge"],
+        },
+      ],
+      error: null,
+      hasNewer: false,
+      hasOlder: false,
+      staleCursor: false,
+      gap: false,
+    });
+
+    const session = useSessionStore.getState().sessions[SERVER_ID];
+    expect([
+      ...(session?.agentStreamTail.get(AGENT_ID) ?? []),
+      ...(session?.agentStreamHead.get(AGENT_ID) ?? []),
+    ]).toMatchObject([{ kind: "assistant_message", text: complete }]);
+    owner.dispose();
+  });
+
   it("does not let a late cache read overwrite newer network state", async () => {
     useSessionStore.getState().initializeSession(SERVER_ID, null);
     let release!: (value: CachedTimeline) => void;

--- a/packages/app/src/timeline/viewed-timeline-sync.ts
+++ b/packages/app/src/timeline/viewed-timeline-sync.ts
@@ -93,11 +93,12 @@ async function prepareCachedTimeline(input: {
 export interface TimelineReplica {
   prepare(agentId: string): Promise<void>;
   readCursor(agentId: string): { epoch: string; endSeq: number } | undefined;
+  readRange(agentId: string): AgentTimelineCursorState | undefined;
   timelineUpdated(agentId: string): void;
 }
 
 class TimelineReplicaOwner implements TimelineReplica {
-  private readonly cachedCursors = new Map<string, { epoch: string; endSeq: number }>();
+  private readonly cachedRanges = new Map<string, AgentTimelineCursorState>();
   private readonly preparations = new Map<string, Promise<void>>();
 
   constructor(
@@ -127,22 +128,24 @@ class TimelineReplicaOwner implements TimelineReplica {
     });
     if (!stored) return;
     if (stored.range) {
-      this.cachedCursors.set(agentId, {
-        epoch: stored.range.epoch,
-        endSeq: stored.range.endSeq,
-      });
+      this.cachedRanges.set(agentId, stored.range);
     }
   }
 
   readCursor(agentId: string): { epoch: string; endSeq: number } | undefined {
-    return this.cachedCursors.get(agentId);
+    const range = this.cachedRanges.get(agentId);
+    return range ? { epoch: range.epoch, endSeq: range.endSeq } : undefined;
+  }
+
+  readRange(agentId: string): AgentTimelineCursorState | undefined {
+    return this.cachedRanges.get(agentId);
   }
 
   timelineUpdated(agentId: string): void {
     const session = useSessionStore.getState().sessions[this.serverId];
     const timeline = selectAgentTimelineState(session, agentId);
     if (timeline.status !== "synced") return;
-    this.cachedCursors.delete(agentId);
+    this.cachedRanges.delete(agentId);
     this.storage.commitTimeline(this.serverId, agentId, {
       agentId,
       items: [...timeline.items, ...(session?.agentStreamHead.get(agentId) ?? [])],
@@ -249,6 +252,7 @@ function finalizeProcessedTimeline(input: {
 function applyAuthoritativeTimelineResponse(input: {
   serverId: string;
   payload: TimelineResponsePayload;
+  cachedCursor?: AgentTimelineCursorState;
   recoverGap: (agentId: string, cursor: { epoch: string; endSeq: number }) => void;
   drainQueuedAgentMessage: (agentId: string) => void;
   transformTimelineItem?: TimelineItemTransform;
@@ -259,7 +263,8 @@ function applyAuthoritativeTimelineResponse(input: {
   const session = useSessionStore.getState().sessions[serverId];
   const timeline = selectAgentTimelineState(session, agentId);
   const activeInitDeferred = getInitDeferred(initKey);
-  const currentCursor = timeline.status === "synced" ? (timeline.range ?? undefined) : undefined;
+  const currentCursor =
+    timeline.status === "synced" ? (timeline.range ?? undefined) : input.cachedCursor;
   const result = processTimelineResponse({
     payload,
     currentTail: timeline.status === "cold" ? [] : timeline.items,
@@ -397,6 +402,7 @@ export function createViewedTimelineOwner(input: {
       const accepted = applyAuthoritativeTimelineResponse({
         serverId: input.serverId,
         payload,
+        cachedCursor: input.replica.readRange(payload.agentId),
         recoverGap: (agentId, cursor) => sync.recoverGap(agentId, cursor),
         drainQueuedAgentMessage: input.drainQueuedAgentMessage,
         transformTimelineItem,


### PR DESCRIPTION
### Linked issue

The repeated CI failure was exposed by #4199 in [Actions run 33611808464, playwright shard 3/4](https://github.com/getpaseo/paseo/actions/runs/33611808464/job/100209337288).

#4191 is a separate, confirmed diagram-sizing regression already addressed by #4107, so this PR does not duplicate that work.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The streaming test sampled the sandbox iframe 80 times for a fixed interval. When a turn completed, React could replace the iframe while reconciling the final message, leaving its content frame temporarily unresolvable even though the accessible diagram container remained rendered. The assertion now follows the actual turn lifecycle and checks that the semantic diagram stays available until completion, with SVG labels asserted before completion, after completion, and after reload.

Strengthening the reload path exposed a product race: cached history could be painted with a valid range, but the response reducer was given no cursor until that history became authoritative. An overlapping projected assistant message was then appended to its cached prefix, corrupting Mermaid source on reload. The timeline replica now retains the full cached range for reconciliation while keeping its existing compact resume cursor API.

### Goals

- Keep the rendered diagram available for the full streaming turn.
- Assert final Mermaid content after completion and reload.
- Reconcile projected messages that overlap a painted cache cursor instead of duplicating their prefix.
- Remove fixed-duration iframe sampling from the timing-sensitive test.

### Non-goals

- Diagram sizing or fullscreen behavior from #4191; #4107 owns those fixes.
- Changes to #4199 or its branch.
- Changes to Mermaid rendering syntax or sandbox behavior.

### QA

Reproduction evidence:

- In run 33611808464, `mermaid-streaming.spec.ts` failed in shard 3/4 on both Playwright attempts and again on the initial job rerun because the iframe content frame was temporarily undefined.
- A local pre-fix stress run reproduced the same content-frame visibility failure.
- A reload diagnostic reproduced duplicated source consisting of a cached Mermaid prefix followed by the full projected Mermaid message.

Focused verification:

```
npm run test:e2e --workspace=@getpaseo/app -- e2e/browser/mermaid-streaming.spec.ts --workers=1
1 passed

npm run test:e2e --workspace=@getpaseo/app -- e2e/browser/mermaid-streaming.spec.ts --workers=1 --repeat-each=3
3 passed

npm test --workspace=@getpaseo/app -- src/timeline/replica.test.ts --bail=1
10 passed

npm run typecheck
passed

npm run lint
0 warnings, 0 errors

npm run format
passed

npm run format:check
passed
```

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| Web | Yes | Exact Playwright streaming/completion/reload flow, repeated serially |
| macOS desktop | No | Uses the web Mermaid path; #4107 owns the sizing regression |
| Windows/Linux desktop | No | Uses the web Mermaid path |
| iOS/Android | No | Timeline reconciliation is shared; Mermaid iframe E2E is browser-only |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense