### PR TITLE
feat(app): copy change request link shortcut (⌘⇧C / Ctrl+Shift+C)

### DIFF
--- a/packages/app/e2e/browser/copy-pr-link-shortcut.spec.ts
+++ b/packages/app/e2e/browser/copy-pr-link-shortcut.spec.ts
@@ -1,0 +1,132 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "../support/fixtures";
+import { createTempGitRepo } from "../support/helpers/workspace";
+import {
+  connectWorkspaceSetupClient,
+  openHomeWithProject,
+  seedProjectForWorkspaceSetup,
+} from "../support/helpers/workspace-setup";
+import { waitForWorkspaceTabsVisible } from "../support/helpers/workspace-tabs";
+import { getServerId } from "../support/helpers/server-id";
+import { buildHostWorkspaceRoute } from "../../src/utils/host-routes";
+
+// The e2e worker's fake `gh` answers `pr view` for the paseo-e2e/local-fixture remote with a
+// PR whose URL is fixed, so the whole PR-detection path runs locally without network access.
+const PR_URL = "https://github.com/paseo-e2e/local-fixture/pull/1";
+const PR_BRANCH = "pr-branch-1";
+const evidenceDir = "/tmp/pr-copy-shortcut";
+
+function pressCopyPrLinkShortcut(page: import("@playwright/test").Page) {
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  return page.keyboard.press(`${modifier}+Shift+C`);
+}
+
+/** A local repo whose origin looks like the fixture GitHub remote the fake `gh` answers for. */
+async function createFixtureRepo(prefix: string, branch: string) {
+  const repo = await createTempGitRepo(prefix, {
+    withRemote: true,
+    originUrl: "https://github.com/paseo-e2e/local-fixture.git",
+    branches: [branch],
+  });
+  execFileSync("git", ["update-ref", `refs/pull/1/head`, `refs/heads/${branch}`], {
+    cwd: path.join(repo.path, "remote.git"),
+  });
+  const localRemote = path.join(repo.path, "remote.git");
+  execFileSync(
+    "git",
+    ["config", `url.${localRemote}.insteadOf`, "git@github.com:paseo-e2e/local-fixture.git"],
+    {
+      cwd: repo.path,
+    },
+  );
+  execFileSync(
+    "git",
+    [
+      "config",
+      "--add",
+      `url.${localRemote}.insteadOf`,
+      "https://github.com/paseo-e2e/local-fixture.git",
+    ],
+    { cwd: repo.path },
+  );
+  return repo;
+}
+
+test("copies the workspace change request link with Cmd/Ctrl+Shift+C", async ({
+  page,
+  context,
+}) => {
+  // Clipboard reads need the browser permissions granted before the press.
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  const client = await connectWorkspaceSetupClient();
+  const repo = await createFixtureRepo("pr-copy-shortcut-", PR_BRANCH);
+  try {
+    await seedProjectForWorkspaceSetup(client, repo.path);
+    const result = await client.createWorkspace({
+      source: {
+        kind: "worktree",
+        cwd: repo.path,
+        action: "checkout",
+        checkoutSource: { kind: "change_request", forge: "github", number: 1 },
+      },
+    });
+    if (!result.workspace || result.error) {
+      throw new Error(result.error ?? "Workspace creation failed");
+    }
+
+    await openHomeWithProject(page, repo.path);
+    await page.goto(buildHostWorkspaceRoute(getServerId(), result.workspace.id));
+    await waitForWorkspaceTabsVisible(page);
+
+    // The shortcut reads the change request off the workspace descriptor, so wait until the
+    // workspace header shows the View PR action before pressing it.
+    await expect(page.getByRole("button", { name: "View PR" })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await pressCopyPrLinkShortcut(page);
+
+    // toast.copied wraps its label: "Copied {{label}}" with the forge-noun label "PR link".
+    await expect(page.getByText("Copied PR link", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect
+      .poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 10_000 })
+      .toBe(PR_URL);
+    mkdirSync(evidenceDir, { recursive: true });
+    await page.screenshot({ path: path.join(evidenceDir, "copied-pr-link-toast.png") });
+  } finally {
+    await client.close();
+    await repo.cleanup();
+  }
+});
+
+test("shows an error toast when the workspace has no change request", async ({ page }) => {
+  const client = await connectWorkspaceSetupClient();
+  // A plain repo with no GitHub remote: no change request to copy.
+  const repo = await createTempGitRepo("pr-copy-shortcut-none-");
+  try {
+    await seedProjectForWorkspaceSetup(client, repo.path);
+    const result = await client.createWorkspace({
+      source: { kind: "directory", path: repo.path },
+    });
+    if (!result.workspace || result.error) {
+      throw new Error(result.error ?? "Workspace creation failed");
+    }
+
+    await openHomeWithProject(page, repo.path);
+    await page.goto(buildHostWorkspaceRoute(getServerId(), result.workspace.id));
+    await waitForWorkspaceTabsVisible(page);
+
+    await pressCopyPrLinkShortcut(page);
+
+    await expect(
+      page.getByText("No change request found for this workspace", { exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await client.close();
+    await repo.cleanup();
+  }
+});

--- a/packages/app/e2e/browser/copy-pr-link-shortcut.spec.ts
+++ b/packages/app/e2e/browser/copy-pr-link-shortcut.spec.ts
@@ -7,6 +7,7 @@ import {
   connectWorkspaceSetupClient,
   openHomeWithProject,
   seedProjectForWorkspaceSetup,
+  type WorkspaceSetupDaemonClient,
 } from "../support/helpers/workspace-setup";
 import { waitForWorkspaceTabsVisible } from "../support/helpers/workspace-tabs";
 import { getServerId } from "../support/helpers/server-id";
@@ -24,6 +25,18 @@ function pressCopyPrLinkShortcut(page: import("@playwright/test").Page) {
 }
 
 /** A local repo whose origin looks like the fixture GitHub remote the fake `gh` answers for. */
+/** Creates the workspace and turns the RPC error shape into a thrown test failure. */
+async function createWorkspaceOrFail(
+  client: WorkspaceSetupDaemonClient,
+  source: Parameters<WorkspaceSetupDaemonClient["createWorkspace"]>[0]["source"],
+) {
+  const result = await client.createWorkspace({ source });
+  if (!result.workspace || result.error) {
+    throw new Error(result.error ?? "Workspace creation failed");
+  }
+  return result.workspace;
+}
+
 async function createFixtureRepo(prefix: string, branch: string) {
   const repo = await createTempGitRepo(prefix, {
     withRemote: true,
@@ -64,20 +77,15 @@ test("copies the workspace change request link with Cmd/Ctrl+Shift+C", async ({
   const repo = await createFixtureRepo("pr-copy-shortcut-", PR_BRANCH);
   try {
     await seedProjectForWorkspaceSetup(client, repo.path);
-    const result = await client.createWorkspace({
-      source: {
-        kind: "worktree",
-        cwd: repo.path,
-        action: "checkout",
-        checkoutSource: { kind: "change_request", forge: "github", number: 1 },
-      },
+    const workspace = await createWorkspaceOrFail(client, {
+      kind: "worktree",
+      cwd: repo.path,
+      action: "checkout",
+      checkoutSource: { kind: "change_request", forge: "github", number: 1 },
     });
-    if (!result.workspace || result.error) {
-      throw new Error(result.error ?? "Workspace creation failed");
-    }
 
     await openHomeWithProject(page, repo.path);
-    await page.goto(buildHostWorkspaceRoute(getServerId(), result.workspace.id));
+    await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.id));
     await waitForWorkspaceTabsVisible(page);
 
     // The shortcut reads the change request off the workspace descriptor, so wait until the
@@ -109,15 +117,13 @@ test("shows an error toast when the workspace has no change request", async ({ p
   const repo = await createTempGitRepo("pr-copy-shortcut-none-");
   try {
     await seedProjectForWorkspaceSetup(client, repo.path);
-    const result = await client.createWorkspace({
-      source: { kind: "directory", path: repo.path },
+    const workspace = await createWorkspaceOrFail(client, {
+      kind: "directory",
+      path: repo.path,
     });
-    if (!result.workspace || result.error) {
-      throw new Error(result.error ?? "Workspace creation failed");
-    }
 
     await openHomeWithProject(page, repo.path);
-    await page.goto(buildHostWorkspaceRoute(getServerId(), result.workspace.id));
+    await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.id));
     await waitForWorkspaceTabsVisible(page);
 
     await pressCopyPrLinkShortcut(page);

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -39,6 +39,7 @@ import { WindowSidebarMenuToggle } from "@/components/headers/menu-header";
 import { DesktopWindowControls } from "@/components/desktop/window-controls";
 import { SidebarModelProvider } from "@/components/sidebar/sidebar-model";
 import { WorkspacePinShortcutHandler } from "@/components/workspace-pin-shortcut-handler";
+import { WorkspacePrCopyShortcutHandler } from "@/components/workspace-pr-copy-shortcut-handler";
 import { WorkspaceRenameHost } from "@/components/workspace-rename-host";
 import { CompactExplorerSidebarHost } from "@/components/compact-explorer-sidebar-host";
 import { ProviderSettingsHost } from "@/components/provider-settings-host";
@@ -596,6 +597,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
       <CommandCenterWorkspaceActions />
       <PluginCommandCenterActions />
       <WorkspacePinShortcutHandler />
+      <WorkspacePrCopyShortcutHandler />
       <WorkspaceRenameHost />
       <CommandCenter />
       <AddProjectFlowHost />

--- a/packages/app/src/components/workspace-pr-copy-shortcut-handler.tsx
+++ b/packages/app/src/components/workspace-pr-copy-shortcut-handler.tsx
@@ -1,0 +1,9 @@
+import { useGlobalWorkspaceCopyPrAction } from "@/hooks/use-global-workspace-copy-pr-action";
+
+// Headless host for the copy-change-request-link shortcut. The hook subscribes to the active
+// workspace's githubRuntime, which ticks often, so it lives in its own component rather than
+// the root layout — same reasoning as the pin shortcut host.
+export function WorkspacePrCopyShortcutHandler() {
+  useGlobalWorkspaceCopyPrAction();
+  return null;
+}

--- a/packages/app/src/hooks/use-global-workspace-copy-pr-action.ts
+++ b/packages/app/src/hooks/use-global-workspace-copy-pr-action.ts
@@ -40,9 +40,12 @@ export function useGlobalWorkspaceCopyPrAction() {
       toast.error(t("workspace.header.toasts.changeRequestLinkUnavailable"));
       return true;
     }
-    void copyToClipboard(hint.url);
     const context = getForgePresentation(normalizeForge(hint.forge)).changeRequestContext;
-    toast.copied(t("workspace.header.toasts.changeRequestLinkCopiedLabel", { context }));
+    void copyToClipboard(hint.url)
+      .then(() =>
+        toast.copied(t("workspace.header.toasts.changeRequestLinkCopiedLabel", { context })),
+      )
+      .catch(() => toast.error(t("common.errors.unableToCopy")));
     return true;
   }, [fields, t, toast]);
 

--- a/packages/app/src/hooks/use-global-workspace-copy-pr-action.ts
+++ b/packages/app/src/hooks/use-global-workspace-copy-pr-action.ts
@@ -1,0 +1,56 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useToast } from "@/contexts/toast-context";
+import { getForgePresentation, normalizeForge } from "@/git/forge";
+import { selectPrHintFromStatus } from "@/git/pr-hint";
+import { useKeyboardActionHandler } from "@/hooks/use-keyboard-action-handler";
+import type { KeyboardActionId } from "@/keyboard/keyboard-action-dispatcher";
+import { useActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
+import { useWorkspaceFields } from "@/stores/session-store-hooks";
+import { copyToClipboard } from "@/utils/copy-to-clipboard";
+
+const WORKSPACE_PR_COPY_ACTIONS: readonly KeyboardActionId[] = ["workspace.pr.copy"];
+
+// The change-request link shortcut mirrors the pin shortcut's shape: one registration keyed on
+// the active route selection, not on a rendered row, so it keeps working while the sidebar is
+// collapsed or focus mode hides the row.
+//
+// The URL comes from the workspace descriptor's `githubRuntime` rather than the checkout PR
+// query: the sidebar's change-request badge reads the same field, so the shortcut never copies
+// a link the UI does not show.
+export function useGlobalWorkspaceCopyPrAction() {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const selection = useActiveWorkspaceSelection();
+  const serverId = selection?.serverId ?? null;
+  const routeWorkspaceId = selection?.workspaceId ?? null;
+  // Narrow projection: only the fields that decide the copied URL, so diffStat and gitRuntime
+  // branch ticks don't re-render this handler.
+  const fields = useWorkspaceFields(serverId, routeWorkspaceId, (workspace) => ({
+    prStatus: workspace.githubRuntime?.pullRequest ?? null,
+    forge: workspace.forge ?? null,
+  }));
+
+  const handle = useCallback(() => {
+    if (!fields) {
+      return false;
+    }
+    const hint = selectPrHintFromStatus(fields.prStatus, fields.forge);
+    if (!hint?.url) {
+      toast.error(t("workspace.header.toasts.changeRequestLinkUnavailable"));
+      return true;
+    }
+    void copyToClipboard(hint.url);
+    const context = getForgePresentation(normalizeForge(hint.forge)).changeRequestContext;
+    toast.copied(t("workspace.header.toasts.changeRequestLinkCopiedLabel", { context }));
+    return true;
+  }, [fields, t, toast]);
+
+  useKeyboardActionHandler({
+    handlerId: "workspace-pr-copy-global",
+    actions: WORKSPACE_PR_COPY_ACTIONS,
+    enabled: serverId !== null && fields !== null,
+    priority: 0,
+    handle,
+  });
+}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -702,6 +702,9 @@ export const ar: TranslationResources = {
         terminalQueued: "تحضير مساحة العمل، وفتح الوحدة الطرفية عندما تكون جاهزة...",
         workspacePathCopiedLabel: "مسار Workspace",
         branchNameCopiedLabel: "اسم الفرع",
+        changeRequestLinkCopiedLabel: "رابط PR",
+        changeRequestLinkCopiedLabel_mr: "رابط MR",
+        changeRequestLinkUnavailable: "لا يوجد طلب تغيير لمساحة العمل هذه",
       },
     },
     scripts: {
@@ -2181,6 +2184,7 @@ export const ar: TranslationResources = {
         newWorkspace: "مساحة عمل جديدة",
         newWorktree: "شجرة عمل جديدة",
         archiveWorkspace: "أرشفة مساحة العمل",
+        copyChangeRequestLink: "نسخ رابط PR",
         newTab: "علامة تبويب جديدة",
         closeCurrentTab: "إغلاق علامة التبويب الحالية",
         jumpToWorkspace: "انتقل إلى مساحة العمل",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -698,6 +698,9 @@ export const en = {
         terminalQueued: "Preparing workspace, opening terminal when ready...",
         workspacePathCopiedLabel: "Workspace path",
         branchNameCopiedLabel: "Branch name",
+        changeRequestLinkCopiedLabel: "PR link",
+        changeRequestLinkCopiedLabel_mr: "MR link",
+        changeRequestLinkUnavailable: "No change request found for this workspace",
       },
     },
     scripts: {
@@ -2279,6 +2282,7 @@ export const en = {
         newWorkspace: "New workspace",
         newWorktree: "New worktree",
         archiveWorkspace: "Archive workspace",
+        copyChangeRequestLink: "Copy change request link",
         newTab: "New tab",
         closeCurrentTab: "Close current tab",
         jumpToWorkspace: "Jump to workspace",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -708,6 +708,10 @@ export const es: TranslationResources = {
           "Preparando el espacio de trabajo, abriendo la terminal cuando esté listo...",
         workspacePathCopiedLabel: "RutaWorkspace",
         branchNameCopiedLabel: "Nombre de la sucursal",
+        changeRequestLinkCopiedLabel: "enlace del PR",
+        changeRequestLinkCopiedLabel_mr: "enlace del MR",
+        changeRequestLinkUnavailable:
+          "Este espacio de trabajo no tiene ninguna solicitud de cambios",
       },
     },
     scripts: {
@@ -2233,6 +2237,7 @@ export const es: TranslationResources = {
         newWorkspace: "Nuevo espacio de trabajo",
         newWorktree: "Nuevo árbol de trabajo",
         archiveWorkspace: "Archivar espacio de trabajo",
+        copyChangeRequestLink: "Copiar enlace del PR",
         newTab: "Nueva pestaña",
         closeCurrentTab: "Cerrar pestaña actual",
         jumpToWorkspace: "Saltar al espacio de trabajo",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -708,6 +708,10 @@ export const fr: TranslationResources = {
           "Préparation de l'espace de travail, ouverture du terminal lorsque vous êtes prêt...",
         workspacePathCopiedLabel: "CheminWorkspace",
         branchNameCopiedLabel: "Nom de la succursale",
+        changeRequestLinkCopiedLabel: "lien de la PR",
+        changeRequestLinkCopiedLabel_mr: "lien de la MR",
+        changeRequestLinkUnavailable:
+          "Aucune demande de changement trouvée pour cet espace de travail",
       },
     },
     scripts: {
@@ -2236,6 +2240,7 @@ export const fr: TranslationResources = {
         newWorkspace: "Nouvel espace de travail",
         newWorktree: "Nouvel arbre de travail",
         archiveWorkspace: "Archiver l’espace de travail",
+        copyChangeRequestLink: "Copier le lien de la PR",
         newTab: "Nouvel onglet",
         closeCurrentTab: "Fermer l'onglet actuel",
         jumpToWorkspace: "Accéder à l'espace de travail",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -704,6 +704,9 @@ export const ja: TranslationResources = {
         terminalQueued: "ワークスペースを準備中、準備ができたらターミナルを開きます...",
         workspacePathCopiedLabel: "ワークスペースパス",
         branchNameCopiedLabel: "ブランチ名",
+        changeRequestLinkCopiedLabel: "PRリンク",
+        changeRequestLinkCopiedLabel_mr: "MRリンク",
+        changeRequestLinkUnavailable: "このワークスペースには変更リクエストがありません",
       },
     },
     scripts: {
@@ -2199,6 +2202,7 @@ export const ja: TranslationResources = {
         newWorkspace: "新しいワークスペース",
         newWorktree: "新しいワークツリー",
         archiveWorkspace: "ワークスペースをアーカイブ",
+        copyChangeRequestLink: "PRリンクをコピー",
         newTab: "新しいタブ",
         closeCurrentTab: "現在のタブを閉じる",
         jumpToWorkspace: "ワークスペースにジャンプ",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -702,6 +702,9 @@ export const ko: TranslationResources = {
         terminalQueued: "워크스페이스 준비 중, 준비되면 터미널을 엽니다...",
         workspacePathCopiedLabel: "워크스페이스 경로",
         branchNameCopiedLabel: "브랜치 이름",
+        changeRequestLinkCopiedLabel: "PR 링크",
+        changeRequestLinkCopiedLabel_mr: "MR 링크",
+        changeRequestLinkUnavailable: "이 워크스페이스에 대한 변경 요청이 없습니다",
       },
     },
     scripts: {
@@ -2191,6 +2194,7 @@ export const ko: TranslationResources = {
         newWorkspace: "새 워크스페이스",
         newWorktree: "새 워크트리",
         archiveWorkspace: "워크스페이스 보관",
+        copyChangeRequestLink: "PR 링크 복사",
         newTab: "새 탭",
         closeCurrentTab: "현재 탭 닫기",
         jumpToWorkspace: "워크스페이스로 이동",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -705,6 +705,10 @@ export const ptBR: TranslationResources = {
         terminalQueued: "Preparando workspace, abrindo terminal quando estiver pronto...",
         workspacePathCopiedLabel: "Caminho do workspace",
         branchNameCopiedLabel: "Nome da branch",
+        changeRequestLinkCopiedLabel: "link do PR",
+        changeRequestLinkCopiedLabel_mr: "link do MR",
+        changeRequestLinkUnavailable:
+          "Nenhuma solicitação de alteração encontrada para este workspace",
       },
     },
     scripts: {
@@ -2215,6 +2219,7 @@ export const ptBR: TranslationResources = {
         newWorkspace: "Novo workspace",
         newWorktree: "Novo worktree",
         archiveWorkspace: "Arquivar workspace",
+        copyChangeRequestLink: "Copiar link do PR",
         newTab: "Nova aba",
         closeCurrentTab: "Fechar aba atual",
         jumpToWorkspace: "Ir para workspace",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -708,6 +708,10 @@ export const ru: TranslationResources = {
           "Рабочее пространство подготавливается. Терминал откроется, когда оно будет готово...",
         workspacePathCopiedLabel: "Путь к рабочему пространству",
         branchNameCopiedLabel: "Имя ветки",
+        changeRequestLinkCopiedLabel: "ссылка на PR",
+        changeRequestLinkCopiedLabel_mr: "ссылка на MR",
+        changeRequestLinkUnavailable:
+          "Для этого рабочего пространства не найдено запросов на изменение",
       },
     },
     scripts: {
@@ -2219,6 +2223,7 @@ export const ru: TranslationResources = {
         newWorkspace: "Новое рабочее пространство",
         newWorktree: "Новый worktree",
         archiveWorkspace: "Архивировать рабочее пространство",
+        copyChangeRequestLink: "Скопировать ссылку на PR",
         newTab: "Новая вкладка",
         closeCurrentTab: "Закрыть текущую вкладку",
         jumpToWorkspace: "Перейти к рабочему пространству",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -698,6 +698,9 @@ export const zhCN: TranslationResources = {
         terminalQueued: "正在准备 workspace，Terminal 准备好后会打开...",
         workspacePathCopiedLabel: "Workspace 路径",
         branchNameCopiedLabel: "分支名称",
+        changeRequestLinkCopiedLabel: "PR 链接",
+        changeRequestLinkCopiedLabel_mr: "MR 链接",
+        changeRequestLinkUnavailable: "此工作区没有变更请求",
       },
     },
     scripts: {
@@ -2155,6 +2158,7 @@ export const zhCN: TranslationResources = {
         newWorkspace: "新建 workspace",
         newWorktree: "新建 worktree",
         archiveWorkspace: "归档工作区",
+        copyChangeRequestLink: "复制 PR 链接",
         newTab: "新建标签",
         closeCurrentTab: "关闭当前标签",
         jumpToWorkspace: "跳转到 workspace",

--- a/packages/app/src/keyboard/actions.ts
+++ b/packages/app/src/keyboard/actions.ts
@@ -53,6 +53,7 @@ export type KeyboardActionId =
   | "worktree.new"
   | "workspace.archive"
   | "workspace.pin"
+  | "workspace.pr.copy"
   | "view.toggle.focus"
   | "theme.cycle"
   | "message-input.action";

--- a/packages/app/src/keyboard/keyboard-action-dispatcher.ts
+++ b/packages/app/src/keyboard/keyboard-action-dispatcher.ts
@@ -52,6 +52,7 @@ export type KeyboardActionId =
   | "worktree.new"
   | "workspace.archive"
   | "workspace.pin"
+  | "workspace.pr.copy"
   // Command-center only: no keybind, so these are absent from route-shortcut.ts.
   | "workspace.rename"
   | "workspace.setup.show";
@@ -110,6 +111,7 @@ export type KeyboardActionDefinition =
   | { id: "worktree.new"; scope: KeyboardActionScope }
   | { id: "workspace.archive"; scope: KeyboardActionScope }
   | { id: "workspace.pin"; scope: KeyboardActionScope }
+  | { id: "workspace.pr.copy"; scope: KeyboardActionScope }
   | { id: "workspace.rename"; scope: KeyboardActionScope }
   | { id: "workspace.setup.show"; scope: KeyboardActionScope };
 

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -295,6 +295,18 @@ describe("keyboard-shortcuts", () => {
       action: "workspace.pane.close",
     },
     {
+      name: "matches Cmd+Shift+C to copy change request link on macOS",
+      event: { key: "C", code: "KeyC", metaKey: true, shiftKey: true },
+      context: { isMac: true, commandCenterOpen: false },
+      action: "workspace.pr.copy",
+    },
+    {
+      name: "matches Ctrl+Shift+C to copy change request link on non-mac",
+      event: { key: "C", code: "KeyC", ctrlKey: true, shiftKey: true },
+      context: { isMac: false, commandCenterOpen: false, focusScope: "other" },
+      action: "workspace.pr.copy",
+    },
+    {
       name: "matches Cmd+B sidebar toggle on macOS",
       event: { key: "b", code: "KeyB", metaKey: true },
       context: { isMac: true },
@@ -661,6 +673,7 @@ describe("keyboard-shortcut help sections", () => {
         "workspace-tab-close-current": ["mod", "W"],
         "workspace-pane-split-right": ["mod", "\\"],
         "workspace-pane-close": ["mod", "shift", "W"],
+        "copy-pr-link": ["mod", "shift", "C"],
       },
     },
     {
@@ -669,6 +682,7 @@ describe("keyboard-shortcut help sections", () => {
       expectedKeys: {
         "workspace-tab-jump-index": ["alt", "1-9"],
         "workspace-tab-close-current": ["ctrl", "W"],
+        "copy-pr-link": ["ctrl", "shift", "C"],
       },
     },
     {

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -168,6 +168,7 @@ export const SHORTCUT_HELP_ROW_ORDER: Record<ShortcutSectionId, readonly string[
     "workspace-next",
     "pin-workspace",
     "archive-workspace",
+    "copy-pr-link",
   ],
   "tabs-panes": [
     "workspace-tab-new",
@@ -218,6 +219,7 @@ const SHORTCUT_HELP_LABEL_KEYS: Record<string, string> = {
   "workspace-tab-jump-index": "settings.shortcuts.help.jumpToTab",
   "workspace-prev": "settings.shortcuts.help.previousWorkspace",
   "workspace-next": "settings.shortcuts.help.nextWorkspace",
+  "copy-pr-link": "settings.shortcuts.help.copyChangeRequestLink",
   "workspace-tab-prev": "settings.shortcuts.help.previousTab",
   "workspace-tab-next": "settings.shortcuts.help.nextTab",
   "workspace-pane-split-right": "settings.shortcuts.help.splitPaneRight",
@@ -381,6 +383,30 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
       id: "pin-workspace",
       section: "workspaces",
       label: "Pin chat",
+    },
+  },
+
+  // --- Copy change request link ---
+  {
+    id: "workspace-pr-copy-cmd-shift-c-mac",
+    action: "workspace.pr.copy",
+    combo: "Cmd+Shift+C",
+    when: { mac: true, commandCenter: false },
+    help: {
+      id: "copy-pr-link",
+      section: "workspaces",
+      label: "Copy change request link",
+    },
+  },
+  {
+    id: "workspace-pr-copy-ctrl-shift-c-non-mac",
+    action: "workspace.pr.copy",
+    combo: "Ctrl+Shift+C",
+    when: { mac: false, commandCenter: false, terminal: false },
+    help: {
+      id: "copy-pr-link",
+      section: "workspaces",
+      label: "Copy change request link",
     },
   },
 

--- a/packages/app/src/keyboard/route-shortcut.test.ts
+++ b/packages/app/src/keyboard/route-shortcut.test.ts
@@ -37,6 +37,7 @@ describe("routeKeyboardShortcut — dispatch passthroughs", () => {
     ["workspace.project.pick", { id: "workspace.project.pick", scope: "workspace" }],
     ["workspace.archive", { id: "workspace.archive", scope: "sidebar" }],
     ["workspace.pin", { id: "workspace.pin", scope: "sidebar" }],
+    ["workspace.pr.copy", { id: "workspace.pr.copy", scope: "workspace" }],
     ["worktree.new", { id: "worktree.new", scope: "sidebar" }],
     ["workspace.terminal.new", { id: "workspace.terminal.new", scope: "workspace" }],
     ["workspace.tab.close.current", { id: "workspace.tab.close-current", scope: "workspace" }],

--- a/packages/app/src/keyboard/route-shortcut.ts
+++ b/packages/app/src/keyboard/route-shortcut.ts
@@ -49,6 +49,7 @@ const PASSTHROUGH_DISPATCH: Record<string, KeyboardActionDefinition> = {
   "workspace.project.pick": { id: "workspace.project.pick", scope: "workspace" },
   "workspace.archive": { id: "workspace.archive", scope: "sidebar" },
   "workspace.pin": { id: "workspace.pin", scope: "sidebar" },
+  "workspace.pr.copy": { id: "workspace.pr.copy", scope: "workspace" },
   "worktree.new": { id: "worktree.new", scope: "sidebar" },
   "workspace.terminal.new": { id: "workspace.terminal.new", scope: "workspace" },
   "workspace.tab.close.current": { id: "workspace.tab.close-current", scope: "workspace" },


### PR DESCRIPTION
### Linked issue

Closes # (feature request: copy the workspace's PR link via a keyboard shortcut)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Working on a workspace, there is no quick way to grab the URL of the change request the workspace is pinned to — you have to open the forge in a tab or use View PR and copy from the browser. This PR adds a keyboard shortcut that copies the link straight to the clipboard, so it can be pasted into a chat, an issue, or a doc without leaving Paseo.

### Goals

- `Cmd+Shift+C` on macOS, `Ctrl+Shift+C` on Windows/Linux copies the active workspace's change request URL (`Cmd+Shift+C` was free after Changes moved to `Cmd+Shift+G`)
- Works from the active route selection (like the pin shortcut), so it keeps working while the sidebar is collapsed or focus mode hides the row
- Reads the URL from the workspace descriptor's `githubRuntime` — the same source the sidebar's change-request badge and the View PR action use — so it never copies a link the UI does not show
- Success toast uses the forge noun ("Copied PR link" / "Copied MR link"); an error toast ("No change request found for this workspace") fires when there is nothing to copy
- Listed in the keyboard-shortcuts help sheet and Settings > Keyboard shortcuts (Projects & Workspaces section), rebindable like every other row
- Translated across all 9 locales, with `_mr` context variants for GitLab

### Non-goals

- No command-center entry or header-menu item — this PR is scoped to the keyboard shortcut; surfacing it as a command can come later if wanted
- No mobile equivalent (keyboard shortcuts are a desktop/web input surface)

### QA

**Automated:**

- `keyboard-shortcuts.test.ts`: new bindings match `Cmd+Shift+C` (mac) and `Ctrl+Shift+C` (non-mac); help rows render the right keys on desktop mac and non-mac
- `route-shortcut.test.ts`: the new action is a passthrough dispatch. This wiring was load-bearing — without the passthrough entry the matcher fires but no handler is reached, which the first e2e run caught
- `resources.test.ts`: all 9 locales stay key-complete
- Full unit suite of the touched modules: 245 tests green
- `npm run typecheck`, `npm run lint`, `npm run format` all pass (also enforced by lefthook pre-commit)

**Browser e2e (new spec, passing locally):**

- `e2e/browser/copy-pr-link-shortcut.spec.ts` seeds a real PR workspace through the fake `gh` fixture (fully local, no network), waits for the View PR action, presses Cmd/Ctrl+Shift+C, and asserts (1) the "Copied PR link" toast appears and (2) the actual clipboard contents equal `https://github.com/paseo-e2e/local-fixture/pull/1`
- A second test presses the shortcut on a workspace without a change request and asserts the error toast

```
2 passed (26.9s)
```

The spec also captures a screenshot of the passing run to `/tmp/pr-copy-shortcut/copied-pr-link-toast.png` (toast visible, View PR action present, `#1` badge on the workspace row).

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
