### PR TITLE
fix(server): fetch the remote base ref before branching off a new worktree

### DIFF
--- a/packages/server/src/utils/worktree.test.ts
+++ b/packages/server/src/utils/worktree.test.ts
@@ -263,6 +263,65 @@ describe("paseo worktree manager", () => {
 
     expect(existsSync(created.worktreePath)).toBe(false);
   });
+
+  describe("branch-off from a remote-tracking base", () => {
+    function git(args: string[], cwd: string): string {
+      return execFileSync("git", ["-c", "commit.gpgsign=false", ...args], {
+        cwd,
+        encoding: "utf8",
+      }).trim();
+    }
+
+    // Repo has origin/main cached at "initial"; origin itself moves one commit ahead via a
+    // second clone so the local remote-tracking ref stays stale, as after a long idle period.
+    function advanceOriginPastCachedRef(): string {
+      const originDir = join(tempDir, "origin.git");
+      git(["clone", "--bare", "-q", repoDir, originDir], tempDir);
+      git(["remote", "add", "origin", originDir], repoDir);
+      git(["fetch", "-q", "origin"], repoDir);
+
+      const pusherDir = join(tempDir, "pusher");
+      git(["clone", "-q", originDir, pusherDir], tempDir);
+      git(["config", "user.email", "test@test.com"], pusherDir);
+      git(["config", "user.name", "Test"], pusherDir);
+      writeFileSync(join(pusherDir, "file.txt"), "hello from origin\n");
+      git(["commit", "-q", "-am", "remote ahead"], pusherDir);
+      git(["push", "-q", "origin", "HEAD:main"], pusherDir);
+      return git(["rev-parse", "HEAD"], pusherDir);
+    }
+
+    it("fetches origin so the new branch starts at the remote tip, not the cached ref", async () => {
+      const remoteTip = advanceOriginPastCachedRef();
+      expect(git(["rev-parse", "refs/remotes/origin/main"], repoDir)).not.toBe(remoteTip);
+
+      const created = await createLegacyWorktreeForTest({
+        branchName: "from-remote-tip",
+        cwd: repoDir,
+        baseBranch: "origin/main",
+        worktreeSlug: "from-remote-tip",
+        paseoHome,
+      });
+
+      expect(git(["rev-parse", "HEAD"], created.worktreePath)).toBe(remoteTip);
+      expect(git(["rev-parse", "refs/remotes/origin/main"], repoDir)).toBe(remoteTip);
+    });
+
+    it("falls back to the cached remote-tracking ref when the remote is unreachable", async () => {
+      advanceOriginPastCachedRef();
+      const cachedTip = git(["rev-parse", "refs/remotes/origin/main"], repoDir);
+      git(["remote", "set-url", "origin", join(tempDir, "does-not-exist.git")], repoDir);
+
+      const created = await createLegacyWorktreeForTest({
+        branchName: "from-cached-ref",
+        cwd: repoDir,
+        baseBranch: "origin/main",
+        worktreeSlug: "from-cached-ref",
+        paseoHome,
+      });
+
+      expect(git(["rev-parse", "HEAD"], created.worktreePath)).toBe(cachedTip);
+    });
+  });
 });
 
 describe("slugify", () => {

--- a/packages/server/src/utils/worktree.test.ts
+++ b/packages/server/src/utils/worktree.test.ts
@@ -274,11 +274,11 @@ describe("paseo worktree manager", () => {
 
     // Repo has origin/main cached at "initial"; origin itself moves one commit ahead via a
     // second clone so the local remote-tracking ref stays stale, as after a long idle period.
-    function advanceOriginPastCachedRef(): string {
+    function advanceOriginPastCachedRef(remoteName = "origin"): string {
       const originDir = join(tempDir, "origin.git");
       git(["clone", "--bare", "-q", repoDir, originDir], tempDir);
-      git(["remote", "add", "origin", originDir], repoDir);
-      git(["fetch", "-q", "origin"], repoDir);
+      git(["remote", "add", remoteName, originDir], repoDir);
+      git(["fetch", "-q", remoteName], repoDir);
 
       const pusherDir = join(tempDir, "pusher");
       git(["clone", "-q", originDir, pusherDir], tempDir);
@@ -320,6 +320,37 @@ describe("paseo worktree manager", () => {
       });
 
       expect(git(["rev-parse", "HEAD"], created.worktreePath)).toBe(cachedTip);
+    });
+
+    it("fetches from a remote whose name contains a slash", async () => {
+      const remoteTip = advanceOriginPastCachedRef("team/upstream");
+
+      const created = await createLegacyWorktreeForTest({
+        branchName: "from-slash-remote",
+        cwd: repoDir,
+        baseBranch: "refs/remotes/team/upstream/main",
+        worktreeSlug: "from-slash-remote",
+        paseoHome,
+      });
+
+      expect(git(["rev-parse", "HEAD"], created.worktreePath)).toBe(remoteTip);
+    });
+
+    it("skips the fetch when the requested branch already exists locally", async () => {
+      advanceOriginPastCachedRef();
+      const cachedTip = git(["rev-parse", "refs/remotes/origin/main"], repoDir);
+      git(["branch", "existing"], repoDir);
+
+      const created = await createLegacyWorktreeForTest({
+        branchName: "existing",
+        cwd: repoDir,
+        baseBranch: "origin/main",
+        worktreeSlug: "existing",
+        paseoHome,
+      });
+
+      expect(git(["rev-parse", "HEAD"], created.worktreePath)).toBe(cachedTip);
+      expect(git(["rev-parse", "refs/remotes/origin/main"], repoDir)).toBe(cachedTip);
     });
   });
 });

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1312,6 +1312,7 @@ async function resolveWorktreeSourcePlan({
       await validateGitBranchName(cwd, branchName);
       const normalizedBaseBranch = normalizeRequiredBaseBranch(source.baseBranch);
       const resolvedBaseBranch = await resolveBaseBranchForWorktree(cwd, source.baseBranch);
+      await refreshRemoteTrackingBaseRef(cwd, resolvedBaseBranch);
       const branchExists = await localBranchExists(cwd, branchName);
       const base = branchExists ? branchName : resolvedBaseBranch;
       const candidateBranch = branchExists ? desiredSlug : branchName;
@@ -1642,6 +1643,21 @@ async function resolveBaseBranchForWorktree(
     }
   }
   throw new Error(`Base branch not found: ${normalized}`);
+}
+
+// A remote-tracking base like refs/remotes/origin/main is only as fresh as the last fetch, and
+// nothing on the branch-off path guarantees one ran. Refresh it so the new branch starts at the
+// remote tip; when the fetch fails (offline, auth) the cached ref is still a usable base.
+async function refreshRemoteTrackingBaseRef(cwd: string, resolvedBaseRef: string): Promise<void> {
+  const match = /^refs\/remotes\/([^/]+)\/(.+)$/.exec(resolvedBaseRef);
+  if (!match) {
+    return;
+  }
+  try {
+    await tryFetchWorktreeTrackingRemote({ cwd, remoteName: match[1], headRef: match[2] });
+  } catch {
+    // Fetch timed out or the remote config could not be read; branch from the cached ref.
+  }
 }
 
 async function localBranchExists(cwd: string, branchName: string): Promise<boolean> {

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1312,9 +1312,9 @@ async function resolveWorktreeSourcePlan({
       await validateGitBranchName(cwd, branchName);
       const normalizedBaseBranch = normalizeRequiredBaseBranch(source.baseBranch);
       const resolvedBaseBranch = await resolveBaseBranchForWorktree(cwd, source.baseBranch);
-      await refreshRemoteTrackingBaseRef(cwd, resolvedBaseBranch);
       const branchExists = await localBranchExists(cwd, branchName);
       const base = branchExists ? branchName : resolvedBaseBranch;
+      await refreshRemoteTrackingBaseRef(cwd, base);
       const candidateBranch = branchExists ? desiredSlug : branchName;
       const newBranchName = await resolveUniqueLocalBranchName(cwd, candidateBranch);
 
@@ -1649,12 +1649,22 @@ async function resolveBaseBranchForWorktree(
 // nothing on the branch-off path guarantees one ran. Refresh it so the new branch starts at the
 // remote tip; when the fetch fails (offline, auth) the cached ref is still a usable base.
 async function refreshRemoteTrackingBaseRef(cwd: string, resolvedBaseRef: string): Promise<void> {
-  const match = /^refs\/remotes\/([^/]+)\/(.+)$/.exec(resolvedBaseRef);
-  if (!match) {
+  if (!resolvedBaseRef.startsWith("refs/remotes/")) {
     return;
   }
   try {
-    await tryFetchWorktreeTrackingRemote({ cwd, remoteName: match[1], headRef: match[2] });
+    // Remote names may contain slashes, so the owner is looked up rather than parsed. Git refuses
+    // a remote whose name is a prefix of another remote's, so at most one configured remote matches.
+    const { stdout } = await runGitCommand(["remote"], { cwd });
+    const remoteName = stdout
+      .split("\n")
+      .map((name) => name.trim())
+      .find((name) => name.length > 0 && resolvedBaseRef.startsWith(`refs/remotes/${name}/`));
+    if (!remoteName) {
+      return;
+    }
+    const headRef = resolvedBaseRef.slice(`refs/remotes/${remoteName}/`.length);
+    await tryFetchWorktreeTrackingRemote({ cwd, remoteName, headRef });
   } catch {
     // Fetch timed out or the remote config could not be read; branch from the cached ref.
   }


### PR DESCRIPTION
### Linked issue

No issue was filed. The bug and this exact change were discussed in #4115 (my comment on 2026-09-01 has the reflog from a live repro on 0.7.1, and @ismatBabirli replied there that it can go in alongside #4116). Overlaps with #4116, which additionally covers the unqualified `main` case, see Non-goals.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Creating a workspace off `origin/<branch>` uses whatever `refs/remotes/origin/<branch>` the repository happens to have cached. Nothing on the `branch-off` path fetches, and the daemon's background fetch only runs for repositories that have an observed workspace, so a repository you have not opened in Paseo for a while starts the new branch behind the remote. You only notice later, when the PR is based on old commits or a rebase turns up conflicts that should not exist.

I hit this on 0.7.1: a workspace created at 21:07 off `origin/main` started from a commit that was two commits behind a remote tip that had been there since 15:26 (reflog in #4115). This was with the qualified base that `public-docs/worktrees.md` recommends as the workaround, so the workaround does not help when the cached ref itself is stale.

With this change, branching off a remote-tracking base refreshes that one ref first, so the new branch starts at the remote tip. If the fetch fails (offline, auth, timeout) the cached ref is used as before, so creation keeps working offline.

### Goals

- When the resolved base is `refs/remotes/<remote>/<branch>`, fetch exactly that branch from that remote before `git worktree add`. The remote comes from the ref, so `upstream/main` fetches `upstream`.
- Fall back to the cached remote-tracking ref when the fetch fails. The fetch never fails workspace creation.
- Reuse the existing `tryFetchWorktreeTrackingRemote` helper (same narrow single-branch fetch, same 120 s timeout as the PR checkout path). No new git plumbing.
- No protocol, client, CLI or UI change. Server-only, `worktree.ts` plus tests.

### Non-goals

- An unqualified base such as `main` still resolves to the local branch and is not refreshed. That is the half #4116 handles (`resolveRepositoryDefaultBranch` prefers the local branch, so a fetch alone cannot fix it).
- No opt-out toggle. The fetch is one branch from one remote, never `--prune`, and never touches the checkout. If a repository's fetching is managed outside Paseo (#3335) and this still gets in the way, a toggle can be added on top.
- Local isolation is untouched. Only the worktree `branch-off` path changes.

### QA

Tested on macOS 26.5.2 (git 2.55.0, Node 26.7.0) in the server package. Not tested on Windows or Linux; the change is git-only server code with no platform-specific paths. No client change, so no screenshots.

| Platform             | Tested | Notes                                   |
| -------------------- | ------ | --------------------------------------- |
| Daemon macOS         | yes    | vitest against real git repositories    |
| Daemon Linux         | no     |                                         |
| Daemon Windows       | no     |                                         |
| iOS / Android / Web / Desktop | n/a | no client or protocol change        |

Before: the reflog in #4115, a branch created from a stale `refs/remotes/origin/main` two commits behind `git ls-remote origin refs/heads/main`, on 0.7.1.

Regression test against the pre-fix `worktree.ts` (fails for the reported reason, the worktree HEAD is the cached ref instead of the remote tip):

```
$ git checkout HEAD~1 -- src/utils/worktree.ts
$ npx vitest run src/utils/worktree.test.ts -t "remote-tracking base"
 ❯ src/utils/worktree.test.ts (22 tests | 1 failed | 20 skipped) 416ms
       × fetches origin so the new branch starts at the remote tip, not the cached ref 219ms
 FAIL  src/utils/worktree.test.ts > paseo worktree manager > branch-off from a remote-tracking base > fetches origin so the new branch starts at the remote tip, not the cached ref
AssertionError: expected 'ebec639f9b64a1bca2af4d08e344853cd817d…' to be '283625cfe4fd39b93b5da160909d882c14289…' // Object.is equality
      Tests  1 failed | 1 passed | 20 skipped (22)
```

With the fix (includes the two tests added for the bot review: a remote named `team/upstream`, and an existing local branch that must not trigger a fetch):

```
$ npx vitest run src/utils/worktree.test.ts
      Tests  24 passed (24)
$ npx vitest run src/utils/worktree.posix.test.ts
      Tests  46 passed | 1 skipped (47)
```

The new tests use real git repositories, no mocks: a bare `origin` that a second clone pushes to so the local remote-tracking ref stays stale, and for the offline case the remote URL is pointed at a path that does not exist.

Checks from the repository root:

```
$ npm run typecheck          # all 11 workspaces
EXIT=0
$ npm run lint
Found 0 warnings and 0 errors.
Finished in 631ms on 3950 files with 177 rules using 14 threads.
$ npm run format:check
All matched files use the correct format.
Finished in 720ms on 4203 files using 14 threads.
```

I did not re-run a manual daemon repro after the fix; the regression test drives the real `createWorktree` branch-off path against a real stale remote.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
