### PR TITLE
fix(acp): track externally initiated session activity

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -12,6 +12,12 @@ initializing → idle → running → idle (or error → closed)
 
 Each live agent in `AgentManager` carries a `lastStatus` of `initializing`, `idle`, `running`, or `error`. `closed` is the persisted, resumable state for an agent record that has no live provider runtime. State transitions persist to disk and stream to subscribed clients via WebSocket.
 
+Imported ACP sessions can report external work through `session_info_update._meta.running`, a
+boolean extension rather than a standard ACP field. Any provider emitting this extension keeps
+its existing Paseo identity while reporting running/idle transitions without submitting prompts
+or copying terminal messages. Providers without the extension are unchanged. These notifications
+cannot complete a foreground prompt submitted by Paseo; its ACP response still owns completion.
+
 ## Runtime residency
 
 An unarchived agent may be `closed` without being deleted or archived. Closing releases its provider

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2762,6 +2762,125 @@ describe("ACPAgentSession", () => {
     ]);
   });
 
+  test("resumed ACP sessions report external turns without creating prompts or duplicate starts", async () => {
+    const session = createSession();
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "resumed-session";
+    const prompt = vi.fn(async (): Promise<PromptResponse> => ({ stopReason: "end_turn" }));
+    internals.connection = { prompt };
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    const report = async (running: boolean) => {
+      await session.sessionUpdate({
+        sessionId: "resumed-session",
+        update: {
+          sessionUpdate: "session_info_update",
+          title: "Resumed work",
+          updatedAt: "2026-09-06T00:00:00Z",
+          _meta: { running },
+        },
+      });
+    };
+    await report(true);
+    await report(true);
+    await expect(session.startTurn("overlapping prompt")).rejects.toThrow(
+      "An external turn is already active",
+    );
+    expect(prompt).not.toHaveBeenCalled();
+    const started = events.filter((event) => event.type === "turn_started");
+    expect(started).toHaveLength(1);
+    expect(started[0].turnId).toEqual(expect.any(String));
+    const lateEvents: AgentStreamEvent[] = [];
+    const unsubscribe = session.subscribe((event) => lateEvents.push(event));
+    expect(lateEvents).toContainEqual(started[0]);
+    unsubscribe();
+    await report(false);
+    await report(false);
+    expect(events.filter((event) => event.type === "turn_completed")).toEqual([
+      { type: "turn_completed", provider: "claude-acp", turnId: started[0].turnId },
+    ]);
+    await report(true);
+    const starts = events.filter((event) => event.type === "turn_started");
+    expect(starts).toHaveLength(2);
+    expect(starts[1].turnId).not.toBe(starts[0].turnId);
+    expect(events.some((event) => event.type === "timeline")).toBe(false);
+    expect(await session.getRuntimeInfo()).toMatchObject({
+      sessionId: "resumed-session",
+      extra: { title: "Resumed work", updatedAt: "2026-09-06T00:00:00Z" },
+    });
+    await report(false);
+  });
+
+  test("external activity ignores malformed metadata and other sessions", async () => {
+    const session = createSession();
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    for (const metadata of [
+      {},
+      { unrelatedRunning: true },
+      { running: "true" },
+      { running: null },
+    ]) {
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: { sessionUpdate: "session_info_update", _meta: metadata },
+      });
+    }
+    await session.sessionUpdate({
+      sessionId: "another-session",
+      update: { sessionUpdate: "session_info_update", _meta: { running: true } },
+    });
+    expect(events.map((event) => event.type)).toEqual(["thread_started"]);
+  });
+
+  test("historical activity and updates after close cannot start an external turn", async () => {
+    const session = createSession();
+    const internals = asInternals<ACPSessionInternals & { replayingHistory: boolean }>(session);
+    internals.sessionId = "session-1";
+    internals.replayingHistory = true;
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: { sessionUpdate: "session_info_update", _meta: { running: true } },
+    });
+    internals.replayingHistory = false;
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    expect(events.map((event) => event.type)).toEqual(["thread_started"]);
+    await session.close();
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: { sessionUpdate: "session_info_update", _meta: { running: true } },
+    });
+    const lateEvents: AgentStreamEvent[] = [];
+    session.subscribe((event) => lateEvents.push(event));
+    expect(lateEvents.map((event) => event.type)).toEqual(["thread_started"]);
+  });
+
+  test("external idle metadata cannot settle a Paseo-owned foreground prompt", async () => {
+    const session = createSession();
+    const pending = Promise.withResolvers<PromptResponse>();
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { prompt: () => pending.promise };
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    const { turnId } = await session.startTurn("owned prompt");
+    for (const running of [true, false]) {
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: { sessionUpdate: "session_info_update", _meta: { running } },
+      });
+    }
+    expect(events.filter((event) => event.type === "turn_started")).toHaveLength(1);
+    expect(events.some((event) => event.type === "turn_completed")).toBe(false);
+    expect(internals.activeForegroundTurnId).toBe(turnId);
+    pending.resolve({ stopReason: "end_turn" });
+    await vi.waitFor(() => {
+      expect(events).toContainEqual(expect.objectContaining({ type: "turn_completed", turnId }));
+    });
+  });
+
   test("startTurn returns before the ACP prompt settles and completes later via subscribers", async () => {
     const session = createSession();
     const events: Array<{ type: string; turnId?: string }> = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1683,6 +1683,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
+  #externalTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
   private closed = false;
   private historyPending = false;
@@ -1845,6 +1846,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     if (this.activeForegroundTurnId) {
       throw new Error("A foreground turn is already active");
     }
+    if (this.#externalTurnId) {
+      throw new Error("An external turn is already active");
+    }
 
     this.deliverTranslatedEvents(this.flushPendingUserMessage());
     const turnId = randomUUID();
@@ -1889,6 +1893,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         provider: this.provider,
         sessionId: this.sessionId,
       });
