### PR TITLE
Surface ACP context usage for generic agents

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1001,6 +1001,25 @@ describe("ACPAgentSession Zed parity", () => {
     });
   });
 
+  test("routes usage_update into context window usage", () => {
+    const session = createSession();
+    const internals = asInternals<ACPSessionInternals>(session);
+
+    const events = internals.translateSessionUpdate({
+      sessionUpdate: "usage_update",
+      size: 200_000,
+      used: 12_345,
+    });
+
+    expect(events).toEqual([
+      {
+        type: "usage_updated",
+        provider: "claude-acp",
+        usage: { contextWindowMaxTokens: 200_000, contextWindowUsedTokens: 12_345 },
+      },
+    ]);
+  });
+
   test("keeps pushed mode when a later config_option_update has no mode payload", async () => {
     const session = createSession();
     const internals = asInternals<ACPSessionInternals>(session);

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2680,8 +2680,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.handleSessionInfoUpdate(update);
         return pendingUserEvents;
       case "usage_update":
-        this.handleUsageUpdate(update);
-        return pendingUserEvents;
+        return [...pendingUserEvents, this.handleUsageUpdate(update)];
       case "available_commands_update":
         this.cachedCommands = update.availableCommands.map((command) => ({
           name: command.name,
@@ -2841,8 +2840,12 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
-  private handleUsageUpdate(update: UsageUpdate): void {
-    void update;
+  private handleUsageUpdate(update: UsageUpdate): AgentStreamEvent {
+    return {
+      type: "usage_updated",
+      provider: this.provider,
+      usage: { contextWindowMaxTokens: update.size, contextWindowUsedTokens: update.used },
+    };
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {


### PR DESCRIPTION
## Problem

The generic ACP provider receives `usage_update` session notifications (ACP SDK 0.17 `UsageUpdate { size, used }`) but `handleUsageUpdate` was a no-op stub. Agents that report context usage over ACP — Hermes does, via `estimate_request_tokens_rough` against the model context window — never populate Paseo's context-window indicator, while Claude/Codex/Pi providers do.

## Change

`handleUsageUpdate` now returns a `usage_updated` stream event:

```ts
{
  type: "usage_updated",
  provider: this.provider,
  usage: { contextWindowMaxTokens: update.size, contextWindowUsedTokens: update.used },
}
```

`AgentManager` already handles `usage_updated` by setting `agent.lastUsage` and re-emitting state, so no downstream changes are needed. Per-turn `inputTokens`/`outputTokens` still arrive via `PromptResponse.usage` as before; the two sources merge in `agent.lastUsage`.

## Test

Added `routes usage_update into context window usage` to `acp-agent.test.ts` — asserts a `usage_update` translates to exactly one `usage_updated` event with both context-window fields. Observed failing (`expected [] to deeply equal [...]`) before the fix.

## Verification

- `vitest run src/server/agent/providers/acp-agent.test.ts` — 98 passed
- `oxfmt --check` / `oxlint` on touched files — clean
- server `typecheck` — no errors in touched files

*Written by Terminus (AI Assistant)*
