### PR TITLE
fix(desktop): repair CLI workspace opening and Linux launcher identity

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -62,7 +62,7 @@ import { isNative, isWeb } from "@/constants/platform";
 import { HorizontalScrollProvider } from "@/contexts/horizontal-scroll-context";
 import { SessionProvider } from "@/contexts/session-context";
 import { SidebarCalloutProvider } from "@/contexts/sidebar-callout-context";
-import { ToastProvider } from "@/contexts/toast-context";
+import { ToastProvider, useToast } from "@/contexts/toast-context";
 import { VoiceProvider } from "@/contexts/voice-context";
 import {
   resolveStartupBlocker,
@@ -92,7 +92,8 @@ import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { resolveExplorerSidebarPresentation } from "@/workspace-tabs/explorer-sidebar";
 import { KeyboardShiftProvider } from "@/hooks/use-keyboard-shift-style";
 import { useCompactWebViewportZoomLock } from "@/hooks/use-compact-web-viewport-zoom-lock";
-import { useOpenProject } from "@/hooks/use-open-project";
+import { openProjectWorkspace } from "@/desktop/open-project-workspace";
+import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store";
 import { useAppSettings } from "@/hooks/use-settings";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import { useOpenAgentListGesture } from "@/mobile-panels/gestures";
@@ -118,7 +119,7 @@ import { getDaemonStartService } from "@/runtime/daemon-start-service";
 import { usePanelStore } from "@/stores/panel-store";
 import { flushDraftPersistStorage } from "@/stores/draft-store";
 import { getNextThemePreference } from "@/styles/theme";
-import { useSessionStore } from "@/stores/session-store";
+import { normalizeWorkspaceDescriptor, useSessionStore } from "@/stores/session-store";
 import { installWebScrollbarStyles } from "@/styles/install-web-scrollbar-styles";
 import type { HostProfile } from "@/types/host-connection";
 import {
@@ -670,6 +671,8 @@ function ProvidersWrapper({ children }: { children: ReactNode }) {
       <VoiceProvider>
         <DesktopWindowControlsSync />
         <OfferLinkListener upsertDaemonFromOfferUrl={upsertConnectionFromOfferUrl} />
+        {/* Appearance hydration remounts the boundary below. Keep consumed CLI requests here. */}
+        <OpenProjectListener />
         <HostSessionManager />
         <FaviconStatusSync />
         <AppearanceStyleBoundary>{children}</AppearanceStyleBoundary>
@@ -756,33 +759,40 @@ function OpenProjectListener() {
   const hostRegistryLoaded = useHostRegistryLoaded();
   const [request, setRequest] = useState<PendingOpenProjectRequest | null>(null);
   const [pendingPath, setPendingPath] = useState<string | null>(null);
-  const openProject = useOpenProject(request?.serverId ?? null);
-
-  const openPathOnChosenHost = useCallback(
-    (path: string) => {
-      const nextPath = path.trim();
-      if (!nextPath) {
-        return;
-      }
-
-      if (!hostRegistryLoaded) {
-        setPendingPath(nextPath);
-        return;
-      }
-
-      chooseHost({
-        title: "Choose host",
-        onChooseHost: (serverId) => {
-          setRequest({
-            id: nextOpenProjectRequestId++,
-            serverId,
-            path: nextPath,
-          });
-        },
-      });
-    },
-    [chooseHost, hostRegistryLoaded],
+  const toast = useToast();
+  const client = useHostRuntimeClient(request?.serverId ?? "");
+  const isConnected = useHostRuntimeIsConnected(request?.serverId ?? "");
+  const serverInfo = useSessionStore((state) =>
+    request ? state.sessions[request.serverId]?.serverInfo : null,
   );
+  const pendingProject = useRef<Promise<string | null> | null>(null);
+  const opening = useRef<{
+    requestId: number;
+    promise: ReturnType<typeof openProjectWorkspace>;
+  } | null>(null);
+
+  const openPathOnChosenHost = useStableEvent((path: string) => {
+    const nextPath = path.trim();
+    if (!nextPath) {
+      return;
+    }
+
+    if (!hostRegistryLoaded) {
+      setPendingPath(nextPath);
+      return;
+    }
+
+    chooseHost({
+      title: "Choose host",
+      onChooseHost: (serverId) => {
+        setRequest({
+          id: nextOpenProjectRequestId++,
+          serverId,
+          path: nextPath,
+        });
+      },
+    });
+  });
 
   useEffect(() => {
     if (!hostRegistryLoaded || !pendingPath) {
@@ -794,33 +804,58 @@ function OpenProjectListener() {
   }, [hostRegistryLoaded, openPathOnChosenHost, pendingPath]);
 
   useEffect(() => {
-    if (!request) {
+    if (!request || !isConnected || !client || !serverInfo) {
       return;
     }
+    if (!serverInfo.features?.workspaceMultiplicity || !serverInfo.features.projectAdd) {
+      toast.show("Update the host to open a workspace from the desktop CLI.", {
+        variant: "error",
+        durationMs: null,
+      });
+      setRequest(null);
+      return;
+    }
+    if (opening.current?.requestId !== request.id) {
+      toast.show(`Opening ${request.path}…`, { durationMs: null });
+      opening.current = {
+        requestId: request.id,
+        promise: openProjectWorkspace({ client, path: request.path }),
+      };
+    }
     let cancelled = false;
-    void openProject(request.path).then((result) => {
-      if (cancelled) {
-        return null;
-      }
-
-      if (!result.ok) {
-        setRequest((current) => (current?.id === request.id ? null : current));
-        return null;
-      }
-
-      setRequest((current) => (current?.id === request.id ? null : current));
-      return null;
-    });
+    void opening.current.promise
+      .then((workspace) => {
+        if (cancelled) return;
+        useSessionStore
+          .getState()
+          .mergeWorkspaces(request.serverId, [normalizeWorkspaceDescriptor(workspace)]);
+        navigateToWorkspace({ serverId: request.serverId, workspaceId: workspace.id });
+        toast.show(`Opened ${workspace.name}`, { variant: "success" });
+        return;
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : String(error);
+        toast.show(`Unable to open ${request.path}: ${message}`, {
+          variant: "error",
+          durationMs: null,
+        });
+      })
+      .finally(() => {
+        if (!cancelled) setRequest((current) => (current?.id === request.id ? null : current));
+      });
     return () => {
       cancelled = true;
     };
-  }, [openProject, request]);
+  }, [client, isConnected, request, serverInfo, toast]);
 
   useEffect(() => {
     let disposed = false;
     let unlisten: (() => void) | null = null;
-    void getDesktopHost()
-      ?.getPendingOpenProject?.()
+    // The desktop consumes this path on read. Keep the same promise through
+    // effect replays so startup hydration cannot discard the launch request.
+    pendingProject.current ??= getDesktopHost()?.getPendingOpenProject?.() ?? null;
+    void pendingProject.current
       ?.then((pending) => {
         if (!disposed && pending) {
           openPathOnChosenHost(pending);
@@ -923,7 +958,6 @@ function AppShell() {
   return (
     <MobilePanelsProvider>
       <HorizontalScrollProvider>
-        <OpenProjectListener />
         <AgentNavigationListener />
         <AppWithSidebar>
           <WorkspaceRouteNavigationBridge />

--- a/packages/app/src/desktop/open-project-workspace.ts
+++ b/packages/app/src/desktop/open-project-workspace.ts
@@ -1,0 +1,38 @@
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import type { WorkspaceDescriptorPayload } from "@getpaseo/protocol/messages";
+
+interface OpenProjectWorkspaceInput {
+  client: Pick<DaemonClient, "addProject" | "fetchWorkspaces" | "createWorkspace">;
+  path: string;
+}
+
+export async function openProjectWorkspace(
+  input: OpenProjectWorkspaceInput,
+): Promise<WorkspaceDescriptorPayload> {
+  const added = await input.client.addProject(input.path);
+  if (added.error || !added.project) {
+    throw new Error(added.error ?? "Unable to add project");
+  }
+
+  const projectId = added.project.projectId;
+  let cursor: string | undefined;
+  do {
+    const page = await input.client.fetchWorkspaces({
+      filter: { projectId },
+      page: { limit: 200, ...(cursor ? { cursor } : {}) },
+    });
+    const existing = page.entries.find(
+      (workspace) => workspace.workspaceDirectory === input.path && !workspace.archivingAt,
+    );
+    if (existing) return existing;
+    cursor = page.pageInfo.nextCursor ?? undefined;
+  } while (cursor);
+
+  const created = await input.client.createWorkspace({
+    source: { kind: "directory", path: input.path, projectId },
+  });
+  if (created.error || !created.workspace) {
+    throw new Error(created.error ?? "Unable to create workspace");
+  }
+  return created.workspace;
+}

--- a/packages/cli/src/commands/open.test.ts
+++ b/packages/cli/src/commands/open.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { resolveDesktopLaunch } from "./open.js";
+
+describe("desktop launch", () => {
+  it("passes the AppImage sandbox flag before a project path containing spaces", () => {
+    expect(
+      resolveDesktopLaunch({
+        platform: "linux",
+        desktopApp: "/home/user/Applications/Paseo.AppImage",
+        args: ["/home/user/My project"],
+      }),
+    ).toEqual({
+      command: "/home/user/Applications/Paseo.AppImage",
+      args: ["--no-sandbox", "/home/user/My project"],
+    });
+  });
+
+  it.each(["/usr/bin/Paseo", "/opt/Paseo/Paseo"])(
+    "keeps sandboxing enabled for the native Linux package at %s",
+    (desktopApp) => {
+      expect(
+        resolveDesktopLaunch({ platform: "linux", desktopApp, args: ["/home/user/project"] }),
+      ).toEqual({ command: desktopApp, args: ["/home/user/project"] });
+    },
+  );
+
+  it("uses the same AppImage launch settings for agent deep links", () => {
+    const deepLink = "paseo://agent?serverId=local&agentId=example";
+    expect(
+      resolveDesktopLaunch({
+        platform: "linux",
+        desktopApp: "/home/user/Applications/Paseo.AppImage",
+        args: [deepLink],
+      }),
+    ).toEqual({
+      command: "/home/user/Applications/Paseo.AppImage",
+      args: ["--no-sandbox", deepLink],
+    });
+  });
+
+  it("opens a separate macOS instance to forward the project path", () => {
+    expect(
+      resolveDesktopLaunch({
+        platform: "darwin",
+        desktopApp: "/Applications/Paseo.app",
+        args: ["/Users/user/My project"],
+      }),
+    ).toEqual({
+      command: "open",
+      args: ["-n", "-g", "-a", "/Applications/Paseo.app", "--args", "/Users/user/My project"],
+    });
+  });
+
+  it("launches Windows without Linux flags", () => {
+    const desktopApp = "C:\\Users\\user\\Programs\\Paseo\\Paseo.exe";
+    expect(
+      resolveDesktopLaunch({ platform: "win32", desktopApp, args: ["C:\\My project"] }),
+    ).toEqual({ command: desktopApp, args: ["C:\\My project"] });
+  });
+});

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -60,15 +60,39 @@ function cleanEnvForDesktopLaunch(): NodeJS.ProcessEnv {
   return env;
 }
 
-function spawnDetached(command: string, args: string[]): void {
-  spawnProcess(command, args, {
-    detached: true,
-    stdio: "ignore",
-    env: cleanEnvForDesktopLaunch(),
-  }).unref();
+export function resolveDesktopLaunch(input: {
+  platform: NodeJS.Platform;
+  desktopApp: string;
+  args: string[];
+}): { command: string; args: string[] } {
+  if (input.platform === "darwin") {
+    // A new instance relays argv through Electron's single-instance lock.
+    return { command: "open", args: ["-n", "-g", "-a", input.desktopApp, "--args", ...input.args] };
+  }
+
+  const isLinuxAppImage = input.platform === "linux" && input.desktopApp.endsWith(".AppImage");
+  // Match the AppImage desktop launcher. Electron can fail on its unprivileged
+  // chrome-sandbox helper before main.ts gets to append this switch.
+  const args = isLinuxAppImage ? ["--no-sandbox", ...input.args] : input.args;
+  return { command: input.desktopApp, args };
 }
 
-function launchDesktop(args: string[]): void {
+async function spawnDetached(command: string, args: string[]): Promise<void> {
+  const child = spawnProcess(command, args, {
+    detached: true,
+    stdio: ["ignore", "ignore", "inherit"],
+    env: cleanEnvForDesktopLaunch(),
+  });
+  await new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("spawn", () => {
+      child.unref();
+      resolve();
+    });
+  });
+}
+
+async function launchDesktop(args: string[]): Promise<void> {
   if (process.env.PASEO_DESKTOP_CLI === "1") {
     throw new Error("Cannot open Paseo Desktop while running in desktop CLI passthrough mode.");
   }
@@ -80,20 +104,13 @@ function launchDesktop(args: string[]): void {
     );
   }
 
-  if (process.platform === "darwin") {
-    // -n forces a new instance even if the app is already running. The new
-    // instance relays its argv to the existing one through Electron's
-    // single-instance lock. -g keeps the terminal in the foreground.
-    spawnDetached("open", ["-n", "-g", "-a", desktopApp, "--args", ...args]);
-    return;
-  }
-
-  spawnDetached(desktopApp, args);
+  const launch = resolveDesktopLaunch({ platform: process.platform, desktopApp, args });
+  await spawnDetached(launch.command, launch.args);
 }
 
 export async function openDesktopWithProject(projectPath: string): Promise<void> {
   try {
-    launchDesktop([projectPath]);
+    await launchDesktop([projectPath]);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`${message}\n`);
@@ -102,5 +119,5 @@ export async function openDesktopWithProject(projectPath: string): Promise<void>
 }
 
 export async function openDesktopWithAgent(target: AgentDeepLinkTarget): Promise<void> {
-  launchDesktop([buildAgentDeepLink(target)]);
+  await launchDesktop([buildAgentDeepLink(target)]);
 }

--- a/packages/desktop/e2e/project-picker.spec.ts
+++ b/packages/desktop/e2e/project-picker.spec.ts
@@ -11,6 +11,50 @@ import { getServerId } from "../../app/e2e/support/helpers/server-id";
 import { connectSeedClient } from "../../app/e2e/support/helpers/seed-client";
 import { installDesktopRuntime, waitForDirectoryDialog } from "./support/runtime";
 
+test("CLI project launch opens a workspace after cold startup", async ({
+  page,
+  projectPickerFixture,
+  e2eWorkerClient,
+}) => {
+  await installDesktopRuntime(page, {
+    serverId: getServerId(),
+    pendingOpenProjectPath: projectPickerFixture.projectPath,
+  });
+  await gotoAppShell(page);
+  await expect(page).toHaveURL(/\/workspace\//u, { timeout: 30_000 });
+  const workspaces = (await e2eWorkerClient.fetchWorkspaces()).entries.filter(
+    (workspace) => workspace.workspaceDirectory === projectPickerFixture.projectPath,
+  );
+  expect(workspaces).toHaveLength(1);
+  const workspace = workspaces[0];
+  projectPickerFixture.rememberProjectId(workspace.projectId);
+  const workspaceUrl = new RegExp(`/workspace/${workspace.id}(?:[/?#]|$)`, "u");
+  await expect(page).toHaveURL(workspaceUrl);
+  const row = page.getByTestId(`sidebar-workspace-row-${getServerId()}:${workspace.id}`);
+  await expect(row).toBeVisible();
+
+  // Reload models a second window receiving the same CLI path.
+  await page.reload();
+  await expect(page).toHaveURL(workspaceUrl, { timeout: 30_000 });
+  await expect(page.getByText(`Opened ${workspace.name}`, { exact: true })).toBeVisible();
+  await expect(row).toBeVisible();
+  expect(
+    (await e2eWorkerClient.fetchWorkspaces({ filter: { projectId: workspace.projectId } })).entries,
+  ).toHaveLength(1);
+});
+
+test("CLI project launch reports a missing folder", async ({ page, projectPickerFixture }) => {
+  const missingPath = `${projectPickerFixture.projectPath}/missing`;
+  await installDesktopRuntime(page, {
+    serverId: getServerId(),
+    pendingOpenProjectPath: missingPath,
+  });
+  await gotoAppShell(page);
+  await expect(page.getByText(`Unable to open ${missingPath}:`, { exact: false })).toBeVisible({
+    timeout: 30_000,
+  });
+});
+
 test("Browse opens the folder selected by the desktop dialog", async ({
   page,
   projectPickerFixture,

--- a/packages/desktop/e2e/support/runtime.ts
+++ b/packages/desktop/e2e/support/runtime.ts
@@ -79,6 +79,7 @@ export interface DesktopRuntimeConfig {
    */
   confirmShouldAccept?: boolean;
   dialogOpenResult?: string | string[] | null;
+  pendingOpenProjectPath?: string;
   editorTargets?: DesktopEditorTargetConfig[];
   editorRecordPath?: string;
 }
@@ -141,6 +142,7 @@ export async function installDesktopRuntime(
     let currentPid: number | null = cfg.daemonPid ?? null;
     let startCount = 0;
     let manualUpdateAdmitted = false;
+    let pendingOpenProjectPath = cfg.pendingOpenProjectPath ?? null;
     window.__desktopDaemonStartRequested = false;
 
     function buildDaemonStatus() {
@@ -292,7 +294,11 @@ export async function installDesktopRuntime(
           return cfg.dialogOpenResult ?? null;
         },
       },
-      getPendingOpenProject: async () => null,
+      getPendingOpenProject: async () => {
+        const pending = pendingOpenProjectPath;
+        pendingOpenProjectPath = null;
+        return pending;
+      },
       events: { on: async () => () => undefined },
     };
 

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -61,6 +61,8 @@ linux:
   extraResources:
     - from: bin/paseo
       to: bin/paseo
+    - from: assets/icon.png
+      to: icon.png
   target:
     - AppImage
     - deb

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -131,6 +131,11 @@ const bootstrapComplete = new Promise<void>((resolve) => {
 let bootstrapIsComplete = false;
 
 app.setName(APP_NAME);
+if (process.platform === "linux" && !app.commandLine.hasSwitch("class")) {
+  // Match electron-builder's desktop entry and StartupWMClass instead of the
+  // scoped npm package name Electron otherwise uses for window identity.
+  app.setDesktopName("Paseo.desktop");
+}
 log.info("[desktop] app startup", {
   version: app.getVersion(),
   platform: process.platform,


### PR DESCRIPTION
Running `paseo .` from a local folder silently failed to open a workspace in my Linux Desktop installation. Linux windows also appeared under a generic taskbar icon after startup. This is the isolated fix from our fork. The implementation and QA notes below were prepared with a coding agent.

### Linked issue

Reported during local use; no GitHub issue filed.

### Type of change

- [x] Bug fix

### Reasoning

The CLI launched the Linux AppImage without the sandbox switch used by the installed desktop launcher. Electron exited before its main process could handle the folder argument, and discarded stderr hid the failure.

After fixing the launch, Desktop could still consume and lose the pending folder request during appearance hydration. The existing handler also only registered the project. This change keeps the request alive through startup, waits for the selected host and its advertised capabilities, then opens an existing workspace for that directory or creates and selects one.

The Linux package also omitted `resources/icon.png`, while Electron published `getpaseo-desktop` as the window class and the installed launcher expected `Paseo`. Include the runtime icon and set the desktop identity before startup, preserving an explicitly supplied `--class`.

### Goals

- `paseo .` opens a workspace for a newly selected local directory.
- Reopening the same directory reuses its workspace.
- Startup hydration and host connection changes preserve the pending request.
- Launch errors reach the terminal; project/workspace failures appear in Desktop.
- Packaged Linux windows show the Paseo icon and match their application launcher.

### Non-goals

- Changing the Add Project dialog or daemon lifecycle.
- Changing sandbox flags for native Linux packages, macOS, or Windows.
- Changing the wire protocol or adding fallback RPCs for older hosts.

### QA

Before the fix, the installed AppImage exited with a SUID sandbox helper error. After the CLI correction, tracing the renderer showed the pending folder read being consumed during startup remounts. The regression test then failed until the listener survived that remount and waited for host capabilities.

Manual Linux verification used two newly created temporary directories, one empty non-Git folder with a space in its name and one Git repository. Neither was registered beforehand. Each launch created one project and one workspace; a repeated Git-directory launch reused the same workspace ID. The empty folder was visually confirmed open in Desktop. Temporary projects were removed through the CLI afterward. This installed-AppImage check ran before rebasing; the automated checks below ran again on this isolated contribution against upstream `38c22139b`.

The final Linux AppImage was also rebuilt and installed from the rebased fork with the same icon and identity changes included here. Launching it through the registered desktop entry produced the expected window class and an icon. The app remained running after startup, with no daemon restart.

```text
Before, observed with xprop:
WM_CLASS(STRING) = "getpaseo-desktop", "getpaseo-desktop"
_NET_WM_ICON:  not found.

After, observed with xprop:
WM_CLASS(STRING) = "paseo", "Paseo"
_NET_WM_ICON(CARDINAL) =
```

The packaged `resources/icon.png` checksum matched the source asset, and the installed AppImage checksum matched the build artifact. Formatting, typecheck, and lint passed after these changes.

The new desktop tests use a real isolated daemon and browser renderer with the desktop bridge fixture. They exercise a consumed cold-start path, exact workspace URL selection, repeated launch without duplicates, and a missing-directory error. They do not launch a packaged Electron binary.

```text
$ npx vitest run packages/cli/src/commands/open.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  3.53s (transform 2.10s, setup 0ms, import 3.41s, tests 4ms, environment 0ms)

$ npx playwright test --config packages/desktop/playwright.config.ts packages/desktop/e2e/project-picker.spec.ts --grep 'CLI project launch'
  ✓  1 [desktop] › packages/desktop/e2e/project-picker.spec.ts:14:5 › CLI project launch opens a workspace after cold startup (10.7s)
  ✓  2 [desktop] › packages/desktop/e2e/project-picker.spec.ts:46:5 › CLI project launch reports a missing folder (4.5s)
  2 passed (1.4m)

$ npm run lint
Found 0 warnings and 0 errors.
```

`npm run build:server`, `npm run typecheck`, and `npm run format` also completed with exit code 0.

Platform coverage: Linux AppImage workspace opening manually before rebase; packaged Linux icon and launcher identity after rebase; Linux desktop renderer on this contribution. macOS and Windows launch argument construction is unit-tested; those platforms and iOS/Android were not run.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
