### PR TITLE
fix(android): align Unistyles NDK version

### DIFF
--- a/patches/react-native-unistyles+3.2.4.patch
+++ b/patches/react-native-unistyles+3.2.4.patch
@@ -317,3 +317,15 @@ index 39e0d9d..a21ba95 100644
          this.stylesCache.clear()
          this.dependenciesMap.clear()
          this.disposeListenersMap.clear()
+diff --git a/node_modules/react-native-unistyles/android/build.gradle b/node_modules/react-native-unistyles/android/build.gradle
+index 195954b..c4ac28c 100644
+--- a/node_modules/react-native-unistyles/android/build.gradle
++++ b/node_modules/react-native-unistyles/android/build.gradle
+@@ -38,6 +38,7 @@ if (isNewArchitectureEnabled()) {
+ 
+ android {
+     compileSdkVersion safeExtGet('compileSdkVersion', 35)
++    ndkVersion safeExtGet('ndkVersion', '27.1.12297006')
+     namespace "com.unistyles"
+ 
+     defaultConfig {


### PR DESCRIPTION
## Summary

- patch `react-native-unistyles@3.2.4` to inherit the Android project `ndkVersion`
- register the version-specific patch in the postinstall patch verification script
- prevent Android builds from installing and compiling Unistyles with NDK `27.0.12077973` alongside the project NDK `27.1.12297006`

Fixes #4211.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- verified the patch applies from a clean package installation
- ran `:react-native-unistyles:configureCMakeRelWithDebInfo[arm64-v8a]` successfully
- verified generated CMake arguments use only NDK `27.1.12297006`:

```text
-DANDROID_NDK=.../ndk/27.1.12297006
-DCMAKE_ANDROID_NDK=.../ndk/27.1.12297006
-DCMAKE_TOOLCHAIN_FILE=.../ndk/27.1.12297006/build/cmake/android.toolchain.cmake
BUILD SUCCESSFUL
```