### PR TITLE
fix(server): expand Claude slash commands when attachments are present

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -17,7 +17,14 @@ import {
 } from "./agent.js";
 import { claudeProjectDirSync } from "./project-dir.js";
 import { streamSession } from "../test-utils/session-stream-adapter.js";
-import type { AgentSession, AgentTimelineItem, AgentStreamEvent } from "../../agent-sdk-types.js";
+import type {
+  AgentPromptInput,
+  AgentSession,
+  AgentTimelineItem,
+  AgentStreamEvent,
+} from "../../agent-sdk-types.js";
+import type { AgentAttachment } from "@getpaseo/protocol/messages";
+import { renderPromptAttachmentAsText } from "../../prompt-attachments.js";
 
 interface TestClaudeSession {
   translateMessageToEvents(message: SDKMessage): AgentStreamEvent[];
@@ -858,6 +865,69 @@ describe("ClaudeAgentSession features", () => {
     expect(queryMock.applyFlagSettings).toHaveBeenCalledWith({ fastMode: true });
 
     await session.close();
+  });
+
+  async function captureFirstSdkUserMessage(prompt: AgentPromptInput): Promise<SDKUserMessage> {
+    let resolveFirstMessage: ((message: SDKUserMessage) => void) | null = null;
+    const firstMessage = new Promise<SDKUserMessage>((resolve) => {
+      resolveFirstMessage = resolve;
+    });
+    const { queryFactory, queryMock } = createQueryMock();
+    queryFactory.mockImplementation((input: { prompt: AsyncIterable<SDKUserMessage> }) => {
+      void (async () => {
+        for await (const message of input.prompt) {
+          resolveFirstMessage?.(message);
+          break;
+        }
+      })();
+      return queryMock;
+    });
+    const client = new ClaudeAgentClient({
+      logger,
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    const session = await client.createSession({ provider: "claude", cwd: process.cwd() });
+    try {
+      await session.startTurn(prompt);
+      return await firstMessage;
+    } finally {
+      await session.close();
+    }
+  }
+
+  const issueAttachment: AgentAttachment = {
+    type: "forge_issue",
+    mimeType: "application/paseo-forge-issue",
+    forge: "github",
+    number: 12,
+    title: "Composer drops the trailing newline",
+    url: "https://example.test/acme/app/issues/12",
+    body: "Steps: type a message ending in a newline and send it.",
+  };
+
+  test("sends a slash command as the last content block when attachments are present", async () => {
+    const message = await captureFirstSdkUserMessage([
+      { type: "text", text: "/review please" },
+      issueAttachment,
+    ]);
+
+    expect(message.message.content).toEqual([
+      { type: "text", text: renderPromptAttachmentAsText(issueAttachment) },
+      { type: "text", text: "/review please" },
+    ]);
+  });
+
+  test("keeps the typed text before attachments when it is not a slash command", async () => {
+    const message = await captureFirstSdkUserMessage([
+      { type: "text", text: "Please look at this issue" },
+      issueAttachment,
+    ]);
+
+    expect(message.message.content).toEqual([
+      { type: "text", text: "Please look at this issue" },
+      { type: "text", text: renderPromptAttachmentAsText(issueAttachment) },
+    ]);
   });
 
   test("maps Ultracode to xhigh effort and Claude ultracode settings", async () => {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -3368,9 +3368,17 @@ class ClaudeAgentSession implements AgentSession {
           };
         }
     > = [];
+    // Claude Code only expands a slash command (custom command or skill) when it is the last
+    // content block of the user message. buildAgentPrompt puts the typed text before images and
+    // rendered attachments, so "/command" plus an attached issue or screenshot would reach the
+    // model as literal text. Track the typed block and move it to the end.
+    let slashCommandIndex = -1;
     if (Array.isArray(prompt)) {
       for (const chunk of prompt) {
         if (chunk.type === "text") {
+          if (slashCommandIndex === -1 && this.parseSlashCommandInput(chunk.text)) {
+            slashCommandIndex = content.length;
+          }
           content.push({ type: "text", text: chunk.text });
         } else if (chunk.type === "image") {
           if (isImageMimeType(chunk.mimeType)) {
@@ -3389,6 +3397,10 @@ class ClaudeAgentSession implements AgentSession {
       }
     } else {
       content.push({ type: "text", text: prompt });
+    }
+    if (slashCommandIndex !== -1 && slashCommandIndex !== content.length - 1) {
+      const [slashCommandBlock] = content.splice(slashCommandIndex, 1);
+      content.push(slashCommandBlock);
     }
 
     const messageId = randomUUID();


### PR DESCRIPTION
### Linked issue

Closes #4999

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Typing a slash command (a custom command or skill) in the composer works with Claude Code, until the message also carries an attachment. Pasting an issue or PR link auto-attaches it, and the message then reaches the model as literal `/command …` text instead of being expanded. The model sometimes recovers by calling the `Skill` tool itself, sometimes doesn't, so the skill "randomly" fails to load.

Cause: Claude Code only recognises a slash command when it is in the **last** content block of the user message. `buildAgentPrompt` orders blocks as `[chat history, typed text, images, attachments]`, so as soon as an image or a rendered attachment is present the typed text is no longer last.

Fix: in the Claude provider's `toSdkUserMessage`, when the typed text parses as a slash command and there are other blocks, move that block to the end. Text that isn't a slash command keeps its position. The app's user bubble is unaffected: it renders `submittedPromptText` (typed text only) plus attachment pills, not the SDK block order.

### Goals

- A slash command sent together with a forge attachment or image is expanded by Claude Code, the same as when sent alone.
- No change for messages that are not slash commands.
- Regression tests on the SDK user message shape.

### Non-goals

- Changing `buildAgentPrompt` ordering for every provider; this is a Claude Code quirk so the fix is scoped to the Claude provider.
- Other providers' slash command handling.

### QA

**1. Isolating the CLI behaviour** (Claude Code 2.1.260, macOS), feeding `claude -p --input-format stream-json` a throwaway `/hello` skill whose only instruction is "reply with exactly `SKILL_LOADED_OK`", `--max-turns 1`:

| user message content | expanded by CLI? |
|---|---|
| `"/hello please"` | yes, answered `SKILL_LOADED_OK` in turn 1 |
| `[text "/hello please"]` | yes |
| `[text "/hello please", text "<rendered issue>"]` (Paseo's shape) | **no**, model called the `Skill` tool itself and hit max-turns |
| `[text "<rendered issue>", text "/hello please"]` | yes |
| `[text "/hello please", image]` | **no** |
| `[image, text "/hello please"]` | yes |

**2. Before/after through the real `ClaudeAgentClient`** (temporary real e2e test, not committed), sending `[{ type: "text", text: "/hello please" }, <forge_issue attachment>]` with `model: "haiku"`, logging every stream event:

Before (this branch with `agent.ts` stashed):
```
turn_started
timeline:user_message "/hello please\n\nGitHub Issue #12: Fake issue for QA\nhttps://example.test/acme/app/issues/12\n\nFake body"
thread_started
timeline:tool_call "Skill"
timeline:tool_call "Skill"
timeline:tool_call "Skill"
timeline:assistant_message "SKILL_LOADED_OK"
turn_completed
```
The model received the raw text and had to guess and invoke `Skill` on its own.

After:
```
turn_started
timeline:user_message "GitHub Issue #12: Fake issue for QA\nhttps://example.test/acme/app/issues/12\n\nFake body\n\n/hello please"
thread_started
timeline:assistant_message "SKILL_LOADED_OK"
turn_completed
```
The CLI expanded the skill before the model saw the message; no `Skill` tool call.

**3. Unit tests** added in `agent.test.ts`:
- `sends a slash command as the last content block when attachments are present`
- `keeps the typed text before attachments when it is not a slash command`

```
$ npx vitest run src/server/agent/providers/claude/agent.test.ts -t "slash command|not a slash command" --bail=1
 Test Files  1 passed (1)
      Tests  3 passed | 74 skipped (77)
```

**4. Checks**
```
$ npm run build:server && npm run typecheck --workspace=@getpaseo/server   # exit 0
$ npm run lint -- <both files>      # Found 0 warnings and 0 errors.
$ npm run format:files -- <both files>
```
lefthook pre-commit (typecheck, format, lint) passed on commit.

Tested on macOS (arm64) with Claude Code 2.1.260 and `@anthropic-ai/claude-agent-sdk` 0.3.246. Not tested on Linux or Windows; the change is provider-side and platform independent.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)

