### PR TITLE
fix(claude): report active context from the last main assistant response

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -2642,6 +2642,312 @@ describe("ClaudeAgentSession context window usage", () => {
     }
   });
 
+  test("main assistant response usage wins over an aggregate empty-iterations result", async () => {
+    // Real-world regression: a translating backend reports the turn's cumulative usage
+    // in the flat result fields with iterations: [], while each main assistant response
+    // carries the true per-response usage.
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        {
+          type: "assistant",
+          message: {
+            id: "resp_final",
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+            usage: {
+              input_tokens: 470,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 127_616,
+              output_tokens: 2_756,
+            },
+          },
+          session_id: "session-1",
+        },
+        createSuccessResult({
+          total_cost_usd: 11.9,
+          usage: {
+            input_tokens: 241_054,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 3_838_464,
+            output_tokens: 21_677,
+            iterations: [],
+          },
+          modelUsage: {
+            "claude-opus-4-8": { contextWindow: 1_000_000 },
+          },
+        }),
+      ],
+    ]);
+
+    try {
+      const result = await session.run("turn");
+
+      expect(result.usage).toEqual({
+        inputTokens: 241_054,
+        cachedInputTokens: 3_838_464,
+        outputTokens: 21_677,
+        totalCostUsd: 11.9,
+        contextWindowMaxTokens: 1_000_000,
+        contextWindowUsedTokens: 130_842,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("subagent assistant responses do not feed the main context usage", async () => {
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        {
+          type: "assistant",
+          parent_tool_use_id: "toolu-subagent-1",
+          message: {
+            id: "resp_subagent",
+            role: "assistant",
+            content: [{ type: "text", text: "subagent answer" }],
+            usage: {
+              input_tokens: 216_174,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 248_320,
+              output_tokens: 5_924,
+            },
+          },
+          session_id: "session-1",
+        },
+        {
+          type: "assistant",
+          message: {
+            id: "resp_main",
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+            usage: {
+              input_tokens: 1_000,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 20_000,
+              output_tokens: 500,
+            },
+          },
+          session_id: "session-1",
+        },
+        createSuccessResult({
+          total_cost_usd: 0.5,
+          usage: {
+            input_tokens: 3_000,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 900_000,
+            output_tokens: 9_000,
+            iterations: [],
+          },
+          modelUsage: {
+            "claude-opus-4-8": { contextWindow: 1_000_000 },
+          },
+        }),
+      ],
+    ]);
+
+    try {
+      const result = await session.run("turn");
+
+      expect(result.usage).toEqual({
+        inputTokens: 3_000,
+        cachedInputTokens: 900_000,
+        outputTokens: 9_000,
+        totalCostUsd: 0.5,
+        contextWindowMaxTokens: 1_000_000,
+        // 1,000 + 0 + 20,000 + 500 — the main response, not the subagent's 470k.
+        contextWindowUsedTokens: 21_500,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("last main assistant response usage carries into a later result turn", async () => {
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        {
+          type: "assistant",
+          message: {
+            id: "resp_turn1",
+            role: "assistant",
+            content: [{ type: "text", text: "hi" }],
+            usage: {
+              input_tokens: 500,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 30_000,
+              output_tokens: 200,
+            },
+          },
+          session_id: "session-1",
+        },
+        createSuccessResult(),
+      ],
+      [
+        createSuccessResult({
+          total_cost_usd: 0.1,
+          usage: {
+            input_tokens: 1_000,
+            cache_read_input_tokens: 200,
+            output_tokens: 300,
+          },
+          uuid: "result-2",
+        }),
+      ],
+    ]);
+
+    try {
+      await session.run("turn 1");
+      const secondTurn = await session.run("turn 2");
+
+      // The flat fields of the second result (1,500 total) are aggregate accounting and
+      // remain excluded after turn one; the last main response usage (30,700) is the
+      // observed real context fill.
+      expect(secondTurn.usage).toEqual({
+        inputTokens: 1_000,
+        cachedInputTokens: 200,
+        outputTokens: 300,
+        totalCostUsd: 0.1,
+        contextWindowMaxTokens: 200_000,
+        contextWindowUsedTokens: 30_700,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("third-party gateway turn reporting full finalized usage wins over partial stream", async () => {
+    // Gemini/GLM gateway pattern: stream message_start reports partial uncached tokens (3400),
+    // but final result reports the true full turn usage (40301 + 36434 + 419 = 77154).
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        createMessageStartEvent({
+          input_tokens: 3_400,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        }),
+        createMessageDeltaEvent(419),
+        createSuccessResult({
+          total_cost_usd: 0.432142,
+          usage: {
+            input_tokens: 40_301,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 36_434,
+            output_tokens: 419,
+            iterations: [],
+          },
+          modelUsage: {
+            "claude-opus-4-8": { contextWindow: 1_000_000 },
+          },
+        }),
+      ],
+    ]);
+
+    try {
+      const result = await session.run("turn");
+
+      expect(result.usage).toEqual({
+        inputTokens: 40_301,
+        cachedInputTokens: 36_434,
+        outputTokens: 419,
+        totalCostUsd: 0.432142,
+        contextWindowMaxTokens: 1_000_000,
+        contextWindowUsedTokens: 77_154,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("empty-iterations finalized usage applies when stream reports no request input", async () => {
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        createMessageStartEvent({
+          input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        }),
+        createMessageDeltaEvent(4_790),
+        createSuccessResult({
+          total_cost_usd: 0.1,
+          usage: {
+            input_tokens: 61_489,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 266_816,
+            output_tokens: 4_790,
+            iterations: [],
+          },
+          modelUsage: {
+            "claude-opus-4-8": { contextWindow: 1_000_000 },
+          },
+        }),
+      ],
+    ]);
+
+    try {
+      const result = await session.run("turn");
+
+      expect(result.usage).toEqual({
+        inputTokens: 61_489,
+        cachedInputTokens: 266_816,
+        outputTokens: 4_790,
+        totalCostUsd: 0.1,
+        contextWindowMaxTokens: 1_000_000,
+        contextWindowUsedTokens: 333_095,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("compaction and advisor iterations are skipped when picking the active iteration", async () => {
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        createSuccessResult({
+          total_cost_usd: 0.1,
+          usage: {
+            input_tokens: 500,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 100,
+            output_tokens: 50,
+            iterations: [
+              {
+                type: "compaction",
+                input_tokens: 180_000,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                output_tokens: 3_500,
+              },
+              {
+                type: "message",
+                input_tokens: 400,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 90,
+                output_tokens: 45,
+              },
+            ],
+          },
+          modelUsage: {
+            "claude-opus-4-8": { contextWindow: 200_000 },
+          },
+        }),
+      ],
+    ]);
+
+    try {
+      const result = await session.run("turn");
+
+      expect(result.usage?.contextWindowUsedTokens).toBe(535);
+    } finally {
+      await session.close();
+    }
+  });
+
   test("manual compact boundary updates context usage from post tokens", async () => {
     const session = await createSessionForTurns([
       [

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1818,20 +1818,6 @@ function readStreamRequestOutputTokens(event: Record<string, unknown>): number |
   return outputTokens;
 }
 
-function readLastUsageIteration(usage: unknown): Record<string, unknown> | undefined {
-  const iterations = toObjectRecord(usage)?.iterations;
-  if (!Array.isArray(iterations)) {
-    return undefined;
-  }
-  for (let index = iterations.length - 1; index >= 0; index -= 1) {
-    const candidate = toObjectRecord(iterations[index]);
-    if (candidate) {
-      return candidate;
-    }
-  }
-  return undefined;
-}
-
 function readUsageTokenTotal(usage: Record<string, unknown>): number | undefined {
   const usageWithCacheCreation = usage as typeof usage & {
     cache_creation_input_tokens?: unknown;
@@ -1858,14 +1844,79 @@ function readUsageTokenTotal(usage: Record<string, unknown>): number | undefined
   return total > 0 ? total : undefined;
 }
 
-function readActiveUsageTokens(usage: unknown): number | undefined {
-  const activeUsage = readLastUsageIteration(usage);
-  return activeUsage ? readUsageTokenTotal(activeUsage) : undefined;
-}
-
 function readLegacyResultUsageTokens(usage: unknown): number | undefined {
   const usageRecord = toObjectRecord(usage);
   return usageRecord ? readUsageTokenTotal(usageRecord) : undefined;
+}
+
+function readFinalizedFlatUsageTokens(usage: unknown): number | undefined {
+  const usageRecord = toObjectRecord(usage);
+  if (!usageRecord || !Array.isArray(usageRecord.iterations) || usageRecord.iterations.length > 0) {
+    return undefined;
+  }
+
+  // Some Anthropic-compatible backends emit an explicit empty iterations array
+  // with finalized per-turn usage. Missing iterations remains unsafe after turn one
+  // because legacy Claude results can contain aggregate totals.
+  return readUsageTokenTotal(usageRecord);
+}
+
+/**
+ * The last iteration is only the active context when it is a main-loop sampling
+ * iteration. Compaction iterations hold the pre-compaction context and advisor
+ * iterations hold sub-reasoning usage; neither is the live window fill.
+ */
+function readLastMainIteration(usage: unknown): Record<string, unknown> | undefined {
+  const iterations = toObjectRecord(usage)?.iterations;
+  if (!Array.isArray(iterations)) {
+    return undefined;
+  }
+  for (let index = iterations.length - 1; index >= 0; index -= 1) {
+    const candidate = toObjectRecord(iterations[index]);
+    if (!candidate) {
+      continue;
+    }
+    if (candidate.type === "compaction" || candidate.type === "advisor_message") {
+      continue;
+    }
+    return candidate;
+  }
+  return undefined;
+}
+
+function readMainIterationUsageTokens(usage: unknown): number | undefined {
+  const iteration = readLastMainIteration(usage);
+  return iteration ? readUsageTokenTotal(iteration) : undefined;
+}
+
+/**
+ * Reads the usage of a main-loop assistant response. Each assistant SDKMessage carries
+ * the final usage of one API response, which is the most direct evidence of the live
+ * context fill at that point in the conversation.
+ */
+function readAssistantResponseUsage(message: SDKMessage): number | undefined {
+  if (message.type !== "assistant") {
+    return undefined;
+  }
+  const usageRecord = toObjectRecord(
+    toObjectRecord((message as { message?: unknown }).message)?.usage,
+  );
+  if (!usageRecord) {
+    return undefined;
+  }
+  return readUsageTokenTotal(usageRecord);
+}
+
+function isTrustworthyContextUsage(
+  usedTokens: number | undefined,
+  contextWindowMaxTokens: number | undefined,
+): usedTokens is number {
+  if (typeof usedTokens !== "number" || !Number.isFinite(usedTokens) || usedTokens <= 0) {
+    return false;
+  }
+  // No successful request can have consumed more than the context window, so anything
+  // above it is session/query accounting, never the active context.
+  return contextWindowMaxTokens === undefined || usedTokens <= contextWindowMaxTokens;
 }
 
 function isClaudeSubagentToolName(name: string | undefined): boolean {
@@ -1885,6 +1936,12 @@ class ClaudeContextUsageState {
   private streamRequestInputTokens: number | undefined;
   private streamRequestOutputTokens: number | undefined;
   private compactedContextWindowUsedTokens: number | undefined;
+  /**
+   * Usage of the most recent main-loop assistant response. Unlike the stream counters
+   * this survives across turns: it is the last observed real context fill, not a
+   * per-turn accumulator.
+   */
+  private lastMainResponseUsage: number | undefined;
   private completedResultTurns = 0;
 
   constructor(initialContextWindowMaxTokens?: number) {
@@ -1907,6 +1964,13 @@ class ClaudeContextUsageState {
       this.contextWindowMaxTokens = contextWindowMaxTokens;
     }
     return this.contextWindowMaxTokens;
+  }
+
+  recordMainAssistantResponse(message: SDKMessage): void {
+    const usageTokens = readAssistantResponseUsage(message);
+    if (usageTokens !== undefined) {
+      this.lastMainResponseUsage = usageTokens;
+    }
   }
 
   buildStreamUsageEvent(event: unknown): AgentStreamEvent | null {
@@ -1958,11 +2022,30 @@ class ClaudeContextUsageState {
         usage.contextWindowMaxTokens = modelContextWindowMaxTokens;
       }
 
-      const activeResultUsageTokens =
-        readActiveUsageTokens(message.usage) ??
-        (this.completedResultTurns === 0 ? readLegacyResultUsageTokens(message.usage) : undefined);
-      const usedTokens =
-        this.streamUsedTokens() ?? activeResultUsageTokens ?? this.compactedContextWindowUsedTokens;
+      const mainIterationUsageTokens = readMainIterationUsageTokens(message.usage);
+      const legacyResultUsageTokens =
+        this.completedResultTurns === 0 ? readLegacyResultUsageTokens(message.usage) : undefined;
+      const finalizedFlatUsageTokens = readFinalizedFlatUsageTokens(message.usage);
+      // Candidate priority:
+      // 1. Observed main-loop assistant response usage (direct per-response evidence).
+      // 2. Valid main-loop sampling iteration (structured per-iteration evidence).
+      // 3. Finalized flat usage for explicit empty-iterations backends (e.g. #4019).
+      // 4. Streamed request usage from message_start / message_delta.
+      // 5. First-turn legacy flat result fallback.
+      // 6. Compaction postTokens fallback.
+      const streamTokens = this.streamUsedTokens();
+      const observedStreamTokens =
+        streamTokens !== undefined && (this.streamRequestInputTokens ?? 0) > 0
+          ? streamTokens
+          : undefined;
+      const usedTokens = [
+        this.lastMainResponseUsage,
+        mainIterationUsageTokens,
+        finalizedFlatUsageTokens,
+        observedStreamTokens,
+        legacyResultUsageTokens,
+        this.compactedContextWindowUsedTokens,
+      ].find((candidate) => isTrustworthyContextUsage(candidate, this.contextWindowMaxTokens));
       if (usedTokens !== undefined) {
         usage.contextWindowUsedTokens = usedTokens;
       }
@@ -4085,6 +4168,7 @@ class ClaudeAgentSession implements AgentSession {
         this.appendSidechainResultEvents(message, events);
         break;
       case "assistant": {
+        this.contextUsage.recordMainAssistantResponse(message);
         const timelineItems = this.mapBlocksToTimeline(message.message.content, {
           suppressAssistantText: options?.suppressAssistantText ?? false,
           suppressReasoning: options?.suppressReasoning ?? false,


### PR DESCRIPTION
### Summary

The context meter could read cumulative turn/query accounting as the active context: backends that emit aggregate flat usage (optionally with `iterations: []`) inflated `contextWindowUsedTokens` far above the window (e.g. 410% of 1M). Conversely, backends streaming partial input tokens could lead to under-reporting when finalized flat usage was available.

### Changes
- Track the usage of the most recent main-loop assistant response and prioritize it.
- Candidate priority:
  1. Direct per-response usage from the most recent main assistant response.
  2. Valid main-loop sampling iteration (excluding `compaction` and `advisor_message`).
  3. Finalized flat usage for empty-iterations gateways (#4019).
  4. Streamed request usage from `message_start` / `message_delta`.
  5. First-turn legacy flat result fallback.
  6. Compaction `postTokens` fallback.
- Guard every candidate with `isTrustworthyContextUsage` (positive, finite, and `< contextWindowMaxTokens`).
- Isolate subagent responses from polluting parent context meter.
- Added comprehensive unit tests covering all aforementioned edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>