### PR TITLE
Preserve the packaged macOS Dock icon

### DIFF
--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -634,7 +634,8 @@ async function getEffectiveAppIconPath(): Promise<string | null> {
 }
 
 async function applyAppIcon(): Promise<void> {
-  if (process.platform !== "darwin") {
+  // Packaged apps keep the bundle icon and its macOS system appearance.
+  if (app.isPackaged || process.platform !== "darwin") {
     return;
   }
 


### PR DESCRIPTION
### Linked issue

Closes #3382

### Type of change

- [x] Bug fix

### Reasoning

Packaged macOS startup replaced the bundled Dock icon with a flat PNG, discarding the system icon appearance. Skip the runtime Dock override for packaged builds so macOS retains the bundle icon.

### Goals

- Preserve the packaged macOS Dock icon at startup.
- Keep development icon stamping working.

### Non-goals

- Change icon artwork or other platforms' window icons.

### QA

- Desktop typecheck and repository lint passed.
- Repository typecheck passed in all other workspaces except CLI, which passed after rebuilding stale workspace declarations with `npm run build:server`.
- `npm run format` passed.
- Inspected the startup call path: packaged builds now return before loading the PNG or calling `app.dock.setIcon()`.
- macOS visual QA was unavailable on the Linux development host. No claim of visual verification; the risk surface is the macOS startup Dock override.

### Supersedes

- [PR #4086](https://github.com/getpaseo/paseo/pull/4086) — Addresses the same packaged Dock override directly at the existing startup guard.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] macOS visual QA evidence
- [ ] Tests added or updated where it made sense
