### PR TITLE
Add terminal close confirmation with remember option

### DIFF
--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -955,3 +955,45 @@ describe("parseClampedFontSize", () => {
     expect(parseClampedFontSize("abc", { min: 11, max: 24 })).toBeNull();
   });
 });
+
+describe("confirmTerminalClose", () => {
+  it("defaults to true", async () => {
+    expect(DEFAULT_CLIENT_SETTINGS.confirmTerminalClose).toBe(true);
+    expect((await loadAppSettingsFromStorage(makeDeps())).confirmTerminalClose).toBe(true);
+  });
+
+  it("loads a persisted false back", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ confirmTerminalClose: false }),
+      }),
+    });
+
+    expect((await loadAppSettingsFromStorage(deps)).confirmTerminalClose).toBe(false);
+  });
+
+  it("falls back to true when the persisted value is invalid", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ confirmTerminalClose: "never" }),
+      }),
+    });
+
+    expect((await loadAppSettingsFromStorage(deps)).confirmTerminalClose).toBe(true);
+  });
+
+  it("round-trips a saved value", async () => {
+    const deps = makeDeps();
+
+    await saveAppSettings({
+      queryClient: new QueryClient(),
+      updates: { confirmTerminalClose: false },
+      deps,
+    });
+
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "{}")).toMatchObject({
+      confirmTerminalClose: false,
+    });
+    expect((await loadAppSettingsFromStorage(deps)).confirmTerminalClose).toBe(false);
+  });
+});

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -72,6 +72,8 @@ export interface AppSettings {
   sendBehavior: SendBehavior;
   serviceUrlBehavior: ServiceUrlBehavior;
   terminalScrollbackLines: number;
+  /** Ask before closing a terminal tab. */
+  confirmTerminalClose: boolean;
   useLegacyTerminalRenderer: boolean;
   uiFontFamily: string; // "" = platform default UI stack
   monoFontFamily: string; // "" = platform default mono stack
@@ -126,6 +128,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   sendBehavior: "steer",
   serviceUrlBehavior: "ask",
   terminalScrollbackLines: DEFAULT_TERMINAL_SCROLLBACK_LINES,
+  confirmTerminalClose: true,
   useLegacyTerminalRenderer: false,
   uiFontFamily: "",
   monoFontFamily: "",
@@ -204,6 +207,7 @@ const StoredAppSettingsSchema = z
       MIN_TERMINAL_SCROLLBACK_LINES,
       MAX_TERMINAL_SCROLLBACK_LINES,
     ).catch(DEFAULT_TERMINAL_SCROLLBACK_LINES),
