### PR TITLE
fix(app): scale pairing QR code to fit its tile on mobile

### DIFF
--- a/packages/app/src/desktop/components/pair-device-section.tsx
+++ b/packages/app/src/desktop/components/pair-device-section.tsx
@@ -273,7 +273,8 @@ function PairingQr({ svg, isError }: { svg: string | null; isError: boolean }) {
     return (
       <SvgXml
         xml={svg}
-        style={styles.qrImage}
+        width="100%"
+        height="100%"
         accessibilityRole="image"
         accessibilityLabel={t("pairing.device.qrAccessibility")}
       />
@@ -362,10 +363,6 @@ const styles = StyleSheet.create((theme) => ({
     borderWidth: 1,
     borderColor: theme.colors.border,
     backgroundColor: theme.colors.palette.white,
-  },
-  qrImage: {
-    width: "100%",
-    height: "100%",
   },
   linkRow: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary

- The QR code generated by `qrcode` ships with explicit `width`/`height` attributes on the SVG element.
- Passing the dimensions only via the `style` prop on `SvgXml` was not reliably overridden on iOS/Android, so the SVG rendered at its intrinsic 480x480 size and was clipped by the white tile, making it impossible or unreliable to scan.

## Fix

Pass `width="100%"` and `height="100%"` directly as props on `SvgXml`, so the viewBox scales to the container. This matches the existing usage in `provider-icons.ts` and `provider-catalog-list.tsx`. The now-redundant `qrImage` style was removed.

## Reproduction

1. Open Paseo on iOS or Android with a host that has relay enabled.
2. Settings → host → Pair device → Pair a device.
3. Before: QR code extends beyond the white tile.
4. After: QR code scales to fit inside the white tile.

## Verification

- `npm run lint -- packages/app/src/desktop/components/pair-device-section.tsx`: clean
- `npx oxfmt --check packages/app/src/desktop/components/pair-device-section.tsx`: clean
- `npm run typecheck`: no new errors in modified file (pre-existing workspace-labels errors unrelated to this change)

Fixes #4317