### PR TITLE
fix(server): support OpenCode 2 in terminal activity plugin

### DIFF
--- a/docs/terminal-activity.md
+++ b/docs/terminal-activity.md
@@ -65,7 +65,7 @@ Codex hook mapping:
 - `PermissionRequest` → `needs-input`
 - `Stop` → `idle`
 
-OpenCode uses a server plugin instead of command hooks. The plugin listens to OpenCode bus events and emits these Paseo hook events:
+OpenCode uses a server plugin instead of command hooks. Both OpenCode generations read the same global config directory and auto-discover this file, so it default-exports a single definition that serves both: OpenCode 2 loads it as a definition object (`id` + `setup()`, events via `ctx.event.subscribe()` with `{ type, data }` payloads) and ignores the 1.x entrypoint; OpenCode 1 loads the same object through its `server()` entrypoint (bus events as `{ type, properties }` payloads). The plugin emits these Paseo hook events:
 
 - `session.status` with `busy` or `retry` → `running`
 - `session.status` with `idle` → `idle`

--- a/docs/terminal-activity.md
+++ b/docs/terminal-activity.md
@@ -65,12 +65,18 @@ Codex hook mapping:
 - `PermissionRequest` → `needs-input`
 - `Stop` → `idle`
 
-OpenCode uses a server plugin instead of command hooks. Both OpenCode generations read the same global config directory and auto-discover this file, so it default-exports a single definition that serves both: OpenCode 2 loads it as a definition object (`id` + `setup()`, events via `ctx.event.subscribe()` with `{ type, data }` payloads) and ignores the 1.x entrypoint; OpenCode 1 loads the same object through its `server()` entrypoint (bus events as `{ type, properties }` payloads). The plugin emits these Paseo hook events:
+OpenCode uses a server plugin instead of command hooks. Both generations discover the same global plugin file. Their loaders select separate entrypoints: OpenCode 1 calls `server()` with `{ type, properties }` bus events; OpenCode 2 calls `setup()` and subscribes to decoded `{ type, data }` events. Do not share their status mapping: V1 publishes `session.status` snapshots, while V2 publishes `session.execution.*` transitions.
 
-- `session.status` with `busy` or `retry` → `running`
-- `session.status` with `idle` → `idle`
-- `permission.asked` → `needs-input`
-- `permission.replied` → `running`
+| OpenCode event                                              | Generation | Activity    |
+| ----------------------------------------------------------- | ---------- | ----------- |
+| `session.status` with `busy` or `retry`                     | 1          | running     |
+| `session.status` with `idle`                                | 1          | idle        |
+| `session.execution.started`                                 | 2          | running     |
+| `session.execution.succeeded`, `.failed`, or `.interrupted` | 2          | idle        |
+| `permission.asked`                                          | Both       | needs-input |
+| `permission.replied`                                        | Both       | running     |
+
+The plugin translates both event contracts into the existing Paseo hook events. OpenCode 2 disposes its event subscription when the plugin unloads.
 
 The daemon maps hook states onto terminal activity like an agent lifecycle plus unread attention: `running` → `state: working`, `idle` → `state: idle`, and `needs-input` → `state: idle` with `attentionReason: needs_input`. A `working` → `idle` transition records `state: idle` with `attentionReason: finished` until the user focuses that terminal; plain idle terminals still contribute no workspace status.
 

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -2487,6 +2487,8 @@ test.each(["hang", "reject"])(
       expect(client.resumeSessionCalls).toBe(0);
       expect(manager.getAgent(snapshot.id)?.session).toBe(client.firstSession);
     } finally {
+      await manager.flush();
+      await storage.flush();
       rmSync(workdir, { recursive: true, force: true });
     }
   },

--- a/packages/server/src/terminal/agent-hooks/opencode/opencode-plugin.ts
+++ b/packages/server/src/terminal/agent-hooks/opencode/opencode-plugin.ts
@@ -1,5 +1,15 @@
 import type { AgentHookPluginFileInstallStrategy } from "../agent-hook-installer.js";
 
