### PR TITLE
fix(claude): open a single compaction marker per compaction

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -24,6 +24,12 @@ interface TestClaudeSession {
   close(): Promise<void>;
 }
 
+function isLoadingCompactionEvent(event: AgentStreamEvent): boolean {
+  return (
+    event.type === "timeline" && event.item.type === "compaction" && event.item.status === "loading"
+  );
+}
+
 function isPermissionResolvedEvent(
   event: AgentStreamEvent,
 ): event is Extract<AgentStreamEvent, { type: "permission_resolved" }> {
@@ -1981,6 +1987,15 @@ describe("ClaudeAgentSession context window usage", () => {
     };
   }
 
+  function createCompactingStatus(): Record<string, unknown> {
+    return {
+      type: "system",
+      subtype: "status",
+      status: "compacting",
+      session_id: "session-1",
+    };
+  }
+
   test("emits turn_started before the submitted user message", async () => {
     const session = await createSessionForTurns([[]]);
     const events: AgentStreamEvent[] = [];
@@ -2852,6 +2867,108 @@ describe("ClaudeAgentSession context window usage", () => {
             event.type === "turn_completed" && event.usage.contextWindowUsedTokens !== undefined,
         ),
       ).toBe(false);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("repeated compacting statuses open a single compaction marker", async () => {
+    const session = await createSessionForTest();
+
+    try {
+      function markersOpenedBy(message: Record<string, unknown>): number {
+        return session
+          .translateMessageToEvents(message as unknown as SDKMessage)
+          .filter(isLoadingCompactionEvent).length;
+      }
+
+      expect(markersOpenedBy(createCompactingStatus())).toBe(1);
+      // Claude Code repeats the status every 30 seconds until the compaction ends.
+      expect(markersOpenedBy(createCompactingStatus())).toBe(0);
+      expect(markersOpenedBy(createCompactingStatus())).toBe(0);
+
+      session.translateMessageToEvents(createCompactBoundary() as unknown as SDKMessage);
+
+      expect(markersOpenedBy(createCompactingStatus())).toBe(1);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("a compaction abandoned mid-turn does not suppress the next compaction marker", async () => {
+    // The first turn starts compacting and then ends without ever reaching a
+    // compact_boundary, so the marker it opened is never resolved.
+    const session = await createSessionForTurns([
+      [createCompactingStatus(), createSuccessResult()],
+      [createCompactingStatus(), createSuccessResult()],
+    ]);
+
+    try {
+      const abandonedTurn = await collectStreamEvents(session, "abandoned compaction");
+      expect(abandonedTurn.filter(isLoadingCompactionEvent)).toHaveLength(1);
+
+      const nextTurn = await collectStreamEvents(session, "next compaction");
+      expect(nextTurn.filter(isLoadingCompactionEvent)).toHaveLength(1);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("an interrupted compaction does not suppress the next compaction marker", async () => {
+    // The first turn starts compacting and is then interrupted, so it never reaches a
+    // compact_boundary and the marker it opened is never resolved.
+    const session = await createSessionForTurns([
+      [createCompactingStatus()],
+      [createCompactingStatus(), createSuccessResult()],
+    ]);
+
+    try {
+      const interruptedTurn: AgentStreamEvent[] = [];
+      const streaming = (async () => {
+        for await (const event of streamSession(session, "interrupted compaction")) {
+          interruptedTurn.push(event);
+        }
+      })();
+
+      await vi.waitFor(() => {
+        expect(interruptedTurn.filter(isLoadingCompactionEvent)).toHaveLength(1);
+      });
+      await session.interrupt();
+      await streaming;
+
+      expect(interruptedTurn).toContainEqual(
+        expect.objectContaining({ type: "turn_canceled", provider: "claude" }),
+      );
+
+      const nextTurn = await collectStreamEvents(session, "next compaction");
+      expect(nextTurn.filter(isLoadingCompactionEvent)).toHaveLength(1);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("a compaction abandoned in an autonomous turn does not suppress the next marker", async () => {
+    // Trailing output after the foreground result opens an autonomous turn, which starts
+    // compacting and is then ended by the next foreground turn, never reaching a boundary.
+    const session = await createSessionForTurns([
+      [createSuccessResult(), createMessageStartEvent(), createCompactingStatus()],
+      [createCompactingStatus(), createSuccessResult()],
+    ]);
+
+    try {
+      const observed: AgentStreamEvent[] = [];
+      const unsubscribe = session.subscribe((event) => {
+        observed.push(event);
+      });
+
+      await collectStreamEvents(session, "foreground turn");
+      await vi.waitFor(() => {
+        expect(observed.filter(isLoadingCompactionEvent)).toHaveLength(1);
+      });
+      unsubscribe();
+
+      const nextTurn = await collectStreamEvents(session, "next compaction");
+      expect(nextTurn.filter(isLoadingCompactionEvent)).toHaveLength(1);
     } finally {
       await session.close();
     }

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -2873,23 +2873,25 @@ describe("ClaudeAgentSession context window usage", () => {
   });
 
   test("repeated compacting statuses open a single compaction marker", async () => {
-    const session = await createSessionForTest();
+    const session = await createSessionForTurns([
+      [
+        createCompactingStatus(),
+        createCompactingStatus(),
+        createCompactingStatus(),
+        createCompactBoundary(),
+        createCompactingStatus(),
+        createCompactingStatus(),
+        createCompactBoundary(),
+        createSuccessResult(),
+      ],
+    ]);
 
     try {
-      function markersOpenedBy(message: Record<string, unknown>): number {
-        return session
-          .translateMessageToEvents(message as unknown as SDKMessage)
-          .filter(isLoadingCompactionEvent).length;
-      }
-
-      expect(markersOpenedBy(createCompactingStatus())).toBe(1);
-      // Claude Code repeats the status every 30 seconds until the compaction ends.
-      expect(markersOpenedBy(createCompactingStatus())).toBe(0);
-      expect(markersOpenedBy(createCompactingStatus())).toBe(0);
-
-      session.translateMessageToEvents(createCompactBoundary() as unknown as SDKMessage);
-
-      expect(markersOpenedBy(createCompactingStatus())).toBe(1);
+      const events = await collectStreamEvents(session, "compact twice");
+      const compactions = events.flatMap((event) =>
+        event.type === "timeline" && event.item.type === "compaction" ? [event.item.status] : [],
+      );
+      expect(compactions).toEqual(["loading", "completed", "loading", "completed"]);
     } finally {
       await session.close();
     }

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -2095,6 +2095,7 @@ class ClaudeAgentSession implements AgentSession {
   private lastOptionsModel: string | null = null;
   private lastRuntimeModel: string | null = null;
   private compacting = false;
+  private compactionMarkerOpen = false;
   private queryPumpPromise: Promise<void> | null = null;
   private queryRestartNeeded = false;
   private pendingInterruptAbort = false;
@@ -3572,6 +3573,7 @@ class ClaudeAgentSession implements AgentSession {
     this.activeForegroundInput = null;
     this.cancelCurrentTurn = null;
     this.activeTurnHasAssistantText = false;
+    this.compactionMarkerOpen = false;
     this.syncTurnState("foreground turn terminal");
   }
 
@@ -3583,6 +3585,7 @@ class ClaudeAgentSession implements AgentSession {
     }
 
     if (terminalSeen) {
+      this.compactionMarkerOpen = false;
       if (this.activeForegroundTurnId) {
         this.activeForegroundTurnId = null;
         this.activeForegroundQuery = null;
@@ -3624,6 +3627,7 @@ class ClaudeAgentSession implements AgentSession {
     this.activeForegroundQuery = null;
     this.activeForegroundInput = null;
     this.activeTurnHasAssistantText = false;
+    this.compactionMarkerOpen = false;
     this.syncTurnState("autonomous turn completed");
   }
 
@@ -4260,15 +4264,22 @@ class ClaudeAgentSession implements AgentSession {
       const status = toObjectRecord(message)?.status;
       if (status === "compacting") {
         this.compacting = true;
-        events.push({
-          type: "timeline",
-          item: { type: "compaction", status: "loading" },
-          provider: "claude",
-        });
+        // Claude Code repeats this status every 30 seconds until the compaction
+        // finishes. Each repeat used to open its own marker, and the app only ever
+        // resolves one of them, so the rest stayed on "Compacting..." forever.
+        if (!this.compactionMarkerOpen) {
+          this.compactionMarkerOpen = true;
+          events.push({
+            type: "timeline",
+            item: { type: "compaction", status: "loading" },
+            provider: "claude",
+          });
+        }
       }
       return;
     }
     if (message.subtype === "compact_boundary") {
+      this.compactionMarkerOpen = false;
       const compactMetadata = readCompactionMetadata(message);
       events.push({
         type: "timeline",


### PR DESCRIPTION
### Linked issue

Closes #4390

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Claude Code doesn't send `status: "compacting"` once. It sends it when compaction starts and then repeats it every 30 seconds until the compaction finishes, as a heartbeat. The Claude provider treated every one of those as a new compaction and pushed a new `loading` timeline item, while the app only ever resolves one of them when the boundary arrives. So a compaction that takes 100 seconds leaves three `Compacting...` rows spinning in the user's timeline forever, and the longer the session, the longer the compaction and the more stuck rows it leaves — worst exactly when the user is already deep in a long piece of work.

This makes the heartbeat a heartbeat: the first `compacting` status opens the marker, the repeats are ignored, and the boundary closes it.

### Goals

- One compaction produces exactly one timeline marker, whatever its duration.
- A second compaction in the same session still gets its own marker.
- A compaction abandoned mid-turn does not silence the marker for the next one.

### Non-goals

- Terminalizing markers that never receive a boundary. That is a different root cause — a compaction that starts and never completes — and is tracked separately in #3776. This fix does not depend on it.
- Any app-side change. With one marker emitted per compaction the existing reducer resolves it correctly.

### QA

Full raw QA transcript, every command with its output: [qa-transcript.md](https://github.com/tomgrin10/paseo/blob/qa-evidence/qa-transcript.md)

**Before** — 112.9s compaction, 1 resolved row + 3 stuck:

![before](https://raw.githubusercontent.com/tomgrin10/paseo/qa-evidence/before-3-stuck-compacting-rows.png)

**After** — 98.4s compaction, all three heartbeats fired, exactly 1 row:

![after](https://raw.githubusercontent.com/tomgrin10/paseo/qa-evidence/after-single-compaction-row.png)

**Reproduced before, confirmed fixed after — same corpus, same viewport, both runs long enough for all three heartbeats to fire.**

|  | BEFORE (unfixed) | AFTER (fixed) |
|---|---|---|
| `preTokens` | 304,441 | 312,666 |
| `durationMs` | 112,921 | 98,371 |
| heartbeats fired (t=30/60/90s) | 3 | 3 |
| compaction markers opened | **4** | **1** |
| rows once complete | 1 resolved + **3 stuck** `Compacting...` | 1 resolved, **0 stuck** |

BEFORE, observed live in the web app:

```
t = 12s    1 x "Compacting..."
t = 30s    2 x "Compacting..."     <- heartbeat #1
t = 43s    2 x "Compacting..."
t = 1m01s  3 x "Compacting..."     <- heartbeat #2
t = 1m32s  4 x "Compacting..."     <- heartbeat #3
done       1 x "Context manually compacted" + 3 x "Compacting..." STUCK
```

AFTER, same scenario:

```
t = 7s     1 x "Compacting..."
t = 38s    1 x "Compacting..."     <- heartbeat #1 fired, no new marker
t = 1m05s  1 x "Compacting..."     <- heartbeat #2 fired, no new marker
t = 1m35s  1 x "Compacting..."     <- heartbeat #3 fired, no new marker
done       1 x "Context manually compacted", zero leftover spinners
```

`compact_boundary` records from the agents' own Claude transcripts:

```json
BEFORE  { "trigger": "manual", "preTokens": 304441, "durationMs": 112921, "postTokens": 19592 }
AFTER   { "trigger": "manual", "preTokens": 312666, "durationMs": 98371,  "postTokens": 9446 }
```

#### Automated tests

New regression test `repeated compacting statuses open a single compaction marker`. Confirmed it fails on the unfixed code for the reported reason — the second `compacting` status opens a second marker:

```
$ npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts \
    -t "repeated compacting statuses"        # fix reverted

 FAIL  ... > repeated compacting statuses open a single compaction marker
AssertionError: expected 1 to be +0 // Object.is equality
- Expected  0
+ Received  1

 ❯ agent.test.ts:2886
    2884|       expect(markersOpenedBy(createCompactingStatus())).toBe(1);
    2885|       // Claude Code repeats the status every 30 seconds until the compaction ends.
    2886|       expect(markersOpenedBy(createCompactingStatus())).toBe(0);
```

With the fix:

```
$ npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts
 Test Files  1 passed (1)
      Tests  76 passed (76)

$ npx oxfmt --check packages/server/src/server/agent/providers/claude/agent.ts \
                    packages/server/src/server/agent/providers/claude/agent.test.ts
All matched files use the correct format.

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run typecheck:server
exit 0
```

The test also asserts that a `compact_boundary` re-arms the marker, so a second compaction in the same session still gets one.

#### One caveat worth recording

If Claude Code has a precomputed compaction cached, `/compact` takes a different branch that returns before the heartbeat interval is armed. Those compactions never showed the bug, which is why it looks intermittent. Both runs above took the heartbeat branch.

#### Platforms

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | ❌     | Not tested |
| Android         | ❌     | Not tested |
| Web             | ✅     | Before and after captured here, dev app against a dev daemon |
| Desktop macOS   | ⚠️     | Where the bug was originally observed; the fix was not re-verified on Electron |
| Desktop Windows | ❌     | Not tested |
| Desktop Linux   | ❌     | Not tested |

The change is daemon-side and provider-side only, so the surface behaves the same on every client; the timeline items it emits are what differ.
