### PR TITLE
Reject pending Codex app-server requests on dispose

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.spawn-error.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.spawn-error.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { CodexAppServerAgentClient } from "./codex-app-server-agent.js";
+import { runProviderRefreshWithDeadline } from "../provider-refresh-deadline.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
+import { createCodexAppServerChildProcess } from "./codex/test-utils/fake-app-server.js";
 
 describe("CodexAppServerAgentClient spawn error handling", () => {
   const logger = createTestLogger();
@@ -30,6 +32,31 @@ describe("CodexAppServerAgentClient spawn error handling", () => {
     } finally {
       process.off("uncaughtException", onUncaught);
     }
+  });
+
+  test("fetchCatalog settles when the refresh deadline aborts an unanswered initialize", async () => {
+    const client = new CodexAppServerAgentClient(logger, {
+      command: {
+        mode: "replace",
+        argv: ["/nonexistent/codex-binary-that-does-not-exist"],
+      },
+    });
+    const child = createCodexAppServerChildProcess();
+    const kill = vi.spyOn(child, "kill");
+    Object.assign(client, { spawnAppServer: async () => child });
+
+    await expect(
+      runProviderRefreshWithDeadline({
+        label: "Codex",
+        timeoutMs: 50,
+        operation: (context) =>
+          client.fetchCatalog(
+            { scope: "workspace", cwd: "/tmp/codex-models", force: false },
+            context,
+          ),
+      }),
+    ).rejects.toThrow("Timed out refreshing Codex after 50ms");
+    expect(kill).toHaveBeenCalled();
   });
 
   test("listImportableSessions rejects gracefully when the codex binary does not exist", async () => {

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
@@ -22,6 +22,16 @@ describe("Codex app-server transport", () => {
     child.stdin.end();
   });
 
+  test("dispose rejects pending requests instead of leaving them hanging", async () => {
+    const child = createCodexAppServerChildProcess();
+    const client = new CodexAppServerClient(child, createTestLogger());
+
+    const request = client.request("initialize", {});
+    await client.dispose();
+
+    await expect(request).rejects.toThrow("Codex app-server client is closed");
+  });
+
   test.each([
     "item/commandExecution/requestApproval",
     "item/fileChange/requestApproval",

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.ts
@@ -261,6 +261,7 @@ export class CodexAppServerClient {
     this.disposed = true;
     this.unexpectedTerminationHandler = null;
     this.rl.close();
+    this.rejectPending(new Error("Codex app-server client is closed"));
     try {
       this.child.stdin.end();
     } catch {
@@ -290,11 +291,7 @@ export class CodexAppServerClient {
     }
     this.disposed = true;
     this.rl.close();
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.reject(error);
-    }
-    this.pending.clear();
+    this.rejectPending(error);
     const handler = this.unexpectedTerminationHandler;
     this.unexpectedTerminationHandler = null;
     if (!handler) {
@@ -305,6 +302,14 @@ export class CodexAppServerClient {
     } catch (handlerError) {
       this.logger.warn({ err: handlerError }, "Codex app-server termination handler threw");
     }
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
   }
 
   private writeJsonRpcResponse(response: JsonRpcResponse): void {


### PR DESCRIPTION
## Problem

Opening the model picker in a new workspace could leave every Codex provider row at "Loading" forever, with no timeout in the daemon log. Details in #4282.

The provider refresh deadline aborts a Codex catalog probe by disposing the app-server client and waiting for the probe to settle. `CodexAppServerClient.dispose()` killed the child without rejecting in-flight requests, and the request fallback timeout is 14 days. An unanswered `initialize` therefore left `fetchCatalog` pending past the deadline, so the workspace snapshot entry never left `loading`.

## Fix

`dispose()` now rejects every pending request with "Codex app-server client is closed", using the same helper as the unexpected-termination path. The deadline surfaces as an error entry with the timeout message, which the picker renders with a retry.

#4281 addresses the other half (one app-server start queued per new workspace). The two changes do not overlap.

## Verification

- New transport test: a pending request rejects when the client is disposed.
- New client test: a deadline-aborted `fetchCatalog` with an unanswered `initialize` settles with the timeout error and kills the child. Both fail on `main` and pass here.
- `npx vitest run` on `codex/app-server-transport.test.ts`, `codex-app-server-agent.spawn-error.test.ts`, and `codex-app-server-agent.test.ts` (148 tests) pass.
- `npm run typecheck`, `npm run lint`, `npm run format:check` clean.

Fixes #4282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
