### PR TITLE
fix(server): preserve fresh locks across PID namespaces

### DIFF
--- a/packages/server/src/server/pid-lock.test.ts
+++ b/packages/server/src/server/pid-lock.test.ts
@@ -254,4 +254,69 @@ describe("pid-lock ownership", () => {
       await rm(paseoHome, { recursive: true, force: true });
     }
   });
+
+  test("keeps a recently heartbeating lock when the recorded pid is not visible", async () => {
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-pid-lock-fresh-unseen-owner-"));
+    const unseenOwnerPid = 2_147_483_647;
+
+    try {
+      await writeFile(
+        join(paseoHome, "paseo.pid"),
+        JSON.stringify({
+          pid: unseenOwnerPid,
+          startedAt: new Date().toISOString(),
+          hostname: "shared-host",
+          uid: process.getuid?.() ?? 0,
+          listen: "127.0.0.1:6767",
+          heartbeat: true,
+        }),
+      );
+
+      await expect(isLocked(paseoHome)).resolves.toMatchObject({
+        locked: true,
+        info: { pid: unseenOwnerPid },
+      });
+      await expect(acquirePidLock(paseoHome, null, { ownerPid: process.pid })).rejects.toThrow(
+        "Another Paseo daemon is already running",
+      );
+
+      const lock = await getPidLockInfo(paseoHome);
+      expect(lock?.pid).toBe(unseenOwnerPid);
+      expect(lock?.listen).toBe("127.0.0.1:6767");
+    } finally {
+      await rm(paseoHome, { recursive: true, force: true });
+    }
+  });
+
+  test("reclaims an unseen owner after its heartbeat grace period expires", async () => {
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-pid-lock-stale-unseen-owner-"));
+    const unseenOwnerPid = 2_147_483_647;
+    const replacementOwnerPid = process.pid;
+
+    try {
+      const pidPath = join(paseoHome, "paseo.pid");
+      await writeFile(
+        pidPath,
+        JSON.stringify({
+          pid: unseenOwnerPid,
+          startedAt: "2026-01-01T00:00:00.000Z",
+          hostname: "shared-host",
+          uid: process.getuid?.() ?? 0,
+          listen: "127.0.0.1:6767",
+          heartbeat: true,
+        }),
+      );
+      const staleTime = new Date(Date.now() - 2 * 60_000);
+      await utimes(pidPath, staleTime, staleTime);
+
+      await expect(isLocked(paseoHome)).resolves.toMatchObject({ locked: false });
+      await acquirePidLock(paseoHome, null, { ownerPid: replacementOwnerPid });
+
+      const lock = await getPidLockInfo(paseoHome);
+      expect(lock?.pid).toBe(replacementOwnerPid);
+      expect(lock?.heartbeat).toBe(true);
+    } finally {
+      await rm(paseoHome, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/server/src/server/pid-lock.test.ts
+++ b/packages/server/src/server/pid-lock.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, open, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdtemp, open, readFile, rm, stat, unlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
@@ -315,6 +315,55 @@ describe("pid-lock ownership", () => {
       const lock = await getPidLockInfo(paseoHome);
       expect(lock?.pid).toBe(replacementOwnerPid);
       expect(lock?.heartbeat).toBe(true);
+    } finally {
+      await rm(paseoHome, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps an unseen owner that refreshes its heartbeat during stale-lock recovery", async () => {
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-pid-lock-racing-heartbeat-"));
+    const unseenOwnerPid = 2_147_483_647;
+    const pidPath = join(paseoHome, "paseo.pid");
+    let statCalls = 0;
+
+    try {
+      await writeFile(
+        pidPath,
+        JSON.stringify({
+          pid: unseenOwnerPid,
+          startedAt: "2026-01-01T00:00:00.000Z",
+          hostname: "shared-host",
+          uid: process.getuid?.() ?? 0,
+          listen: "127.0.0.1:6767",
+          heartbeat: true,
+        }),
+      );
+      const staleTime = new Date(Date.now() - 2 * 60_000);
+      await utimes(pidPath, staleTime, staleTime);
+
+      await expect(
+        acquirePidLock(paseoHome, null, {
+          ownerPid: process.pid,
+          filesystem: {
+            async readTextFile(path) {
+              return readFile(path, "utf-8");
+            },
+            async statMtimeMs(path) {
+              const mtimeMs = (await stat(path)).mtimeMs;
+              statCalls += 1;
+              if (statCalls === 1) {
+                const refreshedAt = new Date();
+                await utimes(path, refreshedAt, refreshedAt);
+              }
+              return mtimeMs;
+            },
+            unlink,
+          },
+        }),
+      ).rejects.toThrow("PID lock changed while checking whether it was abandoned");
+
+      const lock = await getPidLockInfo(paseoHome);
+      expect(lock?.pid).toBe(unseenOwnerPid);
     } finally {
       await rm(paseoHome, { recursive: true, force: true });
     }

--- a/packages/server/src/server/pid-lock.ts
+++ b/packages/server/src/server/pid-lock.ts
@@ -56,22 +56,29 @@ function getPidFilePath(paseoHome: string): string {
   return join(paseoHome, "paseo.pid");
 }
 
-async function isPidLockFresh(pidPath: string): Promise<boolean> {
+async function isPidLockFresh(
+  pidPath: string,
+  filesystem: PidLockFileSystem = nodePidLockFileSystem,
+): Promise<boolean> {
   try {
-    const lockStat = await stat(pidPath);
-    return lockStat.mtimeMs >= Date.now() - PID_LOCK_STALE_MS;
+    const mtimeMs = await filesystem.statMtimeMs(pidPath);
+    return mtimeMs >= Date.now() - PID_LOCK_STALE_MS;
   } catch {
     return false;
   }
 }
 
-async function hasRecentPidLockHeartbeat(pidPath: string, lock: PidLockInfo): Promise<boolean> {
+async function hasRecentPidLockHeartbeat(
+  pidPath: string,
+  lock: PidLockInfo,
+  filesystem: PidLockFileSystem = nodePidLockFileSystem,
+): Promise<boolean> {
   if (lock.heartbeat !== true) {
     return false;
   }
   try {
-    const lockStat = await stat(pidPath);
-    return lockStat.mtimeMs >= Date.now() - PID_LOCK_UNSEEN_OWNER_GRACE_MS;
+    const mtimeMs = await filesystem.statMtimeMs(pidPath);
+    return mtimeMs >= Date.now() - PID_LOCK_UNSEEN_OWNER_GRACE_MS;
   } catch {
     return false;
   }
@@ -82,9 +89,12 @@ async function touchPidLockFile(pidPath: string): Promise<void> {
   await utimes(pidPath, now, now);
 }
 
-async function readPidLock(pidPath: string): Promise<PidLockInfo | null> {
+async function readPidLock(
+  pidPath: string,
+  filesystem: PidLockFileSystem = nodePidLockFileSystem,
+): Promise<PidLockInfo | null> {
   try {
-    const content = await readFile(pidPath, "utf-8");
+    const content = await filesystem.readTextFile(pidPath);
     return parsePidLockInfo(JSON.parse(content));
   } catch {
     return null;
@@ -101,7 +111,24 @@ function resolveOwnerPid(ownerPid?: number): number {
 interface AcquirePidLockOptions {
   ownerPid?: number;
   reclaimStaleDesktopLock?: boolean;
+  filesystem?: PidLockFileSystem;
 }
+
+interface PidLockFileSystem {
+  readTextFile(path: string): Promise<string>;
+  statMtimeMs(path: string): Promise<number>;
+  unlink(path: string): Promise<void>;
+}
+
+const nodePidLockFileSystem: PidLockFileSystem = {
+  async readTextFile(path) {
+    return readFile(path, "utf-8");
+  },
+  async statMtimeMs(path) {
+    return (await stat(path)).mtimeMs;
+  },
+  unlink,
+};
 
 function canReclaimLiveLock(
   lock: PidLockInfo,
@@ -128,6 +155,7 @@ async function clearExistingPidLock(
   existingLock: PidLockInfo,
   lockOwnerPid: number,
   options: AcquirePidLockOptions | undefined,
+  filesystem: PidLockFileSystem,
 ): Promise<"already_owned" | "cleared"> {
   const lockOwnerRunning = isPidRunning(existingLock.pid);
   if (existingLock.pid === lockOwnerPid && lockOwnerRunning) {
@@ -137,32 +165,48 @@ async function clearExistingPidLock(
 
   // A process in another PID namespace cannot signal the lock owner even though both processes
   // share PASEO_HOME. A recent heartbeat is the cross-namespace proof that the owner is alive.
-  if (!lockOwnerRunning && (await hasRecentPidLockHeartbeat(pidPath, existingLock))) {
-    throw createLockHeldError(existingLock);
-  }
-
-  if (lockOwnerRunning) {
-    const reclaimable = canReclaimLiveLock(existingLock, options);
-    if (!reclaimable || (await isPidLockFresh(pidPath))) {
+  if (!lockOwnerRunning) {
+    if (await hasRecentPidLockHeartbeat(pidPath, existingLock, filesystem)) {
       throw createLockHeldError(existingLock);
     }
 
     // Re-read immediately before unlinking so a heartbeat at the stale boundary wins.
-    const confirmedLock = await readPidLock(pidPath);
+    const confirmedLock = await readPidLock(pidPath, filesystem);
     if (
       !confirmedLock ||
       !isSamePidLock(existingLock, confirmedLock) ||
-      (await isPidLockFresh(pidPath))
+      (await hasRecentPidLockHeartbeat(pidPath, confirmedLock, filesystem))
     ) {
       throw new PidLockError("PID lock changed while checking whether it was abandoned");
     }
   }
 
-  await unlink(pidPath).catch(() => {});
+  if (lockOwnerRunning) {
+    const reclaimable = canReclaimLiveLock(existingLock, options);
+    if (!reclaimable || (await isPidLockFresh(pidPath, filesystem))) {
+      throw createLockHeldError(existingLock);
+    }
+
+    // Re-read immediately before unlinking so a heartbeat at the stale boundary wins.
+    const confirmedLock = await readPidLock(pidPath, filesystem);
+    if (
+      !confirmedLock ||
+      !isSamePidLock(existingLock, confirmedLock) ||
+      (await isPidLockFresh(pidPath, filesystem))
+    ) {
+      throw new PidLockError("PID lock changed while checking whether it was abandoned");
+    }
+  }
+
+  await filesystem.unlink(pidPath).catch(() => {});
   return "cleared";
 }
 
-async function writeNewPidLock(pidPath: string, lockInfo: PidLockInfo): Promise<void> {
+async function writeNewPidLock(
+  pidPath: string,
+  lockInfo: PidLockInfo,
+  filesystem: PidLockFileSystem,
+): Promise<void> {
   let fd;
   try {
     fd = await open(pidPath, "wx");
@@ -172,7 +216,7 @@ async function writeNewPidLock(pidPath: string, lockInfo: PidLockInfo): Promise<
       throw error;
     }
 
-    const raceLock = await readPidLock(pidPath);
+    const raceLock = await readPidLock(pidPath, filesystem);
     if (raceLock) {
       throw new PidLockError(
         `Another Paseo daemon is already running (PID ${raceLock.pid})`,
@@ -191,6 +235,7 @@ export async function acquirePidLock(
   options?: AcquirePidLockOptions,
 ): Promise<void> {
   const pidPath = getPidFilePath(paseoHome);
+  const filesystem = options?.filesystem ?? nodePidLockFileSystem;
 
   // Ensure paseoHome directory exists
   if (!existsSync(paseoHome)) {
@@ -198,12 +243,18 @@ export async function acquirePidLock(
   }
 
   // Try to read existing lock
-  const existingLock = await readPidLock(pidPath);
+  const existingLock = await readPidLock(pidPath, filesystem);
 
   // Check if existing lock is stale
   const lockOwnerPid = resolveOwnerPid(options?.ownerPid);
   if (existingLock) {
-    const result = await clearExistingPidLock(pidPath, existingLock, lockOwnerPid, options);
+    const result = await clearExistingPidLock(
+      pidPath,
+      existingLock,
+      lockOwnerPid,
+      options,
+      filesystem,
+    );
     if (result === "already_owned") {
       return;
     }
@@ -220,7 +271,7 @@ export async function acquirePidLock(
     ...(process.env.PASEO_DESKTOP_MANAGED === "1" ? { desktopManaged: true } : {}),
   };
 
-  await writeNewPidLock(pidPath, lockInfo);
+  await writeNewPidLock(pidPath, lockInfo, filesystem);
 }
 
 export async function refreshPidLock(

--- a/packages/server/src/server/pid-lock.ts
+++ b/packages/server/src/server/pid-lock.ts
@@ -39,6 +39,7 @@ export class PidLockError extends Error {
 // Stale recovery is for abandoned locks, so keep this well above ordinary event-loop stalls.
 const PID_LOCK_STALE_MS = 5 * 60_000;
 const PID_LOCK_HEARTBEAT_INTERVAL_MS = 30_000;
+const PID_LOCK_UNSEEN_OWNER_GRACE_MS = 2 * PID_LOCK_HEARTBEAT_INTERVAL_MS;
 const PID_LOCK_READ_RETRY_ATTEMPTS = 10;
 const PID_LOCK_READ_RETRY_DELAY_MS = 50;
 
@@ -59,6 +60,18 @@ async function isPidLockFresh(pidPath: string): Promise<boolean> {
   try {
     const lockStat = await stat(pidPath);
     return lockStat.mtimeMs >= Date.now() - PID_LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
+}
+
+async function hasRecentPidLockHeartbeat(pidPath: string, lock: PidLockInfo): Promise<boolean> {
+  if (lock.heartbeat !== true) {
+    return false;
+  }
+  try {
+    const lockStat = await stat(pidPath);
+    return lockStat.mtimeMs >= Date.now() - PID_LOCK_UNSEEN_OWNER_GRACE_MS;
   } catch {
     return false;
   }
@@ -120,6 +133,12 @@ async function clearExistingPidLock(
   if (existingLock.pid === lockOwnerPid && lockOwnerRunning) {
     await touchPidLockFile(pidPath);
     return "already_owned";
+  }
+
+  // A process in another PID namespace cannot signal the lock owner even though both processes
+  // share PASEO_HOME. A recent heartbeat is the cross-namespace proof that the owner is alive.
+  if (!lockOwnerRunning && (await hasRecentPidLockHeartbeat(pidPath, existingLock))) {
+    throw createLockHeldError(existingLock);
   }
 
   if (lockOwnerRunning) {
@@ -358,6 +377,9 @@ export async function isLocked(
     return { locked: false };
   }
   if (!isPidRunning(info.pid)) {
+    if (await hasRecentPidLockHeartbeat(getPidFilePath(paseoHome), info)) {
+      return { locked: true, info };
+    }
     return { locked: false, info };
   }
   return { locked: true, info };


### PR DESCRIPTION
## Summary

- keep a PID lock held when its recorded process is not visible but its heartbeat was refreshed recently
- make `isLocked()` report the same protected state, so callers do not classify a cross-namespace owner as stale
- preserve crash recovery by expiring the protection after two heartbeat intervals (60 seconds)

Fixes #4307.

Related: #1304 and #1555.

## Why

`process.kill(pid, 0)` only answers whether a PID is visible in the caller's PID namespace. An agent sandbox can share the host's `PASEO_HOME` while being unable to see the healthy host daemon PID. Before this change, the sandbox classified the lock as stale, replaced it with a namespace-local PID, and caused the host supervisor to exit with `pid_lock_ownership_lost`.

The supervisor already refreshes `paseo.pid` every 30 seconds. This change treats a heartbeat refreshed within two intervals as cross-namespace evidence that the owner is alive. If the owner actually crashed, the existing reclaim path becomes available after the 60-second grace period.

Legacy locks without `heartbeat: true` retain their existing behavior. The five-minute desktop stale-lock recovery path is unchanged.

## Regression coverage

The new test uses the real filesystem and the public PID-lock operations. It writes a lock whose PID is not visible to the test process, matching the observable condition inside the sandbox.

Before the implementation, the regression test failed for the reported reason:

```text
FAIL  packages/server/src/server/pid-lock.test.ts > pid-lock ownership > keeps a recently heartbeating lock when the recorded pid is not visible
AssertionError: expected { locked: false, info: { … } } to match object { locked: true, … }
Test Files  1 failed (1)
Tests       1 failed | 8 passed (10)
```

After the implementation:

```text
$ npx vitest run packages/server/src/server/pid-lock.test.ts --bail=1
Test Files  1 passed (1)
Tests       10 passed (10)
```

The second new test verifies that an unseen owner is reclaimable after the heartbeat grace period, so an unclean shutdown does not leave a permanent lock.

## Validation

```text
$ npm run build:server
@getpaseo/protocol build: passed
@getpaseo/client build: passed
@getpaseo/highlight build: passed
@getpaseo/plugin build: passed
@getpaseo/relay build: passed
@getpaseo/server build: passed
@getpaseo/cli build: passed

$ npm run typecheck:server
@getpaseo/relay typecheck: passed
@getpaseo/protocol typecheck: passed
@getpaseo/client typecheck: passed
@getpaseo/server typecheck: passed
@getpaseo/cli typecheck: passed

$ npm run lint
Found 0 warnings and 0 errors.

$ git commit
pre-commit lint: passed
pre-commit format: passed
pre-commit typecheck (all workspaces): passed
```

## Platform QA

| Platform | Tested | Notes |
| --- | --- | --- |
| Linux daemon | Yes | Node 22.23.2; real filesystem regression test and the original systemd incident logs in #4307 |
| Docker / separate PID namespace | Covered at the PID-lock boundary | The regression uses the exact observable condition: owner PID unavailable while the shared lock heartbeat is current |
| macOS daemon | No | No macOS host available |
| Windows daemon | No | No Windows host available |

No UI behavior changed, so screenshots or video are not applicable.
