### PR TITLE
fix(server): keep system errors separate from replies

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -6114,7 +6114,7 @@ test("ignores stale autonomous terminals without lowering the active turn lifecy
   });
 });
 
-test("preserves terminal fallback when no active turn identity was observed", async () => {
+test("preserves terminal fallback and separates untracked failure activity", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-untracked-terminal-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);
   let capturedSession: TestAgentSession | null = null;
@@ -6135,6 +6135,11 @@ test("preserves terminal fallback when no active turn identity was observed", as
   const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
     workspaceId: undefined,
   });
+  await manager.appendTimelineItem(snapshot.id, {
+    type: "assistant_message",
+    text: "Task completed.",
+    messageId: "assistant-1",
+  });
 
   capturedSession!.pushEvent({
     type: "turn_failed",
@@ -6150,10 +6155,22 @@ test("preserves terminal fallback when no active turn identity was observed", as
   });
   expect(manager.getTimeline(snapshot.id)).toContainEqual(
     expect.objectContaining({
-      type: "assistant_message",
-      text: expect.stringContaining("untracked failure"),
+      type: "error",
+      message: expect.stringContaining("untracked failure"),
     }),
   );
+  const projected = projectTimelineRows({
+    rows: await manager.getTimelineRows(snapshot.id),
+    mode: "projected",
+  });
+  expect(projected.map((entry) => entry.item)).toEqual([
+    {
+      type: "assistant_message",
+      text: "Task completed.",
+      messageId: "assistant-1",
+    },
+    { type: "error", message: "untracked failure" },
+  ]);
 });
 
 test("cancelAgentRun waits for an acknowledged autonomous interrupt to settle", async () => {
@@ -8015,7 +8032,7 @@ test("archiveAgent cascade surfaces partial child archive failures", async () =>
   );
 });
 
