### PR TITLE
fix(server): accept an MCP protocol version newer than the bundled SDK

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -517,14 +517,27 @@ function createBootstrapManagedProcessRegistry(
  * ours, or one that is not a date at all, is left untouched: the SDK must keep rejecting what it
  * genuinely cannot speak.
  */
-export function clampAgentMcpProtocolVersion(headers: Record<string, unknown>): void {
-  const raw = headers["mcp-protocol-version"];
+export function clampAgentMcpProtocolVersion(request: {
+  headers: Record<string, unknown>;
+  rawHeaders?: string[];
+}): void {
+  const raw = request.headers["mcp-protocol-version"];
   const requested = Array.isArray(raw) ? raw[0] : raw;
   if (typeof requested !== "string") return;
   if (SUPPORTED_PROTOCOL_VERSIONS.includes(requested)) return;
   if (!/^\d{4}-\d{2}-\d{2}$/u.test(requested)) return;
   if (requested <= LATEST_PROTOCOL_VERSION) return;
-  headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION;
+  request.headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION;
+  // `@hono/node-server`, which the SDK transport uses, rebuilds the Web Request from `rawHeaders`
+  // and never reads `headers`. Rewriting only the parsed object changes nothing -- measured on
+  // cs8, where the 400 kept coming after the first attempt at this fix.
+  const rawList = request.rawHeaders;
+  if (rawList === undefined) return;
+  for (let i = 0; i < rawList.length; i += 2) {
+    if (rawList[i]?.toLowerCase() === "mcp-protocol-version") {
+      rawList[i + 1] = LATEST_PROTOCOL_VERSION;
+    }
+  }
 }
 
 async function reconcileManagedProcessLedger(
@@ -1542,7 +1555,7 @@ export async function createPaseoDaemon(
           void server.close();
         });
 
-        clampAgentMcpProtocolVersion(req.headers);
+        clampAgentMcpProtocolVersion(req as unknown as { headers: Record<string, unknown>; rawHeaders?: string[] });
         await transport.handleRequest(
           req as unknown as IncomingMessage,
           res as unknown as ServerResponse,

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -6,6 +6,10 @@ import { randomUUID } from "node:crypto";
 import { hostname as getHostname } from "node:os";
 import path from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "pino";
 import { z } from "zod";
 import { createBranchChangeRouteHandler } from "./script-route-branch-handler.js";
@@ -496,6 +500,31 @@ function createBootstrapManagedProcessRegistry(
     terminateProcess: terminateWithTreeKill,
     logger,
   });
+}
+
+
+/**
+ * Accepts an `MCP-Protocol-Version` the bundled SDK has never heard of.
+ *
+ * A client that ships ahead of the SDK sends a date we do not know, and the transport answers
+ * `400 Unsupported protocol version` on every call. For an agent that is fatal in a way nobody
+ * sees: it keeps working, but every hub tool is gone, so it can neither reply nor finish, and the
+ * run ends "succeeded" with nothing said. Measured on 2026-09-06 with Claude Code 2.1.259, which
+ * sends `2026-07-28`; the newest published SDK (1.30.0) still tops out at 2025-11-25.
+ *
+ * A date NEWER than ours is downgraded to ours, which is what version negotiation is for -- MCP
+ * is backward compatible, and a client that asked for more can be served less. A date OLDER than
+ * ours, or one that is not a date at all, is left untouched: the SDK must keep rejecting what it
+ * genuinely cannot speak.
+ */
+export function clampAgentMcpProtocolVersion(headers: Record<string, unknown>): void {
+  const raw = headers["mcp-protocol-version"];
+  const requested = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof requested !== "string") return;
+  if (SUPPORTED_PROTOCOL_VERSIONS.includes(requested)) return;
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(requested)) return;
+  if (requested <= LATEST_PROTOCOL_VERSION) return;
+  headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION;
 }
 
 async function reconcileManagedProcessLedger(
@@ -1513,6 +1542,7 @@ export async function createPaseoDaemon(
           void server.close();
         });
 
