### PR TITLE
Keep checked options and the Other answer together on multi-select questions

### DIFF
--- a/packages/app/src/components/question-form-card-core.test.ts
+++ b/packages/app/src/components/question-form-card-core.test.ts
@@ -54,6 +54,54 @@ describe("question form card core", () => {
     });
   });
 
+  test("keeps checked options and appends the other answer for multi-select", () => {
+    const questions = parseQuestionFormQuestions({
+      questions: [
+        {
+          question: "Which fruits do you like?",
+          header: "Fruits",
+          options: [{ label: "Apple" }, { label: "Banana" }, { label: "Cherry" }],
+          multiSelect: true,
+          allowOther: true,
+        },
+      ],
+    });
+
+    if (!questions) throw new Error("questions did not parse");
+    expect(buildQuestionFormAnswers(questions, { 0: new Set([0, 2]) }, { 0: " durian " })).toEqual({
+      Fruits: "Apple, Cherry, durian",
+    });
+    expect(buildQuestionFormAnswers(questions, { 0: new Set([0, 2]) }, {})).toEqual({
+      Fruits: "Apple, Cherry",
+    });
+    expect(buildQuestionFormAnswers(questions, { 0: new Set() }, { 0: "durian" })).toEqual({
+      Fruits: "durian",
+    });
+    expect(buildQuestionFormAnswers(questions, {}, { 0: "durian" })).toEqual({ Fruits: "durian" });
+  });
+
+  test("replaces the selected option with the other answer for single-select", () => {
+    const questions = parseQuestionFormQuestions({
+      questions: [
+        {
+          question: "Which provider?",
+          header: "Provider",
+          options: [{ label: "Claude Code" }, { label: "Codex" }],
+          multiSelect: false,
+          allowOther: true,
+        },
+      ],
+    });
+
+    if (!questions) throw new Error("questions did not parse");
+    expect(buildQuestionFormAnswers(questions, { 0: new Set([1]) }, { 0: "OpenCode" })).toEqual({
+      Provider: "OpenCode",
+    });
+    expect(buildQuestionFormAnswers(questions, { 0: new Set([1]) }, {})).toEqual({
+      Provider: "Codex",
+    });
+  });
+
   test("shows text input for explicit other questions", () => {
     const questions = parseQuestionFormQuestions({
       questions: [

--- a/packages/app/src/components/question-form-card-core.ts
+++ b/packages/app/src/components/question-form-card-core.ts
@@ -111,10 +111,13 @@ export function buildQuestionFormAnswers(
     const q = questions[i];
     const selected = selections[i];
     const otherText = otherTexts[i]?.trim();
+    const labels = selected ? Array.from(selected).map((idx) => q.options[idx].label) : [];
 
     if (questionShowsTextInput(q)) {
       if (otherText && otherText.length > 0) {
-        answers[q.header] = otherText;
+        // Multi-select keeps the checked options and appends the custom answer, the way
+        // Claude Code's own AskUserQuestion UI does. Single-select replaces the option.
+        answers[q.header] = q.multiSelect ? [...labels, otherText].join(", ") : otherText;
         continue;
       }
       if (q.allowEmpty && q.options.length === 0) {
@@ -123,8 +126,7 @@ export function buildQuestionFormAnswers(
       }
     }
 
-    if (selected && selected.size > 0) {
-      const labels = Array.from(selected).map((idx) => q.options[idx].label);
+    if (labels.length > 0) {
       answers[q.header] = labels.join(", ");
     }
   }

--- a/packages/app/src/components/question-form-card.browser.test.tsx
+++ b/packages/app/src/components/question-form-card.browser.test.tsx
@@ -1,0 +1,154 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { AgentPermissionResponse } from "@getpaseo/protocol/agent-types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingPermission } from "@/types/shared";
+import { QuestionFormCard } from "./question-form-card";
+
+// App sources compile against the classic JSX runtime, which expects React on the global.
+beforeEach(() => vi.stubGlobal("React", React));
+
+/**
+ * A real browser with the real web `EditingTextInput`, because the bug under test lives in the
+ * gap between that input and React state: the input owns its text and never replays state, so a
+ * card that drops the Other text from state alone keeps showing it while submit ignores it.
+ */
+
+interface Mounted {
+  root: Root;
+  container: HTMLDivElement;
+}
+
+const mounted: Mounted[] = [];
+
+afterEach(() => {
+  for (const entry of mounted.splice(0)) {
+    act(() => entry.root.unmount());
+    entry.container.remove();
+  }
+});
+
+function buildPermission(question: Record<string, unknown>): PendingPermission {
+  return {
+    key: "perm-1",
+    agentId: "agent-1",
+    request: {
+      id: "perm-1",
+      provider: "claude",
+      name: "AskUserQuestion",
+      kind: "question",
+      input: { questions: [question] },
+    },
+  };
+}
+
+function mountCard(question: Record<string, unknown>) {
+  const onRespond = vi.fn<(response: AgentPermissionResponse) => void>();
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() =>
+    root.render(
+      <QuestionFormCard
+        permission={buildPermission(question)}
+        onRespond={onRespond}
+        isResponding={false}
+      />,
+    ),
+  );
+  mounted.push({ root, container });
+
+  const option = (label: string): HTMLElement => {
+    const element = container.querySelector(`[aria-label="${label}"]`);
+    if (!(element instanceof HTMLElement)) throw new Error(`option ${label} did not render`);
+    return element;
+  };
+  const otherInput = (): HTMLInputElement => {
+    const element = container.querySelector("input");
+    if (!(element instanceof HTMLInputElement)) throw new Error("other input did not render");
+    return element;
+  };
+  const check = (label: string) => act(() => option(label).click());
+  const type = (text: string) => {
+    const input = otherInput();
+    const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    if (!valueSetter) throw new Error("HTML input value setter is unavailable");
+    act(() => {
+      valueSetter.call(input, text);
+      input.dispatchEvent(new InputEvent("input", { bubbles: true, data: text }));
+    });
+  };
+  const submit = () => {
+    const element = container.querySelector('[data-testid="question-form-primary-action"]');
+    if (!(element instanceof HTMLElement)) throw new Error("primary action did not render");
+    act(() => element.click());
+  };
+  const submittedAnswers = (): Record<string, string> => {
+    const response = onRespond.mock.calls[0]?.[0];
+    if (!response || response.behavior !== "allow") throw new Error("card did not submit");
+    return (response.updatedInput as { answers: Record<string, string> }).answers;
+  };
+  return { check, type, otherInput, submit, submittedAnswers };
+}
+
+const multiSelectQuestion = {
+  question: "Which fruits do you like?",
+  header: "Fruits",
+  options: [{ label: "Apple" }, { label: "Banana" }, { label: "Cherry" }],
+  multiSelect: true,
+  allowOther: true,
+};
+
+const singleSelectQuestion = {
+  question: "Which provider?",
+  header: "Provider",
+  options: [{ label: "Claude Code" }, { label: "Codex" }],
+  multiSelect: false,
+  allowOther: true,
+};
+
+describe("QuestionFormCard other answers", () => {
+  it("keeps checked options when the other answer is typed afterwards (multi-select)", () => {
+    const card = mountCard(multiSelectQuestion);
+
+    card.check("Apple");
+    card.check("Cherry");
+    card.type("durian");
+    card.submit();
+
+    expect(card.submittedAnswers()).toEqual({ Fruits: "Apple, Cherry, durian" });
+  });
+
+  it("keeps the typed other answer when options are checked afterwards (multi-select)", () => {
+    const card = mountCard(multiSelectQuestion);
+
+    card.type("durian");
+    card.check("Apple");
+    card.check("Banana");
+
+    expect(card.otherInput().value).toBe("durian");
+    card.submit();
+    expect(card.submittedAnswers()).toEqual({ Fruits: "Apple, Banana, durian" });
+  });
+
+  it("replaces the selected option with the typed other answer (single-select)", () => {
+    const card = mountCard(singleSelectQuestion);
+
+    card.check("Codex");
+    card.type("OpenCode");
+    card.submit();
+
+    expect(card.submittedAnswers()).toEqual({ Provider: "OpenCode" });
+  });
+
+  it("clears the typed other answer on screen when an option is picked afterwards (single-select)", () => {
+    const card = mountCard(singleSelectQuestion);
+
+    card.type("OpenCode");
+    card.check("Codex");
+
+    expect(card.otherInput().value).toBe("");
+    card.submit();
+    expect(card.submittedAnswers()).toEqual({ Provider: "Codex" });
+  });
+});

--- a/packages/app/src/components/question-form-card.tsx
+++ b/packages/app/src/components/question-form-card.tsx
@@ -1,5 +1,5 @@
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef, type RefObject } from "react";
 import { View, Text, Pressable, type PressableStateCallbackType } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useIsCompactFormFactor } from "@/constants/layout";
@@ -9,6 +9,7 @@ import type { PendingPermission } from "@/types/shared";
 import type { AgentPermissionResponse } from "@getpaseo/protocol/agent-types";
 import { isWeb } from "@/constants/platform";
 import { EditingTextInput as TextInput } from "@/components/ui/text-input";
+import type { EditingTextInputHandle } from "@/components/ui/text-input/types";
 import {
   areQuestionsAnswered,
   buildQuestionFormAnswers,
@@ -255,6 +256,7 @@ function QuestionNav({
 
 interface QuestionOtherInputProps {
   qIndex: number;
+  inputRef: RefObject<EditingTextInputHandle | null>;
   accessibilityLabel: string;
   value: string;
   placeholder: string;
@@ -265,6 +267,7 @@ interface QuestionOtherInputProps {
 
 function QuestionOtherInput({
   qIndex,
+  inputRef,
   accessibilityLabel,
   value,
   placeholder,
@@ -300,6 +303,7 @@ function QuestionOtherInput({
   );
   return (
     <TextInput
+      ref={inputRef}
       // @ts-expect-error - outlineStyle is web-only
       style={otherInputStyle}
       accessibilityLabel={accessibilityLabel}
@@ -325,6 +329,7 @@ export function QuestionFormCard({ permission, onRespond, isResponding }: Questi
 
   const [selections, setSelections] = useState<Record<number, Set<number>>>({});
   const [otherTexts, setOtherTexts] = useState<Record<number, string>>({});
+  const otherInputRef = useRef<EditingTextInputHandle | null>(null);
   const [respondingAction, setRespondingAction] = useState<"submit" | "dismiss" | null>(null);
   const [activeQuestionIndex, setActiveQuestionIndex] = useState(0);
 
@@ -346,29 +351,40 @@ export function QuestionFormCard({ permission, onRespond, isResponding }: Questi
       }
 
       setSelections((prev) => ({ ...prev, [qIndex]: next }));
-      setOtherTexts((prev) => {
-        if (!prev[qIndex]) return prev;
-        const nextTexts = { ...prev };
-        delete nextTexts[qIndex];
-        return nextTexts;
-      });
+
+      // Single-select: an option and a custom answer replace each other, as in Claude Code.
+      // Multi-select keeps both. The editing surface owns its text and never replays state
+      // (docs/forms.md), so clearing state alone would leave stale text on screen that
+      // submit ignores; clear the surface explicitly.
+      if (!multiSelect && otherTexts[qIndex]) {
+        setOtherTexts((prev) => {
+          const nextTexts = { ...prev };
+          delete nextTexts[qIndex];
+          return nextTexts;
+        });
+        otherInputRef.current?.replaceText("");
+      }
 
       if (!multiSelect && next.size > 0 && qIndex === activeQuestionIndex && questions) {
         setActiveQuestionIndex(Math.min(qIndex + 1, questions.length - 1));
       }
     },
-    [activeQuestionIndex, questions, selections],
+    [activeQuestionIndex, otherTexts, questions, selections],
   );
 
-  const setOtherText = useCallback((qIndex: number, text: string) => {
-    setOtherTexts((prev) => ({ ...prev, [qIndex]: text }));
-    if (text.length > 0) {
-      setSelections((prev) => {
-        if (!prev[qIndex] || prev[qIndex].size === 0) return prev;
-        return { ...prev, [qIndex]: new Set<number>() };
-      });
-    }
-  }, []);
+  const setOtherText = useCallback(
+    (qIndex: number, text: string) => {
+      setOtherTexts((prev) => ({ ...prev, [qIndex]: text }));
+      const multiSelect = questions?.[qIndex]?.multiSelect ?? false;
+      if (!multiSelect && text.length > 0) {
+        setSelections((prev) => {
+          if (!prev[qIndex] || prev[qIndex].size === 0) return prev;
+          return { ...prev, [qIndex]: new Set<number>() };
+        });
+      }
+    },
+    [questions],
+  );
 
   const allAnswered = areQuestionsAnswered(questions, selections, otherTexts);
   const resolvedActiveQuestionIndex = questions
@@ -551,6 +567,7 @@ export function QuestionFormCard({ permission, onRespond, isResponding }: Questi
           {showTextInput ? (
             <QuestionOtherInput
               qIndex={resolvedActiveQuestionIndex}
+              inputRef={otherInputRef}
               accessibilityLabel={activeQuestion.question}
               value={otherText}
               placeholder={getQuestionInputPlaceholder({


### PR DESCRIPTION
### Linked issue

Closes #4370

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

On a multi-select question card, the Other field and the checked options cannot coexist. Check first and then type, and the boxes clear. Type first and then check, and the card silently drops the typed text on submit: since #3517 the field owns its text and never replays state, so the screen keeps showing a sentence the state has already forgotten. The agent receives the labels alone. Claude Code's own AskUserQuestion UI keeps both and submits `"Apple, durian"`, and the Agent SDK docs describe exactly that shape, so a Paseo user answering from their phone gets a worse answer than they would at the terminal.

This PR makes multi-select keep both inputs and submit the checked labels followed by the trimmed Other text, joined with `", "`. Single-select keeps the replace behavior, which also matches Claude Code, but when it clears the Other text it now calls `replaceText("")` on the field so the screen and the state agree.

### Goals

- Multi-select: checked options survive typing into Other, and Other text survives checking options, in either order.
- Multi-select: the submitted answer is the checked labels followed by the Other text, comma-joined, so Codex and OpenCode split it into the array their APIs expect and Claude receives the same string its own UI would send.
- Single-select: picking an option after typing clears the Other field on screen, not just in state.
- No protocol or daemon change. `answers` stays `Record<string, string>`.

### Non-goals

- Comma quoting for Codex and OpenCode. Both providers split multi-select answers on every comma with no quoting, so a custom answer containing a comma is broken into pieces. That predates this change and is called out as a separate patch in #4370.
- Any change to the question form model in #2241. If that lands first, the same two rules and these tests need to move into `setTextAnswer` and `toggleOption` there.
- Ordering of the checked labels. They are emitted in selection order, as before.

### QA

**Reproduced before the fix** (Paseo 0.7.2, Claude Code 2.1.258, web UI and Android app): on a multi-select AskUserQuestion, typed a sentence into Other, checked four options, submitted. The agent received the four labels joined with commas and nothing else. Checking first and typing afterwards visibly cleared the boxes. Recording is attached to #4370.

**Tests.** `packages/app/src/components/question-form-card-core.test.ts` gains two cases for the answer builder (multi-select combines, single-select replaces). New `packages/app/src/components/question-form-card.browser.test.tsx` mounts the real card in headless Chromium through the Vitest browser project, with the real web `EditingTextInput` and no mocks, and drives both orders through clicks and input events, asserting the answers the card submits and what the field shows. On `main` without the source change, four of the ten tests fail:

```
core:    × keeps checked options and appends the other answer for multi-select
           expected { Fruits: 'durian' } to deeply equal { Fruits: 'Apple, Cherry, durian' }
browser: × keeps checked options when the other answer is typed afterwards (multi-select)
         × keeps the typed other answer when options are checked afterwards (multi-select)
           expected { Fruits: 'Apple, Banana' } to deeply equal { Fruits: 'Apple, Banana, durian' }
         × clears the typed other answer on screen when an option is picked afterwards (single-select)
           expected 'OpenCode' to be ''
```

With the change, all ten pass. `oxlint` and `oxfmt` are clean on the four touched files. Typecheck, lint, and format results for the whole repo are from CI.

Platforms tested for the bug: web UI in a browser and the Android app. The fix is in the shared card and has no platform branches. Not re-tested on device after the fix; the browser tests cover the same interaction sequence against the real web input.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes (CI)
- [x] `npm run lint` passes (CI)
- [x] `npm run format` passes (CI)
- [x] QA evidence
- [x] Tests added or updated where it made sense
