### PR TITLE
fix(app): import session ux

### DIFF
--- a/packages/app/e2e/browser/import-session.opencode.real.spec.ts
+++ b/packages/app/e2e/browser/import-session.opencode.real.spec.ts
@@ -3,8 +3,15 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { buildHostWorkspaceRoute } from "@/utils/host-routes";
 import { expect, test, type Page } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import {
+  openNewWorkspaceComposer,
+  selectWorkspaceIsolation,
+} from "../support/helpers/new-workspace";
+import { importSessionOption, openLaunchMenu } from "../support/helpers/new-workspace-launch";
 import { connectSeedClient, type SeededWorkspace } from "../support/helpers/seed-client";
 import { getServerId } from "../support/helpers/server-id";
+import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
 import { waitForWorkspaceTabsVisible } from "../support/helpers/workspace-tabs";
 
 const OPENCODE_REAL_MODEL = "openrouter/google/gemini-2.5-flash-lite";
@@ -27,6 +34,7 @@ interface OpenCodeImportScenario {
   workspace: SeededWorkspace;
   prompt: string;
   promptPreview: string;
+  providerHandleId: string;
   response: string;
 }
 
@@ -51,11 +59,33 @@ test("imports a real OpenCode session from the workspace import sheet", async ({
   await expectImportedSessionOpen(page, scenario);
 });
 
+test("imports a real OpenCode session from New workspace", async ({ page }) => {
+  const scenario = await seedPaseoWorkspaceWithOpenCodeSession();
+  workspace = scenario.workspace;
+  const importableSession = await waitForImportableOpenCodeSession(scenario);
+  await openNewWorkspace(page, scenario.workspace);
+
+  await importOpenCodeSessionFromNewWorkspace(page, importableSession);
+
+  await expectImportSheetClosed(page);
+  await expectImportedSessionOpen(page, scenario);
+  await expect
+    .poll(
+      async () =>
+        (
+          await scenario.workspace.client.fetchWorkspaces({
+            filter: { projectId: scenario.workspace.projectId },
+          })
+        ).entries.length,
+    )
+    .toBe(2);
+});
+
 async function seedPaseoWorkspaceWithOpenCodeSession(): Promise<OpenCodeImportScenario> {
   const response = `PASEO_OPENCODE_IMPORT_E2E_OK_${randomUUID().slice(0, 8)}`;
   const prompt = `Do not use tools. Reply with exactly: ${response}`;
   const promptPreview = JSON.stringify(prompt);
-  await launchOpenCodeSessionInWorkspace(PASEO_REPO_PATH, prompt);
+  const providerHandleId = await launchOpenCodeSessionInWorkspace(PASEO_REPO_PATH, prompt);
   const client = await connectSeedClient();
   try {
     const createdWorkspace = await client.createWorkspace({
@@ -74,6 +104,7 @@ async function seedPaseoWorkspaceWithOpenCodeSession(): Promise<OpenCodeImportSc
     return {
       prompt,
       promptPreview,
+      providerHandleId,
       response,
       workspace: {
         client,
@@ -95,11 +126,16 @@ async function seedPaseoWorkspaceWithOpenCodeSession(): Promise<OpenCodeImportSc
   }
 }
 
-async function launchOpenCodeSessionInWorkspace(repoPath: string, prompt: string): Promise<void> {
+async function launchOpenCodeSessionInWorkspace(repoPath: string, prompt: string): Promise<string> {
   const result = await runOpenCodeSeed(repoPath, prompt);
   if (result.code !== 0 || result.timedOut) {
     throw new Error(formatOpenCodeLaunchError(result, prompt));
   }
+  const sessionId = parseOpenCodeSessionId(result.stdout);
+  if (!sessionId) {
+    throw new Error(`${formatOpenCodeLaunchError(result, prompt)}\n\nMissing sessionID in output`);
+  }
+  return sessionId;
 }
 
 function openCodeSeedArgs(repoPath: string, prompt: string): string[] {
@@ -150,6 +186,28 @@ function runOpenCodeSeed(repoPath: string, prompt: string): Promise<OpenCodeSeed
   });
 }
 
+function parseOpenCodeSessionId(stdout: string): string | null {
+  for (const line of stdout.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const event: unknown = JSON.parse(trimmed);
+      if (
+        typeof event === "object" &&
+        event !== null &&
+        "sessionID" in event &&
+        typeof event.sessionID === "string" &&
+        event.sessionID
+      ) {
+        return event.sessionID;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
 function formatOpenCodeLaunchError(result: OpenCodeSeedResult, prompt: string): string {
   return [
     "OpenCode launch failed",
@@ -168,6 +226,16 @@ async function openWorkspace(page: Page, seed: SeededWorkspace): Promise<void> {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(buildHostWorkspaceRoute(getServerId(), seed.workspaceId));
   await waitForWorkspaceTabsVisible(page);
+}
+
+async function openNewWorkspace(page: Page, seed: SeededWorkspace): Promise<void> {
+  await gotoAppShell(page);
+  await waitForSidebarHydration(page);
+  await openNewWorkspaceComposer(page, {
+    projectKey: seed.projectKey,
+    projectDisplayName: seed.projectDisplayName,
+  });
+  await selectWorkspaceIsolation(page, "local");
 }
 
 async function waitForImportableOpenCodeSession(
@@ -199,7 +267,7 @@ async function findImportableOpenCodeSession(
   });
   const entry = sessions.entries.find(
     (session) =>
-      session.providerId === "opencode" && session.firstPromptPreview === scenario.promptPreview,
+      session.providerId === "opencode" && session.providerHandleId === scenario.providerHandleId,
   );
   if (!entry) {
     return null;
@@ -219,6 +287,21 @@ async function importOpenCodeSession(
   const sessionRow = importSheet.getByTestId(
     `import-session-session-opencode-${session.providerHandleId}`,
   );
+  await expect(sessionRow).toBeVisible({ timeout: 60_000 });
+  await sessionRow.click();
+}
+
+async function importOpenCodeSessionFromNewWorkspace(
+  page: Page,
+  session: ImportableOpenCodeSession,
+): Promise<void> {
+  await openLaunchMenu(page);
+  await importSessionOption(page).click();
+  await expect(page.getByTestId("import-session-sheet")).toBeVisible({ timeout: 15_000 });
+
+  const sessionRow = page
+    .getByTestId("import-session-sheet")
+    .getByTestId(`import-session-session-opencode-${session.providerHandleId}`);
   await expect(sessionRow).toBeVisible({ timeout: 60_000 });
   await sessionRow.click();
 }

--- a/packages/app/e2e/browser/new-workspace-launch-composer.spec.ts
+++ b/packages/app/e2e/browser/new-workspace-launch-composer.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "../support/fixtures";
+import { expect, test, type Page } from "../support/fixtures";
 import { gotoAppShell } from "../support/helpers/app";
 import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
 import {
@@ -11,10 +11,10 @@ import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-cli
 import {
   attachButton,
   expectChatComposerActive,
+  expectImportSessionUnavailable,
   expectTerminalComposerActive,
   fillTerminalPrompt,
-  importSessionOption,
-  openLaunchMenu,
+  openAndDismissImportSession,
   seedTerminalProfiles,
   selectChatLaunch,
   selectLaunchOption,
@@ -90,28 +90,25 @@ test.describe("New workspace: the composer is one control in two modes", () => {
   test("Import session opens from New workspace and dismisses back to the unchanged Chat form", async ({
     page,
   }) => {
-    await gotoAppShell(page);
-    await waitForSidebarHydration(page);
-    await openNewWorkspaceComposer(page, {
-      projectKey: workspace.projectKey,
-      projectDisplayName: workspace.projectDisplayName,
-    });
-    await selectWorkspaceIsolation(page, "local");
+    await openLocalNewWorkspaceComposer(page, workspace);
     await fillNewWorkspaceDraft(page, "keep this chat draft");
-
-    await openLaunchMenu(page);
-    await expect(importSessionOption(page)).toBeEnabled();
-    await importSessionOption(page).click();
-
-    const importSheet = page.getByTestId("import-session-sheet");
-    await expect(importSheet).toBeVisible({ timeout: 30_000 });
-    await importSheet.getByRole("button", { name: "Close" }).click();
-    await expect(importSheet).toHaveCount(0);
+    await openAndDismissImportSession(page);
     await expectChatComposerActive(page);
     await expectNewWorkspaceDraft(page, "keep this chat draft");
-
     await selectWorkspaceIsolation(page, "worktree");
-    await openLaunchMenu(page);
-    await expect(importSessionOption(page)).toHaveCount(0);
+    await expectImportSessionUnavailable(page);
   });
 });
+
+async function openLocalNewWorkspaceComposer(
+  page: Page,
+  workspace: SeededWorkspace,
+): Promise<void> {
+  await gotoAppShell(page);
+  await waitForSidebarHydration(page);
+  await openNewWorkspaceComposer(page, {
+    projectKey: workspace.projectKey,
+    projectDisplayName: workspace.projectDisplayName,
+  });
+  await selectWorkspaceIsolation(page, "local");
+}

--- a/packages/app/e2e/browser/new-workspace-launch-composer.spec.ts
+++ b/packages/app/e2e/browser/new-workspace-launch-composer.spec.ts
@@ -5,6 +5,7 @@ import {
   expectNewWorkspaceDraft,
   fillNewWorkspaceDraft,
   openNewWorkspaceComposer,
+  selectWorkspaceIsolation,
 } from "../support/helpers/new-workspace";
 import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
 import {
@@ -12,6 +13,8 @@ import {
   expectChatComposerActive,
   expectTerminalComposerActive,
   fillTerminalPrompt,
+  importSessionOption,
+  openLaunchMenu,
   seedTerminalProfiles,
   selectChatLaunch,
   selectLaunchOption,
@@ -82,5 +85,33 @@ test.describe("New workspace: the composer is one control in two modes", () => {
       await expectTerminalComposerActive(page);
       await expect(terminalPromptInput(page)).toHaveValue("a terminal-only draft");
     });
+  });
+
+  test("Import session opens from New workspace and dismisses back to the unchanged Chat form", async ({
+    page,
+  }) => {
+    await gotoAppShell(page);
+    await waitForSidebarHydration(page);
+    await openNewWorkspaceComposer(page, {
+      projectKey: workspace.projectKey,
+      projectDisplayName: workspace.projectDisplayName,
+    });
+    await selectWorkspaceIsolation(page, "local");
+    await fillNewWorkspaceDraft(page, "keep this chat draft");
+
+    await openLaunchMenu(page);
+    await expect(importSessionOption(page)).toBeEnabled();
+    await importSessionOption(page).click();
+
+    const importSheet = page.getByTestId("import-session-sheet");
+    await expect(importSheet).toBeVisible({ timeout: 30_000 });
+    await importSheet.getByRole("button", { name: "Close" }).click();
+    await expect(importSheet).toHaveCount(0);
+    await expectChatComposerActive(page);
+    await expectNewWorkspaceDraft(page, "keep this chat draft");
+
+    await selectWorkspaceIsolation(page, "worktree");
+    await openLaunchMenu(page);
+    await expect(importSessionOption(page)).toHaveCount(0);
   });
 });

--- a/packages/app/e2e/support/helpers/new-workspace-launch.ts
+++ b/packages/app/e2e/support/helpers/new-workspace-launch.ts
@@ -60,7 +60,7 @@ export function launchOption(page: Page, optionId: string) {
 }
 
 export function importSessionOption(page: Page) {
-  return page.getByTestId("new-workspace-launch-import-session");
+  return launchMenu(page).getByRole("menuitem", { name: "Import session", exact: true });
 }
 
 export function manageProfilesOption(page: Page) {
@@ -99,6 +99,23 @@ export function terminalLaunchSubmit(page: Page) {
 export async function openLaunchMenu(page: Page): Promise<void> {
   await launchTrigger(page).click();
   await expect(launchMenu(page)).toBeVisible({ timeout: 30_000 });
+}
+
+export async function openAndDismissImportSession(page: Page): Promise<void> {
+  await openLaunchMenu(page);
+  const option = importSessionOption(page);
+  await expect(option).toBeEnabled();
+  await option.click();
+
+  const sheet = page.getByTestId("import-session-sheet");
+  await expect(sheet).toBeVisible({ timeout: 30_000 });
+  await sheet.getByRole("button", { name: "Close" }).click();
+  await expect(sheet).toHaveCount(0);
+}
+
+export async function expectImportSessionUnavailable(page: Page): Promise<void> {
+  await openLaunchMenu(page);
+  await expect(importSessionOption(page)).toHaveCount(0);
 }
 
 /** `optionId` is `chat`, `blank`, or a terminal profile id. */

--- a/packages/app/e2e/support/helpers/new-workspace-launch.ts
+++ b/packages/app/e2e/support/helpers/new-workspace-launch.ts
@@ -59,6 +59,10 @@ export function launchOption(page: Page, optionId: string) {
   return page.getByTestId(`new-workspace-launch-option-${optionId}`);
 }
 
+export function importSessionOption(page: Page) {
+  return page.getByTestId("new-workspace-launch-import-session");
+}
+
 export function manageProfilesOption(page: Page) {
   return page.getByTestId("new-workspace-launch-manage-profiles");
 }

--- a/packages/app/src/new-workspace-launch/launch-control.tsx
+++ b/packages/app/src/new-workspace-launch/launch-control.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState, type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useRouter } from "expo-router";
-import { ChevronDown, MessageCircle, SquareTerminal } from "lucide-react-native";
+import { ChevronDown, Inbox, MessageCircle, SquareTerminal } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import {
   DropdownMenu,
@@ -33,6 +33,7 @@ import {
 } from "./target";
 
 const ThemedMessageCircle = withUnistyles(MessageCircle);
+const ThemedInbox = withUnistyles(Inbox);
 const ThemedSquareTerminal = withUnistyles(SquareTerminal);
 const ThemedChevronDown = withUnistyles(ChevronDown);
 
@@ -40,6 +41,7 @@ const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMut
 const extraMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundExtraMuted });
 
 const chatIcon = <ThemedMessageCircle size={ICON_SIZE.sm} uniProps={mutedColorMapping} />;
+const importIcon = <ThemedInbox size={ICON_SIZE.sm} uniProps={mutedColorMapping} />;
 const blankTerminalIcon = <ThemedSquareTerminal size={ICON_SIZE.sm} uniProps={mutedColorMapping} />;
 
 /** Owns its own leading icon and select callback so neither is rebuilt per render of the menu. */
@@ -81,6 +83,8 @@ export interface LaunchControlProps {
   serverId: string;
   target: LaunchTarget;
   onChange: (target: LaunchTarget) => void;
+  onImportSession: () => void;
+  showImportSession: boolean;
   profiles: readonly TerminalProfile[];
   disabled?: boolean;
   /**
@@ -117,6 +121,8 @@ export function LaunchControl({
   serverId,
   target,
   onChange,
+  onImportSession,
+  showImportSession,
   profiles,
   disabled = false,
   badgePressableStyle,
@@ -201,6 +207,15 @@ export function LaunchControl({
         >
           {t("newWorkspace.launch.chat")}
         </DropdownMenuItem>
+        {showImportSession ? (
+          <DropdownMenuItem
+            testID="new-workspace-launch-import-session"
+            onSelect={onImportSession}
+            leading={importIcon}
+          >
+            {t("importSession.title")}
+          </DropdownMenuItem>
+        ) : null}
         <DropdownMenuLabel>{t("newWorkspace.launch.terminal")}</DropdownMenuLabel>
         <DropdownMenuItem
           testID="new-workspace-launch-option-blank"

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "r
 import type { ReactElement, RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
+import { useRouter, type Href } from "expo-router";
 import { Pressable, StyleSheet as RNStyleSheet, Text, View } from "react-native";
 import type { PressableStateCallbackType } from "react-native";
 import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles";
@@ -18,6 +19,7 @@ import {
 } from "@/composer/attachments/submit";
 import { HostStatusDot } from "@/components/host-status-dot";
 import { HostPicker } from "@/components/hosts/host-picker";
+import { ImportSessionSheet } from "@/components/import-session-sheet";
 import { ProjectIconView } from "@/components/project-icon-view";
 import { Combobox, ComboboxItem } from "@/components/ui/combobox";
 import type { ComboboxOption as ComboboxOptionType, ComboboxProps } from "@/components/ui/combobox";
@@ -69,6 +71,7 @@ import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import type { CreateAgentInitialValues } from "@/hooks/use-agent-form-state";
 import { generateMessageId } from "@/types/stream";
 import { toErrorMessage } from "@/utils/error-messages";
+import { buildHostAgentDetailRoute } from "@/utils/host-routes";
 import { projectIconPlaceholderLabelFromDisplayName } from "@/utils/project-display-name";
 import {
   getHostProjectSourceDirectory,
@@ -1333,6 +1336,8 @@ interface NewWorkspaceFormStackInput {
     serverId: string;
     target: LaunchTarget;
     onChange: (target: LaunchTarget) => void;
+    onImportSession: () => void;
+    showImportSession: boolean;
     profiles: readonly TerminalProfile[];
     disabled: boolean;
   };
@@ -1508,6 +1513,8 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
       serverId={launch.serverId}
       target={launch.target}
       onChange={launch.onChange}
+      onImportSession={launch.onImportSession}
+      showImportSession={launch.showImportSession}
       profiles={launch.profiles}
       disabled={launch.disabled}
       badgePressableStyle={badgePressableStyle}
@@ -1547,6 +1554,7 @@ export function NewWorkspaceScreen({
   const queryClient = useQueryClient();
   const { theme } = useUnistyles();
   const { t } = useTranslation();
+  const router = useRouter();
   const insets = useSafeAreaInsets();
   const isCompact = useIsCompactFormFactor();
   const toast = useToast();
@@ -1576,6 +1584,7 @@ export function NewWorkspaceScreen({
     typeof normalizeWorkspaceDescriptor
   > | null>(null);
   const [pendingAction, setPendingAction] = useState<"chat" | "empty" | "terminal" | null>(null);
+  const [isImportSheetOpen, setIsImportSheetOpen] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
   const openAddProjectPicker = useOpenAddProject();
@@ -2137,6 +2146,15 @@ export function NewWorkspaceScreen({
     withConnectedClient,
   ]);
 
+  const openImportSession = useCallback(() => setIsImportSheetOpen(true), []);
+  const closeImportSession = useCallback(() => setIsImportSheetOpen(false), []);
+  const handleImportedSession = useCallback(
+    (agent: { id: string }) => {
+      router.push(buildHostAgentDetailRoute(selectedServerId, agent.id) as Href);
+    },
+    [router, selectedServerId],
+  );
+
   const renderPickerOption = useCallback(
     (props: {
       option: ComboboxOptionType;
@@ -2250,6 +2268,8 @@ export function NewWorkspaceScreen({
       serverId: selectedServerId,
       target: launchTarget,
       onChange: setManualLaunchTarget,
+      onImportSession: openImportSession,
+      showImportSession: effectiveIsolation === "local",
       profiles: terminalProfiles,
       disabled: isPending,
     },
@@ -2330,6 +2350,14 @@ export function NewWorkspaceScreen({
           {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
         </KeyboardTranslateView>
       </View>
+      <ImportSessionSheet
+        visible={isImportSheetOpen}
+        client={client}
+        serverId={selectedServerId}
+        cwd={selectedSourceDirectory}
+        onClose={closeImportSession}
+        onImported={handleImportedSession}
+      />
     </FileDropZone>
   );
 }


### PR DESCRIPTION
### Linked issue

None. Raised in [Discord](https://discord.com/channels/1481169421832814616/1481169422990184542/1540388540750364763).

Similar PR: [PR #3116](https://github.com/getpaseo/paseo/pull/3116) and its [Discord product discussion](https://discord.com/channels/1481169421832814616/1536499603300421652/1536499603300421652) (see Alternatives below)

### Type of change

* [x] Enhancement

### Reasoning

As a new user in the UI, it's difficult to discover how to import existing provider sessions when creating a new workspace. This creates friction when migrating from other orchestrator & agent tools. I eventually discovered that once I start an agent chat or terminal in a new workspace, I can then open "New agent" as a tab and then "Import session" is surfaced, but the intermediate step of creating a dummy agent/terminal session is tedious.

Other paths to importing exist but are indirect & not easy to discover:
* **Empty workspace**: Hitting enter on an empty chat in the new workspace form creates an empty workspace which surfaces "Import session".
* **Workspace/tab menus**: In wide desktop/web layouts, there is a workspace kebab menu at the top of the main pane that contains the import action, and a separate new tab menu for creating new agents & terminals. In more compact layouts - primarily mobile - these two menus combine into a workspace actions menu that contains the import action. Neither is discoverable until a workspace is created.
* **Home**: The Home screen includes "Import session". Aside from first-run and recovery situations, users don't default into the Home screen and its button is in the left sidebar footer.

This change adds an "Import session" option to the new workspace form in the chat/terminal launch menu.

### Goals

* Make it easier for users to import provider sessions from a new workspace
* Reduce friction for new users transitioning to Paseo from other agent and orchestrator tools

### Non-goals

* Expand or modify the underlying "import session" functionality
* Modify the UX around creating empty workspaces or using the Home screen
* Improve consistency across the launch, workspace, and tab menus (more below)

### Alternatives and other considerations

#### Alternatives

I considered a few alternatives:
* An import button directly on the new workspace form (the [PR #3116](https://github.com/getpaseo/paseo/pull/3116) approach). Requires one less click, but adds clutter to the form. Importing a session is a distinct, alternative user action to launching a new agent or terminal when adding a new workspace, so it fits well as an option alongside those actions in the launch menu. This matches the compact workspace actions menu that groups these all together.
* Make the "Create Empty Workspace" workflow more prominent. Once you learn to "just hit enter", importing sessions isn't too difficult. If this is intended as a common workflow, make it more prominent to the user (currently, the only indication that this is possible is the Create button's active state in an empty chat). I avoided this because it doesn't entirely solve the problem and expands the scope beyond the narrow import UX issue.
* Make the Home screen more discoverable. Maybe default the user to Home more frequently, or make the Home button more prominent. This option seems wrong; I avoided it for the same reasons as the previous bullet.

#### Worktrees

In the new workspace form, when the user selects “New worktree”, the added “Import session” option is hidden from the launch menu, as the target worktree doesn't exist until workspace creation, so no preexisting session can belong to its path. We might want to rework this if [PR #3468](https://github.com/getpaseo/paseo/pull/3468) or similar gets merged.

#### Workspace handling on import failures

When importing via:
* **Empty workspace**: A new workspace is created first and the user then imports into that workspace by ID. If the import fails, the empty workspace remains.
* **Workspace actions menu**: As the menu is only availabe within an existing workspace, that workspace persists on import failures.
* **Home**: The user first selects a host and session (across various directories), and then the daemon creates a new Local workspace for the session directory and imports. If the import fails, the daemon removes the created workspace.
* **CLI**: `paseo agent import` uses the same atomic create-workspace-and-import-session handling used by Home imports.

I matched the Home and CLI approach, where the daemon removes a created workspace if import fails.  This makes sense as the import is "untargeted"; it's selected by the user before a workspace exists.

#### Consistency across menus

I noticed some minor inconsistencies across the new workspace launch menu, the new tab menu (wide layout), and the workspace actions menu (compact layout):
* "Chat" and "Agent" and "New agent" all refer to the same action
* "Manage profiles" and "Edit profiles" refer to the same action and use different styling
* "Terminal" is grouped separately from the terminal profiles in the new tab menu, but is grouped together with them in the other menus

Screenshots: new workspace launch menu (before change), new tab menu, compact workspace actions menu
<img width="268" height="251" alt="fix:import-session-ux-launch-menu-2026-08-31-9 55 47-AM" src="https://github.com/user-attachments/assets/40e7ec0b-b416-4981-8ab4-32b9b6550409" /><img width="225" height="343" alt="fix:import-session-ux-wide-new-tab-menu-2026-08-31-9 56 53-AM" src="https://github.com/user-attachments/assets/0eb70a62-174f-4a84-a4f1-c9ec194ca451" /><img width="238" height="408" alt="fix:import-session-ux-compact-workspace-actions-menu-2026-08-31-9 57 25-AM" src="https://github.com/user-attachments/assets/7387a999-309d-4b24-bd9d-3d773c78ec5e" />

Also, in wide layout I think it'd be more intuitive to move import from the workspace kebab menu to the new tab menu.

These items are out of scope here but would be good to address separately.

### QA

#### Videos

https://github.com/user-attachments/assets/9388a20d-0159-49d7-888e-8d161b4cf246

https://github.com/user-attachments/assets/c75cefa2-d08e-4698-b045-b47c538a20c5

https://github.com/user-attachments/assets/763d00bc-8222-4be8-aab1-a5c9f3c1bdab


#### Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| Web | Yes | Chrome browser and isolated daemon. |
| Desktop macOS | Yes | Real Electron development app and isolated daemon. |
| Desktop Windows | No | No Windows host is available in this environment. |
| Desktop Linux | No | No Linux host is available in this environment. |
| iOS | Yes | iPhone 17 simulator running iOS 26.3. |
| Android | No | No Android SDK or emulator is installed in this environment. |

#### Tests

```
$ npm run test:e2e --workspace=@getpaseo/app -- e2e/browser/new-workspace-launch-composer.spec.ts --workers=1

> @getpaseo/app@0.7.0-beta.1 test:e2e
> playwright test --project=browser e2e/browser/new-workspace-launch-composer.spec.ts --workers=1

Running 2 tests using 1 worker
1 …omposer.spec.ts:47:7 › New workspace: the composer is one control in two modes › switching launch target does not leak draft text between chat and terminal, and drops the chat-only controls
✓ 1 (4.3s)
2 …/new-workspace-launch-composer.spec.ts:90:7 › New workspace: the composer is one control in two modes › Import session opens from New workspace and dismisses back to the unchanged Chat form
✓ 2 (4.7s)

2 passed (36.9s)
```

```
$ npm run test:e2e:real --workspace=@getpaseo/app -- e2e/browser/import-session.opencode.real.spec.ts --workers=1

> @getpaseo/app@0.7.0-beta.1 test:e2e:real
> cross-env E2E_FORK_PASEO_HOME_FROM=../../.dev/paseo-home playwright test --project=real-provider e2e/browser/import-session.opencode.real.spec.ts --workers=1

Running 2 tests using 1 worker
1 [real-provider] › e2e/browser/import-session.opencode.real.spec.ts:50:5 › imports a real OpenCode session from the workspace import sheet
✓ 1 (10.9s)
2 [real-provider] › e2e/browser/import-session.opencode.real.spec.ts:62:5 › imports a real OpenCode session from New workspace
✓ 2 (11.1s)

2 passed (28.9s)
```

### Checklist

* [x] One focused change
* [x] `npm run typecheck` passes
* [x] `npm run lint` passes
* [x] `npm run format` passes
* [x] `npm run test:e2e --workspace=@getpaseo/app -- e2e/browser/new-workspace-launch-composer.spec.ts --workers=1` 2 pass
* [x] `npm run test:e2e:real --workspace=@getpaseo/app -- e2e/browser/import-session.opencode.real.spec.ts --workers=1` 2 pass
* [x] QA evidence
* [x] Tests added or updated where it made sense
