### PR TITLE
feat(pi): surface pi-subagents runs in the Subagents Track

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -253,6 +253,13 @@ class SessionEvents {
     );
   }
 
+  providerSubagentEvents() {
+    return this.events.filter(
+      (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
+        event.type === "provider_subagent",
+    );
+  }
+
   nextTurnCompletion(): Promise<Extract<AgentStreamEvent, { type: "turn_completed" }>> {
     return this.nextEvent(
       (event): event is Extract<AgentStreamEvent, { type: "turn_completed" }> =>
@@ -1388,6 +1395,49 @@ describe("PiRpcAgentSession", () => {
     await expect(events.nextTurnFailure()).resolves.toMatchObject({
       error: "Pi exited",
     });
+  });
+
+  test("cancels tracked subagents when the Pi process exits", async () => {
+    const { pi, session, events } = await createSession();
+
+    await session.startTurn("hello");
+    pi.latestSession().emit({
+      type: "tool_execution_start",
+      toolCallId: "sub-1",
+      toolName: "subagent",
+      args: { agent: "explore", task: "Find auth code" },
+    });
+    pi.latestSession().emit({ type: "process_exit", error: "Pi exited" });
+
+    await expect(events.nextTurnFailure()).resolves.toMatchObject({
+      error: "Pi exited",
+    });
+    expect(events.providerSubagentEvents()).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "upsert",
+          id: "sub-1",
+          title: "explore",
+          description: "Find auth code",
+          status: "running",
+          toolCallId: "sub-1",
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "upsert",
+          id: "sub-1",
+          title: "explore",
+          description: "Find auth code",
+          status: "canceled",
+          toolCallId: "sub-1",
+        },
+      },
+    ]);
   });
 
   test("completes locally handled slash commands when agentInvoked is false", async () => {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1459,6 +1459,14 @@ export class PiRpcAgentSession implements AgentSession {
       this.provider,
       await this.runtimeSession.getMessages(),
       this.capturedUserEntries,
+      {
+        onSubagentReplayError: (error, sessionFile) => {
+          this.logger.debug(
+            { err: error, sessionFile },
+            "Failed to read Pi subagent child session",
+          );
+        },
+      },
     );
   }
 
@@ -2223,7 +2231,9 @@ export class PiRpcAgentSession implements AgentSession {
         this.activeToolCalls.set(event.toolCallId, toolCall);
         this.activeAskUserDialog = readActiveAskUserDialog(event.toolName, event.args);
         this.emitToolCallEvent(event.toolCallId, toolCall, "running", null, null);
-        this.handleSubagentStart(event.toolCallId, event.args);
+        if (event.toolName === "subagent") {
+          this.handleSubagentStart(event.toolCallId, event.args);
+        }
         return;
       }
       case "tool_execution_update": {
@@ -2234,7 +2244,9 @@ export class PiRpcAgentSession implements AgentSession {
 
         const partialResult = parseToolResult(event.partialResult);
         this.emitToolCallEvent(event.toolCallId, toolCall, "running", partialResult, null);
-        this.handleSubagentUpdate(event.toolCallId, event.partialResult);
+        if (event.toolName === "subagent") {
+          this.handleSubagentUpdate(event.toolCallId, event.partialResult);
+        }
         return;
       }
       case "tool_execution_end": {
@@ -2433,10 +2445,13 @@ export class PiRpcAgentSession implements AgentSession {
     void this.subagentTracker
       .end(toolCallId, result, isError)
       .then((subagentEvents) => {
-        for (const subagentEvent of subagentEvents) {
+        // null: the tracked call was canceled (interrupt/close) while end() was
+        // reading the child transcript. Emit nothing so the canceled status
+        // sticks instead of resurrecting the run as completed.
+        for (const subagentEvent of subagentEvents ?? []) {
           this.emit(subagentEvent);
         }
-        return subagentEvents.length;
+        return subagentEvents === null ? 0 : subagentEvents.length;
       })
       .catch((error) => {
         this.logger.warn({ err: error }, "Failed to finalize Pi subagent tracking");

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -66,6 +66,7 @@ import {
 import { materializeProviderImage } from "../provider-image-output.js";
 import { PiCliRuntime } from "./cli-runtime.js";
 import { revertPiConversation } from "./rewind.js";
+import { PiSubagentTracker } from "./subagent-tracker.js";
 import { listPiImportableSessions, readPiImportSessionConfig } from "./session-descriptor.js";
 import type { PiRuntime, PiRuntimeSession, PiStartSessionInput } from "./runtime.js";
 import type {
@@ -1250,6 +1251,7 @@ export class PiRpcAgentSession implements AgentSession {
   private readonly currentModeId: string | null;
   private readonly logger: Logger;
   private readonly usagePoller: PiUsagePoller;
+  private readonly subagentTracker: PiSubagentTracker;
   private closed = false;
   // Pi reports an aborted OpenAI Responses stream before the abort RPC resolves.
   // Keep the turn active until that RPC acknowledges the user-requested cancellation.
@@ -1271,6 +1273,7 @@ export class PiRpcAgentSession implements AgentSession {
       null;
     this.extensionTimeoutMs = options.extensionTimeoutMs ?? DEFAULT_PI_EXTENSION_RESULT_TIMEOUT_MS;
     this.logger = options.logger;
+    this.subagentTracker = new PiSubagentTracker(options.logger);
     this.usagePoller = new PiUsagePoller({
       scheduler: options.usagePollScheduler,
       readStats: () => this.runtimeSession.getSessionStats(),
@@ -1594,6 +1597,9 @@ export class PiRpcAgentSession implements AgentSession {
     if (this.interruptedTerminalError?.turnId === turnId) {
       this.interruptedTerminalError = null;
     }
+    for (const subagentEvent of this.subagentTracker.cancelAll()) {
+      this.emit(subagentEvent);
+    }
   }
 
   async revertConversation(input: { messageId: string }): Promise<void> {
@@ -1630,6 +1636,9 @@ export class PiRpcAgentSession implements AgentSession {
     }
     this.closed = true;
     this.usagePoller.close();
+    for (const subagentEvent of this.subagentTracker.cancelAll()) {
+      this.emit(subagentEvent);
+    }
     try {
       await this.runtimeSession.close();
     } finally {
@@ -2214,6 +2223,7 @@ export class PiRpcAgentSession implements AgentSession {
         this.activeToolCalls.set(event.toolCallId, toolCall);
         this.activeAskUserDialog = readActiveAskUserDialog(event.toolName, event.args);
         this.emitToolCallEvent(event.toolCallId, toolCall, "running", null, null);
+        this.handleSubagentStart(event.toolCallId, event.args);
         return;
       }
       case "tool_execution_update": {
@@ -2224,6 +2234,7 @@ export class PiRpcAgentSession implements AgentSession {
 
         const partialResult = parseToolResult(event.partialResult);
         this.emitToolCallEvent(event.toolCallId, toolCall, "running", partialResult, null);
+        this.handleSubagentUpdate(event.toolCallId, event.partialResult);
         return;
       }
       case "tool_execution_end": {
@@ -2293,6 +2304,9 @@ export class PiRpcAgentSession implements AgentSession {
   private handleToolExecutionEnd(
     event: Extract<PiAgentSessionEvent, { type: "tool_execution_end" }>,
   ): void {
+    if (event.toolName === "subagent") {
+      this.finalizeSubagent(event.toolCallId, event.result, event.isError === true);
+    }
     const toolCall =
       this.activeToolCalls.get(event.toolCallId) ?? parseToolArgs(event.toolName, null);
     this.activeToolCalls.delete(event.toolCallId);
@@ -2401,6 +2415,33 @@ export class PiRpcAgentSession implements AgentSession {
       this.completeTurn(turnId, []);
       return;
     }
+  }
+
+  private handleSubagentStart(toolCallId: string, args: unknown): void {
+    for (const subagentEvent of this.subagentTracker.start(toolCallId, args)) {
+      this.emit(subagentEvent);
+    }
+  }
+
+  private handleSubagentUpdate(toolCallId: string, partialResult: unknown): void {
+    for (const subagentEvent of this.subagentTracker.update(toolCallId, partialResult)) {
+      this.emit(subagentEvent);
+    }
+  }
+
+  private finalizeSubagent(toolCallId: string, result: unknown, isError: boolean): void {
+    void this.subagentTracker
+      .end(toolCallId, result, isError)
+      .then((subagentEvents) => {
+        for (const subagentEvent of subagentEvents) {
+          this.emit(subagentEvent);
+        }
+        return subagentEvents.length;
+      })
+      .catch((error) => {
+        this.logger.warn({ err: error }, "Failed to finalize Pi subagent tracking");
+        return 0;
+      });
   }
 
   private emitToolCallEvent(

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2167,6 +2167,9 @@ export class PiRpcAgentSession implements AgentSession {
 
   private handleProcessExit(error: string): void {
     this.rejectAllExtensionResults(new Error(error));
+    for (const subagentEvent of this.subagentTracker.cancelAll()) {
+      this.emit(subagentEvent);
+    }
     if (!this.activeTurnId) {
       return;
     }

--- a/packages/server/src/server/agent/providers/pi/history-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.ts
@@ -9,6 +9,15 @@ import {
   type PiToolResult,
   type PiTrackedToolCall,
 } from "./tool-call-mapper.js";
+import {
+  MAX_SUBAGENT_TIMELINE_ROWS,
+  findPiSubagentCallArgs,
+  piSubagentDescriptorId,
+  readPiSubagentInlineOutput,
+  readPiSubagentLaunchArgs,
+  readPiSubagentRunPayload,
+  streamPiChildSessionItems,
+} from "./subagent-run.js";
 
 export interface PiCapturedUserMessageEntry {
   id: string;
@@ -253,6 +262,7 @@ export async function* streamPiHistory(
       yield event;
     }
   }
+  yield* streamPiSubagentHistory(provider, messages);
 }
 
 function toToolResultTimelineItem(input: {
@@ -280,4 +290,154 @@ function toToolResultTimelineItem(input: {
     detail: input.detail,
     error: null,
   };
+}
+
+const MAX_REPLAYED_SUBAGENT_ROWS = MAX_SUBAGENT_TIMELINE_ROWS;
+
+/**
+ * Replay pi-subagents runs recorded in parent history. Each completed
+ * `subagent` tool result carries its run payload in `details` with child
+ * session files; those replays become provider subagent descriptors plus
+ * timeline rows so restored sessions keep their Subagents Track.
+ */
+async function* streamPiSubagentHistory(
+  provider: string,
+  messages: readonly PiAgentMessage[],
+): AsyncGenerator<AgentStreamEvent> {
+  for (const message of messages) {
+    if (message.role !== "toolResult" || message.toolName !== "subagent") {
+      continue;
+    }
+    const run = readPiSubagentRunPayload(
+      message.details === undefined
+        ? { content: message.content }
+        : { content: message.content, details: message.details },
+    );
+    if (!run) {
+      continue;
+    }
+    const presentation = subagentPresentation(messages, message, run);
+    yield subagentUpsertEvent(provider, presentation, "running", message.toolCallId);
+
+    yield* replaySubagentRows(provider, presentation.descriptorId, run, message);
+
+    yield subagentUpsertEvent(provider, presentation, presentation.status, message.toolCallId);
+  }
+}
+
+function subagentUpsertEvent(
+  provider: string,
+  presentation: {
+    descriptorId: string;
+    title: string;
+    description: string | null;
+    status: "completed" | "failed" | "running";
+  },
+  status: "completed" | "failed" | "running",
+  toolCallId: string,
+): AgentStreamEvent {
+  return {
+    type: "provider_subagent",
+    provider,
+    event: {
+      type: "upsert",
+      id: presentation.descriptorId,
+      title: presentation.title,
+      description: presentation.description,
+      status,
+      toolCallId,
+    },
+  };
+}
+
+function subagentPresentation(
+  messages: readonly PiAgentMessage[],
+  message: Extract<PiAgentMessage, { role: "toolResult" }>,
+  run: {
+    runId?: string;
+    asyncId?: string;
+    results: Array<{ agent?: string; task?: string; exitCode?: number; error?: string }>;
+  },
+): {
+  descriptorId: string;
+  title: string;
+  description: string | null;
+  status: "completed" | "failed";
+} {
+  const launchArgs = findPiSubagentCallArgs(messages, message.toolCallId);
+  const launch = readPiSubagentLaunchArgs(launchArgs);
+  const failed =
+    message.isError === true ||
+    run.results.some(
+      (entry) => Boolean(entry.error) || (entry.exitCode !== undefined && entry.exitCode !== 0),
+    );
+  return {
+    descriptorId: piSubagentDescriptorId(message.toolCallId, run),
+    title: firstText(launch?.agent, ...run.results.map((entry) => entry.agent)) ?? "Pi subagent",
+    description: firstText(launch?.task, ...run.results.map((entry) => entry.task)) ?? null,
+    status: failed ? "failed" : "completed",
+  };
+}
+
+async function* replaySubagentRows(
+  provider: string,
+  descriptorId: string,
+  run: { results: Array<{ sessionFile?: string }> },
+  message: Extract<PiAgentMessage, { role: "toolResult" }>,
+): AsyncGenerator<AgentStreamEvent> {
+  let rows = 0;
+  for (const entry of run.results) {
+    if (!entry.sessionFile || rows >= MAX_REPLAYED_SUBAGENT_ROWS) {
+      continue;
+    }
+    try {
+      for await (const { item, timestamp: rowTimestamp } of streamPiChildSessionItems(
+        entry.sessionFile,
+      )) {
+        if (rows >= MAX_REPLAYED_SUBAGENT_ROWS) {
+          break;
+        }
+        rows += 1;
+        yield {
+          type: "provider_subagent",
+          provider,
+          event: {
+            type: "timeline",
+            id: descriptorId,
+            item,
+            ...(rowTimestamp ? { timestamp: rowTimestamp } : {}),
+          },
+        };
+      }
+    } catch {
+      // Child transcripts are best-effort replay data; a missing or corrupt
+      // file must not fail the whole history stream.
+    }
+  }
+  if (rows === 0) {
+    const text = readPiSubagentInlineOutput({
+      content: message.content,
+      ...(message.details === undefined ? {} : { details: message.details }),
+    });
+    if (text) {
+      yield {
+        type: "provider_subagent",
+        provider,
+        event: {
+          type: "timeline",
+          id: descriptorId,
+          item: { type: "assistant_message", text },
+        },
+      };
+    }
+  }
+}
+
+function firstText(...values: (string | undefined)[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
 }

--- a/packages/server/src/server/agent/providers/pi/history-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.ts
@@ -35,6 +35,8 @@ export interface PiHistoryMapperHooks {
     result: PiToolResult,
     context: { toolCallId: string },
   ) => ToolCallDetail | null;
+  /** Invoked when a child session file fails to read during subagent replay. */
+  onSubagentReplayError?: (error: unknown, sessionFile: string) => void;
 }
 
 function isTextContentBlock(block: unknown): block is PiTextContent {
@@ -262,7 +264,7 @@ export async function* streamPiHistory(
       yield event;
     }
   }
-  yield* streamPiSubagentHistory(provider, messages);
+  yield* streamPiSubagentHistory(provider, messages, hooks);
 }
 
 function toToolResultTimelineItem(input: {
@@ -298,11 +300,14 @@ const MAX_REPLAYED_SUBAGENT_ROWS = MAX_SUBAGENT_TIMELINE_ROWS;
  * Replay pi-subagents runs recorded in parent history. Each completed
  * `subagent` tool result carries its run payload in `details` with child
  * session files; those replays become provider subagent descriptors plus
- * timeline rows so restored sessions keep their Subagents Track.
+ * timeline rows so restored sessions keep their Subagents Track. Results with
+ * no run payload (details stripped) still get a descriptor backed by the
+ * inline tool output.
  */
 async function* streamPiSubagentHistory(
   provider: string,
   messages: readonly PiAgentMessage[],
+  hooks: PiHistoryMapperHooks,
 ): AsyncGenerator<AgentStreamEvent> {
   for (const message of messages) {
     if (message.role !== "toolResult" || message.toolName !== "subagent") {
@@ -313,15 +318,59 @@ async function* streamPiSubagentHistory(
         ? { content: message.content }
         : { content: message.content, details: message.details },
     );
-    if (!run) {
+    if (run) {
+      const presentation = subagentPresentation(messages, message, run);
+      yield subagentUpsertEvent(provider, presentation, "running", message.toolCallId);
+
+      yield* replaySubagentRows(provider, presentation.descriptorId, run, message, hooks);
+
+      yield subagentUpsertEvent(provider, presentation, presentation.status, message.toolCallId);
       continue;
     }
-    const presentation = subagentPresentation(messages, message, run);
-    yield subagentUpsertEvent(provider, presentation, "running", message.toolCallId);
-
-    yield* replaySubagentRows(provider, presentation.descriptorId, run, message);
-
-    yield subagentUpsertEvent(provider, presentation, presentation.status, message.toolCallId);
+    // No run payload (details stripped by pi-subagents). Still surface the run
+    // as a descriptor backed by the inline output so the track does not lose
+    // subagents that are visible in the transcript.
+    const text = readPiSubagentInlineOutput({
+      content: message.content,
+      ...(message.details === undefined ? {} : { details: message.details }),
+    });
+    if (!text) {
+      continue;
+    }
+    const failed = message.isError === true;
+    yield {
+      type: "provider_subagent",
+      provider,
+      event: {
+        type: "upsert",
+        id: message.toolCallId,
+        title: "Pi subagent",
+        description: null,
+        status: "running",
+        toolCallId: message.toolCallId,
+      },
+    };
+    yield {
+      type: "provider_subagent",
+      provider,
+      event: {
+        type: "timeline",
+        id: message.toolCallId,
+        item: { type: "assistant_message", text },
+      },
+    };
+    yield {
+      type: "provider_subagent",
+      provider,
+      event: {
+        type: "upsert",
+        id: message.toolCallId,
+        title: "Pi subagent",
+        description: null,
+        status: failed ? "failed" : "completed",
+        toolCallId: message.toolCallId,
+      },
+    };
   }
 }
 
@@ -384,6 +433,7 @@ async function* replaySubagentRows(
   descriptorId: string,
   run: { results: Array<{ sessionFile?: string }> },
   message: Extract<PiAgentMessage, { role: "toolResult" }>,
+  hooks: PiHistoryMapperHooks,
 ): AsyncGenerator<AgentStreamEvent> {
   let rows = 0;
   for (const entry of run.results) {
@@ -409,9 +459,10 @@ async function* replaySubagentRows(
           },
         };
       }
-    } catch {
+    } catch (error) {
       // Child transcripts are best-effort replay data; a missing or corrupt
       // file must not fail the whole history stream.
+      hooks.onSubagentReplayError?.(error, entry.sessionFile!);
     }
   }
   if (rows === 0) {

--- a/packages/server/src/server/agent/providers/pi/subagent-run.ts
+++ b/packages/server/src/server/agent/providers/pi/subagent-run.ts
@@ -1,0 +1,329 @@
+import { readFile } from "node:fs/promises";
+
+import type { AgentStreamEvent, AgentTimelineItem } from "../../agent-sdk-types.js";
+import type { PiAgentMessage } from "./rpc-types.js";
+import { parseToolResult, type PiToolResult } from "./tool-call-mapper.js";
+
+const PI_PROVIDER = "pi";
+export const MAX_SUBAGENT_TIMELINE_ROWS = 200;
+
+export interface PiSubagentLaunchArgs {
+  agent?: string;
+  task?: string;
+}
+
+export interface PiSubagentProgress {
+  activityState?: string;
+  model?: string;
+}
+
+export interface PiSubagentResultEntry {
+  agent?: string;
+  task?: string;
+  model?: string;
+  exitCode?: number;
+  error?: string;
+  interrupted?: boolean;
+  stopped?: boolean;
+  timedOut?: boolean;
+  sessionFile?: string;
+  progress?: PiSubagentProgress;
+}
+
+export interface PiSubagentRunPayload {
+  mode?: string;
+  runId?: string;
+  asyncId?: string;
+  results: PiSubagentResultEntry[];
+}
+
+/** Read the model-facing launch args (`agent`, `task`) from tool call arguments. */
+export function readPiSubagentLaunchArgs(args: unknown): PiSubagentLaunchArgs | null {
+  if (!isRecord(args)) {
+    return null;
+  }
+  const agent = readText(args.agent);
+  const task = readText(args.task);
+  if (agent === undefined && task === undefined) {
+    return null;
+  }
+  return {
+    ...(agent === undefined ? {} : { agent }),
+    ...(task === undefined ? {} : { task }),
+  };
+}
+
+/**
+ * Find the `subagent` tool call arguments for a tool result in parent history,
+ * so replay can recover the original `agent`/`task` presentation.
+ */
+export function findPiSubagentCallArgs(
+  messages: readonly PiAgentMessage[],
+  toolCallId: string,
+): unknown {
+  for (const message of messages) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+    for (const block of message.content) {
+      if (block.type === "toolCall" && block.id === toolCallId && block.name === "subagent") {
+        return block.arguments;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Read the pi-subagents run payload out of a tool result. Stored under
+ * `details` on result objects; requires a `results` array to count as a run.
+ */
+export function readPiSubagentRunPayload(rawResult: unknown): PiSubagentRunPayload | null {
+  const result = parseToolResult(rawResult);
+  if (!result || typeof result === "string") {
+    return null;
+  }
+  const details = result.details;
+  if (!isRecord(details) || !Array.isArray(details.results)) {
+    return null;
+  }
+  return {
+    ...(readText(details.mode) === undefined ? {} : { mode: readText(details.mode) }),
+    ...(readText(details.runId) === undefined ? {} : { runId: readText(details.runId) }),
+    ...(readText(details.asyncId) === undefined ? {} : { asyncId: readText(details.asyncId) }),
+    results: details.results.filter(isRecord) as PiSubagentResultEntry[],
+  };
+}
+
+/** Descriptor id for a run: pi-subagents' run id when known, host tool-call id otherwise. */
+export function piSubagentDescriptorId(
+  toolCallId: string,
+  run: Pick<PiSubagentRunPayload, "runId" | "asyncId"> | null,
+): string {
+  return run?.runId ?? run?.asyncId ?? toolCallId;
+}
+
+/** "explore · ox-alpha (nous_portal)" style compact context for the shared track. */
+export function buildPiSubagentSubtitle(
+  model: string | undefined,
+  activity: string | undefined,
+): string | null {
+  const parts: string[] = [];
+  if (activity) {
+    parts.push(activity);
+  }
+  if (model) {
+    const separator = model.indexOf("/");
+    parts.push(separator > 0 ? model.slice(separator + 1) : model);
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+export function piSubagentStatusFromResult(isError: boolean): "completed" | "failed" {
+  return isError ? "failed" : "completed";
+}
+
+/**
+ * Inline tool output used as a fallback timeline row when no child transcript
+ * exists on disk (launch failure, async run, or stripped details).
+ */
+export function readPiSubagentInlineOutput(result: unknown): string | null {
+  const parsed: PiToolResult = parseToolResult(result);
+  if (!parsed) {
+    return null;
+  }
+  const parts: string[] = [];
+  if (typeof parsed === "string") {
+    parts.push(parsed);
+  } else {
+    if (Array.isArray(parsed.content)) {
+      for (const block of parsed.content) {
+        if (isRecord(block) && block.type === "text" && typeof block.text === "string") {
+          parts.push(block.text);
+        }
+      }
+    }
+    const direct = parsed.output ?? parsed.stdout ?? parsed.text;
+    if (typeof direct === "string" && direct) {
+      parts.push(direct);
+    }
+  }
+  const joined = parts.join("\n").trim();
+  return joined ? truncateText(joined) : null;
+}
+
+export function truncateText(text: string, max = 4_000): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+export function piSubagentTimelineEvents(
+  id: string,
+  items: AgentTimelineItem[],
+): AgentStreamEvent[] {
+  return items.map((item) => ({
+    type: "provider_subagent" as const,
+    provider: PI_PROVIDER,
+    event: {
+      type: "timeline" as const,
+      id,
+      item,
+    },
+  }));
+}
+
+/**
+ * Replay a completed child session file (standard Pi session JSONL) as
+ * timeline items. Yields parent-visible rows only: user prompts, assistant
+ * text, reasoning, tool calls/results.
+ */
+export async function* streamPiChildSessionItems(
+  sessionFile: string,
+): AsyncGenerator<{ item: AgentTimelineItem; timestamp: string | null }> {
+  const entries = await readChildSessionEntries(sessionFile);
+  const messages: PiAgentMessage[] = [];
+  const timestamps: (string | null)[] = [];
+  for (const entry of entries) {
+    const message = entry.message;
+    if (!isRecord(message) || typeof message.role !== "string") {
+      continue;
+    }
+    if (!["user", "assistant", "toolResult", "custom"].includes(message.role)) {
+      continue;
+    }
+    messages.push(message as unknown as PiAgentMessage);
+    timestamps.push(normalizeTimestamp(entry.timestamp));
+  }
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index]!;
+    for (const item of mapPiChildMessageItems(message)) {
+      yield { item, timestamp: timestamps[index] };
+    }
+  }
+}
+
+function mapPiChildMessageItems(message: PiAgentMessage): AgentTimelineItem[] {
+  switch (message.role) {
+    case "user": {
+      const text = readChildUserText(message.content);
+      return text ? [{ type: "user_message", text }] : [];
+    }
+    case "custom": {
+      const text = readChildUserText(message.content);
+      return text ? [{ type: "assistant_message", text }] : [];
+    }
+    case "assistant": {
+      const items: AgentTimelineItem[] = [];
+      for (const content of message.content) {
+        if (content.type === "text" && content.text) {
+          items.push({ type: "assistant_message", text: content.text });
+        } else if (content.type === "thinking" && content.thinking) {
+          items.push({ type: "reasoning", text: content.thinking });
+        } else if (content.type === "toolCall") {
+          items.push({
+            type: "tool_call",
+            callId: content.id,
+            name: content.name,
+            status: "completed",
+            detail: { type: "unknown", input: content.arguments ?? null, output: null },
+            error: null,
+          });
+        }
+      }
+      return items;
+    }
+    case "toolResult": {
+      const errorText = message.isError
+        ? (readChildUserText(message.content) ?? "Tool call failed")
+        : null;
+      const detail: AgentTimelineItem =
+        message.isError === true
+          ? {
+              type: "tool_call",
+              callId: message.toolCallId,
+              name: message.toolName,
+              status: "failed",
+              detail: { type: "unknown", input: null, output: message.content ?? null },
+              error: errorText,
+            }
+          : {
+              type: "tool_call",
+              callId: message.toolCallId,
+              name: message.toolName,
+              status: "completed",
+              detail: { type: "unknown", input: null, output: message.content ?? null },
+              error: null,
+            };
+      return [detail];
+    }
+    default:
+      return [];
+  }
+}
+
+function readChildUserText(content: unknown): string | null {
+  if (typeof content === "string") {
+    return content.trim() ? content : null;
+  }
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    if (isRecord(block) && block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    }
+  }
+  const joined = parts.join("\n\n");
+  return joined.trim() ? joined : null;
+}
+
+interface PiSessionFileEntry {
+  type?: string;
+  timestamp?: string | number;
+  message?: unknown;
+}
+
+async function readChildSessionEntries(sessionFile: string): Promise<PiSessionFileEntry[]> {
+  let content: string;
+  try {
+    content = await readFile(sessionFile, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+  return content.split("\n").flatMap((line) => {
+    if (!line.trim()) return [];
+    try {
+      const value = JSON.parse(line) as PiSessionFileEntry;
+      return value && typeof value === "object" ? [value] : [];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function normalizeTimestamp(value: unknown): string | null {
+  if (typeof value === "string") {
+    const timestamp = value.trim();
+    if (!timestamp || Number.isNaN(Date.parse(timestamp))) {
+      return null;
+    }
+    return timestamp;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  const timestampMs = value > 1_000_000_000_000 ? value : value * 1000;
+  const date = new Date(timestampMs);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}

--- a/packages/server/src/server/agent/providers/pi/subagent-tracker.test.ts
+++ b/packages/server/src/server/agent/providers/pi/subagent-tracker.test.ts
@@ -1,0 +1,368 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import pino from "pino";
+import { afterEach, describe, expect, test } from "vitest";
+
+import type { AgentStreamEvent } from "../../agent-sdk-types.js";
+import { PiSubagentTracker } from "./subagent-tracker.js";
+import { streamPiHistory } from "./history-mapper.js";
+import type { PiAgentMessage } from "./rpc-types.js";
+
+const noopLogger = pino({ level: "silent" });
+
+const SUBAGENT_TOOL_CALL_ID = "call_subagent_1";
+const RUN_ID = "run-1";
+
+function subagentArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { agent: "explore", task: "Find auth code", ...overrides };
+}
+
+function runDetails(results: Record<string, unknown>[]): Record<string, unknown> {
+  return {
+    content: [{ type: "text", text: "done" }],
+    details: {
+      mode: "single",
+      runId: RUN_ID,
+      results,
+    },
+  };
+}
+
+function childSessionLines(): string[] {
+  return [
+    JSON.stringify({
+      type: "session",
+      id: "child-session",
+      timestamp: "2026-01-01T00:00:00.000Z",
+    }),
+    JSON.stringify({
+      type: "message",
+      id: "m1",
+      timestamp: "2026-01-01T00:00:01.000Z",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "Task: Find auth code" }],
+      },
+    }),
+    JSON.stringify({
+      type: "message",
+      id: "m2",
+      timestamp: "2026-01-01T00:00:02.000Z",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "looking" },
+          { type: "text", text: "Found it in src/auth.ts" },
+        ],
+      },
+    }),
+  ];
+}
+
+async function collect(generator: AsyncGenerator<AgentStreamEvent>): Promise<AgentStreamEvent[]> {
+  const events: AgentStreamEvent[] = [];
+  for await (const event of generator) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("PiSubagentTracker", () => {
+  let tempDir: string | null = null;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  test("start with subagent args emits a running descriptor", () => {
+    const tracker = new PiSubagentTracker(noopLogger);
+    const events = tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    expect(events).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "upsert",
+          id: SUBAGENT_TOOL_CALL_ID,
+          title: "explore",
+          description: "Find auth code",
+          status: "running",
+          toolCallId: SUBAGENT_TOOL_CALL_ID,
+        },
+      },
+    ]);
+  });
+
+  test("start ignores non-subagent tool args", () => {
+    const tracker = new PiSubagentTracker(noopLogger);
+    expect(tracker.start(SUBAGENT_TOOL_CALL_ID, { command: "ls" })).toEqual([]);
+    expect(tracker.start(SUBAGENT_TOOL_CALL_ID, null)).toEqual([]);
+  });
+
+  test("update emits descriptor when progress adds a subtitle", () => {
+    const tracker = new PiSubagentTracker(noopLogger);
+    tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    const events = tracker.update(
+      SUBAGENT_TOOL_CALL_ID,
+      runDetails([{ progress: { activityState: "reading", model: "nous_portal/ox-alpha" } }]),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe("provider_subagent");
+    if (events[0]!.type === "provider_subagent" && events[0]!.event.type === "upsert") {
+      expect(events[0]!.event.subtitle).toBe("reading · ox-alpha");
+    }
+  });
+
+  test("update without new presentation emits nothing", () => {
+    const tracker = new PiSubagentTracker(noopLogger);
+    tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    const first = tracker.update(
+      SUBAGENT_TOOL_CALL_ID,
+      runDetails([{ progress: { activityState: "reading" } }]),
+    );
+    expect(first).toHaveLength(1);
+    const repeat = tracker.update(
+      SUBAGENT_TOOL_CALL_ID,
+      runDetails([{ progress: { activityState: "reading" } }]),
+    );
+    expect(repeat).toEqual([]);
+  });
+
+  test("end re-keys descriptor to run id and streams child timeline", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "paseo-pi-subagent-"));
+    const sessionFile = join(tempDir, "session.jsonl");
+    writeFileSync(sessionFile, childSessionLines().join("\n"), "utf8");
+
+    const tracker = new PiSubagentTracker(noopLogger);
+    tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    const events = await tracker.end(
+      SUBAGENT_TOOL_CALL_ID,
+      runDetails([{ agent: "explore", exitCode: 0, sessionFile }]),
+      false,
+    );
+
+    const kinds = events.map((event) =>
+      event.type === "provider_subagent" ? event.event.type : event.type,
+    );
+    expect(kinds).toEqual([
+      "remove", // close the tool-call-id descriptor
+      "timeline",
+      "timeline",
+      "timeline",
+      "upsert", // final descriptor under the run id
+    ]);
+
+    const finalUpsert = events.at(-1);
+    expect(finalUpsert?.type).toBe("provider_subagent");
+    if (finalUpsert?.type === "provider_subagent" && finalUpsert.event.type === "upsert") {
+      expect(finalUpsert.event.id).toBe(RUN_ID);
+      expect(finalUpsert.event.status).toBe("completed");
+      expect(finalUpsert.event.title).toBe("explore");
+    }
+
+    const timelineIds = events
+      .filter(
+        (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
+          event.type === "provider_subagent",
+      )
+      .filter((event) => event.event.type === "timeline")
+      .map((event) => (event.event as { id: string }).id);
+    expect(new Set(timelineIds)).toEqual(new Set([RUN_ID]));
+  });
+
+  test("end without child transcript falls back to inline output", async () => {
+    const tracker = new PiSubagentTracker(noopLogger);
+    tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    const events = await tracker.end(
+      SUBAGENT_TOOL_CALL_ID,
+      { output: "async run started", details: { results: [] } },
+      false,
+    );
+
+    const timelineItems = events
+      .filter(
+        (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
+          event.type === "provider_subagent" && event.event.type === "timeline",
+      )
+      .map((event) => (event.event as { item: { type: string; text?: string } }).item);
+    expect(timelineItems).toEqual([{ type: "assistant_message", text: "async run started" }]);
+
+    const finalUpsert = events.at(-1)!;
+    if (finalUpsert.type === "provider_subagent" && finalUpsert.event.type === "upsert") {
+      expect(finalUpsert.event.status).toBe("completed");
+      expect(finalUpsert.event.id).toBe(SUBAGENT_TOOL_CALL_ID);
+    }
+  });
+
+  test("end with isError marks the descriptor failed", async () => {
+    const tracker = new PiSubagentTracker(noopLogger);
+    tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    const events = await tracker.end(
+      SUBAGENT_TOOL_CALL_ID,
+      { content: [{ type: "text", text: "launch failed" }], details: { results: [] } },
+      true,
+    );
+    const finalUpsert = events.at(-1)!;
+    if (finalUpsert.type === "provider_subagent" && finalUpsert.event.type === "upsert") {
+      expect(finalUpsert.event.status).toBe("failed");
+    }
+  });
+
+  test("cancelAll finalizes running descriptors as canceled", () => {
+    const tracker = new PiSubagentTracker(noopLogger);
+    tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    const events = tracker.cancelAll();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("provider_subagent");
+    if (events[0]?.type === "provider_subagent" && events[0].event.type === "upsert") {
+      expect(events[0].event.status).toBe("canceled");
+      expect(events[0].event.id).toBe(SUBAGENT_TOOL_CALL_ID);
+    }
+    expect(tracker.cancelAll()).toEqual([]);
+  });
+
+  test("end ignores unknown tool calls", async () => {
+    const tracker = new PiSubagentTracker(noopLogger);
+    expect(await tracker.end(SUBAGENT_TOOL_CALL_ID, runDetails([]), false)).toEqual([]);
+  });
+});
+
+describe("pi history subagent replay", () => {
+  let tempDir: string | null = null;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  function parentMessages(sessionFile: string): PiAgentMessage[] {
+    return [
+      {
+        role: "user",
+        content: "run the explore agent",
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: SUBAGENT_TOOL_CALL_ID,
+            name: "subagent",
+            arguments: subagentArgs(),
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: SUBAGENT_TOOL_CALL_ID,
+        toolName: "subagent",
+        content: [{ type: "text", text: "done" }],
+        details: {
+          mode: "single",
+          runId: RUN_ID,
+          results: [{ agent: "explore", exitCode: 0, sessionFile }],
+        },
+      },
+    ] as PiAgentMessage[];
+  }
+
+  test("replays descriptors and child timeline rows from parent history", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "paseo-pi-subagent-"));
+    const sessionFile = join(tempDir, "session.jsonl");
+    writeFileSync(sessionFile, childSessionLines().join("\n"), "utf8");
+
+    const events = await collect(streamPiHistory("pi", parentMessages(sessionFile)));
+    const subagentEvents = events.filter(
+      (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
+        event.type === "provider_subagent",
+    );
+
+    const ups = subagentEvents.filter((event) => event.event.type === "upsert");
+    expect(ups).toHaveLength(2);
+    const first = ups[0]!.event as { id: string; status: string; title: string };
+    const last = ups[1]!.event as { id: string; status: string };
+    expect(first.id).toBe(RUN_ID);
+    expect(first.status).toBe("running");
+    expect(first.title).toBe("explore");
+    expect(last.status).toBe("completed");
+
+    const timeline = subagentEvents.filter((event) => event.event.type === "timeline");
+    expect(timeline).toHaveLength(3);
+    const itemTypes = timeline.map(
+      (event) => (event.event as { item: { type: string } }).item.type,
+    );
+    expect(itemTypes).toEqual(["user_message", "reasoning", "assistant_message"]);
+  });
+
+  test("non-subagent history passes through without subagent events", async () => {
+    const messages: PiAgentMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: [{ type: "text", text: "hi there" }] },
+    ];
+    const events = await collect(streamPiHistory("pi", messages));
+    expect(events.every((event) => event.type !== "provider_subagent")).toBe(true);
+  });
+
+  test("subagent toolResult without run payload is skipped", async () => {
+    const messages: PiAgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "call_x",
+        toolName: "subagent",
+        content: [{ type: "text", text: "no details" }],
+      } as PiAgentMessage,
+    ];
+    const events = await collect(streamPiHistory("pi", messages));
+    expect(events.every((event) => event.type !== "provider_subagent")).toBe(true);
+  });
+
+  test("failed result replay marks descriptor failed", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "paseo-pi-subagent-"));
+    const sessionFile = join(tempDir, "missing.jsonl"); // child file not written
+
+    const messages: PiAgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: SUBAGENT_TOOL_CALL_ID,
+            name: "subagent",
+            arguments: subagentArgs(),
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: SUBAGENT_TOOL_CALL_ID,
+        toolName: "subagent",
+        content: [{ type: "text", text: "child crashed" }],
+        isError: true,
+        details: {
+          mode: "single",
+          results: [{ agent: "explore", exitCode: 1, error: "boom", sessionFile }],
+        },
+      } as PiAgentMessage,
+    ];
+    const events = await collect(streamPiHistory("pi", messages));
+    const subagentEvents = events.filter(
+      (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
+        event.type === "provider_subagent",
+    );
+    const lastUpsert = subagentEvents.findLast((event) => event.event.type === "upsert")!.event as {
+      status: string;
+    };
+    expect(lastUpsert.status).toBe("failed");
+    // Missing child file → inline fallback row from tool content.
+    const timeline = subagentEvents.filter((event) => event.event.type === "timeline");
+    expect(timeline).toHaveLength(1);
+    expect((timeline[0]!.event as { item: { text?: string } }).item.text).toBe("child crashed");
+  });
+});

--- a/packages/server/src/server/agent/providers/pi/subagent-tracker.test.ts
+++ b/packages/server/src/server/agent/providers/pi/subagent-tracker.test.ts
@@ -6,6 +6,8 @@ import pino from "pino";
 import { afterEach, describe, expect, test } from "vitest";
 
 import type { AgentStreamEvent } from "../../agent-sdk-types.js";
+
+type ProviderSubagentStreamEvent = Extract<AgentStreamEvent, { type: "provider_subagent" }>;
 import { PiSubagentTracker } from "./subagent-tracker.js";
 import { streamPiHistory } from "./history-mapper.js";
 import type { PiAgentMessage } from "./rpc-types.js";
@@ -69,6 +71,38 @@ async function collect(generator: AsyncGenerator<AgentStreamEvent>): Promise<Age
   return events;
 }
 
+function subagentEvents(events: AgentStreamEvent[]): ProviderSubagentStreamEvent[] {
+  return events.filter(
+    (event): event is ProviderSubagentStreamEvent => event.type === "provider_subagent",
+  );
+}
+
+function expectUpsert(event: ProviderSubagentStreamEvent): {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  toolCallId: string;
+  subtitle?: string;
+} {
+  expect(event.event.type).toBe("upsert");
+  if (event.event.type !== "upsert") {
+    throw new Error("expected upsert event");
+  }
+  return event.event;
+}
+
+function expectTimeline(event: ProviderSubagentStreamEvent): {
+  id: string;
+  item: { type: string; text?: string };
+} {
+  expect(event.event.type).toBe("timeline");
+  if (event.event.type !== "timeline") {
+    throw new Error("expected timeline event");
+  }
+  return event.event as { id: string; item: { type: string; text?: string } };
+}
+
 describe("PiSubagentTracker", () => {
   let tempDir: string | null = null;
 
@@ -107,128 +141,156 @@ describe("PiSubagentTracker", () => {
   test("update emits descriptor when progress adds a subtitle", () => {
     const tracker = new PiSubagentTracker(noopLogger);
     tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
-    const events = tracker.update(
-      SUBAGENT_TOOL_CALL_ID,
-      runDetails([{ progress: { activityState: "reading", model: "nous_portal/ox-alpha" } }]),
+    const events = subagentEvents(
+      tracker.update(
+        SUBAGENT_TOOL_CALL_ID,
+        runDetails([{ progress: { activityState: "reading", model: "nous_portal/ox-alpha" } }]),
+      ),
     );
     expect(events).toHaveLength(1);
-    expect(events[0]!.type).toBe("provider_subagent");
-    if (events[0]!.type === "provider_subagent" && events[0]!.event.type === "upsert") {
-      expect(events[0]!.event.subtitle).toBe("reading · ox-alpha");
-    }
+    expect(expectUpsert(events[0]!).subtitle).toBe("reading · ox-alpha");
   });
 
   test("update without new presentation emits nothing", () => {
     const tracker = new PiSubagentTracker(noopLogger);
     tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
-    const first = tracker.update(
-      SUBAGENT_TOOL_CALL_ID,
-      runDetails([{ progress: { activityState: "reading" } }]),
-    );
-    expect(first).toHaveLength(1);
-    const repeat = tracker.update(
-      SUBAGENT_TOOL_CALL_ID,
-      runDetails([{ progress: { activityState: "reading" } }]),
-    );
-    expect(repeat).toEqual([]);
+    expect(
+      subagentEvents(
+        tracker.update(
+          SUBAGENT_TOOL_CALL_ID,
+          runDetails([{ progress: { activityState: "reading" } }]),
+        ),
+      ),
+    ).toHaveLength(1);
+    expect(
+      tracker.update(
+        SUBAGENT_TOOL_CALL_ID,
+        runDetails([{ progress: { activityState: "reading" } }]),
+      ),
+    ).toEqual([]);
   });
 
-  test("end re-keys descriptor to run id and streams child timeline", async () => {
+  test("end re-keys descriptor to run id with a running upsert before timeline rows", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "paseo-pi-subagent-"));
     const sessionFile = join(tempDir, "session.jsonl");
     writeFileSync(sessionFile, childSessionLines().join("\n"), "utf8");
 
     const tracker = new PiSubagentTracker(noopLogger);
     tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
-    const events = await tracker.end(
-      SUBAGENT_TOOL_CALL_ID,
-      runDetails([{ agent: "explore", exitCode: 0, sessionFile }]),
-      false,
+    const events = subagentEvents(
+      (await tracker.end(
+        SUBAGENT_TOOL_CALL_ID,
+        runDetails([{ agent: "explore", exitCode: 0, sessionFile }]),
+        false,
+      )) ?? [],
     );
 
-    const kinds = events.map((event) =>
-      event.type === "provider_subagent" ? event.event.type : event.type,
-    );
+    const kinds = events.map((event) => event.event.type);
     expect(kinds).toEqual([
       "remove", // close the tool-call-id descriptor
+      "upsert", // open the run-id descriptor before rows stream
       "timeline",
       "timeline",
       "timeline",
       "upsert", // final descriptor under the run id
     ]);
 
-    const finalUpsert = events.at(-1);
-    expect(finalUpsert?.type).toBe("provider_subagent");
-    if (finalUpsert?.type === "provider_subagent" && finalUpsert.event.type === "upsert") {
-      expect(finalUpsert.event.id).toBe(RUN_ID);
-      expect(finalUpsert.event.status).toBe("completed");
-      expect(finalUpsert.event.title).toBe("explore");
-    }
+    const reopened = expectUpsert(events[1]!);
+    expect(reopened.id).toBe(RUN_ID);
+    expect(reopened.status).toBe("running");
+    // The host tool-call id survives the re-key so the UI can correlate the
+    // descriptor with the parent transcript.
+    expect(reopened.toolCallId).toBe(SUBAGENT_TOOL_CALL_ID);
 
-    const timelineIds = events
-      .filter(
-        (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
-          event.type === "provider_subagent",
-      )
-      .filter((event) => event.event.type === "timeline")
-      .map((event) => (event.event as { id: string }).id);
-    expect(new Set(timelineIds)).toEqual(new Set([RUN_ID]));
+    const finalUpsert = expectUpsert(events[5]!);
+    expect(finalUpsert.id).toBe(RUN_ID);
+    expect(finalUpsert.status).toBe("completed");
+    expect(finalUpsert.title).toBe("explore");
+    expect(finalUpsert.toolCallId).toBe(SUBAGENT_TOOL_CALL_ID);
+
+    for (const event of events.slice(2, 5)) {
+      expect(expectTimeline(event).id).toBe(RUN_ID);
+    }
   });
 
   test("end without child transcript falls back to inline output", async () => {
     const tracker = new PiSubagentTracker(noopLogger);
     tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
-    const events = await tracker.end(
-      SUBAGENT_TOOL_CALL_ID,
-      { output: "async run started", details: { results: [] } },
-      false,
+    const events = subagentEvents(
+      (await tracker.end(
+        SUBAGENT_TOOL_CALL_ID,
+        { output: "async run started", details: { results: [] } },
+        false,
+      )) ?? [],
     );
 
-    const timelineItems = events
-      .filter(
-        (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
-          event.type === "provider_subagent" && event.event.type === "timeline",
-      )
-      .map((event) => (event.event as { item: { type: string; text?: string } }).item);
-    expect(timelineItems).toEqual([{ type: "assistant_message", text: "async run started" }]);
+    const timeline = events.filter((event) => event.event.type === "timeline");
+    expect(timeline).toHaveLength(1);
+    expect(expectTimeline(timeline[0]!).item).toEqual({
+      type: "assistant_message",
+      text: "async run started",
+    });
+    expect(expectTimeline(timeline[0]!).id).toBe(SUBAGENT_TOOL_CALL_ID);
 
-    const finalUpsert = events.at(-1)!;
-    if (finalUpsert.type === "provider_subagent" && finalUpsert.event.type === "upsert") {
-      expect(finalUpsert.event.status).toBe("completed");
-      expect(finalUpsert.event.id).toBe(SUBAGENT_TOOL_CALL_ID);
-    }
+    expect(expectUpsert(events.at(-1)!).status).toBe("completed");
+    expect(expectUpsert(events.at(-1)!).id).toBe(SUBAGENT_TOOL_CALL_ID);
   });
 
-  test("end with isError marks the descriptor failed", async () => {
+  test("end marks failed when isError is set even with a successful payload", async () => {
     const tracker = new PiSubagentTracker(noopLogger);
     tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
-    const events = await tracker.end(
-      SUBAGENT_TOOL_CALL_ID,
-      { content: [{ type: "text", text: "launch failed" }], details: { results: [] } },
-      true,
+    const events = subagentEvents(
+      (await tracker.end(
+        SUBAGENT_TOOL_CALL_ID,
+        { content: [{ type: "text", text: "launch failed" }], details: { results: [] } },
+        true,
+      )) ?? [],
     );
-    const finalUpsert = events.at(-1)!;
-    if (finalUpsert.type === "provider_subagent" && finalUpsert.event.type === "upsert") {
-      expect(finalUpsert.event.status).toBe("failed");
-    }
+    expect(expectUpsert(events.at(-1)!).status).toBe("failed");
+  });
+
+  test("end marks failed when the run payload reports a child failure", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "paseo-pi-subagent-"));
+    const sessionFile = join(tempDir, "session.jsonl");
+    writeFileSync(sessionFile, childSessionLines().join("\n"), "utf8");
+
+    const tracker = new PiSubagentTracker(noopLogger);
+    tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    const events = subagentEvents(
+      (await tracker.end(
+        SUBAGENT_TOOL_CALL_ID,
+        runDetails([{ agent: "explore", exitCode: 1, error: "boom", sessionFile }]),
+        false,
+      )) ?? [],
+    );
+    expect(expectUpsert(events.at(-1)!).status).toBe("failed");
   });
 
   test("cancelAll finalizes running descriptors as canceled", () => {
     const tracker = new PiSubagentTracker(noopLogger);
     tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
-    const events = tracker.cancelAll();
+    const events = subagentEvents(tracker.cancelAll());
     expect(events).toHaveLength(1);
-    expect(events[0]?.type).toBe("provider_subagent");
-    if (events[0]?.type === "provider_subagent" && events[0].event.type === "upsert") {
-      expect(events[0].event.status).toBe("canceled");
-      expect(events[0].event.id).toBe(SUBAGENT_TOOL_CALL_ID);
-    }
+    expect(expectUpsert(events[0]!).status).toBe("canceled");
+    expect(expectUpsert(events[0]!).id).toBe(SUBAGENT_TOOL_CALL_ID);
     expect(tracker.cancelAll()).toEqual([]);
+  });
+
+  test("end after cancelAll is stale and emits nothing", async () => {
+    const tracker = new PiSubagentTracker(noopLogger);
+    tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    tracker.cancelAll();
+    const result = await tracker.end(
+      SUBAGENT_TOOL_CALL_ID,
+      runDetails([{ agent: "explore", exitCode: 0 }]),
+      false,
+    );
+    expect(result).toBeNull();
   });
 
   test("end ignores unknown tool calls", async () => {
     const tracker = new PiSubagentTracker(noopLogger);
-    expect(await tracker.end(SUBAGENT_TOOL_CALL_ID, runDetails([]), false)).toEqual([]);
+    expect(await tracker.end(SUBAGENT_TOOL_CALL_ID, runDetails([]), false)).toBeNull();
   });
 });
 
@@ -278,26 +340,21 @@ describe("pi history subagent replay", () => {
     const sessionFile = join(tempDir, "session.jsonl");
     writeFileSync(sessionFile, childSessionLines().join("\n"), "utf8");
 
-    const events = await collect(streamPiHistory("pi", parentMessages(sessionFile)));
-    const subagentEvents = events.filter(
-      (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
-        event.type === "provider_subagent",
+    const events = subagentEvents(
+      await collect(streamPiHistory("pi", parentMessages(sessionFile))),
     );
-
-    const ups = subagentEvents.filter((event) => event.event.type === "upsert");
+    const ups = events.filter((event) => event.event.type === "upsert");
     expect(ups).toHaveLength(2);
-    const first = ups[0]!.event as { id: string; status: string; title: string };
-    const last = ups[1]!.event as { id: string; status: string };
+    const first = expectUpsert(ups[0]!);
+    const last = expectUpsert(ups[1]!);
     expect(first.id).toBe(RUN_ID);
     expect(first.status).toBe("running");
     expect(first.title).toBe("explore");
     expect(last.status).toBe("completed");
 
-    const timeline = subagentEvents.filter((event) => event.event.type === "timeline");
+    const timeline = events.filter((event) => event.event.type === "timeline");
     expect(timeline).toHaveLength(3);
-    const itemTypes = timeline.map(
-      (event) => (event.event as { item: { type: string } }).item.type,
-    );
+    const itemTypes = timeline.map((event) => expectTimeline(event).item.type);
     expect(itemTypes).toEqual(["user_message", "reasoning", "assistant_message"]);
   });
 
@@ -310,13 +367,44 @@ describe("pi history subagent replay", () => {
     expect(events.every((event) => event.type !== "provider_subagent")).toBe(true);
   });
 
-  test("subagent toolResult without run payload is skipped", async () => {
+  test("subagent toolResult without run payload still surfaces a descriptor", async () => {
+    const messages: PiAgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: SUBAGENT_TOOL_CALL_ID,
+            name: "subagent",
+            arguments: subagentArgs(),
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: SUBAGENT_TOOL_CALL_ID,
+        toolName: "subagent",
+        content: [{ type: "text", text: "details were stripped" }],
+      } as PiAgentMessage,
+    ];
+    const events = subagentEvents(await collect(streamPiHistory("pi", messages)));
+    const ups = events.filter((event) => event.event.type === "upsert");
+    expect(ups).toHaveLength(2);
+    expect(expectUpsert(ups[0]!).status).toBe("running");
+    expect(expectUpsert(ups[0]!).id).toBe(SUBAGENT_TOOL_CALL_ID);
+    expect(expectUpsert(ups[1]!).status).toBe("completed");
+    const timeline = events.filter((event) => event.event.type === "timeline");
+    expect(timeline).toHaveLength(1);
+    expect(expectTimeline(timeline[0]!).item.text).toBe("details were stripped");
+  });
+
+  test("subagent toolResult with no recoverable output is skipped", async () => {
     const messages: PiAgentMessage[] = [
       {
         role: "toolResult",
         toolCallId: "call_x",
         toolName: "subagent",
-        content: [{ type: "text", text: "no details" }],
+        content: [],
       } as PiAgentMessage,
     ];
     const events = await collect(streamPiHistory("pi", messages));
@@ -351,18 +439,53 @@ describe("pi history subagent replay", () => {
         },
       } as PiAgentMessage,
     ];
-    const events = await collect(streamPiHistory("pi", messages));
-    const subagentEvents = events.filter(
-      (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
-        event.type === "provider_subagent",
-    );
-    const lastUpsert = subagentEvents.findLast((event) => event.event.type === "upsert")!.event as {
-      status: string;
-    };
+    const events = subagentEvents(await collect(streamPiHistory("pi", messages)));
+    const lastUpsert = expectUpsert(events.findLast((event) => event.event.type === "upsert")!);
     expect(lastUpsert.status).toBe("failed");
     // Missing child file → inline fallback row from tool content.
-    const timeline = subagentEvents.filter((event) => event.event.type === "timeline");
+    const timeline = events.filter((event) => event.event.type === "timeline");
     expect(timeline).toHaveLength(1);
-    expect((timeline[0]!.event as { item: { text?: string } }).item.text).toBe("child crashed");
+    expect(expectTimeline(timeline[0]!).item.text).toBe("child crashed");
+  });
+
+  test("child session read errors are reported to the replay error hook", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "paseo-pi-subagent-"));
+    // A directory instead of a file: reading it throws a non-ENOENT error.
+    const sessionFile = join(tempDir, "session-dir");
+    rmSync(sessionFile, { force: true });
+    writeFileSync(join(tempDir, "placeholder"), "", "utf8");
+    rmSync(join(tempDir, "placeholder"));
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(sessionFile);
+
+    const messages: PiAgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: SUBAGENT_TOOL_CALL_ID,
+        toolName: "subagent",
+        content: [{ type: "text", text: "done" }],
+        details: {
+          mode: "single",
+          runId: RUN_ID,
+          results: [{ agent: "explore", exitCode: 0, sessionFile }],
+        },
+      } as PiAgentMessage,
+    ];
+
+    const replayErrors: string[] = [];
+    const events = subagentEvents(
+      await collect(
+        streamPiHistory("pi", messages, [], {
+          onSubagentReplayError: (error, file) => {
+            replayErrors.push(`${file}: ${(error as Error).message}`);
+          },
+        }),
+      ),
+    );
+    expect(replayErrors).toHaveLength(1);
+    expect(replayErrors[0]).toContain(sessionFile);
+    // The replay still completes with descriptors and the inline fallback row.
+    expect(events.filter((event) => event.event.type === "upsert")).toHaveLength(2);
+    expect(events.filter((event) => event.event.type === "timeline")).toHaveLength(1);
   });
 });

--- a/packages/server/src/server/agent/providers/pi/subagent-tracker.test.ts
+++ b/packages/server/src/server/agent/providers/pi/subagent-tracker.test.ts
@@ -288,6 +288,28 @@ describe("PiSubagentTracker", () => {
     expect(result).toBeNull();
   });
 
+  test("cancelAll during transcript read drops the late finalization", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "paseo-pi-subagent-"));
+    const sessionFile = join(tempDir, "session.jsonl");
+    writeFileSync(sessionFile, childSessionLines().join("\n"), "utf8");
+
+    const tracker = new PiSubagentTracker(noopLogger);
+    tracker.start(SUBAGENT_TOOL_CALL_ID, subagentArgs());
+    const endPromise = tracker.end(
+      SUBAGENT_TOOL_CALL_ID,
+      runDetails([{ agent: "explore", exitCode: 0, sessionFile }]),
+      false,
+    );
+    // Cancel while end() is awaiting the child transcript read.
+    const cancelEvents = subagentEvents(tracker.cancelAll());
+    expect(cancelEvents).toHaveLength(1);
+    expect(expectUpsert(cancelEvents[0]!).status).toBe("canceled");
+    expect(expectUpsert(cancelEvents[0]!).id).toBe(SUBAGENT_TOOL_CALL_ID);
+
+    // The in-flight end must not resurrect the run as completed.
+    expect(await endPromise).toBeNull();
+  });
+
   test("end ignores unknown tool calls", async () => {
     const tracker = new PiSubagentTracker(noopLogger);
     expect(await tracker.end(SUBAGENT_TOOL_CALL_ID, runDetails([]), false)).toBeNull();

--- a/packages/server/src/server/agent/providers/pi/subagent-tracker.ts
+++ b/packages/server/src/server/agent/providers/pi/subagent-tracker.ts
@@ -5,7 +5,6 @@ import {
   MAX_SUBAGENT_TIMELINE_ROWS,
   buildPiSubagentSubtitle,
   piSubagentDescriptorId,
-  piSubagentStatusFromResult,
   piSubagentTimelineEvents,
   readPiSubagentInlineOutput,
   readPiSubagentLaunchArgs,
@@ -42,6 +41,9 @@ type PiSubagentStatus = "running" | "completed" | "failed" | "canceled";
  */
 export class PiSubagentTracker {
   private readonly states = new Map<string, PiSubagentState>();
+  /** Bumped by cancelAll(); tracked tool calls from older generations are stale. */
+  private generation = 0;
+  private readonly generations = new Map<string, number>();
 
   constructor(private readonly logger: Logger) {}
 
@@ -56,6 +58,7 @@ export class PiSubagentTracker {
       description: input.task ?? null,
       reportedStatus: "running",
     });
+    this.generations.set(toolCallId, this.generation);
     return [this.upsert(toolCallId, "running")];
   }
 
@@ -92,13 +95,26 @@ export class PiSubagentTracker {
   /**
    * tool_execution_end for a `subagent` call: replay child transcripts into
    * the subagent timeline and finalize the descriptor status.
+   *
+   * Returns null when the tracked call is stale (canceled by a newer
+   * generation or superseded), in which case the caller must not emit events —
+   * an interrupted run stays canceled instead of resurrecting as completed.
    */
-  async end(toolCallId: string, result: unknown, isError: boolean): Promise<AgentStreamEvent[]> {
+  async end(
+    toolCallId: string,
+    result: unknown,
+    isError: boolean,
+  ): Promise<AgentStreamEvent[] | null> {
     const state = this.states.get(toolCallId);
     if (!state) {
-      return [];
+      return null;
     }
     this.states.delete(toolCallId);
+    const trackedGeneration = this.generations.get(toolCallId) ?? this.generation;
+    this.generations.delete(toolCallId);
+    if (trackedGeneration !== this.generation) {
+      return null;
+    }
 
     const run = readPiSubagentRunPayload(result);
     const descriptorId = piSubagentDescriptorId(toolCallId, run);
@@ -106,16 +122,21 @@ export class PiSubagentTracker {
     if (descriptorId !== toolCallId) {
       // The store keys descriptors by id and has no rename, so close the
       // tool-call-id descriptor opened at start and continue under the
-      // pi-subagents run id.
+      // pi-subagents run id. Open the run-id descriptor before streaming rows
+      // so timeline events always land on a known descriptor.
       events.push({
         type: "provider_subagent",
         provider: PI_PROVIDER,
         event: { type: "remove", id: toolCallId },
       });
+      events.push(this.upsertFor(descriptorId, "running", state, toolCallId));
     }
 
     let rows = 0;
     for (const sessionFile of sessionFilesOf(run)) {
+      if (rows >= MAX_SUBAGENT_TIMELINE_ROWS) {
+        break;
+      }
       try {
         for await (const { item } of streamPiChildSessionItems(sessionFile)) {
           if (rows >= MAX_SUBAGENT_TIMELINE_ROWS) {
@@ -139,31 +160,38 @@ export class PiSubagentTracker {
         );
       }
     }
-    events.push(this.upsertFor(descriptorId, piSubagentStatusFromResult(isError), state));
+    events.push(this.upsertFor(descriptorId, terminalStatus(run, isError), state, toolCallId));
     return events;
   }
 
-  /** Mark every running subagent canceled (turn interrupted or session closing). */
+  /**
+   * Mark every running subagent canceled (turn interrupted or session
+   * closing). In-flight `end()` continuations for this generation are dropped
+   * by the generation check so a canceled run cannot reappear as completed.
+   */
   cancelAll(): AgentStreamEvent[] {
     const events: AgentStreamEvent[] = [];
     for (const [toolCallId, state] of this.states) {
       if (state.reportedStatus === "running") {
-        events.push(this.upsertFor(toolCallId, "canceled", state));
+        events.push(this.upsertFor(toolCallId, "canceled", state, toolCallId));
         state.reportedStatus = "canceled";
       }
     }
     this.states.clear();
+    this.generations.clear();
+    this.generation += 1;
     return events;
   }
 
   private upsert(toolCallId: string, status: PiSubagentStatus): AgentStreamEvent {
-    return this.upsertFor(toolCallId, status, this.states.get(toolCallId)!);
+    return this.upsertFor(toolCallId, status, this.states.get(toolCallId)!, toolCallId);
   }
 
   private upsertFor(
     id: string,
     status: PiSubagentStatus,
     state: PiSubagentState | undefined,
+    toolCallId: string,
   ): AgentStreamEvent {
     return {
       type: "provider_subagent",
@@ -174,11 +202,30 @@ export class PiSubagentTracker {
         title: state?.title ?? DEFAULT_SUBAGENT_TITLE,
         description: state?.description ?? null,
         status,
-        toolCallId: id,
+        toolCallId,
         ...(state?.subtitle ? { subtitle: state.subtitle } : {}),
       },
     };
   }
+}
+
+/**
+ * Terminal status from the tool result error flag combined with the run
+ * payload: pi-subagents can report a failed child (non-zero exit, error field)
+ * even when the tool call itself completed.
+ */
+function terminalStatus(
+  run: PiSubagentRunPayload | null,
+  isError: boolean,
+): "completed" | "failed" {
+  if (isError) {
+    return "failed";
+  }
+  const failed = (run?.results ?? []).some(
+    (entry: PiSubagentResultEntry) =>
+      Boolean(entry.error) || (entry.exitCode !== undefined && entry.exitCode !== 0),
+  );
+  return failed ? "failed" : "completed";
 }
 
 function sessionFilesOf(run: PiSubagentRunPayload | null): string[] {

--- a/packages/server/src/server/agent/providers/pi/subagent-tracker.ts
+++ b/packages/server/src/server/agent/providers/pi/subagent-tracker.ts
@@ -1,0 +1,194 @@
+import type { Logger } from "pino";
+
+import type { AgentStreamEvent } from "../../agent-sdk-types.js";
+import {
+  MAX_SUBAGENT_TIMELINE_ROWS,
+  buildPiSubagentSubtitle,
+  piSubagentDescriptorId,
+  piSubagentStatusFromResult,
+  piSubagentTimelineEvents,
+  readPiSubagentInlineOutput,
+  readPiSubagentLaunchArgs,
+  readPiSubagentRunPayload,
+  streamPiChildSessionItems,
+  type PiSubagentResultEntry,
+  type PiSubagentRunPayload,
+} from "./subagent-run.js";
+
+const PI_PROVIDER = "pi";
+const DEFAULT_SUBAGENT_TITLE = "Pi subagent";
+
+interface PiSubagentState {
+  title: string;
+  description: string | null;
+  resolvedModel?: string;
+  activity?: string;
+  subtitle?: string;
+  reportedStatus: PiSubagentStatus;
+}
+
+type PiSubagentStatus = "running" | "completed" | "failed" | "canceled";
+
+/**
+ * Tracks `pi-subagents` tool executions and translates them into provider
+ * subagent stream events. The `subagent` tool is an extension tool, so Pi
+ * reports its lifecycle through the generic tool_execution_* events with the
+ * run payload in tool result `details` (see pi-subagents `Details`).
+ *
+ * Child transcripts are standard Pi session files referenced by
+ * `details.results[].sessionFile`. On completion the tracker reads the child
+ * file and replays it as subagent timeline rows so the app can render what the
+ * child did without the parent transcript carrying it.
+ */
+export class PiSubagentTracker {
+  private readonly states = new Map<string, PiSubagentState>();
+
+  constructor(private readonly logger: Logger) {}
+
+  /** tool_execution_start for a `subagent` call: open a running descriptor. */
+  start(toolCallId: string, args: unknown): AgentStreamEvent[] {
+    const input = readPiSubagentLaunchArgs(args);
+    if (!input) {
+      return [];
+    }
+    this.states.set(toolCallId, {
+      title: input.agent ?? DEFAULT_SUBAGENT_TITLE,
+      description: input.task ?? null,
+      reportedStatus: "running",
+    });
+    return [this.upsert(toolCallId, "running")];
+  }
+
+  /** tool_execution_update: refresh the compact subtitle (activity, model). */
+  update(toolCallId: string, partialResult: unknown): AgentStreamEvent[] {
+    const state = this.states.get(toolCallId);
+    if (!state) {
+      return [];
+    }
+    const run = readPiSubagentRunPayload(partialResult);
+    if (!run) {
+      return [];
+    }
+    const first = run.results[0];
+    const model = first?.model ?? first?.progress?.model;
+    const activity = readText(first?.progress?.activityState);
+    const subtitle = buildPiSubagentSubtitle(
+      model ?? state.resolvedModel,
+      activity ?? state.activity,
+    );
+    if (!subtitle || subtitle === state.subtitle) {
+      return [];
+    }
+    if (model) {
+      state.resolvedModel = model;
+    }
+    if (activity) {
+      state.activity = activity;
+    }
+    state.subtitle = subtitle;
+    return [this.upsert(toolCallId, "running")];
+  }
+
+  /**
+   * tool_execution_end for a `subagent` call: replay child transcripts into
+   * the subagent timeline and finalize the descriptor status.
+   */
+  async end(toolCallId: string, result: unknown, isError: boolean): Promise<AgentStreamEvent[]> {
+    const state = this.states.get(toolCallId);
+    if (!state) {
+      return [];
+    }
+    this.states.delete(toolCallId);
+
+    const run = readPiSubagentRunPayload(result);
+    const descriptorId = piSubagentDescriptorId(toolCallId, run);
+    const events: AgentStreamEvent[] = [];
+    if (descriptorId !== toolCallId) {
+      // The store keys descriptors by id and has no rename, so close the
+      // tool-call-id descriptor opened at start and continue under the
+      // pi-subagents run id.
+      events.push({
+        type: "provider_subagent",
+        provider: PI_PROVIDER,
+        event: { type: "remove", id: toolCallId },
+      });
+    }
+
+    let rows = 0;
+    for (const sessionFile of sessionFilesOf(run)) {
+      try {
+        for await (const { item } of streamPiChildSessionItems(sessionFile)) {
+          if (rows >= MAX_SUBAGENT_TIMELINE_ROWS) {
+            break;
+          }
+          rows += 1;
+          events.push(...piSubagentTimelineEvents(descriptorId, [item]));
+        }
+      } catch (error) {
+        this.logger.debug({ err: error, sessionFile }, "Failed to read Pi subagent child session");
+      }
+    }
+    if (rows === 0) {
+      // No child transcript on disk (launch failure, async run still going, or
+      // details stripped). Surface the inline tool output as a single row so
+      // the tab is never empty.
+      const text = readPiSubagentInlineOutput(result);
+      if (text) {
+        events.push(
+          ...piSubagentTimelineEvents(descriptorId, [{ type: "assistant_message", text }]),
+        );
+      }
+    }
+    events.push(this.upsertFor(descriptorId, piSubagentStatusFromResult(isError), state));
+    return events;
+  }
+
+  /** Mark every running subagent canceled (turn interrupted or session closing). */
+  cancelAll(): AgentStreamEvent[] {
+    const events: AgentStreamEvent[] = [];
+    for (const [toolCallId, state] of this.states) {
+      if (state.reportedStatus === "running") {
+        events.push(this.upsertFor(toolCallId, "canceled", state));
+        state.reportedStatus = "canceled";
+      }
+    }
+    this.states.clear();
+    return events;
+  }
+
+  private upsert(toolCallId: string, status: PiSubagentStatus): AgentStreamEvent {
+    return this.upsertFor(toolCallId, status, this.states.get(toolCallId)!);
+  }
+
+  private upsertFor(
+    id: string,
+    status: PiSubagentStatus,
+    state: PiSubagentState | undefined,
+  ): AgentStreamEvent {
+    return {
+      type: "provider_subagent",
+      provider: PI_PROVIDER,
+      event: {
+        type: "upsert",
+        id,
+        title: state?.title ?? DEFAULT_SUBAGENT_TITLE,
+        description: state?.description ?? null,
+        status,
+        toolCallId: id,
+        ...(state?.subtitle ? { subtitle: state.subtitle } : {}),
+      },
+    };
+  }
+}
+
+function sessionFilesOf(run: PiSubagentRunPayload | null): string[] {
+  return (
+    run?.results.flatMap((entry: PiSubagentResultEntry) =>
+      typeof entry.sessionFile === "string" && entry.sessionFile ? [entry.sessionFile] : [],
+    ) ?? []
+  );
+}
+
+function readText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}

--- a/packages/server/src/server/agent/providers/pi/subagent-tracker.ts
+++ b/packages/server/src/server/agent/providers/pi/subagent-tracker.ts
@@ -28,6 +28,12 @@ interface PiSubagentState {
 
 type PiSubagentStatus = "running" | "completed" | "failed" | "canceled";
 
+interface PiInFlightEnd {
+  state: PiSubagentState;
+  toolCallId: string;
+  canceled: boolean;
+}
+
 /**
  * Tracks `pi-subagents` tool executions and translates them into provider
  * subagent stream events. The `subagent` tool is an extension tool, so Pi
@@ -44,6 +50,8 @@ export class PiSubagentTracker {
   /** Bumped by cancelAll(); tracked tool calls from older generations are stale. */
   private generation = 0;
   private readonly generations = new Map<string, number>();
+  /** Finalizations awaiting their child-transcript reads; cancelable mid-flight. */
+  private readonly inFlightEnds = new Map<string, PiInFlightEnd>();
 
   constructor(private readonly logger: Logger) {}
 
@@ -96,9 +104,10 @@ export class PiSubagentTracker {
    * tool_execution_end for a `subagent` call: replay child transcripts into
    * the subagent timeline and finalize the descriptor status.
    *
-   * Returns null when the tracked call is stale (canceled by a newer
-   * generation or superseded), in which case the caller must not emit events —
-   * an interrupted run stays canceled instead of resurrecting as completed.
+   * Returns null when the tracked call is stale — canceled by a newer
+   * generation, superseded, or canceled mid-flight while reading the child
+   * transcript — in which case the caller must not emit events and an
+   * interrupted run stays canceled instead of resurrecting as completed.
    */
   async end(
     toolCallId: string,
@@ -118,6 +127,34 @@ export class PiSubagentTracker {
 
     const run = readPiSubagentRunPayload(result);
     const descriptorId = piSubagentDescriptorId(toolCallId, run);
+    // Register before the first await so cancelAll() can invalidate this
+    // finalization while the child transcript is being read.
+    const inFlight: PiInFlightEnd = { state, toolCallId, canceled: false };
+    this.inFlightEnds.set(toolCallId, inFlight);
+    try {
+      return await this.streamFinalEvents(
+        toolCallId,
+        descriptorId,
+        state,
+        run,
+        result,
+        isError,
+        inFlight,
+      );
+    } finally {
+      this.inFlightEnds.delete(toolCallId);
+    }
+  }
+
+  private async streamFinalEvents(
+    toolCallId: string,
+    descriptorId: string,
+    state: PiSubagentState,
+    run: PiSubagentRunPayload | null,
+    result: unknown,
+    isError: boolean,
+    inFlight: PiInFlightEnd,
+  ): Promise<AgentStreamEvent[] | null> {
     const events: AgentStreamEvent[] = [];
     if (descriptorId !== toolCallId) {
       // The store keys descriptors by id and has no rename, so close the
@@ -139,6 +176,9 @@ export class PiSubagentTracker {
       }
       try {
         for await (const { item } of streamPiChildSessionItems(sessionFile)) {
+          if (inFlight.canceled) {
+            return null;
+          }
           if (rows >= MAX_SUBAGENT_TIMELINE_ROWS) {
             break;
           }
@@ -148,6 +188,9 @@ export class PiSubagentTracker {
       } catch (error) {
         this.logger.debug({ err: error, sessionFile }, "Failed to read Pi subagent child session");
       }
+    }
+    if (inFlight.canceled) {
+      return null;
     }
     if (rows === 0) {
       // No child transcript on disk (launch failure, async run still going, or
@@ -166,8 +209,9 @@ export class PiSubagentTracker {
 
   /**
    * Mark every running subagent canceled (turn interrupted or session
-   * closing). In-flight `end()` continuations for this generation are dropped
-   * by the generation check so a canceled run cannot reappear as completed.
+   * closing). In-flight `end()` continuations are flagged canceled so their
+   * late results are dropped, and the descriptors the store still shows as
+   * running get a canceled upsert keyed by the id the store knows.
    */
   cancelAll(): AgentStreamEvent[] {
     const events: AgentStreamEvent[] = [];
@@ -177,8 +221,15 @@ export class PiSubagentTracker {
         state.reportedStatus = "canceled";
       }
     }
+    for (const inFlight of this.inFlightEnds.values()) {
+      inFlight.canceled = true;
+      events.push(
+        this.upsertFor(inFlight.toolCallId, "canceled", inFlight.state, inFlight.toolCallId),
+      );
+    }
     this.states.clear();
     this.generations.clear();
+    this.inFlightEnds.clear();
     this.generation += 1;
     return events;
   }


### PR DESCRIPTION
## Summary

Pi was the only major provider without a provider-subagent bridge: Claude Code, Codex, OpenCode, and OMP all translate child executions into `provider_subagent` stream events, but the Pi adapter ignored them. The result: subagents launched via `pi-subagents` never appeared in the app's Subagents Track — no pill, no tabs, no child timelines — even though `pi-subagents` reports everything needed through the generic `tool_execution_*` RPC events and writes child transcripts as standard Pi session files.

This adds the missing bridge, server-side only. No changes to `pi-subagents` or any app-side code are required; the existing descriptor/timeline protocol and UI are reused as-is.

## How it works

**Live tracking** (`subagent-tracker.ts`, wired into `pi/agent.ts`):
- `tool_execution_start` for `subagent` → upsert a `running` descriptor (`title` = agent name, `description` = task).
- `tool_execution_update` → refresh the compact subtitle (activity state, model) from `details.results[].progress`.
- `tool_execution_end` → re-key the descriptor to the pi-subagents run id (`details.runId`, falling back to the tool-call id), replay the child session files (`details.results[].sessionFile`) into the subagent timeline, and finalize status (`completed`/`failed`).
- Interrupt and session close mark running subagents `canceled`, matching the manager's `cancelRunningProviderSubagents` semantics.

**History replay** (`history-mapper.ts`):
- `streamPiHistory` now emits `provider_subagent` events for recorded `subagent` tool results: an opening `running` upsert, child transcript rows, then the final status upsert — so restored sessions keep their Subagents Track, matching the OMP/Claude replay behavior.

**Fallbacks**: when no child transcript exists on disk (launch failure, async run, stripped details), the inline tool output becomes a single `assistant_message` timeline row so a subagent tab is never empty. Child reads are best-effort: failures are logged at debug level and never fail the turn or the history stream.

**Presentation**: subtitles follow the shared-track contract (`"reading · ox-alpha"`-style provider-owned strings); titles use the agent name (`explore`, `reviewer`, …).

## Testing

- New `subagent-tracker.test.ts` (13 tests): tracker lifecycle (start/update/end/cancelAll), run-id re-keying, child-session replay, inline fallback, failed status, and history replay including the no-payload and failed-result paths.
- `npx vitest run src/server/agent/providers/pi/` → 7 files, 133 tests pass.
- `npx vitest run src/server/agent/provider-subagents/ src/server/agent/agent-manager.test.ts` → 174 tests pass (the consumers of these events).
- OMP/Claude/OpenCode provider suites pass (483 tests); the only failures are a pre-existing environment-sensitive OMP diagnostic test and credential-gated `*.real.e2e` tests, both failing identically on `main`.
- `npm run typecheck`, `oxlint`, and `oxfmt --check` clean across the workspace (pre-commit hook runs all three).

## Notes for reviewers

- Descriptor ids: live runs are re-keyed from the host tool-call id to `details.runId` via a `remove` + fresh `upsert`, since the store keys by id and has no rename. History replay uses `runId` directly, so live and replayed descriptors for the same run share an id.
- The `subagent`/`task` naming follows pi-subagents' actual tool surface (`subagent` with `agent`/`task` args); `task`-style calls are not special-cased because pi-subagents does not emit them as a separate tool.
- Row caps: 200 timeline rows per subagent for both live streaming and replay, mirroring the bounded payloads other providers emit.