+    }
+    if (this.#externalTurnId) {
+      callback({ type: "turn_started", provider: this.provider, turnId: this.#externalTurnId });
     }
     return () => {
       this.subscribers.delete(callback);
@@ -2403,7 +2410,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
     this.pendingPermissions.clear();
 
-    if (this.activeForegroundTurnId) {
+    if (this.activeForegroundTurnId || this.#externalTurnId) {
       await this.connection.cancel({ sessionId: this.sessionId });
     }
   }
@@ -2455,6 +2462,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.connection = null;
     this.child = null;
     this.activeForegroundTurnId = null;
+    this.#externalTurnId = null;
   }
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
@@ -2738,6 +2746,16 @@ export class ACPAgentSession implements AgentSession, ACPClient {
           turnId: this.activeForegroundTurnId,
         });
       }
+      if (this.#externalTurnId) {
+        const turnId = this.#externalTurnId;
+        this.#externalTurnId = null;
+        this.pushEvent({
+          type: "turn_failed",
+          provider: this.provider,
+          turnId,
+          error: "ACP connection closed during an external turn",
+        });
+      }
     });
 
     const stream = createLoggedNdJsonStream(
@@ -2905,8 +2923,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       case "config_option_update":
         return [...pendingUserEvents, ...this.handleConfigOptionUpdate(update)];
       case "session_info_update":
-        this.handleSessionInfoUpdate(update);
-        return pendingUserEvents;
+        return [...pendingUserEvents, ...this.handleSessionInfoUpdate(update)];
       case "usage_update":
         this.handleUsageUpdate(update);
         return pendingUserEvents;
@@ -3060,13 +3077,29 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     return events;
   }
 
-  private handleSessionInfoUpdate(update: SessionInfoUpdate): void {
+  private handleSessionInfoUpdate(update: SessionInfoUpdate): AgentStreamEvent[] {
     if ("title" in update) {
       this.currentTitle = update.title ?? null;
     }
     if ("updatedAt" in update) {
       this.lastActivityAt = update.updatedAt ?? null;
     }
+    // Optional provider metadata describes external work, not an ACP prompt response.
+    // Never let it finish a foreground turn whose response is still pending.
+    const ignoreActivity =
+      this.closed || this.replayingHistory || this.activeForegroundTurnId !== null;
+    if (ignoreActivity) return [];
+    const running = update._meta?.running;
+    if (typeof running !== "boolean") return [];
+    if (running) {
+      if (this.#externalTurnId) return [];
+      this.#externalTurnId = randomUUID();
+      return [{ type: "turn_started", provider: this.provider, turnId: this.#externalTurnId }];
+    }
+    if (!this.#externalTurnId) return [];
+    const turnId = this.#externalTurnId;
+    this.#externalTurnId = null;
+    return [{ type: "turn_completed", provider: this.provider, turnId }];
   }
 
   private handleUsageUpdate(update: UsageUpdate): void {


### PR DESCRIPTION
## Summary
- Consume optional boolean `session_info_update._meta.running` from any ACP provider; this is an explicit extension, not a standard ACP field.
- Track external running/idle transitions under the existing imported session, deduplicate transitions, and replay current activity to new subscribers.
- Preserve foreground prompt response ownership; ignore malformed, historical, and closed-session updates.
- Handle external interruption and process exit without fabricating transcript content.

## Verification
- ACP provider tests: 106 passed.
- Existing autonomous manager lifecycle tests: 3 passed.
- Server typecheck, focused lint, formatting, and diff checks passed.

No installed Paseo app or running daemon was changed or restarted. Providers that do not emit this extension remain unchanged.