### PR TITLE
Send display: summarized so Claude thinking renders

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -880,7 +880,7 @@ describe("ClaudeAgentSession features", () => {
 
     expect(queryFactory.mock.calls[0]?.[0].options).toMatchObject({
       effort: "xhigh",
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "summarized" },
       settings: { ultracode: true },
     });
 
@@ -1065,7 +1065,7 @@ describe("ClaudeAgentSession features", () => {
 
   test.each([
     ["supported model", "claude-opus-4-8", { type: "disabled" }, undefined],
-    ["unsupported model", "claude-fable-5", { type: "adaptive" }, "high"],
+    ["unsupported model", "claude-fable-5", { type: "adaptive", display: "summarized" }, "high"],
     ["custom model", "openrouter/anthropic/claude-opus-4-8", undefined, undefined],
     ["provider default", null, undefined, undefined],
   ])("reconciles Off when switching to a %s", async (_label, modelId, thinking, effort) => {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -3218,10 +3218,18 @@ class ClaudeAgentSession implements AgentSession {
       return { thinking: { type: "disabled" }, effort: undefined, ultracode: false };
     }
     if (thinkingOptionId === CLAUDE_ULTRACODE_THINKING_OPTION_ID) {
-      return { thinking: { type: "adaptive" }, effort: "xhigh", ultracode: true };
+      return {
+        thinking: { type: "adaptive", display: "summarized" },
+        effort: "xhigh",
+        ultracode: true,
+      };
     }
     if (thinkingOptionId && isClaudeThinkingEffort(thinkingOptionId)) {
-      return { thinking: { type: "adaptive" }, effort: thinkingOptionId, ultracode: false };
+      return {
+        thinking: { type: "adaptive", display: "summarized" },
+        effort: thinkingOptionId,
+        ultracode: false,
+      };
     }
     return { thinking: undefined, effort: undefined, ultracode: false };
   }


### PR DESCRIPTION
### Linked issue

Closes #4342

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Claude Code agents never show a Thought row in the Paseo timeline, on any Claude 4.7+ model at any effort level. The daemon builds `thinking: { type: "adaptive" }` for the Agent SDK but never sets `display`, so the request falls through to the API default, which is `"omitted"` on Opus 4.7 and later. Every thinking block then arrives with empty text and a populated signature, and Paseo's extractor drops empty blocks by design. The result is zero `reasoning` timeline items for Claude, while Codex on the same daemon renders reasoning fine.

This PR sets `display: "summarized"` at both `resolveThinkingConfig()` call sites that enable adaptive thinking. Paseo's only reason to read thinking blocks is to show them to the user, which is exactly the case the Anthropic docs say `summarized` is for. With the change, Claude agents stream a Thought row during the turn, and **Settings > Always expand reasoning** has something to act on.

The bundled SDK (`@anthropic-ai/claude-agent-sdk` 0.3.246) already types the field on `ThinkingAdaptive`, so no dependency change is needed.

### Goals

- Claude agents with thinking enabled (any effort level, and Ultracode) receive thinking text from the API.
- `reasoning` timeline items appear for Claude agents, in the web UI and in `paseo logs --filter text`.
- Existing unit tests for the thinking option shape assert the new `display` field.

### Non-goals

- No config option or daemon setting to gate the display mode. The field is set unconditionally whenever thinking is enabled, as proposed in the issue. Happy to add a gate in a follow-up if preferred.
- No handling of the `{"type":"system","subtype":"thinking_tokens"}` message. That is mentioned as optional in the issue and is a separate change.
- No change for `thinking: { type: "disabled" }` or the provider-default path, which continue to send no `thinking` at all.
- Trade-off: with `summarized`, first answer text arrives a couple of seconds later on average because the server streams the summary first. Total turn time is unchanged, and the user sees the Thought row streaming during that gap instead of a blank wait. Measurements are in the issue.

### QA

**Reproduced before the fix** (Paseo 0.7.2, Claude Code 2.1.258, model `claude-opus-5`, effort `high`, Debian 12 in Docker): a Claude agent turn shows tool calls and assistant text but no Thought row. `paseo logs <agent-id> --filter text` lists only `[User]` and assistant text, no `[Thought]` entries. The raw `stream-json` output from the CLI under the same options carries `thinking` blocks with `"thinking":""` and a populated `signature`, while `usage.output_tokens_details.thinking_tokens` is non-zero. Full captures, the CLI A/B with `--thinking-display summarized`, and timing measurements are in #4342.

**Confirmed after the fix** on the same setup: a child image patching the two call sites in the published dist to `{ type: "adaptive", display: "summarized" }` produces `[Thought]` rows in `paseo logs --filter text` and renders the collapsed Thought row in the web UI. That patch has been running for me from 0.2.1 through 0.7.2.

**Unit tests** (`packages/server/src/server/agent/providers/claude/agent.test.ts`): the Ultracode assertion and the "reconciles Off when switching to an unsupported model" case now assert `{ type: "adaptive", display: "summarized" }`. The `toEqual` case fails on `main` without the source change and passes with it. Test, typecheck, lint, and format results are from the full CI run on my fork before opening this PR: https://github.com/ThePharmer/paseo/actions/runs/33943978065 (22 checks green).

```
 ✓ src/server/agent/providers/claude/agent.test.ts (75 tests) 800ms
 Test Files  354 passed | 11 skipped (365)
```

Platforms tested: web UI in a browser, Android, and `paseo logs` CLI, against a Linux (Docker) daemon. Not tested: iOS and Electron desktop. The change is daemon-side only, so those surfaces receive the same timeline items.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
