### PR TITLE
Add label filtering and workspace metadata to CLI listings

### DIFF
--- a/packages/cli/src/cli-surface.test.ts
+++ b/packages/cli/src/cli-surface.test.ts
@@ -73,6 +73,13 @@ describe("canonical CLI surface", () => {
     expect(open?.helpInformation()).toContain("--server <server-id>");
   });
 
+  it("filters workspace listings by label", () => {
+    const workspace = createCli().commands.find((command) => command.name() === "workspace");
+    const ls = workspace?.commands.find((command) => command.name() === "ls");
+
+    expect(ls?.helpInformation()).toContain("--label <name>");
+  });
+
   it("offers the complete local plugin lifecycle", () => {
     const plugin = createCli().commands.find((command) => command.name() === "plugin");
 

--- a/packages/cli/src/commands/agent/ls.test.ts
+++ b/packages/cli/src/commands/agent/ls.test.ts
@@ -1,6 +1,58 @@
 import { describe, expect, it } from "vitest";
-import { renderTable } from "../../output/table.js";
-import { agentLsSchema, buildAgentLsFetchOptions, toAgentListItem } from "./ls.js";
+import { renderJson, renderTable, type OutputOptions } from "../../output/index.js";
+import {
+  buildAgentLsFetchOptions,
+  runLsCommandWithDeps,
+  type AgentListSource,
+  type AgentLsClient,
+  type AgentLsDeps,
+  type FetchAgentsOptions,
+} from "./ls.js";
+
+/** Explicit so the command never consults this machine's daemon config for a default. */
+const host = "127.0.0.1:6767";
+
+const plainOutput: OutputOptions = {
+  format: "table",
+  quiet: false,
+  noHeaders: true,
+  noColor: true,
+};
+
+function agent(overrides: Partial<AgentListSource> = {}): AgentListSource {
+  return {
+    id: "agent-1234567890",
+    title: "Fix login",
+    provider: "claude",
+    model: "claude-opus-5",
+    effectiveThinkingOptionId: "high",
+    status: "idle",
+    cwd: "/tmp/project",
+    createdAt: new Date().toISOString(),
+    labels: { team: "platform", "paseo.worktree": "feature-auth" },
+    ...overrides,
+  };
+}
+
+class FakeAgentLsClient implements AgentLsClient {
+  readonly requests: FetchAgentsOptions[] = [];
+  closed = false;
+
+  constructor(private readonly agents: AgentListSource[]) {}
+
+  async fetchAgents(options: FetchAgentsOptions) {
+    this.requests.push(options);
+    return { entries: this.agents.map((entry) => ({ agent: entry })) };
+  }
+
+  async close() {
+    this.closed = true;
+  }
+}
+
+function depsFor(client: AgentLsClient): AgentLsDeps {
+  return { connectToDaemon: async () => client };
+}
 
 describe("buildAgentLsFetchOptions", () => {
   it("fetches active agents by default", () => {
@@ -61,38 +113,45 @@ describe("buildAgentLsFetchOptions", () => {
   });
 });
 
-describe("toAgentListItem", () => {
-  const agent = {
-    id: "agent-1234567890",
-    title: "Fix login",
-    provider: "claude",
-    model: "claude-opus-5",
-    effectiveThinkingOptionId: "high",
-    status: "idle" as const,
-    cwd: "/tmp/project",
-    createdAt: new Date().toISOString(),
-    labels: { team: "platform", "paseo.worktree": "feature-auth" },
-  };
+describe("agent ls", () => {
+  it("includes labels in structured output but not in the table", async () => {
+    const client = new FakeAgentLsClient([agent()]);
 
-  it("carries labels into structured output", () => {
-    expect(toAgentListItem(agent)).toMatchObject({
-      id: "agent-1234567890",
-      shortId: "agent-1",
-      name: "Fix login",
-      provider: "claude/claude-opus-5",
-      thinking: "high",
-      status: "idle",
-      cwd: "/tmp/project",
-      labels: { team: "platform", "paseo.worktree": "feature-auth" },
-    });
+    const result = await runLsCommandWithDeps({ host, global: true }, depsFor(client));
+
+    expect(client.closed).toBe(true);
+    expect(result.data).toEqual([
+      expect.objectContaining({
+        id: "agent-1234567890",
+        shortId: "agent-1",
+        name: "Fix login",
+        provider: "claude/claude-opus-5",
+        thinking: "high",
+        status: "idle",
+        cwd: "/tmp/project",
+        labels: { team: "platform", "paseo.worktree": "feature-auth" },
+      }),
+    ]);
+
+    const json = JSON.parse(renderJson(result, plainOutput));
+    expect(json[0].labels).toEqual({ team: "platform", "paseo.worktree": "feature-auth" });
+
+    const table = renderTable(result, plainOutput);
+    expect(table).toContain("Fix login");
+    expect(table).not.toContain("platform");
   });
 
-  it("keeps labels out of the table", () => {
-    const line = renderTable(
-      { type: "list", data: [toAgentListItem(agent)], schema: agentLsSchema },
-      { format: "table", quiet: false, noHeaders: true, noColor: true },
-    );
-    expect(line).toContain("Fix login");
-    expect(line).not.toContain("platform");
+  it("filters by label on the host and again on the returned agents", async () => {
+    const client = new FakeAgentLsClient([
+      agent(),
+      agent({ id: "agent-0987654321", title: "Docs", labels: { team: "docs" } }),
+    ]);
+
+    const result = await runLsCommandWithDeps({ host, label: ["team=platform"] }, depsFor(client));
+
+    expect(client.requests).toEqual([
+      { scope: "active", filter: { labels: { team: "platform" } } },
+    ]);
+    expect(result.data.map((item) => item.id)).toEqual(["agent-1234567890"]);
   });
 });

--- a/packages/cli/src/commands/agent/ls.test.ts
+++ b/packages/cli/src/commands/agent/ls.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { buildAgentLsFetchOptions } from "./ls.js";
+import { renderTable } from "../../output/table.js";
+import { agentLsSchema, buildAgentLsFetchOptions, toAgentListItem } from "./ls.js";
 
 describe("buildAgentLsFetchOptions", () => {
   it("fetches active agents by default", () => {
@@ -57,5 +58,41 @@ describe("buildAgentLsFetchOptions", () => {
         thinkingOptionId: "medium",
       },
     });
+  });
+});
+
+describe("toAgentListItem", () => {
+  const agent = {
+    id: "agent-1234567890",
+    title: "Fix login",
+    provider: "claude",
+    model: "claude-opus-5",
+    effectiveThinkingOptionId: "high",
+    status: "idle" as const,
+    cwd: "/tmp/project",
+    createdAt: new Date().toISOString(),
+    labels: { team: "platform", "paseo.worktree": "feature-auth" },
+  };
+
+  it("carries labels into structured output", () => {
+    expect(toAgentListItem(agent)).toMatchObject({
+      id: "agent-1234567890",
+      shortId: "agent-1",
+      name: "Fix login",
+      provider: "claude/claude-opus-5",
+      thinking: "high",
+      status: "idle",
+      cwd: "/tmp/project",
+      labels: { team: "platform", "paseo.worktree": "feature-auth" },
+    });
+  });
+
+  it("keeps labels out of the table", () => {
+    const line = renderTable(
+      { type: "list", data: [toAgentListItem(agent)], schema: agentLsSchema },
+      { format: "table", quiet: false, noHeaders: true, noColor: true },
+    );
+    expect(line).toContain("Fix login");
+    expect(line).not.toContain("platform");
   });
 });

--- a/packages/cli/src/commands/agent/ls.ts
+++ b/packages/cli/src/commands/agent/ls.ts
@@ -5,7 +5,7 @@ import type { CommandOptions, ListResult, OutputSchema, CommandError } from "../
 import { collectMultiple } from "../../utils/command-options.js";
 import { isSameOrDescendantPath } from "../../utils/paths.js";
 
-type FetchAgentsOptions = NonNullable<
+export type FetchAgentsOptions = NonNullable<
   Parameters<Awaited<ReturnType<typeof connectToDaemon>>["fetchAgents"]>[0]
 >;
 
@@ -48,8 +48,19 @@ export type AgentListSource = Pick<
   | "status"
   | "cwd"
   | "createdAt"
+  | "archivedAt"
   | "labels"
 >;
+
+/** The slice of the daemon client the listing uses, so tests drive the command with an in-memory fake. */
+export interface AgentLsClient {
+  fetchAgents(options: FetchAgentsOptions): Promise<{ entries: Array<{ agent: AgentListSource }> }>;
+  close(): Promise<void>;
+}
+
+export interface AgentLsDeps {
+  connectToDaemon(options: { host?: string }): Promise<AgentLsClient>;
+}
 
 /** Helper to get relative time string */
 function relativeTime(date: Date | string): string {
@@ -104,7 +115,7 @@ export const agentLsSchema: OutputSchema<AgentListItem> = {
 };
 
 /** Transform agent snapshot to AgentListItem */
-export function toAgentListItem(agent: AgentListSource): AgentListItem {
+function toListItem(agent: AgentListSource): AgentListItem {
   const model = normalizeModelId(agent.runtimeInfo?.model) ?? normalizeModelId(agent.model);
   return {
     id: agent.id,
@@ -202,11 +213,18 @@ export async function runLsCommand(
   options: AgentLsOptions,
   _command: Command,
 ): Promise<AgentLsResult> {
+  return runLsCommandWithDeps(options, { connectToDaemon });
+}
+
+export async function runLsCommandWithDeps(
+  options: AgentLsOptions,
+  deps: AgentLsDeps,
+): Promise<AgentLsResult> {
   const host = getDaemonHost({ host: options.host });
 
-  let client;
+  let client: AgentLsClient;
   try {
-    client = await connectToDaemon({ host: options.host });
+    client = await deps.connectToDaemon({ host: options.host });
   } catch (err) {
     throw daemonConnectionFailure(host, err);
   }
@@ -269,7 +287,7 @@ export async function runLsCommand(
       return bTime - aTime;
     });
 
-    const items = agents.map(toAgentListItem);
+    const items = agents.map(toListItem);
 
     return {
       type: "list",

--- a/packages/cli/src/commands/agent/ls.ts
+++ b/packages/cli/src/commands/agent/ls.ts
@@ -33,7 +33,23 @@ export interface AgentListItem {
   status: string;
   cwd: string;
   created: string;
+  /** Rendered in JSON and YAML output only; the table stays scannable without it. */
+  labels: Record<string, string>;
 }
+
+export type AgentListSource = Pick<
+  AgentSnapshotPayload,
+  | "id"
+  | "title"
+  | "provider"
+  | "model"
+  | "runtimeInfo"
+  | "effectiveThinkingOptionId"
+  | "status"
+  | "cwd"
+  | "createdAt"
+  | "labels"
+>;
 
 /** Helper to get relative time string */
 function relativeTime(date: Date | string): string {
@@ -88,7 +104,7 @@ export const agentLsSchema: OutputSchema<AgentListItem> = {
 };
 
 /** Transform agent snapshot to AgentListItem */
-function toListItem(agent: AgentSnapshotPayload): AgentListItem {
+export function toAgentListItem(agent: AgentListSource): AgentListItem {
   const model = normalizeModelId(agent.runtimeInfo?.model) ?? normalizeModelId(agent.model);
   return {
     id: agent.id,
@@ -99,6 +115,7 @@ function toListItem(agent: AgentSnapshotPayload): AgentListItem {
     status: agent.status,
     cwd: shortenPath(agent.cwd),
     created: relativeTime(agent.createdAt),
+    labels: { ...agent.labels },
   };
 }
 
@@ -252,7 +269,7 @@ export async function runLsCommand(
       return bTime - aTime;
     });
 
-    const items = agents.map(toListItem);
+    const items = agents.map(toAgentListItem);
 
     return {
       type: "list",

--- a/packages/cli/src/commands/workspace/index.ts
+++ b/packages/cli/src/commands/workspace/index.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { withOutput } from "../../output/index.js";
-import { addJsonAndDaemonHostOptions } from "../../utils/command-options.js";
+import { addJsonAndDaemonHostOptions, collectMultiple } from "../../utils/command-options.js";
 import { runArchiveCommand } from "./archive.js";
 import { runCreateCommand } from "./create.js";
 import { runLsCommand } from "./ls.js";
@@ -37,9 +37,17 @@ export function createWorkspaceCommand(): Command {
       .option("--forge <forge>", "Forge for --mode checkout-pr (default: source checkout)"),
   ).action(withOutput(runCreateCommand));
 
-  addJsonAndDaemonHostOptions(workspace.command("ls").description("List active workspaces")).action(
-    withOutput(runLsCommand),
-  );
+  addJsonAndDaemonHostOptions(
+    workspace
+      .command("ls")
+      .description("List active workspaces")
+      .option(
+        "--label <name>",
+        "Filter by label (can be used multiple times)",
+        collectMultiple,
+        [],
+      ),
+  ).action(withOutput(runLsCommand));
 
   addJsonAndDaemonHostOptions(
     workspace

--- a/packages/cli/src/commands/workspace/ls.test.ts
+++ b/packages/cli/src/commands/workspace/ls.test.ts
@@ -1,7 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { renderTable } from "../../output/table.js";
-import { matchesWorkspaceLabelFilters, parseWorkspaceLabelFilters } from "./ls.js";
-import { toWorkspaceRow, workspaceSchema, type WorkspaceRowSource } from "./shared.js";
+import { renderJson, renderTable, type OutputOptions } from "../../output/index.js";
+import {
+  runLsCommandWithDeps,
+  type FetchWorkspacesOptions,
+  type WorkspaceLsClient,
+  type WorkspaceLsDeps,
+} from "./ls.js";
+import type { WorkspaceRowSource } from "./shared.js";
+
+/** Explicit so the command never consults this machine's daemon config for a default. */
+const host = "127.0.0.1:6767";
+
+const plainOutput: OutputOptions = {
+  format: "table",
+  quiet: false,
+  noHeaders: true,
+  noColor: true,
+};
 
 function workspace(overrides: Partial<WorkspaceRowSource> = {}): WorkspaceRowSource {
   return {
@@ -30,81 +45,164 @@ function workspace(overrides: Partial<WorkspaceRowSource> = {}): WorkspaceRowSou
   };
 }
 
-describe("toWorkspaceRow", () => {
-  it("carries labels, branch, and the pull request into the row", () => {
-    expect(toWorkspaceRow(workspace())).toEqual({
-      workspaceId: "ws-1",
-      project: "paseo",
-      name: "feature/labels",
-      isolation: "worktree",
-      labels: ["Blocked", "Needs review"],
-      branch: "feature/labels",
-      pullRequest: {
-        number: 4200,
-        url: "https://github.com/getpaseo/paseo/pull/4200",
-        title: "Show workspace labels in the CLI",
-        state: "draft",
-        checksStatus: "pending",
-        reviewDecision: null,
+const unlabelled = (): WorkspaceRowSource =>
+  workspace({
+    id: "ws-2",
+    name: "main",
+    workspaceKind: "local_checkout",
+    workspaceDirectory: "/tmp/paseo",
+    labels: undefined,
+    gitRuntime: null,
+    githubRuntime: null,
+  });
+
+/** Serves one page per array entry; the cursor is the index of the next page. */
+class FakeWorkspaceLsClient implements WorkspaceLsClient {
+  readonly cursors: Array<string | undefined> = [];
+  closed = false;
+
+  constructor(
+    private readonly pages: WorkspaceRowSource[][],
+    private readonly supportsLabels = true,
+  ) {}
+
+  getLastServerInfoMessage() {
+    return { features: { workspaceLabels: this.supportsLabels } };
+  }
+
+  async fetchWorkspaces(options: FetchWorkspacesOptions) {
+    const cursor = options.page?.cursor;
+    this.cursors.push(cursor);
+    const index = cursor ? Number(cursor) : 0;
+    return {
+      entries: this.pages[index] ?? [],
+      pageInfo: { nextCursor: index + 1 < this.pages.length ? String(index + 1) : null },
+    };
+  }
+
+  async close() {
+    this.closed = true;
+  }
+}
+
+function depsFor(client: WorkspaceLsClient): WorkspaceLsDeps {
+  return { connectToDaemon: async () => client };
+}
+
+describe("workspace ls", () => {
+  it("lists labels, branch, and pull request across every page", async () => {
+    const client = new FakeWorkspaceLsClient([[workspace()], [unlabelled()]]);
+
+    const result = await runLsCommandWithDeps({ host }, depsFor(client));
+
+    expect(client.cursors).toEqual([undefined, "1"]);
+    expect(client.closed).toBe(true);
+    expect(result.data).toEqual([
+      {
+        workspaceId: "ws-1",
+        project: "paseo",
+        name: "feature/labels",
+        isolation: "worktree",
+        labels: ["Blocked", "Needs review"],
+        branch: "feature/labels",
+        pullRequest: {
+          number: 4200,
+          url: "https://github.com/getpaseo/paseo/pull/4200",
+          title: "Show workspace labels in the CLI",
+          state: "draft",
+          checksStatus: "pending",
+          reviewDecision: null,
+        },
+        cwd: "/tmp/paseo/worktrees/feature-labels",
       },
-      cwd: "/tmp/paseo/worktrees/feature-labels",
-    });
-  });
-
-  it("leaves metadata empty when the host has none", () => {
-    expect(
-      toWorkspaceRow(
-        workspace({
-          workspaceKind: "local_checkout",
-          labels: undefined,
-          gitRuntime: null,
-          githubRuntime: null,
-        }),
-      ),
-    ).toMatchObject({ isolation: "local", labels: [], branch: null, pullRequest: null });
-  });
-
-  it("derives merged and closed pull request states", () => {
-    const merged = workspace();
-    merged.githubRuntime!.pullRequest!.isMerged = true;
-    expect(toWorkspaceRow(merged).pullRequest?.state).toBe("merged");
-
-    const closed = workspace();
-    closed.githubRuntime!.pullRequest!.state = "CLOSED";
-    expect(toWorkspaceRow(closed).pullRequest?.state).toBe("closed");
-  });
-
-  it("renders labels and the pull request as table cells", () => {
-    const line = renderTable(
-      { type: "list", data: [toWorkspaceRow(workspace())], schema: workspaceSchema },
-      { format: "table", quiet: false, noHeaders: true, noColor: true },
-    );
-    expect(line).toContain("Blocked, Needs review");
-    expect(line).toContain("#4200 draft");
-  });
-});
-
-describe("workspace label filters", () => {
-  it("normalizes and dedupes requested labels", () => {
-    expect(parseWorkspaceLabelFilters([" Blocked ", "blocked", "Needs  review"])).toEqual([
-      "blocked",
-      "needs review",
+      {
+        workspaceId: "ws-2",
+        project: "paseo",
+        name: "main",
+        isolation: "local",
+        labels: [],
+        branch: null,
+        pullRequest: null,
+        cwd: "/tmp/paseo",
+      },
     ]);
-    expect(parseWorkspaceLabelFilters(undefined)).toEqual([]);
   });
 
-  it("rejects an empty label", () => {
-    expect(() => parseWorkspaceLabelFilters(["  "])).toThrow(
-      expect.objectContaining({ code: "INVALID_LABEL" }),
+  it("keeps only workspaces carrying every requested label, ignoring case", async () => {
+    const pages = [[workspace()], [unlabelled()]];
+
+    const both = await runLsCommandWithDeps(
+      { host, label: ["blocked", "Needs  review"] },
+      depsFor(new FakeWorkspaceLsClient(pages)),
     );
+    expect(both.data.map((row) => row.workspaceId)).toEqual(["ws-1"]);
+
+    const missing = await runLsCommandWithDeps(
+      { host, label: ["blocked", "shipped"] },
+      depsFor(new FakeWorkspaceLsClient(pages)),
+    );
+    expect(missing.data).toEqual([]);
   });
 
-  it("requires every requested label, ignoring case", () => {
-    const labels = ["Blocked", "Needs review"];
-    expect(matchesWorkspaceLabelFilters(labels, [])).toBe(true);
-    expect(matchesWorkspaceLabelFilters(labels, ["blocked"])).toBe(true);
-    expect(matchesWorkspaceLabelFilters(labels, ["blocked", "needs review"])).toBe(true);
-    expect(matchesWorkspaceLabelFilters(labels, ["blocked", "shipped"])).toBe(false);
-    expect(matchesWorkspaceLabelFilters([], ["blocked"])).toBe(false);
+  it("rejects an empty label before connecting", async () => {
+    let connected = false;
+    const deps: WorkspaceLsDeps = {
+      connectToDaemon: async () => {
+        connected = true;
+        return new FakeWorkspaceLsClient([]);
+      },
+    };
+
+    await expect(runLsCommandWithDeps({ host, label: ["  "] }, deps)).rejects.toMatchObject({
+      code: "INVALID_LABEL",
+    });
+    expect(connected).toBe(false);
+  });
+
+  it("requires a host that advertises workspace labels when filtering", async () => {
+    const client = new FakeWorkspaceLsClient([[workspace()]], false);
+
+    await expect(
+      runLsCommandWithDeps({ host, label: ["blocked"] }, depsFor(client)),
+    ).rejects.toMatchObject({
+      code: "DAEMON_UPDATE_REQUIRED",
+      message: "Update the host to filter workspaces by label.",
+    });
+    expect(client.closed).toBe(true);
+
+    const unfiltered = await runLsCommandWithDeps({ host }, depsFor(client));
+    expect(unfiltered.data.map((row) => row.workspaceId)).toEqual(["ws-1"]);
+  });
+
+  it("derives merged and closed pull request states", async () => {
+    const merged = workspace({ id: "merged" });
+    merged.githubRuntime!.pullRequest!.isMerged = true;
+    const closed = workspace({ id: "closed" });
+    closed.githubRuntime!.pullRequest!.state = "CLOSED";
+
+    const result = await runLsCommandWithDeps(
+      { host },
+      depsFor(new FakeWorkspaceLsClient([[merged, closed]])),
+    );
+
+    expect(result.data.map((row) => row.pullRequest?.state)).toEqual(["merged", "closed"]);
+  });
+
+  it("renders labels and the pull request in table and JSON output", async () => {
+    const result = await runLsCommandWithDeps(
+      { host },
+      depsFor(new FakeWorkspaceLsClient([[workspace(), unlabelled()]])),
+    );
+
+    const table = renderTable(result, plainOutput);
+    expect(table).toContain("Blocked, Needs review");
+    expect(table).toContain("#4200 draft");
+    expect(table.split("\n")[1]).toMatch(/local {2,}- {2,}-/);
+
+    const json = JSON.parse(renderJson(result, plainOutput));
+    expect(json[0].labels).toEqual(["Blocked", "Needs review"]);
+    expect(json[0].branch).toBe("feature/labels");
+    expect(json[0].pullRequest.state).toBe("draft");
+    expect(json[1]).toMatchObject({ labels: [], branch: null, pullRequest: null });
   });
 });

--- a/packages/cli/src/commands/workspace/ls.test.ts
+++ b/packages/cli/src/commands/workspace/ls.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { renderTable } from "../../output/table.js";
+import { matchesWorkspaceLabelFilters, parseWorkspaceLabelFilters } from "./ls.js";
+import { toWorkspaceRow, workspaceSchema, type WorkspaceRowSource } from "./shared.js";
+
+function workspace(overrides: Partial<WorkspaceRowSource> = {}): WorkspaceRowSource {
+  return {
+    id: "ws-1",
+    projectDisplayName: "paseo",
+    name: "feature/labels",
+    workspaceKind: "worktree",
+    workspaceDirectory: "/tmp/paseo/worktrees/feature-labels",
+    labels: ["Blocked", "Needs review"],
+    gitRuntime: { currentBranch: "feature/labels" },
+    githubRuntime: {
+      pullRequest: {
+        number: 4200,
+        url: "https://github.com/getpaseo/paseo/pull/4200",
+        title: "Show workspace labels in the CLI",
+        state: "open",
+        baseRefName: "main",
+        headRefName: "feature/labels",
+        isMerged: false,
+        isDraft: true,
+        checksStatus: "pending",
+        reviewDecision: null,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("toWorkspaceRow", () => {
+  it("carries labels, branch, and the pull request into the row", () => {
+    expect(toWorkspaceRow(workspace())).toEqual({
+      workspaceId: "ws-1",
+      project: "paseo",
+      name: "feature/labels",
+      isolation: "worktree",
+      labels: ["Blocked", "Needs review"],
+      branch: "feature/labels",
+      pullRequest: {
+        number: 4200,
+        url: "https://github.com/getpaseo/paseo/pull/4200",
+        title: "Show workspace labels in the CLI",
+        state: "draft",
+        checksStatus: "pending",
+        reviewDecision: null,
+      },
+      cwd: "/tmp/paseo/worktrees/feature-labels",
+    });
+  });
+
+  it("leaves metadata empty when the host has none", () => {
+    expect(
+      toWorkspaceRow(
+        workspace({
+          workspaceKind: "local_checkout",
+          labels: undefined,
+          gitRuntime: null,
+          githubRuntime: null,
+        }),
+      ),
+    ).toMatchObject({ isolation: "local", labels: [], branch: null, pullRequest: null });
+  });
+
+  it("derives merged and closed pull request states", () => {
+    const merged = workspace();
+    merged.githubRuntime!.pullRequest!.isMerged = true;
+    expect(toWorkspaceRow(merged).pullRequest?.state).toBe("merged");
+
+    const closed = workspace();
+    closed.githubRuntime!.pullRequest!.state = "CLOSED";
+    expect(toWorkspaceRow(closed).pullRequest?.state).toBe("closed");
+  });
+
+  it("renders labels and the pull request as table cells", () => {
+    const line = renderTable(
+      { type: "list", data: [toWorkspaceRow(workspace())], schema: workspaceSchema },
+      { format: "table", quiet: false, noHeaders: true, noColor: true },
+    );
+    expect(line).toContain("Blocked, Needs review");
+    expect(line).toContain("#4200 draft");
+  });
+});
+
+describe("workspace label filters", () => {
+  it("normalizes and dedupes requested labels", () => {
+    expect(parseWorkspaceLabelFilters([" Blocked ", "blocked", "Needs  review"])).toEqual([
+      "blocked",
+      "needs review",
+    ]);
+    expect(parseWorkspaceLabelFilters(undefined)).toEqual([]);
+  });
+
+  it("rejects an empty label", () => {
+    expect(() => parseWorkspaceLabelFilters(["  "])).toThrow(
+      expect.objectContaining({ code: "INVALID_LABEL" }),
+    );
+  });
+
+  it("requires every requested label, ignoring case", () => {
+    const labels = ["Blocked", "Needs review"];
+    expect(matchesWorkspaceLabelFilters(labels, [])).toBe(true);
+    expect(matchesWorkspaceLabelFilters(labels, ["blocked"])).toBe(true);
+    expect(matchesWorkspaceLabelFilters(labels, ["blocked", "needs review"])).toBe(true);
+    expect(matchesWorkspaceLabelFilters(labels, ["blocked", "shipped"])).toBe(false);
+    expect(matchesWorkspaceLabelFilters([], ["blocked"])).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/workspace/ls.ts
+++ b/packages/cli/src/commands/workspace/ls.ts
@@ -2,7 +2,12 @@ import type { Command } from "commander";
 import { workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
 import type { CommandError, ListResult } from "../../output/index.js";
-import { toWorkspaceRow, workspaceSchema, type WorkspaceRow } from "./shared.js";
+import {
+  toWorkspaceRow,
+  workspaceSchema,
+  type WorkspaceRow,
+  type WorkspaceRowSource,
+} from "./shared.js";
 
 export interface WorkspaceLsOptions {
   host?: string;
@@ -10,11 +15,28 @@ export interface WorkspaceLsOptions {
   label?: string[];
 }
 
+export type FetchWorkspacesOptions = NonNullable<
+  Parameters<Awaited<ReturnType<typeof connectToDaemon>>["fetchWorkspaces"]>[0]
+>;
+
+/** The slice of the daemon client the listing uses, so tests drive the command with an in-memory fake. */
+export interface WorkspaceLsClient {
+  getLastServerInfoMessage(): { features?: { workspaceLabels?: boolean } | null } | null;
+  fetchWorkspaces(
+    options: FetchWorkspacesOptions,
+  ): Promise<{ entries: WorkspaceRowSource[]; pageInfo: { nextCursor?: string | null } }>;
+  close(): Promise<void>;
+}
+
+export interface WorkspaceLsDeps {
+  connectToDaemon(options: { host?: string }): Promise<WorkspaceLsClient>;
+}
+
 /**
  * Labels match by the same key the host catalog uses, so `--label blocked`
  * finds a workspace labelled "Blocked".
  */
-export function parseWorkspaceLabelFilters(labels: string[] | undefined): string[] {
+function parseLabelFilters(labels: string[] | undefined): string[] {
   const keys: string[] = [];
   for (const label of labels ?? []) {
     const key = workspaceLabelKey(label);
@@ -28,10 +50,7 @@ export function parseWorkspaceLabelFilters(labels: string[] | undefined): string
   return keys;
 }
 
-export function matchesWorkspaceLabelFilters(
-  labels: readonly string[],
-  labelKeys: readonly string[],
-): boolean {
+function matchesLabelFilters(labels: readonly string[], labelKeys: readonly string[]): boolean {
   if (labelKeys.length === 0) {
     return true;
   }
@@ -43,9 +62,16 @@ export async function runLsCommand(
   options: WorkspaceLsOptions,
   _command: Command,
 ): Promise<ListResult<WorkspaceRow>> {
-  const labelKeys = parseWorkspaceLabelFilters(options.label);
+  return runLsCommandWithDeps(options, { connectToDaemon });
+}
+
+export async function runLsCommandWithDeps(
+  options: WorkspaceLsOptions,
+  deps: WorkspaceLsDeps,
+): Promise<ListResult<WorkspaceRow>> {
+  const labelKeys = parseLabelFilters(options.label);
   const host = getDaemonHost({ host: options.host });
-  const client = await connectToDaemon({ host: options.host }).catch((error: unknown) => {
+  const client = await deps.connectToDaemon({ host: options.host }).catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     throw {
       code: "DAEMON_NOT_RUNNING",
@@ -72,7 +98,7 @@ export async function runLsCommand(
       workspaces.push(...payload.entries.map(toWorkspaceRow));
       cursor = payload.pageInfo.nextCursor ?? undefined;
     } while (cursor);
-    const data = workspaces.filter((row) => matchesWorkspaceLabelFilters(row.labels, labelKeys));
+    const data = workspaces.filter((row) => matchesLabelFilters(row.labels, labelKeys));
     return { type: "list", data, schema: workspaceSchema };
   } finally {
     await client.close().catch(() => undefined);

--- a/packages/cli/src/commands/workspace/ls.ts
+++ b/packages/cli/src/commands/workspace/ls.ts
@@ -1,12 +1,49 @@
 import type { Command } from "commander";
+import { workspaceLabelKey } from "@getpaseo/protocol/workspace-labels";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
 import type { CommandError, ListResult } from "../../output/index.js";
 import { toWorkspaceRow, workspaceSchema, type WorkspaceRow } from "./shared.js";
 
+export interface WorkspaceLsOptions {
+  host?: string;
+  /** Label names; a workspace must carry every one of them. */
+  label?: string[];
+}
+
+/**
+ * Labels match by the same key the host catalog uses, so `--label blocked`
+ * finds a workspace labelled "Blocked".
+ */
+export function parseWorkspaceLabelFilters(labels: string[] | undefined): string[] {
+  const keys: string[] = [];
+  for (const label of labels ?? []) {
+    const key = workspaceLabelKey(label);
+    if (!key) {
+      throw { code: "INVALID_LABEL", message: "--label cannot be empty" } satisfies CommandError;
+    }
+    if (!keys.includes(key)) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+export function matchesWorkspaceLabelFilters(
+  labels: readonly string[],
+  labelKeys: readonly string[],
+): boolean {
+  if (labelKeys.length === 0) {
+    return true;
+  }
+  const assigned = new Set(labels.map(workspaceLabelKey));
+  return labelKeys.every((key) => assigned.has(key));
+}
+
 export async function runLsCommand(
-  options: { host?: string },
+  options: WorkspaceLsOptions,
   _command: Command,
 ): Promise<ListResult<WorkspaceRow>> {
+  const labelKeys = parseWorkspaceLabelFilters(options.label);
   const host = getDaemonHost({ host: options.host });
   const client = await connectToDaemon({ host: options.host }).catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
@@ -16,6 +53,16 @@ export async function runLsCommand(
     } satisfies CommandError;
   });
   try {
+    // COMPAT(workspaceLabels): added in v0.5.0, remove gate after 2027-08-14.
+    if (
+      labelKeys.length > 0 &&
+      client.getLastServerInfoMessage()?.features?.workspaceLabels !== true
+    ) {
+      throw {
+        code: "DAEMON_UPDATE_REQUIRED",
+        message: "Update the host to filter workspaces by label.",
+      } satisfies CommandError;
+    }
     const workspaces: WorkspaceRow[] = [];
     let cursor: string | undefined;
     do {
@@ -25,7 +72,8 @@ export async function runLsCommand(
       workspaces.push(...payload.entries.map(toWorkspaceRow));
       cursor = payload.pageInfo.nextCursor ?? undefined;
     } while (cursor);
-    return { type: "list", data: workspaces, schema: workspaceSchema };
+    const data = workspaces.filter((row) => matchesWorkspaceLabelFilters(row.labels, labelKeys));
+    return { type: "list", data, schema: workspaceSchema };
   } finally {
     await client.close().catch(() => undefined);
   }

--- a/packages/cli/src/commands/workspace/shared.ts
+++ b/packages/cli/src/commands/workspace/shared.ts
@@ -1,12 +1,51 @@
 import type { WorkspaceDescriptorPayload } from "@getpaseo/protocol/messages";
 import type { OutputSchema } from "../../output/index.js";
 
+export type WorkspacePullRequestState = "open" | "draft" | "merged" | "closed";
+
+export interface WorkspacePullRequestRow {
+  number: number | null;
+  url: string;
+  title: string;
+  state: WorkspacePullRequestState;
+  checksStatus: "none" | "pending" | "success" | "failure" | null;
+  reviewDecision: "approved" | "changes_requested" | "pending" | null;
+}
+
 export interface WorkspaceRow {
   workspaceId: string;
   project: string;
   name: string;
   isolation: "local" | "worktree";
+  labels: string[];
+  branch: string | null;
+  pullRequest: WorkspacePullRequestRow | null;
   cwd: string;
+}
+
+export type WorkspaceRowSource = Pick<
+  WorkspaceDescriptorPayload,
+  | "id"
+  | "projectDisplayName"
+  | "name"
+  | "workspaceKind"
+  | "workspaceDirectory"
+  | "labels"
+  | "gitRuntime"
+  | "githubRuntime"
+>;
+
+type WorkspacePullRequestPayload = NonNullable<
+  NonNullable<WorkspaceRowSource["githubRuntime"]>["pullRequest"]
+>;
+
+function formatPullRequestCell(pullRequest: WorkspacePullRequestRow | null): string {
+  if (!pullRequest) {
+    return "-";
+  }
+  return pullRequest.number === null
+    ? pullRequest.state
+    : `#${pullRequest.number} ${pullRequest.state}`;
 }
 
 export const workspaceSchema: OutputSchema<WorkspaceRow> = {
@@ -16,16 +55,57 @@ export const workspaceSchema: OutputSchema<WorkspaceRow> = {
     { header: "PROJECT", field: "project", width: 20 },
     { header: "NAME", field: "name", width: 22 },
     { header: "ISOLATION", field: "isolation", width: 10 },
+    {
+      header: "LABELS",
+      field: (row) => (row.labels.length > 0 ? row.labels.join(", ") : "-"),
+      width: 12,
+    },
+    { header: "PR", field: (row) => formatPullRequestCell(row.pullRequest), width: 12 },
     { header: "CWD", field: "cwd", width: 42 },
   ],
 };
 
-export function toWorkspaceRow(workspace: WorkspaceDescriptorPayload): WorkspaceRow {
+function derivePullRequestState(
+  pullRequest: WorkspacePullRequestPayload,
+): WorkspacePullRequestState {
+  const state = pullRequest.state.toLowerCase();
+  if (pullRequest.isMerged || state === "merged") {
+    return "merged";
+  }
+  if (state !== "open") {
+    return "closed";
+  }
+  if (pullRequest.isDraft) {
+    return "draft";
+  }
+  return "open";
+}
+
+function toPullRequestRow(workspace: WorkspaceRowSource): WorkspacePullRequestRow | null {
+  const pullRequest = workspace.githubRuntime?.pullRequest;
+  if (!pullRequest) {
+    return null;
+  }
+  return {
+    number: pullRequest.number ?? null,
+    url: pullRequest.url,
+    title: pullRequest.title,
+    state: derivePullRequestState(pullRequest),
+    checksStatus: pullRequest.checksStatus ?? null,
+    reviewDecision: pullRequest.reviewDecision ?? null,
+  };
+}
+
+export function toWorkspaceRow(workspace: WorkspaceRowSource): WorkspaceRow {
   return {
     workspaceId: workspace.id,
     project: workspace.projectDisplayName,
     name: workspace.name,
     isolation: workspace.workspaceKind === "worktree" ? "worktree" : "local",
+    // COMPAT(workspaceLabels): hosts before v0.5.0 omit labels; remove the fallback after 2027-08-14.
+    labels: [...(workspace.labels ?? [])],
+    branch: workspace.gitRuntime?.currentBranch ?? null,
+    pullRequest: toPullRequestRow(workspace),
     cwd: workspace.workspaceDirectory,
   };
 }

--- a/public-docs/cli.md
+++ b/public-docs/cli.md
@@ -120,11 +120,14 @@ Then list, use, rename, or archive it:
 
 ```bash
 paseo workspace ls
+paseo workspace ls --label blocked            # Only workspaces carrying that label (repeat for several)
 paseo run --workspace <workspace-id> "implement authentication"
 paseo workspace rename <workspace-id> "Auth rework"
 paseo workspace rename <workspace-id> --reset   # back to the branch or directory name
 paseo workspace archive <workspace-id>
 ```
+
+The list shows each workspace's labels and pull request. Label filters match by name, ignoring case, and a workspace must carry every label you pass. `--json` also includes the branch and the pull request's URL, title, checks, and review decision.
 
 Add `--forge <name>` to PR checkout when Paseo cannot infer the forge from the source checkout. See [Git worktrees](/docs/worktrees) for setup hooks and services.
 
@@ -196,7 +199,8 @@ behavior.
 paseo ls                    # Running agents in current directory
 paseo ls -a                 # Include completed/stopped agents
 paseo ls -g                 # All directories
-paseo ls -a -g --json       # Full list as JSON
+paseo ls --label team=api   # Only agents carrying that label (repeat for several)
+paseo ls -a -g --json       # Full list as JSON, including each agent's labels
 ```
 
 ## Streaming output


### PR DESCRIPTION
## Problem

`paseo ls` accepts `--label key=value` but never shows which labels an agent carries, so there is no way to discover what to filter on. `paseo workspace ls` has no label filter at all and hides the metadata the app shows for a workspace: its labels, branch, and pull request.

## Change

CLI only. No protocol changes.

- **`paseo ls` / `paseo agent ls`**: `--json` and `--format yaml` rows now include `labels`. The table is unchanged.
- **`paseo workspace ls --label <name>`**: new repeatable filter. Matching uses the same key as the host label catalog (case-insensitive, whitespace-normalized), and a workspace must carry every requested label. Filtering runs in the CLI over the paged list.
- **`paseo workspace ls` output**: the table gains `LABELS` and `PR` columns (`#4200 draft` / `open` / `merged` / `closed`, `-` when none). JSON/YAML rows add `labels`, `branch`, and `pullRequest` (`number`, `url`, `title`, `state`, `checksStatus`, `reviewDecision`). `workspace create` shares the row shape and shows the same fields.
- **Docs**: `public-docs/cli.md` shows the new flag and describes the output.

## Compatibility

- `labels` on the workspace descriptor is already optional on the wire (`COMPAT(workspaceLabels)`); the CLI maps a missing field to an empty list at one tagged site.
- `--label` on `workspace ls` is gated on `server_info.features.workspaceLabels`. An older host gets `DAEMON_UPDATE_REQUIRED` ("Update the host to filter workspaces by label.") instead of a silently empty list. Tagged `COMPAT(workspaceLabels)`.

## Tests

Unit tests in `packages/cli/src/commands/workspace/ls.test.ts`, `packages/cli/src/commands/agent/ls.test.ts`, and `packages/cli/src/cli-surface.test.ts` cover row mapping, PR state derivation, filter parsing and matching, table rendering, and the CLI help surface.

```
$ npx vitest run src/commands/agent/ls.test.ts src/commands/workspace/ls.test.ts src/cli-surface.test.ts
 Test Files  3 passed (3)
      Tests  25 passed (25)
```

`npm run typecheck`, `npm run lint`, and `npm run format` are clean.

## QA evidence

Ran the CLI from source against an isolated in-process daemon (`createTestPaseoDaemon`, see `docs/ad-hoc-daemon-testing.md`) with two workspaces on the same directory. One was labelled "Blocked" and "Needs review" through `workspace.label.assignment.set.request`.

```
$ paseo workspace ls
WORKSPACE ID          PROJECT                  NAME                     ISOLATION   LABELS                 PR            CWD
wks_4fcdfeb5298bcff6  paseo-cli-labels-MrsxMU  Labelled workspace       local       Blocked, Needs review  -             /tmp/paseo-cli-labels-MrsxMU
wks_d91ae9eadfb45a3b  paseo-cli-labels-MrsxMU  paseo-cli-labels-MrsxMU  local       -                      -             /tmp/paseo-cli-labels-MrsxMU

$ paseo workspace ls --label blocked --label 'needs review'
WORKSPACE ID          PROJECT                  NAME                    ISOLATION   LABELS                 PR            CWD
wks_4fcdfeb5298bcff6  paseo-cli-labels-MrsxMU  Labelled workspace      local       Blocked, Needs review  -             /tmp/paseo-cli-labels-MrsxMU

$ paseo workspace ls --label shipped

$ paseo workspace ls --json
[
  {
    "workspaceId": "wks_4fcdfeb5298bcff6",
    "project": "paseo-cli-labels-MrsxMU",
    "name": "Labelled workspace",
    "isolation": "local",
    "labels": [
      "Blocked",
      "Needs review"
    ],
    "branch": null,
    "pullRequest": null,
    "cwd": "/tmp/paseo-cli-labels-MrsxMU"
  },
  {
    "workspaceId": "wks_d91ae9eadfb45a3b",
    "project": "paseo-cli-labels-MrsxMU",
    "name": "paseo-cli-labels-MrsxMU",
    "isolation": "local",
    "labels": [],
    "branch": null,
    "pullRequest": null,
    "cwd": "/tmp/paseo-cli-labels-MrsxMU"
  }
]

$ paseo ls -a -g --json
[]
```

`branch` is null because the temp repo has no commits, and `pullRequest` is null because there is no forge. PR rendering is covered by the unit tests (`draft`, `merged`, and `closed` derivation, and the `#4200 draft` table cell).


## Platforms

| Platform            | Tested | Notes                                  |
| ------------------- | ------ | -------------------------------------- |
| Desktop Linux       | ✅     | Daemon and CLI from source, Node 24    |
| Desktop macOS       | ✅     |                                        |
| Desktop Windows     | ❌     |                                        |
| iOS / Android / Web | n/a    | CLI-only change, no app or UI surfaces |