### PR TITLE
fix(app): replace painted timeline rows on cursorless tail pages

### DIFF
--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -3570,6 +3570,51 @@ describe("processTimelineResponse", () => {
     expect(result.sideEffects.some((e) => e.type === "flush_pending_updates")).toBe(true);
   });
 
+  it("replaces painted rows with a tail page when no cursor anchors them", () => {
+    const priorRows = [
+      makeTimelineEntry(1, "I really like their bass lines", "user_message"),
+      makeTimelineEntry(2, "Totally, the bass is often the real hook.", "assistant_message"),
+    ];
+    const painted = hydrateStreamState(
+      priorRows.map((entry) => ({
+        event: {
+          type: "timeline",
+          provider: entry.provider,
+          item: entry.item,
+        } as AgentStreamEventPayload,
+        timestamp: new Date(entry.timestamp),
+        timelineCursor: { epoch: "epoch-1", seq: entry.seqStart },
+      })),
+      { source: "canonical" },
+    );
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: painted,
+      currentCursor: undefined,
+      isInitializing: false,
+      hasActiveInitDeferred: false,
+      payload: {
+        ...baseTimelineInput.payload,
+        direction: "tail",
+        epoch: "epoch-2",
+        window: { minSeq: 1, maxSeq: 2, nextSeq: 3 },
+        startCursor: { seq: 1 },
+        endCursor: { seq: 2 },
+        entries: priorRows,
+      },
+    });
+
+    expect(result.tail.map((item) => item.kind)).toEqual(["user_message", "assistant_message"]);
+    expect(result.tail.map((item) => item.timelineCursor)).toEqual([
+      { epoch: "epoch-2", seq: 1 },
+      { epoch: "epoch-2", seq: 2 },
+    ]);
+    expect(result.head).toEqual([]);
+    expect(result.cursor).toEqual({ epoch: "epoch-2", startSeq: 1, endSeq: 2 });
+    expect(result.cursorChanged).toBe(true);
+  });
+
   it("initializes cursor when no existing cursor on first entries", () => {
     const result = processTimelineResponse({
       ...baseTimelineInput,

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -310,6 +310,7 @@ function deriveBootstrapTailTimelinePolicy({
   endCursor,
   isInitializing,
   hasActiveInitDeferred,
+  hasCurrentCursor,
 }: {
   direction: TimelineDirection;
   reset: boolean;
@@ -317,6 +318,7 @@ function deriveBootstrapTailTimelinePolicy({
   endCursor: { seq: number } | null;
   isInitializing: boolean;
   hasActiveInitDeferred: boolean;
+  hasCurrentCursor: boolean;
 }): {
   replace: boolean;
   catchUpCursor: { epoch: string; endSeq: number } | null;
@@ -327,6 +329,11 @@ function deriveBootstrapTailTimelinePolicy({
 
   const isBootstrapTailInit = direction === "tail" && isInitializing && hasActiveInitDeferred;
   if (!isBootstrapTailInit) {
+    // Without a cursor nothing anchors the painted rows to this page. Appending would
+    // relocate the matched prompt and duplicate the reply, so the tail page replaces them.
+    if (direction === "tail" && !hasCurrentCursor) {
+      return { replace: true, catchUpCursor: null };
+    }
     return { replace: false, catchUpCursor: null };
   }
 
@@ -1324,6 +1331,7 @@ export function processTimelineResponse(
     endCursor: payload.endCursor,
     isInitializing,
     hasActiveInitDeferred,
+    hasCurrentCursor: currentCursor !== undefined,
   });
   const replace = bootstrapPolicy.replace;
   const sideEffects: TimelineReducerSideEffect[] = [];


### PR DESCRIPTION
### Linked issue

Closes #4255

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

After archiving and later unarchiving a workspace, the desktop app sometimes rendered the agent's last reply twice, with the prompt between the two copies. The daemon's timeline was correct; the duplicate came from the app's timeline reducer.

When the agent's rows are already painted locally (from an earlier view or the replica cache) but no cursor anchors them, and a `tail` page arrives while no initialization deferred is active, `processTimelineResponse` took the incremental path. With no cursor, `acceptIncrementalTimelineUnits` accepted every row, `placeCanonicalUserMessageAtTail` matched the existing prompt and moved it to the end, and the reply was appended as a new item. Tail fetches without an init deferred include the unarchive flow through `refreshAgent`, the `agent.timeline.replacement` handler, and late timeline responses whose request already failed or timed out.

A tail page is the authoritative view of the timeline when nothing anchors the local rows, so it now replaces them instead of appending.

### Goals

- A `tail` page applied with no current cursor replaces painted rows instead of appending to them.
- Existing bootstrap, resume, and reset behaviour is unchanged.
- Regression test covering the painted-rows + cursorless tail page case.

### Non-goals

- Changing which app flows fetch a tail page without an initialization deferred.
- Changing how the daemon builds or resets timeline epochs on unarchive.

### QA

- Reproduced the bug in a unit test first: painted prompt + reply from epoch-1 with no cursor and no init deferred, then a `tail` page for epoch-2 with the same two rows. Before the fix the tail came back with three items (the reply duplicated); after the fix it is exactly prompt + reply carrying the epoch-2 cursors.
- `NODE_ENV=test npx vitest run packages/app/src/timeline/session-stream-reducers.test.ts`: 121 passed.
- `npm run typecheck`, `npm run lint`, `npm run format:check` on the changed files: clean.
- Live check: a fast archive → History → Unarchive cycle in a dev daemon (web app driven by Playwright, Claude agent) renders one prompt and one reply before and after the change; that flow keeps a cursor and never hit the broken path, which is why the field report was intermittent.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)