+// The plugin must load under both OpenCode generations because both read the
+// same global config directory:
+//
+// - OpenCode 2 rejects V1 hook-object plugins and requires a default-exported
+//   definition object with an id and a setup() function. Unknown keys are
+//   ignored, so the 1.x server entrypoint below is inert there. Events arrive
+//   through ctx.event.subscribe() as decoded payloads shaped { type, data }.
+// - OpenCode 1 accepts a default-exported object exposing a callable server()
+//   entrypoint (an id is required for path plugins). Bus events arrive through
+//   the returned `event` hook as payloads shaped { type, properties }.
 export const OPENCODE_PLUGIN_SOURCE = [
   "const STATUS_EVENTS = {",
   '  busy: "session.status.busy",',
@@ -7,11 +17,11 @@ export const OPENCODE_PLUGIN_SOURCE = [
   '  idle: "session.status.idle",',
   "};",
   "",
-  "function paseoEventFor(event) {",
-  '  if (event?.type === "permission.asked") return "permission.asked";',
-  '  if (event?.type === "permission.replied") return "permission.replied";',
-  '  if (event?.type !== "session.status") return null;',
-  "  return STATUS_EVENTS[event?.properties?.status?.type] ?? null;",
+  "function paseoEventFor(type, statusType) {",
+  '  if (type === "permission.asked") return "permission.asked";',
+  '  if (type === "permission.replied") return "permission.replied";',
+  '  if (type !== "session.status") return null;',
+  "  return STATUS_EVENTS[statusType] ?? null;",
   "}",
   "",
   "function runPaseoHook(event) {",
@@ -26,12 +36,27 @@ export const OPENCODE_PLUGIN_SOURCE = [
   "  } catch {}",
   "}",
   "",
-  "export default async () => ({",
-  "  event: async ({ event }) => {",
-  "    const paseoEvent = paseoEventFor(event);",
-  "    if (paseoEvent) runPaseoHook(paseoEvent);",
+  "export default {",
+  '  id: "paseo-terminal-activity",',
+  "  server() {",
+  "    return {",
+  "      event: async ({ event }) => {",
+  "        const paseoEvent = paseoEventFor(event?.type, event?.properties?.status?.type);",
+  "        if (paseoEvent) runPaseoHook(paseoEvent);",
+  "      },",
+  "    };",
   "  },",
-  "});",
+  "  setup(ctx) {",
+  "    const controller = new AbortController();",
+  "    void (async () => {",
+  "      for await (const event of ctx.event.subscribe({ signal: controller.signal })) {",
+  "        const paseoEvent = paseoEventFor(event?.type, event?.data?.status?.type);",
+  "        if (paseoEvent) runPaseoHook(paseoEvent);",
+  "      }",
+  "    })().catch(() => {});",
+  "    return () => controller.abort();",
+  "  },",
+  "};",
   "",
 ].join("\n");
 

--- a/packages/server/src/terminal/agent-hooks/opencode/opencode-plugin.ts
+++ b/packages/server/src/terminal/agent-hooks/opencode/opencode-plugin.ts
@@ -1,39 +1,49 @@
 import type { AgentHookPluginFileInstallStrategy } from "../agent-hook-installer.js";
 
-// The plugin must load under both OpenCode generations because both read the
-// same global config directory:
-//
-// - OpenCode 2 rejects V1 hook-object plugins and requires a default-exported
-//   definition object with an id and a setup() function. Unknown keys are
-//   ignored, so the 1.x server entrypoint below is inert there. Events arrive
-//   through ctx.event.subscribe() as decoded payloads shaped { type, data }.
-// - OpenCode 1 accepts a default-exported object exposing a callable server()
-//   entrypoint (an id is required for path plugins). Bus events arrive through
-//   the returned `event` hook as payloads shaped { type, properties }.
+// Both generations discover the same file. Their loaders select the entrypoint:
+// OpenCode 1 calls server(); OpenCode 2 calls setup(). Keep their event contracts
+// separate: V1 publishes status snapshots, V2 publishes execution transitions.
 export const OPENCODE_PLUGIN_SOURCE = [
-  "const STATUS_EVENTS = {",
+  "const V1_STATUS_EVENTS = {",
   '  busy: "session.status.busy",',
   '  retry: "session.status.retry",',
   '  idle: "session.status.idle",',
   "};",
   "",
-  "function paseoEventFor(type, statusType) {",
+  "const V2_EVENTS = {",
+  '  "session.execution.started": "session.status.busy",',
+  '  "session.execution.succeeded": "session.status.idle",',
+  '  "session.execution.failed": "session.status.idle",',
+  '  "session.execution.interrupted": "session.status.idle",',
+  '  "permission.asked": "permission.asked",',
+  '  "permission.replied": "permission.replied",',
+  "};",
+  "",
+  "function paseoEventForV1(event) {",
+  "  const type = event.type;",
   '  if (type === "permission.asked") return "permission.asked";',
   '  if (type === "permission.replied") return "permission.replied";',
   '  if (type !== "session.status") return null;',
-  "  return STATUS_EVENTS[statusType] ?? null;",
+  "  return V1_STATUS_EVENTS[event.properties.status.type] ?? null;",
   "}",
+  "",
+  // CLI processes can finish out of order, especially for immediate failures.
+  // Both entrypoints enqueue reports so an older busy report cannot overwrite idle.
+  "let pendingHook = Promise.resolve();",
   "",
   "function runPaseoHook(event) {",
   "  if (!process.env.PASEO_TERMINAL_ID) return;",
-  "  try {",
-  '    const child = Bun.spawn(["paseo", "hooks", "opencode", event], {',
-  '      stdin: "ignore",',
-  '      stdout: "ignore",',
-  '      stderr: "ignore",',
-  "    });",
-  "    void child.exited.catch(() => {});",
-  "  } catch {}",
+  "  pendingHook = pendingHook.then(async () => {",
+  "    try {",
+  '      const child = Bun.spawn(["paseo", "hooks", "opencode", event], {',
+  '        stdin: "ignore",',
+  '        stdout: "ignore",',
+  '        stderr: "ignore",',
+  "      });",
+  "      await child.exited;",
+  "    } catch {}",
+  "  });",
+  "  return pendingHook;",
   "}",
   "",
   "export default {",
@@ -41,8 +51,8 @@ export const OPENCODE_PLUGIN_SOURCE = [
   "  server() {",
   "    return {",
   "      event: async ({ event }) => {",
-  "        const paseoEvent = paseoEventFor(event?.type, event?.properties?.status?.type);",
-  "        if (paseoEvent) runPaseoHook(paseoEvent);",
+  "        const paseoEvent = paseoEventForV1(event);",
+  "        if (paseoEvent) await runPaseoHook(paseoEvent);",
   "      },",
   "    };",
   "  },",
@@ -50,8 +60,8 @@ export const OPENCODE_PLUGIN_SOURCE = [
   "    const controller = new AbortController();",
   "    void (async () => {",
   "      for await (const event of ctx.event.subscribe({ signal: controller.signal })) {",
-  "        const paseoEvent = paseoEventFor(event?.type, event?.data?.status?.type);",
-  "        if (paseoEvent) runPaseoHook(paseoEvent);",
+  "        const paseoEvent = V2_EVENTS[event.type];",
+  "        if (paseoEvent) await runPaseoHook(paseoEvent);",
   "      }",
   "    })().catch(() => {});",
   "    return () => controller.abort();",

--- a/packages/server/src/terminal/agent-hooks/opencode/opencode.test.ts
+++ b/packages/server/src/terminal/agent-hooks/opencode/opencode.test.ts
@@ -48,10 +48,29 @@ describe("OpenCode terminal agent hooks", () => {
     expect(source).toContain('busy: "session.status.busy"');
     expect(source).toContain('retry: "session.status.retry"');
     expect(source).toContain('idle: "session.status.idle"');
-    expect(source).toContain('event?.type === "permission.asked"');
-    expect(source).toContain('event?.type === "permission.replied"');
+    expect(source).toContain('type === "permission.asked"');
+    expect(source).toContain('type === "permission.replied"');
     expect(source).toContain('Bun.spawn(["paseo", "hooks", "opencode", event]');
     expect(source).toContain("PASEO_TERMINAL_ID");
+  });
+
+  it("writes a default definition that loads under OpenCode 1 and 2", () => {
+    const configDir = createTempDir("paseo-opencode-config-generations-");
+    const { configPath } = installAgentHooks(opencodeAgentHookProvider, { configDir });
+    const source = readFileSync(configPath, "utf8");
+
+    // OpenCode 2 requires a default-exported definition object with an id and
+    // setup(), and ignores unknown keys such as the 1.x server entrypoint.
+    expect(source).toContain("export default {");
+    expect(source).toContain('id: "paseo-terminal-activity"');
+    expect(source).toContain("setup(ctx)");
+    expect(source).toContain("ctx.event.subscribe({ signal: controller.signal })");
+    // OpenCode 1 loads object exports through their server() entrypoint and
+    // delivers bus events as { type, properties } payloads.
+    expect(source).toContain("server()");
+    expect(source).toContain("event?.properties?.status?.type");
+    // OpenCode 2 decoded events carry { type, data } payloads.
+    expect(source).toContain("event?.data?.status?.type");
   });
 
   it("uninstalls the OpenCode plugin file", () => {

--- a/packages/server/src/terminal/agent-hooks/opencode/opencode.test.ts
+++ b/packages/server/src/terminal/agent-hooks/opencode/opencode.test.ts
@@ -1,6 +1,9 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { addAbortSignal, PassThrough, Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+import { runInNewContext } from "node:vm";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   agentHooksAreInstalled,
@@ -40,37 +43,123 @@ describe("OpenCode terminal agent hooks", () => {
     expect(agentHooksAreInstalled(opencodeAgentHookProvider, { configDir })).toBe(true);
   });
 
-  it("writes the plugin that maps OpenCode bus events to paseo hook events", () => {
-    const configDir = createTempDir("paseo-opencode-config-source-");
-    const { configPath } = installAgentHooks(opencodeAgentHookProvider, { configDir });
-    const source = readFileSync(configPath, "utf8");
+  it.each(["succeeded", "failed", "interrupted"])(
+    "reports OpenCode 2 execution start and %s as running then idle",
+    async (outcome) => {
+      const { plugin, commands } = loadInstalledPlugin();
+      const events = Readable.from([
+        { type: "session.execution.started", data: { sessionID: "session-1" } },
+        { type: `session.execution.${outcome}`, data: { sessionID: "session-1" } },
+      ]);
 
-    expect(source).toContain('busy: "session.status.busy"');
-    expect(source).toContain('retry: "session.status.retry"');
-    expect(source).toContain('idle: "session.status.idle"');
-    expect(source).toContain('type === "permission.asked"');
-    expect(source).toContain('type === "permission.replied"');
-    expect(source).toContain('Bun.spawn(["paseo", "hooks", "opencode", event]');
-    expect(source).toContain("PASEO_TERMINAL_ID");
+      const dispose = plugin.setup({ event: { subscribe: () => events } });
+      await finished(events);
+      dispose();
+
+      expect(commands).toEqual([
+        ["paseo", "hooks", "opencode", "session.status.busy"],
+        ["paseo", "hooks", "opencode", "session.status.idle"],
+      ]);
+    },
+  );
+
+  it("reports OpenCode 1 status and permission events through server()", async () => {
+    const { plugin, commands } = loadInstalledPlugin();
+    const hooks = plugin.server();
+    for (const event of [
+      { type: "session.status", properties: { status: { type: "busy" } } },
+      { type: "permission.asked" },
+      { type: "permission.replied" },
+      { type: "session.status", properties: { status: { type: "retry" } } },
+      { type: "session.status", properties: { status: { type: "idle" } } },
+      { type: "session.execution.started", data: { sessionID: "session-1" } },
+      { type: "message.updated" },
+    ]) {
+      await hooks.event({ event });
+    }
+
+    expect(plugin.id).toBe("paseo-terminal-activity");
+    expect(commands).toEqual([
+      ["paseo", "hooks", "opencode", "session.status.busy"],
+      ["paseo", "hooks", "opencode", "permission.asked"],
+      ["paseo", "hooks", "opencode", "permission.replied"],
+      ["paseo", "hooks", "opencode", "session.status.retry"],
+      ["paseo", "hooks", "opencode", "session.status.idle"],
+    ]);
   });
 
-  it("writes a default definition that loads under OpenCode 1 and 2", () => {
-    const configDir = createTempDir("paseo-opencode-config-generations-");
-    const { configPath } = installAgentHooks(opencodeAgentHookProvider, { configDir });
-    const source = readFileSync(configPath, "utf8");
+  it("reports OpenCode 2 permission events and ignores V1 status snapshots", async () => {
+    const { plugin, commands } = loadInstalledPlugin();
+    const events = Readable.from([
+      { type: "permission.asked", data: { sessionID: "session-1" } },
+      { type: "permission.replied", data: { sessionID: "session-1" } },
+      { type: "session.status", properties: { status: { type: "busy" } } },
+      { type: "session.text.delta", data: { sessionID: "session-1" } },
+    ]);
 
-    // OpenCode 2 requires a default-exported definition object with an id and
-    // setup(), and ignores unknown keys such as the 1.x server entrypoint.
-    expect(source).toContain("export default {");
-    expect(source).toContain('id: "paseo-terminal-activity"');
-    expect(source).toContain("setup(ctx)");
-    expect(source).toContain("ctx.event.subscribe({ signal: controller.signal })");
-    // OpenCode 1 loads object exports through their server() entrypoint and
-    // delivers bus events as { type, properties } payloads.
-    expect(source).toContain("server()");
-    expect(source).toContain("event?.properties?.status?.type");
-    // OpenCode 2 decoded events carry { type, data } payloads.
-    expect(source).toContain("event?.data?.status?.type");
+    const dispose = plugin.setup({ event: { subscribe: () => events } });
+    await finished(events);
+    dispose();
+
+    expect(commands).toEqual([
+      ["paseo", "hooks", "opencode", "permission.asked"],
+      ["paseo", "hooks", "opencode", "permission.replied"],
+    ]);
+  });
+
+  it("preserves activity order when the host dispatches events concurrently", async () => {
+    let finishFirstHook = () => {};
+    const firstExit = new Promise<number>((resolve) => {
+      finishFirstHook = () => resolve(0);
+    });
+    const { plugin, commands } = loadInstalledPlugin("terminal-1", firstExit);
+    const hooks = plugin.server();
+
+    const working = hooks.event({
+      event: { type: "session.status", properties: { status: { type: "busy" } } },
+    });
+    const idle = hooks.event({
+      event: { type: "session.status", properties: { status: { type: "idle" } } },
+    });
+    await Promise.resolve();
+    expect(commands).toEqual([["paseo", "hooks", "opencode", "session.status.busy"]]);
+
+    finishFirstHook();
+    await Promise.all([working, idle]);
+    expect(commands).toEqual([
+      ["paseo", "hooks", "opencode", "session.status.busy"],
+      ["paseo", "hooks", "opencode", "session.status.idle"],
+    ]);
+  });
+
+  it("stops the OpenCode 2 subscription when unloaded", async () => {
+    const { plugin, commands } = loadInstalledPlugin();
+    const events = new PassThrough({ objectMode: true });
+    const closed = finished(events);
+    const dispose = plugin.setup({
+      event: { subscribe: ({ signal }) => addAbortSignal(signal, events) },
+    });
+
+    dispose();
+
+    await expect(closed).rejects.toMatchObject({ name: "AbortError" });
+    expect(commands).toEqual([]);
+  });
+
+  it("keeps both generations inert outside Paseo terminals", async () => {
+    const { plugin, commands } = loadInstalledPlugin("");
+    await plugin.server().event({
+      event: { type: "session.status", properties: { status: { type: "busy" } } },
+    });
+    const events = Readable.from([
+      { type: "session.execution.started", data: { sessionID: "session-1" } },
+      { type: "permission.asked", data: { sessionID: "session-1" } },
+    ]);
+    const dispose = plugin.setup({ event: { subscribe: () => events } });
+    await finished(events);
+    dispose();
+
+    expect(commands).toEqual([]);
   });
 
   it("uninstalls the OpenCode plugin file", () => {
@@ -140,3 +229,39 @@ describe("OpenCode terminal agent hooks", () => {
     ).resolves.toBe(state);
   });
 });
+
+interface OpenCodeEvent {
+  type: string;
+  properties?: { status: { type: string } };
+  data?: { sessionID: string };
+}
+
+interface InstalledPlugin {
+  id: string;
+  server(): { event(input: { event: OpenCodeEvent }): Promise<void> };
+  setup(context: {
+    event: { subscribe(options: { signal: AbortSignal }): AsyncIterable<OpenCodeEvent> };
+  }): () => void;
+}
+
+function loadInstalledPlugin(terminalId = "terminal-1", exited = Promise.resolve(0)) {
+  const configDir = createTempDir("paseo-opencode-runtime-");
+  const { configPath } = installAgentHooks(opencodeAgentHookProvider, { configDir });
+  const source = readFileSync(configPath, "utf8");
+  const commands: string[][] = [];
+  // Supply the host runtime at the script boundary; execute the installed source.
+  const plugin: InstalledPlugin = runInNewContext(
+    source.replace("export default", "globalThis.plugin ="),
+    {
+      AbortController,
+      process: { env: { PASEO_TERMINAL_ID: terminalId } },
+      Bun: {
+        spawn(command: string[]) {
+          commands.push(command);
+          return { exited };
+        },
+      },
+    },
+  );
+  return { plugin, commands };
+}


### PR DESCRIPTION
Fixes #4299

OpenCode 2 rejects Paseo's legacy function-exported terminal activity plugin. This change installs one default definition with explicit entrypoints for both generations: OpenCode 1 calls `server()` and maps status snapshots; OpenCode 2 calls `setup()` and maps execution transitions. There is no event-shape fallback between generations.

OpenCode 2 execution start reports running; success, failure, and interruption report idle. Both generations retain permission reporting and the `PASEO_TERMINAL_ID` gate. Hook CLI processes run in order so a fast completion cannot be overwritten by a delayed running report. The V2 event subscription is aborted when the plugin unloads.

## Independent QA

Linux, real OpenCode 1.14.33 and OpenCode 2 `0.0.0-beta-19059`, isolated HOME/XDG directories, auto-discovered generated plugin, real Paseo CLI from this checkout, and HTTP capture of activity reports. Real model prompts used `opencode/big-pickle`; failure used an unconfigured provider; interruption used the real session interrupt endpoint after observing execution start.

| Journey | Observed result |
| --- | --- |
| Baseline on OpenCode 2 | Reproduced the reported default-definition schema load failure |
| Initial PR on OpenCode 2 | Loaded, but completed prompts produced no activity: actual events are `session.execution.*` |
| Corrected OpenCode 2: permission ask → approve → completed prompt | `needs-input → running → running → idle`; prompt returned `OK` |
| Corrected OpenCode 2: failed execution | `running → idle` |
| Corrected OpenCode 2: interrupted execution | `running → idle` |
| Corrected OpenCode 1: shell command and completed prompt | `running → idle → running → running → running → idle`; prompt returned `OK` |

Real failure QA also reproduced out-of-order CLI delivery before serialization (`idle → running`); the corrected run and a failing-first concurrency regression test verify report ordering.

Automated tests execute the installed plugin source with a supplied host runtime, covering both entrypoints, all V2 terminal outcomes, permissions, cross-generation event isolation, concurrent delivery ordering, the terminal gate, and subscription disposal. These unit tests use an in-memory subprocess adapter; the manual QA above exercises real subprocesses and provider loaders.

```
cd packages/server
npx --no-install vitest run src/terminal/agent-hooks/opencode/opencode.test.ts --bail=1
Test Files  1 passed (1)
     Tests  18 passed (18)
```

`npm run build:server`, `npm run typecheck`, `npm run lint`, and `npm run format` pass. Dependencies were installed and workspace declarations rebuilt before typechecking.

CI also exposed a teardown race in a reload test added on main: directory removal raced pending persistence. After rebasing, its cleanup now awaits manager and storage flushes. All 179 agent-manager tests pass locally, including 10 repeated focused runs (20 cases) of the affected hang/reject test.

Not exercised: macOS/Windows, app UI indicators/notifications, or other OpenCode 1 releases. No production daemon restart or user config changes were needed.
