### PR TITLE
fix(app): keep pairing QR codes within their container

### DIFF
--- a/packages/app/e2e/browser/pair-device-relay.spec.ts
+++ b/packages/app/e2e/browser/pair-device-relay.spec.ts
@@ -1,6 +1,8 @@
+import { expect } from "@playwright/test";
 import { test } from "../support/fixtures";
 import { startIsolatedHostDaemon } from "../support/helpers/isolated-host-daemon";
 import {
+  expectPairingOffer,
   expectRelayConsent,
   openPairDeviceModal,
   preparePairingHost,
@@ -14,6 +16,44 @@ test("opens relay consent in browser web", async ({ page }) => {
     await preparePairingHost(page, daemon);
     await openPairDeviceModal(page);
     await expectRelayConsent(page);
+  } finally {
+    await daemon.close();
+  }
+});
+
+test("keeps the pairing QR code inside its compact tile", async ({ page }, testInfo) => {
+  const daemon = await startIsolatedHostDaemon("pair-device-browser-compact", {
+    mutableRelay: { enabled: true },
+  });
+  try {
+    await preparePairingHost(page, daemon);
+    await page.setViewportSize({ width: 320, height: 568 });
+    await openPairDeviceModal(page);
+    await expectPairingOffer(page);
+
+    const qr = page.getByRole("img", { name: "Pairing QR code" });
+    await qr.scrollIntoViewIfNeeded();
+    try {
+      // IntersectionObserver rounds fractional sheet/scroll coordinates.
+      await expect(qr).toBeInViewport({ ratio: 0.999 });
+    } finally {
+      await page.screenshot({ path: testInfo.outputPath("pairing-compact.png") });
+    }
+    const bounds = await qr.evaluate((element) => {
+      const tile = element.parentElement;
+      if (!tile) throw new Error("Pairing QR tile is missing");
+      const qrRect = element.getBoundingClientRect();
+      const tileRect = tile.getBoundingClientRect();
+      return {
+        qr: { x: qrRect.x, y: qrRect.y, right: qrRect.right, bottom: qrRect.bottom },
+        tile: { x: tileRect.x, y: tileRect.y, right: tileRect.right, bottom: tileRect.bottom },
+      };
+    });
+
+    expect(bounds.qr.x).toBeGreaterThanOrEqual(bounds.tile.x);
+    expect(bounds.qr.y).toBeGreaterThanOrEqual(bounds.tile.y);
+    expect(bounds.qr.right).toBeLessThanOrEqual(bounds.tile.right);
+    expect(bounds.qr.bottom).toBeLessThanOrEqual(bounds.tile.bottom);
   } finally {
     await daemon.close();
   }

--- a/packages/app/e2e/browser/pair-device-relay.spec.ts
+++ b/packages/app/e2e/browser/pair-device-relay.spec.ts
@@ -33,12 +33,8 @@ test("keeps the pairing QR code inside its compact tile", async ({ page }, testI
 
     const qr = page.getByRole("img", { name: "Pairing QR code" });
     await qr.scrollIntoViewIfNeeded();
-    try {
-      // IntersectionObserver rounds fractional sheet/scroll coordinates.
-      await expect(qr).toBeInViewport({ ratio: 0.999 });
-    } finally {
-      await page.screenshot({ path: testInfo.outputPath("pairing-compact.png") });
-    }
+    // IntersectionObserver rounds fractional sheet/scroll coordinates.
+    await expect(qr).toBeInViewport({ ratio: 0.999 });
     const bounds = await qr.evaluate((element) => {
       const tile = element.parentElement;
       if (!tile) throw new Error("Pairing QR tile is missing");
@@ -54,6 +50,7 @@ test("keeps the pairing QR code inside its compact tile", async ({ page }, testI
     expect(bounds.qr.y).toBeGreaterThanOrEqual(bounds.tile.y);
     expect(bounds.qr.right).toBeLessThanOrEqual(bounds.tile.right);
     expect(bounds.qr.bottom).toBeLessThanOrEqual(bounds.tile.bottom);
+    await page.screenshot({ path: testInfo.outputPath("pairing-compact.png") });
   } finally {
     await daemon.close();
   }

--- a/packages/app/src/desktop/components/pair-device-section.tsx
+++ b/packages/app/src/desktop/components/pair-device-section.tsx
@@ -80,7 +80,6 @@ export function PairDeviceSection({ serverId, onClose }: PairDeviceSectionProps)
         type: "svg",
         errorCorrectionLevel: "M",
         margin: 1,
-        width: 480,
       }),
     enabled: Boolean(pairingQuery.data?.url),
     dataShape: "value",
@@ -273,7 +272,8 @@ function PairingQr({ svg, isError }: { svg: string | null; isError: boolean }) {
     return (
       <SvgXml
         xml={svg}
-        style={styles.qrImage}
+        width="100%"
+        height="100%"
         accessibilityRole="image"
         accessibilityLabel={t("pairing.device.qrAccessibility")}
       />
@@ -362,10 +362,6 @@ const styles = StyleSheet.create((theme) => ({
     borderWidth: 1,
     borderColor: theme.colors.border,
     backgroundColor: theme.colors.palette.white,
-  },
-  qrImage: {
-    width: "100%",
-    height: "100%",
   },
   linkRow: {
     flexDirection: "row",


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

You MUST read CONTRIBUTING.md before sending a PR.
-->

### Linked issue

Closes #4317

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

<!-- A short description of the reasoning of this change in your own words. What was wrong, and how do you hope this PR fixes it. If you can't explain this briefly, the PR is probably too big. This description must be grounded in real user flows and framed as value provided to Paseo users. -->

When users open Settings → Host → Pair device on iOS or Android, the pairing QR code can overflow its container and become clipped, preventing them from scanning it.

The generated SVG included fixed 480×480 dimensions that conflicted with the percentage-based display style. This change removes those fixed dimensions and sets percentage width and height directly on `SvgXml`, allowing the QR code to fit its existing container.

### Goals

<!-- A bullet list of what this PR wants to accomplish, include requirements and acceptance criteria. This helps lock down the scope of the PR and prevent expanding scope over the intended goal. -->

- Display the complete pairing QR code within its container on compact screens.
- Preserve the existing desktop container layout and pairing interactions.
- Add a regression test that fails with the previous implementation.

### Non-goals

<!-- A bullet list of what this PR does not want to accomplish. Add any intentional trade offs taken. This helps lock down the scope of the PR and prevent expanding scope over the intended goal. -->

- Change pairing URLs, relay behavior, or QR encoding options.
- Redesign the pairing dialog or change its container dimensions.
- Address unrelated desktop daemon-status loading errors.

### QA

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.
-->


Testing was performed with real isolated local daemons.

**Before the fix**

- Opened the pairing dialog at a 320×568 browser viewport.
- The QR code was clipped; the regression test failed its viewport assertion.
- Captured a screenshot showing the clipped code.

**After the fix**

- Both tests in `packages/app/e2e/browser/pair-device-relay.spec.ts` passed.
- At 320×568, the QR code was fully displayed within its tile.
- Captured and inspected the updated screenshot.

**Desktop renderer**

- Checked 1024×768, 1280×800, and 1440×900 viewports.
- The QR code remained 278×278 inside its 304×304 tile.
- The dialog, link field, copy button, and security warning were fully visible.
- Verified that Copy placed the complete pairing link on the clipboard.
- Verified closing and reopening the dialog.
- These checks used a temporary diagnostic test, not a committed desktop regression test.

**Coverage limitations**

- iOS and Android device/simulator verification is still pending. Browser viewport testing does not validate native rendering.
- The packaged Electron application was not tested.
- Desktop renderer screenshots contain an unresolved daemon-status loading notification; the checks above cover the pairing layout and interactions only.

<img width="320" height="568" alt="2014ad22-ad34-44d1-824f-93aa6a758abc" src="https://github.com/user-attachments/assets/8c3b253b-ad4b-4a22-bb70-2242de9c8575" />

<img width="1440" height="900" alt="af816ab3-3b2a-4101-8535-ffd6568a752e" src="https://github.com/user-attachments/assets/9da6ea66-7986-4f65-a438-0a8735bb1715" />


**Checks**

- `npm run typecheck` passed.
- `npm run lint` passed.
- Targeted formatting of the changed files passed.
- `git diff --check` passed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense
