### PR TITLE
Fix local speech sessions leaked by cancel-during-connect race

### DIFF
--- a/packages/server/src/server/dictation/dictation-stream-manager.test.ts
+++ b/packages/server/src/server/dictation/dictation-stream-manager.test.ts
@@ -218,6 +218,47 @@ describe("DictationStreamManager (provider-agnostic provider)", () => {
     expect(sttProvider.lastLanguage).toBe("pt");
   });
 
+  it("closes the STT session when cancel arrives while connect is in flight", async () => {
+    let releaseConnect: () => void = () => {};
+    const session = new FakeRealtimeSession();
+    session.connect = () =>
+      new Promise<void>((resolve) => {
+        releaseConnect = () => {
+          session.connected = true;
+          resolve();
+        };
+      });
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+    });
+
+    const start = manager.handleStart("d-race", "audio/pcm;rate=16000;bits=16");
+    await tick();
+    manager.handleCancel("d-race");
+    releaseConnect();
+    await start;
+
+    expect(session.closed).toBe(true);
+    // No stream was registered for the cancelled dictation.
+    await manager.handleChunk({
+      dictationId: "d-race",
+      seq: 0,
+      audioBase64: buildPcmBase64(1000, 160),
+      format: "audio/pcm;rate=16000;bits=16",
+    });
+    expect(
+      emitted.find(
+        (msg) =>
+          msg.type === "dictation_stream_error" &&
+          (msg.payload as { error: string }).error === "Dictation stream not started",
+      ),
+    ).toBeDefined();
+  });
+
   it("does not require OPENAI_API_KEY", async () => {
     const original = process.env.OPENAI_API_KEY;
     delete process.env.OPENAI_API_KEY;

--- a/packages/server/src/server/dictation/dictation-stream-manager.ts
+++ b/packages/server/src/server/dictation/dictation-stream-manager.ts
@@ -135,6 +135,9 @@ export class DictationStreamManager {
   private readonly finalTimeoutMs: number;
   private readonly autoCommitSeconds: number;
   private readonly streams = new Map<string, DictationStreamState>();
+  // STT sessions still inside `connect()`; a cancel/cleanup that lands during
+  // that await must be able to close them or the provider session leaks.
+  private readonly connecting = new Map<string, StreamingTranscriptionSession>();
 
   constructor(params: {
     logger: pino.Logger;
@@ -158,7 +161,7 @@ export class DictationStreamManager {
   }
 
   public cleanupAll(): void {
-    for (const dictationId of this.streams.keys()) {
+    for (const dictationId of [...this.streams.keys(), ...this.connecting.keys()]) {
       this.cleanupDictationStream(dictationId);
     }
   }
@@ -249,10 +252,22 @@ export class DictationStreamManager {
       void this.failAndCleanupDictationStream(dictationId, message, true);
     });
 
+    this.connecting.set(dictationId, stt);
+    let connectError: unknown = null;
     try {
       await stt.connect();
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      connectError = error;
+    }
+    // handleCancel/cleanupAll during the await already closed `stt` and
+    // removed it; do not register a stream for a dictation that is gone.
+    const wasCancelled = this.connecting.get(dictationId) !== stt;
+    this.connecting.delete(dictationId);
+    if (wasCancelled) {
+      return;
+    }
+    if (connectError !== null) {
+      const message = connectError instanceof Error ? connectError.message : String(connectError);
       this.failDictationStream(dictationId, message, true);
       try {
         stt.close();
@@ -554,6 +569,15 @@ export class DictationStreamManager {
   }
 
   private cleanupDictationStream(dictationId: string): void {
+    const pending = this.connecting.get(dictationId);
+    if (pending) {
+      this.connecting.delete(dictationId);
+      try {
+        pending.close();
+      } catch {
+        // no-op
+      }
+    }
     const state = this.streams.get(dictationId) ?? null;
     if (!state) {
       return;

--- a/packages/server/src/server/speech/providers/local/worker-client.test.ts
+++ b/packages/server/src/server/speech/providers/local/worker-client.test.ts
@@ -374,6 +374,35 @@ describe("LocalSpeechWorkerClient", () => {
     await expect(stoppedPromise).resolves.toEqual([]);
   });
 
+  it("releases a session closed while its create round-trip is in flight", async () => {
+    const { client, workers } = createClient({ idleTtlMs: 5 });
+    const provider = new WorkerBackedSpeechToTextProvider(client, "dictationStt");
+    const session = provider.createSession({ logger: pino({ level: "silent" }) });
+
+    const connect = session.connect();
+    const createRequest = workers[0].sent[0];
+    expect(createRequest).toMatchObject({ type: "session.create", kind: "dictationStt" });
+
+    // Cancel lands before the worker has answered session.create.
+    session.close();
+    workers[0].respond(createRequest, { requiredSampleRate: 16000 });
+    await connect;
+    await waitForMicrotasks();
+
+    const closeRequest = workers[0].sent[1];
+    expect(workers[0].sent.map((m) => m.type)).toEqual(["session.create", "session.close"]);
+    expect(closeRequest).toMatchObject({
+      type: "session.close",
+      sessionId: createRequest.sessionId,
+    });
+    workers[0].respond(closeRequest);
+    await waitForMicrotasks();
+
+    // With no session left registered the idle shutdown must fire.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(workers[0].kills).toBe(1);
+  });
+
   it("kills an idle worker and respawns on later use", async () => {
     const { client, workers } = createClient({ idleTtlMs: 5 });
 

--- a/packages/server/src/server/speech/providers/local/worker-client.ts
+++ b/packages/server/src/server/speech/providers/local/worker-client.ts
@@ -637,6 +637,7 @@ class WorkerBackedTranscriptionSession
   public requiredSampleRate = DEFAULT_LOCAL_SAMPLE_RATE;
   private connectedSessionId: string | null = null;
   private connecting: Promise<void> | null = null;
+  private closed = false;
 
   constructor(
     private readonly client: LocalSpeechWorkerClient,
@@ -658,6 +659,13 @@ class WorkerBackedTranscriptionSession
   private async connectRemoteSession(): Promise<void> {
     try {
       const result = await this.client.createSession(this.kind, this);
+      if (this.closed) {
+        // close() raced the worker round-trip; release the session the
+        // worker just registered or it stays in activeSessionIds forever
+        // and the idle shutdown never fires.
+        this.client.closeSession(result.sessionId);
+        return;
+      }
       this.connectedSessionId = result.sessionId;
       this.requiredSampleRate = result.requiredSampleRate;
     } finally {
@@ -691,6 +699,7 @@ class WorkerBackedTranscriptionSession
   }
 
   close(): void {
+    this.closed = true;
     const sessionId = this.connectedSessionId;
     this.connectedSessionId = null;
     if (sessionId) {
@@ -703,6 +712,7 @@ class WorkerBackedTurnDetectionSession extends EventEmitter implements TurnDetec
   public requiredSampleRate = DEFAULT_LOCAL_SAMPLE_RATE;
   private connectedSessionId: string | null = null;
   private connecting: Promise<void> | null = null;
+  private closed = false;
 
   constructor(private readonly client: LocalSpeechWorkerClient) {
     super();
@@ -721,6 +731,10 @@ class WorkerBackedTurnDetectionSession extends EventEmitter implements TurnDetec
   private async connectRemoteSession(): Promise<void> {
     try {
       const result = await this.client.createSession("vad", this);
+      if (this.closed) {
+        this.client.closeSession(result.sessionId);
+        return;
+      }
       this.connectedSessionId = result.sessionId;
       this.requiredSampleRate = result.requiredSampleRate;
     } finally {
@@ -752,6 +766,7 @@ class WorkerBackedTurnDetectionSession extends EventEmitter implements TurnDetec
   }
 
   close(): void {
+    this.closed = true;
     const sessionId = this.connectedSessionId;
     this.connectedSessionId = null;
     if (sessionId) {


### PR DESCRIPTION
## Problem

A dictation cancel can arrive while `DictationStreamManager.handleStart()` is awaiting the local STT `session.create` IPC round-trip. At that point the session is not yet in `streams`, so `handleCancel()` has nothing to close. When the worker replies, `LocalSpeechWorkerClient.activeSessionIds` retains the session forever. Because idle shutdown requires `activeSessionIds.size === 0`, the local speech worker and its loaded models never unload.

Observed on daemon 0.7.2 after a canceled dictation:

- `Paseo Voice`: 1,150 MiB RSS for 108 minutes
- forced SIGTERM reported `activeSessionCount: 2`, with no pending requests
- expected idle TTL: 5 minutes

This pushed a 5 GiB daemon cgroup past its pressure threshold and caused unrelated agent workers to be killed.

## Fix

Two complementary guards:

1. Track dictation sessions during `connect()` so `handleCancel()` and `cleanupAll()` can close them before they enter the active stream map. A canceled connect does not subsequently register a stream.
2. Make worker-backed STT and VAD sessions remember `close()` during their create round-trip. If `session.create` responds afterward, immediately send `session.close`, removing the late registration from `activeSessionIds`.

The second guard fixes the lifecycle invariant at the provider seam and covers non-dictation callers; the first prevents canceled dictations from becoming active streams.

## Verification

### RED — tests against `origin/main` implementations

```
Test Files  2 failed (2)
Tests       2 failed | 22 passed (24)
```

Failures were the new cancel-during-connect tests:

- manager session remained open (`expected false to be true`)
- worker emitted only `session.create`, not the required `session.close`

### GREEN — fixed implementation

```
Test Files  2 passed (2)
Tests       24 passed (24)
typecheck_exit=0 lines=0
Found 0 warnings and 0 errors.
fmt_exit=0
```

Tests were run on Node 22.12 after building the protocol/client/plugin/highlight workspace dependencies.