### PR TITLE
Accept hostname-style patterns and port wildcards in cors.allowedOrigins and hostnames

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,7 +66,7 @@ Host header validation and CORS origin checks are defense-in-depth controls for 
 
 CORS is not a complete security boundary. It controls which browser origins can make requests, but does not prevent a malicious website from resolving its domain to your local machine (DNS rebinding).
 
-Paseo validates the `Host` header on every HTTP request and every WebSocket upgrade against an allowlist (Vite-style semantics). By default, only `localhost`, `*.localhost`, and any literal IP address (IPv4 or IPv6) are accepted. Additional hostnames can be configured via `hostnames` in `config.json` or the `PASEO_HOSTNAMES` env var (comma-separated; entries beginning with `.` match a domain and its subdomains; the value `true` disables the allowlist entirely). Requests with unrecognized hosts are rejected with `403 Host not allowed`.
+Paseo validates the `Host` header on every HTTP request and every WebSocket upgrade against an allowlist (Vite-style semantics). By default, only `localhost`, `*.localhost`, and any literal IP address (IPv4 or IPv6) are accepted. Additional hostnames can be configured via `hostnames` in `config.json` or the `PASEO_HOSTNAMES` env var (comma-separated; entries beginning with `.` match a domain and its subdomains; a `:port` suffix requires that port; the value `true` disables the allowlist entirely). Requests with unrecognized hosts are rejected with `403 Host not allowed`. `cors.allowedOrigins` uses the same syntax with an optional scheme; [public-docs/security.md](public-docs/security.md#browser-origins) has the full grammar for both lists.
 
 ## HTML file preview
 

--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -237,7 +237,7 @@ describe("paseo daemon bootstrap", () => {
         daemon: {
           ...initialPersisted.daemon,
           hostnames: ["127.0.0.1", "after.example.test"],
-          cors: { allowedOrigins: ["https://after.example.test"] },
+          cors: { allowedOrigins: ["after.example.test"] },
           trustedProxies: true as const,
           mcp: { enabled: false, injectIntoAgents: false },
           git: { maxProcessesPerSecond: 5, maxProcessConcurrency: 1 },

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -200,6 +200,7 @@ import {
 } from "./managed-processes/managed-processes.js";
 import { terminateWithTreeKill } from "../utils/tree-kill.js";
 import { isHostnameAllowed, type HostnamesConfig } from "./hostnames.js";
+import { isOriginAllowed } from "./origins.js";
 import {
   createRequireBearerMiddleware,
   isAgentMcpRequestAuthorized,
@@ -736,7 +737,7 @@ export async function createPaseoDaemon(
 
   app.use((req, res, next) => {
     const origin = req.headers.origin;
-    if (origin && (allowedOrigins.has("*") || allowedOrigins.has(origin))) {
+    if (origin && isOriginAllowed(origin, allowedOrigins)) {
       res.setHeader("Access-Control-Allow-Origin", origin);
       res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
       res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");

--- a/packages/server/src/server/host-patterns.test.ts
+++ b/packages/server/src/server/host-patterns.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { parseHostAuthority, parseHostPattern } from "./host-patterns.js";
+
+describe("parseHostPattern", () => {
+  it("splits scheme, subdomain marker, host, and port", () => {
+    expect(parseHostPattern("HTTPS://.Example.com:8443", { unspecifiedPort: "any" })).toEqual({
+      scheme: "https",
+      host: "example.com",
+      matchesSubdomains: true,
+      port: { kind: "exact", port: "8443" },
+    });
+  });
+
+  it("applies the caller's rule when no port is written", () => {
+    expect(parseHostPattern("example.com", { unspecifiedPort: "any" })?.port).toEqual({
+      kind: "any",
+    });
+    expect(parseHostPattern("example.com", { unspecifiedPort: "implicit" })?.port).toEqual({
+      kind: "implicit",
+    });
+  });
+
+  it("reads a trailing colon as any port", () => {
+    expect(parseHostPattern(".example.com:", { unspecifiedPort: "implicit" })?.port).toEqual({
+      kind: "any",
+    });
+  });
+
+  it("parses bracketed IPv6 hosts and canonicalizes the port", () => {
+    expect(parseHostPattern("[::1]:6767", { unspecifiedPort: "any" })).toEqual({
+      scheme: null,
+      host: "::1",
+      matchesSubdomains: false,
+      port: { kind: "exact", port: "6767" },
+    });
+    expect(parseHostPattern("example.com:08443", { unspecifiedPort: "any" })?.port).toEqual({
+      kind: "exact",
+      port: "8443",
+    });
+  });
+
+  it("rejects empty hosts, empty schemes, bad ports, and unbracketed IPv6", () => {
+    const rejected = [
+      "",
+      ".",
+      ":",
+      "://example.com",
+      "example.com:abc",
+      "example.com:65536",
+      "[::1",
+      "[::1]x",
+      "[example.com]:6767",
+      "::1",
+    ];
+    for (const raw of rejected) {
+      expect(parseHostPattern(raw, { unspecifiedPort: "any" })).toBeNull();
+    }
+  });
+});
+
+describe("parseHostAuthority", () => {
+  it("lowercases the hostname and keeps an explicit port", () => {
+    expect(parseHostAuthority("Example.com:6767")).toEqual({
+      hostname: "example.com",
+      port: "6767",
+    });
+    expect(parseHostAuthority("example.com")).toEqual({ hostname: "example.com", port: null });
+    expect(parseHostAuthority("[::1]:6767")).toEqual({ hostname: "::1", port: "6767" });
+    expect(parseHostAuthority("example.com:06767")).toEqual({
+      hostname: "example.com",
+      port: "6767",
+    });
+  });
+
+  it("rejects empty, non-numeric, or out-of-range ports", () => {
+    expect(parseHostAuthority("example.com:")).toBeNull();
+    expect(parseHostAuthority("example.com:abc")).toBeNull();
+    expect(parseHostAuthority("example.com:65536")).toBeNull();
+    expect(parseHostAuthority("")).toBeNull();
+  });
+
+  it("rejects brackets around anything but an IPv6 literal, and bare IPv6", () => {
+    expect(parseHostAuthority("[example.com]:6767")).toBeNull();
+    expect(parseHostAuthority("::1")).toBeNull();
+  });
+});

--- a/packages/server/src/server/host-patterns.ts
+++ b/packages/server/src/server/host-patterns.ts
@@ -1,0 +1,148 @@
+import net from "node:net";
+
+/**
+ * Allowlist grammar shared by `daemon.hostnames` and `daemon.cors.allowedOrigins`:
+ *
+ *   [scheme://][.]host[:[port]]
+ *
+ * A leading `.` matches the host and every subdomain. `host:1234` matches that
+ * port only; `host:` matches any port, including none. What a pattern without a
+ * port means is the caller's decision, see `ParseHostPatternOptions`. IPv6
+ * literals are bracketed so the port separator stays unambiguous.
+ */
+export interface HostPattern {
+  scheme: string | null;
+  host: string;
+  matchesSubdomains: boolean;
+  port: PortRule;
+}
+
+export type PortRule = { kind: "any" } | { kind: "implicit" } | { kind: "exact"; port: string };
+
+export interface HostAuthority {
+  hostname: string;
+  port: string | null;
+}
+
+export interface HostTarget extends HostAuthority {
+  scheme: string | null;
+  defaultPort: string | null;
+}
+
+export interface ParseHostPatternOptions {
+  /**
+   * Rule for a pattern that has no `:` at all. Host header checks use `any`
+   * (Vite semantics; `hostnames: ["myhost"]` has always matched `myhost:6767`).
+   * Origin checks use `implicit`, so `https://app.example.com` keeps meaning
+   * exactly that origin and not `https://app.example.com:8443`.
+   */
+  unspecifiedPort: "any" | "implicit";
+}
+
+interface HostPortSplit {
+  host: string;
+  /** `null` when there is no `:` separator, `""` when nothing follows it. */
+  port: string | null;
+}
+
+function splitHostPort(value: string): HostPortSplit | null {
+  if (value.startsWith("[")) {
+    const end = value.indexOf("]");
+    if (end === -1) return null;
+    const host = value.slice(1, end);
+    if (!net.isIPv6(host)) return null;
+    const rest = value.slice(end + 1);
+    if (!rest) return { host, port: null };
+    if (!rest.startsWith(":")) return null;
+    return { host, port: rest.slice(1) };
+  }
+
+  const colon = value.indexOf(":");
+  if (colon === -1) return { host: value, port: null };
+  const port = value.slice(colon + 1);
+  if (port.includes(":")) return null;
+  return { host: value.slice(0, colon), port };
+}
+
+/** Canonical decimal port, so `06767` and `6767` compare equal. */
+function parsePort(value: string): string | null {
+  if (!/^\d{1,5}$/.test(value)) return null;
+  const port = Number(value);
+  return port <= 65535 ? String(port) : null;
+}
+
+export function stripIpv6Brackets(hostname: string): string {
+  return hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+}
+
+/** Default port for a `URL.protocol` value such as `https:`. */
+export function defaultPortForProtocol(protocol: string): string | null {
+  if (protocol === "http:") return "80";
+  if (protocol === "https:") return "443";
+  return null;
+}
+
+/** Parses a raw `Host` header into hostname and explicit port. */
+export function parseHostAuthority(hostHeader: string): HostAuthority | null {
+  const split = splitHostPort(hostHeader.trim());
+  if (!split || !split.host) return null;
+  const hostname = split.host.toLowerCase();
+  if (split.port === null) return { hostname, port: null };
+  const port = parsePort(split.port);
+  return port ? { hostname, port } : null;
+}
+
+export function parseHostPattern(
+  raw: string,
+  options: ParseHostPatternOptions,
+): HostPattern | null {
+  let rest = raw.trim().toLowerCase();
+  let scheme: string | null = null;
+  const schemeEnd = rest.indexOf("://");
+  if (schemeEnd !== -1) {
+    scheme = rest.slice(0, schemeEnd);
+    rest = rest.slice(schemeEnd + 3);
+    if (!scheme) return null;
+  }
+
+  const matchesSubdomains = rest.startsWith(".");
+  if (matchesSubdomains) rest = rest.slice(1);
+
+  const split = splitHostPort(rest);
+  if (!split || !split.host) return null;
+  const port = parsePortRule(split.port, options.unspecifiedPort);
+  if (!port) return null;
+  return { scheme, host: split.host, matchesSubdomains, port };
+}
+
+function parsePortRule(
+  port: string | null,
+  unspecified: ParseHostPatternOptions["unspecifiedPort"],
+): PortRule | null {
+  if (port === null) return { kind: unspecified };
+  if (port === "") return { kind: "any" };
+  const canonical = parsePort(port);
+  return canonical ? { kind: "exact", port: canonical } : null;
+}
+
+export function matchesHostPattern(pattern: HostPattern, target: HostTarget): boolean {
+  if (pattern.scheme !== null && pattern.scheme !== target.scheme) return false;
+  if (!matchesHost(pattern, target.hostname)) return false;
+  return matchesPort(pattern.port, target);
+}
+
+function matchesHost(pattern: HostPattern, hostname: string): boolean {
+  if (hostname === pattern.host) return true;
+  return pattern.matchesSubdomains && hostname.endsWith(`.${pattern.host}`);
+}
+
+function matchesPort(rule: PortRule, target: HostTarget): boolean {
+  switch (rule.kind) {
+    case "any":
+      return true;
+    case "implicit":
+      return target.port === null;
+    case "exact":
+      return (target.port ?? target.defaultPort) === rule.port;
+  }
+}

--- a/packages/server/src/server/hostnames.test.ts
+++ b/packages/server/src/server/hostnames.test.ts
@@ -32,6 +32,38 @@ describe("hostnames (vite-style)", () => {
     expect(isHostnameAllowed("notexample.com:6767", hostnames)).toBe(false);
   });
 
+  it("ignores the Host header port unless the pattern names one", () => {
+    expect(isHostnameAllowed("example.com:6767", ["example.com"])).toBe(true);
+    expect(isHostnameAllowed("example.com", ["example.com:"])).toBe(true);
+    expect(isHostnameAllowed("foo.example.com:6767", [".example.com:"])).toBe(true);
+    expect(isHostnameAllowed("example.com:6767", ["example.com:6767"])).toBe(true);
+    expect(isHostnameAllowed("foo.example.com:6767", [".example.com:6767"])).toBe(true);
+    expect(isHostnameAllowed("example.com:6768", ["example.com:6767"])).toBe(false);
+    expect(isHostnameAllowed("example.com", ["example.com:6767"])).toBe(false);
+  });
+
+  it("keeps default hosts allowed on every port, whatever the entries say", () => {
+    expect(isHostnameAllowed("localhost:9999", ["localhost:6767"])).toBe(true);
+    expect(isHostnameAllowed("127.0.0.1:9999", ["127.0.0.1:6767"])).toBe(true);
+  });
+
+  it("compares ports numerically", () => {
+    expect(isHostnameAllowed("example.com:06767", ["example.com:6767"])).toBe(true);
+  });
+
+  it("never matches a pattern that names a scheme", () => {
+    expect(isHostnameAllowed("example.com:6767", ["https://example.com"])).toBe(false);
+  });
+
+  it("rejects malformed Host headers", () => {
+    expect(isHostnameAllowed("example.com:abc", true)).toBe(false);
+    expect(isHostnameAllowed("example.com:65536", true)).toBe(false);
+    expect(isHostnameAllowed("[::1", true)).toBe(false);
+    expect(isHostnameAllowed("[example.com]:6767", true)).toBe(false);
+    expect(isHostnameAllowed("::1", true)).toBe(false);
+    expect(isHostnameAllowed("", true)).toBe(false);
+  });
+
   it("merges arrays (append + de-dupe) and short-circuits on true", () => {
     expect(mergeHostnames([["a"], ["a", "b"]])).toEqual(["a", "b"]);
     expect(mergeHostnames([["a"], true, ["b"]])).toBe(true);

--- a/packages/server/src/server/hostnames.ts
+++ b/packages/server/src/server/hostnames.ts
@@ -1,42 +1,12 @@
 import net from "node:net";
+import {
+  type HostTarget,
+  matchesHostPattern,
+  parseHostAuthority,
+  parseHostPattern,
+} from "./host-patterns.js";
 
 export type HostnamesConfig = true | string[] | undefined;
-
-function normalizeHostname(hostname: string): string {
-  return hostname.trim().toLowerCase();
-}
-
-function parseHostnameFromHostHeader(hostHeader: string): string | null {
-  const trimmed = hostHeader.trim();
-  if (!trimmed) return null;
-
-  // IPv6 in brackets: [::1]:6767
-  if (trimmed.startsWith("[")) {
-    const end = trimmed.indexOf("]");
-    if (end === -1) return null;
-    return normalizeHostname(trimmed.slice(1, end));
-  }
-
-  // IPv4/hostname with optional port: localhost:6767
-  const colonIndex = trimmed.indexOf(":");
-  if (colonIndex === -1) {
-    return normalizeHostname(trimmed);
-  }
-  return normalizeHostname(trimmed.slice(0, colonIndex));
-}
-
-function matchesHostnamePattern(hostname: string, pattern: string): boolean {
-  const normalizedPattern = normalizeHostname(pattern);
-  if (!normalizedPattern) return false;
-
-  if (normalizedPattern.startsWith(".")) {
-    const base = normalizedPattern.slice(1);
-    if (!base) return false;
-    return hostname === base || hostname.endsWith(`.${base}`);
-  }
-
-  return hostname === normalizedPattern;
-}
 
 function isDefaultAllowedHostname(hostname: string): boolean {
   // Vite-style defaults: localhost, *.localhost, and all IP addresses.
@@ -53,22 +23,26 @@ function isDefaultAllowedHostname(hostname: string): boolean {
  * - `hostnames === true` => allow any host.
  * - `hostnames === []` or `undefined` => allow localhost, *.localhost, and all IPs.
  * - `hostnames === ['.example.com', 'myhost']` => allow those *in addition* to defaults.
+ *
+ * Entries follow the grammar in host-patterns.ts. The Host header's port is
+ * ignored unless the entry names one.
  */
 export function isHostnameAllowed(
   hostHeader: string | undefined,
   hostnames: HostnamesConfig,
 ): boolean {
-  const hostname = hostHeader ? parseHostnameFromHostHeader(hostHeader) : null;
-  if (!hostname) return false;
+  const authority = hostHeader ? parseHostAuthority(hostHeader) : null;
+  if (!authority) return false;
 
   if (hostnames === true) return true;
 
   // Defaults are always allowed.
-  if (isDefaultAllowedHostname(hostname)) return true;
+  if (isDefaultAllowedHostname(authority.hostname)) return true;
 
-  const patterns = hostnames ?? [];
-  for (const pattern of patterns) {
-    if (matchesHostnamePattern(hostname, pattern)) return true;
+  const target: HostTarget = { ...authority, scheme: null, defaultPort: null };
+  for (const raw of hostnames ?? []) {
+    const pattern = parseHostPattern(raw, { unspecifiedPort: "any" });
+    if (pattern && matchesHostPattern(pattern, target)) return true;
   }
   return false;
 }

--- a/packages/server/src/server/origins.test.ts
+++ b/packages/server/src/server/origins.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { isOriginAllowed } from "./origins.js";
+
+describe("isOriginAllowed", () => {
+  it("matches exact origins and the * wildcard", () => {
+    expect(isOriginAllowed("https://app.paseo.sh", ["https://app.paseo.sh"])).toBe(true);
+    expect(isOriginAllowed("https://app.paseo.sh", ["https://other.paseo.sh"])).toBe(false);
+    expect(isOriginAllowed("https://anything.test", ["*"])).toBe(true);
+    expect(isOriginAllowed("https://anything.test", [])).toBe(false);
+  });
+
+  it("keeps an exact origin bound to its port", () => {
+    expect(isOriginAllowed("http://localhost:8081", ["http://localhost:8081"])).toBe(true);
+    expect(isOriginAllowed("http://localhost:8082", ["http://localhost:8081"])).toBe(false);
+    expect(isOriginAllowed("https://app.paseo.sh:8443", ["https://app.paseo.sh"])).toBe(false);
+  });
+
+  it("matches a bare host on any scheme without an explicit port", () => {
+    expect(isOriginAllowed("https://example.com", ["example.com"])).toBe(true);
+    expect(isOriginAllowed("http://example.com", ["example.com"])).toBe(true);
+    expect(isOriginAllowed("https://example.com:8443", ["example.com"])).toBe(false);
+    expect(isOriginAllowed("https://foo.example.com", ["example.com"])).toBe(false);
+  });
+
+  it("matches subdomains with a leading dot", () => {
+    expect(isOriginAllowed("https://example.com", [".example.com"])).toBe(true);
+    expect(isOriginAllowed("https://foo.bar.example.com", [".example.com"])).toBe(true);
+    expect(isOriginAllowed("https://notexample.com", [".example.com"])).toBe(false);
+  });
+
+  it("matches any port with a trailing colon", () => {
+    expect(isOriginAllowed("https://foo.example.com:8443", [".example.com:"])).toBe(true);
+    expect(isOriginAllowed("https://example.com", [".example.com:"])).toBe(true);
+    expect(isOriginAllowed("http://example.com:3000", ["example.com:"])).toBe(true);
+  });
+
+  it("matches an explicit port, resolving the scheme default", () => {
+    expect(isOriginAllowed("https://example.com:8443", ["example.com:8443"])).toBe(true);
+    expect(isOriginAllowed("https://example.com", ["example.com:8443"])).toBe(false);
+    expect(isOriginAllowed("https://example.com", ["example.com:443"])).toBe(true);
+    expect(isOriginAllowed("http://example.com", ["example.com:443"])).toBe(false);
+  });
+
+  it("restricts the scheme when the entry names one", () => {
+    expect(isOriginAllowed("https://foo.example.com", ["https://.example.com"])).toBe(true);
+    expect(isOriginAllowed("http://foo.example.com", ["https://.example.com"])).toBe(false);
+    expect(isOriginAllowed("https://foo.example.com:8443", ["https://.example.com:"])).toBe(true);
+  });
+
+  it("matches custom schemes and IPv6 hosts", () => {
+    expect(isOriginAllowed("paseo://app", ["paseo://app"])).toBe(true);
+    expect(isOriginAllowed("paseo://app", ["app"])).toBe(true);
+    expect(isOriginAllowed("http://[::1]:8080", ["[::1]:"])).toBe(true);
+    expect(isOriginAllowed("http://[::1]:8080", ["[::1]:8080"])).toBe(true);
+  });
+
+  it("ignores entry case", () => {
+    expect(isOriginAllowed("https://example.com", ["Example.COM"])).toBe(true);
+  });
+
+  it("does not let lookalike hosts through a subdomain entry", () => {
+    for (const origin of [
+      "https://evil-example.com",
+      "https://example.com.evil",
+      "https://example.com.",
+      "https://example.com.evil.test",
+    ]) {
+      expect(isOriginAllowed(origin, [".example.com", ".example.com:"])).toBe(false);
+    }
+  });
+
+  it("only evaluates canonical serialized origins against patterns", () => {
+    const entries = ["https://app.paseo.sh", ".paseo.sh:"];
+    for (const origin of [
+      "https://app.paseo.sh/attacker",
+      "https://app.paseo.sh?x",
+      "https://app.paseo.sh#x",
+      "https:app.paseo.sh",
+      "https://user@app.paseo.sh",
+      "https://app.paseo.sh:443",
+      "https://APP.paseo.sh",
+      " https://app.paseo.sh",
+      "https://app.paseo.sh/",
+    ]) {
+      expect(isOriginAllowed(origin, entries)).toBe(false);
+    }
+    expect(
+      isOriginAllowed("https://app.paseo.sh/attacker", ["https://app.paseo.sh/attacker"]),
+    ).toBe(true);
+  });
+
+  it("only matches unparseable origins exactly", () => {
+    expect(isOriginAllowed("null", ["null"])).toBe(true);
+    expect(isOriginAllowed("null", [".example.com", "*"])).toBe(true);
+    expect(isOriginAllowed("null", [".example.com"])).toBe(false);
+  });
+
+  it("canonicalizes entry ports", () => {
+    expect(isOriginAllowed("https://example.com:8443", ["example.com:08443"])).toBe(true);
+  });
+
+  it("skips malformed entries", () => {
+    expect(isOriginAllowed("https://example.com", ["example.com:abc", "https://"])).toBe(false);
+  });
+});

--- a/packages/server/src/server/origins.ts
+++ b/packages/server/src/server/origins.ts
@@ -1,0 +1,45 @@
+import {
+  type HostTarget,
+  defaultPortForProtocol,
+  matchesHostPattern,
+  parseHostPattern,
+  stripIpv6Brackets,
+} from "./host-patterns.js";
+
+/**
+ * `daemon.cors.allowedOrigins` check shared by the CORS middleware and the
+ * WebSocket upgrade. `*` allows every origin. Other entries follow the grammar
+ * in host-patterns.ts: an entry without a scheme matches any scheme, and one
+ * without a port matches only an origin that has no explicit port.
+ */
+export function isOriginAllowed(origin: string, allowedOrigins: Iterable<string>): boolean {
+  const target = parseOrigin(origin);
+  for (const entry of allowedOrigins) {
+    if (entry === "*" || entry === origin) return true;
+    if (!target) continue;
+    const pattern = parseHostPattern(entry, { unspecifiedPort: "implicit" });
+    if (pattern && matchesHostPattern(pattern, target)) return true;
+  }
+  return false;
+}
+
+// Browsers serialize origins canonically: lowercase scheme and host, default
+// port omitted, nothing after the authority. Anything else, including `null`
+// for opaque origins, only matches an exact entry.
+function parseOrigin(origin: string): HostTarget | null {
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return null;
+  }
+  if (`${url.protocol}//${url.host}` !== origin) return null;
+  const hostname = stripIpv6Brackets(url.hostname).toLowerCase();
+  if (!hostname) return null;
+  return {
+    scheme: url.protocol.slice(0, -1),
+    hostname,
+    port: url.port || null,
+    defaultPort: defaultPortForProtocol(url.protocol),
+  };
+}

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -31,6 +31,8 @@ import { asUint8Array, decodeBinaryFrame } from "@getpaseo/protocol/binary-frame
 import type { TerminalActivity } from "@getpaseo/protocol/terminal-activity";
 import type { HostnamesConfig } from "./hostnames.js";
 import { isHostnameAllowed } from "./hostnames.js";
+import { defaultPortForProtocol, parseHostAuthority, stripIpv6Brackets } from "./host-patterns.js";
+import { isOriginAllowed } from "./origins.js";
 import {
   Session,
   type SessionLifecycleIntent,
@@ -889,7 +891,7 @@ export class VoiceAssistantWebSocketServer {
     }
     const sameOrigin = isWebSocketSameOrigin(origin, requestHost);
 
-    if (!origin || allowedOrigins.has("*") || allowedOrigins.has(origin) || sameOrigin) {
+    if (!origin || sameOrigin || isOriginAllowed(origin, allowedOrigins)) {
       callback(true);
     } else {
       this.incrementRuntimeCounter("originRejected");
@@ -2774,60 +2776,6 @@ function extractSocketRequestMetadata(request: unknown): SocketRequestMetadata {
   };
 }
 
-interface HostAuthority {
-  hostname: string;
-  port: string | null;
-}
-
-function stripIpv6Brackets(hostname: string): string {
-  return hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
-}
-
-function parseHostAuthority(host: string): HostAuthority | null {
-  const trimmed = host.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  if (trimmed.startsWith("[")) {
-    const end = trimmed.indexOf("]");
-    if (end === -1) {
-      return null;
-    }
-    const hostname = stripIpv6Brackets(trimmed.slice(0, end + 1)).toLowerCase();
-    const rest = trimmed.slice(end + 1);
-    if (!rest) {
-      return { hostname, port: null };
-    }
-    if (!rest.startsWith(":")) {
-      return null;
-    }
-    const port = rest.slice(1);
-    return port ? { hostname, port } : null;
-  }
-
-  const firstColon = trimmed.indexOf(":");
-  if (firstColon === -1) {
-    return { hostname: trimmed.toLowerCase(), port: null };
-  }
-  if (trimmed.indexOf(":", firstColon + 1) !== -1) {
-    return { hostname: trimmed.toLowerCase(), port: null };
-  }
-  const hostname = trimmed.slice(0, firstColon).toLowerCase();
-  const port = trimmed.slice(firstColon + 1);
-  return hostname && port ? { hostname, port } : null;
-}
-
-function defaultPortForOriginProtocol(protocol: string): string | null {
-  if (protocol === "http:") {
-    return "80";
-  }
-  if (protocol === "https:") {
-    return "443";
-  }
-  return null;
-}
-
 function isLoopbackAlias(hostname: string): boolean {
   const normalized = stripIpv6Brackets(hostname).toLowerCase();
   if (normalized === "localhost" || normalized.endsWith(".localhost")) {
@@ -2857,7 +2805,7 @@ export function isWebSocketSameOrigin(
   } catch {
     return false;
   }
-  const originPort = originUrl.port || defaultPortForOriginProtocol(originUrl.protocol);
+  const originPort = originUrl.port || defaultPortForProtocol(originUrl.protocol);
   if (!originPort) {
     return false;
   }
@@ -2866,7 +2814,7 @@ export function isWebSocketSameOrigin(
   if (!requestAuthority) {
     return false;
   }
-  const requestPort = requestAuthority.port || defaultPortForOriginProtocol(originUrl.protocol);
+  const requestPort = requestAuthority.port || defaultPortForProtocol(originUrl.protocol);
   if (originPort !== requestPort) {
     return false;
   }

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -49,6 +49,8 @@ Minimal example that configures listening address, hostnames, and MCP:
 
 `daemon.hostnames` is the primary field. The old `daemon.allowedHosts` name still works as a deprecated alias for backward compatibility.
 
+`daemon.hostnames` and `daemon.cors.allowedOrigins` share one pattern syntax, described under [Security](/docs/security#dns-rebinding-protection).
+
 ## Apply changes
 
 After saving `config.json`, reload it:
@@ -235,6 +237,7 @@ Set the persisted value in `config.json`:
 - `PASEO_LISTEN`, override `daemon.listen`
 - `PASEO_RELAY_ENABLED`, enable or disable the outbound relay for this daemon launch
 - `PASEO_HOSTNAMES`, override/extend `daemon.hostnames`
+- `PASEO_CORS_ORIGINS`, extend `daemon.cors.allowedOrigins`
 - `PASEO_ALLOWED_HOSTS`, deprecated alias for `PASEO_HOSTNAMES`
 - `PASEO_WEB_UI_ENABLED`, enable or disable the daemon-served web UI
 - `PASEO_WEB_UI_DIST_DIR`, override the daemon web UI build directory

--- a/public-docs/security.md
+++ b/public-docs/security.md
@@ -79,8 +79,25 @@ Paseo uses a host allowlist to validate the `Host` header on incoming requests. 
 Configure via `daemon.hostnames` in `config.json`:
 
 - Default (`[]`): allow `localhost`, `*.localhost`, and all IP addresses
-- `['.example.com']`: allow `example.com` and any subdomain, plus defaults
+- `["myhost"]`: allow `myhost`, plus defaults
+- `[".example.com"]`: allow `example.com` and any subdomain, plus defaults
 - `true`: allow any host (not recommended)
+
+Entries ignore the port in the `Host` header. Append a port to require it, `example.com:6767`. A trailing colon, `example.com:`, spells out any port. A port narrows only the entry it is written on: the defaults stay allowed on every port, so `localhost:6767` does not block `localhost:9999`. Entries take no scheme; schemes belong to origins.
+
+## Browser origins
+
+Browsers send an `Origin` header on cross-origin requests and on every WebSocket connection. The daemon adds CORS headers, and accepts the upgrade, only when that origin is listed in `daemon.cors.allowedOrigins` or `PASEO_CORS_ORIGINS` (comma-separated). Same-origin traffic, including the web UI the daemon serves itself, needs no entry, and neither does the desktop app.
+
+Entries use the `hostnames` syntax with an optional scheme. Without a port, an entry matches only an origin that has no explicit port:
+
+- `https://app.example.com`: that origin exactly
+- `.example.com`: `example.com` and any subdomain, on any scheme, without an explicit port
+- `.example.com:`: the same on any port
+- `https://.example.com:8443`: HTTPS subdomains on port 8443
+- `*`: any origin (not recommended)
+
+Prefer entries with a scheme. Without one, `.example.com` also admits plain `http://` pages on those hosts. Browsers send `Origin: null` for sandboxed frames and local files, so an entry of `null` admits all of them and is as broad as `*`.
 
 ## Password authentication
 


### PR DESCRIPTION
### Linked issue

None. Related context, not fixed here: #449 (the `*` entry still reflects any origin).

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

When the daemon sits behind a reverse proxy and the web UI or app is served from a sibling host, every browser origin has to be listed in `daemon.cors.allowedOrigins` as an exact `scheme://host:port` string. Preview deployments on `*.example.com`, a dev server that picks a different port each run, or http and https variants of the same host each need another entry and a config reload. `daemon.hostnames` already accepts `.example.com` for a domain and its subdomains, so people reasonably try the same in `allowedOrigins` and it silently never matches.

This PR gives both lists one grammar: `[scheme://][.]host[:[port]]`. A leading `.` covers subdomains, `host:1234` pins a port, and `host:` accepts any port. Origin entries may carry a scheme; without one they match any scheme. Existing entries keep their meaning: `https://app.example.com` still matches exactly that origin and nothing else, `*` still allows everything, and `hostnames: ["myhost"]` still matches `myhost:6767`.

### Goals

- `allowedOrigins` accepts `example.com` and `.example.com`, matching any scheme on the default port.
- `allowedOrigins` and `hostnames` accept a trailing-colon form (`example.com:`, `.example.com:`) meaning any port or none, and an explicit `:port` form that pins one.
- Origin entries may be scheme-qualified (`https://.example.com:8443`).
- Existing configs behave exactly as before: exact origin entries, `*`, and port-agnostic hostname entries.
- One parser and matcher for both lists, used by the CORS middleware, the Host check, and the WebSocket upgrade.
- Only canonical serialized origins are pattern-matched. `https://app.paseo.sh/attacker`, `https:app.paseo.sh`, and `https://app.paseo.sh:443` are rejected, as the old exact-match code rejected them.
- Host header parsing validates the port range, compares ports numerically (`06767` equals `6767`), and requires brackets to wrap a real IPv6 literal.
- Docs: `public-docs/security.md` owns the grammar for both lists in a new "Browser origins" section, `SECURITY.md` links to it, and `PASEO_CORS_ORIGINS` is listed with the other env vars.

### Non-goals

- No change to the default-allowed hosts. `localhost`, `*.localhost`, and IP literals stay allowed on every port, so a `localhost:6767` entry does not block `localhost:9999`. This is documented.
- No config-load validation of entries. A `hostnames` entry with a scheme never matches, as before, and the docs now say schemes belong to origins. Rejecting it at load would stop the daemon on a config that today merely fails to match.
- No change to the `*` or `null` entries. `null` matching every opaque origin predates this PR; it is now documented as being as broad as `*`.
- No protocol or schema change. Both fields stay `string[]`; only the matching of the strings changed.
- Hostname entries without a port keep ignoring the Host header port. Making them port-strict would break every existing `hostnames: ["myhost"]` config.

### QA

Daemon only. Tested on Linux (Debian devbox, Node 22). Not tested on macOS, Windows, or Docker. The app is untouched.

| Platform        | Tested | Notes                 |
| --------------- | ------ | --------------------- |
| iOS             | n/a    | daemon-only change    |
| Android         | n/a    | daemon-only change    |
| Web             | n/a    | daemon-only change    |
| Desktop macOS   |        | daemon not run here   |
| Desktop Windows |        | daemon not run here   |
| Desktop Linux   | yes    | daemon, see below     |

**Real daemon, real requests.** An in-process daemon (per `docs/ad-hoc-daemon-testing.md`) started with pattern entries in both lists and was probed over raw HTTP and a WebSocket upgrade. Pino warnings about local speech providers trimmed.

```
daemon listening on 127.0.0.1:40613
cors.allowedOrigins = [".example.test:","https://exact.test"]
hostnames           = [".example.test","pinned.test:6767"]

GET /api/health with Origin (Host = daemon address)
  Origin: https://app.example.test:8443    -> 200  Access-Control-Allow-Origin: https://app.example.test:8443
  Origin: http://example.test              -> 200  Access-Control-Allow-Origin: http://example.test
  Origin: https://evil-example.test        -> 200  (no CORS headers)
  Origin: https://example.test.evil        -> 200  (no CORS headers)
  Origin: https://exact.test               -> 200  Access-Control-Allow-Origin: https://exact.test
  Origin: https://exact.test:8443          -> 200  (no CORS headers)
  Origin: https://exact.test/attacker      -> 200  (no CORS headers)

GET /api/health with Host
  Host: foo.example.test:9999              -> 200
  Host: pinned.test:6767                   -> 200
  Host: pinned.test:06767                  -> 200
  Host: pinned.test:6768                   -> 403
  Host: evil.test:6767                     -> 403

WebSocket upgrade /ws
  Host: app.example.test   Origin: https://app.example.test:8443    -> 101 connected
  Host: app.example.test   Origin: https://evil-example.test        -> 403 rejected
  Host: pinned.test:6768   Origin: https://app.example.test         -> 403 rejected
```

Daemon log for the two rejections:

```
{"module":"websocket-server","host":"app.example.test","origin":"https://evil-example.test","remoteAddress":"127.0.0.1","msg":"Rejected connection from origin"}
{"module":"websocket-server","host":"pinned.test:6768","origin":"https://app.example.test","remoteAddress":"127.0.0.1","msg":"Rejected connection from disallowed host"}
```

**Automated tests.** New `host-patterns.test.ts` and `origins.test.ts`, extended `hostnames.test.ts`. They cover subdomain and port forms, scheme restriction, custom schemes (`paseo://app`), IPv6, lookalike hosts (`evil-example.com`, `example.com.evil`, trailing dot), every non-canonical origin shape listed above, port range and leading zeros, bracketed non-IP hosts, and that default hosts stay allowed regardless of port entries. `bootstrap.smoke.test.ts` now reloads a bare-host origin entry and checks it end to end through the CORS headers and the WebSocket upgrade on a real daemon.

```
$ npx vitest run src/server/host-patterns.test.ts src/server/origins.test.ts src/server/hostnames.test.ts src/server/websocket-server.origin.test.ts --bail=1
 Test Files  4 passed (4)
      Tests  40 passed (40)

$ npx vitest run src/server/bootstrap.smoke.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

**Pre-commit hook** (`lefthook`: format, lint, full `npm run typecheck`):

```
✔️ format (0.57 seconds)
✔️ lint (0.71 seconds)
✔️ typecheck (20.51 seconds)
```

**Adversarial review.** A second pass was run specifically to find bypasses: suffix tricks, userinfo, case and Unicode, trailing dots, embedded ports, `Origin: null`, and non-canonical Origin values. No browser-reachable bypass was found. Its findings drove the canonical-origin check, the stricter Host parsing, and the docs notes on `null` and on default hosts.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense