### PR TITLE
Arm the finish notification when a blocking send_agent_prompt times out

### DIFF
--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -328,6 +328,8 @@ export interface WaitForAgentResult {
   status: AgentLifecycleStatus;
   permission: AgentPermissionRequest | null;
   lastMessage: string | null;
+  /** Set when a bounded wait gave up while the agent was still working. */
+  timedOut?: boolean;
 }
 
 export interface WaitForAgentStartOptions {

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -3806,6 +3806,127 @@ describe("send_agent_prompt MCP tool", () => {
       expect.objectContaining({ waitForActive: true }),
     );
   });
+
+  function blockingPromptDeps(childLifecycleAfterTimeout: ManagedAgent["lifecycle"]) {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const parentAgent = {
+      id: "parent-agent",
+      cwd: existingCwd,
+      workspaceId: "wks_parent",
+      provider: "codex",
+      currentModeId: "full-access",
+    } as ManagedAgent;
+    const childAgent = {
+      id: "child-agent",
+      cwd: existingCwd,
+      lifecycle: "running",
+      currentModeId: null,
+      availableModes: [],
+      config: { title: "Child" },
+    } as ManagedAgent;
+    spies.agentManager.getAgent.mockImplementation((agentId: string) => {
+      if (agentId === "parent-agent") return parentAgent;
+      if (agentId === "child-agent") return childAgent;
+      return null;
+    });
+    // The real wait: pending until the caller's abort signal (the 30s timeout) fires.
+    spies.agentManager.waitForAgentEvent.mockImplementationOnce(
+      (_agentId: string, options?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => {
+              childAgent.lifecycle = childLifecycleAfterTimeout;
+              reject(options.signal?.reason);
+            },
+            { once: true },
+          );
+        }),
+    );
+    return { agentManager, agentStorage, spies };
+  }
+
+  it("arms a finish notification when a blocking agent-scoped prompt times out while the child is still running", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agentManager, agentStorage, spies } = blockingPromptDeps("running");
+      const server = await createAgentMcpServer({
+        agentManager,
+        agentStorage,
+        providerSnapshotManager: createOpenCodeManager().manager,
+        callerAgentId: "parent-agent",
+        logger,
+      });
+
+      const tool = registeredTool(server, "send_agent_prompt");
+      const pending = invokeToolWithParsedInput(tool, {
+        agentId: "child-agent",
+        prompt: "Follow up",
+        background: false,
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+      const response = await pending;
+
+      expect(spies.agentManager.subscribe).toHaveBeenCalledTimes(1);
+      expect(spies.agentManager.subscribe).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ agentId: "child-agent" }),
+      );
+      expect(response.structuredContent).toMatchObject({
+        success: true,
+        status: "running",
+        guidance:
+          "You will get notified when the prompted agent finishes, errors, or needs permission. Do not poll for status; continue with other work until the notification arrives.",
+      });
+      expect(response.structuredContent.lastMessage).toContain("timed out after 30s");
+      expect(response.structuredContent.lastMessage).not.toContain(
+        "if you will receive a finish notification",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns the settled result instead of arming when the child finished during the timed-out wait", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agentManager, agentStorage, spies } = blockingPromptDeps("idle");
+      spies.agentManager.waitForAgentEvent.mockResolvedValueOnce({
+        status: "idle",
+        permission: null,
+        lastMessage: "Done.",
+      });
+      const server = await createAgentMcpServer({
+        agentManager,
+        agentStorage,
+        providerSnapshotManager: createOpenCodeManager().manager,
+        callerAgentId: "parent-agent",
+        logger,
+      });
+
+      const tool = registeredTool(server, "send_agent_prompt");
+      const pending = invokeToolWithParsedInput(tool, {
+        agentId: "child-agent",
+        prompt: "Follow up",
+        background: false,
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+      const response = await pending;
+
+      expect(spies.agentManager.subscribe).not.toHaveBeenCalled();
+      expect(spies.agentManager.waitForAgentEvent).toHaveBeenLastCalledWith("child-agent", {
+        waitForActive: false,
+      });
+      expect(response.structuredContent).toEqual({
+        success: true,
+        status: "idle",
+        lastMessage: "Done.",
+        permission: null,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("update_agent MCP tool", () => {

--- a/packages/server/src/server/agent/mcp-shared.ts
+++ b/packages/server/src/server/agent/mcp-shared.ts
@@ -145,11 +145,12 @@ export async function waitForAgentWithTimeout(
       });
       const recentActivity = curateAgentActivity(recent.items);
       const waitedSeconds = Math.round(AGENT_WAIT_TIMEOUT_MS / 1000);
-      const message = `Awaiting the agent timed out after ${waitedSeconds}s. This does not mean the agent failed - it is still running. Call get_agent_status to check on it, or continue with other work if you will receive a finish notification.\n\nRecent activity:\n${recentActivity}`;
+      const message = `Awaiting the agent timed out after ${waitedSeconds}s. This does not mean the agent failed - it is still running. Call get_agent_status to check on it.\n\nRecent activity:\n${recentActivity}`;
       return {
         status: snapshot?.lifecycle ?? "idle",
         permission: null,
         lastMessage: message,
+        timedOut: true,
       };
     }
     throw error;

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -1865,6 +1865,9 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
     }
   }
 
+  const FINISH_NOTIFICATION_GUIDANCE =
+    "You will get notified when the prompted agent finishes, errors, or needs permission. Do not poll for status; continue with other work until the notification arrives.";
+
   registerTool(
     "send_agent_prompt",
     {
@@ -1910,15 +1913,40 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
 
       // If not running in background, wait for completion
       if (!background) {
-        const result = await waitForAgentWithTimeout(agentManager, agentId, {
+        let result = await waitForAgentWithTimeout(agentManager, agentId, {
           waitForActive: true,
         });
+        let guidance: string | undefined;
+
+        if (result.timedOut && callerAgentId && notifyOnFinish) {
+          // The caller asked to wait but the wait ran out. Without a finish
+          // notification the result would be lost, so arm the same notification
+          // a background prompt gets. No await between the lifecycle check and
+          // the subscribe inside setupFinishNotification, so a finish cannot
+          // slip through the gap.
+          const liveSnapshot = agentManager.getAgent(agentId);
+          if (liveSnapshot && liveSnapshot.lifecycle === "running") {
+            setupFinishNotification({
+              agentManager,
+              agentStorage,
+              childAgentId: agentId,
+              callerAgentId,
+              logger: childLogger,
+            });
+            guidance = FINISH_NOTIFICATION_GUIDANCE;
+          } else {
+            // The agent settled while the timeout was being reported; return
+            // its final state instead of a stale "still running" message.
+            result = await agentManager.waitForAgentEvent(agentId, { waitForActive: false });
+          }
+        }
 
         const responseData = {
           success: true,
           status: result.status,
           lastMessage: result.lastMessage,
           permission: sanitizePermissionRequest(result.permission),
+          ...(guidance ? { guidance } : {}),
         };
         const validJson = ensureValidJson(responseData);
 
@@ -1938,12 +1966,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         status: currentSnapshot?.lifecycle ?? "idle",
         lastMessage: null,
         permission: null,
-        ...(shouldNotifyOnFinish
-          ? {
-              guidance:
-                "You will get notified when the prompted agent finishes, errors, or needs permission. Do not poll for status; continue with other work until the notification arrives.",
-            }
-          : {}),
+        ...(shouldNotifyOnFinish ? { guidance: FINISH_NOTIFICATION_GUIDANCE } : {}),
       };
       const validJson = ensureValidJson(responseData);
 


### PR DESCRIPTION
### Linked issue

Closes #4384

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

An agent that orchestrates others sometimes needs a synchronous answer from a child, so it calls `send_agent_prompt` with `background: false`. If the child takes longer than the 30 s wait, the tool returns "continue with other work if you will receive a finish notification", but the handler only arms that notification when `background` is true. The parent follows the advice, the child finishes, and nothing arrives. The parent only recovers by polling `get_agent_status` by hand (in my case, a day later when a human asked why the result never came back).

The fix keeps the deliberate behavior for blocking prompts that complete inside the wait (no notification; the result is in the tool response, and the existing test for that stays as is) and only changes the timed-out case: the wait result now says `timedOut`, and when the child is still running at that point the handler arms the same finish notification a background prompt gets and says so in `guidance`. If the child settled while the timeout was being reported, the handler returns the settled result instead of arming a subscription that would fire on some later, unrelated turn. The shared timeout message no longer promises a notification the caller may not get.

### Goals

- A blocking agent-scoped `send_agent_prompt` whose wait times out while the child is still running arms the finish notification and tells the caller so.
- A blocking prompt whose child settled during the timeout returns the settled result, with no stale subscription.
- The timeout text is accurate for every caller (agent-scoped or top-level, notification armed or not).

### Non-goals

- Blocking prompts that finish within the wait: unchanged, no notification (existing test kept).
- `create_agent`'s blocking path: unchanged; it already arms independently of the wait.
- The related notification issues #3248, #3875, #4231 (Windows background run, one-shot unsubscribe, error→resume) are not addressed here.

### QA

Daemon code only; no UI. Tested on Linux (Ubuntu, kernel 6.8, Node 22.23.1). Not run on a macOS or Windows daemon.

**Reproduced before the fix** (Paseo 0.7.2, live daemon): agent-scoped Claude Code session called `send_agent_prompt` on a Codex child with `background: false`; after 30 s the tool returned `status: "running"` with the "if you will receive a finish notification" message; the child finished two minutes later (`updatedAt 2026-09-05T16:13:36Z`, `attentionReason: "finished"`) and no `<paseo-system>` notification reached the parent. Full timeline in #4384.

**Tests, red on `main` (fix stashed, new tests only):**

```
npx vitest run src/server/agent/mcp-server.test.ts -t "timed-out wait|times out while the child"
     × arms a finish notification when a blocking agent-scoped prompt times out while the child is still running 20ms
     × returns the settled result instead of arming when the child finished during the timed-out wait 13ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
AssertionError: expected last "vi.fn()" call to have been called with [ 'child-agent', …(1) ]
      Tests  2 failed | 119 skipped (121)
```

**Tests, green with the fix (whole file):**

```
npx vitest run src/server/agent/mcp-server.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  121 passed (121)
```

The two new tests drive the real `waitForAgentWithTimeout` under fake timers: `waitForAgentEvent` stays pending until the tool's own 30 s abort fires, then the child is either still `running` (expects one `subscribe` for the child and the guidance text) or `idle` (expects no `subscribe` and a second, non-waiting `waitForAgentEvent` returning the settled result).

**Checks** (pre-commit via lefthook, all workspaces):

```
✔️ lint (0.23 seconds)
✔️ format (0.23 seconds)
✔️ typecheck (8.87 seconds)
```

Not verified against a live daemon after the fix: the only daemon on this machine is the production one that hosts the agents I would test with, and restarting it is off-limits.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
