### PR TITLE
Hide empty ACP sessions from session import

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -10157,7 +10157,7 @@ test("listImportableSessions returns healthy rows alongside thrown and timed-out
     });
 
     const resultPromise = manager.listImportableSessions();
-    await vi.advanceTimersByTimeAsync(8_000);
+    await vi.advanceTimersByTimeAsync(12_000);
 
     await expect(resultPromise).resolves.toEqual({
       sessions: [
@@ -10175,7 +10175,7 @@ test("listImportableSessions returns healthy rows alongside thrown and timed-out
         { provider: "codex", message: "codex listing failed" },
         {
           provider: "pi",
-          message: "Timed out listing importable sessions for provider 'pi' after 8000ms",
+          message: "Timed out listing importable sessions for provider 'pi' after 12000ms",
         },
       ],
     });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -10157,7 +10157,7 @@ test("listImportableSessions returns healthy rows alongside thrown and timed-out
     });
 
     const resultPromise = manager.listImportableSessions();
-    await vi.advanceTimersByTimeAsync(12_000);
+    await vi.advanceTimersByTimeAsync(90_000);
 
     await expect(resultPromise).resolves.toEqual({
       sessions: [
@@ -10175,7 +10175,7 @@ test("listImportableSessions returns healthy rows alongside thrown and timed-out
         { provider: "codex", message: "codex listing failed" },
         {
           provider: "pi",
-          message: "Timed out listing importable sessions for provider 'pi' after 12000ms",
+          message: "Timed out listing importable sessions for provider 'pi' after 90000ms",
         },
       ],
     });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -10157,7 +10157,7 @@ test("listImportableSessions returns healthy rows alongside thrown and timed-out
     });
 
     const resultPromise = manager.listImportableSessions();
