### PR TITLE
Keep the draft tab locked while its create request is in flight

### DIFF
--- a/packages/app/src/composer/draft/create-flow.test.ts
+++ b/packages/app/src/composer/draft/create-flow.test.ts
@@ -8,6 +8,14 @@ import type { UserMessageImageAttachment } from "@/types/stream";
 import type { AgentAttachment } from "@getpaseo/protocol/messages";
 import { useDraftAgentCreateFlow, type DraftCreateAttempt } from "./create-flow";
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe("useDraftAgentCreateFlow", () => {
   beforeEach(() => {
     useCreateFlowStore.setState({ pendingByDraftId: {} });
@@ -33,6 +41,16 @@ describe("useDraftAgentCreateFlow", () => {
       images: [image],
       attachments: [attachment],
     };
+    useCreateFlowStore.getState().setPending({
+      draftId: "draft-1",
+      serverId: "server-1",
+      agentId: null,
+      clientMessageId: attempt.clientMessageId,
+      text: attempt.text,
+      timestamp: attempt.timestamp.getTime(),
+      images: [image],
+      attachments: [attachment],
+    });
     const createRequest = vi.fn(
       async (ctx: {
         attempt: DraftCreateAttempt;
@@ -145,5 +163,103 @@ describe("useDraftAgentCreateFlow", () => {
       cwd: "/repo",
     });
     expect(onCreateSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a restored in-flight attempt locked without re-sending it", async () => {
+    const attempt: DraftCreateAttempt = {
+      clientMessageId: "msg-in-flight",
+      text: "build this",
+      timestamp: new Date("2026-05-25T00:00:00.000Z"),
+    };
+    useCreateFlowStore.getState().setPending({
+      draftId: "draft-1",
+      serverId: "server-1",
+      agentId: null,
+      clientMessageId: attempt.clientMessageId,
+      text: attempt.text,
+      timestamp: attempt.timestamp.getTime(),
+    });
+    const createRequest = vi.fn(async () => ({ agentId: "agent-1", result: { id: "agent-1" } }));
+
+    const { result } = renderHook(() =>
+      useDraftAgentCreateFlow({
+        draftId: "draft-1",
+        getPendingServerId: () => "server-1",
+        initialAttempt: attempt,
+        buildDraftAgent: (currentAttempt) => ({ currentAttempt }),
+        createRequest,
+        onCreateSuccess: vi.fn(),
+      }),
+    );
+
+    expect(result.current.isSubmitting).toBe(true);
+    expect(createRequest).not.toHaveBeenCalled();
+    await expect(
+      result.current.handleCreateFromInput({ text: "again", attachments: [], cwd: "/repo" }),
+    ).rejects.toThrow();
+    expect(createRequest).not.toHaveBeenCalled();
+
+    act(() => {
+      useCreateFlowStore.getState().markLifecycle({ draftId: "draft-1", lifecycle: "sent" });
+    });
+    expect(result.current.isSubmitting).toBe(true);
+
+    act(() => {
+      useCreateFlowStore.getState().clear({ draftId: "draft-1" });
+    });
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.formErrorMessage).toBe("");
+  });
+
+  it("leaves the store and tab alone when a newer attempt replaced this one", async () => {
+    const createStarted = createDeferred<void>();
+    const createResult = createDeferred<{ agentId: string; result: { id: string } }>();
+    const createRequest = vi.fn(() => {
+      createStarted.resolve();
+      return createResult.promise;
+    });
+    const onCreateSuccess = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDraftAgentCreateFlow({
+        draftId: "draft-1",
+        getPendingServerId: () => "server-1",
+        buildDraftAgent: (currentAttempt) => ({ currentAttempt }),
+        createRequest,
+        onCreateSuccess,
+      }),
+    );
+
+    let submission: Promise<void> = Promise.resolve();
+    await act(async () => {
+      submission = result.current.handleCreateFromInput({
+        text: "first",
+        attachments: [],
+        cwd: "/repo",
+      });
+      await createStarted.promise;
+    });
+    expect(createRequest).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useCreateFlowStore.getState().setPending({
+        draftId: "draft-1",
+        serverId: "server-1",
+        agentId: null,
+        clientMessageId: "msg-newer",
+        text: "second",
+        timestamp: new Date("2026-05-25T00:01:00.000Z").getTime(),
+      });
+    });
+    await act(async () => {
+      createResult.resolve({ agentId: "agent-old", result: { id: "agent-old" } });
+      await submission;
+    });
+
+    expect(onCreateSuccess).not.toHaveBeenCalled();
+    const pending = useCreateFlowStore.getState().pendingByDraftId["draft-1"];
+    expect(pending?.clientMessageId).toBe("msg-newer");
+    expect(pending?.agentId).toBeNull();
+    expect(pending?.lifecycle).toBe("active");
   });
 });

--- a/packages/app/src/composer/draft/create-flow.ts
+++ b/packages/app/src/composer/draft/create-flow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useReducer } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { ComposerAttachment } from "@/attachments/types";
 import {
@@ -128,6 +128,10 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
   const updatePendingAgentId = useCreateFlowStore((state) => state.updateAgentId);
   const markPendingCreateLifecycle = useCreateFlowStore((state) => state.markLifecycle);
   const clearPendingCreateAttempt = useCreateFlowStore((state) => state.clear);
+  const storedAttempt = useCreateFlowStore((state) => state.pendingByDraftId[draftId] ?? null);
+  // The attempt this instance sent itself. A restored attempt (mounted while an
+  // earlier instance's request is still in flight) is never owned here.
+  const ownedClientMessageIdRef = useRef<string | null>(null);
   const formErrorMessage = machine.tag === "draft" ? machine.errorMessage : "";
   const isSubmitting = machine.tag === "creating";
 
@@ -163,6 +167,24 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
     ];
   }, [machine]);
 
