### PR TITLE
fix(app): hide open in file manager for remote-host workspaces

### DIFF
--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -541,6 +541,10 @@ function ProjectMenuItems({
 }) {
   const { t } = useTranslation();
   const toast = useToast();
+  // `projectPath` comes from `resolveSidebarProjectLocalPath`, so it is the local daemon's
+  // checkout of the project or nothing at all. `settingsTarget` is the first host, which can
+  // be a remote one, so it is not the owner of this path.
+  const localDaemonServerId = useLocalDaemonServerId();
   const handleOpenProjectSettings = useCallback(() => {
     if (!settingsTarget) return;
     router.navigate(buildProjectSettingsRoute(settingsTarget.serverId, settingsTarget.projectId));
@@ -581,6 +585,7 @@ function ProjectMenuItems({
       ) : null}
       <OpenInFileManagerMenuItem
         surface={surface}
+        serverId={localDaemonServerId}
         path={projectPath}
         testID={`sidebar-project-menu-open-folder-${projectViewKey}`}
       />

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
@@ -214,6 +214,7 @@ function SidebarWorkspaceMenuItems({
       ) : null}
       <OpenInFileManagerMenuItem
         surface={surface}
+        serverId={serverId ?? null}
         path={openInFileManagerPath}
         testID={`sidebar-workspace-menu-open-folder-${workspaceKey}`}
       />

--- a/packages/app/src/workspace/open-in-file-manager/menu-item.test.tsx
+++ b/packages/app/src/workspace/open-in-file-manager/menu-item.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+const { LOCAL_SERVER_ID, REMOTE_SERVER_ID, fileManagerTarget, openTargetMock } = vi.hoisted(() => ({
+  LOCAL_SERVER_ID: "local-daemon",
+  REMOTE_SERVER_ID: "paired-remote-host",
+  fileManagerTarget: {
+    id: "file-manager",
+    label: "Finder",
+    kind: "file-manager" as const,
+    icon: { kind: "symbol" as const, name: "folder" as const },
+  },
+  openTargetMock: vi.fn(async () => {}),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/constants/platform", () => ({
+  isNative: false,
+  isWeb: true,
+  getIsElectron: () => true,
+}));
+
+vi.mock("@/contexts/toast-context", () => ({
+  useToast: () => ({ error: vi.fn() }),
+}));
+
+vi.mock("@/desktop/host", () => ({
+  getDesktopHost: () => ({
+    editor: {
+      listTargets: async () => [fileManagerTarget],
+      openTarget: openTargetMock,
+    },
+  }),
+}));
+
+vi.mock("@/desktop/daemon/desktop-daemon", () => ({
+  shouldUseDesktopDaemon: () => true,
+  getDesktopDaemonStatus: async () => ({ serverId: LOCAL_SERVER_ID }),
+}));
+
+function menuItemStub({
+  children,
+  testID,
+  onSelect,
+}: {
+  children?: React.ReactNode;
+  testID?: string;
+  onSelect?: () => void;
+}) {
+  return (
+    <button type="button" data-testid={testID} onClick={onSelect}>
+      {children}
+    </button>
+  );
+}
+
+vi.mock("@/components/ui/dropdown-menu", () => ({ DropdownMenuItem: menuItemStub }));
+vi.mock("@/components/ui/context-menu", () => ({ ContextMenuItem: menuItemStub }));
+
+// The component builds its leading icon at module scope, so React has to be global before the
+// module is evaluated. Vitest transforms JSX with the classic runtime.
+vi.stubGlobal("React", React);
+const { OpenInFileManagerMenuItem } = await import("@/workspace/open-in-file-manager/menu-item");
+
+const TEST_ID = "open-folder";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+async function renderMenuItem(serverId: string | null, path: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <OpenInFileManagerMenuItem serverId={serverId} path={path} testID={TEST_ID} />
+      </QueryClientProvider>,
+    );
+  });
+  // Two chained queries: resolving the local-daemon identity is what enables the desktop
+  // target query, so the render settles over several ticks.
+  for (let tick = 0; tick < 10; tick += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  return container.querySelector<HTMLButtonElement>(`[data-testid="${TEST_ID}"]`);
+}
+
+it("offers the action for a workspace owned by the local daemon", async () => {
+  const item = await renderMenuItem(LOCAL_SERVER_ID, "/Users/dev/project");
+
+  expect(item).not.toBeNull();
+
+  await act(async () => {
+    item?.click();
+  });
+
+  expect(openTargetMock).toHaveBeenCalledWith({
+    editorId: fileManagerTarget.id,
+    workspacePath: "/Users/dev/project",
+  });
+});
+
+it("hides the action for a workspace owned by a paired remote host", async () => {
+  const item = await renderMenuItem(REMOTE_SERVER_ID, "/home/user/project");
+
+  expect(item).toBeNull();
+  expect(openTargetMock).not.toHaveBeenCalled();
+});
+
+it("hides the action when the owning host is unknown", async () => {
+  const item = await renderMenuItem(null, "/home/user/project");
+
+  expect(item).toBeNull();
+});

--- a/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
+++ b/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
@@ -6,10 +6,16 @@ import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { ContextMenuItem } from "@/components/ui/context-menu";
 import { getIsElectron } from "@/constants/platform";
 import { useToast } from "@/contexts/toast-context";
+import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
 import type { Theme } from "@/styles/theme";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
 
 interface OpenInFileManagerMenuItemProps {
+  /**
+   * Host that owns `path`. Required (and nullable) so a new call site has to answer the
+   * question instead of silently offering a remote path to the local file manager.
+   */
+  serverId: string | null;
   path?: string | null;
   testID: string;
   surface?: "context" | "dropdown";
@@ -24,6 +30,7 @@ const foregroundMutedColorMapping = (theme: Theme) => ({
 const leadingIcon = <ThemedFolderOpen size={14} uniProps={foregroundMutedColorMapping} />;
 
 export function OpenInFileManagerMenuItem({
+  serverId,
   path,
   testID,
   surface = "dropdown",
@@ -32,8 +39,12 @@ export function OpenInFileManagerMenuItem({
   const toast = useToast();
   const isElectron = getIsElectron();
   const workspacePath = path?.trim() ?? "";
+  // The desktop bridge only reaches the machine Paseo Desktop runs on, so the path has to
+  // belong to the local daemon. A paired remote host's path is not openable here, and the
+  // entry stays hidden rather than being offered and then failing.
+  const isLocalDaemon = useIsLocalDaemon(serverId ?? "");
   const { targets } = useDesktopOpenTargets({
-    isLocalExecution: isElectron && workspacePath.length > 0,
+    isLocalExecution: isLocalDaemon && workspacePath.length > 0,
   });
   const fileManagerTarget = targets.find((target) => target.kind === "file-manager");
 


### PR DESCRIPTION
### Linked issue

Fixes #2509

### Type of change

- [x] Bug fix

### Reasoning

The sidebar's "Open in file manager" entry decided whether it could act by asking "am I running in Electron, and is the path non-empty". It never asked which daemon owns the workspace. Paseo Desktop can be paired with remote hosts, so the entry was offered for workspaces that live on another machine, and choosing it handed a remote path to the local file manager and failed with the generic "Couldn't open folder" toast. Someone on a Windows client connected to an Ubuntu host sees a working-looking action, clicks it, and gets an error with nothing to do about it.

The fix applies the rule the other desktop open targets already use: this action is for the local daemon's workspaces, so it is only offered for them.

### Goals

- Gate the entry on workspace ownership (`useIsLocalDaemon`) instead of on "is this Electron".
- The entry is absent for a remote-host workspace or project, in the row context menu and in the `...` menu.
- Nothing changes for a local-daemon workspace.
- Automated coverage that fails if the gate is removed again.

### Non-goals

- Opening remote workspaces. That is #826 (Remote SSH URIs), a separate feature.
- Any change to the desktop bridge or to `desktop-open-targets`.
- Rendering the entry disabled with an explanation, see below.

### What changed

`OpenInFileManagerMenuItem` now takes the `serverId` of the host that owns the path and derives `isLocalExecution` from `useIsLocalDaemon(serverId)`. The prop is required rather than optional (nullable, but you have to pass it) so a future call site has to answer the ownership question instead of quietly defaulting to offering the action.

Both call sites already had the value, so nothing new is threaded through the component tree. The sidebar workspace menus already carry `serverId` for the label submenu, and every `SidebarWorkspaceMenu` and `SidebarWorkspaceContextMenu` call site passes the workspace's own `serverId`. The project menu passes the local daemon id, because its `projectPath` comes from `resolveSidebarProjectLocalPath`, which already resolves either to the local daemon's checkout or to nothing at all; that makes the local daemon the host the path belongs to. `settingsTarget` would have been the wrong source there, since it is just `project.hosts[0]` and can be a remote host.

The entry is hidden, not disabled. `docs/menus.md` documents no pattern for disabled menu items, hiding is what the other desktop targets do when execution is not local, and it is what the reporter asked for.

One thing worth knowing for review: the project menu was already correct, by accident, because `resolveSidebarProjectLocalPath` returns an empty path for a project that only exists on a remote host. The bug was reachable only through the workspace menus, which pass `workspace.workspaceDirectory` unconditionally for every row regardless of host.

### QA

New test file `packages/app/src/workspace/open-in-file-manager/menu-item.test.tsx`, three cases: offered for a local-daemon workspace and actually calls `openTarget` with that path, hidden for a workspace owned by a paired remote host, hidden when the owner is unknown.

The test reproduces the bug rather than just describing it. Reverting only the gate in `menu-item.tsx` (`isLocalDaemon` back to `isElectron`) and leaving everything else in place makes the two "hidden" cases fail:

```
 ❯ src/workspace/open-in-file-manager/menu-item.test.tsx (3 tests | 2 failed)
   × hides the action for a workspace owned by a paired remote host
   × hides the action when the owning host is unknown

AssertionError: expected <button type="button" …(1)></button> to be null

- Expected:
null

+ Received:
<button
  data-testid="open-folder"
  type="button"
>
  sidebar.project.actions.openFolder
</button>
```

With the gate in place:

```
$ npx vitest run --project unit src/workspace/open-in-file-manager/menu-item.test.tsx

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

`src/components/sidebar-workspace-list.test.tsx` also still passes (3 tests), since this PR touches that file.

Manual verification in the desktop app, against a workspace on a paired remote host and a local one:

- Remote-host workspace: the entry is gone from the row context menu and from the `...` menu.
- Remote-host project: same, gone from both menus.
- Local-daemon workspace: the entry is still there and still opens the file manager at the right directory.

No video. The visible effect is a menu entry not being offered, and the two states are described above.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | n/a    | Entry is behind `getIsElectron()`, never shown |
| Android         | n/a    | Same |
| Web             | n/a    | Same |
| Desktop macOS   | yes    | Manual pass described above |
| Desktop Windows | no     | The gate is a `serverId` comparison in JS with no OS-specific path handling, so behaviour is the same. The original report is Windows client + Ubuntu host |
| Desktop Linux   | no     | Same |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