+        clampAgentMcpProtocolVersion(req.headers);
         await transport.handleRequest(
           req as unknown as IncomingMessage,
           res as unknown as ServerResponse,

--- a/packages/server/src/server/mcp-protocol-version.test.ts
+++ b/packages/server/src/server/mcp-protocol-version.test.ts
@@ -6,30 +6,35 @@ describe("clampAgentMcpProtocolVersion", () => {
   it("downgrades a version newer than the bundled SDK, instead of rejecting the call", () => {
     // Claude Code 2.1.259 sends 2026-07-28; SDK 1.30.0 tops out at 2025-11-25, and the transport
     // answers 400 to every request -- the agent loses hub.reply and finishes silently.
-    const headers: Record<string, unknown> = { "mcp-protocol-version": "2026-07-28" };
-    clampAgentMcpProtocolVersion(headers);
-    expect(headers["mcp-protocol-version"]).toBe(LATEST_PROTOCOL_VERSION);
+    const request = {
+      headers: { "mcp-protocol-version": "2026-07-28" } as Record<string, unknown>,
+      rawHeaders: ["Accept", "application/json", "MCP-Protocol-Version", "2026-07-28"],
+    };
+    clampAgentMcpProtocolVersion(request);
+    expect(request.headers["mcp-protocol-version"]).toBe(LATEST_PROTOCOL_VERSION);
+    // The transport rebuilds the request from rawHeaders and never reads the parsed object.
+    expect(request.rawHeaders[3]).toBe(LATEST_PROTOCOL_VERSION);
   });
 
   it("leaves a version the SDK knows exactly as it is", () => {
-    const headers: Record<string, unknown> = { "mcp-protocol-version": "2025-06-18" };
-    clampAgentMcpProtocolVersion(headers);
-    expect(headers["mcp-protocol-version"]).toBe("2025-06-18");
+    const request = { headers: { "mcp-protocol-version": "2025-06-18" } as Record<string, unknown> };
+    clampAgentMcpProtocolVersion(request);
+    expect(request.headers["mcp-protocol-version"]).toBe("2025-06-18");
   });
 
   it("leaves an older unknown version to the SDK, which must still refuse it", () => {
-    const headers: Record<string, unknown> = { "mcp-protocol-version": "2019-01-01" };
-    clampAgentMcpProtocolVersion(headers);
-    expect(headers["mcp-protocol-version"]).toBe("2019-01-01");
+    const request = { headers: { "mcp-protocol-version": "2019-01-01" } as Record<string, unknown> };
+    clampAgentMcpProtocolVersion(request);
+    expect(request.headers["mcp-protocol-version"]).toBe("2019-01-01");
   });
 
   it("ignores anything that is not a date, and a missing header", () => {
-    const garbage: Record<string, unknown> = { "mcp-protocol-version": "latest" };
+    const garbage = { headers: { "mcp-protocol-version": "latest" } as Record<string, unknown> };
     clampAgentMcpProtocolVersion(garbage);
-    expect(garbage["mcp-protocol-version"]).toBe("latest");
+    expect(garbage.headers["mcp-protocol-version"]).toBe("latest");
 
-    const absent: Record<string, unknown> = {};
+    const absent = { headers: {} as Record<string, unknown> };
     expect(() => clampAgentMcpProtocolVersion(absent)).not.toThrow();
-    expect(absent["mcp-protocol-version"]).toBeUndefined();
+    expect(absent.headers["mcp-protocol-version"]).toBeUndefined();
   });
 });

--- a/packages/server/src/server/mcp-protocol-version.test.ts
+++ b/packages/server/src/server/mcp-protocol-version.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
+import { clampAgentMcpProtocolVersion } from "./bootstrap.js";
+
+describe("clampAgentMcpProtocolVersion", () => {
+  it("downgrades a version newer than the bundled SDK, instead of rejecting the call", () => {
+    // Claude Code 2.1.259 sends 2026-07-28; SDK 1.30.0 tops out at 2025-11-25, and the transport
+    // answers 400 to every request -- the agent loses hub.reply and finishes silently.
+    const headers: Record<string, unknown> = { "mcp-protocol-version": "2026-07-28" };
+    clampAgentMcpProtocolVersion(headers);
+    expect(headers["mcp-protocol-version"]).toBe(LATEST_PROTOCOL_VERSION);
+  });
+
+  it("leaves a version the SDK knows exactly as it is", () => {
+    const headers: Record<string, unknown> = { "mcp-protocol-version": "2025-06-18" };
+    clampAgentMcpProtocolVersion(headers);
+    expect(headers["mcp-protocol-version"]).toBe("2025-06-18");
+  });
+
+  it("leaves an older unknown version to the SDK, which must still refuse it", () => {
+    const headers: Record<string, unknown> = { "mcp-protocol-version": "2019-01-01" };
+    clampAgentMcpProtocolVersion(headers);
+    expect(headers["mcp-protocol-version"]).toBe("2019-01-01");
+  });
+
+  it("ignores anything that is not a date, and a missing header", () => {
+    const garbage: Record<string, unknown> = { "mcp-protocol-version": "latest" };
+    clampAgentMcpProtocolVersion(garbage);
+    expect(garbage["mcp-protocol-version"]).toBe("latest");
+
+    const absent: Record<string, unknown> = {};
+    expect(() => clampAgentMcpProtocolVersion(absent)).not.toThrow();
+    expect(absent["mcp-protocol-version"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What breaks today

A client that ships ahead of the SDK sends an `MCP-Protocol-Version` we do not know, and the Streamable HTTP transport answers `400 Unsupported protocol version` on **every** request.

For an agent this is fatal in a way nobody sees. It keeps running, but every hub tool is gone — so it can neither reply nor call `finish_execution`. The run ends `succeeded` with nothing said, and the surface shows "finished this workflow without posting a reply".

Measured on 2026-09-06 with **Claude Code 2.1.259**, which sends `2026-07-28`:

```
Agent MCP transport error
  Bad Request: Unsupported protocol version: 2026-07-28
  (supported: 2025-11-25, 2025-06-18, 2025-03-26, 2024-11-05, 2024-10-07)
```

Three Linear issues ran to completion and answered nothing. Upgrading the SDK does not help: the newest published `@modelcontextprotocol/sdk` (1.30.0) still tops out at `2025-11-25`, so any daemon is one client release away from this.

## The change

One guard before `transport.handleRequest`: a protocol date **newer** than ours is downgraded to ours. That is what version negotiation is for — MCP is backward compatible, and a client that asked for more can be served less.

Left untouched, so the SDK keeps refusing what it genuinely cannot speak:
- a version the SDK already supports,
- a date older than ours,
- anything that is not a date, or a missing header.

Four tests cover those cases.