+  // A restored attempt stays in the creating state only while the store still
+  // tracks it. When the owning instance abandons or clears it, fall back to draft
+  // so the composer unlocks; "sent" keeps the tab locked until it is retargeted.
+  useEffect(() => {
+    if (machine.tag !== "creating") {
+      return;
+    }
+    if (ownedClientMessageIdRef.current === machine.attempt.clientMessageId) {
+      return;
+    }
+    const stillTracked =
+      storedAttempt?.clientMessageId === machine.attempt.clientMessageId &&
+      storedAttempt.lifecycle !== "abandoned";
+    if (!stillTracked) {
+      dispatch({ type: "CREATE_FAILED", message: "" });
+    }
+  }, [machine, storedAttempt]);
+
   const draftAgent = useMemo<TDraftAgent | null>(() => {
     if (machine.tag !== "creating") {
       return null;
@@ -179,6 +201,7 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
         throw error;
       }
 
+      ownedClientMessageIdRef.current = attempt.clientMessageId;
       await onBeforeSubmit?.({
         attempt,
         text: attempt.text,
@@ -186,6 +209,12 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
         attachments: attempt.attachments,
         cwd,
       });
+      // The store entry is the source of truth for which attempt the draft tab is
+      // waiting on. A later submit for the same draft replaces it, and this
+      // (stale) instance must then leave the store and the tab alone.
+      const isCurrentAttempt = () =>
+        useCreateFlowStore.getState().pendingByDraftId[draftId]?.clientMessageId ===
+        attempt.clientMessageId;
 
       try {
         const createResult = await createRequest({
@@ -197,7 +226,6 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
         });
 
         if (createResult.agentId) {
-          updatePendingAgentId({ draftId, agentId: createResult.agentId });
           handoffCreatedAgentMessageSubmission(
             pendingServerId,
             createResult.agentId,
@@ -209,6 +237,12 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
               attachments: attempt.attachments,
             }),
           );
+        }
+        if (!isCurrentAttempt()) {
+          return;
+        }
+        if (createResult.agentId) {
+          updatePendingAgentId({ draftId, agentId: createResult.agentId });
           markPendingCreateLifecycle({ draftId, lifecycle: "sent" });
         }
 
@@ -217,8 +251,10 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
         const resolved =
           error instanceof Error ? error : new Error(t("composer.errors.failedToCreateAgent"));
         dispatch({ type: "CREATE_FAILED", message: resolved.message });
-        markPendingCreateLifecycle({ draftId, lifecycle: "abandoned" });
-        clearPendingCreateAttempt({ draftId });
+        if (isCurrentAttempt()) {
+          markPendingCreateLifecycle({ draftId, lifecycle: "abandoned" });
+          clearPendingCreateAttempt({ draftId });
+        }
         onCreateError?.(resolved);
         throw error;
       }

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -408,11 +408,12 @@ export function WorkspaceDraftAgentTab({
     (state) => state.consumePending,
   );
   const autoSubmitConfig = resolveAutoSubmitConfig(pendingAutoSubmit);
+  // Any active attempt for this draft restores the creating state, whether or not
+  // the one-shot pending submission is still here. Without this, a remount while
+  // the create request is in flight shows an empty, unlocked draft, and sending
+  // the prompt again creates a second agent.
   const initialCreateAttempt = useMemo<DraftCreateAttempt | null>(() => {
-    if (!pendingAutoSubmit || !pendingCreateAttempt) {
-      return null;
-    }
-    if (pendingAutoSubmit.clientMessageId !== pendingCreateAttempt.clientMessageId) {
+    if (!pendingCreateAttempt) {
       return null;
     }
     return {
@@ -426,7 +427,7 @@ export function WorkspaceDraftAgentTab({
         ? { attachments: pendingCreateAttempt.attachments }
         : {}),
     };
-  }, [pendingAutoSubmit, pendingCreateAttempt]);
+  }, [pendingCreateAttempt]);
   const allowsEmptyAutoSubmit = pendingAutoSubmit?.allowEmptyText === true;
   const isCompactFormFactor = useIsCompactFormFactor();
   const { onLayout: onInputAreaLayout, isBelow: isCompactComposerLayout } = useContainerWidthBelow(


### PR DESCRIPTION
Fixes #4279.

## Problem

`WorkspaceDraftAgentTab` only restored its "creating" state from `initialCreateAttempt`, which required the one-shot pending entry in `workspace-draft-submission-store`. The first mount consumes that entry when it sends `create_agent_request`. If the tab remounted while the request was still in flight, it came back as an empty, fully enabled draft even though `create-flow-store` still held the active attempt. Re-entering the prompt sent a second create, and since the daemon does not dedupe creates, the workspace ended up with duplicate agents and tabs. This is easy to hit when creates are slow (Codex app-server start took 19–33 s in the reported case).

## Fix

- The draft tab restores the creating state from any active `create-flow-store` attempt for its draft id, independent of the pending submission. The composer stays locked, so a remount cannot resubmit.
- `useDraftAgentCreateFlow` tracks which attempt an instance sent itself. A restored (unowned) attempt drops back to draft only when the store no longer tracks it or it was abandoned; `sent` keeps it locked until the tab is retargeted.
- The success and failure paths check that the store still points at this attempt before touching it or retargeting the tab, so a stale instance cannot overwrite a newer attempt's record.

## Test plan

- `NODE_ENV=test npx vitest run src/composer/draft/create-flow.test.ts` (two new cases: restored attempt stays locked and never re-sends; superseded attempt leaves the store alone).
- `src/composer/draft/workspace-tab.test.ts`, `src/stores/create-flow-store.test.ts` pass.
- `npm run typecheck --workspace=@getpaseo/app`, lint and format on the changed files.
- Manual: with a 25 s artificial delay in `createAgentCommand`, submit from `/new`, reload mid-create, and confirm the draft tab comes back locked with the prompt instead of empty. Before this change the same steps produced two agents with the same prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
