### PR TITLE
fix(terminal): report active theme colors for OSC replies

### DIFF
--- a/packages/app/e2e/browser/terminal-protocol-query.spec.ts
+++ b/packages/app/e2e/browser/terminal-protocol-query.spec.ts
@@ -1,24 +1,80 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { Page } from "@playwright/test";
 import { test, expect } from "../support/fixtures";
 import { TerminalE2EHarness } from "../support/helpers/terminal-dsl";
-import { getTerminalBufferText, waitForTerminalContent } from "../support/helpers/terminal-perf";
+import { clickNewTerminal, gotoWorkspace } from "../support/helpers/launcher";
+import {
+  expectTerminalSurfaceVisible,
+  setupDeterministicPrompt,
+  waitForTerminalContent,
+} from "../support/helpers/terminal-perf";
 
-const CODEX_START_COMMAND =
-  "TERM=xterm-256color codex --no-alt-screen --ask-for-approval never --sandbox read-only";
-
-async function launchCodex(page: Page): Promise<void> {
-  const terminal = page.locator('[data-testid="terminal-surface"]');
-  await terminal.pressSequentially(`${CODEX_START_COMMAND}\n`, { delay: 0 });
-  await waitForTerminalContent(
-    page,
-    (text) => text.includes("Do you trust the contents of this directory?"),
-    10_000,
-  ).catch(() => undefined);
-  const trustPrompt = await getTerminalBufferText(page);
-  if (trustPrompt.includes("Do you trust the contents of this directory?")) {
-    await terminal.pressSequentially("1\n", { delay: 0 });
+const OSC_COLOR_PROBE_SCRIPT = `process.stdin.setRawMode(true);
+process.stdin.resume();
+const code = process.argv[2];
+let buf = "";
+const timer = setTimeout(() => {
+  process.stdout.write("OSC_COLOR_TIMEOUT\\n");
+  process.exit(2);
+}, 2500);
+process.stdin.on("data", (chunk) => {
+  buf += chunk.toString("binary");
+  const match = buf.match(new RegExp("\\\\x1b\\\\]" + code + ";rgb:[0-9a-f/]+\\\\x1b\\\\\\\\"));
+  if (!match) {
+    return;
   }
-  await waitForTerminalContent(page, (text) => text.includes("OpenAI Codex"), 30_000);
+  clearTimeout(timer);
+  process.stdout.write("OSC_COLOR_OK:" + code + ":" + match[0].replace(/\\x1b/g, "ESC") + "\\n");
+  process.exit(0);
+});
+process.stdout.write("\\x1b]" + code + ";?\\x07");
+`;
+
+const LIGHT_TERMINAL_COLORS = {
+  10: "rgb:1a1a/1a1a/1e1e",
+  11: "rgb:ffff/ffff/ffff",
+  12: "rgb:1a1a/1a1a/1e1e",
+} as const;
+
+const DARK_TERMINAL_COLORS = {
+  10: "rgb:fafa/fafa/fafa",
+  11: "rgb:1818/1b1b/1a1a",
+  12: "rgb:fafa/fafa/fafa",
+} as const;
+
+async function waitForCreatedTerminal(
+  harness: TerminalE2EHarness,
+  knownTerminalIds: Set<string>,
+): Promise<string> {
+  let createdTerminalId: string | undefined;
+  await expect
+    .poll(
+      async () => {
+        const result = await harness.client.listTerminals(harness.tempRepo.path, undefined, {
+          workspaceId: harness.workspaceId,
+        });
+        createdTerminalId = result.terminals.find(
+          (terminal) => !knownTerminalIds.has(terminal.id),
+        )?.id;
+        return createdTerminalId;
+      },
+      { timeout: 10_000 },
+    )
+    .toBeTruthy();
+  return createdTerminalId!;
+}
+
+async function queryOscColor(
+  page: Page,
+  probePath: string,
+  code: 10 | 11 | 12,
+  expected: string,
+): Promise<void> {
+  const terminal = page.locator('[data-testid="terminal-surface"]');
+  const expectedOutput = `OSC_COLOR_OK:${code}:ESC]${code};${expected}ESC\\`;
+  await terminal.pressSequentially(`${process.execPath} "${probePath}" ${code}\n`, { delay: 0 });
+  await waitForTerminalContent(page, (text) => text.includes(expectedOutput), 10_000);
 }
 
 test.describe("Terminal protocol colors", () => {
@@ -32,45 +88,51 @@ test.describe("Terminal protocol colors", () => {
     await harness?.cleanup();
   });
 
-  test("keeps Codex terminal colors readable in light and dark mode", async ({ page }) => {
-    await page.emulateMedia({ colorScheme: "light" });
+  test("reports the active app palette through OSC color queries", async ({ page }) => {
+    const probePath = join(harness.tempRepo.path, "osc-color-probe.cjs");
+    writeFileSync(probePath, OSC_COLOR_PROBE_SCRIPT, "utf8");
 
-    const lightTerminal = await harness.createTerminal({
-      name: "codex-light-colors",
-      defaultColors: { foreground: "#1a1a1e", background: "#ffffff", cursor: "#1a1a1e" },
+    await page.addInitScript(() => {
+      if (!localStorage.getItem("@paseo:app-settings")) {
+        localStorage.setItem("@paseo:app-settings", JSON.stringify({ theme: "light" }));
+      }
     });
+    await gotoWorkspace(page, harness.workspaceId);
+    const lightTerminals = await harness.client.listTerminals(harness.tempRepo.path, undefined, {
+      workspaceId: harness.workspaceId,
+    });
+    const lightTerminalIds = new Set(lightTerminals.terminals.map((terminal) => terminal.id));
+    await clickNewTerminal(page);
+    await expectTerminalSurfaceVisible(page);
+    await setupDeterministicPrompt(page);
+    const lightTerminalId = await waitForCreatedTerminal(harness, lightTerminalIds);
     try {
-      await harness.openTerminal(page, { terminalId: lightTerminal.id });
-      await harness.setupPrompt(page);
-      await launchCodex(page);
-      const lightText = await getTerminalBufferText(page);
-      expect(lightText).toContain("OpenAI Codex");
-
-      await page.waitForTimeout(3000);
-      await page.keyboard.press("Control+C");
-      await page.waitForTimeout(1000);
-
-      const darkTerminal = await harness.createTerminal({
-        name: "codex-dark-colors",
-        defaultColors: { foreground: "#fafafa", background: "#181b1a", cursor: "#fafafa" },
-      });
-      try {
-        await page.emulateMedia({ colorScheme: "dark" });
-        await page.reload();
-        await page.waitForTimeout(1000);
-        await harness.openTerminal(page, { terminalId: darkTerminal.id });
-        await harness.setupPrompt(page);
-        await launchCodex(page);
-        const darkText = await getTerminalBufferText(page);
-        expect(darkText).toContain("OpenAI Codex");
-        await page.waitForTimeout(3000);
-        await page.keyboard.press("Control+C");
-        await page.waitForTimeout(1000);
-      } finally {
-        await harness.killTerminal(darkTerminal.id);
+      for (const code of [10, 11, 12] as const) {
+        await queryOscColor(page, probePath, code, LIGHT_TERMINAL_COLORS[code]);
       }
     } finally {
-      await harness.killTerminal(lightTerminal.id);
+      await harness.killTerminal(lightTerminalId);
+    }
+
+    await page.evaluate(() => {
+      localStorage.setItem("@paseo:app-settings", JSON.stringify({ theme: "dark" }));
+    });
+    await page.reload();
+    await gotoWorkspace(page, harness.workspaceId);
+    const darkTerminals = await harness.client.listTerminals(harness.tempRepo.path, undefined, {
+      workspaceId: harness.workspaceId,
+    });
+    const darkTerminalIds = new Set(darkTerminals.terminals.map((terminal) => terminal.id));
+    await clickNewTerminal(page);
+    await expectTerminalSurfaceVisible(page);
+    await setupDeterministicPrompt(page);
+    const darkTerminalId = await waitForCreatedTerminal(harness, darkTerminalIds);
+    try {
+      for (const code of [10, 11, 12] as const) {
+        await queryOscColor(page, probePath, code, DARK_TERMINAL_COLORS[code]);
+      }
+    } finally {
+      await harness.killTerminal(darkTerminalId);
     }
   });
 });

--- a/packages/app/e2e/browser/terminal-protocol-query.spec.ts
+++ b/packages/app/e2e/browser/terminal-protocol-query.spec.ts
@@ -4,6 +4,7 @@ import type { Page } from "@playwright/test";
 import { test, expect } from "../support/fixtures";
 import { TerminalE2EHarness } from "../support/helpers/terminal-dsl";
 import { clickNewTerminal, gotoWorkspace } from "../support/helpers/launcher";
+import { openSettingsSection } from "../support/helpers/settings";
 import {
   expectTerminalSurfaceVisible,
   setupDeterministicPrompt,
@@ -31,17 +32,29 @@ process.stdin.on("data", (chunk) => {
 process.stdout.write("\\x1b]" + code + ";?\\x07");
 `;
 
-const LIGHT_TERMINAL_COLORS = {
-  10: "rgb:1a1a/1a1a/1e1e",
-  11: "rgb:ffff/ffff/ffff",
-  12: "rgb:1a1a/1a1a/1e1e",
+const TERMINAL_PALETTE_SCENARIOS = {
+  light: {
+    label: "Light",
+    foreground: "rgb(26, 26, 30)",
+    colors: {
+      10: "rgb:1a1a/1a1a/1e1e",
+      11: "rgb:ffff/ffff/ffff",
+      12: "rgb:1a1a/1a1a/1e1e",
+    },
+  },
+  dark: {
+    label: "Dark",
+    foreground: "rgb(250, 250, 250)",
+    colors: {
+      10: "rgb:fafa/fafa/fafa",
+      11: "rgb:1818/1b1b/1a1a",
+      12: "rgb:fafa/fafa/fafa",
+    },
+  },
 } as const;
 
-const DARK_TERMINAL_COLORS = {
-  10: "rgb:fafa/fafa/fafa",
-  11: "rgb:1818/1b1b/1a1a",
-  12: "rgb:fafa/fafa/fafa",
-} as const;
+type TerminalPaletteScenario =
+  (typeof TERMINAL_PALETTE_SCENARIOS)[keyof typeof TERMINAL_PALETTE_SCENARIOS];
 
 async function waitForCreatedTerminal(
   harness: TerminalE2EHarness,
@@ -77,6 +90,61 @@ async function queryOscColor(
   await waitForTerminalContent(page, (text) => text.includes(expectedOutput), 10_000);
 }
 
+function createOscColorProbe(repoPath: string): string {
+  const probePath = join(repoPath, "osc-color-probe.cjs");
+  writeFileSync(probePath, OSC_COLOR_PROBE_SCRIPT, "utf8");
+  return probePath;
+}
+
+async function selectAppTheme(page: Page, scenario: TerminalPaletteScenario): Promise<void> {
+  await page.goto("/settings");
+  await expect(page.getByTestId("settings-sidebar")).toBeVisible();
+  await openSettingsSection(page, "appearance");
+
+  const themeTrigger = page.getByLabel(/^Theme: /).first();
+  await themeTrigger.click();
+  await page.getByRole("menuitem", { name: scenario.label, exact: true }).click();
+  await expect(themeTrigger).toHaveAccessibleName(`Theme: ${scenario.label}`);
+  await expect(themeTrigger.getByText(scenario.label, { exact: true })).toHaveCSS(
+    "color",
+    scenario.foreground,
+  );
+}
+
+async function assertTerminalPalette(
+  page: Page,
+  probePath: string,
+  colors: TerminalPaletteScenario["colors"],
+): Promise<void> {
+  for (const code of [10, 11, 12] as const) {
+    await queryOscColor(page, probePath, code, colors[code]);
+  }
+}
+
+async function exerciseTerminalPalette(
+  page: Page,
+  harness: TerminalE2EHarness,
+  probePath: string,
+  scenario: TerminalPaletteScenario,
+): Promise<void> {
+  await selectAppTheme(page, scenario);
+  await gotoWorkspace(page, harness.workspaceId);
+
+  const existingTerminals = await harness.client.listTerminals(harness.tempRepo.path, undefined, {
+    workspaceId: harness.workspaceId,
+  });
+  const knownTerminalIds = new Set(existingTerminals.terminals.map((terminal) => terminal.id));
+  await clickNewTerminal(page);
+  await expectTerminalSurfaceVisible(page);
+  await setupDeterministicPrompt(page);
+  const terminalId = await waitForCreatedTerminal(harness, knownTerminalIds);
+  try {
+    await assertTerminalPalette(page, probePath, scenario.colors);
+  } finally {
+    await harness.killTerminal(terminalId);
+  }
+}
+
 test.describe("Terminal protocol colors", () => {
   let harness: TerminalE2EHarness;
 
@@ -89,50 +157,8 @@ test.describe("Terminal protocol colors", () => {
   });
 
   test("reports the active app palette through OSC color queries", async ({ page }) => {
-    const probePath = join(harness.tempRepo.path, "osc-color-probe.cjs");
-    writeFileSync(probePath, OSC_COLOR_PROBE_SCRIPT, "utf8");
-
-    await page.addInitScript(() => {
-      if (!localStorage.getItem("@paseo:app-settings")) {
-        localStorage.setItem("@paseo:app-settings", JSON.stringify({ theme: "light" }));
-      }
-    });
-    await gotoWorkspace(page, harness.workspaceId);
-    const lightTerminals = await harness.client.listTerminals(harness.tempRepo.path, undefined, {
-      workspaceId: harness.workspaceId,
-    });
-    const lightTerminalIds = new Set(lightTerminals.terminals.map((terminal) => terminal.id));
-    await clickNewTerminal(page);
-    await expectTerminalSurfaceVisible(page);
-    await setupDeterministicPrompt(page);
-    const lightTerminalId = await waitForCreatedTerminal(harness, lightTerminalIds);
-    try {
-      for (const code of [10, 11, 12] as const) {
-        await queryOscColor(page, probePath, code, LIGHT_TERMINAL_COLORS[code]);
-      }
-    } finally {
-      await harness.killTerminal(lightTerminalId);
-    }
-
-    await page.evaluate(() => {
-      localStorage.setItem("@paseo:app-settings", JSON.stringify({ theme: "dark" }));
-    });
-    await page.reload();
-    await gotoWorkspace(page, harness.workspaceId);
-    const darkTerminals = await harness.client.listTerminals(harness.tempRepo.path, undefined, {
-      workspaceId: harness.workspaceId,
-    });
-    const darkTerminalIds = new Set(darkTerminals.terminals.map((terminal) => terminal.id));
-    await clickNewTerminal(page);
-    await expectTerminalSurfaceVisible(page);
-    await setupDeterministicPrompt(page);
-    const darkTerminalId = await waitForCreatedTerminal(harness, darkTerminalIds);
-    try {
-      for (const code of [10, 11, 12] as const) {
-        await queryOscColor(page, probePath, code, DARK_TERMINAL_COLORS[code]);
-      }
-    } finally {
-      await harness.killTerminal(darkTerminalId);
-    }
+    const probePath = createOscColorProbe(harness.tempRepo.path);
+    await exerciseTerminalPalette(page, harness, probePath, TERMINAL_PALETTE_SCENARIOS.light);
+    await exerciseTerminalPalette(page, harness, probePath, TERMINAL_PALETTE_SCENARIOS.dark);
   });
 });

--- a/packages/app/e2e/browser/terminal-protocol-query.spec.ts
+++ b/packages/app/e2e/browser/terminal-protocol-query.spec.ts
@@ -39,7 +39,14 @@ test.describe("Terminal protocol queries", () => {
   });
 
   test("does not send browser OSC 11 color-query replies back to the PTY", async ({ page }) => {
-    const terminalInstance = await harness.createTerminal({ name: "osc11-query" });
+    const terminalInstance = await harness.createTerminal({
+      name: "osc11-query",
+      defaultColors: {
+        foreground: "#18181b",
+        background: "#ffffff",
+        cursor: "#18181b",
+      },
+    });
     try {
       await harness.openTerminal(page, { terminalId: terminalInstance.id });
       await harness.setupPrompt(page);
@@ -52,8 +59,8 @@ test.describe("Terminal protocol queries", () => {
 
       const text = await getTerminalBufferText(page);
 
-      expect(text).toContain("rgb:0b0b/0b0b/0b0b");
-      expect(text).not.toContain("rgb:ffff/ffff/ffff");
+      expect(text).toContain("rgb:ffff/ffff/ffff");
+      expect(text).not.toContain("rgb:0b0b/0b0b/0b0b");
     } finally {
       await harness.killTerminal(terminalInstance.id);
     }

--- a/packages/app/e2e/browser/terminal-protocol-query.spec.ts
+++ b/packages/app/e2e/browser/terminal-protocol-query.spec.ts
@@ -1,68 +1,76 @@
-import { writeFile } from "node:fs/promises";
-import path from "node:path";
+import type { Page } from "@playwright/test";
 import { test, expect } from "../support/fixtures";
 import { TerminalE2EHarness } from "../support/helpers/terminal-dsl";
 import { getTerminalBufferText, waitForTerminalContent } from "../support/helpers/terminal-perf";
 
-const OSC11_CAPTURE_SCRIPT = `
-let captured = Buffer.alloc(0);
+const CODEX_START_COMMAND =
+  "TERM=xterm-256color codex --no-alt-screen --ask-for-approval never --sandbox read-only";
 
-function finish() {
-  process.stdout.write("PASEO_OSC11_CAPTURE:" + JSON.stringify(captured.toString("latin1")) + "\\n");
-  process.exit(0);
-}
-
-process.stdout.write("\\x1b]11;?\\x07");
-if (process.stdin.isTTY) {
-  process.stdin.setRawMode(true);
-}
-process.stdin.resume();
-process.stdin.on("data", (chunk) => {
-  captured = Buffer.concat([captured, chunk]);
-  if (captured.includes(Buffer.from("rgb:"))) {
-    finish();
+async function launchCodex(page: Page): Promise<void> {
+  const terminal = page.locator('[data-testid="terminal-surface"]');
+  await terminal.pressSequentially(`${CODEX_START_COMMAND}\n`, { delay: 0 });
+  await waitForTerminalContent(
+    page,
+    (text) => text.includes("Do you trust the contents of this directory?"),
+    10_000,
+  ).catch(() => undefined);
+  const trustPrompt = await getTerminalBufferText(page);
+  if (trustPrompt.includes("Do you trust the contents of this directory?")) {
+    await terminal.pressSequentially("1\n", { delay: 0 });
   }
-});
-setTimeout(finish, 700);
-`;
+  await waitForTerminalContent(page, (text) => text.includes("OpenAI Codex"), 30_000);
+}
 
-test.describe("Terminal protocol queries", () => {
+test.describe("Terminal protocol colors", () => {
   let harness: TerminalE2EHarness;
 
   test.beforeAll(async () => {
     harness = await TerminalE2EHarness.create({ tempPrefix: "terminal-protocol-query-" });
-    await writeFile(path.join(harness.tempRepo.path, "osc11-capture.cjs"), OSC11_CAPTURE_SCRIPT);
   });
 
   test.afterAll(async () => {
     await harness?.cleanup();
   });
 
-  test("does not send browser OSC 11 color-query replies back to the PTY", async ({ page }) => {
-    const terminalInstance = await harness.createTerminal({
-      name: "osc11-query",
-      defaultColors: {
-        foreground: "#18181b",
-        background: "#ffffff",
-        cursor: "#18181b",
-      },
+  test("keeps Codex terminal colors readable in light and dark mode", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+
+    const lightTerminal = await harness.createTerminal({
+      name: "codex-light-colors",
+      defaultColors: { foreground: "#1a1a1e", background: "#ffffff", cursor: "#1a1a1e" },
     });
     try {
-      await harness.openTerminal(page, { terminalId: terminalInstance.id });
+      await harness.openTerminal(page, { terminalId: lightTerminal.id });
       await harness.setupPrompt(page);
+      await launchCodex(page);
+      const lightText = await getTerminalBufferText(page);
+      expect(lightText).toContain("OpenAI Codex");
 
-      const terminal = harness.terminalSurface(page);
-      await terminal.pressSequentially("node osc11-capture.cjs\n", { delay: 0 });
+      await page.waitForTimeout(3000);
+      await page.keyboard.press("Control+C");
+      await page.waitForTimeout(1000);
 
-      await waitForTerminalContent(page, (text) => text.includes("PASEO_OSC11_CAPTURE:"), 10_000);
-      await page.waitForTimeout(500);
-
-      const text = await getTerminalBufferText(page);
-
-      expect(text).toContain("rgb:ffff/ffff/ffff");
-      expect(text).not.toContain("rgb:0b0b/0b0b/0b0b");
+      const darkTerminal = await harness.createTerminal({
+        name: "codex-dark-colors",
+        defaultColors: { foreground: "#fafafa", background: "#181b1a", cursor: "#fafafa" },
+      });
+      try {
+        await page.emulateMedia({ colorScheme: "dark" });
+        await page.reload();
+        await page.waitForTimeout(1000);
+        await harness.openTerminal(page, { terminalId: darkTerminal.id });
+        await harness.setupPrompt(page);
+        await launchCodex(page);
+        const darkText = await getTerminalBufferText(page);
+        expect(darkText).toContain("OpenAI Codex");
+        await page.waitForTimeout(3000);
+        await page.keyboard.press("Control+C");
+        await page.waitForTimeout(1000);
+      } finally {
+        await harness.killTerminal(darkTerminal.id);
+      }
     } finally {
-      await harness.killTerminal(terminalInstance.id);
+      await harness.killTerminal(lightTerminal.id);
     }
   });
 });

--- a/packages/app/e2e/support/helpers/seed-client.ts
+++ b/packages/app/e2e/support/helpers/seed-client.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { readFileSync } from "node:fs";
+import type { TerminalDefaultColors } from "@getpaseo/protocol/messages";
 import type { TerminalActivity } from "@getpaseo/protocol/terminal-activity";
 import { connectDaemonClient } from "./daemon-client-loader";
 import { withProjectOwnership } from "./project-ownership";
@@ -81,7 +82,13 @@ export interface SeedDaemonClient {
     cwd: string,
     name?: string,
     requestId?: string,
-    options?: { agentId?: string; command?: string; args?: string[]; workspaceId?: string },
+    options?: {
+      agentId?: string;
+      command?: string;
+      args?: string[];
+      workspaceId?: string;
+      defaultColors?: TerminalDefaultColors;
+    },
   ): Promise<{
     terminal: { id: string; name: string; cwd: string; activity?: TerminalActivity | null } | null;
     error: string | null;

--- a/packages/app/e2e/support/helpers/terminal-dsl.ts
+++ b/packages/app/e2e/support/helpers/terminal-dsl.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import type { TerminalDefaultColors } from "@getpaseo/protocol/messages";
 import type { TerminalActivity, TerminalActivityState } from "@getpaseo/protocol/terminal-activity";
 import { createTempGitRepo } from "./workspace";
 import { navigateToTerminal, setupDeterministicPrompt } from "./terminal-perf";
@@ -19,6 +20,7 @@ interface CreateTerminalInput {
   name: string;
   command?: string;
   args?: string[];
+  defaultColors?: TerminalDefaultColors;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -69,14 +71,11 @@ export class TerminalE2EHarness {
   }
 
   async createTerminal(input: CreateTerminalInput): Promise<TerminalInstance> {
-    const options =
-      input.command || input.args
-        ? {
-            command: input.command,
-            args: input.args,
-            workspaceId: this.workspaceId,
-          }
-        : { workspaceId: this.workspaceId };
+    const options = {
+      ...(input.command || input.args ? { command: input.command, args: input.args } : {}),
+      workspaceId: this.workspaceId,
+      ...(input.defaultColors ? { defaultColors: input.defaultColors } : {}),
+    };
     const result = await this.client.createTerminal(
       this.tempRepo.path,
       input.name,

--- a/packages/app/src/plugins/themes/index.ts
+++ b/packages/app/src/plugins/themes/index.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { z } from "zod";
 import type { PluginThemeContribution } from "@getpaseo/plugin";
+import { HexColorSchema } from "@getpaseo/protocol/messages";
 import { useHostFeatureMap } from "@/runtime/host-features";
 import {
   buildDarkSemanticColors,
@@ -18,23 +19,19 @@ import {
 import { useInstalledPlugins } from "../registry";
 import type { InstalledPlugin } from "../types";
 
-const hexColorSchema = z
-  .string()
-  .regex(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/, "Must be a hex color");
-
 const contributionSchema: z.ZodType<PluginThemeContribution> = z.strictObject({
   id: z.string(),
   name: z.string().trim().min(1).max(60),
   appearance: z.enum(["light", "dark"]),
   colors: z.strictObject({
-    background: hexColorSchema,
-    foreground: hexColorSchema,
-    raised: hexColorSchema,
-    control: hexColorSchema,
-    border: hexColorSchema,
-    accent: hexColorSchema.optional(),
-    mutedForeground: hexColorSchema,
-    ring: hexColorSchema,
+    background: HexColorSchema,
+    foreground: HexColorSchema,
+    raised: HexColorSchema,
+    control: HexColorSchema,
+    border: HexColorSchema,
+    accent: HexColorSchema.optional(),
+    mutedForeground: HexColorSchema,
+    ring: HexColorSchema,
   }),
 });
 

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -5,6 +5,7 @@ import type { TFunction } from "i18next";
 import { Pressable, StyleSheet as RNStyleSheet, Text, View } from "react-native";
 import type { PressableStateCallbackType } from "react-native";
 import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles";
+import { getActiveTerminalDefaultColors } from "@/utils/terminal-default-colors";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { createNameId } from "mnemonic-id";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -2109,7 +2110,12 @@ export function NewWorkspaceScreen({
             input.workspaceDirectory,
             input.name,
             undefined,
-            { command: input.command, args: input.args, workspaceId: input.workspaceId },
+            {
+              command: input.command,
+              args: input.args,
+              workspaceId: input.workspaceId,
+              defaultColors: getActiveTerminalDefaultColors(),
+            },
           );
           const terminal = createdTerminal.terminal;
           if (!terminal) {

--- a/packages/app/src/screens/workspace/terminals/use-workspace-terminals.ts
+++ b/packages/app/src/screens/workspace/terminals/use-workspace-terminals.ts
@@ -7,6 +7,7 @@ import type { WorkspaceDescriptor } from "@/stores/session-store";
 import { useTranslation } from "react-i18next";
 import { useReplicaQuery } from "@/data/query";
 import { workspaceTerminalsPushRoute } from "@/data/push-router";
+import { getActiveTerminalDefaultColors } from "@/utils/terminal-default-colors";
 import {
   buildTerminalsQueryKey,
   canCreateWorkspaceTerminal,
@@ -134,14 +135,17 @@ export function useWorkspaceTerminals(input: UseWorkspaceTerminalsInput) {
         throw new Error(t("workspace.terminal.hostDisconnected"));
       }
       const profile = _input.profile ? resolveTerminalProfileLaunch(_input.profile, "") : undefined;
+      const defaultColors = getActiveTerminalDefaultColors();
       const payload = profile
         ? await client.createTerminal(workspaceDirectory, profile.name, undefined, {
             command: profile.command,
             args: profile.args,
             workspaceId: normalizedWorkspaceId || undefined,
+            defaultColors,
           })
         : await client.createTerminal(workspaceDirectory, undefined, undefined, {
             workspaceId: normalizedWorkspaceId || undefined,
+            defaultColors,
           });
       // The daemon reports a failed spawn (e.g. a profile command that isn't
       // installed) via payload.error with a null terminal. Surface it instead

--- a/packages/app/src/utils/terminal-default-colors.ts
+++ b/packages/app/src/utils/terminal-default-colors.ts
@@ -1,0 +1,16 @@
+import type { TerminalDefaultColors } from "@getpaseo/protocol/messages";
+import { UnistylesRuntime } from "react-native-unistyles";
+
+/**
+ * Terminal OSC replies are fixed when the PTY is created. Read the active
+ * palette at the action boundary so a terminal opened from any app surface
+ * gets the same colors that its renderer will use.
+ */
+export function getActiveTerminalDefaultColors(): TerminalDefaultColors {
+  const terminal = UnistylesRuntime.getTheme().colors.terminal;
+  return {
+    foreground: terminal.foreground,
+    background: terminal.background,
+    cursor: terminal.cursor,
+  };
+}

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -16,6 +16,7 @@ import {
   SessionInboundMessageSchema,
   type ActiveTurnBehavior,
   type ServerInfoStatusPayload,
+  type TerminalDefaultColors,
 } from "@getpaseo/protocol/messages";
 import { validateWSOutboundMessage } from "@getpaseo/protocol/validation/ws-outbound";
 import type {
@@ -5329,6 +5330,7 @@ export class DaemonClient {
       args?: string[];
       workspaceId?: string;
       size?: { rows: number; cols: number };
+      defaultColors?: TerminalDefaultColors;
     },
   ): Promise<CreateTerminalPayload> {
     const resolvedRequestId = this.createRequestId(requestId);
@@ -5341,6 +5343,7 @@ export class DaemonClient {
       args: options?.args,
       ...(options?.workspaceId !== undefined ? { workspaceId: options.workspaceId } : {}),
       ...(options?.size !== undefined ? { size: options.size } : {}),
+      ...(options?.defaultColors !== undefined ? { defaultColors: options.defaultColors } : {}),
       requestId: resolvedRequestId,
     });
     return this.sendCorrelatedRequest({

--- a/packages/protocol/src/messages.create-terminal-size.test.ts
+++ b/packages/protocol/src/messages.create-terminal-size.test.ts
@@ -20,6 +20,25 @@ describe("CreateTerminalRequest size", () => {
     expect(parsed.size).toEqual({ rows: 55, cols: 136 });
   });
 
+  it("parses an optional terminal creation palette", () => {
+    const defaultColors = {
+      foreground: "#18181b",
+      background: "#ffffff",
+      cursor: "#18181b",
+    };
+    const parsed = CreateTerminalRequestSchema.parse({ ...base, defaultColors });
+    expect(parsed.defaultColors).toEqual(defaultColors);
+  });
+
+  it("rejects non-hex terminal colors", () => {
+    expect(() =>
+      CreateTerminalRequestSchema.parse({
+        ...base,
+        defaultColors: { foreground: "rgb(24 24 27)", background: "#ffffff" },
+      }),
+    ).toThrow();
+  });
+
   it("rejects a non-positive or non-integer size", () => {
     expect(() =>
       CreateTerminalRequestSchema.parse({ ...base, size: { rows: 0, cols: 80 } }),

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -108,6 +108,10 @@ export const DAEMON_PERMISSIONS = [
 export const DaemonPermissionSchema = z.enum(DAEMON_PERMISSIONS);
 export type DaemonPermission = z.infer<typeof DaemonPermissionSchema>;
 
+export const HexColorSchema = z
+  .string()
+  .regex(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/, "Must be a hex color");
+
 const MutableDaemonProviderModelSchema = z
   .object({
     id: z.string().min(1),
@@ -2846,6 +2850,14 @@ export const UnsubscribeTerminalsRequestSchema = z.object({
   workspaceId: z.string().optional(),
 });
 
+export const TerminalDefaultColorsSchema = z.object({
+  foreground: HexColorSchema,
+  background: HexColorSchema,
+  cursor: HexColorSchema.optional(),
+});
+
+export type TerminalDefaultColors = z.infer<typeof TerminalDefaultColorsSchema>;
+
 export const CreateTerminalRequestSchema = z.object({
   type: z.literal("create_terminal_request"),
   cwd: z.string(),
@@ -2854,6 +2866,10 @@ export const CreateTerminalRequestSchema = z.object({
   agentId: z.string().optional(),
   command: z.string().optional(),
   args: z.array(z.string()).optional(),
+  // The palette selected by the client when this terminal was created. The
+  // daemon owns OSC color-query replies, so it must not infer these from a
+  // later viewer's theme.
+  defaultColors: TerminalDefaultColorsSchema.optional(),
   // Initial PTY size. Added in v0.1.107; the app no longer sends it (the estimate cache that fed
   // it was removed — the pane-focus resize claim sizes the PTY instead). Kept and honored
   // permanently: released v0.1.107 clients still send it, and programmatic callers may pass an

--- a/packages/server/src/terminal/terminal-manager.ts
+++ b/packages/server/src/terminal/terminal-manager.ts
@@ -10,6 +10,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { resolve, sep } from "node:path";
 import { assertAbsolutePath, isSameOrDescendantPath } from "../server/path-utils.js";
 import type { TerminalActivity, TerminalActivityState } from "@getpaseo/protocol/terminal-activity";
+import type { TerminalDefaultColors } from "@getpaseo/protocol/messages";
 import { deriveTerminalActivityStatusBucket } from "@getpaseo/protocol/terminal-activity";
 
 export interface TerminalListItem {
@@ -58,6 +59,7 @@ export interface TerminalManager {
     name?: string;
     title?: string;
     env?: Record<string, string>;
+    defaultColors?: TerminalDefaultColors;
     command?: string;
     args?: string[];
     rows?: number;
@@ -315,6 +317,7 @@ export function createTerminalManager(
       name?: string;
       title?: string;
       env?: Record<string, string>;
+      defaultColors?: TerminalDefaultColors;
       command?: string;
       args?: string[];
       rows?: number;
@@ -348,6 +351,7 @@ export function createTerminalManager(
             id: terminalId,
             cwd: options.cwd,
             workspaceId: options.workspaceId,
+            ...(options.defaultColors ? { defaultColors: options.defaultColors } : {}),
             name: options.name ?? defaultName,
             ...(options.title ? { title: options.title } : {}),
             ...(options.command ? { command: options.command } : {}),

--- a/packages/server/src/terminal/terminal-session-controller.ts
+++ b/packages/server/src/terminal/terminal-session-controller.ts
@@ -564,6 +564,7 @@ export class TerminalSessionController {
         name: msg.name,
         command: msg.command,
         args: msg.args,
+        defaultColors: msg.defaultColors,
         rows: msg.size?.rows,
         cols: msg.size?.cols,
       });

--- a/packages/server/src/terminal/terminal-worker-protocol.ts
+++ b/packages/server/src/terminal/terminal-worker-protocol.ts
@@ -5,7 +5,7 @@ import type {
   TerminalStateSnapshot,
   TerminalStateSnapshotOptions,
 } from "./terminal.js";
-import type { TerminalState } from "@getpaseo/protocol/messages";
+import type { TerminalDefaultColors, TerminalState } from "@getpaseo/protocol/messages";
 import type { TerminalActivity, TerminalActivityState } from "@getpaseo/protocol/terminal-activity";
 import type { CaptureTerminalLinesResult } from "./terminal-capture.js";
 
@@ -25,6 +25,7 @@ export interface WorkerCreateTerminalOptions {
   name?: string;
   title?: string;
   env?: Record<string, string>;
+  defaultColors?: TerminalDefaultColors;
   command?: string;
   args?: string[];
   rows?: number;

--- a/packages/server/src/terminal/terminal.posix.test.ts
+++ b/packages/server/src/terminal/terminal.posix.test.ts
@@ -220,6 +220,35 @@ function writeOsc11Helper(prefix: string): string {
   return path;
 }
 
+const OSC_COLOR_HELPER_SCRIPT = `process.stdin.setRawMode(true);
+process.stdin.resume();
+const code = process.argv[2];
+let buf = "";
+const timer = setTimeout(() => {
+  process.stdout.write("OSC_COLOR_TIMEOUT\\n");
+  process.exit(2);
+}, 2500);
+process.stdin.on("data", (chunk) => {
+  buf += chunk.toString("binary");
+  const match = buf.match(new RegExp("\\\\x1b\\\\]" + code + ";rgb:[0-9a-f/]+\\\\x1b\\\\\\\\"));
+  if (!match) {
+    return;
+  }
+  clearTimeout(timer);
+  process.stdout.write("OSC_COLOR_OK:" + code + ":" + match[0].replace(/\\x1b/g, "ESC") + "\\n");
+  process.exit(0);
+});
+process.stdout.write("\\x1b]" + code + ";?\\x07");
+`;
+
+function writeOscColorHelper(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirs.push(dir);
+  const path = join(dir, "helper.cjs");
+  writeFileSync(path, OSC_COLOR_HELPER_SCRIPT);
+  return path;
+}
+
 function isDaOkLine(line: string): boolean {
   return line.startsWith("DA_OK:");
 }
@@ -1065,6 +1094,40 @@ describe.skipIf(isPlatform("win32"))("terminal POSIX-only", () => {
 
       const ack = getLines(session.getState()).find(isOsc11OkLine) ?? "";
       expect(ack).toBe("OSC11_OK:ESC]11;rgb:0b0b/0b0b/0b0bESC\\");
+    });
+    it("reports the terminal creation palette for OSC color queries", async () => {
+      const colors = {
+        foreground: "#112233",
+        background: "#abcdef",
+        cursor: "#445566",
+      };
+
+      for (const [code, expected] of [
+        [10, "rgb:1111/2222/3333"],
+        [11, "rgb:abab/cdcd/efef"],
+        [12, "rgb:4444/5555/6666"],
+      ] as const) {
+        const helperPath = writeOscColorHelper(`terminal-osc${code}-helper-`);
+        const session = trackSession(
+          await createTerminal({
+            workspaceId: "ws-test",
+            cwd: "/tmp",
+            shell: "/bin/sh",
+            env: { PS1: "$ " },
+            defaultColors: colors,
+          }),
+        );
+        await waitForLines(session, ["$"]);
+
+        session.send({ type: "input", data: `${process.execPath} ${helperPath} ${code}\r` });
+        await waitForState(session, (state) =>
+          getLines(state).some((line) => line.startsWith("OSC_COLOR_OK:")),
+        );
+
+        const ack =
+          getLines(session.getState()).find((line) => line.startsWith("OSC_COLOR_OK:")) ?? "";
+        expect(ack).toBe(`OSC_COLOR_OK:${code}:ESC]${code};${expected}ESC\\`);
+      }
     });
   });
 

--- a/packages/server/src/terminal/terminal.posix.test.ts
+++ b/packages/server/src/terminal/terminal.posix.test.ts
@@ -1129,6 +1129,42 @@ describe.skipIf(isPlatform("win32"))("terminal POSIX-only", () => {
         expect(ack).toBe(`OSC_COLOR_OK:${code}:ESC]${code};${expected}ESC\\`);
       }
     });
+
+    it("composites translucent terminal colors before reporting OSC queries", async () => {
+      const colors = {
+        foreground: "#33669980",
+        background: "#112233cc",
+        cursor: "#abcdef40",
+      };
+      const expected = new Map([
+        [10, "rgb:2222/4242/6262"],
+        [11, "rgb:1010/1d1d/2b2b"],
+        [12, "rgb:3737/4949/5c5c"],
+      ]);
+
+      for (const [code, response] of expected) {
+        const helperPath = writeOscColorHelper(`terminal-osc${code}-alpha-helper-`);
+        const session = trackSession(
+          await createTerminal({
+            workspaceId: "ws-test",
+            cwd: "/tmp",
+            shell: "/bin/sh",
+            env: { PS1: "$ " },
+            defaultColors: colors,
+          }),
+        );
+        await waitForLines(session, ["$"]);
+
+        session.send({ type: "input", data: `${process.execPath} ${helperPath} ${code}\r` });
+        await waitForState(session, (state) =>
+          getLines(state).some((line) => line.startsWith("OSC_COLOR_OK:")),
+        );
+
+        const ack =
+          getLines(session.getState()).find((line) => line.startsWith("OSC_COLOR_OK:")) ?? "";
+        expect(ack).toBe(`OSC_COLOR_OK:${code}:ESC]${code};${response}ESC\\`);
+      }
+    });
   });
 
   describe("stream snapshots", () => {

--- a/packages/server/src/terminal/terminal.ts
+++ b/packages/server/src/terminal/terminal.ts
@@ -25,41 +25,97 @@ let nodePtySpawnHelperChecked = false;
 const TERMINAL_TITLE_DEBOUNCE_MS = 150;
 const TERMINAL_EXIT_OUTPUT_LINE_LIMIT = 12;
 const TERMINAL_EXIT_OUTPUT_CHAR_LIMIT = 16000;
-const DEFAULT_TERMINAL_OSC_COLOR_QUERY_RESPONSES = new Map<number, string>([
-  [10, "rgb:e6e6/e6e6/e6e6"],
-  [11, "rgb:0b0b/0b0b/0b0b"],
-  [12, "rgb:e6e6/e6e6/e6e6"],
-]);
+interface RgbColor {
+  red: number;
+  green: number;
+  blue: number;
+}
 
-function toOscColor(value: string | undefined, fallback: string): string {
+const DEFAULT_TERMINAL_BACKGROUND: RgbColor = { red: 0x0b, green: 0x0b, blue: 0x0b };
+const DEFAULT_TERMINAL_FOREGROUND: RgbColor = { red: 0xe6, green: 0xe6, blue: 0xe6 };
+
+function parseHexColor(value: string | undefined): { color: RgbColor; alpha: number } | undefined {
   const hex = value?.trim().replace(/^#/, "").toLowerCase();
   if (!hex || ![3, 4, 6, 8].includes(hex.length) || !/^[0-9a-f]+$/.test(hex)) {
-    return fallback;
+    return undefined;
   }
 
   const rgb =
     hex.length <= 4
       ? hex.slice(0, 3).replaceAll(/./g, (channel) => channel + channel)
       : hex.slice(0, 6);
-  return `rgb:${rgb.slice(0, 2).repeat(2)}/${rgb.slice(2, 4).repeat(2)}/${rgb.slice(4, 6).repeat(2)}`;
+  let alpha = 0xff;
+  if (hex.length === 4) {
+    alpha = Number.parseInt(hex[3]!.repeat(2), 16);
+  } else if (hex.length === 8) {
+    alpha = Number.parseInt(hex.slice(6), 16);
+  }
+
+  return {
+    color: {
+      red: Number.parseInt(rgb.slice(0, 2), 16),
+      green: Number.parseInt(rgb.slice(2, 4), 16),
+      blue: Number.parseInt(rgb.slice(4, 6), 16),
+    },
+    alpha,
+  };
+}
+
+function compositeColor(
+  foreground: { color: RgbColor; alpha: number },
+  background: RgbColor,
+): RgbColor {
+  if (foreground.alpha === 0xff) {
+    return foreground.color;
+  }
+
+  const opacity = foreground.alpha / 0xff;
+  return {
+    red: Math.round(background.red + (foreground.color.red - background.red) * opacity),
+    green: Math.round(background.green + (foreground.color.green - background.green) * opacity),
+    blue: Math.round(background.blue + (foreground.color.blue - background.blue) * opacity),
+  };
+}
+
+function resolveColor(
+  value: string | undefined,
+  fallback: RgbColor,
+  background: RgbColor,
+): RgbColor {
+  const parsed = parseHexColor(value);
+  return parsed ? compositeColor(parsed, background) : fallback;
+}
+
+function toOscColor(color: RgbColor): string {
+  const channel = (value: number): string => value.toString(16).padStart(2, "0").repeat(2);
+  return `rgb:${channel(color.red)}/${channel(color.green)}/${channel(color.blue)}`;
 }
 
 function createOscColorQueryResponses(
   defaultColors?: TerminalDefaultColors,
 ): ReadonlyMap<number, string> {
-  const foreground = toOscColor(
-    defaultColors?.foreground,
-    DEFAULT_TERMINAL_OSC_COLOR_QUERY_RESPONSES.get(10)!,
-  );
-  const background = toOscColor(
+  // OSC RGB responses cannot carry alpha. xterm blends the foreground and cursor over the
+  // terminal background; use the existing dark fallback as the backdrop for a translucent
+  // background because the protocol does not carry another compositing surface.
+  const displayedBackground = resolveColor(
     defaultColors?.background,
-    DEFAULT_TERMINAL_OSC_COLOR_QUERY_RESPONSES.get(11)!,
+    DEFAULT_TERMINAL_BACKGROUND,
+    DEFAULT_TERMINAL_BACKGROUND,
   );
-  const cursor = toOscColor(defaultColors?.cursor ?? defaultColors?.foreground, foreground);
+  const displayedForeground = resolveColor(
+    defaultColors?.foreground,
+    DEFAULT_TERMINAL_FOREGROUND,
+    displayedBackground,
+  );
+  const displayedCursor = resolveColor(
+    defaultColors?.cursor ?? defaultColors?.foreground,
+    displayedForeground,
+    displayedBackground,
+  );
   return new Map([
-    [10, foreground],
-    [11, background],
-    [12, cursor],
+    [10, toOscColor(displayedForeground)],
+    [11, toOscColor(displayedBackground)],
+    [12, toOscColor(displayedCursor)],
   ]);
 }
 

--- a/packages/server/src/terminal/terminal.ts
+++ b/packages/server/src/terminal/terminal.ts
@@ -9,7 +9,11 @@ import { fileURLToPath } from "node:url";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
 import { writePrivateFileAtomicSync } from "../server/private-files.js";
 import { findExecutable } from "../executable-resolution/executable-resolution.js";
-import type { TerminalCell, TerminalState } from "@getpaseo/protocol/messages";
+import type {
+  TerminalCell,
+  TerminalDefaultColors,
+  TerminalState,
+} from "@getpaseo/protocol/messages";
 import { TerminalInputModeTracker } from "@getpaseo/protocol/terminal-input-mode";
 import { TerminalActivityTracker } from "./activity/terminal-activity-tracker.js";
 import type { TerminalActivity, TerminalActivityState } from "@getpaseo/protocol/terminal-activity";
@@ -21,11 +25,43 @@ let nodePtySpawnHelperChecked = false;
 const TERMINAL_TITLE_DEBOUNCE_MS = 150;
 const TERMINAL_EXIT_OUTPUT_LINE_LIMIT = 12;
 const TERMINAL_EXIT_OUTPUT_CHAR_LIMIT = 16000;
-const TERMINAL_OSC_COLOR_QUERY_RESPONSES = new Map<number, string>([
+const DEFAULT_TERMINAL_OSC_COLOR_QUERY_RESPONSES = new Map<number, string>([
   [10, "rgb:e6e6/e6e6/e6e6"],
   [11, "rgb:0b0b/0b0b/0b0b"],
   [12, "rgb:e6e6/e6e6/e6e6"],
 ]);
+
+function toOscColor(value: string | undefined, fallback: string): string {
+  const hex = value?.trim().replace(/^#/, "").toLowerCase();
+  if (!hex || ![3, 4, 6, 8].includes(hex.length) || !/^[0-9a-f]+$/.test(hex)) {
+    return fallback;
+  }
+
+  const rgb =
+    hex.length <= 4
+      ? hex.slice(0, 3).replaceAll(/./g, (channel) => channel + channel)
+      : hex.slice(0, 6);
+  return `rgb:${rgb.slice(0, 2).repeat(2)}/${rgb.slice(2, 4).repeat(2)}/${rgb.slice(4, 6).repeat(2)}`;
+}
+
+function createOscColorQueryResponses(
+  defaultColors?: TerminalDefaultColors,
+): ReadonlyMap<number, string> {
+  const foreground = toOscColor(
+    defaultColors?.foreground,
+    DEFAULT_TERMINAL_OSC_COLOR_QUERY_RESPONSES.get(10)!,
+  );
+  const background = toOscColor(
+    defaultColors?.background,
+    DEFAULT_TERMINAL_OSC_COLOR_QUERY_RESPONSES.get(11)!,
+  );
+  const cursor = toOscColor(defaultColors?.cursor ?? defaultColors?.foreground, foreground);
+  return new Map([
+    [10, foreground],
+    [11, background],
+    [12, cursor],
+  ]);
+}
 
 export interface TerminalExitInfo {
   exitCode: number | null;
@@ -119,6 +155,7 @@ export interface CreateTerminalOptions {
   id?: string;
   cwd: string;
   workspaceId: string;
+  defaultColors?: TerminalDefaultColors;
   shell?: string;
   env?: Record<string, string>;
   activityEnv?: Record<string, string>;
@@ -1041,7 +1078,7 @@ export async function createTerminal(options: CreateTerminalOptions): Promise<Te
     ptyProcess.write(`\x1b[?${buffer.cursorY + 1};${buffer.cursorX + 1}R`);
     return true;
   });
-  for (const [code, response] of TERMINAL_OSC_COLOR_QUERY_RESPONSES) {
+  for (const [code, response] of createOscColorQueryResponses(options.defaultColors)) {
     terminal.parser.registerOscHandler(code, (data) => {
       if (data.trim() !== "?") {
         return false;


### PR DESCRIPTION
Fixes #2795

## Problem

Paseo's daemon answered OSC 10, 11, and 12 with fixed dark colors for every terminal. In a light terminal, Codex used the dark background response and rendered its input with unreadable contrast.

## Solution

Capture the active terminal theme colors when the app creates a PTY. Send them as optional `defaultColors` in `create_terminal_request`, pass them through the daemon and worker, and use them for per-terminal OSC replies. The shared protocol schema validates hex colors, which the daemon converts to X11 16-bit `rgb:` values. Terminals created by older clients or the CLI keep the existing dark defaults.

```mermaid
sequenceDiagram
  participant App
  participant Daemon
  participant Agent
  App->>Daemon: create terminal + active palette
  Daemon->>Agent: start PTY
  Agent->>Daemon: OSC 10/11/12 query
  Daemon-->>Agent: terminal creation palette
```

## Scope

- Update terminal creation in the app, protocol, client, daemon, and worker forwarding.
- Reuse the protocol color schema for plugin theme validation.
- Add protocol, daemon, and browser regression coverage.
- Leave ANSI palettes and existing fallback behavior unchanged.

## Risk

The new field is optional for protocol compatibility. Invalid colors are rejected at the message boundary. 

<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/27131c84-e856-4802-8fca-b19ecaa02206" />
<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/67afdb9f-afae-4f1b-a9d8-a30681686552" />

