### PR TITLE
Let loopback clients skip the daemon password

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -205,7 +205,7 @@ snapshot so a mixed edit can apply its live subset and still name the paths that
     agentProfiles: AgentProfile[],        // named agent launch bundles; omitted means none
     cors: { allowedOrigins: string[] },
     relay: { enabled: boolean, endpoint: string, publicEndpoint: string, useTls: boolean, publicUseTls: boolean }, // new homes materialize enabled: false
-    auth: { password: string }    // bcrypt hash, optional
+    auth: { password: string, allowLoopbackWithoutPassword: boolean }  // bcrypt hash, optional; exemption is config-file only
   },
   app: {
     baseUrl: string

--- a/packages/server/src/server/auth.test.ts
+++ b/packages/server/src/server/auth.test.ts
@@ -8,6 +8,8 @@ import {
   isAgentMcpRequestAuthorized,
   isBearerTokenValidAsync,
   isBearerTokenValid,
+  isLoopbackConnection,
+  isLoopbackPasswordExempt,
   shouldBypassBearerAuth,
 } from "./auth.js";
 
@@ -119,5 +121,90 @@ describe("agent MCP request authorizer", () => {
         authorizationHeader: "Bearer wrong-token",
       }),
     ).toBe(false);
+  });
+});
+
+describe("loopback password exemption", () => {
+  const AUTH = {
+    password: CORRECT_PASSWORD_HASH,
+    allowLoopbackWithoutPassword: true,
+  };
+
+  test("recognizes loopback peers, including IPv6 and IPv4-mapped forms", () => {
+    for (const remoteAddress of [
+      "127.0.0.1",
+      "127.0.0.53",
+      "::1",
+      "0:0:0:0:0:0:0:1",
+      "::ffff:127.0.0.1",
+    ]) {
+      expect(isLoopbackConnection({ remoteAddress, headers: {} })).toBe(true);
+    }
+  });
+
+  test("treats a Unix socket peer, which has no address, as loopback", () => {
+    expect(isLoopbackConnection({ remoteAddress: undefined, headers: {} })).toBe(true);
+  });
+
+  test("rejects non-loopback peers", () => {
+    for (const remoteAddress of [
+      "192.168.1.10",
+      "10.0.0.4",
+      "::ffff:192.168.1.10",
+      "2001:db8::1",
+    ]) {
+      expect(isLoopbackConnection({ remoteAddress, headers: {} })).toBe(false);
+    }
+  });
+
+  test("rejects a loopback peer that forwarded someone else's request", () => {
+    // A reverse proxy on the same host connects from 127.0.0.1 for every remote
+    // client, so a forwarding header means the real caller is not local.
+    expect(
+      isLoopbackConnection({
+        remoteAddress: "127.0.0.1",
+        headers: { "x-forwarded-for": "203.0.113.7" },
+      }),
+    ).toBe(false);
+    expect(
+      isLoopbackConnection({
+        remoteAddress: "127.0.0.1",
+        headers: { forwarded: "for=203.0.113.7" },
+      }),
+    ).toBe(false);
+    expect(
+      isLoopbackConnection({ remoteAddress: "127.0.0.1", headers: { "x-real-ip": "203.0.113.7" } }),
+    ).toBe(false);
+  });
+
+  test("exempts loopback only when the config opts in", () => {
+    const origin = { remoteAddress: "127.0.0.1", headers: {} };
+
+    expect(isLoopbackPasswordExempt(AUTH, origin)).toBe(true);
+    expect(isLoopbackPasswordExempt({ password: CORRECT_PASSWORD_HASH }, origin)).toBe(false);
+    expect(
+      isLoopbackPasswordExempt(
+        { password: CORRECT_PASSWORD_HASH, allowLoopbackWithoutPassword: false },
+        origin,
+      ),
+    ).toBe(false);
+    expect(isLoopbackPasswordExempt(undefined, origin)).toBe(false);
+  });
+
+  test("never exempts a remote peer, even with the option on", () => {
+    expect(isLoopbackPasswordExempt(AUTH, { remoteAddress: "192.168.1.10", headers: {} })).toBe(
+      false,
+    );
+  });
+
+  test("opens the agent MCP endpoint to exempt loopback callers", async () => {
+    expect(
+      await isAgentMcpRequestAuthorized({
+        password: CORRECT_PASSWORD_HASH,
+        capabilityToken: "cap-token-abc123",
+        authorizationHeader: undefined,
+        loopbackExempt: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/server/src/server/auth.ts
+++ b/packages/server/src/server/auth.ts
@@ -1,11 +1,62 @@
 import { compare, compareSync, hashSync } from "bcryptjs";
 import { timingSafeEqual } from "node:crypto";
+import type { IncomingHttpHeaders } from "node:http";
 import type { RequestHandler } from "express";
 
 export const DAEMON_PASSWORD_BCRYPT_COST = 12;
 
 export interface DaemonAuthConfig {
   password?: string;
+  /**
+   * Lets connections from this machine skip the password. Config-file only, and
+   * deliberately so: it punches a hole in the daemon's only authentication, so
+   * an environment variable or CLI flag could turn it on somewhere the operator
+   * never looks. See isLoopbackConnection for what counts as "this machine".
+   */
+  allowLoopbackWithoutPassword?: boolean;
+}
+
+export interface ConnectionOrigin {
+  /** The kernel-reported peer address. Undefined for a Unix socket peer. */
+  remoteAddress: string | undefined;
+  headers: IncomingHttpHeaders | undefined;
+}
+
+const LOOPBACK_IPV6_ADDRESSES = new Set(["::1", "0:0:0:0:0:0:0:1"]);
+const FORWARDING_HEADERS = ["forwarded", "x-forwarded-for", "x-real-ip"] as const;
+
+export function isLoopbackAddress(address: string): boolean {
+  const normalized = address.trim().toLowerCase();
+  if (LOOPBACK_IPV6_ADDRESSES.has(normalized)) {
+    return true;
+  }
+  const ipv4 = normalized.startsWith("::ffff:") ? normalized.slice("::ffff:".length) : normalized;
+  return ipv4.startsWith("127.");
+}
+
+/**
+ * True when the peer is a process on this machine: a loopback TCP address, or a
+ * Unix socket, which has no peer address and is guarded by file permissions.
+ *
+ * Requests carrying a forwarding header are treated as remote even when the
+ * socket is loopback, because a reverse proxy on the same host relays the whole
+ * internet from 127.0.0.1. `req.ip` is deliberately not used here: it honours
+ * the `trust proxy` setting, so a daemon configured to trust every proxy would
+ * accept `X-Forwarded-For: 127.0.0.1` from anyone.
+ */
+export function isLoopbackConnection(origin: ConnectionOrigin): boolean {
+  const headers = origin.headers;
+  if (headers && FORWARDING_HEADERS.some((header) => headers[header] !== undefined)) {
+    return false;
+  }
+  return origin.remoteAddress === undefined || isLoopbackAddress(origin.remoteAddress);
+}
+
+export function isLoopbackPasswordExempt(
+  auth: DaemonAuthConfig | undefined,
+  origin: ConnectionOrigin,
+): boolean {
+  return auth?.allowLoopbackWithoutPassword === true && isLoopbackConnection(origin);
 }
 
 export interface BearerAuthRejectContext {
@@ -98,6 +149,16 @@ export function createRequireBearerMiddleware(
       return;
     }
 
+    if (
+      isLoopbackPasswordExempt(auth, {
+        remoteAddress: req.socket.remoteAddress,
+        headers: req.headers,
+      })
+    ) {
+      next();
+      return;
+    }
+
     void (async () => {
       try {
         const token = extractHttpBearerToken(req.header("authorization"));
@@ -138,14 +199,16 @@ export function shouldBypassBearerAuth(method: string, path: string): boolean {
  * capability token the daemon injects into its own agents' configs and MCP
  * client, or a valid daemon-password bearer (so existing password-authenticated
  * callers keep working). When no daemon password is configured the endpoint is
- * open, matching the global middleware's behavior.
+ * open, matching the global middleware's behavior, as is a loopback caller once
+ * the password is exempt for loopback.
  */
 export async function isAgentMcpRequestAuthorized(input: {
   password: string | undefined;
   capabilityToken: string | null;
   authorizationHeader: string | undefined;
+  loopbackExempt?: boolean;
 }): Promise<boolean> {
-  if (!input.password) {
+  if (!input.password || input.loopbackExempt) {
     return true;
   }
   const token = extractHttpBearerToken(input.authorizationHeader);

--- a/packages/server/src/server/bootstrap-auth.test.ts
+++ b/packages/server/src/server/bootstrap-auth.test.ts
@@ -151,4 +151,35 @@ describe("daemon bearer auth", () => {
       await daemonHandle.close();
     }
   });
+
+  test("lets loopback clients through without a password when the exemption is enabled", async () => {
+    const daemonHandle = await createTestPaseoDaemon({
+      auth: { password: CORRECT_PASSWORD_HASH, allowLoopbackWithoutPassword: true },
+    });
+    try {
+      const status = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/status`);
+      expect(status.status).toBe(200);
+
+      // A loopback socket relaying a remote client still needs the password.
+      const forwarded = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/status`, {
+        headers: { "X-Forwarded-For": "203.0.113.7" },
+      });
+      expect(forwarded.status).toBe(401);
+
+      // No subprotocol at all, the shape a CLI on this machine connects with.
+      const { ws, protocol } = await connectWebSocket({ port: daemonHandle.port });
+      expect(protocol).toBe("");
+      ws.close();
+
+      // A stale or wrong password from loopback is ignored rather than rejected.
+      const stale = await connectWebSocket({
+        port: daemonHandle.port,
+        protocol: "paseo.bearer.wrong-password",
+      });
+      expect(stale.protocol).toBe("paseo.bearer.wrong-password");
+      stale.ws.close();
+    } finally {
+      await daemonHandle.close();
+    }
+  });
 });

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -203,6 +203,8 @@ import { isHostnameAllowed, type HostnamesConfig } from "./hostnames.js";
 import {
   createRequireBearerMiddleware,
   isAgentMcpRequestAuthorized,
+  isLoopbackConnection,
+  isLoopbackPasswordExempt,
   type DaemonAuthConfig,
 } from "./auth.js";
 import { createWebUiMiddleware } from "./web-ui.js";
@@ -284,17 +286,11 @@ const TERMINAL_ACTIVITY_STATE_MAP = {
   "needs-input": "attention",
 } as const;
 
-const LOOPBACK_REMOTE_ADDRESSES = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
-
-function isLoopbackRemoteAddress(remoteAddress: string | undefined): boolean {
-  return remoteAddress !== undefined && LOOPBACK_REMOTE_ADDRESSES.has(remoteAddress);
-}
-
 export function createTerminalActivityRouteHandler(
   terminalManager: TerminalManager,
 ): express.RequestHandler {
   return async (req, res) => {
-    if (!isLoopbackRemoteAddress(req.socket.remoteAddress)) {
+    if (!isLoopbackConnection({ remoteAddress: req.socket.remoteAddress, headers: req.headers })) {
       res.status(403).json({ error: "Forbidden" });
       return;
     }
@@ -1486,6 +1482,10 @@ export async function createPaseoDaemon(
           password: config.auth?.password,
           capabilityToken: agentMcpAuthToken,
           authorizationHeader: req.header("authorization"),
+          loopbackExempt: isLoopbackPasswordExempt(config.auth, {
+            remoteAddress: req.socket.remoteAddress,
+            headers: req.headers,
+          }),
         }))
       ) {
         res.status(401).json({ error: "Unauthorized" });
@@ -1645,7 +1645,12 @@ export async function createPaseoDaemon(
               );
             }
             if (config.auth?.password) {
-              logger.info("Daemon password authentication enabled");
+              logger.info(
+                {
+                  allowLoopbackWithoutPassword: config.auth.allowLoopbackWithoutPassword === true,
+                },
+                "Daemon password authentication enabled",
+              );
             }
 
             wsServer = new VoiceAssistantWebSocketServer(

--- a/packages/server/src/server/config-auth.test.ts
+++ b/packages/server/src/server/config-auth.test.ts
@@ -39,6 +39,47 @@ describe("daemon auth config", () => {
     );
   });
 
+  test("loads the loopback exemption from config.json", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      daemon: {
+        auth: { password: CONFIG_PASSWORD_HASH, allowLoopbackWithoutPassword: true },
+      },
+    });
+
+    expect(loadConfig(paseoHome, { env: {} }).auth?.allowLoopbackWithoutPassword).toBe(true);
+  });
+
+  test("leaves the loopback exemption off unless config.json sets it", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      daemon: { auth: { password: CONFIG_PASSWORD_HASH } },
+    });
+
+    expect(loadConfig(paseoHome, { env: {} }).auth?.allowLoopbackWithoutPassword).toBeUndefined();
+  });
+
+  test("keeps the config.json loopback exemption when PASEO_PASSWORD supplies the password", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      daemon: { auth: { allowLoopbackWithoutPassword: true } },
+    });
+
+    const config = loadConfig(paseoHome, { env: { PASEO_PASSWORD: "from-env" } });
+
+    expect(config.auth?.allowLoopbackWithoutPassword).toBe(true);
+    expect(isBearerTokenValid({ password: config.auth?.password, token: "from-env" })).toBe(true);
+  });
+
+  test("ignores the loopback exemption when no password is configured", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      daemon: { auth: { allowLoopbackWithoutPassword: true } },
+    });
+
+    expect(loadConfig(paseoHome, { env: {} }).auth).toBeUndefined();
+  });
+
   test("lets PASEO_PASSWORD override config.json auth password hash", async () => {
     const paseoHome = await createPaseoHome({
       version: 1,

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -476,12 +476,16 @@ function resolveAuthConfig(
   persisted: ReturnType<typeof loadPersistedConfig>,
 ): PaseoDaemonConfig["auth"] {
   const envPassword = env.PASEO_PASSWORD?.trim();
-  if (envPassword) {
-    return { password: hashDaemonPassword(envPassword) };
+  const password = envPassword ? hashDaemonPassword(envPassword) : persisted.daemon?.auth?.password;
+  if (!password) {
+    return undefined;
   }
-  return persisted.daemon?.auth?.password
-    ? { password: persisted.daemon.auth.password }
-    : undefined;
+  // The exemption is read from config.json even when PASEO_PASSWORD supplies the
+  // password, so a container that takes its password from the environment can
+  // still open loopback in the file.
+  return persisted.daemon?.auth?.allowLoopbackWithoutPassword === true
+    ? { password, allowLoopbackWithoutPassword: true }
+    : { password };
 }
 
 function resolveWorktreesRoot(

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -95,6 +95,7 @@ const BcryptHashSchema = z.string().regex(/^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/
 const DaemonAuthSchema = z
   .object({
     password: BcryptHashSchema.optional(),
+    allowLoopbackWithoutPassword: z.boolean().optional(),
   })
   .strict();
 

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -78,6 +78,8 @@ import {
   extractWsBearerProtocol,
   extractWsBearerToken,
   isBearerTokenValid,
+  isLoopbackAddress,
+  isLoopbackPasswordExempt,
   type DaemonAuthConfig,
 } from "./auth.js";
 import {
@@ -808,7 +810,8 @@ export class VoiceAssistantWebSocketServer {
     const wss = new WebSocketServer({
       server,
       path: "/ws",
-      handleProtocols: (protocols) => selectWebSocketProtocol(protocols, password),
+      handleProtocols: (protocols, request) =>
+        selectWebSocketProtocol(protocols, password, isUpgradePasswordExempt(auth, request)),
       verifyClient: ({ req }, callback) => {
         this.verifyWsUpgrade(
           req,
@@ -819,7 +822,7 @@ export class VoiceAssistantWebSocketServer {
       },
     });
     wss.on("connection", (ws, request) => {
-      void this.attachAuthenticatedSocket(ws, request, password);
+      void this.attachAuthenticatedSocket(ws, request, auth);
     });
     return wss;
   }
@@ -901,9 +904,10 @@ export class VoiceAssistantWebSocketServer {
   private async attachAuthenticatedSocket(
     ws: WebSocket,
     request: IncomingMessage,
-    password: string | undefined,
+    auth: DaemonAuthConfig | undefined,
   ): Promise<void> {
-    if (password) {
+    const password = auth?.password;
+    if (password && !isUpgradePasswordExempt(auth, request)) {
       const requestMetadata = extractSocketRequestMetadata(request);
       const protocol = extractWsBearerProtocol(request.headers["sec-websocket-protocol"]);
       const token = extractWsBearerToken(protocol);
@@ -2735,13 +2739,6 @@ function resolveConnectionPeer(
   return isLoopbackAddress(requestMetadata.remoteAddress) ? "loopback" : "external";
 }
 
-function isLoopbackAddress(address: string): boolean {
-  const normalized = address.toLowerCase();
-  if (normalized === "::1" || normalized === "0:0:0:0:0:0:0:1") return true;
-  const ipv4 = normalized.startsWith("::ffff:") ? normalized.slice("::ffff:".length) : normalized;
-  return ipv4.startsWith("127.");
-}
-
 function extractSocketRequestMetadata(request: unknown): SocketRequestMetadata {
   if (!request || typeof request !== "object") {
     return {};
@@ -2874,11 +2871,22 @@ export function isWebSocketSameOrigin(
   return isLoopbackAlias(originUrl.hostname) && isLoopbackAlias(requestAuthority.hostname);
 }
 
+function isUpgradePasswordExempt(
+  auth: DaemonAuthConfig | undefined,
+  request: IncomingMessage,
+): boolean {
+  return isLoopbackPasswordExempt(auth, {
+    remoteAddress: request.socket.remoteAddress,
+    headers: request.headers,
+  });
+}
+
 function selectWebSocketProtocol(
   protocols: Set<string>,
   password: string | undefined,
+  loopbackExempt: boolean,
 ): string | false {
-  if (!password) {
+  if (!password || loopbackExempt) {
     return protocols.values().next().value ?? false;
   }
 

--- a/packages/website/public/schemas/paseo.config.v1.json
+++ b/packages/website/public/schemas/paseo.config.v1.json
@@ -153,6 +153,9 @@
                 "password": {
                   "type": "string",
                   "pattern": "^\\$2[aby]\\$\\d{2}\\$[./A-Za-z0-9]{53}$"
+                },
+                "allowLoopbackWithoutPassword": {
+                  "type": "boolean"
                 }
               },
               "additionalProperties": false

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -188,6 +188,27 @@ Or write the hash directly in `config.json`:
 
 After setting a password, restart the daemon for the change to take effect.
 
+### Exempting this machine
+
+Set `allowLoopbackWithoutPassword` to let clients on the daemon's own machine connect without the password, so remote devices authenticate while `paseo` on the box, agents, and a browser at `localhost` do not:
+
+```json
+{
+  "daemon": {
+    "auth": {
+      "password": "$2b$12$...",
+      "allowLoopbackWithoutPassword": true
+    }
+  }
+}
+```
+
+There is no environment variable or flag for this. It is a hole in the daemon's only authentication, so it lives where you can see it next to the password it exempts. It is read from `config.json` even when `PASEO_PASSWORD` supplies the password.
+
+A connection is exempt when its peer is a loopback address or a Unix socket, and the request carries no `Forwarded`, `X-Forwarded-For`, or `X-Real-IP` header. That last condition matters if you front the daemon with a reverse proxy on the same host: the proxy connects from `127.0.0.1` for every remote client, so without it the exemption would drop the password for the entire internet. A proxy that strips forwarding headers still defeats this, so leave the exemption off when one sits in front of the daemon.
+
+This widens access rather than merely saving you some typing. The password is stored as a bcrypt hash, so a process on the machine cannot read it out of `config.json` and authenticate with it; the password does keep local callers out, and the exemption gives that up. It also lets a browser on that machine reach the API without the password, leaving the host allowlist and CORS origins as the defence against a hostile page trying to use it (see [Security](/docs/security#dns-rebinding-protection)). Enable it when you trust everything running on the machine and want the password to apply to remote devices only.
+
 ### Connecting with a password
 
 The CLI picks up a password from, in order:

--- a/public-docs/security.md
+++ b/public-docs/security.md
@@ -92,10 +92,13 @@ If you enable the [bundled web UI](/docs/web-ui), its static files are also serv
 
 The password is stored as a bcrypt hash in `config.json`, the daemon never stores it in plaintext. See [Configuration](/docs/configuration#password-authentication) for setup instructions.
 
+`daemon.auth.allowLoopbackWithoutPassword` exempts clients on the daemon's own machine, so remote devices authenticate while `paseo` on the box and agents do not. The daemon decides from the kernel-reported peer address, and refuses the exemption to any request carrying a forwarding header, so a reverse proxy on the same host cannot launder remote clients through it. Leave it off when a proxy fronts the daemon, since one that strips those headers still defeats the check. See [Configuration](/docs/configuration#exempting-this-machine).
+
 ### What password auth does and does not do
 
 - **Does:** Prevents unauthorized clients from controlling your agents, even if they can reach the daemon over the network.
 - **Does not:** Encrypt traffic. Password auth protects access, not confidentiality. If you need encrypted connections over an untrusted network, use the relay (which provides end-to-end encryption) or a VPN like Tailscale.
+- **Does not:** Keep other processes on the daemon's own machine out, once you enable the loopback exemption. `config.json` stores a bcrypt hash rather than the password, so a local process cannot read the password back out and authenticate with it. The password is a real barrier against local callers, and the exemption gives it up deliberately. Turn it on only where you accept that anything running on that machine can drive your agents.
 
 ### When to use it
 


### PR DESCRIPTION
### Linked issue

None. There's no existing issue or discussion for this — it came out of running a password-protected daemon day to day. Happy to open a product discussion first if you'd rather that came before the code.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Setting a daemon password is the right move the moment you bind past localhost, but today it locks out the machine the daemon runs on. `paseo` on that box, agents that call back into the daemon, and a browser at `localhost` all have to present the password too. In practice that means exporting `PASEO_PASSWORD` into your shell profile and into the environment of every local tool — which spreads the plaintext password across exactly the places you set a password to avoid.

The flow I actually want is "authenticate my phone, don't authenticate me." This adds a config-file option for that: remote devices still need the password, connections from the daemon's own machine don't.

### Goals

- A daemon with a password set can still be driven from its own machine with no password: `paseo ls`, agents, the MCP endpoint, and a browser at `localhost`.
- Remote clients are unaffected — the password is still required, and nothing about the relay or Hub paths changes.
- The exemption cannot be tricked by a header. It's decided from the kernel-reported peer address, never `req.ip`, because `req.ip` honours `trust proxy` and a daemon with `trustedProxies: true` would otherwise accept `X-Forwarded-For: 127.0.0.1` from anyone.
- A reverse proxy on the same host can't launder remote clients through it. Any request carrying `Forwarded`, `X-Forwarded-For`, or `X-Real-IP` counts as remote even on a loopback socket, because such a proxy connects from `127.0.0.1` for every client it relays.
- Off by default; existing daemons behave exactly as before.
- The security trade-off is written down where someone deciding whether to enable it will read it.

### Non-goals

- **No environment variable and no CLI flag.** Config file only. This punches a hole in the daemon's only authentication, so it should live next to the password it exempts, not somewhere a container image or a shell profile can set it by accident. Deliberate ergonomic cost.
- **Not a defence against local processes.** Enabling it hands the daemon to anything that can open a socket on that machine. The stored bcrypt hash is not a usable credential, so the password genuinely was keeping local callers out and this gives that up on purpose. The docs say so plainly.
- **Doesn't help behind a header-stripping reverse proxy.** If a proxy removes the forwarding headers, the check can't see it. Documented as "leave this off when a proxy fronts the daemon" rather than papered over.
- **No UI.** No settings toggle, no app surface.
- **No protocol change.** `packages/protocol` is untouched; this is server-local persisted config.

### QA

Config used throughout, in a throwaway `PASEO_HOME`, daemon on port 6799. The main daemon on 6767 was not touched.

```json
{
  "daemon": {
    "listen": "127.0.0.1:6799",
    "auth": {
      "password": "$2b$12$...",           // "correct-password"
      "allowLoopbackWithoutPassword": true
    }
  }
}
```

**Startup confirms the field is read:**

```
{"host":"127.0.0.1","port":6799,"authRequired":true,"msg":"Server listening on http://127.0.0.1:6799"}
{"allowLoopbackWithoutPassword":true,"msg":"Daemon password authentication enabled"}
```

**HTTP, exemption on:**

```
$ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:6799/api/status
200
$ curl -s -o /dev/null -w "%{http_code}\n" -H "X-Forwarded-For: 203.0.113.7" http://127.0.0.1:6799/api/status
401
$ curl -s -o /dev/null -w "%{http_code}\n" -H "X-Forwarded-For: 203.0.113.7" \
       -H "Authorization: Bearer correct-password" http://127.0.0.1:6799/api/status
200
```

**CLI with no `PASEO_PASSWORD` in the environment, exemption on** — connects and exits 0:

```
$ env -u PASEO_PASSWORD PASEO_HOST=127.0.0.1:6799 paseo ls -a
$ echo $?
0
```

Daemon log for that session, no bearer presented:

```
{"connectionId":"conn_193416...","transport":"direct","peer":"loopback","remoteAddress":"127.0.0.1",
 "clientId":"cid_fb89...","appVersion":"0.7.0","msg":"Client connected via hello"}
```

**Then I flipped the flag to `false`, restarted, and re-ran the same commands** to confirm nothing was left open:

```
$ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:6799/api/status
401
$ curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer correct-password" http://127.0.0.1:6799/api/status
200
$ env -u PASEO_PASSWORD PASEO_HOST=127.0.0.1:6799 paseo ls -a
Error: Cannot reach the daemon at 127.0.0.1:6799: Password required
$ env PASEO_PASSWORD=correct-password PASEO_HOST=127.0.0.1:6799 paseo ls -a   # connects, exit 0
```

**Tests — 12 added,** going through the real interfaces (`loadConfig` against a real `config.json`, and a real daemon over HTTP and WebSocket via `createTestPaseoDaemon`), no mocks:

- `auth.test.ts` (+7) — loopback recognition incl. `::1`, `0:0:0:0:0:0:0:1`, `::ffff:127.0.0.1`; Unix-socket peer; non-loopback peers rejected; each of the three forwarding headers rejected on a loopback socket; opt-in required; `/mcp/agents` opens to exempt callers.
- `config-auth.test.ts` (+4) — parsed from `config.json`; absent by default; survives `PASEO_PASSWORD` supplying the password; ignored when no password is set.
- `bootstrap-auth.test.ts` (+1) — against a running daemon: 200 without credentials, 401 with `X-Forwarded-For`, WebSocket connects with no subprotocol, stale bearer from loopback ignored rather than rejected.

Run over the changed files plus the adjacent auth, config, and connection suites:

```
$ npx vitest run \
    packages/server/src/server/auth.test.ts \
    packages/server/src/server/config-auth.test.ts \
    packages/server/src/server/bootstrap-auth.test.ts \
    packages/server/src/server/config.test.ts \
    packages/server/src/server/persisted-config.test.ts \
    packages/server/src/server/bootstrap.smoke.test.ts \
    packages/server/src/server/websocket-server.origin.test.ts \
    packages/server/src/server/daemon-config-store.test.ts

 Test Files  8 passed (8)
      Tests  141 passed (141)
```

```
$ npm run typecheck    → exit 0
$ npm run lint         → Found 0 warnings and 0 errors.
$ npm run format:check → All matched files use the correct format.
```

**Pre-existing failure, not from this PR.** `websocket-server.liveness.e2e.test.ts > a resumed stale socket is bounded and removed without disrupting its replacement` times out at 30s. I checked out the base versions of the five source files I touched and ran it again — it fails identically on unmodified `main`. Left alone.

**What I did not test.** A genuinely non-loopback peer end to end: that needs binding to `0.0.0.0`, and this machine's only interface is a public IP, so I wasn't going to expose a daemon with a known test password to the internet. It's covered by unit tests over `isLoopbackConnection`, and the middleware path itself is proven by the `X-Forwarded-For` → 401 above. Also not run on macOS or Windows — it's plain Node `net`/`http`, and the "no peer address" branch covers Windows named pipes as well as Unix sockets, but I haven't executed it there.

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | n/a | No app change |
| Android | n/a | No app change |
| Web | n/a | No app change |
| Desktop macOS | ❌ | Daemon-side change, not run there |
| Desktop Windows | ❌ | Daemon-side change, not run there |
| Desktop Linux | ✅ | All evidence above |

No UI change, so no screenshots or video.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense