### PR TITLE
fix: keep mouse left click alive on android

### DIFF
--- a/patches/react-native-gesture-handler+2.28.0.patch
+++ b/patches/react-native-gesture-handler+2.28.0.patch
@@ -138,20 +138,39 @@ index a532cf6..7b66222 100644
      viewGroup: ViewGroup,
      coords: FloatArray,
 diff --git a/node_modules/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt b/node_modules/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
-index d8f8fd6..ed101b9 100644
+index d8f8fd6..be42af7 100644
 --- a/node_modules/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
 +++ b/node_modules/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
-@@ -19,6 +19,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
+@@ -19,7 +19,10 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
    private val jsGestureHandler: GestureHandler?
    val rootView: ViewGroup
    private var shouldIntercept = false
 +  private var wasIntercepting = false
    private var passingTouch = false
++  // The event the orchestrator is currently delivering, so `onCancel` can tell what triggered it.
++  private var dispatchingEvent: MotionEvent? = null
  
    init {
-@@ -117,6 +118,14 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
+     UiThreadUtil.assertOnUiThread()
+@@ -88,6 +91,11 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
+     override fun onHandleHover(event: MotionEvent, sourceEvent: MotionEvent) = handleEvent(event)
+ 
+     override fun onCancel() {
++      // A Tap activating on a mouse ACTION_BUTTON_RELEASE cancels this handler before ACTION_UP.
++      // Reporting a native gesture start here makes RN drop the Pressable's release, so skip it.
++      if (dispatchingEvent?.actionMasked == MotionEvent.ACTION_BUTTON_RELEASE) {
++        return
++      }
+       shouldIntercept = true
+       val time = SystemClock.uptimeMillis()
+       val event = MotionEvent.obtain(time, time, MotionEvent.ACTION_CANCEL, 0f, 0f, 0).apply {
+@@ -115,8 +123,18 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
+     // if `requestDisallow` has been called as a result of a normal gesture handling process or
+     // as a result of one of the gesture handlers activating
      passingTouch = true
++    dispatchingEvent = ev
      orchestrator!!.onTouchEvent(ev)
++    dispatchingEvent = null
      passingTouch = false
 +
 +    // On the transition into interception, cancel the native views the pointers landed on - the


### PR DESCRIPTION
### Linked issue

Closes #3996

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Left click with a mouse or touchpad does nothing on most of the Android app. Long press and drag work, so the app cannot be driven from a keyboard case or in desktop mode.

A mouse click arrives as DOWN, BUTTON_PRESS, BUTTON_RELEASE, UP. List rows are a `Pressable` inside a `Gesture.Tap()` (`PressHighlight`). The Tap finishes on BUTTON_RELEASE, before UP. That cancels gesture-handler's root handler, which reports a native gesture start, so React Native sends `touchCancel` to JS and drops the UP. `onPress` never fires. With a finger the Tap finishes on UP, after `touchend` was already sent, so touch is unaffected.

Fix, in the existing `patches/react-native-gesture-handler+2.28.0.patch`: the root handler's `onCancel` returns early while a BUTTON_RELEASE is being delivered. The pointer is already lifting, so there is nothing to intercept.

### Goals

- Mouse and touchpad left click press any Android `Pressable`.
- Touch, long press, and drag are unchanged.

### Non-goals

- No JS change. The fix sits where the bad cancel originates.
- No gesture-handler bump. Upstream main delivers the same event order, so an upgrade would not fix it.
- No change to iOS, web, or desktop. Android Kotlin only.

### QA

Pixel 10 Pro Fold, Android 17, Bluetooth mouse (Logitech MX Master) and Bluetooth touchpad. Release APK, arm64.

Before, on one workspace row (centre from `adb shell uiautomator dump`):

| Input                                     | Result          |
| ----------------------------------------- | --------------- |
| Physical mouse left click                 | nothing happens |
| `adb shell input mouse tap 540 866`       | row opens       |
| `adb shell input touchscreen tap 540 866` | row opens       |

The synthetic mouse tap sends only DOWN and UP. The physical mouse adds the button events. That is what pointed at BUTTON_RELEASE.

After, same phone, mouse and touchpad: left click opens the row, drag reorders it, finger tap and drag work as before.

Checks:

- `./gradlew assembleRelease -PreactNativeArchitectures=arm64-v8a`: `BUILD SUCCESSFUL`
- Patch applied, reversed, and reapplied on pristine `react-native-gesture-handler@2.28.0`: `✔` each time
- `npm run typecheck`, `npm run lint`, `npm run format`: clean
- No unit test: the failure is native `MotionEvent` ordering, covered by the device run above.

Tested on Android only. This change touches one Android Kotlin file inside the patch, so other platforms are not affected.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
