### PR TITLE
fix(claude): read cumulative input usage from message_delta

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -1912,13 +1912,17 @@ describe("ClaudeAgentSession context window usage", () => {
     };
   }
 
-  function createMessageDeltaEvent(outputTokens: number): Record<string, unknown> {
+  function createMessageDeltaEvent(
+    outputTokens: number,
+    usage: Record<string, unknown> = {},
+  ): Record<string, unknown> {
     return {
       type: "stream_event",
       event: {
         type: "message_delta",
         usage: {
           output_tokens: outputTokens,
+          ...usage,
         },
       },
       session_id: "session-1",
@@ -2648,6 +2652,89 @@ describe("ClaudeAgentSession context window usage", () => {
           provider: "claude",
           usage: {
             contextWindowUsedTokens: 175,
+          },
+        }),
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("message_delta input usage replaces an empty message_start count", async () => {
+    // Translating gateways (LiteLLM in front of an OpenAI-compatible backend) do not know the
+    // prompt size when message_start is emitted, so they report input_tokens: 0 there and send
+    // the cumulative counts on message_delta, as the Anthropic Messages API allows.
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        createMessageStartEvent({
+          input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        }),
+        createMessageDeltaEvent(64, { input_tokens: 20_236 }),
+        createSuccessResult({
+          usage: {
+            input_tokens: 20_236,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 64,
+            iterations: [],
+          },
+        }),
+      ],
+    ]);
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "usage_updated",
+          provider: "claude",
+          usage: {
+            contextWindowUsedTokens: 20_300,
+          },
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "turn_completed",
+          usage: expect.objectContaining({
+            inputTokens: 20_236,
+            outputTokens: 64,
+            contextWindowUsedTokens: 20_300,
+          }),
+        }),
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("message_delta without cache counters keeps the message_start cache usage", async () => {
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        createMessageStartEvent({
+          input_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 1_000,
+        }),
+        createMessageDeltaEvent(64, { input_tokens: 5 }),
+        createSuccessResult(),
+      ],
+    ]);
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "usage_updated",
+          provider: "claude",
+          usage: {
+            contextWindowUsedTokens: 1_069,
           },
         }),
       );

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -1912,18 +1912,16 @@ describe("ClaudeAgentSession context window usage", () => {
     };
   }
 
