### PR TITLE
fix(app): reflow iPad chat rows after pane resize [WIP]

### DIFF
--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -23,6 +23,8 @@ import {
 } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { MAX_CONTENT_WIDTH, useIsCompactFormFactor } from "@/constants/layout";
+import { useContainerWidth } from "@/hooks/use-container-width";
+import { isNative } from "@/constants/platform";
 import { useMutation } from "@tanstack/react-query";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { Check, ChevronDown, X } from "lucide-react-native";
@@ -666,23 +668,20 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       });
     }, [agentId, handleTimelineHistoryLoadError, isTimelineDetached, resolvedServerId]);
 
-    const setInlineDetailsExpanded = useCallback(
-      (itemId: string, expanded: boolean) => {
-        if (!streamRenderStrategy.shouldDisableParentScrollOnInlineDetailsExpansion()) {
-          return;
+    const setInlineDetailsExpanded = useCallback((itemId: string, expanded: boolean) => {
+      if (!isNative) {
+        return;
+      }
+      setExpandedInlineToolCallIds((previous) => {
+        const next = new Set(previous);
+        if (expanded) {
+          next.add(itemId);
+        } else {
+          next.delete(itemId);
         }
-        setExpandedInlineToolCallIds((previous) => {
-          const next = new Set(previous);
-          if (expanded) {
-            next.add(itemId);
-          } else {
-            next.delete(itemId);
-          }
-          return next;
-        });
-      },
-      [streamRenderStrategy],
-    );
+        return next;
+      });
+    }, []);
 
     const setToolCallGroupExpanded = useCallback((groupId: string, expanded: boolean) => {
       setExpandedToolCallGroupIds((previous) => {
@@ -756,11 +755,11 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             text={item.text}
             status={item.status}
             isLastInSequence={layoutItem.isLastInToolSequence}
-            defaultExpanded={autoExpandReasoning}
+            defaultExpanded={autoExpandReasoning || expandedInlineToolCallIds.has(item.id)}
           />
         );
       },
-      [autoExpandReasoning, setInlineDetailsExpanded],
+      [autoExpandReasoning, expandedInlineToolCallIds, setInlineDetailsExpanded],
     );
 
     const renderSingleToolCallItem = useCallback(
@@ -789,6 +788,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             <ToolCallSlot
               itemId={item.id}
               onInlineDetailsExpandedChangeByItemId={setInlineDetailsExpanded}
+              defaultExpanded={expandedInlineToolCallIds.has(item.id)}
               toolName={data.name}
               error={data.error}
               status={data.status}
@@ -807,6 +807,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           <ToolCallSlot
             itemId={item.id}
             onInlineDetailsExpandedChangeByItemId={setInlineDetailsExpanded}
+            defaultExpanded={expandedInlineToolCallIds.has(item.id)}
             toolName={data.toolName}
             args={data.arguments}
             result={data.result}
@@ -817,7 +818,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           />
         );
       },
-      [context.cwd, setInlineDetailsExpanded, handleToolCallOpenFile],
+      [context.cwd, expandedInlineToolCallIds, handleToolCallOpenFile, setInlineDetailsExpanded],
     );
 
     // Read through a stable event so live group updates do not change the renderer identity
@@ -1759,9 +1760,14 @@ interface StreamItemWrapperProps {
 }
 
 function StreamItemWrapper({ gapBelow, children }: StreamItemWrapperProps) {
+  const { onLayout, width } = useContainerWidth();
   const wrapperStyle = useMemo(
     () => [stylesheet.streamItemWrapper, { marginBottom: gapBelow }],
     [gapBelow],
   );
-  return <View style={wrapperStyle}>{children}</View>;
+  return (
+    <View style={wrapperStyle} onLayout={isNative ? onLayout : undefined}>
+      <React.Fragment key={isNative ? width : 0}>{children}</React.Fragment>
+    </View>
+  );
 }


### PR DESCRIPTION
### Linked issue

Closes #4394

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

On iPad, closing Explorer widens the chat pane, but existing native stream rows can retain layout measured at the previous narrow width. The inverted virtualized `FlatList` does not reliably rerender every width-sensitive descendant after its parent changes width. Measuring each native row and remounting its content when that width changes makes existing messages reflow to the available chat width.

The remount would otherwise collapse expanded inline details. The existing native expansion-ID set now initializes `defaultExpanded` for a remounted tool call or thought, preserving expanded details without changing `ToolCall`.

### Goals

- Reflow existing iPad chat rows after Explorer changes the chat-pane width.
- Preserve expanded native inline details across that width-driven row remount.
- Leave browser and Electron web reflow behavior unchanged.

### Non-goals

- Do not change the shared stream renderer contract or add viewport state to `FlatList`.
- Do not change `ToolCall` into a controlled component.
- Do not address the outstanding case where an auto-expanded thought that a user manually collapsed reopens after a width remount; Greptile reported this separately and it needs a follow-up decision.

### QA

Commands run:

```text
npx vitest run packages/app/src/agent-stream/strategy-web.test.tsx packages/app/src/hooks/use-container-width.test.ts --bail=1
2 files, 20 tests passed

npm run lint -- packages/app/src/agent-stream/view.tsx
passed

npm run format
passed

git diff --check
passed
```

`npm run typecheck --workspace=@getpaseo/app` remains blocked by the pre-existing `dragGestureHostPresented` error in `packages/app/src/components/draggable-list.native.tsx`.

The iOS bundle loaded on an iPad simulator. Exact Explorer open/close automation was unavailable because `agent-device` is not installed and Maestro requires Java. No before/after screenshot or video was captured, so the UI-evidence requirement remains unmet.

Platform coverage:

- iOS: bundle loaded on iPad simulator; Explorer transition not automated
- Android: not tested
- Web (browser): targeted stream strategy tests passed
- Electron: not tested

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes (blocked by pre-existing `draggable-list.native.tsx` error)
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence (no UI screenshot or video captured)
- [ ] Tests added or updated where it made sense (no focused regression harness was available; existing targeted tests were run)