### PR TITLE
Handle draft tabs on an offline host

### DIFF
--- a/packages/app/src/composer/draft/workspace-tab.test.ts
+++ b/packages/app/src/composer/draft/workspace-tab.test.ts
@@ -27,6 +27,19 @@ describe("workspace draft agent model validation", () => {
     expect(validate({})).toBeNull();
   });
 
+  test("reports the disconnected host before the empty provider list", () => {
+    expect(
+      validate({
+        hasClient: false,
+        composerState: {
+          ...baseComposerState,
+          providerDefinitions: [],
+          selectedProvider: null,
+        },
+      }),
+    ).toBe("Host is not connected");
+  });
+
   test("keeps waiting while model defaults are loading", () => {
     expect(
       validate({

--- a/packages/app/src/hooks/use-agent-form-state.ts
+++ b/packages/app/src/hooks/use-agent-form-state.ts
@@ -6,6 +6,7 @@ import type {
   AgentProvider,
   ProviderSnapshotEntry,
 } from "@getpaseo/protocol/agent-types";
+import { useHostRuntimeConnectionStatus } from "@/runtime/host-runtime";
 import { buildProviderDefinitions } from "@/utils/provider-definitions";
 import {
   buildSelectableProviderSelectorProviders,
@@ -185,6 +186,10 @@ export function useAgentFormState(options: UseAgentFormStateOptions): UseAgentFo
     refresh: refreshSnapshot,
     refetchIfStale: refetchSnapshotIfStale,
   } = useProvidersSnapshot(serverId, { cwd: workingDir });
+  const hostConnectionStatus = useHostRuntimeConnectionStatus(serverId ?? "");
+  // The snapshot query is disabled while the host is unreachable, so resolution
+  // stays pending with no data. That is not "loading"; it resumes on reconnect.
+  const isHostUnreachable = hostConnectionStatus === "offline" || hostConnectionStatus === "error";
 
   const allProviderEntries = useMemo(() => snapshotEntries ?? [], [snapshotEntries]);
   const snapshotProviderDefinitions = useMemo(
@@ -247,7 +252,8 @@ export function useAgentFormState(options: UseAgentFormStateOptions): UseAgentFo
   const availableModels = snapshotSelectedProviderModels;
   const modeOptions = snapshotSelectedProviderModes;
   const isModelSelectionLoading =
-    resolution.status === "pending" || snapshotIsLoading || selectedProviderIsLoading;
+    !isHostUnreachable &&
+    (resolution.status === "pending" || snapshotIsLoading || selectedProviderIsLoading);
   const isAllModelsLoading = isModelSelectionLoading;
 
   useEffect(() => {

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -520,13 +520,15 @@ type AgentLookupState =
   | { tag: "not_found"; message: string }
   | { tag: "error"; message: string };
 
-function useHostUnavailableState(serverId: string | null): {
+interface HostUnavailableState {
   serverLabel: string;
   connectionStatus: HostRuntimeConnectionStatus;
   lastError: string | null;
   isUnknownDaemon: boolean;
   t: TFunction;
-} {
+}
+
+function useHostUnavailableState(serverId: string | null): HostUnavailableState {
   const { t } = useTranslation();
   const daemons = useHosts();
   const runtimeServerId = serverId ?? "";
@@ -1740,15 +1742,9 @@ function AgentSessionUnavailableState({
   serverLabel,
   connectionStatus,
   lastError,
-  isUnknownDaemon = false,
+  isUnknownDaemon,
   t,
-}: {
-  serverLabel: string;
-  connectionStatus: HostRuntimeConnectionStatus;
-  lastError: string | null;
-  isUnknownDaemon?: boolean;
-  t: TFunction;
-}) {
+}: HostUnavailableState) {
   if (isUnknownDaemon) {
     return (
       <View style={styles.container}>

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -406,6 +406,8 @@ function DraftPanel() {
   } = usePaneContext();
   const { isInteractive } = usePaneFocus();
   invariant(target.kind === "draft", "DraftPanel requires draft target");
+  const runtimeClient = useHostRuntimeClient(serverId);
+  const hostUnavailable = useHostUnavailableState(serverId);
 
   const handleCreated = useCallback(
     (agentSnapshot: Parameters<typeof normalizeAgentSnapshot>[0]) => {
@@ -416,6 +418,10 @@ function DraftPanel() {
     },
     [retargetCurrentTab, serverId],
   );
+
+  if (!runtimeClient) {
+    return <AgentSessionUnavailableState {...hostUnavailable} />;
+  }
 
   return (
     <WorkspaceDraftAgentTab
@@ -514,6 +520,28 @@ type AgentLookupState =
   | { tag: "not_found"; message: string }
   | { tag: "error"; message: string };
 
+function useHostUnavailableState(serverId: string | null): {
+  serverLabel: string;
+  connectionStatus: HostRuntimeConnectionStatus;
+  lastError: string | null;
+  isUnknownDaemon: boolean;
+  t: TFunction;
+} {
+  const { t } = useTranslation();
+  const daemons = useHosts();
+  const runtimeServerId = serverId ?? "";
+  const runtimeConnectionStatus = useHostRuntimeConnectionStatus(runtimeServerId);
+  const lastError = useHostRuntimeLastError(runtimeServerId);
+  const daemon = serverId ? (daemons.find((entry) => entry.serverId === serverId) ?? null) : null;
+  const serverLabel = daemon?.label ?? serverId ?? t("agentPanel.unavailable.selectedHost");
+  const isUnknownDaemon = Boolean(serverId && !daemon);
+  const connectionStatus: HostRuntimeConnectionStatus =
+    isUnknownDaemon && runtimeConnectionStatus === "connecting"
+      ? "offline"
+      : runtimeConnectionStatus;
+  return { serverLabel, connectionStatus, lastError, isUnknownDaemon, t };
+}
+
 function AgentPanelContent({
   serverId,
   workspaceId,
@@ -527,15 +555,12 @@ function AgentPanelContent({
   isPaneFocused: boolean;
   onOpenWorkspaceFile?: (request: WorkspaceFileOpenRequest) => void;
 }) {
-  const { t } = useTranslation();
   const resolvedAgentId = agentId.trim() || undefined;
   const resolvedServerId = serverId.trim() || undefined;
-  const daemons = useHosts();
   const runtimeServerId = resolvedServerId ?? "";
   const runtimeClient = useHostRuntimeClient(runtimeServerId);
   const runtimeIsConnected = useHostRuntimeIsConnected(runtimeServerId);
-  const runtimeConnectionStatus = useHostRuntimeConnectionStatus(runtimeServerId);
-  const runtimeLastError = useHostRuntimeLastError(runtimeServerId);
+  const hostUnavailable = useHostUnavailableState(resolvedServerId ?? null);
   const hasCachedAgent = useSessionStore((state) => {
     if (!resolvedServerId || !resolvedAgentId) return false;
     const session = state.sessions[resolvedServerId];
@@ -544,30 +569,10 @@ function AgentPanelContent({
     );
   });
 
-  const connectionServerId = resolvedServerId ?? null;
-  const daemon = connectionServerId
-    ? (daemons.find((entry) => entry.serverId === connectionServerId) ?? null)
-    : null;
-  const serverLabel =
-    daemon?.label ?? connectionServerId ?? t("agentPanel.unavailable.selectedHost");
-  const isUnknownDaemon = Boolean(connectionServerId && !daemon);
-  const connectionStatus: HostRuntimeConnectionStatus =
-    isUnknownDaemon && runtimeConnectionStatus === "connecting"
-      ? "offline"
-      : runtimeConnectionStatus;
-  const lastConnectionError = runtimeLastError;
-
   if (!resolvedServerId || (!runtimeClient && !hasCachedAgent)) {
-    return (
-      <AgentSessionUnavailableState
-        serverLabel={serverLabel}
-        connectionStatus={connectionStatus}
-        lastError={lastConnectionError}
-        isUnknownDaemon={isUnknownDaemon}
-        t={t}
-      />
-    );
+    return <AgentSessionUnavailableState {...hostUnavailable} />;
   }
+  const connectionStatus = hostUnavailable.connectionStatus;
 
   return (
     <AgentPanelBody

--- a/packages/app/src/provider-selection/provider-selection.test.ts
+++ b/packages/app/src/provider-selection/provider-selection.test.ts
@@ -391,6 +391,25 @@ describe("combined model selector data", () => {
     ).toEqual({ ok: true });
   });
 
+  it("blames the disconnected host rather than the missing provider snapshot", () => {
+    expect(
+      resolveSubmissionReadiness({
+        text: "hello",
+        allowsEmptyAutoSubmit: false,
+        providerCount: 0,
+        selection: {
+          provider: null,
+          modelId: "",
+          availableModels: [],
+          isModelLoading: false,
+        },
+        autoSubmitConfig: null,
+        workspaceDirectory: "/repo",
+        hasClient: false,
+      }),
+    ).toEqual({ ok: false, reason: "Host is not connected" });
+  });
+
   it("uses the active app language for utility labels", async () => {
     await i18n.changeLanguage("zh-CN");
     try {

--- a/packages/app/src/provider-selection/provider-selection.ts
+++ b/packages/app/src/provider-selection/provider-selection.ts
@@ -329,6 +329,9 @@ export function resolveSubmissionReadiness(input: {
   if (!input.allowsEmptyAutoSubmit && !input.text.trim()) {
     return { ok: false, reason: i18n.t("providerSelection.readiness.initialPromptRequired") };
   }
+  if (!input.hasClient) {
+    return { ok: false, reason: i18n.t("providerSelection.readiness.hostDisconnected") };
+  }
   if (input.providerCount === 0) {
     return { ok: false, reason: i18n.t("providerSelection.readiness.noProviders") };
   }
@@ -344,9 +347,6 @@ export function resolveSubmissionReadiness(input: {
   }
   if (!input.workspaceDirectory) {
     return { ok: false, reason: i18n.t("providerSelection.readiness.workspaceDirectoryNotFound") };
-  }
-  if (!input.hasClient) {
-    return { ok: false, reason: i18n.t("providerSelection.readiness.hostDisconnected") };
   }
   return { ok: true };
 }


### PR DESCRIPTION
Fixes #4257

## Problem

Opening a draft agent tab whose host is offline left the model selector stuck on "Loading..." indefinitely, and the submit gate reported "No available providers on the selected host" instead of "Host is not connected". The providers snapshot query is disabled while the host is unreachable, which left the draft form's resolution pending with no data and nothing downstream could tell "offline" from "still fetching".

## Changes

- **Readiness ordering** (`provider-selection.ts`): check for a connected host before the provider count, so the reported reason is "Host is not connected".
- **Form loading gate** (`use-agent-form-state.ts`): read the host connection status and stop reporting model loading while the host is `offline` or `error`. Resolution stays pending underneath and still completes on reconnect.
- **Draft panel host gate** (`agent-panel.tsx`): render the existing host-unavailable state on the draft panel when the host has no client. The status/label logic is extracted into a shared `useHostUnavailableState` hook used by both the agent and draft panels.

Auto-submit needs no separate change: the draft composer no longer mounts while the host is down, so a queued create-and-send waits in its store and fires once the host reconnects.

## Testing

- New tests for the readiness ordering at the readiness function and the draft validation layer.
- `provider-selection.test.ts` and `workspace-tab.test.ts` pass (21 tests).
- Format, lint, and full workspace typecheck pass (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