-  function createMessageDeltaEvent(
-    outputTokens: number,
-    usage: Record<string, unknown> = {},
-  ): Record<string, unknown> {
+  function createMessageDeltaEvent(outputTokens: number): Record<string, unknown> {
+    return createMessageDeltaUsageEvent({ output_tokens: outputTokens });
+  }
+
+  function createMessageDeltaUsageEvent(usage: Record<string, unknown>): Record<string, unknown> {
     return {
       type: "stream_event",
       event: {
         type: "message_delta",
-        usage: {
-          output_tokens: outputTokens,
-          ...usage,
-        },
+        usage,
       },
       session_id: "session-1",
     };
@@ -2672,7 +2670,7 @@ describe("ClaudeAgentSession context window usage", () => {
           cache_creation_input_tokens: 0,
           cache_read_input_tokens: 0,
         }),
-        createMessageDeltaEvent(64, { input_tokens: 20_236 }),
+        createMessageDeltaUsageEvent({ input_tokens: 20_236, output_tokens: 64 }),
         createSuccessResult({
           usage: {
             input_tokens: 20_236,
@@ -2721,7 +2719,7 @@ describe("ClaudeAgentSession context window usage", () => {
           cache_creation_input_tokens: 0,
           cache_read_input_tokens: 1_000,
         }),
-        createMessageDeltaEvent(64, { input_tokens: 5 }),
+        createMessageDeltaUsageEvent({ input_tokens: 5, output_tokens: 64 }),
         createSuccessResult(),
       ],
     ]);
@@ -2750,7 +2748,7 @@ describe("ClaudeAgentSession context window usage", () => {
     const session = await createSessionForTurns([
       [
         createInitMessage(),
-        createMessageDeltaEvent(64, { input_tokens: 20_236 }),
+        createMessageDeltaUsageEvent({ input_tokens: 20_236, output_tokens: 64 }),
         createMessageStartEvent({
           input_tokens: 40,
           cache_creation_input_tokens: 5,

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -2743,6 +2743,36 @@ describe("ClaudeAgentSession context window usage", () => {
     }
   });
 
+  test("message_delta before this request's message_start does not seed usage", async () => {
+    // A canceled request can leave its terminal message_delta queued behind the next turn.
+    // Nothing is known about the new request until its message_start, so that straggler
+    // must not produce a usage_updated event or leak into the next request's counters.
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        createMessageDeltaEvent(64, { input_tokens: 20_236 }),
+        createMessageStartEvent({
+          input_tokens: 40,
+          cache_creation_input_tokens: 5,
+          cache_read_input_tokens: 10,
+        }),
+        createMessageDeltaEvent(7),
+        createSuccessResult(),
+      ],
+    ]);
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      const usedTokens = events
+        .filter((event) => event.type === "usage_updated")
+        .map((event) => event.usage.contextWindowUsedTokens);
+      expect(usedTokens).toEqual([55, 62]);
+    } finally {
+      await session.close();
+    }
+  });
+
   test("per-request stream usage is not cumulative across API calls in a turn", async () => {
     const session = await createSessionForTurns([
       [

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1795,30 +1795,59 @@ function extractContextWindowSize(modelUsage: unknown): number | undefined {
   return maxContextWindow;
 }
 
-function readStreamRequestInputTokens(event: Record<string, unknown>): number | undefined {
-  const messageUsage = toObjectRecord(toObjectRecord(event.message)?.usage);
-  if (!messageUsage) {
+interface StreamRequestInputUsage {
+  inputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+}
+
+function readUsageCount(usage: Record<string, unknown>, key: string): number | undefined {
+  const value = usage[key];
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
     return undefined;
   }
-  const usage = messageUsage;
-  const inputTokens =
-    typeof usage.input_tokens === "number" && Number.isFinite(usage.input_tokens)
-      ? usage.input_tokens
-      : undefined;
-  const cacheCreationInputTokens =
-    typeof usage.cache_creation_input_tokens === "number" &&
-    Number.isFinite(usage.cache_creation_input_tokens)
-      ? usage.cache_creation_input_tokens
-      : 0;
-  const cacheReadInputTokens =
-    typeof usage.cache_read_input_tokens === "number" &&
-    Number.isFinite(usage.cache_read_input_tokens)
-      ? usage.cache_read_input_tokens
-      : 0;
-  if (typeof inputTokens !== "number" || inputTokens < 0) {
+  return value;
+}
+
+function readStreamRequestInputUsage(
+  event: Record<string, unknown>,
+): StreamRequestInputUsage | undefined {
+  const usage = toObjectRecord(toObjectRecord(event.message)?.usage);
+  if (!usage) {
     return undefined;
   }
-  return inputTokens + cacheCreationInputTokens + cacheReadInputTokens;
+  const inputTokens = readUsageCount(usage, "input_tokens");
+  if (inputTokens === undefined) {
+    return undefined;
+  }
+  return {
+    inputTokens,
+    cacheCreationInputTokens: readUsageCount(usage, "cache_creation_input_tokens") ?? 0,
+    cacheReadInputTokens: readUsageCount(usage, "cache_read_input_tokens") ?? 0,
+  };
+}
+
+/**
+ * The input counters on `message_delta.usage` are cumulative whole-request totals and are
+ * optional. Mirror the Anthropic SDK's MessageStream: a counter present on the delta replaces
+ * the `message_start` value, a missing counter keeps it. Translating gateways report
+ * `input_tokens: 0` on `message_start` and only know the real count by `message_delta`.
+ */
+function mergeStreamDeltaInputUsage(
+  current: StreamRequestInputUsage,
+  event: Record<string, unknown>,
+): StreamRequestInputUsage {
+  const usage = toObjectRecord(event.usage);
+  if (!usage) {
+    return current;
+  }
+  return {
+    inputTokens: readUsageCount(usage, "input_tokens") ?? current.inputTokens,
+    cacheCreationInputTokens:
+      readUsageCount(usage, "cache_creation_input_tokens") ?? current.cacheCreationInputTokens,
+    cacheReadInputTokens:
+      readUsageCount(usage, "cache_read_input_tokens") ?? current.cacheReadInputTokens,
+  };
 }
 
 function readStreamRequestOutputTokens(event: Record<string, unknown>): number | undefined {
@@ -1893,7 +1922,7 @@ function readClaudeParentToolUseId(message: SDKMessage): string | null {
 
 class ClaudeContextUsageState {
   private contextWindowMaxTokens: number | undefined;
-  private streamRequestInputTokens: number | undefined;
+  private streamRequestInputUsage: StreamRequestInputUsage | undefined;
   private streamRequestOutputTokens: number | undefined;
   private compactedContextWindowUsedTokens: number | undefined;
   private completedResultTurns = 0;
@@ -1903,7 +1932,7 @@ class ClaudeContextUsageState {
   }
 
   beginTurn(): void {
-    this.streamRequestInputTokens = undefined;
+    this.streamRequestInputUsage = undefined;
     this.streamRequestOutputTokens = undefined;
     this.compactedContextWindowUsedTokens = undefined;
   }
@@ -1927,11 +1956,11 @@ class ClaudeContextUsageState {
     }
     const eventType = readTrimmedString(streamEvent.type);
     if (eventType === "message_start") {
-      const inputTokens = readStreamRequestInputTokens(streamEvent);
-      if (typeof inputTokens !== "number") {
+      const inputUsage = readStreamRequestInputUsage(streamEvent);
+      if (!inputUsage) {
         return null;
       }
-      this.streamRequestInputTokens = inputTokens;
+      this.streamRequestInputUsage = inputUsage;
       this.streamRequestOutputTokens = 0;
     } else if (eventType === "message_delta") {
       const outputTokens = readStreamRequestOutputTokens(streamEvent);
@@ -1939,6 +1968,12 @@ class ClaudeContextUsageState {
         return null;
       }
       this.streamRequestOutputTokens = outputTokens;
+      if (this.streamRequestInputUsage) {
+        this.streamRequestInputUsage = mergeStreamDeltaInputUsage(
+          this.streamRequestInputUsage,
+          streamEvent,
+        );
+      }
     } else {
       return null;
     }
@@ -1985,13 +2020,15 @@ class ClaudeContextUsageState {
   }
 
   private streamUsedTokens(): number | undefined {
-    if (
-      typeof this.streamRequestInputTokens !== "number" ||
-      typeof this.streamRequestOutputTokens !== "number"
-    ) {
+    const inputUsage = this.streamRequestInputUsage;
+    if (!inputUsage || typeof this.streamRequestOutputTokens !== "number") {
       return undefined;
     }
-    const usedTokens = this.streamRequestInputTokens + this.streamRequestOutputTokens;
+    const usedTokens =
+      inputUsage.inputTokens +
+      inputUsage.cacheCreationInputTokens +
+      inputUsage.cacheReadInputTokens +
+      this.streamRequestOutputTokens;
     return usedTokens > 0 ? usedTokens : undefined;
   }
 
@@ -2010,7 +2047,7 @@ class ClaudeContextUsageState {
   }
 
   buildCompactionUsageEvent(postTokens: number | undefined): AgentStreamEvent {
-    this.streamRequestInputTokens = undefined;
+    this.streamRequestInputUsage = undefined;
     this.streamRequestOutputTokens = undefined;
     this.compactedContextWindowUsedTokens = postTokens;
     const usage: AgentUsage = {};


### PR DESCRIPTION
### Linked issue

Closes #4294

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

With one `extends: "claude"` provider on a LiteLLM proxy, the context meter works for Bedrock Claude models and freezes for non-Claude models behind the same proxy: `contextWindowUsedTokens` equals `outputTokens` while `inputTokens` is right. The proxy reports `input_tokens: 0` on `message_start` and the cumulative counts on `message_delta`, which the Messages API allows. `buildStreamUsageEvent` read the input side only from `message_start`, so the stream total became `0 + output_tokens`, and that total is the first candidate in `buildResultUsage` and the only source of `usage_updated` during a turn.

The change keeps the `message_start` input counters per field and lets a counter present on `message_delta` replace it, the rule the Anthropic SDK's `MessageStream` applies. A counter missing from the delta keeps the `message_start` value, so a gateway that omits cache fields on the delta does not lose `cache_read_input_tokens`.

### Goals

- Report input, cache and output tokens when the input counts arrive on `message_delta`, both in `usage_updated` during the turn and on the result.
- Keep the numbers unchanged for backends that report the counts on `message_start`.
- Regression tests for both.

### Non-goals

- Result-time candidate selection in `buildResultUsage` (#4083, #4227 change that; this PR does not read or change it).
- `contextWindowMaxTokens` resolution for non-Claude models.
- App or UI changes.

### QA

The first new test fails on main for the reported reason (`usage_updated` carried 64, expected 20300):

```text
× message_delta input usage replaces an empty message_start count
  AssertionError: expected [ Array(4) ] to deep equally contain ObjectContaining{…}
```

With the change:

```text
$ npx vitest run src/server/agent/providers/claude/agent.test.ts --bail=1 --reporter=verbose
 ✓ message_delta stream events update per-request usage
 ✓ message_delta input usage replaces an empty message_start count
 ✓ message_delta without cache counters keeps the message_start cache usage
 Test Files  1 passed (1)
      Tests  77 passed (77)

$ npm run lint -- <the two files>        Found 0 warnings and 0 errors.
$ npm run format:check:files -- <the two files>   All matched files use the correct format.
$ npm run typecheck                      all workspaces exit 0
```

Runtime on an isolated dev daemon (`127.0.0.1:6768`, own `PASEO_HOME`) with the real Claude Code 2.1.259 binary. Backend: LiteLLM v1.98.0 (Docker) in front of an OpenAI-compatible backend, and a second endpoint replaying the Anthropic-shaped stream as a control. Two-turn agent via `paseo run` plus a second prompt, `lastUsage` from the agent snapshot:

| backend | code | inputTokens | outputTokens | contextWindowUsedTokens |
| --- | --- | --- | --- | --- |
| LiteLLM v1.98.0 | main | 20347 | 64 | 64 |
| LiteLLM v1.98.0 | this PR | 20347 | 64 | 20411 |
| Anthropic-shaped control | main | 20238 | 64 | 20302 |
| Anthropic-shaped control | this PR | 20238 | 64 | 20302 |

Only the changed test file was run locally; the full suite is left to CI.

Tested on Linux (WSL2, Ubuntu 26.04). Not tested on macOS or Windows; the change is daemon logic with no platform-specific code, and CI runs the server tests on windows-latest. No app or UI change, so no screenshots.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