-    await vi.advanceTimersByTimeAsync(90_000);
+    await vi.advanceTimersByTimeAsync(8_000);
 
     await expect(resultPromise).resolves.toEqual({
       sessions: [
@@ -10175,7 +10175,37 @@ test("listImportableSessions returns healthy rows alongside thrown and timed-out
         { provider: "codex", message: "codex listing failed" },
         {
           provider: "pi",
-          message: "Timed out listing importable sessions for provider 'pi' after 90000ms",
+          message: "Timed out listing importable sessions for provider 'pi' after 8000ms",
+        },
+      ],
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("listImportableSessions gives a single requested provider the full listing deadline", async () => {
+  vi.useFakeTimers();
+  try {
+    const hangingClient = new RecordingPersistedAgentsClient("acp");
+    hangingClient.listImportableSessions = async () => await new Promise(() => undefined);
+    const manager = new AgentManager({
+      clients: { acp: hangingClient },
+      providerDefinitions: {
+        acp: { enabled: true, derivedFromProviderId: null },
+      },
+      logger,
+    });
+
+    const resultPromise = manager.listImportableSessions({ providerFilter: new Set(["acp"]) });
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    await expect(resultPromise).resolves.toEqual({
+      sessions: [],
+      providerErrors: [
+        {
+          provider: "acp",
+          message: "Timed out listing importable sessions for provider 'acp' after 90000ms",
         },
       ],
     });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -10157,7 +10157,7 @@ test("listImportableSessions returns healthy rows alongside thrown and timed-out
     });
 
     const resultPromise = manager.listImportableSessions();
-    await vi.advanceTimersByTimeAsync(8_000);
+    await vi.advanceTimersByTimeAsync(90_000);
 
     await expect(resultPromise).resolves.toEqual({
       sessions: [
@@ -10175,37 +10175,7 @@ test("listImportableSessions returns healthy rows alongside thrown and timed-out
         { provider: "codex", message: "codex listing failed" },
         {
           provider: "pi",
-          message: "Timed out listing importable sessions for provider 'pi' after 8000ms",
-        },
-      ],
-    });
-  } finally {
-    vi.useRealTimers();
-  }
-});
-
-test("listImportableSessions gives a single requested provider the full listing deadline", async () => {
-  vi.useFakeTimers();
-  try {
-    const hangingClient = new RecordingPersistedAgentsClient("acp");
-    hangingClient.listImportableSessions = async () => await new Promise(() => undefined);
-    const manager = new AgentManager({
-      clients: { acp: hangingClient },
-      providerDefinitions: {
-        acp: { enabled: true, derivedFromProviderId: null },
-      },
-      logger,
-    });
-
-    const resultPromise = manager.listImportableSessions({ providerFilter: new Set(["acp"]) });
-    await vi.advanceTimersByTimeAsync(90_000);
-
-    await expect(resultPromise).resolves.toEqual({
-      sessions: [],
-      providerErrors: [
-        {
-          provider: "acp",
-          message: "Timed out listing importable sessions for provider 'acp' after 90000ms",
+          message: "Timed out listing importable sessions for provider 'pi' after 90000ms",
         },
       ],
     });

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -88,6 +88,7 @@ import { withTimeout } from "../../utils/promise-timeout.js";
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
 const IMPORTABLE_SESSION_LIST_TIMEOUT_MS = 90_000;
+const AGGREGATE_IMPORTABLE_SESSION_LIST_TIMEOUT_MS = 8_000;
 const STORED_AGENT_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: false,
   supportsSessionPersistence: true,
@@ -955,6 +956,10 @@ export class AgentManager {
     );
     const providerResults = await Promise.all(
       providerEntries.map(async ([provider, client]) => {
+        const timeoutMs =
+          providerEntries.length === 1
+            ? IMPORTABLE_SESSION_LIST_TIMEOUT_MS
+            : AGGREGATE_IMPORTABLE_SESSION_LIST_TIMEOUT_MS;
         try {
           const sessions = await withTimeout(
             client.listImportableSessions!({
@@ -963,8 +968,8 @@ export class AgentManager {
               scanLimit: options?.scanLimit,
               cwd: options?.cwd,
             }),
-            IMPORTABLE_SESSION_LIST_TIMEOUT_MS,
-            `Timed out listing importable sessions for provider '${provider}' after ${IMPORTABLE_SESSION_LIST_TIMEOUT_MS}ms`,
+            timeoutMs,
+            `Timed out listing importable sessions for provider '${provider}' after ${timeoutMs}ms`,
           );
           return {
             sessions: sessions

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -87,7 +87,7 @@ import { withTimeout } from "../../utils/promise-timeout.js";
 
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
-const IMPORTABLE_SESSION_LIST_TIMEOUT_MS = 8_000;
+const IMPORTABLE_SESSION_LIST_TIMEOUT_MS = 12_000;
 const STORED_AGENT_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: false,
   supportsSessionPersistence: true,

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -87,7 +87,7 @@ import { withTimeout } from "../../utils/promise-timeout.js";
 
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
-const IMPORTABLE_SESSION_LIST_TIMEOUT_MS = 12_000;
+const IMPORTABLE_SESSION_LIST_TIMEOUT_MS = 90_000;
 const STORED_AGENT_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: false,
   supportsSessionPersistence: true,

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -88,7 +88,6 @@ import { withTimeout } from "../../utils/promise-timeout.js";
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
 const IMPORTABLE_SESSION_LIST_TIMEOUT_MS = 90_000;
-const AGGREGATE_IMPORTABLE_SESSION_LIST_TIMEOUT_MS = 8_000;
 const STORED_AGENT_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: false,
   supportsSessionPersistence: true,
@@ -956,10 +955,6 @@ export class AgentManager {
     );
     const providerResults = await Promise.all(
       providerEntries.map(async ([provider, client]) => {
-        const timeoutMs =
-          providerEntries.length === 1
-            ? IMPORTABLE_SESSION_LIST_TIMEOUT_MS
-            : AGGREGATE_IMPORTABLE_SESSION_LIST_TIMEOUT_MS;
         try {
           const sessions = await withTimeout(
             client.listImportableSessions!({
@@ -968,8 +963,8 @@ export class AgentManager {
               scanLimit: options?.scanLimit,
               cwd: options?.cwd,
             }),
-            timeoutMs,
-            `Timed out listing importable sessions for provider '${provider}' after ${timeoutMs}ms`,
+            IMPORTABLE_SESSION_LIST_TIMEOUT_MS,
+            `Timed out listing importable sessions for provider '${provider}' after ${IMPORTABLE_SESSION_LIST_TIMEOUT_MS}ms`,
           );
           return {
             sessions: sessions

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -3516,6 +3516,119 @@ describe("ACPAgentClient probe cleanup", () => {
     expect(child.stdout.destroyed).toBe(true);
     expect(child.stderr.destroyed).toBe(true);
   });
+
+  test("closes the native catalog probe session before terminating its process", async () => {
+    const terminator = new FakeTerminator();
+    const child = createProbeChildStub();
+    const closeSession = vi.fn().mockImplementation(async () => {
+      expect(terminator.terminated).toEqual([]);
+      return {};
+    });
+
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child,
+          connection: {
+            newSession: vi.fn().mockResolvedValue({
+              sessionId: "catalog-probe-session",
+              modes: null,
+              models: null,
+              configOptions: [],
+            }),
+            unstable_closeSession: closeSession,
+          },
+          initialize: { agentCapabilities: { sessionCapabilities: { close: {} } } },
+        } as unknown as SpawnedACPProcess;
+      }
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "claude-acp",
+      logger: createTestLogger(),
+      defaultCommand: ["claude", "--acp"],
+      defaultModes: [],
+      terminateProcess: terminator.terminate,
+    });
+
+    await client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-models", force: false });
+
+    expect(closeSession).toHaveBeenCalledWith({ sessionId: "catalog-probe-session" });
+    expect(terminator.terminated).toContain(child);
+  });
+
+  test("closes the native feature probe session before terminating its process", async () => {
+    const terminator = new FakeTerminator();
+    const child = createProbeChildStub();
+    const closeSession = vi.fn().mockResolvedValue({});
+
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child,
+          connection: {
+            newSession: vi.fn().mockResolvedValue({
+              sessionId: "feature-probe-session",
+              modes: null,
+              models: null,
+              configOptions: [copilotAgentConfigOption("Probe Agent")],
+            }),
+            unstable_closeSession: closeSession,
+          },
+          initialize: { agentCapabilities: { sessionCapabilities: { close: {} } } },
+        } as unknown as SpawnedACPProcess;
+      }
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "copilot",
+      logger: createTestLogger(),
+      defaultCommand: ["copilot", "--acp"],
+      defaultModes: [],
+      configFeatureOptions: [COPILOT_AGENT_FEATURE_OPTION],
+      terminateProcess: terminator.terminate,
+    });
+
+    await client.listFeatures({ provider: "copilot", cwd: "/tmp/acp-features" });
+
+    expect(closeSession).toHaveBeenCalledWith({ sessionId: "feature-probe-session" });
+    expect(terminator.terminated).toContain(child);
+  });
+
+  test("still terminates the probe when native session close fails", async () => {
+    const terminator = new FakeTerminator();
+    const child = createProbeChildStub();
+
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child,
+          connection: {
+            newSession: vi.fn().mockResolvedValue({
+              sessionId: "catalog-probe-session",
+              modes: null,
+              models: null,
+              configOptions: [],
+            }),
+            unstable_closeSession: vi.fn().mockRejectedValue(new Error("close failed")),
+          },
+          initialize: { agentCapabilities: { sessionCapabilities: { close: {} } } },
+        } as unknown as SpawnedACPProcess;
+      }
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "claude-acp",
+      logger: createTestLogger(),
+      defaultCommand: ["claude", "--acp"],
+      defaultModes: [],
+      terminateProcess: terminator.terminate,
+    });
+
+    await client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-models", force: false });
+
+    expect(terminator.terminated).toContain(child);
+  });
 });
 
 describe("ACP session/load invariant — cwd and mcpServers always passed", () => {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -45,7 +45,11 @@ import { GenericACPAgentClient } from "./generic-acp-agent.js";
 import { parseKiroExtensionCommands } from "./kiro-acp-agent.js";
 import { transformPiModels } from "./pi/agent.js";
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
-import type { AgentCapabilityFlags, AgentPersistenceHandle } from "../agent-sdk-types.js";
+import type {
+  AgentCapabilityFlags,
+  AgentPersistenceHandle,
+  ProviderRefreshContext,
+} from "../agent-sdk-types.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { buildStringCommandShellInvocation } from "../../../utils/string-command-shell.js";
 import { asInternals } from "../../test-utils/class-mocks.js";
@@ -3554,6 +3558,69 @@ describe("ACPAgentClient probe cleanup", () => {
     await client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-models", force: false });
 
     expect(closeSession).toHaveBeenCalledWith({ sessionId: "catalog-probe-session" });
+    expect(terminator.terminated).toContain(child);
+  });
+
+  test("closes a catalog probe session that finishes being created after refresh aborts", async () => {
+    const terminator = new FakeTerminator();
+    const child = createProbeChildStub();
+    const abort = new AbortController();
+    let resolveNewSession!: (value: {
+      sessionId: string;
+      modes: null;
+      models: null;
+      configOptions: [];
+    }) => void;
+    const newSession = vi.fn(
+      () =>
+        new Promise<{
+          sessionId: string;
+          modes: null;
+          models: null;
+          configOptions: [];
+        }>((resolve) => {
+          resolveNewSession = resolve;
+        }),
+    );
+    const closeSession = vi.fn().mockResolvedValue({});
+
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child,
+          connection: { newSession, unstable_closeSession: closeSession },
+          initialize: { agentCapabilities: { sessionCapabilities: { close: {} } } },
+        } as unknown as SpawnedACPProcess;
+      }
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "claude-acp",
+      logger: createTestLogger(),
+      defaultCommand: ["claude", "--acp"],
+      defaultModes: [],
+      terminateProcess: terminator.terminate,
+    });
+    const context: ProviderRefreshContext = {
+      signal: abort.signal,
+      runActivity: async (_name, operation) => await operation(),
+    };
+    const catalog = client.fetchCatalog(
+      { scope: "workspace", cwd: "/tmp/acp-models", force: false },
+      context,
+    );
+    await vi.waitFor(() => expect(newSession).toHaveBeenCalledOnce());
+
+    abort.abort(new Error("refresh cancelled"));
+    resolveNewSession({
+      sessionId: "late-catalog-probe-session",
+      modes: null,
+      models: null,
+      configOptions: [],
+    });
+
+    await expect(catalog).rejects.toThrow("refresh cancelled");
+    expect(closeSession).toHaveBeenCalledWith({ sessionId: "late-catalog-probe-session" });
     expect(terminator.terminated).toContain(child);
   });
 

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -3696,6 +3696,70 @@ describe("ACPAgentClient probe cleanup", () => {
 
     expect(terminator.terminated).toContain(child);
   });
+
+  test("keeps a session visible and cleans up after its history load times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const terminator = new FakeTerminator();
+      const child = createProbeChildStub();
+      const loadSession = vi.fn(async () => await new Promise(() => undefined));
+
+      class TestACPAgentClient extends ACPAgentClient {
+        protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+          return {
+            child,
+            connection: {
+              listSessions: vi.fn().mockResolvedValue({
+                sessions: [
+                  {
+                    sessionId: "slow-session",
+                    cwd: "/tmp/acp-import",
+                    title: "Slow but real",
+                    updatedAt: "2026-09-04T20:00:00.000Z",
+                  },
+                ],
+                nextCursor: null,
+              }),
+              loadSession,
+              unstable_closeSession: vi.fn().mockResolvedValue({}),
+            },
+            initialize: {
+              agentCapabilities: {
+                loadSession: true,
+                sessionCapabilities: { list: {}, close: {} },
+              },
+            },
+          } as unknown as SpawnedACPProcess;
+        }
+      }
+
+      const client = new TestACPAgentClient({
+        provider: "claude-acp",
+        logger: createTestLogger(),
+        defaultCommand: ["claude", "--acp"],
+        defaultModes: [],
+        terminateProcess: terminator.terminate,
+      });
+      const listing = client.listImportableSessions({ limit: 1 });
+      await vi.waitFor(() => expect(loadSession).toHaveBeenCalledOnce());
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expect(listing).resolves.toEqual([
+        {
+          providerHandleId: "slow-session",
+          cwd: "/tmp/acp-import",
+          title: "Slow but real",
+          firstPromptPreview: null,
+          lastPromptPreview: null,
+          lastActivityAt: new Date("2026-09-04T20:00:00.000Z"),
+        },
+      ]);
+      expect(terminator.terminated).toContain(child);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("ACP session/load invariant — cwd and mcpServers always passed", () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -442,6 +442,7 @@ interface ACPAgentClientOptions {
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
+  now?: () => number;
 }
 
 interface ACPAgentSessionOptions {
@@ -902,6 +903,7 @@ export class ACPAgentClient implements AgentClient {
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private readonly importPromptCache = new Map<string, ACPImportPromptCacheEntry>();
+  private readonly now: () => number;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -930,6 +932,7 @@ export class ACPAgentClient implements AgentClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.now = options.now ?? Date.now;
   }
 
   async createSession(
@@ -1160,7 +1163,7 @@ export class ACPAgentClient implements AgentClient {
       const resultLimit = options?.limit ?? Number.POSITIVE_INFINITY;
       const scanLimit = Math.min(options?.scanLimit ?? 500, 500);
       const canLoadHistory = probe.initialize.agentCapabilities.loadSession === true;
-      const historyDeadline = Date.now() + ACP_IMPORT_HISTORY_BUDGET_MS;
+      const historyDeadline = this.now() + ACP_IMPORT_HISTORY_BUDGET_MS;
       let scanned = 0;
       let cursor: string | null | undefined;
       for (;;) {
@@ -1227,7 +1230,7 @@ export class ACPAgentClient implements AgentClient {
       };
     }
 
-    const remainingMs = historyDeadline - Date.now();
+    const remainingMs = historyDeadline - this.now();
     if (remainingMs <= 0) return null;
     const loadTimeoutMs = Math.min(ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS, remainingMs);
 
@@ -1267,7 +1270,7 @@ export class ACPAgentClient implements AgentClient {
     historyDeadline: number,
   ): Promise<void> {
     if (!probe.initialize.agentCapabilities?.sessionCapabilities?.close) return;
-    const remainingMs = historyDeadline - Date.now();
+    const remainingMs = historyDeadline - this.now();
     if (remainingMs <= 0) return;
     const closeTimeoutMs = Math.min(ACP_PROBE_CLOSE_TIMEOUT_MS, remainingMs);
     try {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -278,8 +278,8 @@ export function buildACPClientCapabilities(
 const PROBE_ENV: Record<string, string> = { NO_BROWSER: "true" };
 const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
 const ACP_PROBE_CLOSE_TIMEOUT_MS = 2_000;
-const ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS = 2_000;
-const ACP_IMPORT_HISTORY_BUDGET_MS = 5_000;
+const ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS = 3_000;
+const ACP_IMPORT_HISTORY_BUDGET_MS = 8_000;
 
 function summarizeMalformedACPStdoutError(error: unknown): { type: string; message: string } {
   return {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -279,6 +279,7 @@ const PROBE_ENV: Record<string, string> = { NO_BROWSER: "true" };
 const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
 const ACP_PROBE_CLOSE_TIMEOUT_MS = 2_000;
 const ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS = 2_000;
+const ACP_IMPORT_HISTORY_BUDGET_MS = 5_000;
 
 function summarizeMalformedACPStdoutError(error: unknown): { type: string; message: string } {
   return {
@@ -1024,10 +1025,29 @@ export class ACPAgentClient implements AgentClient {
     const cwd = options.scope === "global" ? homedir() : options.cwd;
     let probe: UninitializedACPProcess | null = null;
     let probeSessionId: string | null = null;
+    let probeSessionPromise: Promise<NewSessionResponse> | null = null;
     let closePromise: Promise<void> | null = null;
     const closeProbe = (): Promise<void> => {
       if (!probe) return Promise.resolve();
-      closePromise ??= this.closeProbe(probe, probeSessionId);
+      closePromise ??= (async () => {
+        if (!probeSessionId && probeSessionPromise) {
+          try {
+            probeSessionId = (
+              await withTimeout(
+                probeSessionPromise,
+                ACP_PROBE_CLOSE_TIMEOUT_MS,
+                `ACP probe session/new cleanup timed out after ${ACP_PROBE_CLOSE_TIMEOUT_MS}ms`,
+              )
+            ).sessionId;
+          } catch (error) {
+            this.logger.debug(
+              { err: error },
+              "ACP probe session/new did not finish during cleanup",
+            );
+          }
+        }
+        await this.closeProbe(probe, probeSessionId);
+      })();
       return closePromise;
     };
     const handleAbort = () => void closeProbe().catch(() => undefined);
@@ -1046,16 +1066,14 @@ export class ACPAgentClient implements AgentClient {
         ),
       );
       probe = initializedProbe;
+      probeSessionPromise = this.runACPRequest(() =>
+        initializedProbe.connection.newSession({
+          cwd,
+          mcpServers: [],
+        }),
+      );
       const response = await runProviderRefreshActivity(context, "session/new", () =>
-        raceProviderRefreshAbort(
-          context?.signal,
-          this.runACPRequest(() =>
-            initializedProbe.connection.newSession({
-              cwd,
-              mcpServers: [],
-            }),
-          ),
-        ),
+        raceProviderRefreshAbort(context?.signal, probeSessionPromise!),
       );
       probeSessionId = response.sessionId;
       const transformed = this.transformSessionResponse(response);
@@ -1142,6 +1160,7 @@ export class ACPAgentClient implements AgentClient {
       const resultLimit = options?.limit ?? Number.POSITIVE_INFINITY;
       const scanLimit = Math.min(options?.scanLimit ?? 500, 500);
       const canLoadHistory = probe.initialize.agentCapabilities.loadSession === true;
+      const historyDeadline = Date.now() + ACP_IMPORT_HISTORY_BUDGET_MS;
       let scanned = 0;
       let cursor: string | null | undefined;
       for (;;) {
@@ -1156,6 +1175,7 @@ export class ACPAgentClient implements AgentClient {
             history,
             session,
             canLoadHistory,
+            historyDeadline,
           );
           if (descriptor) sessions.push(descriptor);
         }
@@ -1175,9 +1195,10 @@ export class ACPAgentClient implements AgentClient {
     history: ACPImportHistoryCollector,
     session: ListSessionsResponse["sessions"][number],
     canLoadHistory: boolean,
+    historyDeadline: number,
   ): Promise<ImportableProviderSession | null> {
     const loadedPreviews = canLoadHistory
-      ? await this.loadImportPromptPreviews(probe, history, session)
+      ? await this.loadImportPromptPreviews(probe, history, session, historyDeadline)
       : null;
     if (loadedPreviews?.hasConversation === false) return null;
     return {
@@ -1194,6 +1215,7 @@ export class ACPAgentClient implements AgentClient {
     probe: SpawnedACPProcess,
     history: ACPImportHistoryCollector,
     session: ListSessionsResponse["sessions"][number],
+    historyDeadline: number,
   ): Promise<ACPImportPromptPreviews | null> {
     const updatedAt = session.updatedAt ?? null;
     const cached = this.importPromptCache.get(session.sessionId);
@@ -1205,6 +1227,10 @@ export class ACPAgentClient implements AgentClient {
       };
     }
 
+    const remainingMs = historyDeadline - Date.now();
+    if (remainingMs <= 0) return null;
+    const loadTimeoutMs = Math.min(ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS, remainingMs);
+
     history.begin(session.sessionId);
     try {
       await withTimeout(
@@ -1215,8 +1241,8 @@ export class ACPAgentClient implements AgentClient {
             mcpServers: [],
           }),
         ),
-        ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS,
-        `ACP import history load timed out after ${ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS}ms`,
+        loadTimeoutMs,
+        `ACP import history load timed out after ${loadTimeoutMs}ms`,
       );
       const previews = history.finish(session.sessionId);
       if (updatedAt !== null) {
@@ -1231,17 +1257,24 @@ export class ACPAgentClient implements AgentClient {
       );
       return null;
     } finally {
-      await this.closeLoadedSession(probe, session.sessionId);
+      await this.closeLoadedSession(probe, session.sessionId, historyDeadline);
     }
   }
 
-  private async closeLoadedSession(probe: SpawnedACPProcess, sessionId: string): Promise<void> {
+  private async closeLoadedSession(
+    probe: SpawnedACPProcess,
+    sessionId: string,
+    historyDeadline: number,
+  ): Promise<void> {
     if (!probe.initialize.agentCapabilities?.sessionCapabilities?.close) return;
+    const remainingMs = historyDeadline - Date.now();
+    if (remainingMs <= 0) return;
+    const closeTimeoutMs = Math.min(ACP_PROBE_CLOSE_TIMEOUT_MS, remainingMs);
     try {
       await withTimeout(
         probe.connection.unstable_closeSession({ sessionId }),
-        ACP_PROBE_CLOSE_TIMEOUT_MS,
-        `ACP loaded session/close timed out after ${ACP_PROBE_CLOSE_TIMEOUT_MS}ms`,
+        closeTimeoutMs,
+        `ACP loaded session/close timed out after ${closeTimeoutMs}ms`,
       );
     } catch (error) {
       this.logger.debug({ err: error, sessionId }, "ACP loaded session close failed");

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -277,6 +277,8 @@ export function buildACPClientCapabilities(
 // NO_BROWSER is honored by Gemini CLI; other ACP agents ignore it.
 const PROBE_ENV: Record<string, string> = { NO_BROWSER: "true" };
 const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
+const ACP_PROBE_CLOSE_TIMEOUT_MS = 2_000;
+const ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS = 2_000;
 
 function summarizeMalformedACPStdoutError(error: unknown): { type: string; message: string } {
   return {
@@ -491,6 +493,78 @@ interface ACPProcessTransport {
   stderrChunks: string[];
   spawnReady: Promise<void>;
   spawnError: Promise<never>;
+}
+
+interface ACPImportPromptPreviews {
+  firstPromptPreview: string | null;
+  lastPromptPreview: string | null;
+  hasConversation: boolean;
+}
+
+interface ACPImportPromptCacheEntry extends ACPImportPromptPreviews {
+  updatedAt: string | null;
+}
+
+class ACPImportHistoryCollector {
+  private readonly prompts = new Map<
+    string,
+    {
+      completed: string[];
+      current: { messageId: string | null; text: string } | null;
+      hasConversation: boolean;
+    }
+  >();
+
+  begin(sessionId: string): void {
+    this.prompts.set(sessionId, { completed: [], current: null, hasConversation: false });
+  }
+
+  accept(params: SessionNotification): void {
+    const state = this.prompts.get(params.sessionId);
+    if (!state) return;
+    const update = params.update;
+    if (isACPConversationUpdate(update)) state.hasConversation = true;
+    if (update.sessionUpdate !== "user_message_chunk") {
+      this.flushCurrent(state);
+      return;
+    }
+
+    const text = contentBlockToText(update.content);
+    if (!text) return;
+    const messageId = update.messageId ?? null;
+    if (state.current?.messageId && messageId !== state.current.messageId) {
+      this.flushCurrent(state);
+    }
+    state.current ??= { messageId, text: "" };
+    state.current.text += text;
+  }
+
+  finish(sessionId: string): ACPImportPromptPreviews {
+    const state = this.prompts.get(sessionId);
+    if (!state) {
+      return { firstPromptPreview: null, lastPromptPreview: null, hasConversation: false };
+    }
+    this.flushCurrent(state);
+    this.prompts.delete(sessionId);
+    return {
+      firstPromptPreview: normalizeACPImportPromptPreview(state.completed[0] ?? null),
+      lastPromptPreview: normalizeACPImportPromptPreview(state.completed.at(-1) ?? null),
+      hasConversation: state.hasConversation,
+    };
+  }
+
+  discard(sessionId: string): void {
+    this.prompts.delete(sessionId);
+  }
+
+  private flushCurrent(state: {
+    completed: string[];
+    current: { messageId: string | null; text: string } | null;
+    hasConversation: boolean;
+  }): void {
+    if (state.current?.text.trim()) state.completed.push(state.current.text);
+    state.current = null;
+  }
 }
 
 export interface ACPToolSnapshot {
@@ -826,6 +900,7 @@ export class ACPAgentClient implements AgentClient {
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly importPromptCache = new Map<string, ACPImportPromptCacheEntry>();
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -948,10 +1023,11 @@ export class ACPAgentClient implements AgentClient {
   ): Promise<ProviderCatalog> {
     const cwd = options.scope === "global" ? homedir() : options.cwd;
     let probe: UninitializedACPProcess | null = null;
+    let probeSessionId: string | null = null;
     let closePromise: Promise<void> | null = null;
     const closeProbe = (): Promise<void> => {
       if (!probe) return Promise.resolve();
-      closePromise ??= this.closeProbe(probe);
+      closePromise ??= this.closeProbe(probe, probeSessionId);
       return closePromise;
     };
     const handleAbort = () => void closeProbe().catch(() => undefined);
@@ -981,6 +1057,7 @@ export class ACPAgentClient implements AgentClient {
           ),
         ),
       );
+      probeSessionId = response.sessionId;
       const transformed = this.transformSessionResponse(response);
       const derivedModels = deriveModelDefinitionsFromACP(
         this.provider,
@@ -1030,6 +1107,7 @@ export class ACPAgentClient implements AgentClient {
 
     this.assertProvider(config);
     const probe = await this.spawnProcess(PROBE_ENV);
+    let probeSessionId: string | null = null;
     try {
       const response = await this.runACPRequest(() =>
         probe.connection.newSession({
@@ -1037,50 +1115,136 @@ export class ACPAgentClient implements AgentClient {
           mcpServers: [],
         }),
       );
+      probeSessionId = response.sessionId;
       const transformed = this.transformSessionResponse(response);
       return [
         autoAcceptFeature,
         ...deriveFeaturesFromACP(transformed.configOptions, this.configFeatureOptions),
       ];
     } finally {
-      await this.closeProbe(probe);
+      await this.closeProbe(probe, probeSessionId);
     }
   }
 
   async listImportableSessions(
     options?: ListImportableSessionsOptions,
   ): Promise<ImportableProviderSession[]> {
-    const probe = await this.spawnProcess(PROBE_ENV);
+    const history = new ACPImportHistoryCollector();
+    const probe = await this.spawnProcess(PROBE_ENV, {
+      client: this.buildProbeClient((params) => history.accept(params)),
+    });
     try {
       if (!probe.initialize.agentCapabilities?.sessionCapabilities?.list) {
         return [];
       }
 
       const sessions: ImportableProviderSession[] = [];
-      const scanLimit = Math.min(options?.scanLimit ?? options?.limit ?? 500, 500);
+      const resultLimit = options?.limit ?? Number.POSITIVE_INFINITY;
+      const scanLimit = Math.min(options?.scanLimit ?? 500, 500);
+      const canLoadHistory = probe.initialize.agentCapabilities.loadSession === true;
+      let scanned = 0;
       let cursor: string | null | undefined;
       for (;;) {
         const page: ListSessionsResponse = await this.runACPRequest(() =>
           probe.connection.listSessions(acpSessionListRequest(cursor, options?.cwd)),
         );
         for (const session of page.sessions) {
-          sessions.push({
-            providerHandleId: session.sessionId,
-            cwd: session.cwd,
-            title: session.title ?? null,
-            firstPromptPreview: null,
-            lastPromptPreview: null,
-            lastActivityAt: session.updatedAt ? new Date(session.updatedAt) : new Date(0),
-          });
+          if (scanned >= scanLimit || sessions.length >= resultLimit) break;
+          scanned += 1;
+          const descriptor = await this.describeImportableSession(
+            probe,
+            history,
+            session,
+            canLoadHistory,
+          );
+          if (descriptor) sessions.push(descriptor);
         }
         cursor = page.nextCursor ?? null;
         if (!cursor) break;
-        if (sessions.length >= scanLimit) break;
+        if (scanned >= scanLimit || sessions.length >= resultLimit) break;
       }
 
-      return typeof options?.limit === "number" ? sessions.slice(0, options.limit) : sessions;
+      return sessions;
     } finally {
       await this.closeProbe(probe);
+    }
+  }
+
+  private async describeImportableSession(
+    probe: SpawnedACPProcess,
+    history: ACPImportHistoryCollector,
+    session: ListSessionsResponse["sessions"][number],
+    canLoadHistory: boolean,
+  ): Promise<ImportableProviderSession | null> {
+    const loadedPreviews = canLoadHistory
+      ? await this.loadImportPromptPreviews(probe, history, session)
+      : null;
+    if (loadedPreviews?.hasConversation === false) return null;
+    return {
+      providerHandleId: session.sessionId,
+      cwd: session.cwd,
+      title: session.title ?? null,
+      firstPromptPreview: loadedPreviews?.firstPromptPreview ?? null,
+      lastPromptPreview: loadedPreviews?.lastPromptPreview ?? null,
+      lastActivityAt: session.updatedAt ? new Date(session.updatedAt) : new Date(0),
+    };
+  }
+
+  private async loadImportPromptPreviews(
+    probe: SpawnedACPProcess,
+    history: ACPImportHistoryCollector,
+    session: ListSessionsResponse["sessions"][number],
+  ): Promise<ACPImportPromptPreviews | null> {
+    const updatedAt = session.updatedAt ?? null;
+    const cached = this.importPromptCache.get(session.sessionId);
+    if (updatedAt !== null && cached?.updatedAt === updatedAt) {
+      return {
+        firstPromptPreview: cached.firstPromptPreview,
+        lastPromptPreview: cached.lastPromptPreview,
+        hasConversation: cached.hasConversation,
+      };
+    }
+
+    history.begin(session.sessionId);
+    try {
+      await withTimeout(
+        this.runACPRequest(() =>
+          probe.connection.loadSession({
+            sessionId: session.sessionId,
+            cwd: session.cwd,
+            mcpServers: [],
+          }),
+        ),
+        ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS,
+        `ACP import history load timed out after ${ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS}ms`,
+      );
+      const previews = history.finish(session.sessionId);
+      if (updatedAt !== null) {
+        this.importPromptCache.set(session.sessionId, { updatedAt, ...previews });
+      }
+      return previews;
+    } catch (error) {
+      history.discard(session.sessionId);
+      this.logger.debug(
+        { err: error, sessionId: session.sessionId },
+        "ACP import history load failed; keeping the session visible",
+      );
+      return null;
+    } finally {
+      await this.closeLoadedSession(probe, session.sessionId);
+    }
+  }
+
+  private async closeLoadedSession(probe: SpawnedACPProcess, sessionId: string): Promise<void> {
+    if (!probe.initialize.agentCapabilities?.sessionCapabilities?.close) return;
+    try {
+      await withTimeout(
+        probe.connection.unstable_closeSession({ sessionId }),
+        ACP_PROBE_CLOSE_TIMEOUT_MS,
+        `ACP loaded session/close timed out after ${ACP_PROBE_CLOSE_TIMEOUT_MS}ms`,
+      );
+    } catch (error) {
+      this.logger.debug({ err: error, sessionId }, "ACP loaded session close failed");
     }
   }
 
@@ -1107,9 +1271,10 @@ export class ACPAgentClient implements AgentClient {
     options?: {
       initializeTimeoutMs?: number;
       onSpawned?: (probe: UninitializedACPProcess) => void;
+      client?: ACPClient;
     },
   ): Promise<SpawnedACPProcess> {
-    const transport = await this.spawnTransport(launchEnv);
+    const transport = await this.spawnTransport(launchEnv, options?.client);
     const probe: UninitializedACPProcess = {
       child: transport.child,
       connection: transport.connection,
@@ -1130,7 +1295,10 @@ export class ACPAgentClient implements AgentClient {
     }
   }
 
-  protected async spawnTransport(launchEnv?: Record<string, string>): Promise<ACPProcessTransport> {
+  protected async spawnTransport(
+    launchEnv?: Record<string, string>,
+    client: ACPClient = this.buildProbeClient(),
+  ): Promise<ACPProcessTransport> {
     const { command, args } = await this.resolveLaunchCommand();
     const child = spawnProcess(command, args, {
       cwd: process.cwd(),
@@ -1164,7 +1332,7 @@ export class ACPAgentClient implements AgentClient {
       Readable.toWeb(child.stdout),
       { logger: this.logger, provider: this.provider },
     );
-    const connection = new ClientSideConnection(() => this.buildProbeClient(), stream);
+    const connection = new ClientSideConnection(() => client, stream);
 
     return {
       child,
@@ -1210,12 +1378,16 @@ export class ACPAgentClient implements AgentClient {
     }
   }
 
-  protected buildProbeClient(): ACPClient {
+  protected buildProbeClient(
+    onSessionUpdate?: (params: SessionNotification) => void | Promise<void>,
+  ): ACPClient {
     return {
       async requestPermission(): Promise<RequestPermissionResponse> {
         return { outcome: { outcome: "cancelled" } };
       },
-      async sessionUpdate(): Promise<void> {},
+      async sessionUpdate(params): Promise<void> {
+        await onSessionUpdate?.(params);
+      },
       async readTextFile(params: ReadTextFileRequest) {
         const content = await fs.readFile(params.path, "utf8");
         return { content };
@@ -1231,11 +1403,20 @@ export class ACPAgentClient implements AgentClient {
     };
   }
 
-  protected async closeProbe(probe: UninitializedACPProcess): Promise<void> {
+  protected async closeProbe(
+    probe: UninitializedACPProcess,
+    sessionId: string | null = null,
+  ): Promise<void> {
     try {
-      if (probe.initialize?.agentCapabilities?.sessionCapabilities?.close) {
-        // No active session to close here; ignore capability.
+      if (sessionId && probe.initialize?.agentCapabilities?.sessionCapabilities?.close) {
+        await withTimeout(
+          probe.connection.unstable_closeSession({ sessionId }),
+          ACP_PROBE_CLOSE_TIMEOUT_MS,
+          `ACP probe session/close timed out after ${ACP_PROBE_CLOSE_TIMEOUT_MS}ms`,
+        );
       }
+    } catch (error) {
+      this.logger.debug({ err: error, sessionId }, "ACP probe closeSession failed during cleanup");
     } finally {
       await terminateChildProcess(probe.child, 2_000, this.terminateProcess);
     }
@@ -1259,6 +1440,8 @@ export class ACPAgentClient implements AgentClient {
     const phaseTimeoutMs = options.phaseTimeoutMs ?? ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS;
     const cwd = options.cwd ?? homedir();
     let transport: ACPProcessTransport | null = null;
+    let initialize: InitializeResponse | null = null;
+    let probeSessionId: string | null = null;
 
     try {
       const spawnStartedAt = Date.now();
@@ -1284,7 +1467,7 @@ export class ACPAgentClient implements AgentClient {
 
       const initializeStartedAt = Date.now();
       try {
-        await this.initializeTransport(activeTransport, phaseTimeoutMs);
+        initialize = await this.initializeTransport(activeTransport, phaseTimeoutMs);
         rows.push({
           label: "ACP initialize",
           value: `ok (${formatDurationMs(initializeStartedAt)})`,
@@ -1310,6 +1493,7 @@ export class ACPAgentClient implements AgentClient {
           phaseTimeoutMs,
           `ACP session/new timed out after ${phaseTimeoutMs}ms`,
         );
+        probeSessionId = response.sessionId;
         const transformed = this.transformSessionResponse(response);
         const models = deriveModelDefinitionsFromACP(
           this.provider,
@@ -1342,7 +1526,15 @@ export class ACPAgentClient implements AgentClient {
       if (transport) {
         const cleanupStartedAt = Date.now();
         try {
-          await terminateChildProcess(transport.child, 2_000, this.terminateProcess);
+          await this.closeProbe(
+            {
+              child: transport.child,
+              connection: transport.connection,
+              stderrChunks: transport.stderrChunks,
+              ...(initialize ? { initialize } : {}),
+            },
+            probeSessionId,
+          );
           rows.push({
             label: "ACP cleanup",
             value: `ok (${formatDurationMs(cleanupStartedAt)})`,
@@ -3223,6 +3415,23 @@ function contentBlockToText(content: ContentBlock): string {
     default:
       return "";
   }
+}
+
+function normalizeACPImportPromptPreview(text: string | null): string | null {
+  const normalized = text?.trim().replace(/\s+/g, " ") ?? "";
+  if (!normalized) return null;
+  return normalized.length > 160 ? normalized.slice(0, 160) : normalized;
+}
+
+function isACPConversationUpdate(update: SessionUpdate): boolean {
+  return (
+    update.sessionUpdate === "user_message_chunk" ||
+    update.sessionUpdate === "agent_message_chunk" ||
+    update.sessionUpdate === "agent_thought_chunk" ||
+    update.sessionUpdate === "tool_call" ||
+    update.sessionUpdate === "tool_call_update" ||
+    update.sessionUpdate === "plan"
+  );
 }
 
 function coalesceDefined<T>(next: T | undefined, previous: T | undefined, fallback: T): T {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -278,8 +278,8 @@ export function buildACPClientCapabilities(
 const PROBE_ENV: Record<string, string> = { NO_BROWSER: "true" };
 const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
 const ACP_PROBE_CLOSE_TIMEOUT_MS = 2_000;
-const ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS = 3_000;
-const ACP_IMPORT_HISTORY_BUDGET_MS = 8_000;
+const ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS = 30_000;
+const ACP_IMPORT_HISTORY_BUDGET_MS = 60_000;
 
 function summarizeMalformedACPStdoutError(error: unknown): { type: string; message: string } {
   return {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { runProviderRefreshWithDeadline } from "../provider-refresh-deadline.js";
@@ -115,49 +115,36 @@ describe("GenericACPAgentClient diagnostics", () => {
     });
   });
 
-  test("times out a hung history load, keeps the row visible, and terminates the ACP process", async () => {
-    await withFakeACPAgent("history-load-hang", async (scriptPath, mode, testDir) => {
-      const pidPath = path.join(testDir, "agent.pid");
-      const client = new GenericACPAgentClient({
-        logger: createTestLogger(),
-        command: [process.execPath, scriptPath, mode, pidPath, "", "", testDir],
-      });
-
-      await expect(client.listImportableSessions({ limit: 1 })).resolves.toEqual([
-        {
-          providerHandleId: "hung-session",
-          cwd: testDir,
-          title: "Slow but real",
-          firstPromptPreview: null,
-          lastPromptPreview: null,
-          lastActivityAt: new Date("2026-09-04T20:00:00.000Z"),
-        },
-      ]);
-      await expectProcessExit(Number(await readFile(pidPath, "utf8")));
-    });
-  });
-
   test("bounds the total time spent loading inaccessible session histories", async () => {
-    await withFakeACPAgent("history-load-hangs", async (scriptPath, mode, testDir) => {
+    await withFakeACPAgent("history-load-failures", async (scriptPath, mode, testDir) => {
       const loadTracePath = path.join(testDir, "session-load.jsonl");
       const client = new GenericACPAgentClient({
         logger: createTestLogger(),
         command: [process.execPath, scriptPath, mode, "", "", "", testDir, loadTracePath],
       });
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0)
+        .mockReturnValue(60_001);
 
-      const sessions = await client.listImportableSessions({ limit: 4 });
+      try {
+        const sessions = await client.listImportableSessions({ limit: 4 });
 
-      expect(sessions).toMatchObject([
-        { providerHandleId: "hung-session-1" },
-        { providerHandleId: "hung-session-2" },
-        { providerHandleId: "hung-session-3" },
-        { providerHandleId: "hung-session-4" },
-      ]);
-      const attemptedLoads = (await readFile(loadTracePath, "utf8")).trim().split("\n");
-      expect(attemptedLoads.length).toBeGreaterThan(0);
-      expect(attemptedLoads.length).toBeLessThan(4);
+        expect(sessions).toMatchObject([
+          { providerHandleId: "failed-session-1" },
+          { providerHandleId: "failed-session-2" },
+          { providerHandleId: "failed-session-3" },
+          { providerHandleId: "failed-session-4" },
+        ]);
+        await expect(readFile(loadTracePath, "utf8")).resolves.toBe(
+          `${JSON.stringify({ sessionId: "failed-session-1" })}\n`,
+        );
+      } finally {
+        now.mockRestore();
+      }
     });
-  }, 15_000);
+  });
 
   test("probes npx-backed agent packages instead of npx itself", () => {
     expect(buildVersionProbeCommand(["npx", "-y", "@google/gemini-cli@0.41.1", "--acp"])).toEqual({
@@ -346,8 +333,7 @@ async function withFakeACPAgent(
     | "hang-session"
     | "history-list"
     | "history-load-failure"
-    | "history-load-hang"
-    | "history-load-hangs",
+    | "history-load-failures",
   run: (scriptPath: string, mode: string, testDir: string) => Promise<void>,
 ): Promise<void> {
   await withTempDir("paseo-acp-diagnostic-", async (testDir) => {
@@ -427,8 +413,7 @@ rl.on("line", (line) => {
         loadSession:
           mode === "history-list" ||
           mode === "history-load-failure" ||
-          mode === "history-load-hang" ||
-          mode === "history-load-hangs",
+          mode === "history-load-failures",
         sessionCapabilities: { close: {}, list: {} },
       },
     });
@@ -503,25 +488,12 @@ rl.on("line", (line) => {
     return;
   }
 
-  if (message.method === "session/list" && mode === "history-load-hang") {
-    send(message.id, {
-      sessions: [{
-        sessionId: "hung-session",
-        cwd: sessionCwd,
-        title: "Slow but real",
-        updatedAt: "2026-09-04T20:00:00.000Z",
-      }],
-      nextCursor: null,
-    });
-    return;
-  }
-
-  if (message.method === "session/list" && mode === "history-load-hangs") {
+  if (message.method === "session/list" && mode === "history-load-failures") {
     send(message.id, {
       sessions: [1, 2, 3, 4].map((number) => ({
-        sessionId: "hung-session-" + number,
+        sessionId: "failed-session-" + number,
         cwd: sessionCwd,
-        title: "Slow but real " + number,
+        title: "Could still be real " + number,
         updatedAt: "2026-09-04T20:00:00.000Z",
       })),
       nextCursor: null,
@@ -569,14 +541,9 @@ rl.on("line", (line) => {
     return;
   }
 
-  if (message.method === "session/load" && mode === "history-load-failure") {
-    sendError(message.id, -32602, "stale session");
-    return;
-  }
-
   if (
     message.method === "session/load" &&
-    (mode === "history-load-hang" || mode === "history-load-hangs")
+    (mode === "history-load-failure" || mode === "history-load-failures")
   ) {
     if (loadTracePath) {
       fs.appendFileSync(
@@ -584,6 +551,7 @@ rl.on("line", (line) => {
         JSON.stringify({ sessionId: message.params.sessionId }) + "\\n",
       );
     }
+    sendError(message.id, -32602, "stale session");
     return;
   }
 });

--- a/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
@@ -18,6 +18,125 @@ function parseInitializeTrace(content: string): Array<{ clientCapabilities: unkn
 }
 
 describe("GenericACPAgentClient diagnostics", () => {
+  test("filters empty ACP sessions by replaying history and returns prompt previews", async () => {
+    await withFakeACPAgent("history-list", async (scriptPath, mode, testDir) => {
+      const closeTracePath = path.join(testDir, "session-close.jsonl");
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", closeTracePath, testDir],
+      });
+
+      await expect(client.listImportableSessions({ limit: 1 })).resolves.toEqual([
+        {
+          providerHandleId: "conversation-session",
+          cwd: testDir,
+          title: "Conversation",
+          firstPromptPreview: "First prompt",
+          lastPromptPreview: "Last prompt",
+          lastActivityAt: new Date("2026-09-04T20:00:00.000Z"),
+        },
+      ]);
+      await expect(readFile(closeTracePath, "utf8")).resolves.toBe(
+        `${JSON.stringify({ sessionId: "empty-session" })}\n${JSON.stringify({ sessionId: "conversation-session" })}\n`,
+      );
+    });
+  });
+
+  test("keeps a listed session visible when its ACP history cannot be loaded", async () => {
+    await withFakeACPAgent("history-load-failure", async (scriptPath, mode, testDir) => {
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", "", testDir],
+      });
+
+      await expect(client.listImportableSessions({ limit: 1 })).resolves.toEqual([
+        {
+          providerHandleId: "stale-session",
+          cwd: testDir,
+          title: "Could still be real",
+          firstPromptPreview: null,
+          lastPromptPreview: null,
+          lastActivityAt: new Date("2026-09-04T20:00:00.000Z"),
+        },
+      ]);
+    });
+  });
+
+  test("keeps sessions with replayed conversation activity but no user text preview", async () => {
+    await withFakeACPAgent("history-list", async (scriptPath, mode, testDir) => {
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", "", testDir],
+      });
+
+      const result = await client.listImportableSessions({ limit: 2 });
+
+      expect(result).toMatchObject([
+        { providerHandleId: "conversation-session" },
+        { providerHandleId: "assistant-only-session" },
+      ]);
+      expect(result[1]).toMatchObject({
+        firstPromptPreview: null,
+        lastPromptPreview: null,
+      });
+    });
+  });
+
+  test("reuses ACP prompt previews while the listed session timestamp is unchanged", async () => {
+    await withFakeACPAgent("history-list", async (scriptPath, mode, testDir) => {
+      const loadTracePath = path.join(testDir, "session-load.jsonl");
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", "", testDir, loadTracePath],
+      });
+
+      const first = await client.listImportableSessions({ limit: 1 });
+      const second = await client.listImportableSessions({ limit: 1 });
+
+      expect(second).toEqual(first);
+      await expect(readFile(loadTracePath, "utf8")).resolves.toBe(
+        `${JSON.stringify({ sessionId: "empty-session" })}\n${JSON.stringify({ sessionId: "conversation-session" })}\n`,
+      );
+    });
+  });
+
+  test("bounds history loads by scanLimit when every inspected session is empty", async () => {
+    await withFakeACPAgent("history-list", async (scriptPath, mode, testDir) => {
+      const closeTracePath = path.join(testDir, "session-close.jsonl");
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", closeTracePath, testDir],
+      });
+
+      await expect(client.listImportableSessions({ limit: 1, scanLimit: 1 })).resolves.toEqual([]);
+      await expect(readFile(closeTracePath, "utf8")).resolves.toBe(
+        `${JSON.stringify({ sessionId: "empty-session" })}\n`,
+      );
+    });
+  });
+
+  test("times out a hung history load, keeps the row visible, and terminates the ACP process", async () => {
+    await withFakeACPAgent("history-load-hang", async (scriptPath, mode, testDir) => {
+      const pidPath = path.join(testDir, "agent.pid");
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, pidPath, "", "", testDir],
+      });
+
+      await expect(client.listImportableSessions({ limit: 1 })).resolves.toEqual([
+        {
+          providerHandleId: "hung-session",
+          cwd: testDir,
+          title: "Slow but real",
+          firstPromptPreview: null,
+          lastPromptPreview: null,
+          lastActivityAt: new Date("2026-09-04T20:00:00.000Z"),
+        },
+      ]);
+      await expectProcessExit(Number(await readFile(pidPath, "utf8")));
+    });
+  });
+
   test("probes npx-backed agent packages instead of npx itself", () => {
     expect(buildVersionProbeCommand(["npx", "-y", "@google/gemini-cli@0.41.1", "--acp"])).toEqual({
       command: "npx",
@@ -54,6 +173,25 @@ describe("GenericACPAgentClient diagnostics", () => {
       expect(diagnostic).toContain("modes=1");
       expect(diagnostic).toContain("ACP cleanup: ok");
       expect(diagnostic).not.toContain("Status:");
+    });
+  });
+
+  test("closes the native diagnostic probe session", async () => {
+    await withFakeACPAgent("success", async (scriptPath, mode, testDir) => {
+      const closeTracePath = path.join(testDir, "session-close.jsonl");
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", closeTracePath],
+        providerId: "custom-acp",
+        label: "Custom ACP",
+        diagnosticPhaseTimeoutMs: TEST_ACP_TIMEOUT_MS,
+      });
+
+      await client.getDiagnostic();
+
+      await expect(readFile(closeTracePath, "utf8")).resolves.toContain(
+        JSON.stringify({ sessionId: "session-1" }),
+      );
     });
   });
 
@@ -181,7 +319,7 @@ describe("GenericACPAgentClient diagnostics", () => {
 });
 
 async function withFakeACPAgent(
-  mode: "success" | "hang-session",
+  mode: "success" | "hang-session" | "history-list" | "history-load-failure" | "history-load-hang",
   run: (scriptPath: string, mode: string, testDir: string) => Promise<void>,
 ): Promise<void> {
   await withTempDir("paseo-acp-diagnostic-", async (testDir) => {
@@ -230,6 +368,9 @@ const readline = require("node:readline");
 const mode = process.argv[2];
 const pidPath = process.argv[3];
 const initializeTracePath = process.argv[4];
+const closeTracePath = process.argv[5];
+const sessionCwd = process.argv[6];
+const loadTracePath = process.argv[7];
 if (pidPath) {
   fs.writeFileSync(pidPath, String(process.pid));
 }
@@ -237,6 +378,10 @@ const rl = readline.createInterface({ input: process.stdin });
 
 function send(id, result) {
   process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");
+}
+
+function sendError(id, code, message) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } }) + "\\n");
 }
 
 rl.on("line", (line) => {
@@ -250,7 +395,13 @@ rl.on("line", (line) => {
     }
     send(message.id, {
       protocolVersion: message.params?.protocolVersion ?? 1,
-      agentCapabilities: {},
+      agentCapabilities: {
+        loadSession:
+          mode === "history-list" ||
+          mode === "history-load-failure" ||
+          mode === "history-load-hang",
+        sessionCapabilities: { close: {}, list: {} },
+      },
     });
     return;
   }
@@ -272,6 +423,117 @@ rl.on("line", (line) => {
       },
       configOptions: [],
     });
+    return;
+  }
+
+  if (message.method === "session/close") {
+    if (closeTracePath) {
+      fs.appendFileSync(closeTracePath, JSON.stringify(message.params) + "\\n");
+    }
+    send(message.id, {});
+    return;
+  }
+
+  if (message.method === "session/list" && mode === "history-list") {
+    send(message.id, {
+      sessions: [
+        {
+          sessionId: "empty-session",
+          cwd: sessionCwd,
+          title: "Empty",
+          updatedAt: "2026-09-04T21:00:00.000Z",
+        },
+        {
+          sessionId: "conversation-session",
+          cwd: sessionCwd,
+          title: "Conversation",
+          updatedAt: "2026-09-04T20:00:00.000Z",
+        },
+        {
+          sessionId: "assistant-only-session",
+          cwd: sessionCwd,
+          title: "Recovered conversation",
+          updatedAt: "2026-09-04T19:00:00.000Z",
+        },
+      ],
+      nextCursor: null,
+    });
+    return;
+  }
+
+  if (message.method === "session/list" && mode === "history-load-failure") {
+    send(message.id, {
+      sessions: [{
+        sessionId: "stale-session",
+        cwd: sessionCwd,
+        title: "Could still be real",
+        updatedAt: "2026-09-04T20:00:00.000Z",
+      }],
+      nextCursor: null,
+    });
+    return;
+  }
+
+  if (message.method === "session/list" && mode === "history-load-hang") {
+    send(message.id, {
+      sessions: [{
+        sessionId: "hung-session",
+        cwd: sessionCwd,
+        title: "Slow but real",
+        updatedAt: "2026-09-04T20:00:00.000Z",
+      }],
+      nextCursor: null,
+    });
+    return;
+  }
+
+  if (message.method === "session/load" && mode === "history-list") {
+    if (loadTracePath) {
+      fs.appendFileSync(
+        loadTracePath,
+        JSON.stringify({ sessionId: message.params.sessionId }) + "\\n",
+      );
+    }
+    if (message.params.sessionId === "conversation-session") {
+      for (const [messageId, text] of [["user-1", "First prompt"], ["user-2", "Last prompt"]]) {
+        process.stdout.write(JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId: message.params.sessionId,
+            update: {
+              sessionUpdate: "user_message_chunk",
+              messageId,
+              content: { type: "text", text },
+            },
+          },
+        }) + "\\n");
+      }
+    }
+    if (message.params.sessionId === "assistant-only-session") {
+      process.stdout.write(JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: message.params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "Recovered response" },
+          },
+        },
+      }) + "\\n");
+    }
+    send(message.id, { modes: null, models: null, configOptions: [] });
+    return;
+  }
+
+  if (message.method === "session/load" && mode === "history-load-failure") {
+    sendError(message.id, -32602, "stale session");
+    return;
+  }
+
+  if (message.method === "session/load" && mode === "history-load-hang") {
+    return;
   }
 });
 `;

--- a/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
@@ -139,11 +139,11 @@ describe("GenericACPAgentClient diagnostics", () => {
 
   test("bounds the total time spent loading inaccessible session histories", async () => {
     await withFakeACPAgent("history-load-hangs", async (scriptPath, mode, testDir) => {
+      const loadTracePath = path.join(testDir, "session-load.jsonl");
       const client = new GenericACPAgentClient({
         logger: createTestLogger(),
-        command: [process.execPath, scriptPath, mode, "", "", "", testDir],
+        command: [process.execPath, scriptPath, mode, "", "", "", testDir, loadTracePath],
       });
-      const startedAt = Date.now();
 
       const sessions = await client.listImportableSessions({ limit: 4 });
 
@@ -153,9 +153,11 @@ describe("GenericACPAgentClient diagnostics", () => {
         { providerHandleId: "hung-session-3" },
         { providerHandleId: "hung-session-4" },
       ]);
-      expect(Date.now() - startedAt).toBeLessThan(7_500);
+      const attemptedLoads = (await readFile(loadTracePath, "utf8")).trim().split("\n");
+      expect(attemptedLoads.length).toBeGreaterThan(0);
+      expect(attemptedLoads.length).toBeLessThan(4);
     });
-  }, 10_000);
+  }, 15_000);
 
   test("probes npx-backed agent packages instead of npx itself", () => {
     expect(buildVersionProbeCommand(["npx", "-y", "@google/gemini-cli@0.41.1", "--acp"])).toEqual({
@@ -576,6 +578,12 @@ rl.on("line", (line) => {
     message.method === "session/load" &&
     (mode === "history-load-hang" || mode === "history-load-hangs")
   ) {
+    if (loadTracePath) {
+      fs.appendFileSync(
+        loadTracePath,
+        JSON.stringify({ sessionId: message.params.sessionId }) + "\\n",
+      );
+    }
     return;
   }
 });

--- a/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
@@ -137,6 +137,26 @@ describe("GenericACPAgentClient diagnostics", () => {
     });
   });
 
+  test("bounds the total time spent loading inaccessible session histories", async () => {
+    await withFakeACPAgent("history-load-hangs", async (scriptPath, mode, testDir) => {
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", "", testDir],
+      });
+      const startedAt = Date.now();
+
+      const sessions = await client.listImportableSessions({ limit: 4 });
+
+      expect(sessions).toMatchObject([
+        { providerHandleId: "hung-session-1" },
+        { providerHandleId: "hung-session-2" },
+        { providerHandleId: "hung-session-3" },
+        { providerHandleId: "hung-session-4" },
+      ]);
+      expect(Date.now() - startedAt).toBeLessThan(7_500);
+    });
+  }, 10_000);
+
   test("probes npx-backed agent packages instead of npx itself", () => {
     expect(buildVersionProbeCommand(["npx", "-y", "@google/gemini-cli@0.41.1", "--acp"])).toEqual({
       command: "npx",
@@ -319,7 +339,13 @@ describe("GenericACPAgentClient diagnostics", () => {
 });
 
 async function withFakeACPAgent(
-  mode: "success" | "hang-session" | "history-list" | "history-load-failure" | "history-load-hang",
+  mode:
+    | "success"
+    | "hang-session"
+    | "history-list"
+    | "history-load-failure"
+    | "history-load-hang"
+    | "history-load-hangs",
   run: (scriptPath: string, mode: string, testDir: string) => Promise<void>,
 ): Promise<void> {
   await withTempDir("paseo-acp-diagnostic-", async (testDir) => {
@@ -399,7 +425,8 @@ rl.on("line", (line) => {
         loadSession:
           mode === "history-list" ||
           mode === "history-load-failure" ||
-          mode === "history-load-hang",
+          mode === "history-load-hang" ||
+          mode === "history-load-hangs",
         sessionCapabilities: { close: {}, list: {} },
       },
     });
@@ -487,6 +514,19 @@ rl.on("line", (line) => {
     return;
   }
 
+  if (message.method === "session/list" && mode === "history-load-hangs") {
+    send(message.id, {
+      sessions: [1, 2, 3, 4].map((number) => ({
+        sessionId: "hung-session-" + number,
+        cwd: sessionCwd,
+        title: "Slow but real " + number,
+        updatedAt: "2026-09-04T20:00:00.000Z",
+      })),
+      nextCursor: null,
+    });
+    return;
+  }
+
   if (message.method === "session/load" && mode === "history-list") {
     if (loadTracePath) {
       fs.appendFileSync(
@@ -532,7 +572,10 @@ rl.on("line", (line) => {
     return;
   }
 
-  if (message.method === "session/load" && mode === "history-load-hang") {
+  if (
+    message.method === "session/load" &&
+    (mode === "history-load-hang" || mode === "history-load-hangs")
+  ) {
     return;
   }
 });

--- a/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { runProviderRefreshWithDeadline } from "../provider-refresh-deadline.js";
@@ -15,6 +15,11 @@ function parseInitializeTrace(content: string): Array<{ clientCapabilities: unkn
     .trim()
     .split("\n")
     .map((line) => JSON.parse(line) as { clientCapabilities: unknown });
+}
+
+function historyBudgetClock(): () => number {
+  let calls = 0;
+  return () => (calls++ < 2 ? 0 : 60_001);
 }
 
 describe("GenericACPAgentClient diagnostics", () => {
@@ -121,28 +126,20 @@ describe("GenericACPAgentClient diagnostics", () => {
       const client = new GenericACPAgentClient({
         logger: createTestLogger(),
         command: [process.execPath, scriptPath, mode, "", "", "", testDir, loadTracePath],
+        now: historyBudgetClock(),
       });
-      const now = vi
-        .spyOn(Date, "now")
-        .mockReturnValueOnce(0)
-        .mockReturnValueOnce(0)
-        .mockReturnValue(60_001);
 
-      try {
-        const sessions = await client.listImportableSessions({ limit: 4 });
+      const sessions = await client.listImportableSessions({ limit: 4 });
 
-        expect(sessions).toMatchObject([
-          { providerHandleId: "failed-session-1" },
-          { providerHandleId: "failed-session-2" },
-          { providerHandleId: "failed-session-3" },
-          { providerHandleId: "failed-session-4" },
-        ]);
-        await expect(readFile(loadTracePath, "utf8")).resolves.toBe(
-          `${JSON.stringify({ sessionId: "failed-session-1" })}\n`,
-        );
-      } finally {
-        now.mockRestore();
-      }
+      expect(sessions).toMatchObject([
+        { providerHandleId: "failed-session-1" },
+        { providerHandleId: "failed-session-2" },
+        { providerHandleId: "failed-session-3" },
+        { providerHandleId: "failed-session-4" },
+      ]);
+      await expect(readFile(loadTracePath, "utf8")).resolves.toBe(
+        `${JSON.stringify({ sessionId: "failed-session-1" })}\n`,
+      );
     });
   });
 

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -51,6 +51,7 @@ interface GenericACPAgentClientOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
   catalogModelResolver?: ACPCatalogModelResolver;
+  now?: () => number;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -76,6 +77,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
       catalogModelResolver: options.catalogModelResolver,
+      now: options.now,
     });
 
     this.command = options.command;


### PR DESCRIPTION
### Linked issue

No dedicated issue found.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The session importer showed persisted ACP sessions even when they contained no conversation. Metadata and diagnostic probes can create such sessions, and closing an ACP session does not imply deleting its persisted record.

This change loads listed session history when the provider supports it, filters entries with no conversation updates, and derives the first and last prompt previews from replayed history. Failed or timed-out history loads remain visible so inaccessible history cannot hide a real session. Probe and loaded sessions are closed before their short-lived ACP process exits.

### Goals

- Hide truly empty ACP sessions from the import-session picker.
- Populate first and last prompt previews from replayed ACP history.
- Preserve sessions when history loading is unsupported, fails, or times out.
- Bound history scanning and reuse results while a session timestamp is unchanged.
- Close temporary probe and loaded sessions without relying on close to delete persistence.

### Non-goals

- Delete native provider session persistence.
- Change import behavior for ACP providers without session history loading.
- Add provider-specific filtering rules.

### QA

- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts --bail=1` — 2 files, 115 tests passed.
- `npm run typecheck` — passed across all workspaces.
- `npm run typecheck --workspace=@getpaseo/server` — passed after the final fixture-only edit.
- `npm run lint -- packages/server/src/server/agent/providers/acp-agent.ts packages/server/src/server/agent/providers/acp-agent.test.ts packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts` — 0 warnings and 0 errors.
- `npm run format:files -- packages/server/src/server/agent/providers/acp-agent.ts packages/server/src/server/agent/providers/acp-agent.test.ts packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts` — passed.
- Exercised initialization and session capabilities against three installed ACP implementations; each advertised session history loading.
- With a real ACP implementation in an isolated home, force-created 25 persisted empty sessions, confirmed raw `session/list` returned them, then confirmed Paseo filtered all 25 in 4.614 seconds.
- A real persisted non-empty history could not be created for two implementations because credentials were unavailable; replay behavior is covered through the ACP SDK over NDJSON JSON-RPC, including empty, conversation, assistant-only, failure, timeout, cache, scan-limit, and close paths.

### Risk surface

ACP session listing now performs sequential history loads for providers that advertise the capability. Each load has a 30-second timeout, all history enrichment shares a 60-second budget, and provider listing has a 90-second deadline. The picker requests each provider independently, so a slow provider does not withhold another provider's rows. Failures are conservative, scans cap at 500 entries, and unchanged timestamps use an in-memory cache. Catalog abort cleanup waits up to 2 seconds for an in-flight session creation before terminating the probe.

### Supersedes

- [PR #1794 — Close metadata probe sessions after probe reads](https://github.com/getpaseo/paseo/pull/1794) — This PR takes over the probe-cleanup workflow, covers catalog, feature, and diagnostic probes, and also filters already-persisted empty sessions during import.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
