### PR TITLE
feat(workspace): add service quick links

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -414,6 +414,11 @@ Every `scripts` entry with `"type": "service"` receives these environment variab
 
 Service proxy hostnames use the double-dash shape: `web--feature-auth--project.localhost` or, on the default branch, `web--project.localhost`. Optional public aliases use the same leftmost label under the configured public base host.
 
+Service quick links are paths under the route selected in the Scripts menu. The app always includes
+the service root `/`; a configured `/` link replaces its label, and other configured paths follow it.
+Keep the root fallback in the app rather than migrating `paseo.json`: existing project files predate
+the field, and older daemons omit the optional link metadata.
+
 `<NAME>` is normalized from the script name by uppercasing it, replacing each run of non-`A-Z0-9` characters with `_`, and trimming leading or trailing `_`. For example, `app-server` and `app.server` both normalize to `APP_SERVER`; that collision fails at spawn time with an actionable error.
 
 `PORT` is not injected by default. If a framework requires `PORT`, set it in the command:

--- a/docs/development.md
+++ b/docs/development.md
@@ -414,10 +414,10 @@ Every `scripts` entry with `"type": "service"` receives these environment variab
 
 Service proxy hostnames use the double-dash shape: `web--feature-auth--project.localhost` or, on the default branch, `web--project.localhost`. Optional public aliases use the same leftmost label under the configured public base host.
 
-Service quick links are paths under the route selected in the Scripts menu. The app always includes
-the service root `/`; a configured `/` link replaces its label, and other configured paths follow it.
-Keep the root fallback in the app rather than migrating `paseo.json`: existing project files predate
-the field, and older daemons omit the optional link metadata.
+Service quick links are paths under the route selected in the Scripts menu. Without configured links,
+the app keeps the existing root open action. Configured links replace that action, so include `/`
+explicitly when the root should remain available. Keep the fallback in the app rather than migrating
+`paseo.json`: existing project files predate the field, and older daemons omit the optional metadata.
 
 `<NAME>` is normalized from the script name by uppercasing it, replacing each run of non-`A-Z0-9` characters with `_`, and trimming leading or trailing `_`. For example, `app-server` and `app.server` both normalize to `APP_SERVER`; that collision fails at spawn time with an actionable error.
 