+    confirmTerminalClose: z.boolean().catch(true),
     useLegacyTerminalRenderer: z.boolean().catch(false),
     uiFontFamily: sanitizedFontFamily().catch(""),
     monoFontFamily: sanitizedFontFamily().catch(""),

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -650,6 +650,7 @@ export const ar: TranslationResources = {
         reloadedAgent: "وكيل إعادة تحميل",
         failedToReloadAgent: "فشل في إعادة تحميل الوكيل",
         failedToCloseAgent: "فشل في إغلاق الوكيل",
+        failedToSaveClosePreference: "تعذّر حفظ تفضيل إغلاق المحطة",
       },
       confirmations: {
         unsavedTitle: "تغييرات غير محفوظة",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -664,6 +664,8 @@ export const ar: TranslationResources = {
         archive: "أرشيف",
         closeTerminalTitle: "إغلاق المحطة؟",
         closeTerminalMessage: "سيتم إيقاف أي عملية جارية في هذه المحطة على الفور.",
+        rememberChoice: "تذكر هذا الاختيار",
+        closeAndDontAskAgain: "إغلاق وعدم السؤال مرة أخرى",
         archiveRunningAgentTitle: "وكيل تشغيل الأرشيف؟",
         archiveRunningAgentMessage:
           "هذا الوكيل لا يزال قيد التشغيل. ستؤدي أرشفته إلى إيقاف الوكيل وإغلاق علامة التبويب.",
@@ -2005,6 +2007,10 @@ export const ar: TranslationResources = {
         label: "التمرير Terminal",
         description: "يتم الاحتفاظ بالخطوط في المخزن المؤقت الطرفي المدمج",
         accessibilityLabel: "خطوط التمرير Terminal",
+      },
+      confirmTerminalClose: {
+        label: "تأكيد إغلاق المحطات",
+        description: "اسأل قبل إغلاق علامة تبويب المحطة",
       },
       autoExpandReasoning: {
         label: "عرض التفكير دائماً",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -648,6 +648,7 @@ export const en = {
         reloadedAgent: "Reloaded agent",
         failedToReloadAgent: "Failed to reload agent",
         failedToCloseAgent: "Failed to close agent",
+        failedToSaveClosePreference: "Couldn't save your terminal close preference",
       },
       confirmations: {
         close: "Close",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -661,6 +661,8 @@ export const en = {
         bulkUnsaved: "{{count}} tab(s) have unsaved changes. Closing will discard those drafts.",
         closeTerminalTitle: "Close terminal?",
         closeTerminalMessage: "Any running process in this terminal will be stopped immediately.",
+        rememberChoice: "Remember this choice",
+        closeAndDontAskAgain: "Close and don't ask again",
         archiveRunningAgentTitle: "Archive running agent?",
         archiveRunningAgentMessage:
           "This agent is still running. Archiving it will stop the agent and close the tab.",
@@ -2110,6 +2112,10 @@ export const en = {
         label: "Terminal scrollback",
         description: "Lines kept in the built-in terminal buffer",
         accessibilityLabel: "Terminal scrollback lines",
+      },
+      confirmTerminalClose: {
+        label: "Confirm closing terminals",
+        description: "Ask before closing a terminal tab",
       },
       autoExpandReasoning: {
         label: "Always expand reasoning",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -655,6 +655,7 @@ export const es: TranslationResources = {
         reloadedAgent: "Agente recargado",
         failedToReloadAgent: "No se pudo recargar el agente",
         failedToCloseAgent: "No se pudo cerrar el agente",
+        failedToSaveClosePreference: "No se pudo guardar tu preferencia de cierre de terminal",
       },
       confirmations: {
         unsavedTitle: "Cambios sin guardar",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -670,6 +670,8 @@ export const es: TranslationResources = {
         closeTerminalTitle: "¿Cerrar terminal?",
         closeTerminalMessage:
           "Cualquier proceso en ejecución en esta terminal se detendrá inmediatamente.",
+        rememberChoice: "Recordar esta elección",
+        closeAndDontAskAgain: "Cerrar y no volver a preguntar",
         archiveRunningAgentTitle: "¿Agente de ejecución de archivos?",
         archiveRunningAgentMessage:
           "Este agente todavía está ejecutándose. Archivarlo detendrá al agente y cerrará la pestaña.",
@@ -2054,6 +2056,10 @@ export const es: TranslationResources = {
         label: "Historial de terminal",
         description: "Líneas mantenidas en el búfer de terminal incorporado",
         accessibilityLabel: "Líneas del historial de terminal",
+      },
+      confirmTerminalClose: {
+        label: "Confirmar el cierre de terminales",
+        description: "Preguntar antes de cerrar una pestaña de terminal",
       },
       autoExpandReasoning: {
         label: "Siempre expandir razonamiento",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -655,6 +655,8 @@ export const fr: TranslationResources = {
         reloadedAgent: "Agent rechargé",
         failedToReloadAgent: "Échec du rechargement de l'agent",
         failedToCloseAgent: "Échec de la fermeture de l'agent",
+        failedToSaveClosePreference:
+          "Impossible d'enregistrer votre préférence de fermeture du terminal",
       },
       confirmations: {
         unsavedTitle: "Modifications non enregistrées",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -670,6 +670,8 @@ export const fr: TranslationResources = {
         closeTerminalTitle: "Fermer le terminal?",
         closeTerminalMessage:
           "Tout processus en cours d’exécution dans ce terminal sera immédiatement arrêté.",
+        rememberChoice: "Mémoriser ce choix",
+        closeAndDontAskAgain: "Fermer et ne plus demander",
         archiveRunningAgentTitle: "Archiver l'agent en cours d'exécution?",
         archiveRunningAgentMessage:
           "Cet agent est toujours en cours d'exécution. L'archiver arrêtera l'agent et fermera l'onglet.",
@@ -2058,6 +2060,10 @@ export const fr: TranslationResources = {
         label: "DéfilementTerminal",
         description: "Lignes conservées dans le tampon du terminal intégré",
         accessibilityLabel: "Lignes de défilementTerminal",
+      },
+      confirmTerminalClose: {
+        label: "Confirmer la fermeture des terminaux",
+        description: "Demander avant de fermer un onglet de terminal",
       },
       autoExpandReasoning: {
         label: "Toujours afficher le raisonnement",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -655,6 +655,7 @@ export const ja: TranslationResources = {
         reloadedAgent: "エージェントを再読み込みしました",
         failedToReloadAgent: "エージェントの再読み込みに失敗しました",
         failedToCloseAgent: "エージェントを閉じられませんでした",
+        failedToSaveClosePreference: "ターミナルを閉じる設定を保存できませんでした",
       },
       confirmations: {
         unsavedTitle: "未保存の変更",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -667,6 +667,8 @@ export const ja: TranslationResources = {
         archive: "アーカイブ",
         closeTerminalTitle: "ターミナルを閉じますか？",
         closeTerminalMessage: "このターミナルで実行中のプロセスはすぐに停止されます。",
+        rememberChoice: "この選択を記憶する",
+        closeAndDontAskAgain: "閉じて今後確認しない",
         archiveRunningAgentTitle: "実行中のエージェントをアーカイブしますか？",
         archiveRunningAgentMessage:
           "このエージェントはまだ実行中です。アーカイブするとエージェントが停止してタブが閉じられます。",
@@ -2022,6 +2024,10 @@ export const ja: TranslationResources = {
         label: "ターミナルスクロールバック",
         description: "組み込みターミナルバッファに保持する行数",
         accessibilityLabel: "ターミナルスクロールバック行数",
+      },
+      confirmTerminalClose: {
+        label: "ターミナルを閉じる前に確認",
+        description: "ターミナルのタブを閉じる前に確認します",
       },
       autoExpandReasoning: {
         label: "常に思考プロセスを展開",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -652,6 +652,7 @@ export const ko: TranslationResources = {
         reloadedAgent: "에이전트를 다시 로드했습니다",
         failedToReloadAgent: "에이전트를 다시 로드하지 못했습니다",
         failedToCloseAgent: "에이전트를 닫지 못했습니다",
+        failedToSaveClosePreference: "터미널 닫기 설정을 저장하지 못했습니다",
       },
       confirmations: {
         close: "닫기",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -665,6 +665,8 @@ export const ko: TranslationResources = {
           "{{count}} 탭에 저장되지 않은 변경 사항이 있습니다. 종료하면 해당 초안이 삭제됩니다.",
         closeTerminalTitle: "터미널을 닫을까요?",
         closeTerminalMessage: "이 터미널에서 실행 중인 프로세스가 즉시 중지됩니다.",
+        rememberChoice: "이 선택 기억하기",
+        closeAndDontAskAgain: "닫고 다시 묻지 않기",
         archiveRunningAgentTitle: "실행 중인 에이전트를 보관할까요?",
         archiveRunningAgentMessage:
           "이 에이전트는 아직 실행 중입니다. 보관하면 에이전트가 중지되고 탭이 닫힙니다.",
@@ -2016,6 +2018,10 @@ export const ko: TranslationResources = {
         label: "터미널 스크롤백",
         description: "내장 터미널 버퍼에 보관되는 줄 수",
         accessibilityLabel: "터미널 스크롤백 줄 수",
+      },
+      confirmTerminalClose: {
+        label: "터미널 닫기 전 확인",
+        description: "터미널 탭을 닫기 전에 물어봅니다",
       },
       autoExpandReasoning: {
         label: "추론 항상 펼치기",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -654,6 +654,8 @@ export const ptBR: TranslationResources = {
         reloadedAgent: "Agente recarregado",
         failedToReloadAgent: "Falha ao recarregar agente",
         failedToCloseAgent: "Falha ao fechar agente",
+        failedToSaveClosePreference:
+          "Não foi possível salvar sua preferência de fechamento do terminal",
       },
       confirmations: {
         unsavedTitle: "Alterações não salvas",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -668,6 +668,8 @@ export const ptBR: TranslationResources = {
         closeTerminalTitle: "Fechar terminal?",
         closeTerminalMessage:
           "Qualquer processo em execução neste terminal será interrompido imediatamente.",
+        rememberChoice: "Lembrar desta escolha",
+        closeAndDontAskAgain: "Fechar e não perguntar novamente",
         archiveRunningAgentTitle: "Arquivar agente em execução?",
         archiveRunningAgentMessage:
           "Este agente ainda está em execução. Arquivá-lo interromperá o agente e fechará a aba.",
@@ -2038,6 +2040,10 @@ export const ptBR: TranslationResources = {
         label: "Scrollback do terminal",
         description: "Linhas mantidas no buffer do terminal integrado",
         accessibilityLabel: "Linhas do scrollback do terminal",
+      },
+      confirmTerminalClose: {
+        label: "Confirmar o fechamento de terminais",
+        description: "Perguntar antes de fechar uma aba de terminal",
       },
       autoExpandReasoning: {
         label: "Sempre expandir raciocínio",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -655,6 +655,7 @@ export const ru: TranslationResources = {
         reloadedAgent: "Агент перезагружен",
         failedToReloadAgent: "Не удалось перезагрузить агента",
         failedToCloseAgent: "Не удалось закрыть агента",
+        failedToSaveClosePreference: "Не удалось сохранить настройку закрытия терминала",
       },
       confirmations: {
         unsavedTitle: "Несохранённые изменения",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -670,6 +670,8 @@ export const ru: TranslationResources = {
         closeTerminalTitle: "Закрыть терминал?",
         closeTerminalMessage:
           "Любой запущенный процесс в этом терминале будет немедленно остановлен.",
+        rememberChoice: "Запомнить выбор",
+        closeAndDontAskAgain: "Закрыть и больше не спрашивать",
         archiveRunningAgentTitle: "Архивировать работающего агента?",
         archiveRunningAgentMessage:
           "Этот агент всё ещё работает. При архивировании агент будет остановлен, а вкладка закрыта.",
@@ -2038,6 +2040,10 @@ export const ru: TranslationResources = {
         label: "Буфер прокрутки терминала",
         description: "Количество строк, сохраняемых во встроенном буфере терминала",
         accessibilityLabel: "Количество строк в буфере прокрутки терминала",
+      },
+      confirmTerminalClose: {
+        label: "Подтверждать закрытие терминалов",
+        description: "Спрашивать перед закрытием вкладки терминала",
       },
       autoExpandReasoning: {
         label: "Всегда разворачивать размышления",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -650,6 +650,7 @@ export const zhCN: TranslationResources = {
         reloadedAgent: "已重新加载 Agent",
         failedToReloadAgent: "重新加载 Agent 失败",
         failedToCloseAgent: "关闭 Agent 失败",
+        failedToSaveClosePreference: "无法保存终端关闭偏好设置",
       },
       confirmations: {
         unsavedTitle: "未保存的更改",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -662,6 +662,8 @@ export const zhCN: TranslationResources = {
         archive: "归档",
         closeTerminalTitle: "关闭 Terminal？",
         closeTerminalMessage: "此 Terminal 中任何正在运行的进程都会立即停止。",
+        rememberChoice: "记住此选择",
+        closeAndDontAskAgain: "关闭并不再询问",
         archiveRunningAgentTitle: "归档正在运行的 Agent？",
         archiveRunningAgentMessage: "此 Agent 仍在运行。归档会停止该 Agent 并关闭标签。",
         closeTabsLeftTitle: "关闭左侧标签？",
@@ -1981,6 +1983,10 @@ export const zhCN: TranslationResources = {
         label: "终端回滚",
         description: "内置终端缓冲区保留的行数",
         accessibilityLabel: "终端回滚行数",
+      },
+      confirmTerminalClose: {
+        label: "关闭终端前确认",
+        description: "关闭终端标签前先询问",
       },
       autoExpandReasoning: {
         label: "始终展开推理过程",

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -285,6 +285,7 @@ interface GeneralSectionProps {
   handleServiceUrlBehaviorChange: (behavior: ServiceUrlBehavior) => void;
   handleLanguageChange: (language: AppLanguage) => void;
   handleTerminalScrollbackLinesChange: (lines: number) => void;
+  handleConfirmTerminalCloseChange: (enabled: boolean) => void;
 }
 
 interface ServiceUrlBehaviorMenuItemProps {
@@ -359,6 +360,7 @@ function GeneralSection({
   handleServiceUrlBehaviorChange,
   handleLanguageChange,
   handleTerminalScrollbackLinesChange,
+  handleConfirmTerminalCloseChange,
 }: GeneralSectionProps) {
   const { t, i18n } = useTranslation();
   const activeLocale = getActiveLocale(i18n.language);
@@ -504,6 +506,21 @@ function GeneralSection({
             selectTextOnFocus
             style={styles.terminalScrollbackInput}
             accessibilityLabel={t("settings.general.terminalScrollback.accessibilityLabel")}
+          />
+        </View>
+        <View style={[settingsStyles.row, settingsStyles.rowBorder]}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>
+              {t("settings.general.confirmTerminalClose.label")}
+            </Text>
+            <Text style={settingsStyles.rowHint}>
+              {t("settings.general.confirmTerminalClose.description")}
+            </Text>
+          </View>
+          <Switch
+            value={settings.confirmTerminalClose}
+            onValueChange={handleConfirmTerminalCloseChange}
+            accessibilityLabel={t("settings.general.confirmTerminalClose.label")}
           />
         </View>
       </View>
@@ -1263,6 +1280,13 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     [updateSettings],
   );
 
+  const handleConfirmTerminalCloseChange = useCallback(
+    (confirmTerminalClose: boolean) => {
+      void updateSettings({ confirmTerminalClose });
+    },
+    [updateSettings],
+  );
+
   const handleUseLegacyTerminalRendererChange = useCallback(
     (useLegacyTerminalRenderer: boolean) => {
       void updateSettings({ useLegacyTerminalRenderer });
@@ -1501,6 +1525,7 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
                   handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
                   handleLanguageChange={handleLanguageChange}
                   handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
+                  handleConfirmTerminalCloseChange={handleConfirmTerminalCloseChange}
                 />
                 {isDesktopApp ? <BrowserDataSection /> : null}
               </>

--- a/packages/app/src/screens/workspace/terminals/remember-close-choice.test.ts
+++ b/packages/app/src/screens/workspace/terminals/remember-close-choice.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { rememberTerminalCloseChoice } from "./remember-close-choice";
+
+describe("rememberTerminalCloseChoice", () => {
+  it("reports success and stays quiet when the preference is written", async () => {
+    const failures: unknown[] = [];
+    let persisted = 0;
+
+    const stored = await rememberTerminalCloseChoice({
+      persist: async () => {
+        persisted += 1;
+      },
+      onFailure: (error) => failures.push(error),
+    });
+
+    expect(stored).toBe(true);
+    expect(persisted).toBe(1);
+    expect(failures).toEqual([]);
+  });
+
+  it("surfaces the rejection instead of leaving an unhandled promise", async () => {
+    const writeError = new Error("quota exceeded");
+    const failures: unknown[] = [];
+
+    const stored = await rememberTerminalCloseChoice({
+      persist: async () => {
+        throw writeError;
+      },
+      onFailure: (error) => failures.push(error),
+    });
+
+    expect(stored).toBe(false);
+    expect(failures).toEqual([writeError]);
+  });
+});

--- a/packages/app/src/screens/workspace/terminals/remember-close-choice.ts
+++ b/packages/app/src/screens/workspace/terminals/remember-close-choice.ts
@@ -1,0 +1,26 @@
+export interface RememberTerminalCloseChoiceInput {
+  /** Writes the preference. Rejects when the underlying storage write fails. */
+  persist: () => Promise<void>;
+  /** Called with the rejection so the caller can keep the failure visible to the user. */
+  onFailure: (error: unknown) => void;
+}
+
+/**
+ * Stores the user's "don't ask again" answer from the terminal close dialog.
+ *
+ * The settings cache is updated before the storage write, so a rejected write leaves the app
+ * behaving as if the preference stuck while nothing was saved. Swallowing that would hand the
+ * user a setting that silently reverts on restart, so the failure is reported instead. Closing
+ * the terminal is what the user actually asked for and still goes ahead either way.
+ */
+export async function rememberTerminalCloseChoice(
+  input: RememberTerminalCloseChoiceInput,
+): Promise<boolean> {
+  try {
+    await input.persist();
+    return true;
+  } catch (error) {
+    input.onFailure(error);
+    return false;
+  }
+}

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -79,7 +79,7 @@ import {
   type WorkspaceTab,
   type WorkspaceTabTarget,
 } from "@/workspace-tabs/model";
-import { useSettings } from "@/hooks/use-settings";
+import { persistAppSettings, useSettings } from "@/hooks/use-settings";
 import { useKeyboardActionHandler } from "@/hooks/use-keyboard-action-handler";
 import { buildWorkspaceKeyboardHandlerId } from "@/keyboard/handler-id";
 import type {
@@ -105,7 +105,7 @@ import {
 import { useWorkspace } from "@/stores/session-store-hooks";
 import { useWorkspaceTerminalSessionRetention } from "@/terminal/hooks/use-workspace-terminal-session-retention";
 import type { CheckoutStatusPayload } from "@/git/use-status-query";
-import { confirmDialog } from "@/utils/confirm-dialog";
+import { confirmDialog, confirmDialogWithRemember } from "@/utils/confirm-dialog";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import { removeResidentBrowserWebview } from "@/desktop/browser/resident-webviews";
@@ -1837,6 +1837,7 @@ function WorkspaceScreenContent({
   );
   const openInSidePane = useSettings((settings) => settings.openInSidePane);
   const pullRequestOpenLocation = useSettings((settings) => settings.pullRequestOpenLocation);
+  const confirmTerminalClose = useSettings((settings) => settings.confirmTerminalClose);
   const focusWorkspaceTab = useWorkspaceLayoutStore((state) => state.focusTab);
   const selectWorkspaceTabInPane = useWorkspaceLayoutStore((state) => state.selectTabInPane);
   const closeWorkspaceTab = useWorkspaceLayoutStore((state) => state.closeTab);
@@ -2488,15 +2489,22 @@ function WorkspaceScreenContent({
     async (input: { tabId: string; terminalId: string }) => {
       const { tabId, terminalId } = input;
       await closeTab(tabId, async () => {
-        const confirmed = await confirmDialog({
-          title: t("workspace.tabs.confirmations.closeTerminalTitle"),
-          message: t("workspace.tabs.confirmations.closeTerminalMessage"),
-          confirmLabel: t("workspace.tabs.confirmations.close"),
-          cancelLabel: t("workspace.tabs.confirmations.cancel"),
-          destructive: true,
-        });
-        if (!confirmed) {
-          return;
+        if (confirmTerminalClose) {
+          const { confirmed, remember } = await confirmDialogWithRemember({
+            title: t("workspace.tabs.confirmations.closeTerminalTitle"),
+            message: t("workspace.tabs.confirmations.closeTerminalMessage"),
+            confirmLabel: t("workspace.tabs.confirmations.close"),
+            cancelLabel: t("workspace.tabs.confirmations.cancel"),
+            rememberLabel: t("workspace.tabs.confirmations.rememberChoice"),
+            rememberConfirmLabel: t("workspace.tabs.confirmations.closeAndDontAskAgain"),
+            destructive: true,
+          });
+          if (!confirmed) {
+            return;
+          }
+          if (remember) {
+            void persistAppSettings({ confirmTerminalClose: false });
+          }
         }
 
         removeTerminalFromCache(terminalId);
@@ -2514,6 +2522,7 @@ function WorkspaceScreenContent({
     [
       closeTab,
       closeWorkspaceTabWithCleanup,
+      confirmTerminalClose,
       invalidateTerminals,
       killTerminalAsync,
       persistenceKey,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -106,6 +106,7 @@ import { useWorkspace } from "@/stores/session-store-hooks";
 import { useWorkspaceTerminalSessionRetention } from "@/terminal/hooks/use-workspace-terminal-session-retention";
 import type { CheckoutStatusPayload } from "@/git/use-status-query";
 import { confirmDialog, confirmDialogWithRemember } from "@/utils/confirm-dialog";
+import { rememberTerminalCloseChoice } from "@/screens/workspace/terminals/remember-close-choice";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import { removeResidentBrowserWebview } from "@/desktop/browser/resident-webviews";
@@ -2503,7 +2504,15 @@ function WorkspaceScreenContent({
             return;
           }
           if (remember) {
-            void persistAppSettings({ confirmTerminalClose: false });
+            await rememberTerminalCloseChoice({
+              persist: () => persistAppSettings({ confirmTerminalClose: false }),
+              onFailure: (error) => {
+                console.error("[WorkspaceScreen] Failed to save terminal close preference", {
+                  error,
+                });
+                toast.error(t("workspace.tabs.toasts.failedToSaveClosePreference"));
+              },
+            });
           }
         }
 
@@ -2528,6 +2537,7 @@ function WorkspaceScreenContent({
       persistenceKey,
       removeTerminalFromCache,
       t,
+      toast,
     ],
   );
 

--- a/packages/app/src/utils/confirm-dialog.fakes.ts
+++ b/packages/app/src/utils/confirm-dialog.fakes.ts
@@ -1,0 +1,118 @@
+import type {
+  DesktopDialogAskOptions,
+  DesktopDialogAskWithCheckboxOptions,
+  DesktopDialogAskWithCheckboxResult,
+  DesktopDialogBridge,
+} from "@/desktop/host";
+import type {
+  ConfirmDialogAlertRequest,
+  ConfirmDialogHost,
+  ConfirmDialogAlertButtonStyle,
+} from "./confirm-dialog";
+
+export interface RecordedDesktopAsk {
+  message: string;
+  options?: DesktopDialogAskOptions;
+}
+
+export interface RecordedDesktopAskWithCheckbox {
+  message: string;
+  options: DesktopDialogAskWithCheckboxOptions;
+}
+
+export interface FakeConfirmDialogHostOptions {
+  isNative?: boolean;
+  /** Which alert button the user presses; `undefined` dismisses the alert instead. */
+  pressAlertButton?: string;
+  desktopAsk?: (message: string, options?: DesktopDialogAskOptions) => boolean;
+  desktopAskWithCheckbox?: (
+    message: string,
+    options: DesktopDialogAskWithCheckboxOptions,
+  ) => DesktopDialogAskWithCheckboxResult;
+  browserConfirm?: (message: string) => boolean;
+}
+
+export interface FakeConfirmDialogHost extends ConfirmDialogHost {
+  readonly alerts: ConfirmDialogAlertRequest[];
+  readonly desktopAsks: RecordedDesktopAsk[];
+  readonly desktopAsksWithCheckbox: RecordedDesktopAskWithCheckbox[];
+  readonly browserPrompts: string[];
+  readonly blurCount: () => number;
+  /** Button labels of the last alert, in the order the platform would render them. */
+  lastAlertButtons(): Array<{ text: string; style: ConfirmDialogAlertButtonStyle }>;
+}
+
+/**
+ * In-memory stand-in for the platform behind a confirmation. It records what each backend was
+ * asked and replays the answer the test configured, so a test never has to stand in for React
+ * Native, the desktop bridge, or `window`.
+ */
+export function createFakeConfirmDialogHost(
+  options: FakeConfirmDialogHostOptions = {},
+): FakeConfirmDialogHost {
+  const alerts: ConfirmDialogAlertRequest[] = [];
+  const desktopAsks: RecordedDesktopAsk[] = [];
+  const desktopAsksWithCheckbox: RecordedDesktopAskWithCheckbox[] = [];
+  const browserPrompts: string[] = [];
+  let blurs = 0;
+
+  const dialog: DesktopDialogBridge = {};
+  if (options.desktopAsk) {
+    const answer = options.desktopAsk;
+    dialog.ask = async (message, askOptions) => {
+      desktopAsks.push({ message, options: askOptions });
+      return answer(message, askOptions);
+    };
+  }
+  if (options.desktopAskWithCheckbox) {
+    const answer = options.desktopAskWithCheckbox;
+    dialog.askWithCheckbox = async (message, askOptions) => {
+      desktopAsksWithCheckbox.push({ message, options: askOptions });
+      return answer(message, askOptions);
+    };
+  }
+  const hasDesktopDialog = Boolean(dialog.ask ?? dialog.askWithCheckbox);
+
+  return {
+    isNative: options.isNative ?? false,
+    alerts,
+    desktopAsks,
+    desktopAsksWithCheckbox,
+    browserPrompts,
+    blurCount: () => blurs,
+
+    lastAlertButtons() {
+      const buttons = alerts[alerts.length - 1]?.buttons ?? [];
+      return buttons.map((button) => ({ text: button.text, style: button.style }));
+    },
+
+    showAlert(request) {
+      alerts.push(request);
+      const pressed = request.buttons.find((button) => button.text === options.pressAlertButton);
+      if (pressed) {
+        pressed.onPress();
+        return;
+      }
+      request.onDismiss();
+    },
+
+    getDesktopDialog() {
+      return hasDesktopDialog ? dialog : null;
+    },
+
+    getBrowserConfirm() {
+      const answer = options.browserConfirm;
+      if (!answer) {
+        return null;
+      }
+      return (message: string) => {
+        browserPrompts.push(message);
+        return answer(message);
+      };
+    },
+
+    blurActiveElement() {
+      blurs += 1;
+    },
+  };
+}

--- a/packages/app/src/utils/confirm-dialog.test.ts
+++ b/packages/app/src/utils/confirm-dialog.test.ts
@@ -4,6 +4,10 @@ const desktopHostState = {
   api: null as {
     dialog?: {
       ask?: (message: string, options?: Record<string, unknown>) => Promise<boolean>;
+      askWithCheckbox?: (
+        message: string,
+        options: Record<string, unknown>,
+      ) => Promise<{ confirmed: boolean; dontAskAgain: boolean }>;
     };
   } | null,
 };
@@ -11,11 +15,13 @@ const desktopHostState = {
 type MockPlatform = "web" | "ios" | "android";
 
 interface AlertButton {
+  text?: string;
   onPress?: () => void;
 }
 
 async function loadModuleForPlatform(platform: MockPlatform): Promise<{
   confirmDialog: typeof import("./confirm-dialog").confirmDialog;
+  confirmDialogWithRemember: typeof import("./confirm-dialog").confirmDialogWithRemember;
   alertMock: ReturnType<typeof vi.fn>;
 }> {
   vi.resetModules();
@@ -32,7 +38,20 @@ async function loadModuleForPlatform(platform: MockPlatform): Promise<{
   }));
 
   const module = await import("./confirm-dialog");
-  return { confirmDialog: module.confirmDialog, alertMock };
+  return {
+    confirmDialog: module.confirmDialog,
+    confirmDialogWithRemember: module.confirmDialogWithRemember,
+    alertMock,
+  };
+}
+
+function pressAlertButton(buttons: AlertButton[] | undefined, label: string): void {
+  for (const button of buttons ?? []) {
+    if (button.text === label) {
+      button.onPress?.();
+      return;
+    }
+  }
 }
 
 function clearDialogGlobals(): void {
@@ -125,5 +144,115 @@ describe("confirmDialog", () => {
 
     expect(confirmed).toBe(true);
     expect(alertMock).toHaveBeenCalled();
+  });
+});
+
+describe("confirmDialogWithRemember", () => {
+  const input = {
+    title: "Close terminal?",
+    message: "Any running process in this terminal will be stopped immediately.",
+    confirmLabel: "Close",
+    cancelLabel: "Cancel",
+    rememberLabel: "Remember this choice",
+    rememberConfirmLabel: "Close and don't ask again",
+    destructive: true,
+  };
+
+  afterEach(() => {
+    vi.doUnmock("react-native");
+    vi.restoreAllMocks();
+    vi.resetModules();
+    clearDialogGlobals();
+  });
+
+  it("reports the checkbox from the desktop dialog", async () => {
+    const askWithCheckbox = vi.fn(async () => ({ confirmed: true, dontAskAgain: true }));
+    desktopHostState.api = { dialog: { askWithCheckbox } };
+
+    const { confirmDialogWithRemember } = await loadModuleForPlatform("web");
+
+    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+      confirmed: true,
+      remember: true,
+    });
+    expect(askWithCheckbox).toHaveBeenCalledWith(
+      "Any running process in this terminal will be stopped immediately.",
+      {
+        title: "Close terminal?",
+        okLabel: "Close",
+        cancelLabel: "Cancel",
+        kind: "warning",
+        checkboxLabel: "Remember this choice",
+      },
+    );
+  });
+
+  it("never remembers a cancelled desktop dialog", async () => {
+    desktopHostState.api = {
+      dialog: { askWithCheckbox: async () => ({ confirmed: false, dontAskAgain: true }) },
+    };
+
+    const { confirmDialogWithRemember } = await loadModuleForPlatform("web");
+
+    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+      confirmed: false,
+      remember: false,
+    });
+  });
+
+  it("falls back to the plain desktop dialog when the checkbox bridge is missing", async () => {
+    const ask = vi.fn(async () => true);
+    desktopHostState.api = { dialog: { ask } };
+
+    const { confirmDialogWithRemember } = await loadModuleForPlatform("web");
+
+    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+      confirmed: true,
+      remember: false,
+    });
+    expect(ask).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to browser confirm with no way to remember", async () => {
+    (globalThis as { confirm?: unknown }).confirm = vi.fn(() => true);
+
+    const { confirmDialogWithRemember } = await loadModuleForPlatform("web");
+
+    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+      confirmed: true,
+      remember: false,
+    });
+  });
+
+  it.each([
+    ["Cancel", { confirmed: false, remember: false }],
+    ["Close", { confirmed: true, remember: false }],
+    ["Close and don't ask again", { confirmed: true, remember: true }],
+  ])("maps the native %s button", async (label, expected) => {
+    const { confirmDialogWithRemember, alertMock } = await loadModuleForPlatform("ios");
+    alertMock.mockImplementation((_title: string, _message: string, buttons?: AlertButton[]) => {
+      pressAlertButton(buttons, label);
+    });
+
+    await expect(confirmDialogWithRemember(input)).resolves.toEqual(expected);
+  });
+
+  it("declines when the native alert is dismissed", async () => {
+    const { confirmDialogWithRemember, alertMock } = await loadModuleForPlatform("ios");
+    alertMock.mockImplementation(
+      (
+        _title: string,
+        _message: string,
+        _buttons?: AlertButton[],
+        options?: { onDismiss?: () => void },
+      ) => {
+        options?.onDismiss?.();
+      },
+    );
+
+    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+      confirmed: false,
+      remember: false,
+    });
   });
 });

--- a/packages/app/src/utils/confirm-dialog.test.ts
+++ b/packages/app/src/utils/confirm-dialog.test.ts
@@ -1,256 +1,153 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { confirmDialog, confirmDialogWithRemember } from "./confirm-dialog";
+import { createFakeConfirmDialogHost } from "./confirm-dialog.fakes";
 
-const desktopHostState = {
-  api: null as {
-    dialog?: {
-      ask?: (message: string, options?: Record<string, unknown>) => Promise<boolean>;
-      askWithCheckbox?: (
-        message: string,
-        options: Record<string, unknown>,
-      ) => Promise<{ confirmed: boolean; dontAskAgain: boolean }>;
-    };
-  } | null,
+const RESTART_HOST = {
+  title: "Restart host",
+  message: "This will restart the daemon.",
+  confirmLabel: "Restart",
+  cancelLabel: "Cancel",
+  destructive: true,
 };
 
-type MockPlatform = "web" | "ios" | "android";
-
-interface AlertButton {
-  text?: string;
-  onPress?: () => void;
-}
-
-async function loadModuleForPlatform(platform: MockPlatform): Promise<{
-  confirmDialog: typeof import("./confirm-dialog").confirmDialog;
-  confirmDialogWithRemember: typeof import("./confirm-dialog").confirmDialogWithRemember;
-  alertMock: ReturnType<typeof vi.fn>;
-}> {
-  vi.resetModules();
-
-  const alertMock = vi.fn();
-  vi.doMock("react-native", () => ({
-    Alert: {
-      alert: alertMock,
-    },
-    Platform: { OS: platform },
-  }));
-  vi.doMock("@/desktop/host", () => ({
-    getDesktopHost: () => desktopHostState.api,
-  }));
-
-  const module = await import("./confirm-dialog");
-  return {
-    confirmDialog: module.confirmDialog,
-    confirmDialogWithRemember: module.confirmDialogWithRemember,
-    alertMock,
-  };
-}
-
-function pressAlertButton(buttons: AlertButton[] | undefined, label: string): void {
-  for (const button of buttons ?? []) {
-    if (button.text === label) {
-      button.onPress?.();
-      return;
-    }
-  }
-}
-
-function clearDialogGlobals(): void {
-  desktopHostState.api = null;
-  delete (globalThis as { confirm?: unknown }).confirm;
-}
+const CLOSE_TERMINAL = {
+  title: "Close terminal?",
+  message: "Any running process in this terminal will be stopped immediately.",
+  confirmLabel: "Close",
+  cancelLabel: "Cancel",
+  rememberLabel: "Remember this choice",
+  rememberConfirmLabel: "Close and don't ask again",
+  destructive: true,
+};
 
 describe("confirmDialog", () => {
-  afterEach(() => {
-    vi.doUnmock("react-native");
-    vi.restoreAllMocks();
-    vi.resetModules();
-    clearDialogGlobals();
-  });
+  it("asks the desktop dialog and drops focus first", async () => {
+    const host = createFakeConfirmDialogHost({ desktopAsk: () => true });
 
-  it("uses the desktop dialog bridge on web when available", async () => {
-    const askMock = vi.fn(async () => true);
-    const blurMock = vi.fn();
-    (globalThis as { document?: unknown }).document = {
-      activeElement: { blur: blurMock },
-    } as unknown as Document;
-    desktopHostState.api = {
-      dialog: { ask: askMock },
-    };
-
-    const { confirmDialog, alertMock } = await loadModuleForPlatform("web");
-    const confirmed = await confirmDialog({
-      title: "Restart host",
-      message: "This will restart the daemon.",
-      confirmLabel: "Restart",
-      cancelLabel: "Cancel",
-      destructive: true,
-    });
-
-    expect(confirmed).toBe(true);
-    expect(alertMock).not.toHaveBeenCalled();
-    expect(blurMock).toHaveBeenCalledTimes(1);
-    expect(askMock).toHaveBeenCalledWith("This will restart the daemon.", {
-      title: "Restart host",
-      okLabel: "Restart",
-      cancelLabel: "Cancel",
-      kind: "warning",
-    });
-  });
-
-  it("falls back to browser confirm on web when desktop APIs are unavailable", async () => {
-    const browserConfirm = vi.fn(() => true);
-    const blurMock = vi.fn();
-    (globalThis as { document?: unknown }).document = {
-      activeElement: { blur: blurMock },
-    } as unknown as Document;
-    (globalThis as { confirm?: unknown }).confirm = browserConfirm;
-
-    const { confirmDialog } = await loadModuleForPlatform("web");
-    const confirmed = await confirmDialog({
-      title: "Restart host",
-      message: "This will restart the daemon.",
-    });
-
-    expect(confirmed).toBe(true);
-    expect(blurMock).toHaveBeenCalledTimes(1);
-    expect(browserConfirm).toHaveBeenCalledWith("Restart host\n\nThis will restart the daemon.");
-  });
-
-  it("throws on web when no confirm backend exists", async () => {
-    const { confirmDialog } = await loadModuleForPlatform("web");
-
-    await expect(
-      confirmDialog({
-        title: "Restart host",
+    await expect(confirmDialog(RESTART_HOST, host)).resolves.toBe(true);
+    expect(host.desktopAsks).toEqual([
+      {
         message: "This will restart the daemon.",
-      }),
-    ).rejects.toThrow("[ConfirmDialog] No web confirmation backend is available.");
+        options: {
+          title: "Restart host",
+          okLabel: "Restart",
+          cancelLabel: "Cancel",
+          kind: "warning",
+        },
+      },
+    ]);
+    expect(host.blurCount()).toBe(1);
+    expect(host.alerts).toEqual([]);
   });
 
-  it("uses native Alert on iOS/Android", async () => {
-    const { confirmDialog, alertMock } = await loadModuleForPlatform("ios");
-    alertMock.mockImplementation((_title: string, _message: string, buttons?: AlertButton[]) => {
-      const confirmButton = buttons?.[1];
-      confirmButton?.onPress?.();
-    });
+  it("falls back to browser confirm when no desktop bridge exists", async () => {
+    const host = createFakeConfirmDialogHost({ browserConfirm: () => true });
 
-    const confirmed = await confirmDialog({
-      title: "Restart host",
-      message: "This will restart the daemon.",
-      confirmLabel: "Restart",
-      cancelLabel: "Cancel",
-      destructive: true,
-    });
+    await expect(confirmDialog(RESTART_HOST, host)).resolves.toBe(true);
+    expect(host.browserPrompts).toEqual(["Restart host\n\nThis will restart the daemon."]);
+    expect(host.blurCount()).toBe(1);
+  });
 
-    expect(confirmed).toBe(true);
-    expect(alertMock).toHaveBeenCalled();
+  it("throws when no web confirmation backend is available", async () => {
+    const host = createFakeConfirmDialogHost();
+
+    await expect(confirmDialog(RESTART_HOST, host)).rejects.toThrow(
+      "[ConfirmDialog] No web confirmation backend is available.",
+    );
+  });
+
+  it("uses a two-button alert on native", async () => {
+    const host = createFakeConfirmDialogHost({ isNative: true, pressAlertButton: "Restart" });
+
+    await expect(confirmDialog(RESTART_HOST, host)).resolves.toBe(true);
+    expect(host.lastAlertButtons()).toEqual([
+      { text: "Cancel", style: "cancel" },
+      { text: "Restart", style: "destructive" },
+    ]);
+    expect(host.desktopAsks).toEqual([]);
   });
 });
 
 describe("confirmDialogWithRemember", () => {
-  const input = {
-    title: "Close terminal?",
-    message: "Any running process in this terminal will be stopped immediately.",
-    confirmLabel: "Close",
-    cancelLabel: "Cancel",
-    rememberLabel: "Remember this choice",
-    rememberConfirmLabel: "Close and don't ask again",
-    destructive: true,
-  };
-
-  afterEach(() => {
-    vi.doUnmock("react-native");
-    vi.restoreAllMocks();
-    vi.resetModules();
-    clearDialogGlobals();
-  });
-
   it("reports the checkbox from the desktop dialog", async () => {
-    const askWithCheckbox = vi.fn(async () => ({ confirmed: true, dontAskAgain: true }));
-    desktopHostState.api = { dialog: { askWithCheckbox } };
+    const host = createFakeConfirmDialogHost({
+      desktopAskWithCheckbox: () => ({ confirmed: true, dontAskAgain: true }),
+    });
 
-    const { confirmDialogWithRemember } = await loadModuleForPlatform("web");
-
-    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+    await expect(confirmDialogWithRemember(CLOSE_TERMINAL, host)).resolves.toEqual({
       confirmed: true,
       remember: true,
     });
-    expect(askWithCheckbox).toHaveBeenCalledWith(
-      "Any running process in this terminal will be stopped immediately.",
+    expect(host.desktopAsksWithCheckbox).toEqual([
       {
-        title: "Close terminal?",
-        okLabel: "Close",
-        cancelLabel: "Cancel",
-        kind: "warning",
-        checkboxLabel: "Remember this choice",
+        message: "Any running process in this terminal will be stopped immediately.",
+        options: {
+          title: "Close terminal?",
+          okLabel: "Close",
+          cancelLabel: "Cancel",
+          kind: "warning",
+          checkboxLabel: "Remember this choice",
+        },
       },
-    );
+    ]);
   });
 
   it("never remembers a cancelled desktop dialog", async () => {
-    desktopHostState.api = {
-      dialog: { askWithCheckbox: async () => ({ confirmed: false, dontAskAgain: true }) },
-    };
+    const host = createFakeConfirmDialogHost({
+      desktopAskWithCheckbox: () => ({ confirmed: false, dontAskAgain: true }),
+    });
 
-    const { confirmDialogWithRemember } = await loadModuleForPlatform("web");
-
-    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+    await expect(confirmDialogWithRemember(CLOSE_TERMINAL, host)).resolves.toEqual({
       confirmed: false,
       remember: false,
     });
   });
 
   it("falls back to the plain desktop dialog when the checkbox bridge is missing", async () => {
-    const ask = vi.fn(async () => true);
-    desktopHostState.api = { dialog: { ask } };
+    const host = createFakeConfirmDialogHost({ desktopAsk: () => true });
 
-    const { confirmDialogWithRemember } = await loadModuleForPlatform("web");
-
-    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+    await expect(confirmDialogWithRemember(CLOSE_TERMINAL, host)).resolves.toEqual({
       confirmed: true,
       remember: false,
     });
-    expect(ask).toHaveBeenCalledTimes(1);
+    expect(host.desktopAsks).toHaveLength(1);
   });
 
   it("falls back to browser confirm with no way to remember", async () => {
-    (globalThis as { confirm?: unknown }).confirm = vi.fn(() => true);
+    const host = createFakeConfirmDialogHost({ browserConfirm: () => true });
 
-    const { confirmDialogWithRemember } = await loadModuleForPlatform("web");
-
-    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+    await expect(confirmDialogWithRemember(CLOSE_TERMINAL, host)).resolves.toEqual({
       confirmed: true,
       remember: false,
     });
+  });
+
+  it("offers cancel, close, and close-and-remember on native", async () => {
+    const host = createFakeConfirmDialogHost({ isNative: true, pressAlertButton: "Cancel" });
+
+    await confirmDialogWithRemember(CLOSE_TERMINAL, host);
+
+    expect(host.lastAlertButtons()).toEqual([
+      { text: "Cancel", style: "cancel" },
+      { text: "Close", style: "destructive" },
+      { text: "Close and don't ask again", style: "destructive" },
+    ]);
   });
 
   it.each([
     ["Cancel", { confirmed: false, remember: false }],
     ["Close", { confirmed: true, remember: false }],
     ["Close and don't ask again", { confirmed: true, remember: true }],
-  ])("maps the native %s button", async (label, expected) => {
-    const { confirmDialogWithRemember, alertMock } = await loadModuleForPlatform("ios");
-    alertMock.mockImplementation((_title: string, _message: string, buttons?: AlertButton[]) => {
-      pressAlertButton(buttons, label);
-    });
+  ])("maps the native %s button", async (pressAlertButton, expected) => {
+    const host = createFakeConfirmDialogHost({ isNative: true, pressAlertButton });
 
-    await expect(confirmDialogWithRemember(input)).resolves.toEqual(expected);
+    await expect(confirmDialogWithRemember(CLOSE_TERMINAL, host)).resolves.toEqual(expected);
   });
 
   it("declines when the native alert is dismissed", async () => {
-    const { confirmDialogWithRemember, alertMock } = await loadModuleForPlatform("ios");
-    alertMock.mockImplementation(
-      (
-        _title: string,
-        _message: string,
-        _buttons?: AlertButton[],
-        options?: { onDismiss?: () => void },
-      ) => {
-        options?.onDismiss?.();
-      },
-    );
+    const host = createFakeConfirmDialogHost({ isNative: true });
 
-    await expect(confirmDialogWithRemember(input)).resolves.toEqual({
+    await expect(confirmDialogWithRemember(CLOSE_TERMINAL, host)).resolves.toEqual({
       confirmed: false,
       remember: false,
     });

--- a/packages/app/src/utils/confirm-dialog.ts
+++ b/packages/app/src/utils/confirm-dialog.ts
@@ -1,5 +1,9 @@
 import { Alert } from "react-native";
-import { getDesktopHost, type DesktopDialogAskOptions } from "@/desktop/host";
+import {
+  getDesktopHost,
+  type DesktopDialogAskOptions,
+  type DesktopDialogAskWithCheckboxOptions,
+} from "@/desktop/host";
 import { isNative } from "@/constants/platform";
 
 export interface ConfirmDialogInput {
@@ -9,6 +13,26 @@ export interface ConfirmDialogInput {
   cancelLabel?: string;
   destructive?: boolean;
 }
+
+/**
+ * A confirmation the user can choose to stop being asked. Only the desktop and VS Code bridges
+ * offer a real checkbox, so native gets a third Alert button instead and plain browser web —
+ * where `window.confirm` is all there is — cannot offer the choice at all.
+ */
+export interface RememberableConfirmDialogInput extends ConfirmDialogInput {
+  /** Checkbox label on desktop. */
+  rememberLabel: string;
+  /** Labels the extra native Alert button that confirms and remembers. */
+  rememberConfirmLabel: string;
+}
+
+export interface RememberableConfirmDialogResult {
+  confirmed: boolean;
+  /** Never true alongside `confirmed: false` — "always cancel" is not a choice worth storing. */
+  remember: boolean;
+}
+
+const DECLINED: RememberableConfirmDialogResult = { confirmed: false, remember: false };
 
 interface ConfirmButtonConfig {
   confirmLabel: string;
@@ -44,6 +68,41 @@ async function showNativeConfirmDialog(input: ConfirmDialogInput): Promise<boole
       {
         cancelable: true,
         onDismiss: () => resolve(false),
+      },
+    );
+  });
+}
+
+async function showNativeRememberableConfirmDialog(
+  input: RememberableConfirmDialogInput,
+): Promise<RememberableConfirmDialogResult> {
+  const labels = resolveButtonLabels(input);
+  const style = input.destructive ? "destructive" : "default";
+
+  return new Promise<RememberableConfirmDialogResult>((resolve) => {
+    Alert.alert(
+      input.title,
+      input.message,
+      [
+        {
+          text: labels.cancelLabel,
+          style: "cancel",
+          onPress: () => resolve(DECLINED),
+        },
+        {
+          text: labels.confirmLabel,
+          style,
+          onPress: () => resolve({ confirmed: true, remember: false }),
+        },
+        {
+          text: input.rememberConfirmLabel,
+          style,
+          onPress: () => resolve({ confirmed: true, remember: true }),
+        },
+      ],
+      {
+        cancelable: true,
+        onDismiss: () => resolve(DECLINED),
       },
     );
   });
@@ -92,6 +151,34 @@ async function showDesktopConfirmDialog(input: ConfirmDialogInput): Promise<bool
   return null;
 }
 
+function buildDesktopAskWithCheckboxOptions(
+  input: RememberableConfirmDialogInput,
+): DesktopDialogAskWithCheckboxOptions {
+  return {
+    ...buildDesktopAskOptions(input),
+    checkboxLabel: input.rememberLabel,
+  };
+}
+
+async function showDesktopRememberableConfirmDialog(
+  input: RememberableConfirmDialogInput,
+): Promise<RememberableConfirmDialogResult | null> {
+  const desktopAskWithCheckbox = getDesktopApi()?.dialog?.askWithCheckbox;
+  if (typeof desktopAskWithCheckbox !== "function") {
+    return null;
+  }
+
+  blurActiveWebElement();
+  const result = await desktopAskWithCheckbox(
+    input.message,
+    buildDesktopAskWithCheckboxOptions(input),
+  );
+  return {
+    confirmed: result.confirmed,
+    remember: result.confirmed && result.dontAskAgain,
+  };
+}
+
 function showWebConfirmDialog(input: ConfirmDialogInput): boolean {
   const browserConfirm = (globalThis as { confirm?: (message?: string) => boolean }).confirm;
   if (typeof browserConfirm !== "function") {
@@ -116,7 +203,27 @@ export async function confirmDialog(input: ConfirmDialogInput): Promise<boolean>
   return showWebConfirmDialog(input);
 }
 
+/**
+ * Like {@link confirmDialog}, plus a way for the user to say they do not want to be asked again.
+ * A host that cannot offer the choice still confirms; it just always reports `remember: false`.
+ */
+export async function confirmDialogWithRemember(
+  input: RememberableConfirmDialogInput,
+): Promise<RememberableConfirmDialogResult> {
+  if (isNative) {
+    return showNativeRememberableConfirmDialog(input);
+  }
+
+  const desktopResult = await showDesktopRememberableConfirmDialog(input);
+  if (desktopResult !== null) {
+    return desktopResult;
+  }
+
+  return { confirmed: await confirmDialog(input), remember: false };
+}
+
 export const __private__ = {
   blurActiveWebElement,
   buildDesktopAskOptions,
+  buildDesktopAskWithCheckboxOptions,
 };

--- a/packages/app/src/utils/confirm-dialog.ts
+++ b/packages/app/src/utils/confirm-dialog.ts
@@ -3,6 +3,7 @@ import {
   getDesktopHost,
   type DesktopDialogAskOptions,
   type DesktopDialogAskWithCheckboxOptions,
+  type DesktopDialogBridge,
 } from "@/desktop/host";
 import { isNative } from "@/constants/platform";
 
@@ -16,13 +17,13 @@ export interface ConfirmDialogInput {
 
 /**
  * A confirmation the user can choose to stop being asked. Only the desktop and VS Code bridges
- * offer a real checkbox, so native gets a third Alert button instead and plain browser web —
+ * offer a real checkbox, so native gets a third alert button instead and plain browser web —
  * where `window.confirm` is all there is — cannot offer the choice at all.
  */
 export interface RememberableConfirmDialogInput extends ConfirmDialogInput {
   /** Checkbox label on desktop. */
   rememberLabel: string;
-  /** Labels the extra native Alert button that confirms and remembers. */
+  /** Labels the extra native alert button that confirms and remembers. */
   rememberConfirmLabel: string;
 }
 
@@ -31,6 +32,81 @@ export interface RememberableConfirmDialogResult {
   /** Never true alongside `confirmed: false` — "always cancel" is not a choice worth storing. */
   remember: boolean;
 }
+
+export type ConfirmDialogAlertButtonStyle = "cancel" | "default" | "destructive";
+
+export interface ConfirmDialogAlertButton {
+  text: string;
+  style: ConfirmDialogAlertButtonStyle;
+  onPress: () => void;
+}
+
+export interface ConfirmDialogAlertRequest {
+  title: string;
+  message: string;
+  buttons: ConfirmDialogAlertButton[];
+  onDismiss: () => void;
+}
+
+/**
+ * Everything a confirmation needs from the platform underneath it. Injected so tests drive the
+ * three backends through this interface instead of standing in for React Native, the desktop
+ * bridge, and `window` themselves.
+ */
+export interface ConfirmDialogHost {
+  /** iOS and Android, where the OS alert is the only dialog available. */
+  isNative: boolean;
+  showAlert(request: ConfirmDialogAlertRequest): void;
+  /** The Electron or VS Code bridge, or null when running outside both. */
+  getDesktopDialog(): DesktopDialogBridge | null;
+  /** `window.confirm`, or null where it does not exist. */
+  getBrowserConfirm(): ((message: string) => boolean) | null;
+  /** Web dialogs steal focus, so drop it before opening one. */
+  blurActiveElement(): void;
+}
+
+export const platformConfirmDialogHost: ConfirmDialogHost = {
+  isNative,
+
+  showAlert(request: ConfirmDialogAlertRequest): void {
+    Alert.alert(
+      request.title,
+      request.message,
+      request.buttons.map((button) => ({
+        text: button.text,
+        style: button.style,
+        onPress: button.onPress,
+      })),
+      {
+        cancelable: true,
+        onDismiss: request.onDismiss,
+      },
+    );
+  },
+
+  getDesktopDialog(): DesktopDialogBridge | null {
+    if (isNative) {
+      return null;
+    }
+    return getDesktopHost()?.dialog ?? null;
+  },
+
+  getBrowserConfirm(): ((message: string) => boolean) | null {
+    if (isNative) {
+      return null;
+    }
+    const browserConfirm = (globalThis as { confirm?: (message?: string) => boolean }).confirm;
+    return typeof browserConfirm === "function" ? browserConfirm.bind(globalThis) : null;
+  },
+
+  blurActiveElement(): void {
+    if (isNative) {
+      return;
+    }
+    const activeElement = (globalThis as { document?: Document }).document?.activeElement;
+    (activeElement as HTMLElement | null)?.blur?.();
+  },
+};
 
 const DECLINED: RememberableConfirmDialogResult = { confirmed: false, remember: false };
 
@@ -46,73 +122,8 @@ function resolveButtonLabels(input: ConfirmDialogInput): ConfirmButtonConfig {
   };
 }
 
-async function showNativeConfirmDialog(input: ConfirmDialogInput): Promise<boolean> {
-  const labels = resolveButtonLabels(input);
-
-  return new Promise<boolean>((resolve) => {
-    Alert.alert(
-      input.title,
-      input.message,
-      [
-        {
-          text: labels.cancelLabel,
-          style: "cancel",
-          onPress: () => resolve(false),
-        },
-        {
-          text: labels.confirmLabel,
-          style: input.destructive ? "destructive" : "default",
-          onPress: () => resolve(true),
-        },
-      ],
-      {
-        cancelable: true,
-        onDismiss: () => resolve(false),
-      },
-    );
-  });
-}
-
-async function showNativeRememberableConfirmDialog(
-  input: RememberableConfirmDialogInput,
-): Promise<RememberableConfirmDialogResult> {
-  const labels = resolveButtonLabels(input);
-  const style = input.destructive ? "destructive" : "default";
-
-  return new Promise<RememberableConfirmDialogResult>((resolve) => {
-    Alert.alert(
-      input.title,
-      input.message,
-      [
-        {
-          text: labels.cancelLabel,
-          style: "cancel",
-          onPress: () => resolve(DECLINED),
-        },
-        {
-          text: labels.confirmLabel,
-          style,
-          onPress: () => resolve({ confirmed: true, remember: false }),
-        },
-        {
-          text: input.rememberConfirmLabel,
-          style,
-          onPress: () => resolve({ confirmed: true, remember: true }),
-        },
-      ],
-      {
-        cancelable: true,
-        onDismiss: () => resolve(DECLINED),
-      },
-    );
-  });
-}
-
-function getDesktopApi() {
-  if (isNative) {
-    return null;
-  }
-  return getDesktopHost();
+function resolveConfirmButtonStyle(input: ConfirmDialogInput): ConfirmDialogAlertButtonStyle {
+  return input.destructive ? "destructive" : "default";
 }
 
 function buildDesktopAskOptions(input: ConfirmDialogInput): DesktopDialogAskOptions {
@@ -126,31 +137,6 @@ function buildDesktopAskOptions(input: ConfirmDialogInput): DesktopDialogAskOpti
   };
 }
 
-function blurActiveWebElement(): void {
-  if (isNative) {
-    return;
-  }
-  const activeElement = (globalThis as { document?: Document }).document?.activeElement;
-  (activeElement as HTMLElement | null)?.blur?.();
-}
-
-async function showDesktopConfirmDialog(input: ConfirmDialogInput): Promise<boolean | null> {
-  const desktopApi = getDesktopApi();
-  if (!desktopApi) {
-    return null;
-  }
-
-  blurActiveWebElement();
-  const options = buildDesktopAskOptions(input);
-  const desktopAsk = desktopApi.dialog?.ask;
-
-  if (typeof desktopAsk === "function") {
-    return await desktopAsk(input.message, options);
-  }
-
-  return null;
-}
-
 function buildDesktopAskWithCheckboxOptions(
   input: RememberableConfirmDialogInput,
 ): DesktopDialogAskWithCheckboxOptions {
@@ -160,15 +146,85 @@ function buildDesktopAskWithCheckboxOptions(
   };
 }
 
+function buildWebPromptMessage(input: ConfirmDialogInput): string {
+  return `${input.title}\n\n${input.message}`;
+}
+
+async function showNativeConfirmDialog(
+  input: ConfirmDialogInput,
+  host: ConfirmDialogHost,
+): Promise<boolean> {
+  const labels = resolveButtonLabels(input);
+
+  return new Promise<boolean>((resolve) => {
+    host.showAlert({
+      title: input.title,
+      message: input.message,
+      buttons: [
+        { text: labels.cancelLabel, style: "cancel", onPress: () => resolve(false) },
+        {
+          text: labels.confirmLabel,
+          style: resolveConfirmButtonStyle(input),
+          onPress: () => resolve(true),
+        },
+      ],
+      onDismiss: () => resolve(false),
+    });
+  });
+}
+
+async function showNativeRememberableConfirmDialog(
+  input: RememberableConfirmDialogInput,
+  host: ConfirmDialogHost,
+): Promise<RememberableConfirmDialogResult> {
+  const labels = resolveButtonLabels(input);
+  const style = resolveConfirmButtonStyle(input);
+
+  return new Promise<RememberableConfirmDialogResult>((resolve) => {
+    host.showAlert({
+      title: input.title,
+      message: input.message,
+      buttons: [
+        { text: labels.cancelLabel, style: "cancel", onPress: () => resolve(DECLINED) },
+        {
+          text: labels.confirmLabel,
+          style,
+          onPress: () => resolve({ confirmed: true, remember: false }),
+        },
+        {
+          text: input.rememberConfirmLabel,
+          style,
+          onPress: () => resolve({ confirmed: true, remember: true }),
+        },
+      ],
+      onDismiss: () => resolve(DECLINED),
+    });
+  });
+}
+
+async function showDesktopConfirmDialog(
+  input: ConfirmDialogInput,
+  host: ConfirmDialogHost,
+): Promise<boolean | null> {
+  const desktopAsk = host.getDesktopDialog()?.ask;
+  if (typeof desktopAsk !== "function") {
+    return null;
+  }
+
+  host.blurActiveElement();
+  return await desktopAsk(input.message, buildDesktopAskOptions(input));
+}
+
 async function showDesktopRememberableConfirmDialog(
   input: RememberableConfirmDialogInput,
+  host: ConfirmDialogHost,
 ): Promise<RememberableConfirmDialogResult | null> {
-  const desktopAskWithCheckbox = getDesktopApi()?.dialog?.askWithCheckbox;
+  const desktopAskWithCheckbox = host.getDesktopDialog()?.askWithCheckbox;
   if (typeof desktopAskWithCheckbox !== "function") {
     return null;
   }
 
-  blurActiveWebElement();
+  host.blurActiveElement();
   const result = await desktopAskWithCheckbox(
     input.message,
     buildDesktopAskWithCheckboxOptions(input),
@@ -179,28 +235,30 @@ async function showDesktopRememberableConfirmDialog(
   };
 }
 
-function showWebConfirmDialog(input: ConfirmDialogInput): boolean {
-  const browserConfirm = (globalThis as { confirm?: (message?: string) => boolean }).confirm;
-  if (typeof browserConfirm !== "function") {
+function showWebConfirmDialog(input: ConfirmDialogInput, host: ConfirmDialogHost): boolean {
+  const browserConfirm = host.getBrowserConfirm();
+  if (!browserConfirm) {
     throw new Error("[ConfirmDialog] No web confirmation backend is available.");
   }
 
-  blurActiveWebElement();
-  const promptMessage = `${input.title}\n\n${input.message}`;
-  return browserConfirm(promptMessage);
+  host.blurActiveElement();
+  return browserConfirm(buildWebPromptMessage(input));
 }
 
-export async function confirmDialog(input: ConfirmDialogInput): Promise<boolean> {
-  if (isNative) {
-    return showNativeConfirmDialog(input);
+export async function confirmDialog(
+  input: ConfirmDialogInput,
+  host: ConfirmDialogHost = platformConfirmDialogHost,
+): Promise<boolean> {
+  if (host.isNative) {
+    return showNativeConfirmDialog(input, host);
   }
 
-  const desktopResult = await showDesktopConfirmDialog(input);
+  const desktopResult = await showDesktopConfirmDialog(input, host);
   if (desktopResult !== null) {
     return desktopResult;
   }
 
-  return showWebConfirmDialog(input);
+  return showWebConfirmDialog(input, host);
 }
 
 /**
@@ -209,21 +267,16 @@ export async function confirmDialog(input: ConfirmDialogInput): Promise<boolean>
  */
 export async function confirmDialogWithRemember(
   input: RememberableConfirmDialogInput,
+  host: ConfirmDialogHost = platformConfirmDialogHost,
 ): Promise<RememberableConfirmDialogResult> {
-  if (isNative) {
-    return showNativeRememberableConfirmDialog(input);
+  if (host.isNative) {
+    return showNativeRememberableConfirmDialog(input, host);
   }
 
-  const desktopResult = await showDesktopRememberableConfirmDialog(input);
+  const desktopResult = await showDesktopRememberableConfirmDialog(input, host);
   if (desktopResult !== null) {
     return desktopResult;
   }
 
-  return { confirmed: await confirmDialog(input), remember: false };
+  return { confirmed: await confirmDialog(input, host), remember: false };
 }
-
-export const __private__ = {
-  blurActiveWebElement,
-  buildDesktopAskOptions,
-  buildDesktopAskWithCheckboxOptions,
-};


### PR DESCRIPTION
### Linked issue

None

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Closing a terminal tab always asks for confirmation, every single time.

This change makes the confirmation optional, and lets you turn it off from the dialog itself with "Remember this choice", the same affordance Paseo already uses when it asks where to open a service link. The default is unchanged, so nobody loses the safety net without asking to.

### Goals

- New General setting, **Confirm closing terminals**, on by default — existing behaviour is untouched for everyone who doesn't change it.
- **Remember this choice** in the close dialog. Confirming with it checked flips the setting off, so the dialog stops appearing.
- Reversible from Settings → General at any time.
- Remember is honoured wherever the platform can express it: a real checkbox on desktop and VS Code, an extra button on iOS/Android.

### Non-goals

- **No process detection.** An earlier draft added a `terminal.inspect` RPC that read the pty's foreground process group so the dialog could be skipped only for idle shells, and name the process otherwise. It worked, but it cost a protocol message, a feature flag, worker plumbing and per-platform pty semantics for a preference toggle. Dropped deliberately in favour of a plain on/off.
- **Bulk close paths unchanged.** Close others / left / right / pane keep their own confirmation. Those close several things at once and are worth a prompt.
- **No remember on plain browser web.** `window.confirm` has no checkbox and no third button. The dialog behaves as it does today there; the setting is still reachable from Settings.
- **No new rendered modal.** Confirmations keep using the OS dialog, consistent with every other confirmation in the app.

### QA

8 new tests in `confirm-dialog.test.ts` cover the new dialog surface:

- reports the checkbox from the desktop dialog
- never remembers a cancelled desktop dialog
- falls back to the plain desktop dialog when the checkbox bridge is missing
- falls back to browser confirm with no way to remember
- maps the native Cancel / Close / "Close and don't ask again" buttons (3 cases)
- declines when the native alert is dismissed

4 new tests in `storage.test.ts` cover persistence: defaults to true, loads a persisted false, falls back to true on an invalid stored value, round-trips a save.

#### Manual QA


| Platform | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | ✅     | Three-button `Alert` |
| Android         | No     |  |
| Web             | No     |  |
| Desktop macOS   |  ✅    | `askWithCheckbox` |
| Desktop Windows | No     | |
| Desktop Linux   | No     | |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence — automated only, no screenshots or video
- [x] Tests added or updated where it made sense