### PR TITLE
Fix Enter submission in narrow desktop panes

### DIFF
--- a/packages/app/e2e/browser/composer-focus.spec.ts
+++ b/packages/app/e2e/browser/composer-focus.spec.ts
@@ -1,5 +1,6 @@
-import { test } from "../support/fixtures";
+import { expect, test } from "../support/fixtures";
 import {
+  composerLocator,
   expectComposerDraft,
   expectComposerFocused,
   expectComposerVisible,
@@ -23,6 +24,30 @@ test("submitting a message leaves the composer ready for the next message", asyn
 
     await typeIntoFocusedComposer(page, "Second message");
     await expectComposerDraft(page, "Second message");
+  } finally {
+    await agent.cleanup();
+  }
+});
+
+test("Enter submits from a narrow desktop pane", async ({ page }) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const agent = await seedMockAgentWorkspace({
+    repoPrefix: "composer-narrow-desktop-",
+    title: "Narrow desktop composer",
+  });
+
+  try {
+    await openAgentRoute(page, agent);
+    await expectComposerVisible(page);
+
+    const composer = composerLocator(page);
+    await composer.fill("Send from a narrow desktop pane");
+    await composer.press("Enter");
+
+    await expect(
+      page.getByTestId("user-message").filter({ hasText: "Send from a narrow desktop pane" }),
+    ).toBeVisible();
+    await expect(composer).toHaveValue("");
   } finally {
     await agent.cleanup();
   }

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -53,6 +53,7 @@ import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
 import { isWeb } from "@/constants/platform";
 import { useIsCompactFormFactor } from "@/constants/layout";
+import { useHasFinePointer } from "@/hooks/use-fine-pointer";
 import { useComposerKeyboardScope } from "@/composer/keyboard-scope";
 import { RenderProfile } from "@/utils/render-profiler";
 import { useComposerHeight } from "./height";
@@ -391,6 +392,12 @@ interface DesktopKeyPressContext {
   disabled: boolean;
   handleAlternateSendAction: () => void;
   handleDefaultSendAction: () => void;
+}
+
+function shouldSubmitOnEnter(isCompact: boolean, hasFinePointer: boolean): boolean {
+  // Compact web can also be a narrow desktop pane. Keep phone keyboards multiline
+  // while preserving desktop Enter behavior when a mouse-like pointer is present.
+  return isWeb && (!isCompact || hasFinePointer);
 }
 
 function handleDesktopKeyPressImpl(
@@ -1189,6 +1196,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const mode = resolveComposerInputMode(inputMode);
     const { t } = useTranslation();
     const isCompact = useIsCompactFormFactor();
+    const hasFinePointer = useHasFinePointer();
     const { height: windowHeight } = useWindowDimensions();
     const maxInputHeight = resolveMaxInputHeight(windowHeight);
     const buttonIconSize = isWeb ? ICON_SIZE.md : ICON_SIZE.lg;
@@ -1585,7 +1593,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     );
 
     const shouldHandleWebKeyPress = isWeb;
-    const shouldSubmitOnEnter = isWeb && !isCompact;
+    const submitOnEnter = shouldSubmitOnEnter(isCompact, hasFinePointer);
 
     function handleDesktopKeyPress(event: WebTextInputKeyPressEvent) {
       if (!shouldHandleWebKeyPress) return;
@@ -1596,7 +1604,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
           valueRef.current,
           selectionRef.current,
         ),
-        submitOnEnter: shouldSubmitOnEnter,
+        submitOnEnter,
         isAgentRunning,
         onQueue,
         isSubmitDisabled,


### PR DESCRIPTION
## Problem

The web composer treats every viewport below 500 pixels as mobile. In narrow desktop panes, including an embedded Paseo chat in an Obsidian sidebar, Enter inserts a newline and no keyboard submission path remains.

## Fix

Use Paseo's existing fine-pointer capability check. Compact web with a mouse-like pointer keeps desktop Enter-to-submit behavior. Compact touch web keeps multiline Enter behavior.

## Proof

- Added a real browser regression at a 480px viewport.
- The new test failed before the change because no user message appeared.
- The full focused browser spec passes after the change, 2 tests passed.
- Root typecheck passed across all workspaces.
- Targeted lint and formatting checks passed.

## Platform scope

- Web desktop and embedded desktop panes gain Enter-to-submit at compact widths.
- Compact touch web behavior is unchanged.
- Native iOS and Android behavior is unchanged.