### PR TITLE
fix(cli): honor --json in the logs command

### DIFF
--- a/packages/cli/src/cli-surface.test.ts
+++ b/packages/cli/src/cli-surface.test.ts
@@ -27,6 +27,16 @@ describe("canonical CLI surface", () => {
     expect(nestedReload?.helpInformation()).toContain("--json");
   });
 
+  it("offers JSON output on both top-level and agent logs", () => {
+    const cli = createCli();
+    const logs = cli.commands.find((command) => command.name() === "logs");
+    const agent = cli.commands.find((command) => command.name() === "agent");
+    const nestedLogs = agent?.commands.find((command) => command.name() === "logs");
+
+    expect(logs?.helpInformation()).toContain("--json");
+    expect(nestedLogs?.helpInformation()).toContain("--json");
+  });
+
   it("names explicit workspace creation without exposing older syntax", () => {
     const run = createCli().commands.find((command) => command.name() === "run");
     const help = run?.helpInformation();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -92,7 +92,7 @@ export function createCli(): Command {
     withGlobalOptions(runAttachCommand),
   );
 
-  addDaemonHostOption(addLogsOptions(program.command("logs"))).action(
+  addJsonAndDaemonHostOptions(addLogsOptions(program.command("logs"))).action(
     withGlobalOptions(runLogsCommand),
   );
 

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -41,7 +41,7 @@ export function createAgentCommand(): Command {
     withGlobalOptions(runAttachCommand),
   );
 
-  addDaemonHostOption(addLogsOptions(agent.command("logs"))).action(
+  addJsonAndDaemonHostOptions(addLogsOptions(agent.command("logs"))).action(
     withGlobalOptions(runLogsCommand),
   );
 

--- a/packages/cli/src/commands/agent/logs.test.ts
+++ b/packages/cli/src/commands/agent/logs.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runLogsCommand, selectTimelineItemsForJson } from "./logs.js";
+import type { AgentTimelineItem } from "@getpaseo/protocol/agent-types";
+
+const agent = {
+  id: "11111111-1111-4111-8111-111111111111",
+  status: "idle",
+  archivedAt: null,
+  cwd: "/tmp/project",
+};
+
+const fixtures = vi.hoisted(() => {
+  const toolCall = {
+    type: "tool_call",
+    callId: "call-1",
+    name: "shell",
+    status: "completed",
+    error: null,
+    detail: { type: "shell", command: "echo third", output: "third", exitCode: 0 },
+  };
+  const items = [
+    { type: "user_message", text: "first" },
+    { type: "assistant_message", text: "second" },
+    toolCall,
+  ];
+  return { items, toolCall };
+});
+
+const close = vi.fn(async () => undefined);
+
+vi.mock("../../utils/client.js", () => ({
+  connectToDaemon: vi.fn(async () => ({
+    fetchAgent: vi.fn(async () => ({ agent })),
+    close,
+  })),
+  getDaemonHost: vi.fn(() => "ws://127.0.0.1:6767"),
+}));
+
+vi.mock("../../utils/timeline.js", () => ({
+  fetchProjectedTimelineItems: vi.fn(async () => fixtures.items),
+  LIVE_HISTORY_FETCH_TIMEOUT_MS: 1_000,
+}));
+
+const timelineItems = fixtures.items as unknown as AgentTimelineItem[];
+
+function captureStdout(): { lines: () => string[]; restore: () => void } {
+  const written: string[] = [];
+  const spy = vi.spyOn(console, "log").mockImplementation((value?: unknown) => {
+    written.push(String(value));
+  });
+  return { lines: () => written, restore: () => spy.mockRestore() };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("selectTimelineItemsForJson", () => {
+  it("returns every item when no tail is requested", () => {
+    expect(selectTimelineItemsForJson(timelineItems)).toEqual(timelineItems);
+  });
+
+  it("returns the last n items, matching the transcript's maxItems slice", () => {
+    expect(selectTimelineItemsForJson(timelineItems, 2)).toEqual(timelineItems.slice(-2));
+  });
+
+  it("returns nothing for a zero tail", () => {
+    expect(selectTimelineItemsForJson(timelineItems, 0)).toEqual([]);
+  });
+
+  it("returns every item when the tail exceeds the timeline length", () => {
+    expect(selectTimelineItemsForJson(timelineItems, 99)).toEqual(timelineItems);
+  });
+});
+
+describe("runLogsCommand with --json", () => {
+  it("emits the timeline as parseable JSON instead of the text transcript", async () => {
+    const stdout = captureStdout();
+
+    await runLogsCommand(agent.id, { json: true }, {} as never);
+
+    const output = stdout.lines().join("\n");
+    stdout.restore();
+
+    expect(() => JSON.parse(output)).not.toThrow();
+    expect(JSON.parse(output)).toEqual(timelineItems);
+  });
+
+  it("applies --tail to the JSON payload", async () => {
+    const stdout = captureStdout();
+
+    await runLogsCommand(agent.id, { json: true, tail: "2" }, {} as never);
+
+    const parsed = JSON.parse(stdout.lines().join("\n"));
+    stdout.restore();
+
+    expect(parsed).toEqual(timelineItems.slice(-2));
+  });
+
+  it("applies --filter to the JSON payload", async () => {
+    const stdout = captureStdout();
+
+    await runLogsCommand(agent.id, { json: true, filter: "tools" }, {} as never);
+
+    const parsed = JSON.parse(stdout.lines().join("\n"));
+    stdout.restore();
+
+    expect(parsed).toEqual([fixtures.toolCall]);
+  });
+
+  it("still prints the text transcript when --json is absent", async () => {
+    const stdout = captureStdout();
+
+    await runLogsCommand(agent.id, {}, {} as never);
+
+    const output = stdout.lines().join("\n");
+    stdout.restore();
+
+    expect(() => JSON.parse(output)).toThrow();
+    expect(output).toContain("second");
+  });
+});

--- a/packages/cli/src/commands/agent/logs.ts
+++ b/packages/cli/src/commands/agent/logs.ts
@@ -53,6 +53,24 @@ export function formatAgentActivityTranscript(
   );
 }
 
+/**
+ * Items the command should emit, applying the same tail semantics the text
+ * transcript uses (`curateAgentActivity` slices the raw timeline by `maxItems`),
+ * so `--tail n` selects the same entries with and without `--json`.
+ */
+export function selectTimelineItemsForJson(
+  timelineItems: AgentTimelineItem[],
+  tailCount?: number,
+): AgentTimelineItem[] {
+  if (tailCount === undefined) {
+    return timelineItems;
+  }
+  if (tailCount <= 0) {
+    return [];
+  }
+  return timelineItems.length > tailCount ? timelineItems.slice(-tailCount) : timelineItems;
+}
+
 function parseTailCount(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
   const parsed = Number.parseInt(raw, 10);
@@ -150,6 +168,11 @@ export async function runLogsCommand(
 
     await client.close();
 
+    if (options.json) {
+      console.log(JSON.stringify(selectTimelineItemsForJson(timelineItems, tailCount), null, 2));
+      return;
+    }
+
     // Use curateAgentActivity to format the transcript
     if (tailCount === 0) {
       return;
@@ -191,18 +214,27 @@ async function runFollowMode(
     existingItems = existingItems.filter((item) => matchesFilter(item, options.filter));
   }
 
-  // Print existing transcript (tail-like behavior)
-  if (tailCount > 0) {
-    const existingTranscript = formatAgentActivityTranscript(existingItems, tailCount);
-    if (existingTranscript !== NO_ACTIVITY_MESSAGE) {
-      console.log(existingTranscript);
+  // In JSON mode the stream is newline-delimited JSON: one timeline item per
+  // line, so a consumer can parse each line as it arrives. The human banner is
+  // omitted because it would not parse.
+  if (options.json) {
+    for (const item of selectTimelineItemsForJson(existingItems, tailCount)) {
+      console.log(JSON.stringify(item));
     }
-  }
+  } else {
+    // Print existing transcript (tail-like behavior)
+    if (tailCount > 0) {
+      const existingTranscript = formatAgentActivityTranscript(existingItems, tailCount);
+      if (existingTranscript !== NO_ACTIVITY_MESSAGE) {
+        console.log(existingTranscript);
+      }
+    }
 
-  // Subscribe to new events
-  const tailLabel =
-    tailCount === 0 ? "no history" : `last ${tailCount} entr${tailCount === 1 ? "y" : "ies"}`;
-  console.log(`\n--- Following logs (${tailLabel}; Ctrl+C to stop) ---\n`);
+    // Subscribe to new events
+    const tailLabel =
+      tailCount === 0 ? "no history" : `last ${tailCount} entr${tailCount === 1 ? "y" : "ies"}`;
+    console.log(`\n--- Following logs (${tailLabel}; Ctrl+C to stop) ---\n`);
+  }
 
   const unsubscribe = client.on("agent_stream", (msg: unknown) => {
     const message = msg as AgentStreamMessage;
@@ -213,6 +245,10 @@ async function runFollowMode(
       const item = message.payload.event.item;
       // Apply filter
       if (options.filter && !matchesFilter(item, options.filter)) {
+        return;
+      }
+      if (options.json) {
+        console.log(JSON.stringify(item));
         return;
       }
       // Print each timeline item as it arrives using the curator format

--- a/packages/cli/tests/08-agent-logs.test.ts
+++ b/packages/cli/tests/08-agent-logs.test.ts
@@ -143,6 +143,26 @@ try {
     assert(!output.includes("error: option"), "should not have option parsing error");
     console.log("✓ -q (quiet) flag is accepted with logs\n");
   }
+
+  // Test 10: logs --help advertises --json
+  {
+    console.log("Test 10: logs --help advertises --json");
+    const result = await $`npx paseo logs --help`.nothrow();
+    assert.strictEqual(result.exitCode, 0, "logs --help should exit 0");
+    assert(result.stdout.includes("--json"), "help should mention --json option");
+    console.log("✓ logs --help advertises --json\n");
+  }
+
+  // Test 11: logs --json flag is accepted
+  {
+    console.log("Test 11: logs --json flag is accepted");
+    const result =
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo logs --json abc123`.nothrow();
+    const output = result.stdout + result.stderr;
+    assert(!output.includes("unknown option"), "should accept --json flag");
+    assert(!output.includes("error: option"), "should not have option parsing error");
+    console.log("✓ logs --json flag is accepted\n");
+  }
 } finally {
   // Clean up temp directory
   await rm(paseoHome, { recursive: true, force: true });


### PR DESCRIPTION
### Linked issue

No dedicated issue — I raised this as a separate nit at the end of #4144 and offered to file it on its own. Happy to open one if you'd rather track it that way.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

`paseo logs --json` parses without error but always prints the human transcript, so a script cannot consume it. `ls --json` and `inspect --json` both emit valid JSON, so the inconsistency is easy to hit — I hit it while scripting timeline inspection and assumed my parser was wrong before I checked the source.

Root cause is two-part:

- `logs` is wired with `addDaemonHostOption` (`cli.ts`, `commands/agent/index.ts`) rather than `addJsonAndDaemonHostOptions`, so `--json` is never advertised in `--help`. The global `--json` still parses, which is why it looks supported.
- `runLogsCommand` never consults the flag; before this change `commands/agent/logs.ts` contained no reference to JSON at all.

### Goals

- Make `--json` work on both `paseo logs` and `paseo agent logs`, and advertise it in help.
- Keep `--tail` and `--filter` meaning the same thing with and without `--json`.
- Give follow mode a stream a consumer can parse incrementally.

### Non-goals

- Change the text transcript output in any way.
- Add a schema/envelope around the payload. This emits the `AgentTimelineItem[]` the command already fetched; say the word if you'd prefer a wrapper like the other commands' result shapes and I'll rework it.

### Implementation notes

`--tail` parity is the one judgement call. The text path passes `tailCount` to `curateAgentActivity`, which does `items.slice(-maxItems)` on the raw timeline (`activity-curator.ts:144`), so the JSON path applies the same slice via `selectTimelineItemsForJson`. `--tail n` therefore selects the same entries in both modes.

Follow mode emits newline-delimited JSON — one item per line — and omits the `--- Following logs ---` banner, which would not parse.

### QA

**Before / after.** Released 0.7.2 CLI vs. this build:

```
$ /Applications/Paseo.app/Contents/Resources/bin/paseo logs --help | grep -E '^\s+--(json|tail|host)'
  --tail <n>       Show last n entries
  --host <host>    Daemon host target: host:port, tcp://host:port, or

$ npx paseo logs --help | grep -E '^\s+--(json|tail|host)'
  --tail <n>       Show last n entries
  --json           Output in JSON format
  --host <host>    Daemon host target: host:port, tcp://host:port, or
```

**New unit tests** (`packages/cli/src/commands/agent/logs.test.ts`) drive the real `runLogsCommand` with the daemon client and timeline fetch mocked, covering: JSON output parses and equals the timeline; `--tail` applied to the JSON payload; `--filter` applied to the JSON payload; and a control that the text transcript is unchanged when `--json` is absent (that one asserts the output does *not* parse as JSON and still contains the message text).

```
$ npx vitest run src/commands/agent/logs.test.ts src/cli-surface.test.ts
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

**Real CLI end-to-end** (`packages/cli/tests/08-agent-logs.test.ts`, two cases added — help advertises `--json`, and `--json` is accepted without an option-parsing error):

```
$ npx tsx tests/08-agent-logs.test.ts
...
Test 10: logs --help advertises --json
✓ logs --help advertises --json

Test 11: logs --json flag is accepted
✓ logs --json flag is accepted

=== All logs tests passed ===
```

**Full CLI unit suite:**

```
$ npx vitest run src
 Test Files  1 failed | 37 passed (38)
      Tests  2 failed | 284 passed (286)
```

The 2 failures are `src/commands/plugin/scaffold.test.ts` and are pre-existing — I verified they fail identically with my changes stashed on a clean tree (they need `@getpaseo/plugin` typecheck artifacts). Everything else passes.

**Hooks:** the pre-commit hook ran clean on this commit — `format ✔`, `lint ✔`, repo-wide `typecheck ✔`. No `--no-verify`.

### What I did not test

- The JSON payload against a **real provider-backed agent timeline**. The mocked tests exercise the command function, and the E2E case covers option acceptance against the real binary, but I did not stand up a provider to produce genuine timeline items. If you want that wired through the E2E daemon helper, tell me and I'll add it.
- Follow-mode NDJSON against a live stream — the follow path is covered by reading, not by a test.
- macOS only (Apple Silicon, Node 22). Not tested on Linux or Windows.
