### PR TITLE
Stabilize sidebar order checks after reload

### DIFF
--- a/packages/app/e2e/support/helpers/sidebar-nav-settings.ts
+++ b/packages/app/e2e/support/helpers/sidebar-nav-settings.ts
@@ -38,12 +38,9 @@ function itemLabel(key: SidebarNavKey): string {
   }[key];
 }
 
-async function rowTop(locator: Locator): Promise<number> {
+async function rowTop(locator: Locator): Promise<number | null> {
   const box = await locator.boundingBox();
-  if (!box) {
-    throw new Error("Expected a laid-out sidebar row to measure");
-  }
-  return box.y;
+  return box?.y ?? null;
 }
 
 export async function seedSidebarNavPreferences(
@@ -139,7 +136,11 @@ async function expectVerticalOrder(
         const measured = await Promise.all(
           keys.map(async (key) => ({ key, top: await rowTop(locate(key)) })),
         );
-        return measured.sort((a, b) => a.top - b.top).map((entry) => entry.key);
+        const laidOut = measured.filter(
+          (entry): entry is { key: SidebarNavKey; top: number } => entry.top !== null,
+        );
+        if (laidOut.length !== keys.length) return null;
+        return laidOut.sort((a, b) => a.top - b.top).map((entry) => entry.key);
       },
       { message: `Expected ${subject} in order`, timeout: 15_000 },
     )


### PR DESCRIPTION
### Linked issue

N/A — discovered from identical Playwright shard failures on `main` and PR #4107.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The sidebar order E2E helper threw when a row briefly had no bounding box during reload. Because the exception escapes `expect.poll`, the matcher cannot wait for layout even though the sidebar renders correctly moments later. Missing geometry now returns a retryable poll result until every requested row is laid out.

### Goals

- Keep sidebar order assertions synchronized with post-reload layout.
- Preserve the existing 15-second timeout and user journey.
- Unblock the failing Playwright shard on `main` and dependent PRs.

### Non-goals

- Change sidebar behavior or appearance.
- Weaken the expected order.
- Change Playwright retry configuration.

### QA

The failing CI artifact showed all expected rows visibly rendered in the correct order while `rowTop()` terminated the poll on transient missing geometry. Current `main` and PR #4107 failed at the same helper and line.

```
npx playwright test --project=browser e2e/browser/sidebar-nav-settings.spec.ts --grep "owner reorders" --repeat-each=6 --workers=6
6 passed
```

Also passed: `npm run build:server`, `npm run typecheck`, `npm run lint`, `npm run format`, and `npm run format:check`.

Risk surface: test helper only; production code is unchanged.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense