### PR TITLE
fix(server): stop rejecting agent MCP requests over an unadvertised protocol version header

### DIFF
--- a/packages/server/src/server/agent/agent-mcp.e2e.test.ts
+++ b/packages/server/src/server/agent/agent-mcp.e2e.test.ts
@@ -6,6 +6,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { describe, expect, test } from "vitest";
 import { experimental_createMCPClient } from "ai";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
 import pino from "pino";
 
 import { withTimeout } from "../../utils/promise-timeout.js";
@@ -87,6 +88,25 @@ async function createMcpClient(url: string, authToken?: string): Promise<McpClie
   const rawClient = await experimental_createMCPClient({ transport });
   const boundCallTool: McpClient["callTool"] = Reflect.get(rawClient, "callTool").bind(rawClient);
   return { callTool: boundCallTool, close: () => rawClient.close() };
+}
+
+/**
+ * Extract the JSON-RPC result object from a raw MCP HTTP response body, which
+ * is either a JSON object or an SSE stream with a single `data:` line.
+ */
+function parseJsonRpcResult(body: string): Record<string, unknown> {
+  const dataLine = body
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("data:"));
+  const payload = JSON.parse(dataLine ? dataLine.slice("data:".length).trim() : body);
+  if (payload?.error) {
+    throw new Error(`MCP response carried an error: ${JSON.stringify(payload.error)}`);
+  }
+  if (payload?.result === undefined || typeof payload.result !== "object") {
+    throw new Error(`MCP response had no result object: ${body.slice(0, 200)}`);
+  }
+  return payload.result as Record<string, unknown>;
 }
 
 interface LaunchRecorder {
@@ -232,6 +252,89 @@ describe("agent MCP end-to-end (offline)", () => {
       await rm(paseoHome, { recursive: true, force: true });
       await rm(staticDir, { recursive: true, force: true });
       await rm(agentCwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("agent MCP tolerates clients echoing an unadvertised protocol version header", async () => {
+    // Reproduces #3599: a client (Codex CLI >= 0.148) that sends its
+    // *preferred* protocol version in the MCP-Protocol-Version header of
+    // post-initialize requests, instead of the negotiated one, must not lose
+    // the injected tool surface to a 400 "Unsupported protocol version".
+    const paseoHome = await mkdtemp(path.join(os.tmpdir(), "paseo-home-"));
+    const staticDir = await mkdtemp(path.join(os.tmpdir(), "paseo-static-"));
+    const port = await getAvailablePort();
+
+    const daemonConfig: PaseoDaemonConfig = {
+      listen: `127.0.0.1:${port}`,
+      paseoHome,
+      corsAllowedOrigins: [],
+      hostnames: true,
+      mcpEnabled: true,
+      staticDir,
+      mcpDebug: false,
+      agentClients: createTestAgentClients(),
+      agentStoragePath: path.join(paseoHome, "agents"),
+    };
+
+    const daemon = await createPaseoDaemon(daemonConfig, pino({ level: "silent" }));
+    await daemon.start();
+
+    const mcpUrl = `http://127.0.0.1:${port}/mcp/agents`;
+    // A protocol revision the bundled SDK will never advertise, standing in
+    // for a client speaking a newer spec than the daemon's SDK supports.
+    const futureVersion = "2999-01-01";
+
+    try {
+      // The handshake still negotiates DOWN to a version the server supports.
+      const initialize = await fetch(mcpUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: futureVersion,
+            capabilities: {},
+            clientInfo: { name: "future-client", version: "1.0.0" },
+          },
+        }),
+      });
+      expect(initialize.status).toBe(200);
+      const initializeResult = parseJsonRpcResult(await initialize.text());
+      expect(typeof initializeResult.protocolVersion).toBe("string");
+      expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(initializeResult.protocolVersion);
+
+      // Post-handshake requests carrying the client's preferred (unadvertised)
+      // version in MCP-Protocol-Version must not be rejected with the 400
+      // "Unsupported protocol version" the bundled transport raises.
+      const toolsList = await fetch(mcpUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": futureVersion,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/list",
+        }),
+      });
+      expect(toolsList.status).toBe(200);
+      const toolsListResult = parseJsonRpcResult(await toolsList.text());
+      const toolNames = (toolsListResult.tools as Array<{ name: string }>).map(
+        (tool) => tool.name,
+      );
+      expect(toolNames.length).toBeGreaterThan(0);
+      expect(toolNames).toContain("create_agent");
+    } finally {
+      await daemon.stop();
+      await rm(paseoHome, { recursive: true, force: true });
+      await rm(staticDir, { recursive: true, force: true });
     }
   }, 30_000);
 

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { hostname as getHostname } from "node:os";
 import path from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "pino";
 import { z } from "zod";
 import { createBranchChangeRouteHandler } from "./script-route-branch-handler.js";
@@ -1506,6 +1507,41 @@ export async function createPaseoDaemon(
             id: null,
           });
           return;
+        }
+        // Some MCP clients (Codex CLI >= 0.148, Claude Code >= 2.1.257) send
+        // their *preferred* protocol version in the MCP-Protocol-Version
+        // header on post-initialize requests instead of the *negotiated* one
+        // (#3599). The bundled SDK only advertises versions up to its own
+        // LATEST_PROTOCOL_VERSION, so every tools/list and tools/call is then
+        // rejected with 400 "Unsupported protocol version". Claude Code
+        // recovers by retrying with an accepted value; Codex does not, and
+        // its agents silently lose the injected Paseo tools.
+        //
+        // The header is a post-handshake sanity echo, not a negotiation
+        // point: initialize already negotiated a version this server
+        // supports, and this stateless transport serves every request
+        // independently. Drop unadvertised header values so misbehaving
+        // clients keep working; advertised values pass through untouched.
+        const requestedProtocolVersion = req.headers["mcp-protocol-version"];
+        if (
+          typeof requestedProtocolVersion === "string" &&
+          !SUPPORTED_PROTOCOL_VERSIONS.includes(requestedProtocolVersion)
+        ) {
+          logger.warn(
+            { requestedProtocolVersion },
+            "Agent MCP client sent an unadvertised MCP-Protocol-Version header; ignoring it (see #3599)",
+          );
+          delete req.headers["mcp-protocol-version"];
+          // The SDK's Node-to-web-standard adapter builds the fetch Request
+          // from rawHeaders, which the delete above does not touch — strip
+          // the header pair there too, or the transport still sees it.
+          const filteredRawHeaders: string[] = [];
+          for (let i = 0; i < req.rawHeaders.length; i += 2) {
+            if (req.rawHeaders[i].toLowerCase() !== "mcp-protocol-version") {
+              filteredRawHeaders.push(req.rawHeaders[i], req.rawHeaders[i + 1]);
+            }
+          }
+          req.rawHeaders = filteredRawHeaders;
         }
         const callerAgentIdRaw = req.query.callerAgentId;
         let callerAgentId: string | undefined;


### PR DESCRIPTION
Fixes #3599 (the protocol-rejection half).

## Problem

Clients that send their *preferred* MCP protocol version in the `MCP-Protocol-Version` header of post-initialize requests — instead of the negotiated one — get every `tools/list` / `tools/call` rejected with `400 "Unsupported protocol version"` and never see the injected Paseo tools.

- **Codex CLI >= 0.148** does this and does not retry, so a Paseo-managed Codex agent silently loses the whole injected tool surface (`create_agent`, `notifyOnFinish`, everything).
- **Claude Code >= 2.1.257** sends the same non-conforming header but recovers after one rejected request, which is why Claude agents look fine while Codex agents are broken.
- The bundled `@modelcontextprotocol/sdk` 1.29.0 (and the current latest 1.30.0) advertises versions only up to `2025-11-25`, while these clients speak `2026-07-28`. No SDK release accepts that header today, so the daemon cannot negotiate or tolerate it without help.

## Fix

The header is a post-handshake sanity echo, not a negotiation point: `initialize` already negotiates down to a version this server supports, and the stateless agent MCP transport serves every request independently. So in `runAgentMcpRequest`, when the header value is not one the SDK advertises, drop it (log a `warn`) and let the request proceed. Advertised values pass through untouched.

Two implementation details worth flagging:
- The check is against the SDK's own `SUPPORTED_PROTOCOL_VERSIONS` import, so when the SDK is eventually bumped to know `2026-07-28`, this path simply stops firing for it.
- The header must be stripped from **both** `req.headers` and `req.rawHeaders` — the SDK's node-to-web-standard adapter (`@hono/node-server` `getRequestListener`) builds the fetch `Request` from `rawHeaders`, so deleting only the parsed headers has no effect.

## QA evidence

Against a production daemon (Linux x86_64, daemon 0.7.1, `daemon.mcp.injectIntoAgents: true`, Codex CLI 0.153.3), probing `/mcp/agents` directly with raw JSON-RPC:

| request | before | after |
|---|---|---|
| `initialize` with `protocolVersion: 2026-07-28` | 200, negotiated `2025-11-25` | 200, negotiated `2025-11-25` (unchanged) |
| `tools/list` with `MCP-Protocol-Version: 2026-07-28` | **400** `Unsupported protocol version` | **200**, full tool list |
| `tools/list` with `MCP-Protocol-Version: 2025-11-25` | 200 | 200 (unchanged) |
| `tools/list` with no header | 200 | 200 (unchanged) |

After applying the same change on the live daemon, a Paseo-managed Codex orchestrator session regained the injected `mcp__paseo__*` tools and subagent finish notifications started arriving; the daemon log shows no further `Unsupported protocol version` errors.

## Tests

- New e2e regression test in `agent-mcp.e2e.test.ts`: `initialize` with a never-advertised version (`2999-01-01`) must still negotiate down to an advertised version, and a following `tools/list` carrying that version in `MCP-Protocol-Version` must return the tool list instead of the 400. Reverting the fix makes this test fail with exactly `expected 400 to be 200`.
- `agent-mcp.e2e.test.ts`: the new test passes; the two pre-existing failures (`create_agent auto-injects paseo MCP by default and can be disabled`, `create_agent injects a loopback MCP URL...`) fail identically on unmodified `main` — not affected by this change.
- `bootstrap.smoke.test.ts`: 21/21 pass.
- `tsc -p tsconfig.server.typecheck.json --noEmit`: clean.

Tested on Linux x86_64 only (headless daemon); I did not test macOS or the desktop app.