### PR TITLE
docs: add Hub Notion connection and webhook setup

### DIFF
--- a/public-docs/hub/self-hosting/index.md
+++ b/public-docs/hub/self-hosting/index.md
@@ -14,7 +14,7 @@ The shortest path is one command:
 npx @getpaseo/hub
 ```
 
-Open <http://localhost:3000>. A fresh Hub creates its embedded database and authentication secret, then guides you through creating the operator account and the GitHub, Slack, or Discord apps you want.
+Open <http://localhost:3000>. A fresh Hub creates its embedded database and authentication secret, then guides you through creating the operator account and the GitHub, Slack, Discord, or Notion apps you want.
 
 Follow the [quickstart](/docs/hub/quickstart) to connect Slack over Socket Mode and run the first workflow without a public server.
 
@@ -34,7 +34,7 @@ Embedded mode supports one Hub process per data directory. It is intended for a 
 
 Hub defaults to `http://localhost:3000`. That is enough for its dashboard, daemons, Slack Socket Mode, and providers that connect out from Hub.
 
-GitHub event triggers use webhooks and need a public HTTPS address. Repository access can still work without the webhook. Slack's optional Webhooks transport also needs public HTTPS; Socket Mode does not.
+GitHub event triggers use webhooks and need a public HTTPS address. Notion setup and native webhooks also require HTTPS. Repository access can still work without the webhook. Slack's optional Webhooks transport also needs public HTTPS; Socket Mode does not.
 
 When Hub is available at a stable public origin, set it before starting:
 
@@ -59,7 +59,7 @@ The database also stores Hub's generated authentication secret. Set `PASEO_HUB_A
 
 ## App configuration
 
-The operator configures GitHub, Slack, and Discord under **Apps**. Hub verifies the credentials before saving them in its database and starts the same provider runtime used by environment-configured deployments.
+The operator configures GitHub, Slack, Discord, and Notion under **Apps**. Hub verifies the credentials before saving them in its database and starts the same provider runtime used by environment-configured deployments.
 
 Environment variables remain available for deployments that manage secrets outside Hub. A complete environment configuration takes precedence over a saved application and appears as **Managed by environment** in the dashboard.
 
@@ -89,6 +89,8 @@ DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
 DISCORD_BOT_TOKEN=
 ```
+
+Notion uses an internal integration configured through Apps. Follow [Notion for Hub](/docs/hub/self-hosting/notion-app) to verify its permissions and native webhook subscription.
 
 See [GitHub](/docs/hub/self-hosting/github-app), [Slack](/docs/hub/self-hosting/slack-app), and [Discord](/docs/hub/self-hosting/discord-app) for provider behavior and connection steps.
 

--- a/public-docs/hub/self-hosting/notion-app.md
+++ b/public-docs/hub/self-hosting/notion-app.md
@@ -1,0 +1,51 @@
+---
+title: Notion for Hub
+description: Connect an internal Notion integration and verify native webhook deliveries.
+nav: Notion app
+order: 78
+category: Hub
+---
+
+# Notion for Hub
+
+Hub supports one internal Notion integration per instance. It verifies a workspace and bot identity, saves a connection for the active Hub organization, and receives signed native webhook events. Task triggers, agent execution, context loading, and result writeback are not available yet.
+
+## Connect the integration
+
+Open Hub at its public HTTPS address and sign in as the instance operator. Select the organization that should own the connection, then open **Apps → Notion**.
+
+1. Create an internal connection in the [Notion developer portal](https://www.notion.so/profile/integrations).
+2. Enable **Read content**, **Read comments**, **Update content**, and **Insert comments**.
+3. Share a dedicated verification page with the connection. Share any other content the integration should be able to access separately in Notion.
+4. Enter the integration ID from its developer settings, the internal integration token, and the verification page ID in Hub. Page IDs may include or omit UUID separators.
+5. Choose **Verify permissions and connect**.
+
+Verification reads the bot identity, page, content, and comments. It sends an empty property update and adds a verification comment to the dedicated page. Each attempt may add another comment. Do not use a production task as the verification page unless these writes are acceptable.
+
+Hub displays the verified workspace and bot IDs. The integration ID is supplied by the operator and checked against subsequent signed webhook deliveries. The connection cannot be transferred to another Hub organization or integration by replacing its credentials; disconnect it first.
+
+Notion controls content access. Configuring a data source or workflow in Hub does not grant additional access in Notion. Hub keeps the token in its credential storage and does not expose it through ordinary configuration or pass it to an agent.
+
+## Verify the webhook subscription
+
+REST requests and the subscription version are fixed to **2026-03-11**.
+
+1. In **Apps → Notion → Notion webhook**, choose **Prepare verification address**.
+2. Copy the generated HTTPS URL into the integration's **Webhooks** settings in Notion. Select `page.properties_updated` and API version `2026-03-11`.
+3. Create the subscription. Notion sends its verification challenge to Hub.
+4. Choose **Check verification** in Hub. Copy the verification token into Notion to complete its subscription verification.
+5. Copy that subscription's ID from Notion into Hub and choose **Bind verified subscription**. Confirm the subscription is active in Notion.
+
+The temporary verification address expires after ten minutes. If it expires, prepare another address and repeat the subscription setup. The saved subscription continues using its configured URL after verification; the temporary parameter only controls challenge reception. It is not event authentication.
+
+Challenges never start runs or replace an active webhook secret. Preparing a replacement leaves the active subscription usable until an operator explicitly binds the replacement. The verification token is shown only through the protected setup action; it is not part of ordinary readable configuration.
+
+## Check delivery and maintain the connection
+
+Change a property on a page shared with the integration. Hub checks `X-Notion-Signature` against the original request bytes and verifies the workspace, integration, subscription, and active connection before recording `page.properties_updated` deliveries. Events appear in the existing activity records with no matching trigger. Delayed retries are allowed, and repeated deliveries of the same event reuse the existing receipt. Other correctly authenticated event types are ignored.
+
+Use **Replace credentials** in Apps to verify a rotated token. Failed verification or activation leaves the previously working Hub configuration intact. Correct the token, capabilities, page sharing, or reported conflict and try again. A rate limit or unavailable Notion service is reported without treating the check as successful; retry after the service recovers.
+
+Use the organization's **Connections** page to disconnect Notion. This removes the local binding and its webhook secrets, immediately stopping event admission. It does not delete the integration or subscription in Notion. Disable those in the Notion portal when they are no longer needed. Reconnecting requires setting up and binding the webhook again.
+
+Keep tokens, verification secrets, real workspace IDs, and private operational notes outside public repositories. Examples and deployment instructions need only placeholder IDs; no OAuth credentials or daemon protocol changes are required.


### PR DESCRIPTION
Hub's Notion connection needs operator instructions for verifying an internal integration and binding its native webhook subscription. This adds a self-hosting guide covering the four capability probes on a dedicated verification page, explicit challenge binding, signed delivery checks, credential rotation, and disconnect behavior.

The guide describes connection and event receipt support only; task triggers and execution are not available yet. It accompanies the Notion Provider 01 implementation in Hub and should land with that feature.

Validation: formatted both changed Markdown files with the repository's `format:files` script and reviewed the instructions against the Hub implementation and its settings/browser tests.