--- a/packages/app/e2e/browser/workspace-scripts-menu-resize.spec.ts
+++ b/packages/app/e2e/browser/workspace-scripts-menu-resize.spec.ts
@@ -25,6 +25,7 @@ test("scripts menu resizes and shows quick links after a service launches", asyn
           command:
             "node -e \"const http = require('http'); const s = http.createServer((q,r) => r.end('ok')); s.listen(process.env.PASEO_PORT, () => console.log('listening on ' + s.address().port))\"",
           links: [
+            { label: "Website", path: "/" },
             { label: "Admin", path: "/admin" },
             { label: "GraphQL", path: "/api/graphql" },
           ],
@@ -61,7 +62,7 @@ test("scripts menu resizes and shows quick links after a service launches", asyn
 
     await startWorkspaceScriptFromMenu(page, "web");
     await expect(menu).toContainText("localhost:", { timeout: 15_000 });
-    await expect(page.getByTestId("workspace-scripts-link-web-0")).toContainText("View service");
+    await expect(page.getByTestId("workspace-scripts-link-web-0")).toContainText("Website");
     await expect(page.getByTestId("workspace-scripts-link-web-0")).toContainText("/");
     await expect(page.getByTestId("workspace-scripts-link-web-1")).toContainText("Admin");
     await expect(page.getByTestId("workspace-scripts-link-web-1")).toContainText("/admin");

--- a/packages/app/e2e/browser/workspace-scripts-menu-resize.spec.ts
+++ b/packages/app/e2e/browser/workspace-scripts-menu-resize.spec.ts
@@ -12,7 +12,7 @@ import { waitForWorkspaceTabsVisible } from "../support/helpers/workspace-tabs";
 import { getServerId } from "../support/helpers/server-id";
 import { buildHostWorkspaceRoute } from "../../src/utils/host-routes";
 
-test("scripts menu resizes when a service row grows after launch", async ({ page }) => {
+test("scripts menu resizes and shows quick links after a service launches", async ({ page }) => {
   const client = await connectWorkspaceSetupClient();
   const repo = await createTempGitRepo("script-menu-resize-", {
     paseoConfig: {
@@ -23,7 +23,11 @@ test("scripts menu resizes when a service row grows after launch", async ({ page
         web: {
           type: "service",
           command:
-            "node -e \"const http = require('http'); const s = http.createServer((q,r) => r.end('ok')); s.listen(process.env.PORT || 3000, () => console.log('listening on ' + s.address().port))\"",
+            "node -e \"const http = require('http'); const s = http.createServer((q,r) => r.end('ok')); s.listen(process.env.PASEO_PORT, () => console.log('listening on ' + s.address().port))\"",
+          links: [
+            { label: "Admin", path: "/admin" },
+            { label: "GraphQL", path: "/api/graphql" },
+          ],
         },
       },
     },
@@ -57,6 +61,12 @@ test("scripts menu resizes when a service row grows after launch", async ({ page
 
     await startWorkspaceScriptFromMenu(page, "web");
     await expect(menu).toContainText("localhost:", { timeout: 15_000 });
+    await expect(page.getByTestId("workspace-scripts-link-web-0")).toContainText("View service");
+    await expect(page.getByTestId("workspace-scripts-link-web-0")).toContainText("/");
+    await expect(page.getByTestId("workspace-scripts-link-web-1")).toContainText("Admin");
+    await expect(page.getByTestId("workspace-scripts-link-web-1")).toContainText("/admin");
+    await expect(page.getByTestId("workspace-scripts-link-web-2")).toContainText("GraphQL");
+    await expect(page.getByTestId("workspace-scripts-link-web-2")).toContainText("/api/graphql");
 
     const after = await menu.evaluate((element) => {
       const rect = element.getBoundingClientRect();
@@ -73,6 +83,15 @@ test("scripts menu resizes when a service row grows after launch", async ({ page
     expect(after.height).toBeGreaterThan(before.height);
     expect(after.scrollHeight).toBeLessThanOrEqual(after.clientHeight + 1);
     expect(after.childHeight).toBeGreaterThan(before.height);
+
+    const selectedHost = (await page.getByTestId("workspace-scripts-route-web").innerText()).trim();
+    const popupPromise = page.waitForEvent("popup");
+    await page.getByTestId("workspace-scripts-link-web-1").click();
+    const popup = await popupPromise;
+
+    await expect(menu).toBeHidden();
+    await expect.poll(() => popup.url()).toBe(`http://${selectedHost}/admin`);
+    await popup.close();
   } finally {
     await client.close();
     await repo.cleanup();

--- a/packages/app/e2e/browser/workspace-scripts-menu-resize.spec.ts
+++ b/packages/app/e2e/browser/workspace-scripts-menu-resize.spec.ts
@@ -1,38 +1,43 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
 import { test, expect } from "../support/fixtures";
+import type { PaseoServiceLink } from "@getpaseo/protocol/paseo-config-schema";
 import { createTempGitRepo } from "../support/helpers/workspace";
 import {
   connectWorkspaceSetupClient,
   createWorkspaceThroughDaemon,
-  openWorkspaceScriptsMenu,
+  fetchWorkspaceById,
   seedProjectForWorkspaceSetup,
-  startWorkspaceScriptFromMenu,
   waitForWorkspaceSetupProgress,
 } from "../support/helpers/workspace-setup";
 import { waitForWorkspaceTabsVisible } from "../support/helpers/workspace-tabs";
 import { getServerId } from "../support/helpers/server-id";
 import { buildHostWorkspaceRoute } from "../../src/utils/host-routes";
 
-test("scripts menu resizes and shows quick links after a service launches", async ({ page }) => {
+test("scripts menu resizes and updates configured quick links for a running service", async ({
+  page,
+}) => {
+  const duplicateKeyErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error" && message.text().includes("same key")) {
+      duplicateKeyErrors.push(message.text());
+    }
+  });
+
   const client = await connectWorkspaceSetupClient();
-  const repo = await createTempGitRepo("script-menu-resize-", {
-    paseoConfig: {
-      worktree: {
-        setup: ["sh -c 'echo setup complete'"],
-      },
-      scripts: {
-        web: {
-          type: "service",
-          command:
-            "node -e \"const http = require('http'); const s = http.createServer((q,r) => r.end('ok')); s.listen(process.env.PASEO_PORT, () => console.log('listening on ' + s.address().port))\"",
-          links: [
-            { label: "Website", path: "/" },
-            { label: "Admin", path: "/admin" },
-            { label: "GraphQL", path: "/api/graphql" },
-          ],
-        },
+  const paseoConfig = {
+    worktree: {
+      setup: ["node -e \"console.log('setup complete')\""],
+    },
+    scripts: {
+      web: {
+        type: "service",
+        command:
+          "node -e \"const http = require('http'); const s = http.createServer((q,r) => r.end(q.url)); s.listen(process.env.PASEO_PORT, () => console.log('listening on ' + s.address().port))\"",
       },
     },
-  });
+  };
+  const repo = await createTempGitRepo("script-menu-resize-", { paseoConfig });
 
   try {
     await seedProjectForWorkspaceSetup(client, repo.path);
@@ -45,12 +50,26 @@ test("scripts menu resizes and shows quick links after a service launches", asyn
       worktreeSlug: `script-menu-resize-${Date.now()}`,
     });
     await completed;
+    const { workspaceDirectory } = await fetchWorkspaceById(client, workspace.id);
+
+    async function reloadWithLinks(links: PaseoServiceLink[]): Promise<void> {
+      const config = {
+        ...paseoConfig,
+        scripts: { web: { ...paseoConfig.scripts.web, links } },
+      };
+      await writeFile(path.join(workspaceDirectory, "paseo.json"), JSON.stringify(config));
+      await page.reload();
+      await waitForWorkspaceTabsVisible(page);
+      await page.getByRole("button", { name: "Workspace scripts", exact: true }).click();
+    }
 
     await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.id));
     await waitForWorkspaceTabsVisible(page);
-    await openWorkspaceScriptsMenu(page);
+    const scriptsTrigger = page.getByRole("button", { name: "Workspace scripts", exact: true });
+    await scriptsTrigger.click();
 
     const menu = page.getByTestId("workspace-scripts-menu");
+    await expect(menu).toBeVisible();
     const before = await menu.evaluate((element) => {
       const rect = element.getBoundingClientRect();
       return {
@@ -60,14 +79,43 @@ test("scripts menu resizes and shows quick links after a service launches", asyn
       };
     });
 
-    await startWorkspaceScriptFromMenu(page, "web");
+    await menu.getByRole("button", { name: "Run web script", exact: true }).click();
     await expect(menu).toContainText("localhost:", { timeout: 15_000 });
-    await expect(page.getByTestId("workspace-scripts-link-web-0")).toContainText("Website");
-    await expect(page.getByTestId("workspace-scripts-link-web-0")).toContainText("/");
-    await expect(page.getByTestId("workspace-scripts-link-web-1")).toContainText("Admin");
-    await expect(page.getByTestId("workspace-scripts-link-web-1")).toContainText("/admin");
-    await expect(page.getByTestId("workspace-scripts-link-web-2")).toContainText("GraphQL");
-    await expect(page.getByTestId("workspace-scripts-link-web-2")).toContainText("/api/graphql");
+    const rootAction = menu.getByRole("button", { name: "View web service", exact: true });
+    const quickLinks = menu.getByRole("menuitem");
+    await expect(rootAction).toBeVisible();
+    await expect(quickLinks).toHaveCount(0);
+
+    const afterLaunch = await menu.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      const childRect = element.firstElementChild?.getBoundingClientRect();
+      return {
+        height: rect.height,
+        clientHeight: element.clientHeight,
+        scrollHeight: element.scrollHeight,
+        childHeight: childRect?.height ?? 0,
+      };
+    });
+    expect(afterLaunch.height).toBeGreaterThan(before.height);
+    expect(afterLaunch.scrollHeight).toBeLessThanOrEqual(afterLaunch.clientHeight + 1);
+    expect(afterLaunch.childHeight).toBeGreaterThan(before.height);
+
+    const website = { label: "Website", path: "/" };
+    const admin = { label: "Admin", path: "/admin" };
+    const graphQL = { label: "GraphQL", path: "/api/graphql" };
+    await reloadWithLinks([website, admin, graphQL, admin]);
+    await expect(quickLinks).toHaveText([
+      "Website /",
+      "Admin /admin",
+      "GraphQL /api/graphql",
+      "Admin /admin",
+    ]);
+    await expect(rootAction).toHaveCount(0);
+    await expect(menu.getByRole("menuitem", { name: "Website /", exact: true })).toBeVisible();
+    await expect(menu.getByRole("menuitem", { name: "Admin /admin", exact: true })).toHaveCount(2);
+    await expect(
+      menu.getByRole("menuitem", { name: "GraphQL /api/graphql", exact: true }),
+    ).toBeVisible();
 
     const after = await menu.evaluate((element) => {
       const rect = element.getBoundingClientRect();
@@ -81,18 +129,41 @@ test("scripts menu resizes and shows quick links after a service launches", asyn
       };
     });
 
-    expect(after.height).toBeGreaterThan(before.height);
+    expect(after.height).toBeGreaterThan(afterLaunch.height);
     expect(after.scrollHeight).toBeLessThanOrEqual(after.clientHeight + 1);
     expect(after.childHeight).toBeGreaterThan(before.height);
 
-    const selectedHost = (await page.getByTestId("workspace-scripts-route-web").innerText()).trim();
+    await reloadWithLinks([graphQL, admin, website, admin]);
+    await expect(quickLinks).toHaveText([
+      "GraphQL /api/graphql",
+      "Admin /admin",
+      "Website /",
+      "Admin /admin",
+    ]);
+    await reloadWithLinks([admin, graphQL]);
+    await expect(quickLinks).toHaveText(["Admin /admin", "GraphQL /api/graphql"]);
+    expect(duplicateKeyErrors).toEqual([]);
+
+    const routeSelector = menu.getByRole("button", { name: "Choose URL for web", exact: true });
+    const selectedHost = (await routeSelector.innerText()).trim();
     const popupPromise = page.waitForEvent("popup");
-    await page.getByTestId("workspace-scripts-link-web-1").click();
+    await menu.getByRole("menuitem", { name: "Admin /admin", exact: true }).click();
     const popup = await popupPromise;
 
     await expect(menu).toBeHidden();
     await expect.poll(() => popup.url()).toBe(`http://${selectedHost}/admin`);
+    await expect(popup.locator("body")).toHaveText("/admin");
     await popup.close();
+
+    await reloadWithLinks([{ label: "Unsafe", path: "/\t//evil.example" }]);
+    await expect(quickLinks).toHaveCount(0);
+    await expect(rootAction).toBeVisible();
+    const rootPopupPromise = page.waitForEvent("popup");
+    await rootAction.click();
+    const rootPopup = await rootPopupPromise;
+    await expect.poll(() => rootPopup.url()).toBe("http://" + selectedHost + "/");
+    await expect(rootPopup.locator("body")).toHaveText("/");
+    await rootPopup.close();
   } finally {
     await client.close();
     await repo.cleanup();

--- a/packages/app/src/screens/workspace/workspace-scripts-button.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-scripts-button.test.tsx
@@ -341,6 +341,7 @@ describe("WorkspaceScriptsButton", () => {
   afterEach(() => {
     current?.unmount();
     current = null;
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -559,6 +560,45 @@ describe("WorkspaceScriptsButton", () => {
       expect(link?.querySelector('[data-icon="Eye"]')).not.toBeNull();
       expect(link?.querySelector('[data-icon="ExternalLink"]')).not.toBeNull();
     }
+  });
+
+  it("preserves duplicate quick-link rows when links are reordered or removed", async () => {
+    const consoleError = vi.spyOn(console, "error");
+    const admin = { label: "Admin", path: "/admin" };
+    const graphQL = { label: "GraphQL", path: "/api/graphql" };
+    const service = script({
+      scriptName: "dev",
+      type: "service",
+      lifecycle: "running",
+      port: 3000,
+      proxyUrl: "http://dev--proj--repo.localhost:6767",
+      links: [admin, graphQL, admin],
+    });
+    current = renderScripts([service]);
+
+    const row = requireRow("dev");
+    const originalLinks = Array.from(
+      row.querySelectorAll('[data-testid^="workspace-scripts-link-dev-"]'),
+    );
+    expect(originalLinks.map((link) => link.textContent)).toEqual([
+      "Admin /admin",
+      "GraphQL /api/graphql",
+      "Admin /admin",
+    ]);
+
+    await current.rerender([{ ...service, links: [graphQL, admin, admin] }]);
+    let links = Array.from(row.querySelectorAll('[data-testid^="workspace-scripts-link-dev-"]'));
+    expect(links).toHaveLength(3);
+    expect(links[0]).toBe(originalLinks[1]);
+    expect(links[1]).toBe(originalLinks[0]);
+    expect(links[2]).toBe(originalLinks[2]);
+
+    await current.rerender([{ ...service, links: [admin, graphQL] }]);
+    links = Array.from(row.querySelectorAll('[data-testid^="workspace-scripts-link-dev-"]'));
+    expect(links).toHaveLength(2);
+    expect(links[0]).toBe(originalLinks[0]);
+    expect(links[1]).toBe(originalLinks[1]);
+    expect(consoleError).not.toHaveBeenCalled();
   });
 
   it("stops a running script through its terminal", async () => {

--- a/packages/app/src/screens/workspace/workspace-scripts-button.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-scripts-button.test.tsx
@@ -510,7 +510,26 @@ describe("WorkspaceScriptsButton", () => {
     expect(requireRow("dev").textContent).toContain("dev--proj--repo.services.example.com");
   });
 
-  it("lists the root service URL before configured quick links", () => {
+  it("keeps the legacy root action when no quick links are configured", () => {
+    current = renderScripts([
+      script({
+        scriptName: "dev",
+        type: "service",
+        lifecycle: "running",
+        port: 57483,
+        proxyUrl: "http://dev--proj--repo.localhost:6767",
+        terminalId: "terminal-script-1",
+      }),
+    ]);
+
+    const row = requireRow("dev");
+    const openAction = row.querySelector('[data-testid="workspace-scripts-open-dev"]');
+    expect(openAction).not.toBeNull();
+    expect(openAction?.querySelector('[data-icon="Eye"]')).not.toBeNull();
+    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-0"]')).toBeNull();
+  });
+
+  it("replaces the legacy root action with configured quick links", () => {
     current = renderScripts([
       script({
         scriptName: "dev",
@@ -529,15 +548,13 @@ describe("WorkspaceScriptsButton", () => {
     const row = requireRow("dev");
     expect(row.querySelector('[data-testid="workspace-scripts-open-dev"]')).toBeNull();
     expect(row.querySelector('[data-testid="workspace-scripts-link-dev-0"]')?.textContent).toBe(
-      "View service /",
-    );
-    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-1"]')?.textContent).toBe(
       "Admin /admin",
     );
-    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-2"]')?.textContent).toBe(
+    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-1"]')?.textContent).toBe(
       "GraphQL /api/graphql",
     );
-    for (let index = 0; index < 3; index += 1) {
+    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-2"]')).toBeNull();
+    for (let index = 0; index < 2; index += 1) {
       const link = row.querySelector(`[data-testid="workspace-scripts-link-dev-${index}"]`);
       expect(link?.querySelector('[data-icon="Eye"]')).not.toBeNull();
       expect(link?.querySelector('[data-icon="ExternalLink"]')).not.toBeNull();

--- a/packages/app/src/screens/workspace/workspace-scripts-button.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-scripts-button.test.tsx
@@ -32,7 +32,6 @@ const {
       foreground: "#fff",
       foregroundMuted: "#aaa",
       surface2: "#222",
-      interactionHighlight: "rgba(255, 255, 255, 0.08)",
       borderAccent: "#444",
       palette: {
         blue: { 500: "#0a84ff" },
@@ -149,23 +148,17 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuItem: ({
     children,
     description,
-    leading,
     onSelect,
     testID,
-    trailing,
   }: {
     children: React.ReactNode;
     description?: string;
-    leading?: React.ReactNode;
     onSelect?: () => void;
     testID?: string;
-    trailing?: React.ReactNode;
   }) => (
     <button type="button" data-testid={testID} onClick={onSelect}>
-      {leading}
       {children}
       {description}
-      {trailing}
     </button>
   ),
   DropdownMenuTrigger: ({
@@ -235,7 +228,6 @@ function script(
     health: input.health ?? null,
     exitCode: input.exitCode ?? null,
     terminalId: input.terminalId ?? null,
-    links: input.links,
   };
 }
 
@@ -341,7 +333,6 @@ describe("WorkspaceScriptsButton", () => {
   afterEach(() => {
     current?.unmount();
     current = null;
-    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -509,96 +500,6 @@ describe("WorkspaceScriptsButton", () => {
     ]);
 
     expect(requireRow("dev").textContent).toContain("dev--proj--repo.services.example.com");
-  });
-
-  it("keeps the legacy root action when no quick links are configured", () => {
-    current = renderScripts([
-      script({
-        scriptName: "dev",
-        type: "service",
-        lifecycle: "running",
-        port: 57483,
-        proxyUrl: "http://dev--proj--repo.localhost:6767",
-        terminalId: "terminal-script-1",
-      }),
-    ]);
-
-    const row = requireRow("dev");
-    const openAction = row.querySelector('[data-testid="workspace-scripts-open-dev"]');
-    expect(openAction).not.toBeNull();
-    expect(openAction?.querySelector('[data-icon="Eye"]')).not.toBeNull();
-    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-0"]')).toBeNull();
-  });
-
-  it("replaces the legacy root action with configured quick links", () => {
-    current = renderScripts([
-      script({
-        scriptName: "dev",
-        type: "service",
-        lifecycle: "running",
-        port: 57483,
-        proxyUrl: "http://dev--proj--repo.localhost:6767",
-        terminalId: "terminal-script-1",
-        links: [
-          { label: "Admin", path: "/admin" },
-          { label: "GraphQL", path: "/api/graphql" },
-        ],
-      }),
-    ]);
-
-    const row = requireRow("dev");
-    expect(row.querySelector('[data-testid="workspace-scripts-open-dev"]')).toBeNull();
-    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-0"]')?.textContent).toBe(
-      "Admin /admin",
-    );
-    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-1"]')?.textContent).toBe(
-      "GraphQL /api/graphql",
-    );
-    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-2"]')).toBeNull();
-    for (let index = 0; index < 2; index += 1) {
-      const link = row.querySelector(`[data-testid="workspace-scripts-link-dev-${index}"]`);
-      expect(link?.querySelector('[data-icon="Eye"]')).not.toBeNull();
-      expect(link?.querySelector('[data-icon="ExternalLink"]')).not.toBeNull();
-    }
-  });
-
-  it("preserves duplicate quick-link rows when links are reordered or removed", async () => {
-    const consoleError = vi.spyOn(console, "error");
-    const admin = { label: "Admin", path: "/admin" };
-    const graphQL = { label: "GraphQL", path: "/api/graphql" };
-    const service = script({
-      scriptName: "dev",
-      type: "service",
-      lifecycle: "running",
-      port: 3000,
-      proxyUrl: "http://dev--proj--repo.localhost:6767",
-      links: [admin, graphQL, admin],
-    });
-    current = renderScripts([service]);
-
-    const row = requireRow("dev");
-    const originalLinks = Array.from(
-      row.querySelectorAll('[data-testid^="workspace-scripts-link-dev-"]'),
-    );
-    expect(originalLinks.map((link) => link.textContent)).toEqual([
-      "Admin /admin",
-      "GraphQL /api/graphql",
-      "Admin /admin",
-    ]);
-
-    await current.rerender([{ ...service, links: [graphQL, admin, admin] }]);
-    let links = Array.from(row.querySelectorAll('[data-testid^="workspace-scripts-link-dev-"]'));
-    expect(links).toHaveLength(3);
-    expect(links[0]).toBe(originalLinks[1]);
-    expect(links[1]).toBe(originalLinks[0]);
-    expect(links[2]).toBe(originalLinks[2]);
-
-    await current.rerender([{ ...service, links: [admin, graphQL] }]);
-    links = Array.from(row.querySelectorAll('[data-testid^="workspace-scripts-link-dev-"]'));
-    expect(links).toHaveLength(2);
-    expect(links[0]).toBe(originalLinks[0]);
-    expect(links[1]).toBe(originalLinks[1]);
-    expect(consoleError).not.toHaveBeenCalled();
   });
 
   it("stops a running script through its terminal", async () => {

--- a/packages/app/src/screens/workspace/workspace-scripts-button.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-scripts-button.test.tsx
@@ -32,6 +32,7 @@ const {
       foreground: "#fff",
       foregroundMuted: "#aaa",
       surface2: "#222",
+      interactionHighlight: "rgba(255, 255, 255, 0.08)",
       borderAccent: "#444",
       palette: {
         blue: { 500: "#0a84ff" },
@@ -148,17 +149,23 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuItem: ({
     children,
     description,
+    leading,
     onSelect,
     testID,
+    trailing,
   }: {
     children: React.ReactNode;
     description?: string;
+    leading?: React.ReactNode;
     onSelect?: () => void;
     testID?: string;
+    trailing?: React.ReactNode;
   }) => (
     <button type="button" data-testid={testID} onClick={onSelect}>
+      {leading}
       {children}
       {description}
+      {trailing}
     </button>
   ),
   DropdownMenuTrigger: ({
@@ -228,6 +235,7 @@ function script(
     health: input.health ?? null,
     exitCode: input.exitCode ?? null,
     terminalId: input.terminalId ?? null,
+    links: input.links,
   };
 }
 
@@ -500,6 +508,40 @@ describe("WorkspaceScriptsButton", () => {
     ]);
 
     expect(requireRow("dev").textContent).toContain("dev--proj--repo.services.example.com");
+  });
+
+  it("lists the root service URL before configured quick links", () => {
+    current = renderScripts([
+      script({
+        scriptName: "dev",
+        type: "service",
+        lifecycle: "running",
+        port: 57483,
+        proxyUrl: "http://dev--proj--repo.localhost:6767",
+        terminalId: "terminal-script-1",
+        links: [
+          { label: "Admin", path: "/admin" },
+          { label: "GraphQL", path: "/api/graphql" },
+        ],
+      }),
+    ]);
+
+    const row = requireRow("dev");
+    expect(row.querySelector('[data-testid="workspace-scripts-open-dev"]')).toBeNull();
+    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-0"]')?.textContent).toBe(
+      "View service /",
+    );
+    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-1"]')?.textContent).toBe(
+      "Admin /admin",
+    );
+    expect(row.querySelector('[data-testid="workspace-scripts-link-dev-2"]')?.textContent).toBe(
+      "GraphQL /api/graphql",
+    );
+    for (let index = 0; index < 3; index += 1) {
+      const link = row.querySelector(`[data-testid="workspace-scripts-link-dev-${index}"]`);
+      expect(link?.querySelector('[data-icon="Eye"]')).not.toBeNull();
+      expect(link?.querySelector('[data-icon="ExternalLink"]')).not.toBeNull();
+    }
   });
 
   it("stops a running script through its terminal", async () => {

--- a/packages/app/src/screens/workspace/workspace-scripts-button.tsx
+++ b/packages/app/src/screens/workspace/workspace-scripts-button.tsx
@@ -586,7 +586,7 @@ function ScriptRow({
           </View>
           {quickLinks.map((link, index) => (
             <ServiceQuickLinkRow
-              key={`${link.label}:${link.path}`}
+              key={link.key}
               index={index}
               link={link}
               scriptName={script.scriptName}

--- a/packages/app/src/screens/workspace/workspace-scripts-button.tsx
+++ b/packages/app/src/screens/workspace/workspace-scripts-button.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, type ReactElement } from "react";
+import { createElement, useCallback, useEffect, useMemo, useRef, type ReactElement } from "react";
 import type { GestureResponderEvent } from "react-native";
 import { Pressable, Text, View } from "react-native";
 import * as Clipboard from "expo-clipboard";
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   Copy,
   Eye,
+  ExternalLink,
   Globe,
   Play,
   RotateCw,
@@ -31,6 +32,8 @@ import { useToast } from "@/contexts/toast-context";
 import { openServiceUrl } from "@/utils/open-service-url";
 import {
   resolveWorkspaceScriptLink,
+  resolveWorkspaceScriptQuickLinks,
+  type WorkspaceScriptQuickLinkTarget,
   type WorkspaceScriptLinkKind,
   type WorkspaceScriptLinkTarget,
 } from "@/utils/workspace-script-links";
@@ -39,7 +42,7 @@ import { useWorkspaceServiceRoutePreferencesStore } from "@/workspace-service-ro
 import { buttonControlHeight, HEADER_CONTROL_HEIGHT } from "@/components/ui/control-geometry";
 import { extraMutedIconColorMapping } from "@/components/ui/icon-color";
 
-type RowActionIcon = "copy" | "open" | "restart" | "start" | "stop" | "terminal";
+type RowActionIcon = "copy" | "restart" | "start" | "stop" | "terminal";
 
 interface WorkspaceScriptsButtonProps {
   serverId: string;
@@ -58,6 +61,7 @@ const ThemedSquareTerminal = withUnistyles(SquareTerminal);
 const ThemedGlobe = withUnistyles(Globe);
 const ThemedChevronDown = withUnistyles(ChevronDown);
 const ThemedEye = withUnistyles(Eye);
+const ThemedExternalLink = withUnistyles(ExternalLink);
 const ThemedCopy = withUnistyles(Copy);
 const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedSquare = withUnistyles(Square);
@@ -81,6 +85,14 @@ const redColorMapping = (theme: Theme) => ({
 });
 const playFillTransparent = { fill: "transparent" };
 const ghostPlayStroke = { strokeWidth: 1.5 };
+const serviceQuickLinkLeading = createElement(ThemedEye, {
+  size: 12,
+  uniProps: mutedColorMapping,
+});
+const serviceQuickLinkTrailing = createElement(ThemedExternalLink, {
+  size: 11,
+  uniProps: mutedColorMapping,
+});
 
 interface ScriptRowActionButtonProps {
   accessibilityLabel: string;
@@ -102,8 +114,6 @@ function RowActionIconElement({
   switch (icon) {
     case "copy":
       return <ThemedCopy size={11} uniProps={colorMapping} />;
-    case "open":
-      return <ThemedEye size={12} uniProps={colorMapping} />;
     case "restart":
       return <ThemedRotateCw size={11} uniProps={colorMapping} />;
     case "start":
@@ -158,7 +168,7 @@ function ScriptRowActionButton({
   );
 }
 
-interface ServiceLinkRowProps {
+interface ServiceRouteRowProps {
   selectedTarget: WorkspaceScriptLinkTarget;
   targets: WorkspaceScriptLinkTarget[];
   scriptName: string;
@@ -289,13 +299,13 @@ function ServiceRouteSelector({
   );
 }
 
-function ServiceLinkRow({
+function ServiceRouteRow({
   selectedTarget,
   targets,
   scriptName,
   onSelectKind,
   onCopy,
-}: ServiceLinkRowProps): ReactElement {
+}: ServiceRouteRowProps): ReactElement {
   const { t } = useTranslation();
   const closeMenu = useDropdownMenuClose();
   const { label, url } = selectedTarget;
@@ -330,6 +340,34 @@ function ServiceLinkRow({
         tooltipLabel={t("workspace.scripts.actions.copyUrl")}
       />
     </View>
+  );
+}
+
+interface ServiceQuickLinkRowProps {
+  index: number;
+  link: WorkspaceScriptQuickLinkTarget;
+  scriptName: string;
+  onOpen: (url: string) => void;
+}
+
+function ServiceQuickLinkRow({
+  index,
+  link,
+  scriptName,
+  onOpen,
+}: ServiceQuickLinkRowProps): ReactElement {
+  const handleSelect = useCallback(() => onOpen(link.url), [link.url, onOpen]);
+
+  return (
+    <DropdownMenuItem
+      testID={`workspace-scripts-link-${scriptName}-${index}`}
+      leading={serviceQuickLinkLeading}
+      trailing={serviceQuickLinkTrailing}
+      onSelect={handleSelect}
+    >
+      <Text style={styles.quickLinkLabel}>{link.label}</Text>
+      <Text style={styles.quickLinkPath}> {link.path}</Text>
+    </DropdownMenuItem>
   );
 }
 
@@ -405,19 +443,26 @@ function ScriptRow({
       ? (serviceLink.targets.find((target) => target.kind === preferredRouteKind) ??
         serviceLink.primary)
       : null;
+  const quickLinks = selectedLink
+    ? resolveWorkspaceScriptQuickLinks({
+        baseUrl: selectedLink.url,
+        defaultLabel: t("workspace.scripts.actions.openService"),
+        links: script.links,
+      })
+    : [];
   const liveTerminalId =
     script.terminalId && liveTerminalIdSet.has(script.terminalId) ? script.terminalId : null;
 
   const iconColorMapping = resolveScriptIconColorMapping({ script, isService, isRunning });
   const ScriptIcon = isService ? ThemedGlobe : ThemedSquareTerminal;
   const showExitBadge = !isRunning && exitCode !== null;
-  const closeMenu = useDropdownMenuClose();
 
-  const handleOpenService = useCallback(() => {
-    if (!selectedLink) return;
-    closeMenu();
-    void openServiceUrl(selectedLink.url, { openInApp: onOpenUrlInBrowserTab });
-  }, [selectedLink, closeMenu, onOpenUrlInBrowserTab]);
+  const handleOpenServiceLink = useCallback(
+    (url: string) => {
+      void openServiceUrl(url, { openInApp: onOpenUrlInBrowserTab });
+    },
+    [onOpenUrlInBrowserTab],
+  );
 
   const handleView = useCallback(() => {
     if (liveTerminalId) onViewTerminal?.(liveTerminalId);
@@ -452,18 +497,6 @@ function ScriptRow({
         tooltipLabel={t("workspace.scripts.actions.view")}
       />
     ) : null;
-
-  const openServiceAction = selectedLink ? (
-    <ScriptRowActionButton
-      accessibilityLabel={t("workspace.scripts.accessibility.openService", {
-        scriptName: script.scriptName,
-      })}
-      testID={`workspace-scripts-open-${script.scriptName}`}
-      icon="open"
-      onPress={handleOpenService}
-      tooltipLabel={t("workspace.scripts.actions.openService")}
-    />
-  ) : null;
 
   const lifecycleAction = isRunning ? (
     <ScriptRowActionButton
@@ -503,7 +536,6 @@ function ScriptRow({
         </Text>
         {showExitBadge ? <ExitCodeBadge code={exitCode} /> : null}
         <View style={styles.spacer} />
-        {openServiceAction}
         {viewAction}
         {isRunning ? (
           <ScriptRowActionButton
@@ -520,15 +552,26 @@ function ScriptRow({
         {lifecycleAction}
       </View>
       {selectedLink ? (
-        <View style={styles.hostList}>
-          <ServiceLinkRow
-            selectedTarget={selectedLink}
-            targets={serviceLink.targets}
-            scriptName={script.scriptName}
-            onSelectKind={onSelectRouteKind}
-            onCopy={onCopyUrl}
-          />
-        </View>
+        <>
+          <View style={styles.hostList}>
+            <ServiceRouteRow
+              selectedTarget={selectedLink}
+              targets={serviceLink.targets}
+              scriptName={script.scriptName}
+              onSelectKind={onSelectRouteKind}
+              onCopy={onCopyUrl}
+            />
+          </View>
+          {quickLinks.map((link, index) => (
+            <ServiceQuickLinkRow
+              key={link.path}
+              index={index}
+              link={link}
+              scriptName={script.scriptName}
+              onOpen={handleOpenServiceLink}
+            />
+          ))}
+        </>
       ) : null}
     </View>
   );
@@ -826,6 +869,16 @@ const styles = StyleSheet.create((theme) => ({
     gap: theme.spacing[2],
     paddingVertical: 2,
     minHeight: 18,
+  },
+  quickLinkLabel: {
+    fontSize: theme.fontSize.sm,
+    lineHeight: 14,
+    color: theme.colors.foreground,
+  },
+  quickLinkPath: {
+    fontSize: theme.fontSize.sm,
+    lineHeight: 14,
+    color: theme.colors.foregroundMuted,
   },
   routeDisplay: {
     flex: 1,

--- a/packages/app/src/screens/workspace/workspace-scripts-button.tsx
+++ b/packages/app/src/screens/workspace/workspace-scripts-button.tsx
@@ -42,7 +42,7 @@ import { useWorkspaceServiceRoutePreferencesStore } from "@/workspace-service-ro
 import { buttonControlHeight, HEADER_CONTROL_HEIGHT } from "@/components/ui/control-geometry";
 import { extraMutedIconColorMapping } from "@/components/ui/icon-color";
 
-type RowActionIcon = "copy" | "restart" | "start" | "stop" | "terminal";
+type RowActionIcon = "copy" | "open" | "restart" | "start" | "stop" | "terminal";
 
 interface WorkspaceScriptsButtonProps {
   serverId: string;
@@ -114,6 +114,8 @@ function RowActionIconElement({
   switch (icon) {
     case "copy":
       return <ThemedCopy size={11} uniProps={colorMapping} />;
+    case "open":
+      return <ThemedEye size={12} uniProps={colorMapping} />;
     case "restart":
       return <ThemedRotateCw size={11} uniProps={colorMapping} />;
     case "start":
@@ -446,7 +448,6 @@ function ScriptRow({
   const quickLinks = selectedLink
     ? resolveWorkspaceScriptQuickLinks({
         baseUrl: selectedLink.url,
-        defaultLabel: t("workspace.scripts.actions.openService"),
         links: script.links,
       })
     : [];
@@ -456,6 +457,13 @@ function ScriptRow({
   const iconColorMapping = resolveScriptIconColorMapping({ script, isService, isRunning });
   const ScriptIcon = isService ? ThemedGlobe : ThemedSquareTerminal;
   const showExitBadge = !isRunning && exitCode !== null;
+  const closeMenu = useDropdownMenuClose();
+
+  const handleOpenService = useCallback(() => {
+    if (!selectedLink) return;
+    closeMenu();
+    void openServiceUrl(selectedLink.url, { openInApp: onOpenUrlInBrowserTab });
+  }, [selectedLink, closeMenu, onOpenUrlInBrowserTab]);
 
   const handleOpenServiceLink = useCallback(
     (url: string) => {
@@ -498,6 +506,19 @@ function ScriptRow({
       />
     ) : null;
 
+  const openServiceAction =
+    selectedLink && quickLinks.length === 0 ? (
+      <ScriptRowActionButton
+        accessibilityLabel={t("workspace.scripts.accessibility.openService", {
+          scriptName: script.scriptName,
+        })}
+        testID={`workspace-scripts-open-${script.scriptName}`}
+        icon="open"
+        onPress={handleOpenService}
+        tooltipLabel={t("workspace.scripts.actions.openService")}
+      />
+    ) : null;
+
   const lifecycleAction = isRunning ? (
     <ScriptRowActionButton
       accessibilityLabel={t("workspace.scripts.accessibility.stopScript", {
@@ -536,6 +557,7 @@ function ScriptRow({
         </Text>
         {showExitBadge ? <ExitCodeBadge code={exitCode} /> : null}
         <View style={styles.spacer} />
+        {openServiceAction}
         {viewAction}
         {isRunning ? (
           <ScriptRowActionButton
@@ -564,7 +586,7 @@ function ScriptRow({
           </View>
           {quickLinks.map((link, index) => (
             <ServiceQuickLinkRow
-              key={link.path}
+              key={`${link.label}:${link.path}`}
               index={index}
               link={link}
               scriptName={script.scriptName}

--- a/packages/app/src/utils/project-config-form.test.ts
+++ b/packages/app/src/utils/project-config-form.test.ts
@@ -172,6 +172,29 @@ describe("applyDraftToConfig", () => {
     expect(lintEntry.type).toBe("task");
   });
 
+  it("preserves service quick links on round-trip", () => {
+    const base = PaseoConfigRawSchema.parse({
+      scripts: {
+        web: {
+          type: "service",
+          command: "npm run dev",
+          links: [
+            { label: "Admin", path: "/admin" },
+            { label: "GraphQL", path: "/api/graphql" },
+          ],
+        },
+      },
+    });
+
+    const next = applyDraftToConfig({ draft: configToDraft(base), base });
+    const web = next.scripts?.web;
+    if (!web) throw new Error("expected web script after round-trip");
+    expect((web as Record<string, unknown>).links).toEqual([
+      { label: "Admin", path: "/admin" },
+      { label: "GraphQL", path: "/api/graphql" },
+    ]);
+  });
+
   it("normalizes script command text into the original command kind", () => {
     const base = PaseoConfigRawSchema.parse({
       scripts: {

--- a/packages/app/src/utils/project-config-form.test.ts
+++ b/packages/app/src/utils/project-config-form.test.ts
@@ -189,7 +189,7 @@ describe("applyDraftToConfig", () => {
     const next = applyDraftToConfig({ draft: configToDraft(base), base });
     const web = next.scripts?.web;
     if (!web) throw new Error("expected web script after round-trip");
-    expect((web as Record<string, unknown>).links).toEqual([
+    expect(web.links).toEqual([
       { label: "Admin", path: "/admin" },
       { label: "GraphQL", path: "/api/graphql" },
     ]);

--- a/packages/app/src/utils/workspace-script-links.test.ts
+++ b/packages/app/src/utils/workspace-script-links.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import type { WorkspaceScriptPayload } from "@getpaseo/protocol/messages";
+import {
+  WorkspaceScriptPayloadSchema,
+  type WorkspaceScriptPayload,
+} from "@getpaseo/protocol/messages";
 import type { ActiveConnection } from "@/runtime/host-runtime";
 import {
   resolveWorkspaceScriptLink,
@@ -207,6 +210,39 @@ describe("resolveWorkspaceScriptLink", () => {
 });
 
 describe("resolveWorkspaceScriptQuickLinks", () => {
+  it.each([
+    "https://web--feature--paseo.services.example.com",
+    "http://web--feature--paseo.localhost:6767",
+    "http://localhost:3000",
+  ])("drops cross-origin and unparseable links received from a daemon for %s", (baseUrl) => {
+    const script = WorkspaceScriptPayloadSchema.parse({
+      ...runningService,
+      links: [
+        { label: "Admin", path: "/admin?next=https://example.com#settings" },
+        { label: "Escape", path: "/\t//evil.example" },
+        { label: "Port", path: "/\t/localhost:3001/" },
+        { label: "Invalid host", path: "/\t/[" },
+        { label: "Invalid authority", path: "/\t/" },
+        { label: "Encoded path", path: "/%2f%2fevil.example" },
+      ],
+    });
+
+    expect(resolveWorkspaceScriptQuickLinks({ baseUrl, links: script.links })).toEqual([
+      {
+        key: '["Admin","/admin?next=https://example.com#settings",0]',
+        label: "Admin",
+        path: "/admin?next=https://example.com#settings",
+        url: baseUrl + "/admin?next=https://example.com#settings",
+      },
+      {
+        key: '["Encoded path","/%2f%2fevil.example",0]',
+        label: "Encoded path",
+        path: "/%2f%2fevil.example",
+        url: baseUrl + "/%2f%2fevil.example",
+      },
+    ]);
+  });
+
   it("returns no quick links when none are configured", () => {
     expect(
       resolveWorkspaceScriptQuickLinks({
@@ -227,11 +263,13 @@ describe("resolveWorkspaceScriptQuickLinks", () => {
       }),
     ).toEqual([
       {
+        key: '["Admin","/admin",0]',
         label: "Admin",
         path: "/admin",
         url: "https://web--feature--paseo.services.example.com/admin",
       },
       {
+        key: '["GraphQL","/api/graphql?studio=1",0]',
         label: "GraphQL",
         path: "/api/graphql?studio=1",
         url: "https://web--feature--paseo.services.example.com/api/graphql?studio=1",
@@ -249,8 +287,13 @@ describe("resolveWorkspaceScriptQuickLinks", () => {
         ],
       }),
     ).toEqual([
-      { label: "Admin", path: "/admin", url: "http://localhost:3000/admin" },
-      { label: "Site", path: "/", url: "http://localhost:3000/" },
+      {
+        key: '["Admin","/admin",0]',
+        label: "Admin",
+        path: "/admin",
+        url: "http://localhost:3000/admin",
+      },
+      { key: '["Site","/",0]', label: "Site", path: "/", url: "http://localhost:3000/" },
     ]);
   });
 });

--- a/packages/app/src/utils/workspace-script-links.test.ts
+++ b/packages/app/src/utils/workspace-script-links.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { WorkspaceScriptPayload } from "@getpaseo/protocol/messages";
 import type { ActiveConnection } from "@/runtime/host-runtime";
-import { resolveWorkspaceScriptLink } from "./workspace-script-links";
+import {
+  resolveWorkspaceScriptLink,
+  resolveWorkspaceScriptQuickLinks,
+} from "./workspace-script-links";
 
 const runningService: WorkspaceScriptPayload = {
   scriptName: "web",
@@ -200,5 +203,68 @@ describe("resolveWorkspaceScriptLink", () => {
       primary: null,
       targets: [],
     });
+  });
+});
+
+describe("resolveWorkspaceScriptQuickLinks", () => {
+  it("keeps the root service URL when no links are configured", () => {
+    expect(
+      resolveWorkspaceScriptQuickLinks({
+        baseUrl: "http://web--feature--paseo.localhost:6767",
+        defaultLabel: "View service",
+        links: undefined,
+      }),
+    ).toEqual([
+      {
+        label: "View service",
+        path: "/",
+        url: "http://web--feature--paseo.localhost:6767/",
+      },
+    ]);
+  });
+
+  it("adds configured paths after the root URL", () => {
+    expect(
+      resolveWorkspaceScriptQuickLinks({
+        baseUrl: "https://web--feature--paseo.services.example.com",
+        defaultLabel: "View service",
+        links: [
+          { label: "Admin", path: "/admin" },
+          { label: "GraphQL", path: "/api/graphql?studio=1" },
+        ],
+      }),
+    ).toEqual([
+      {
+        label: "View service",
+        path: "/",
+        url: "https://web--feature--paseo.services.example.com/",
+      },
+      {
+        label: "Admin",
+        path: "/admin",
+        url: "https://web--feature--paseo.services.example.com/admin",
+      },
+      {
+        label: "GraphQL",
+        path: "/api/graphql?studio=1",
+        url: "https://web--feature--paseo.services.example.com/api/graphql?studio=1",
+      },
+    ]);
+  });
+
+  it("uses a configured root label without duplicating the root URL", () => {
+    expect(
+      resolveWorkspaceScriptQuickLinks({
+        baseUrl: "http://localhost:3000",
+        defaultLabel: "View service",
+        links: [
+          { label: "Admin", path: "/admin" },
+          { label: "Site", path: "/" },
+        ],
+      }),
+    ).toEqual([
+      { label: "Site", path: "/", url: "http://localhost:3000/" },
+      { label: "Admin", path: "/admin", url: "http://localhost:3000/admin" },
+    ]);
   });
 });

--- a/packages/app/src/utils/workspace-script-links.test.ts
+++ b/packages/app/src/utils/workspace-script-links.test.ts
@@ -207,38 +207,25 @@ describe("resolveWorkspaceScriptLink", () => {
 });
 
 describe("resolveWorkspaceScriptQuickLinks", () => {
-  it("keeps the root service URL when no links are configured", () => {
+  it("returns no quick links when none are configured", () => {
     expect(
       resolveWorkspaceScriptQuickLinks({
         baseUrl: "http://web--feature--paseo.localhost:6767",
-        defaultLabel: "View service",
         links: undefined,
       }),
-    ).toEqual([
-      {
-        label: "View service",
-        path: "/",
-        url: "http://web--feature--paseo.localhost:6767/",
-      },
-    ]);
+    ).toEqual([]);
   });
 
-  it("adds configured paths after the root URL", () => {
+  it("uses configured paths instead of the root fallback", () => {
     expect(
       resolveWorkspaceScriptQuickLinks({
         baseUrl: "https://web--feature--paseo.services.example.com",
-        defaultLabel: "View service",
         links: [
           { label: "Admin", path: "/admin" },
           { label: "GraphQL", path: "/api/graphql?studio=1" },
         ],
       }),
     ).toEqual([
-      {
-        label: "View service",
-        path: "/",
-        url: "https://web--feature--paseo.services.example.com/",
-      },
       {
         label: "Admin",
         path: "/admin",
@@ -252,19 +239,18 @@ describe("resolveWorkspaceScriptQuickLinks", () => {
     ]);
   });
 
-  it("uses a configured root label without duplicating the root URL", () => {
+  it("keeps an explicitly configured root in configured order", () => {
     expect(
       resolveWorkspaceScriptQuickLinks({
         baseUrl: "http://localhost:3000",
-        defaultLabel: "View service",
         links: [
           { label: "Admin", path: "/admin" },
           { label: "Site", path: "/" },
         ],
       }),
     ).toEqual([
-      { label: "Site", path: "/", url: "http://localhost:3000/" },
       { label: "Admin", path: "/admin", url: "http://localhost:3000/admin" },
+      { label: "Site", path: "/", url: "http://localhost:3000/" },
     ]);
   });
 });

--- a/packages/app/src/utils/workspace-script-links.test.ts
+++ b/packages/app/src/utils/workspace-script-links.test.ts
@@ -210,6 +210,32 @@ describe("resolveWorkspaceScriptLink", () => {
 });
 
 describe("resolveWorkspaceScriptQuickLinks", () => {
+  it("keeps distinct keys for duplicate links across reordering, removal, and route changes", () => {
+    const admin = { label: "Admin", path: "/admin" };
+    const graphQL = { label: "GraphQL", path: "/api/graphql" };
+    const original = resolveWorkspaceScriptQuickLinks({
+      baseUrl: "http://localhost:3000",
+      links: [admin, graphQL, admin],
+    });
+    expect(new Set(original.map((link) => link.key)).size).toBe(3);
+
+    const reordered = resolveWorkspaceScriptQuickLinks({
+      baseUrl: "https://web.services.example.com",
+      links: [graphQL, admin, admin],
+    });
+    expect(reordered.map((link) => link.key)).toEqual([
+      original[1].key,
+      original[0].key,
+      original[2].key,
+    ]);
+
+    const remaining = resolveWorkspaceScriptQuickLinks({
+      baseUrl: "https://web.services.example.com",
+      links: [admin, graphQL],
+    });
+    expect(remaining.map((link) => link.key)).toEqual([original[0].key, original[1].key]);
+  });
+
   it.each([
     "https://web--feature--paseo.services.example.com",
     "http://web--feature--paseo.localhost:6767",

--- a/packages/app/src/utils/workspace-script-links.ts
+++ b/packages/app/src/utils/workspace-script-links.ts
@@ -97,16 +97,9 @@ export function resolveWorkspaceScriptLink(input: {
 
 export function resolveWorkspaceScriptQuickLinks(input: {
   baseUrl: string;
-  defaultLabel: string;
   links: WorkspaceScriptPayload["links"];
 }): WorkspaceScriptQuickLinkTarget[] {
-  const configuredRoot = input.links?.find((link) => link.path === "/");
-  const root = configuredRoot ?? { label: input.defaultLabel, path: "/" };
-  const linksByPath = new Map<string, PaseoServiceLink>([[root.path, root]]);
-  for (const link of input.links ?? []) {
-    if (!linksByPath.has(link.path)) linksByPath.set(link.path, link);
-  }
-  return Array.from(linksByPath.values(), (link) => ({
+  return (input.links ?? []).map((link) => ({
     label: link.label,
     path: link.path,
     url: new URL(link.path, input.baseUrl).toString(),

--- a/packages/app/src/utils/workspace-script-links.ts
+++ b/packages/app/src/utils/workspace-script-links.ts
@@ -16,6 +16,7 @@ export interface ResolvedWorkspaceScriptLink {
 }
 
 export interface WorkspaceScriptQuickLinkTarget extends PaseoServiceLink {
+  key: string;
   url: string;
 }
 
@@ -99,9 +100,31 @@ export function resolveWorkspaceScriptQuickLinks(input: {
   baseUrl: string;
   links: WorkspaceScriptPayload["links"];
 }): WorkspaceScriptQuickLinkTarget[] {
-  return (input.links ?? []).map((link) => ({
-    label: link.label,
-    path: link.path,
-    url: new URL(link.path, input.baseUrl).toString(),
-  }));
+  const links = input.links ?? [];
+  if (links.length === 0) return [];
+
+  const baseUrl = new URL(input.baseUrl);
+  const targets: WorkspaceScriptQuickLinkTarget[] = [];
+  const occurrences = new Map<string, number>();
+  for (const link of links) {
+    let url: URL;
+    try {
+      url = new URL(link.path, baseUrl);
+    } catch (error) {
+      if (error instanceof TypeError) continue;
+      throw error;
+    }
+    if (url.origin !== baseUrl.origin) continue;
+
+    const identity = JSON.stringify([link.label, link.path]);
+    const occurrence = occurrences.get(identity) ?? 0;
+    occurrences.set(identity, occurrence + 1);
+    targets.push({
+      key: JSON.stringify([link.label, link.path, occurrence]),
+      label: link.label,
+      path: link.path,
+      url: url.toString(),
+    });
+  }
+  return targets;
 }

--- a/packages/app/src/utils/workspace-script-links.ts
+++ b/packages/app/src/utils/workspace-script-links.ts
@@ -1,5 +1,5 @@
 import { parseHostPort } from "@getpaseo/protocol/daemon-endpoints";
-import type { WorkspaceScriptPayload } from "@getpaseo/protocol/messages";
+import type { PaseoServiceLink, WorkspaceScriptPayload } from "@getpaseo/protocol/messages";
 import type { ActiveConnection } from "@/runtime/host-runtime";
 
 export type WorkspaceScriptLinkKind = "public" | "paseo" | "direct";
@@ -13,6 +13,10 @@ export interface WorkspaceScriptLinkTarget {
 export interface ResolvedWorkspaceScriptLink {
   primary: WorkspaceScriptLinkTarget | null;
   targets: WorkspaceScriptLinkTarget[];
+}
+
+export interface WorkspaceScriptQuickLinkTarget extends PaseoServiceLink {
+  url: string;
 }
 
 function isLoopbackHost(host: string): boolean {
@@ -89,4 +93,22 @@ export function resolveWorkspaceScriptLink(input: {
   addTarget(targets, "direct", buildDirectServiceUrl(activeConnection, script.port));
 
   return { primary: targets[0] ?? null, targets };
+}
+
+export function resolveWorkspaceScriptQuickLinks(input: {
+  baseUrl: string;
+  defaultLabel: string;
+  links: WorkspaceScriptPayload["links"];
+}): WorkspaceScriptQuickLinkTarget[] {
+  const configuredRoot = input.links?.find((link) => link.path === "/");
+  const root = configuredRoot ?? { label: input.defaultLabel, path: "/" };
+  const linksByPath = new Map<string, PaseoServiceLink>([[root.path, root]]);
+  for (const link of input.links ?? []) {
+    if (!linksByPath.has(link.path)) linksByPath.set(link.path, link);
+  }
+  return Array.from(linksByPath.values(), (link) => ({
+    label: link.label,
+    path: link.path,
+    url: new URL(link.path, input.baseUrl).toString(),
+  }));
 }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -65,6 +65,7 @@ import {
   PaseoLifecycleCommandRawSchema,
   PaseoMetadataGenerationEntrySchema,
   PaseoMetadataGenerationSchema,
+  PaseoServiceLinkSchema,
   PaseoScriptEntryRawSchema,
   PaseoWorktreeConfigRawSchema,
   PaseoConfigRevisionSchema,
@@ -73,6 +74,7 @@ import {
   type PaseoConfigRevision,
   type PaseoMetadataGeneration,
   type PaseoMetadataGenerationEntry,
+  type PaseoServiceLink,
   type PaseoScriptEntryRaw,
   type ProjectConfigRpcError,
 } from "./paseo-config-schema.js";
@@ -81,12 +83,14 @@ export {
   PaseoLifecycleCommandRawSchema,
   PaseoMetadataGenerationEntrySchema,
   PaseoMetadataGenerationSchema,
+  PaseoServiceLinkSchema,
   PaseoScriptEntryRawSchema,
   PaseoWorktreeConfigRawSchema,
   type PaseoConfigRaw,
   type PaseoConfigRevision,
   type PaseoMetadataGeneration,
   type PaseoMetadataGenerationEntry,
+  type PaseoServiceLink,
   type PaseoScriptEntryRaw,
   type ProjectConfigRpcError,
 };
@@ -3741,6 +3745,7 @@ export const WorkspaceScriptPayloadSchema = z.object({
   health: WorkspaceScriptHealthSchema.nullable(),
   exitCode: z.number().nullable().optional().default(null),
   terminalId: z.string().nullable().optional().default(null),
+  links: z.array(PaseoServiceLinkSchema).optional(),
 });
 
 const WorkspaceGitRuntimePayloadSchema = z

--- a/packages/protocol/src/messages.workspaces.test.ts
+++ b/packages/protocol/src/messages.workspaces.test.ts
@@ -855,11 +855,34 @@ describe("workspace message schemas", () => {
       proxyUrl: "https://web--repo.services.example.com",
       lifecycle: "running",
       health: "healthy",
+      links: [
+        { label: "Site", path: "/" },
+        { label: "Admin", path: "/admin" },
+      ],
     });
 
     expect(parsed.localProxyUrl).toBe("http://web--repo.localhost:6767");
     expect(parsed.publicProxyUrl).toBe("https://web--repo.services.example.com");
     expect(parsed.proxyUrl).toBe("https://web--repo.services.example.com");
+    expect(parsed.links).toEqual([
+      { label: "Site", path: "/" },
+      { label: "Admin", path: "/admin" },
+    ]);
+  });
+
+  test("rejects service link paths that can escape the selected service origin", () => {
+    const parsed = WorkspaceScriptPayloadSchema.safeParse({
+      scriptName: "web",
+      type: "service",
+      hostname: "web--repo.localhost",
+      port: 3000,
+      proxyUrl: "http://web--repo.localhost:6767",
+      lifecycle: "running",
+      health: "healthy",
+      links: [{ label: "Other host", path: "//example.com" }],
+    });
+
+    expect(parsed.success).toBe(false);
   });
 
   test("defaults omitted workspace script proxyUrl to null", () => {

--- a/packages/protocol/src/paseo-config-schema.test.ts
+++ b/packages/protocol/src/paseo-config-schema.test.ts
@@ -54,6 +54,30 @@ describe("paseo config schema", () => {
     ]);
   });
 
+  it.each(["\u0000", "\t", "\n", "\r", "\u001f", "\u007f"])(
+    "drops service links containing control character %j without dropping valid siblings",
+    (control) => {
+      const parsed = PaseoConfigSchema.parse({
+        scripts: {
+          dev: {
+            type: "service",
+            command: "npm run dev",
+            links: [
+              { label: "Admin", path: "/admin" },
+              { label: "Unsafe", path: `/${control}//evil.example` },
+              { label: "GraphQL", path: "/api/graphql?studio=1#query" },
+            ],
+          },
+        },
+      });
+
+      expect(parsed.scripts?.dev.links).toEqual([
+        { label: "Admin", path: "/admin" },
+        { label: "GraphQL", path: "/api/graphql?studio=1#query" },
+      ]);
+    },
+  );
+
   it("parses service port allocation", () => {
     expect(
       PaseoConfigSchema.parse({

--- a/packages/protocol/src/paseo-config-schema.test.ts
+++ b/packages/protocol/src/paseo-config-schema.test.ts
@@ -33,6 +33,27 @@ describe("paseo config schema", () => {
     });
   });
 
+  it("preserves valid service links when a sibling entry is malformed", () => {
+    const parsed = PaseoConfigSchema.parse({
+      scripts: {
+        dev: {
+          type: "service",
+          command: "npm run dev",
+          links: [
+            { label: "Admin", path: "/admin" },
+            { label: "External", path: "//example.com" },
+            { label: "GraphQL", path: "/api/graphql" },
+          ],
+        },
+      },
+    });
+
+    expect(parsed.scripts?.dev.links).toEqual([
+      { label: "Admin", path: "/admin" },
+      { label: "GraphQL", path: "/api/graphql" },
+    ]);
+  });
+
   it("parses service port allocation", () => {
     expect(
       PaseoConfigSchema.parse({

--- a/packages/protocol/src/paseo-config-schema.ts
+++ b/packages/protocol/src/paseo-config-schema.ts
@@ -35,11 +35,31 @@ export function normalizeLifecycleCommands(commands: unknown): string[] {
 
 export const PaseoLifecycleCommandRawSchema = z.union([z.string(), z.array(z.string())]);
 
+export const PaseoServiceLinkSchema = z.object({
+  label: z.string().regex(/\S/, "Expected a non-empty label"),
+  path: z
+    .string()
+    .regex(/^\/(?!\/)[^\r\n\\]*$/, "Expected an absolute service path starting with one slash"),
+});
+export type PaseoServiceLink = z.infer<typeof PaseoServiceLinkSchema>;
+
+function normalizeServiceLinks(links: unknown): PaseoServiceLink[] {
+  if (!Array.isArray(links)) return [];
+
+  const validLinks: PaseoServiceLink[] = [];
+  for (const link of links) {
+    const parsed = PaseoServiceLinkSchema.safeParse(link);
+    if (parsed.success) validLinks.push(parsed.data);
+  }
+  return validLinks;
+}
+
 export const PaseoScriptEntryRawSchema = z
   .object({
     type: z.unknown().optional(),
     command: z.unknown().optional(),
     port: z.unknown().optional(),
+    links: z.unknown().optional(),
   })
   .passthrough();
 
@@ -86,7 +106,9 @@ export const WorktreeConfigSchema = PaseoWorktreeConfigRawSchema.extend({
   .passthrough()
   .catch({ setup: [], teardown: [] });
 
-export const ScriptEntrySchema = PaseoScriptEntryRawSchema.catch({});
+export const ScriptEntrySchema = PaseoScriptEntryRawSchema.extend({
+  links: z.unknown().transform(normalizeServiceLinks).optional(),
+}).catch({});
 
 export const PaseoConfigSchema = PaseoConfigRawSchema.extend({
   worktree: WorktreeConfigSchema.optional(),

--- a/packages/protocol/src/paseo-config-schema.ts
+++ b/packages/protocol/src/paseo-config-schema.ts
@@ -49,7 +49,10 @@ function normalizeServiceLinks(links: unknown): PaseoServiceLink[] {
   const validLinks: PaseoServiceLink[] = [];
   for (const link of links) {
     const parsed = PaseoServiceLinkSchema.safeParse(link);
-    if (parsed.success) validLinks.push(parsed.data);
+    if (!parsed.success) continue;
+    // URL parsing strips tabs and newlines. Keep this stricter check outside the wire schema.
+    if (/\p{Cc}/u.test(parsed.data.path)) continue;
+    validLinks.push(parsed.data);
   }
   return validLinks;
 }

--- a/packages/server/src/server/script-status-projection.test.ts
+++ b/packages/server/src/server/script-status-projection.test.ts
@@ -243,6 +243,40 @@ describe("script-status-projection", () => {
     }
   });
 
+  it("projects configured service links", () => {
+    const workspaceId = "workspace-service-links";
+    const workspace = createWorkspaceRepo({
+      paseoConfig: {
+        scripts: {
+          web: {
+            type: "service",
+            command: "npm run web",
+            links: [
+              { label: " Site ", path: "/ " },
+              { label: "Admin", path: "/admin" },
+            ],
+          },
+        },
+      },
+    });
+
+    try {
+      expect(
+        buildPayloads({
+          workspaceId,
+          workspaceDirectory: workspace.repoDir,
+          runtimeStore: new WorkspaceScriptRuntimeStore(),
+          daemonPort: 6767,
+        })[0]?.links,
+      ).toEqual([
+        { label: "Site", path: "/" },
+        { label: "Admin", path: "/admin" },
+      ]);
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
   it("overlays runtime, route, and health state for running services", () => {
     const workspaceId = "workspace-running-service";
     const workspace = createWorkspaceRepo({

--- a/packages/server/src/server/script-status-projection.ts
+++ b/packages/server/src/server/script-status-projection.ts
@@ -160,6 +160,7 @@ function buildConfiguredScriptPayload(
     health: toWireHealth(ctx.resolveHealth?.(hostname) ?? null),
     exitCode: runtimeEntry?.exitCode ?? null,
     terminalId: runtimeEntry?.terminalId ?? null,
+    ...(config.links.length > 0 ? { links: config.links } : {}),
   };
 }
 

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -1123,7 +1123,7 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(isServiceScript(typecheck!)).toBe(false);
     });
 
-    it("parses service scripts and preserves optional port", async () => {
+    it("parses service scripts, links, and optional port", async () => {
       writeFileSync(
         join(repoDir, "paseo.json"),
         JSON.stringify({
@@ -1132,6 +1132,7 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
               type: "service",
               command: "npm run dev",
               port: 4321,
+              links: [{ label: " Admin ", path: "/admin " }],
             },
           },
         }),
@@ -1144,6 +1145,7 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
         type: "service",
         command: "npm run dev",
         port: 4321,
+        links: [{ label: "Admin", path: "/admin" }],
       });
       expect(server).toBeDefined();
       expect(isServiceScript(server!)).toBe(true);
@@ -1181,7 +1183,7 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
         new Map([
           ["valid", { command: "npm run valid" }],
           ["invalidType", { command: "npm run worker" }],
-          ["invalidPort", { type: "service", command: "npm run dev" }],
+          ["invalidPort", { type: "service", command: "npm run dev", links: [] }],
         ]),
       );
     });

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -27,7 +27,11 @@ export {
   type PaseoConfig,
   type PaseoConfigRaw,
 } from "@getpaseo/protocol/paseo-config-schema";
-import { PaseoConfigSchema, type PaseoConfig } from "@getpaseo/protocol/paseo-config-schema";
+import {
+  PaseoConfigSchema,
+  type PaseoConfig,
+  type PaseoServiceLink,
+} from "@getpaseo/protocol/paseo-config-schema";
 import {
   createPaseoWorktreeChangeRequestHint,
   normalizeBaseRefName,
@@ -119,6 +123,7 @@ export interface ServiceScriptConfig {
   type: "service";
   command: string;
   port?: number; // explicit port override, otherwise auto-assigned
+  links: PaseoServiceLink[];
 }
 
 export type ScriptConfig = PlainScriptConfig | ServiceScriptConfig;
@@ -345,6 +350,10 @@ export function getScriptConfigs(config: PaseoConfig | null): Map<string, Script
         ? {
             type: "service",
             command,
+            links: (entry.links ?? []).map((link) => ({
+              label: link.label.trim(),
+              path: link.path.trim(),
+            })),
           }
         : { command };
 

--- a/public-docs/worktrees.md
+++ b/public-docs/worktrees.md
@@ -168,9 +168,10 @@ Add quick links for pages you open often:
 }
 ```
 
-The Scripts menu always includes the service root `/`. Add a `/` entry to rename that root link.
-Every path opens under the route selected for the service, so paths must start with one `/`; they
-cannot be absolute URLs.
+Without `links`, the Scripts menu keeps its existing action for opening the service root. Adding
+`links` replaces that action with the configured list, so include a `/` entry when you want the root
+to remain available. Every path opens under the route selected for the service, so paths must start
+with one `/`; they cannot be absolute URLs.
 
 ### Dynamic port allocation
 

--- a/public-docs/worktrees.md
+++ b/public-docs/worktrees.md
@@ -150,6 +150,27 @@ Run them from the app, or manage them from automation with [`paseo script`](/doc
 
 Omit `port` to let Paseo auto-assign one. Bind your process to `$PASEO_PORT` rather than hard-coding, each worktree gets a distinct port so multiple copies of the same service coexist.
 
+Add quick links for pages you open often:
+
+```json
+{
+  "scripts": {
+    "web": {
+      "type": "service",
+      "command": "npm run dev -- --port $PASEO_PORT",
+      "links": [
+        { "label": "Admin", "path": "/admin" },
+        { "label": "GraphQL", "path": "/api/graphql" }
+      ]
+    }
+  }
+}
+```
+
+The Scripts menu always includes the service root `/`. Add a `/` entry to rename that root link.
+Every path opens under the route selected for the service, so paths must start with one `/`; they
+cannot be absolute URLs.
+
 ### Dynamic port allocation
 
 By default, Paseo asks the OS for an available ephemeral port. Configure a range globally in

--- a/public-docs/worktrees.md
+++ b/public-docs/worktrees.md
@@ -159,6 +159,7 @@ Add quick links for pages you open often:
       "type": "service",
       "command": "npm run dev -- --port $PASEO_PORT",
       "links": [
+        { "label": "Website", "path": "/" },
         { "label": "Admin", "path": "/admin" },
         { "label": "GraphQL", "path": "/api/graphql" }
       ]


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A workspace service currently has one eye action that opens its root. Services commonly expose several useful destinations—such as the site, an admin panel, or an API explorer—so every newly created workspace forces the user to open the root and navigate to the same destination again. Bookmarks do not remove that repeated work because each worktree can receive a different hostname, port, or preferred route.

This change lets a service declare labeled paths in `paseo.json`. The behavior is intentionally replacement-based: when no valid links are configured, the existing root eye action remains unchanged; when links are configured, they replace that action exactly. Projects that want to retain or rename the root include an explicit `/` entry.

For example, a complete minimal `paseo.json` looks like:

```json
{
  "scripts": {
    "web": {
      "type": "service",
      "command": "npm run dev -- --port $PASEO_PORT",
      "links": [
        { "label": "Website", "path": "/" },
        { "label": "Admin", "path": "/admin" },
        { "label": "GraphQL", "path": "/api/graphql" }
      ]
    }
  }
}
```

#### Separation of concerns

- `paseo.json` owns the declarative labels and service-relative paths.
- The protocol carries optional link metadata without requiring older clients or daemons to understand it.
- The daemon validates and projects configuration; it does not create routes or decide which URL to open.
- The service proxy continues to own service reachability and routing.
- The app combines each path with the user-selected public, Paseo, or direct service origin, then renders and opens the result.

### Goals

- Add optional labeled service paths to `paseo.json` and the workspace script payload.
- Preserve the original root eye action when no valid links are configured.
- Replace that action with exactly the configured links when links are present.
- Require an explicit `/` entry when the configured list should include the service root.
- Keep paths on the selected service origin and reject protocol-relative or otherwise unsafe paths.
- Preserve valid links when a sibling configuration entry is malformed.
- Keep the wire format backward-compatible and document the configuration.

### Non-goals

- Creating new proxy routes or changing service routing.
- Supporting external or cross-origin URLs.
- Adding bookmark persistence.
- Changing how public, Paseo, or direct routes are selected.
- Adding quick-link editing to the project configuration form.

### QA

#### Automated checks

- `npm run build:client` — passed.
- Service-link configuration and URL utility tests — 34 passed, including duplicate-key stability across reordering, removal, and route changes.
- `messages.wire-compat.test.ts` — 9 passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 warnings and 0 errors.
- `npm run format:check` — passed.

#### Browser flow

The focused Chromium scenario passed in 19.3 seconds against a real daemon and workspace service. It verifies menu resizing, the root action with no valid links, explicitly configured Website/Admin/GraphQL links, duplicate entries, changed link order and removal after configuration reloads, and navigation to the selected service origin. Visible controls use roles and accessible names; the menu container uses a test ID for geometry measurements.

On Windows, Playwright reported its existing process-tree teardown error after all test assertions passed and exited with status 1. The daemon helper had exited, and both the daemon and Metro ports were released.

#### Platforms

| Platform | Verified | Evidence |
| --- | --- | --- |
| Web / Chromium | Yes | Focused Playwright scenario passed |
| Desktop / Windows | Partial | Menu rendering shown below; Chromium interaction passed |
| iOS | No | Not run locally |
| Android | No | Not run locally |
| Desktop / macOS | No | Not run locally |
| Desktop / Linux | No | Covered by CI after submission |

#### Visual evidence

<img width="367" height="263" alt="Service quick links in the Scripts menu" src="https://github.com/user-attachments/assets/34cb364b-8416-4fa1-8a08-bf40571a5ab7" />

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Formatting passes for every changed file
- [x] QA evidence
- [x] Tests added or updated where it made sense
