### PR TITLE
feat(app): add Google Antigravity to the ACP provider catalog

### DIFF
--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -37,10 +37,10 @@ const CATALOG_DATA = [
     title: "Google Antigravity",
     description:
       "Google Antigravity ACP adapter with multi-model support, session isolation, and token metering",
-    version: "1.1.2",
+    version: "1.1.3",
     iconId: null,
     installLink: "https://github.com/tucomel/paseo-acp-agy",
-    command: ["npx", "-y", "paseo-acp-agy@1.1.2", "--acp"],
+    command: ["npx", "-y", "paseo-acp-agy@1.1.3", "--acp"],
   },
   {
     id: "auggie",

--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -40,7 +40,7 @@ const CATALOG_DATA = [
     version: "1.1.2",
     iconId: null,
     installLink: "https://github.com/tucomel/paseo-acp-agy",
-    command: ["npx", "-y", "paseo-acp-agy@latest", "--acp"],
+    command: ["npx", "-y", "paseo-acp-agy@1.1.2", "--acp"],
   },
   {
     id: "auggie",

--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -37,10 +37,10 @@ const CATALOG_DATA = [
     title: "Google Antigravity",
     description:
       "Google Antigravity ACP adapter with multi-model support, session isolation, and token metering",
-    version: "1.1.3",
+    version: "1.1.4",
     iconId: null,
     installLink: "https://github.com/tucomel/paseo-acp-agy",
-    command: ["npx", "-y", "paseo-acp-agy@1.1.3", "--acp"],
+    command: ["npx", "-y", "paseo-acp-agy@1.1.4", "--acp"],
   },
   {
     id: "auggie",

--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -33,6 +33,16 @@ const CATALOG_DATA = [
     command: ["amp-acp"],
   },
   {
+    id: "antigravity",
+    title: "Google Antigravity",
+    description:
+      "Google Antigravity ACP adapter with multi-model support, session isolation, and token metering",
+    version: "1.1.2",
+    iconId: null,
+    installLink: "https://github.com/tucomel/paseo-acp-agy",
+    command: ["npx", "-y", "paseo-acp-agy@latest", "--acp"],
+  },
+  {
     id: "auggie",
     title: "Auggie CLI",
     description:

--- a/packages/app/src/hooks/use-acp-provider-catalog.test.ts
+++ b/packages/app/src/hooks/use-acp-provider-catalog.test.ts
@@ -54,7 +54,7 @@ describe("ACP provider catalog", () => {
     expect(findProvider("antigravity")).toMatchObject({
       title: "Google Antigravity",
       version: "1.1.2",
-      command: ["npx", "-y", "paseo-acp-agy@latest", "--acp"],
+      command: ["npx", "-y", "paseo-acp-agy@1.1.2", "--acp"],
     });
   });
 

--- a/packages/app/src/hooks/use-acp-provider-catalog.test.ts
+++ b/packages/app/src/hooks/use-acp-provider-catalog.test.ts
@@ -53,8 +53,8 @@ describe("ACP provider catalog", () => {
   it("offers Google Antigravity through its npm package", () => {
     expect(findProvider("antigravity")).toMatchObject({
       title: "Google Antigravity",
-      version: "1.1.2",
-      command: ["npx", "-y", "paseo-acp-agy@1.1.2", "--acp"],
+      version: "1.1.3",
+      command: ["npx", "-y", "paseo-acp-agy@1.1.3", "--acp"],
     });
   });
 

--- a/packages/app/src/hooks/use-acp-provider-catalog.test.ts
+++ b/packages/app/src/hooks/use-acp-provider-catalog.test.ts
@@ -50,6 +50,14 @@ describe("ACP provider catalog", () => {
     expect(findProvider("traecli").command).toEqual(["traecli", "acp", "serve"]);
   });
 
+  it("offers Google Antigravity through its npm package", () => {
+    expect(findProvider("antigravity")).toMatchObject({
+      title: "Google Antigravity",
+      version: "1.1.2",
+      command: ["npx", "-y", "paseo-acp-agy@latest", "--acp"],
+    });
+  });
+
   it("offers MiniMax Code through its pinned public ACP package", () => {
     expect(findProvider("minimax-code")).toMatchObject({
       title: "MiniMax Code",

--- a/packages/app/src/hooks/use-acp-provider-catalog.test.ts
+++ b/packages/app/src/hooks/use-acp-provider-catalog.test.ts
@@ -53,8 +53,8 @@ describe("ACP provider catalog", () => {
   it("offers Google Antigravity through its npm package", () => {
     expect(findProvider("antigravity")).toMatchObject({
       title: "Google Antigravity",
-      version: "1.1.3",
-      command: ["npx", "-y", "paseo-acp-agy@1.1.3", "--acp"],
+      version: "1.1.4",
+      command: ["npx", "-y", "paseo-acp-agy@1.1.4", "--acp"],
     });
   });
 

--- a/public-docs/supported-providers.md
+++ b/public-docs/supported-providers.md
@@ -41,6 +41,7 @@ Pick any of these from the in-app provider catalog. Each entry is a one-click in
 - [fast-agent](https://fast-agent.ai/acp/), multi-provider coding agent.
 - [Gajae Code](https://gajae-code.com), subscription-based coding agent with plan-before-mutation workflows.
 - [Gemini CLI](https://geminicli.com), Google's official Gemini CLI.
+- [Google Antigravity](https://github.com/tucomel/paseo-acp-agy), Google Antigravity ACP adapter for autonomous coding.
 - [GitHub Copilot](https://github.com/features/copilot/cli/), GitHub's AI pair programmer via ACP.
 - [GLM Agent](https://github.com/stefandevo/glm-acp-agent), Zhipu AI's GLM coding agent.
 - [goose](https://block.github.io/goose/), Block's local open-source AI agent.


### PR DESCRIPTION
   ### Linked issue

    None

    ### Type of change

    - [x] New feature

    ### Reasoning

    Google Antigravity (`agy`) is Google's autonomous coding assistant CLI with support for Gemini 3.8/3.7/3.6/3.1, Claude, and open-source models. While users
  can run Antigravity in Paseo today by manually configuring `~/.paseo/config.json` with an `extends: "acp"` block, adding it to the in-app ACP provider catalog
  enables one-click installation for all Paseo users via the community adapter [`paseo-acp-agy`](https://github.com/tucomel/paseo-acp-agy) (published on npm as
  `paseo-acp-agy`).

    ### Goals

    - Add `antigravity` to `packages/app/src/data/acp-provider-catalog.ts` pointing to `npx -y paseo-acp-agy@latest --acp`.
    - Add test coverage in `packages/app/src/hooks/use-acp-provider-catalog.test.ts`.
    - Document Google Antigravity in `public-docs/supported-providers.md`.

    ### Non-goals

    - Custom SVG icon vendor (falls back to default icon with `iconId: null`, same as other ACP community providers).

    ### QA

    Tested against a running Paseo daemon:
    1. Provider registration & diagnostic:
       - `paseo provider diagnostic antigravity` reports:
         ```text
         Google Antigravity (ACP)
           Provider ID: antigravity
           Configured command: npx -y paseo-acp-agy@latest --acp
           Version: 1.1.2
           ACP spawn: ok (5ms)
           ACP initialize: ok (1666ms)
           ACP session/new: ok (778ms; models=7; modes=2)
           ACP cleanup: ok (41ms)
           Models: 7
           Status: Ready
         ```
    2. Real task execution & session lifecycle:
       - Started session with `gemini-3.8-flash`
       - Model switching between Gemini and Claude models works cleanly
       - Multi-session isolation with persistent backend processes verified
       - Timeline, token tracking, and context window metering reported through ACP protocol updates

    ### Checklist

    - [x] One focused change
    - [x] QA evidence
    - [x] Tests added or updated where it made sense