### PR TITLE
Fix macOS Command-arrow terminal navigation

### DIFF
--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
@@ -17,10 +17,8 @@ import {
   type PendingTerminalModifiers,
   isAppleHandheldPlatform,
   isTerminalModifierDomKey,
-  mergeTerminalModifiers,
   normalizeDomTerminalKey,
-  normalizeTerminalTransportKey,
-  shouldInterceptDomTerminalKey,
+  resolveDomTerminalKeyInput,
 } from "@/utils/terminal-keys";
 import { renderTerminalSnapshotToAnsi } from "./terminal-snapshot";
 import {
@@ -447,32 +445,23 @@ export class TerminalEmulatorRuntime {
         return true;
       }
 
-      if (
-        !shouldInterceptDomTerminalKey({
-          key: normalizedKey,
-          ctrlKey: event.ctrlKey,
-          shiftKey: event.shiftKey,
-          altKey: event.altKey,
-          metaKey: event.metaKey,
-          pendingModifiers: this.pendingModifiers,
-          enhancedInputActive: this.inputModeTracker.supportsModifiedEnter(),
-          isAppleHandheld,
-        })
-      ) {
-        return true;
-      }
-
-      const modifiers = mergeTerminalModifiers({
-        pendingModifiers: this.pendingModifiers,
+      const terminalKeyInput = resolveDomTerminalKeyInput({
+        key: normalizedKey,
         ctrlKey: event.ctrlKey,
         shiftKey: event.shiftKey,
         altKey: event.altKey,
         metaKey: event.metaKey,
+        pendingModifiers: this.pendingModifiers,
+        enhancedInputActive: this.inputModeTracker.supportsModifiedEnter(),
+        isAppleHandheld,
+        isMacDesktop: isMac && !isAppleHandheld,
       });
-      this.callbacks.onTerminalKey?.({
-        key: normalizeTerminalTransportKey(normalizedKey),
-        ...modifiers,
-      });
+
+      if (!terminalKeyInput) {
+        return true;
+      }
+
+      this.callbacks.onTerminalKey?.(terminalKeyInput);
 
       if (this.pendingModifiers.ctrl || this.pendingModifiers.shift || this.pendingModifiers.alt) {
         this.callbacks.onPendingModifiersConsumed?.();

--- a/packages/app/src/utils/terminal-keys.test.ts
+++ b/packages/app/src/utils/terminal-keys.test.ts
@@ -89,6 +89,26 @@ describe("terminal key helpers", () => {
     expect(resolveDomTerminalKeyInput({ ...baseInput, key: "ArrowUp" })).toBeNull();
   });
 
+  it("preserves pending terminal modifiers instead of applying macOS line-boundary mapping", () => {
+    expect(
+      resolveDomTerminalKeyInput({
+        key: "ArrowLeft",
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        metaKey: true,
+        pendingModifiers: { ctrl: false, shift: true, alt: false },
+        isMacDesktop: true,
+      }),
+    ).toEqual({
+      key: "ArrowLeft",
+      ctrl: false,
+      shift: true,
+      alt: false,
+      meta: true,
+    });
+  });
+
   it("merges pending modifiers with native key modifiers", () => {
     expect(
       mergeTerminalModifiers({

--- a/packages/app/src/utils/terminal-keys.test.ts
+++ b/packages/app/src/utils/terminal-keys.test.ts
@@ -7,6 +7,7 @@ import {
   mergeTerminalModifiers,
   normalizeDomTerminalKey,
   normalizeTerminalTransportKey,
+  resolveDomTerminalKeyInput,
   resolvePendingModifierDataInput,
   shouldInterceptDomTerminalKey,
 } from "./terminal-keys";
@@ -41,6 +42,51 @@ describe("terminal key helpers", () => {
   it("lowercases printable transport keys", () => {
     expect(normalizeTerminalTransportKey("C")).toBe("c");
     expect(normalizeTerminalTransportKey("Escape")).toBe("Escape");
+  });
+
+  it("maps bare macOS Cmd+Left/Right to terminal line-boundary controls", () => {
+    const baseInput = {
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      metaKey: true,
+      pendingModifiers: { ctrl: false, shift: false, alt: false },
+      isMacDesktop: true,
+    };
+
+    expect(resolveDomTerminalKeyInput({ ...baseInput, key: "ArrowLeft" })).toEqual({
+      key: "a",
+      ctrl: true,
+      shift: false,
+      alt: false,
+      meta: false,
+    });
+    expect(resolveDomTerminalKeyInput({ ...baseInput, key: "ArrowRight" })).toEqual({
+      key: "e",
+      ctrl: true,
+      shift: false,
+      alt: false,
+      meta: false,
+    });
+  });
+
+  it("leaves non-macOS and modified Command arrows available to their existing shortcuts", () => {
+    const baseInput = {
+      key: "ArrowLeft",
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      metaKey: true,
+      pendingModifiers: { ctrl: false, shift: false, alt: false },
+      isMacDesktop: true,
+    };
+
+    expect(resolveDomTerminalKeyInput({ ...baseInput, isMacDesktop: false })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, shiftKey: true })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, altKey: true })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, ctrlKey: true })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, metaKey: false })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, key: "ArrowUp" })).toBeNull();
   });
 
   it("merges pending modifiers with native key modifiers", () => {

--- a/packages/app/src/utils/terminal-keys.ts
+++ b/packages/app/src/utils/terminal-keys.ts
@@ -122,14 +122,16 @@ export function resolveDomTerminalKeyInput(args: {
   alt: boolean;
   meta: boolean;
 } | null {
-  const macLineBoundaryKey = resolveMacLineBoundaryTerminalKey({
-    key: args.key,
-    ctrlKey: args.ctrlKey,
-    shiftKey: args.shiftKey,
-    altKey: args.altKey,
-    metaKey: args.metaKey,
-    isMacDesktop: Boolean(args.isMacDesktop),
-  });
+  const macLineBoundaryKey = hasPendingTerminalModifiers(args.pendingModifiers)
+    ? null
+    : resolveMacLineBoundaryTerminalKey({
+        key: args.key,
+        ctrlKey: args.ctrlKey,
+        shiftKey: args.shiftKey,
+        altKey: args.altKey,
+        metaKey: args.metaKey,
+        isMacDesktop: Boolean(args.isMacDesktop),
+      });
   if (macLineBoundaryKey) {
     return macLineBoundaryKey;
   }

--- a/packages/app/src/utils/terminal-keys.ts
+++ b/packages/app/src/utils/terminal-keys.ts
@@ -78,6 +78,72 @@ export function normalizeTerminalTransportKey(key: string): string {
   return key;
 }
 
+function resolveMacLineBoundaryTerminalKey(args: {
+  key: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  isMacDesktop: boolean;
+}): {
+  key: "a" | "e";
+  ctrl: true;
+  shift: false;
+  alt: false;
+  meta: false;
+} | null {
+  if (!args.isMacDesktop || !args.metaKey || args.ctrlKey || args.shiftKey || args.altKey) {
+    return null;
+  }
+
+  if (args.key === "ArrowLeft") {
+    return { key: "a", ctrl: true, shift: false, alt: false, meta: false };
+  }
+  if (args.key === "ArrowRight") {
+    return { key: "e", ctrl: true, shift: false, alt: false, meta: false };
+  }
+  return null;
+}
+
+export function resolveDomTerminalKeyInput(args: {
+  key: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  pendingModifiers: PendingTerminalModifiers;
+  enhancedInputActive?: boolean;
+  isAppleHandheld?: boolean;
+  isMacDesktop?: boolean;
+}): {
+  key: string;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+} | null {
+  const macLineBoundaryKey = resolveMacLineBoundaryTerminalKey({
+    key: args.key,
+    ctrlKey: args.ctrlKey,
+    shiftKey: args.shiftKey,
+    altKey: args.altKey,
+    metaKey: args.metaKey,
+    isMacDesktop: Boolean(args.isMacDesktop),
+  });
+  if (macLineBoundaryKey) {
+    return macLineBoundaryKey;
+  }
+
+  if (!shouldInterceptDomTerminalKey(args)) {
+    return null;
+  }
+
+  return {
+    key: normalizeTerminalTransportKey(args.key),
+    ...mergeTerminalModifiers(args),
+  };
+}
+
 export function hasPendingTerminalModifiers(modifiers: PendingTerminalModifiers): boolean {
   return modifiers.ctrl || modifiers.shift || modifiers.alt;
 }


### PR DESCRIPTION
### Linked issue

Closes #4219

Superseded by #4543, which includes the requested macOS Electron evidence and automated regression. GitHub reports `viewerCanReopen: false` for this PR, so the verified update is submitted there.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

In a focused terminal on macOS, bare `Cmd+Left` and `Cmd+Right` currently fall through xterm's custom key handler. Chromium can then consume them as navigation, taking keyboard focus away from the terminal instead of moving the shell cursor.

This change resolves bare Command+Left/Right on a real macOS desktop before the event can fall through. It forwards `Ctrl+A`/`Ctrl+E`, the canonical terminal controls for beginning/end of line, and prevents the original DOM event. The existing terminal key resolution is consolidated in one tested helper so the runtime callback stays within the repository's complexity limit.

### Goals

- Keep keyboard focus in a macOS terminal when bare `Cmd+Left` or `Cmd+Right` is pressed.
- Move to the beginning/end of the terminal command line.
- Preserve all existing modified-arrow workspace shortcuts.
- Restrict the behavior to macOS desktop, excluding iPadOS's Mac-like user agent.

### Non-goals

- Change `Option+Left`/`Option+Right`; those remain shell-configurable word-motion sequences.
- Change `Cmd+Up`/`Cmd+Down`.
- Change `Cmd+Shift+Arrow` pane focus or `Cmd+Alt+Shift+Arrow` tab movement.
- Change terminal behavior on Windows, Linux, iOS, or Android.

### QA

Verified on 2026-09-09 in the real **macOS 14.8.9 (23J631), arm64, Electron 41.2.0** desktop dev app, built from this checkout with an isolated daemon and real Bash PTY. Keyboard events were sent through Playwright/CDP to Electron.

[Successful macOS run](https://github.com/EasyAsABC123/paseo/actions/runs/34313869809) · [Patched interaction video](https://raw.githubusercontent.com/EasyAsABC123/paseo/c8648d443911b1ee0393d3edb37f8dd169b32c47/.qa/terminal-command-arrows/patched/interaction.mp4) · [Original runtime video](https://raw.githubusercontent.com/EasyAsABC123/paseo/c8648d443911b1ee0393d3edb37f8dd169b32c47/.qa/terminal-command-arrows/unpatched/interaction.mp4) · [Raw output](https://github.com/EasyAsABC123/paseo/blob/c8648d443911b1ee0393d3edb37f8dd169b32c47/.qa/terminal-command-arrows/macos-check.log) · [Screenshots and result JSON](https://github.com/EasyAsABC123/paseo/blob/c8648d443911b1ee0393d3edb37f8dd169b32c47/.qa/terminal-command-arrows/README.md)

The QA run used `45db561c5`. Its app, daemon, regression test, and documentation files are identical to PR commit `d1e8cb61d`; the only difference is the fork's QA workflow. Results also record the runtime file's Git blob hash. Videos export the actual trace screen frames with their recorded timing. Full Playwright traces and process logs are attached to the Actions run.

Steps and observed results:

1. Type `echo one two` in the focused terminal. Cmd+Left moves the cursor from column 16 to column 4, immediately after the prompt.
2. Insert `PASEO_PREFIX=ok; ` at the beginning. Cmd+Right moves the cursor to column 33 at the end. Both arrow checks retain the same textarea, URL, pane, and tabs; the textarea emits **zero blur events**.
3. Append ` "$PASEO_PREFIX"` and execute the edited command. The shell prints `one two ok`.
4. Create split panes with terminal tabs. Cmd+Shift+Left/Right focuses each adjacent pane. Cmd+Alt+Shift+Left/Right moves the selected terminal tab in both directions.
5. Restore the original runtime from `ff0171cf7` and rerun the same check. It fails on Cmd+Left: the cursor remains at column 16 instead of moving to column 4. The workflow requires that specific failure, then uploads both runs' evidence.

```text
Patched macOS Electron:
PASS 02-command-left: cursorX=4, sameTextarea=true, blurCount=0
PASS 03-command-right: cursorX=33, sameTextarea=true, blurCount=0
PASS 04-command-executed: one two ok
PASS 05-focus-left
PASS 06-focus-right
PASS 07-move-tab-left
PASS 08-move-tab-right

Original runtime:
AssertionError: LINE_BOUNDARY_CURSOR: Meta+ArrowLeft did not move the shell cursor
16 !== 4
```

Reproduce on a Mac after building the server stack and `@getpaseo/expo-two-way-audio`:

```bash
npm run test:e2e:terminal-command-arrows --workspace=@getpaseo/desktop
```

Local validation on Linux:

```text
npx vitest run src/utils/terminal-keys.test.ts --bail=1  # from packages/app
Test Files  1 passed (1)
Tests       27 passed (27)

npm run typecheck
All 11 workspace typechecks passed.

npm run lint
Found 0 warnings and 0 errors.

npm run format
Completed; the commit's formatting check also passed.
```

[Typecheck output](https://github.com/EasyAsABC123/paseo/blob/c8648d443911b1ee0393d3edb37f8dd169b32c47/.qa/terminal-command-arrows/typecheck.log), [lint output](https://github.com/EasyAsABC123/paseo/blob/c8648d443911b1ee0393d3edb37f8dd169b32c47/.qa/terminal-command-arrows/lint.log), [format output](https://github.com/EasyAsABC123/paseo/blob/c8648d443911b1ee0393d3edb37f8dd169b32c47/.qa/terminal-command-arrows/format.log).

Untested: physical-keyboard interaction on the originally reported macOS 26.6.2, the packaged release build, standalone browser web, iOS, Android, Windows, and Linux desktop. The macOS evidence above is automated interaction with the real Electron dev app.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