-test("turn_failed emits a system error assistant timeline message and keeps error lifecycle", async () => {
+test("turn_failed emits error activity and keeps error lifecycle", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-turn-failed-"));
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
@@ -8083,12 +8100,9 @@ test("turn_failed emits a system error assistant timeline message and keeps erro
 
   const systemErrors = manager
     .getTimeline(agent.id)
-    .filter(
-      (item): item is Extract<AgentTimelineItem, { type: "assistant_message" }> =>
-        item.type === "assistant_message" && item.text.includes("[System Error]"),
-    );
+    .filter((item): item is Extract<AgentTimelineItem, { type: "error" }> => item.type === "error");
   expect(systemErrors).toHaveLength(1);
-  expect(systemErrors[0]?.text).toContain("invalid model id");
+  expect(systemErrors[0]?.message).toContain("invalid model id");
 });
 
 test("turn_failed surfaces provider code and diagnostic in system error message", async () => {
@@ -8159,13 +8173,10 @@ test("turn_failed surfaces provider code and diagnostic in system error message"
 
   const systemError = manager
     .getTimeline(agent.id)
-    .find(
-      (item): item is Extract<AgentTimelineItem, { type: "assistant_message" }> =>
-        item.type === "assistant_message" && item.text.includes("[System Error]"),
-    );
-  expect(systemError?.text).toContain("Provider execution failed");
-  expect(systemError?.text).toContain("code: 126");
-  expect(systemError?.text).toContain("No preset version installed for command claude");
+    .find((item): item is Extract<AgentTimelineItem, { type: "error" }> => item.type === "error");
+  expect(systemError?.message).toContain("Provider execution failed");
+  expect(systemError?.message).toContain("code: 126");
+  expect(systemError?.message).toContain("No preset version installed for command claude");
 });
 
 test("permission request notifies once without forcing unread attention state", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -513,8 +513,6 @@ interface AgentMetadataPatch {
   labels?: AgentLabelPatch;
 }
 
-const SYSTEM_ERROR_PREFIX = "[System Error]";
-
 function attachPersistenceCwd(
   handle: AgentPersistenceHandle | null,
   cwd: string,
@@ -4419,13 +4417,12 @@ export class AgentManager {
       return;
     }
 
-    const text = `${SYSTEM_ERROR_PREFIX} ${normalized}`;
     const lastItem = await this.getLastItemFromStores(agent.id);
-    if (lastItem?.type === "assistant_message" && lastItem.text === text) {
+    if (lastItem?.type === "error" && lastItem.message === normalized) {
       return;
     }
 
-    const item: AgentTimelineItem = { type: "assistant_message", text };
+    const item: AgentTimelineItem = { type: "error", message: normalized };
     const row = this.recordTimeline(agent.id, item);
     this.dispatchStream(
       agent.id,


### PR DESCRIPTION
### Linked issue

Closes #4262

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The daemon stores its own turn failures as unscoped `assistant_message` rows with a `[System Error]` prefix. Projected timelines merge adjacent assistant chunks, so a failure immediately after a model response becomes part of that response and looks model-authored.

The protocol and every client already support a dedicated `error` timeline item. This change uses that item for new daemon-generated failures and deduplicates consecutive identical typed errors.

Persisted legacy rows are not reclassified or used for deduplication: without provenance, an unscoped provider message with the same text cannot be distinguished safely from the old daemon format.

### Goals

- Persist new daemon-generated system failures as `error` timeline items.
- Keep consecutive identical typed failure deduplication.
- Verify that an untracked turn failure remains separate from the preceding assistant response after projection.
- Keep provider error text and agent lifecycle behavior unchanged.

### Non-goals

- Rewrite or reclassify persisted legacy timeline rows.
- Deduplicate across the ambiguous legacy assistant-message representation.
- Change the protocol schema or client error component.
- Change provider error text, retry behavior, or lifecycle transitions.

### QA

#### Reproduction before the fix

Built `eb753813a` and projected the two canonical rows from #4262:

```sh
npm run build:server
node --input-type=module -e 'import { projectTimelineRows } from "./packages/server/dist/server/server/agent/timeline-projection.js"; const rows=[{seq:1,timestamp:"2026-02-13T00:00:00.000Z",item:{type:"assistant_message",text:"Task completed.",messageId:"msg-1"}},{seq:2,timestamp:"2026-02-13T00:00:00.100Z",item:{type:"assistant_message",text:"[System Error] provider failed"}}]; console.log(JSON.stringify(projectTimelineRows({rows,mode:"projected"}),null,2));'
```

Raw result:

```json
[
  {
    "item": {
      "type": "assistant_message",
      "text": "Task completed.[System Error] provider failed",
      "messageId": "msg-1"
    },
    "seqStart": 1,
    "seqEnd": 2,
    "collapsed": ["assistant_merge"]
  }
]
```

The initial focused reproducer produced:

```text
FAIL packages/server/src/server/agent/timeline-projection.test.ts
AssertionError: expected [ { item: { …(3) }, …(5) } ] to have a length of 2 but got 1

Test Files  1 failed (1)
Tests       1 failed | 3 passed (21)
```

#### Result after the fix

The retained regression drives the real AgentManager event path: it appends an identified assistant response, emits an untracked `turn_failed`, reads the manager's canonical rows, and projects them. It asserts this exact result:

```json
[
  {
    "type": "assistant_message",
    "text": "Task completed.",
    "messageId": "assistant-1"
  },
  {
    "type": "error",
    "message": "untracked failure"
  }
]
```

Focused output:

```text
$ npx vitest run packages/server/src/server/agent/agent-manager.test.ts -t "preserves terminal fallback and separates untracked failure activity" --reporter=verbose --bail=1

✓ preserves terminal fallback and separates untracked failure activity

Test Files  1 passed (1)
Tests       1 passed | 170 skipped (171)
```

#### Automated checks

```text
$ npx vitest run packages/server/src/server/agent/agent-manager.test.ts --bail=1
Test Files  1 passed (1)
Tests       171 passed (171)

$ npm run typecheck
@getpaseo/expo-two-way-audio, highlight, plugin, protocol, client, server,
app, relay, website, desktop, and cli typechecks completed successfully.

$ npm run lint
Found 0 warnings and 0 errors.
Finished in 7.5s on 3997 files with 177 rules using 8 threads.

$ npm run format
Finished in 19460ms on 4256 files using 8 threads.

$ npm run build --workspace=@getpaseo/server
@getpaseo/server build:lib and build:scripts completed successfully.

$ git diff --check
# no output
```

The final pre-commit hook repeated formatting, lint, and the full workspace typecheck successfully.

Dependency installation used npm 11.6.0 because the host npm 9.2.0 cannot parse the repository's `react-native-reanimated >=4.0.0-` peer range. The host runs Node 20.19.2; npm reported engine warnings for app/desktop dependencies that require 20.19.4 or Node 22, but the checks listed above completed.

#### Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | No client code changed |
| Android | No | No client code changed |
| Web | No | Existing error timeline renderer is unchanged |
| Desktop macOS | No | No access to macOS |
| Desktop Windows | No | No access to Windows |
| Desktop Linux | No | No desktop UI code changed |
| Daemon Linux | Yes | Debian 13, kernel 6.12.101; AgentManager regression and server build |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense