### PR TITLE
feat(editor): open remote-daemon workspaces in a local editor over SSH

### DIFF
--- a/packages/app/src/components/file-explorer-pane.tsx
+++ b/packages/app/src/components/file-explorer-pane.tsx
@@ -60,7 +60,6 @@ import { FileActionsContextMenuContent } from "@/components/file-actions-menu";
 import { ContextMenu, ContextMenuTrigger, useContextMenu } from "@/components/ui/context-menu";
 import { useFileDownload } from "@/hooks/use-file-download";
 import { useFileExplorerActions } from "@/hooks/use-file-explorer-actions";
-import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
 import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
 import { usePanelStore, type ExpandedPathsUpdate, type SortOption } from "@/stores/panel-store";
 import { buildAbsoluteExplorerPath } from "@/utils/explorer-paths";
@@ -77,6 +76,7 @@ import { useWorkspaceFileDragSource } from "@/attachments/use-workspace-file-dra
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { useToast } from "@/contexts/toast-context";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
+import { useDesktopOpenExecution } from "@/workspace/open-in-editor/remote-destination";
 import { useOpenDirectoryInEditor } from "@/workspace/open-in-editor/directory";
 
 const SORT_OPTIONS: { value: SortOption }[] = [
@@ -445,9 +445,9 @@ export function FileExplorerPane({
     workspaceRoot: normalizedWorkspaceRoot,
   });
   const toast = useToast();
-  const isLocalDaemon = useIsLocalDaemon(serverId);
+  const desktopOpenExecution = useDesktopOpenExecution(serverId);
   const { targets: desktopOpenTargets } = useDesktopOpenTargets({
-    isLocalExecution: isLocalDaemon,
+    execution: desktopOpenExecution,
   });
   const fileManagerTarget = desktopOpenTargets.find((target) => target.kind === "file-manager");
   const openDirectoryInEditor = useOpenDirectoryInEditor({

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -69,6 +69,7 @@ export interface DesktopEditorTargetDescriptor {
   label: string;
   kind: "editor" | "file-manager";
   icon: { kind: "image"; dataUrl: string } | { kind: "symbol"; name: "folder" | "terminal" };
+  remoteDestinationKinds: readonly "ssh"[];
 }
 
 export interface DesktopEditorOpenTargetInput {
@@ -77,6 +78,7 @@ export interface DesktopEditorOpenTargetInput {
   filePath?: string;
   line?: number;
   column?: number;
+  remoteDestination?: { kind: "ssh"; host: string };
 }
 
 export interface DesktopEditorBridge {

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -59,7 +59,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import * as Clipboard from "expo-clipboard";
 import { useFileDownload } from "@/hooks/use-file-download";
-import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
 import { buildAbsoluteExplorerPath } from "@/utils/explorer-paths";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { GitActionsSplitButton } from "@/git/actions-split-button";
@@ -100,6 +99,7 @@ import { usePublishWorkingDiffAttachment, useWorkingDiff } from "@/git/use-worki
 import type { CheckoutStatusPayload } from "@/git/use-status-query";
 import { DiffTooLargeState } from "@/git/diff-too-large-state";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
+import { useDesktopOpenExecution } from "@/workspace/open-in-editor/remote-destination";
 import { PullRequestStateIcon } from "@/git/pull-request-state-icon";
 import { openExternalUrl } from "@/utils/open-external-url";
 import { openWorkspacePullRequest } from "@/workspace-tabs/open-supporting-view";
@@ -1597,9 +1597,9 @@ export function ChangesSurface({
   const codeFontSize = appSettings.codeFontSize;
 
   const toast = useToast();
-  const isLocalDaemon = useIsLocalDaemon(serverId);
+  const desktopOpenExecution = useDesktopOpenExecution(serverId);
   const { targets: desktopOpenTargets } = useDesktopOpenTargets({
-    isLocalExecution: isLocalDaemon,
+    execution: desktopOpenExecution,
   });
   const fileManagerTarget = desktopOpenTargets.find((target) => target.kind === "file-manager");
   const {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -930,6 +930,9 @@ export const ar: TranslationResources = {
         openIn: "افتح مساحة العمل في{{target}}",
         openFileIn: "Open {{fileName}} in {{target}}",
         failedOpen: "فشل في فتح مساحة العمل",
+        setUp: "الإعداد…",
+        setUpRemoteHost: "إعداد فتح هذا المضيف في محرر",
+        setUpToast: 'لفتح {{host}} في محرر، حدّد مضيف SSH الخاص به ضمن "الفتح في المحرر".',
       },
       pr: {
         actions: {
@@ -2283,6 +2286,22 @@ export const ar: TranslationResources = {
         },
         preview: {
           workspaceName: "my-workspace",
+        },
+      },
+      openInEditor: {
+        title: "الفتح في المحرر",
+        info: 'يشغّل "الفتح في المحرر" المحرر المثبّت على هذا الحاسوب. عندما يعمل الخادم على جهاز آخر، يصل المحرر إليه عبر SSH — VS Code وCursor عبر Remote-SSH، وZed عبر عنوان ssh://.',
+        sshHost: {
+          label: "مضيف SSH",
+          hint: "يتيح للمحررات على هذا الحاسوب فتح ملفات هذا المضيف عبر SSH",
+          notSet: "غير محدد",
+          editLabel: "تعديل مضيف SSH",
+          modalTitle: "مضيف SSH",
+          modalHint:
+            "عادةً اسم مستعار من ملف ~/.ssh/config لديك، مثل my-dev-host. اتركه فارغًا لتعطيل ذلك.",
+          placeholder: "my-dev-host",
+          save: "حفظ",
+          invalid: "استخدم مضيف SSH واحدًا، بدون مسافات أو شرطات مائلة.",
         },
       },
       notFound: "لم يتم العثور على Host",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -939,6 +939,9 @@ export const en = {
         openIn: "Open workspace in {{target}}",
         openFileIn: "Open {{fileName}} in {{target}}",
         failedOpen: "Failed to open workspace",
+        setUp: "Set up…",
+        setUpRemoteHost: "Set up opening this host in an editor",
+        setUpToast: "To open {{host}} in an editor, set its SSH host under Open in editor.",
       },
       pr: {
         actions: {
@@ -2387,6 +2390,22 @@ export const en = {
         },
         preview: {
           workspaceName: "my-workspace",
+        },
+      },
+      openInEditor: {
+        title: "Open in editor",
+        info: "Open in editor launches the editor installed on this computer. When the daemon runs on another machine, the editor reaches it over SSH — VS Code and Cursor through Remote-SSH, Zed through an ssh:// URL.",
+        sshHost: {
+          label: "SSH host",
+          hint: "Lets editors on this computer open this host's files over SSH",
+          notSet: "Not set",
+          editLabel: "Edit the SSH host",
+          modalTitle: "SSH host",
+          modalHint:
+            "Normally an alias from your ~/.ssh/config, such as my-dev-host. Leave empty to turn this off.",
+          placeholder: "my-dev-host",
+          save: "Save",
+          invalid: "Use a single SSH host, with no spaces or slashes.",
         },
       },
       notFound: "Host not found",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -961,6 +961,9 @@ export const es: TranslationResources = {
         openIn: "Abrir espacio de trabajo en{{target}}",
         openFileIn: "Open {{fileName}} in {{target}}",
         failedOpen: "No se pudo abrir el espacio de trabajo",
+        setUp: "Configurar…",
+        setUpRemoteHost: "Configurar la apertura de este host en un editor",
+        setUpToast: "Para abrir {{host}} en un editor, define su host SSH en Abrir en el editor.",
       },
       pr: {
         actions: {
@@ -2335,6 +2338,22 @@ export const es: TranslationResources = {
         },
         preview: {
           workspaceName: "my-workspace",
+        },
+      },
+      openInEditor: {
+        title: "Abrir en el editor",
+        info: "Abrir en el editor inicia el editor instalado en este equipo. Cuando el daemon se ejecuta en otra máquina, el editor llega hasta él por SSH: VS Code y Cursor mediante Remote-SSH, Zed mediante una URL ssh://.",
+        sshHost: {
+          label: "Host SSH",
+          hint: "Permite que los editores de este equipo abran los archivos de este host por SSH",
+          notSet: "Sin definir",
+          editLabel: "Editar el host SSH",
+          modalTitle: "Host SSH",
+          modalHint:
+            "Normalmente un alias de tu ~/.ssh/config, como my-dev-host. Déjalo vacío para desactivarlo.",
+          placeholder: "my-dev-host",
+          save: "Guardar",
+          invalid: "Usa un único host SSH, sin espacios ni barras.",
         },
       },
       notFound: "Hostno encontrado",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -960,6 +960,10 @@ export const fr: TranslationResources = {
         openIn: "Espace de travail ouvert dans{{target}}",
         openFileIn: "Open {{fileName}} in {{target}}",
         failedOpen: "Échec de l'ouverture de l'espace de travail",
+        setUp: "Configurer…",
+        setUpRemoteHost: "Configurer l'ouverture de cet hôte dans un éditeur",
+        setUpToast:
+          "Pour ouvrir {{host}} dans un éditeur, renseignez son hôte SSH sous Ouvrir dans l'éditeur.",
       },
       pr: {
         actions: {
@@ -2339,6 +2343,22 @@ export const fr: TranslationResources = {
         },
         preview: {
           workspaceName: "my-workspace",
+        },
+      },
+      openInEditor: {
+        title: "Ouvrir dans l'éditeur",
+        info: "Ouvrir dans l'éditeur lance l'éditeur installé sur cet ordinateur. Lorsque le démon tourne sur une autre machine, l'éditeur l'atteint par SSH : VS Code et Cursor via Remote-SSH, Zed via une URL ssh://.",
+        sshHost: {
+          label: "Hôte SSH",
+          hint: "Permet aux éditeurs de cet ordinateur d'ouvrir les fichiers de cet hôte par SSH",
+          notSet: "Non défini",
+          editLabel: "Modifier l'hôte SSH",
+          modalTitle: "Hôte SSH",
+          modalHint:
+            "Généralement un alias de votre ~/.ssh/config, par exemple my-dev-host. Laissez vide pour désactiver.",
+          placeholder: "my-dev-host",
+          save: "Enregistrer",
+          invalid: "Utilisez un seul hôte SSH, sans espaces ni barres obliques.",
         },
       },
       notFound: "Hostintrouvable",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -941,6 +941,10 @@ export const ja: TranslationResources = {
         openIn: "{{target}}でワークスペースを開く",
         openFileIn: "{{target}}で{{fileName}}を開く",
         failedOpen: "ワークスペースを開けませんでした",
+        setUp: "設定…",
+        setUpRemoteHost: "このホストをエディタで開く設定",
+        setUpToast:
+          "{{host}} をエディタで開くには、「エディタで開く」で SSH ホストを設定してください。",
       },
       pr: {
         actions: {
@@ -2302,6 +2306,22 @@ export const ja: TranslationResources = {
         },
         preview: {
           workspaceName: "my-workspace",
+        },
+      },
+      openInEditor: {
+        title: "エディタで開く",
+        info: "「エディタで開く」はこのコンピュータにインストールされたエディタを起動します。デーモンが別のマシンで動作している場合、エディタは SSH 経由で接続します。VS Code と Cursor は Remote-SSH、Zed は ssh:// URL を使います。",
+        sshHost: {
+          label: "SSH ホスト",
+          hint: "このコンピュータのエディタが SSH 経由でこのホストのファイルを開けるようにします",
+          notSet: "未設定",
+          editLabel: "SSH ホストを編集",
+          modalTitle: "SSH ホスト",
+          modalHint:
+            "通常は ~/.ssh/config のエイリアス（例: my-dev-host）です。空欄にすると無効になります。",
+          placeholder: "my-dev-host",
+          save: "保存",
+          invalid: "空白やスラッシュを含まない単一の SSH ホストを入力してください。",
         },
       },
       notFound: "ホストが見つかりません",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -937,6 +937,9 @@ export const ko: TranslationResources = {
         openIn: "{{target}}에서 워크스페이스 열기",
         openFileIn: "{{target}}에서 {{fileName}} 열기",
         failedOpen: "워크스페이스를 열지 못했습니다",
+        setUp: "설정…",
+        setUpRemoteHost: "이 호스트를 에디터에서 여는 설정",
+        setUpToast: "{{host}}을(를) 에디터에서 열려면 에디터에서 열기에서 SSH 호스트를 설정하세요.",
       },
       pr: {
         actions: {
@@ -2293,6 +2296,21 @@ export const ko: TranslationResources = {
         },
         preview: {
           workspaceName: "내-워크스페이스",
+        },
+      },
+      openInEditor: {
+        title: "에디터에서 열기",
+        info: "에디터에서 열기는 이 컴퓨터에 설치된 에디터를 실행합니다. 데몬이 다른 머신에서 실행 중이면 에디터가 SSH로 접근합니다. VS Code와 Cursor는 Remote-SSH를, Zed는 ssh:// URL을 사용합니다.",
+        sshHost: {
+          label: "SSH 호스트",
+          hint: "이 컴퓨터의 에디터가 SSH로 이 호스트의 파일을 열 수 있게 합니다",
+          notSet: "설정되지 않음",
+          editLabel: "SSH 호스트 편집",
+          modalTitle: "SSH 호스트",
+          modalHint: "보통 ~/.ssh/config의 별칭입니다(예: my-dev-host). 비워 두면 비활성화됩니다.",
+          placeholder: "my-dev-host",
+          save: "저장",
+          invalid: "공백이나 슬래시 없이 하나의 SSH 호스트를 사용하세요.",
         },
       },
       notFound: "호스트를 찾을 수 없습니다",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -952,6 +952,9 @@ export const ptBR: TranslationResources = {
         openIn: "Abrir workspace em {{target}}",
         openFileIn: "Abrir {{fileName}} em {{target}}",
         failedOpen: "Falha ao abrir workspace",
+        setUp: "Configurar…",
+        setUpRemoteHost: "Configurar a abertura deste host em um editor",
+        setUpToast: "Para abrir {{host}} em um editor, defina o host SSH dele em Abrir no editor.",
       },
       pr: {
         actions: {
@@ -2318,6 +2321,22 @@ export const ptBR: TranslationResources = {
         },
         preview: {
           workspaceName: "my-workspace",
+        },
+      },
+      openInEditor: {
+        title: "Abrir no editor",
+        info: "Abrir no editor inicia o editor instalado neste computador. Quando o daemon roda em outra máquina, o editor chega até ele por SSH: VS Code e Cursor via Remote-SSH, Zed via uma URL ssh://.",
+        sshHost: {
+          label: "Host SSH",
+          hint: "Permite que editores deste computador abram os arquivos deste host por SSH",
+          notSet: "Não definido",
+          editLabel: "Editar o host SSH",
+          modalTitle: "Host SSH",
+          modalHint:
+            "Normalmente um alias do seu ~/.ssh/config, como my-dev-host. Deixe vazio para desativar.",
+          placeholder: "my-dev-host",
+          save: "Salvar",
+          invalid: "Use um único host SSH, sem espaços ou barras.",
         },
       },
       notFound: "Host não encontrado",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -945,6 +945,10 @@ export const ru: TranslationResources = {
         openIn: "Открыть рабочее пространство в {{target}}",
         openFileIn: "Открыть {{fileName}} в {{target}}",
         failedOpen: "Не удалось открыть рабочее пространство",
+        setUp: "Настроить…",
+        setUpRemoteHost: "Настроить открытие этого хоста в редакторе",
+        setUpToast:
+          "Чтобы открыть {{host}} в редакторе, задайте её SSH-хост в разделе «Открыть в редакторе».",
       },
       pr: {
         actions: {
@@ -2321,6 +2325,22 @@ export const ru: TranslationResources = {
         },
         preview: {
           workspaceName: "my-workspace",
+        },
+      },
+      openInEditor: {
+        title: "Открыть в редакторе",
+        info: "«Открыть в редакторе» запускает редактор, установленный на этом компьютере. Если демон работает на другой машине, редактор подключается к ней по SSH: VS Code и Cursor через Remote-SSH, Zed через ssh://-адрес.",
+        sshHost: {
+          label: "SSH-хост",
+          hint: "Позволяет редакторам на этом компьютере открывать файлы этого хоста по SSH",
+          notSet: "Не задан",
+          editLabel: "Изменить SSH-хост",
+          modalTitle: "SSH-хост",
+          modalHint:
+            "Обычно это псевдоним из вашего ~/.ssh/config, например my-dev-host. Оставьте пустым, чтобы отключить.",
+          placeholder: "my-dev-host",
+          save: "Сохранить",
+          invalid: "Укажите один SSH-хост, без пробелов и слешей.",
         },
       },
       notFound: "Хост не найден",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -922,6 +922,9 @@ export const zhCN: TranslationResources = {
         openIn: "在 {{target}} 中打开 workspace",
         openFileIn: "在 {{target}} 中打开 {{fileName}}",
         failedOpen: "打开 workspace 失败",
+        setUp: "设置…",
+        setUpRemoteHost: "设置在编辑器中打开此主机",
+        setUpToast: "要在编辑器中打开 {{host}}，请在“在编辑器中打开”下设置它的 SSH 主机。",
       },
       pr: {
         actions: {
@@ -2257,6 +2260,21 @@ export const zhCN: TranslationResources = {
         },
         preview: {
           workspaceName: "my-workspace",
+        },
+      },
+      openInEditor: {
+        title: "在编辑器中打开",
+        info: "“在编辑器中打开”会启动本机安装的编辑器。当守护进程运行在另一台机器上时，编辑器通过 SSH 访问它：VS Code 和 Cursor 使用 Remote-SSH，Zed 使用 ssh:// 地址。",
+        sshHost: {
+          label: "SSH 主机",
+          hint: "让本机的编辑器通过 SSH 打开此主机上的文件",
+          notSet: "未设置",
+          editLabel: "编辑 SSH 主机",
+          modalTitle: "SSH 主机",
+          modalHint: "通常是你 ~/.ssh/config 中的别名，例如 my-dev-host。留空则关闭此功能。",
+          placeholder: "my-dev-host",
+          save: "保存",
+          invalid: "请使用单个 SSH 主机，不能包含空格或斜杠。",
         },
       },
       notFound: "Host 未找到",

--- a/packages/app/src/screens/settings/host-open-in-editor-section.tsx
+++ b/packages/app/src/screens/settings/host-open-in-editor-section.tsx
@@ -1,0 +1,245 @@
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Pressable, Text, View } from "react-native";
+import { Pencil } from "lucide-react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import {
+  AdaptiveModalSheet,
+  AdaptiveTextInput,
+  type SheetHeader,
+} from "@/components/adaptive-modal-sheet";
+import { Button } from "@/components/ui/button";
+import { getIsElectron } from "@/constants/platform";
+import { SettingsSection } from "@/components/settings/headings/settings-section";
+import { useSessionStore } from "@/stores/session-store";
+import { settingsStyles } from "@/styles/settings";
+import { ICON_SIZE, type Theme } from "@/styles/theme";
+import type { RemoteDestination } from "@/workspace/desktop-open-targets";
+import {
+  sshDestination,
+  suggestSshHost,
+  useEditorRemoteDestination,
+} from "@/workspace/open-in-editor/remote-destination";
+
+const ThemedPencil = withUnistyles(Pencil);
+
+const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+
+interface SshHostModalProps {
+  initialValue: string;
+  onClose: () => void;
+  onSubmit: (destination: RemoteDestination | null) => Promise<void>;
+}
+
+/**
+ * Asks for a plain SSH host. No `ssh-remote+` decoration: that is a VS Code dialect, and the
+ * same value also builds Zed's `ssh://` URL. Unlike the rename modal this accepts the value
+ * it was prefilled with — the suggestion from the host name is usually the answer — and
+ * treats an empty field as "not configured", which is how the setting is turned off.
+ */
+function SshHostModal({ initialValue, onClose, onSubmit }: SshHostModalProps) {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState(initialValue);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const header = useMemo<SheetHeader>(
+    () => ({ title: t("settings.host.openInEditor.sshHost.modalTitle") }),
+    [t],
+  );
+
+  const handleChange = useCallback((value: string) => {
+    setDraft(value);
+    setError(null);
+  }, []);
+
+  const submit = useCallback(async () => {
+    if (isPending) return;
+    const destination = sshDestination(draft);
+    if (!destination && draft.trim().length > 0) {
+      setError(t("settings.host.openInEditor.sshHost.invalid"));
+      return;
+    }
+    setIsPending(true);
+    try {
+      await onSubmit(destination);
+      onClose();
+    } catch (cause) {
+      setIsPending(false);
+      setError(cause instanceof Error ? cause.message : t("common.errors.unableToSave"));
+    }
+  }, [draft, isPending, onClose, onSubmit, t]);
+
+  const handleSubmit = useCallback(() => void submit(), [submit]);
+  const handleCancel = useCallback(() => {
+    if (!isPending) onClose();
+  }, [isPending, onClose]);
+
+  return (
+    <AdaptiveModalSheet
+      visible
+      onClose={handleCancel}
+      header={header}
+      testID="host-open-in-editor-modal"
+    >
+      <View style={styles.modalBody}>
+        <AdaptiveTextInput
+          initialValue={initialValue}
+          onChangeText={handleChange}
+          placeholder={t("settings.host.openInEditor.sshHost.placeholder")}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isPending}
+          onSubmitEditing={handleSubmit}
+          style={styles.modalInput}
+          testID="host-open-in-editor-modal-input"
+        />
+        <Text style={styles.modalHint}>{t("settings.host.openInEditor.sshHost.modalHint")}</Text>
+        {error ? (
+          <Text style={styles.modalError} testID="host-open-in-editor-modal-error">
+            {error}
+          </Text>
+        ) : null}
+        <View style={styles.modalActions}>
+          <Button
+            variant="secondary"
+            size="sm"
+            style={styles.modalAction}
+            onPress={handleCancel}
+            disabled={isPending}
+          >
+            {t("common.actions.cancel")}
+          </Button>
+          <Button
+            variant="default"
+            size="sm"
+            style={styles.modalAction}
+            onPress={handleSubmit}
+            disabled={isPending}
+            testID="host-open-in-editor-modal-submit"
+          >
+            {t("settings.host.openInEditor.sshHost.save")}
+          </Button>
+        </View>
+      </View>
+    </AdaptiveModalSheet>
+  );
+}
+
+interface HostOpenInEditorSectionProps {
+  serverId: string;
+  isLocalDaemon: boolean;
+}
+
+/**
+ * Only the desktop app can launch an editor, and a daemon on this machine needs no
+ * destination — everywhere else the setting would be dead weight, so it is not rendered.
+ */
+export function HostOpenInEditorSection({ serverId, isLocalDaemon }: HostOpenInEditorSectionProps) {
+  const { t } = useTranslation();
+  const { remoteDestination, updateRemoteDestination } = useEditorRemoteDestination(serverId);
+  const hostname = useSessionStore(
+    (state) => state.sessions[serverId]?.serverInfo?.hostname ?? null,
+  );
+  const [isEditing, setIsEditing] = useState(false);
+
+  const openEditor = useCallback(() => setIsEditing(true), []);
+  const closeEditor = useCallback(() => setIsEditing(false), []);
+
+  if (!getIsElectron() || isLocalDaemon || remoteDestination === undefined) {
+    return null;
+  }
+
+  const draft = remoteDestination?.host ?? suggestSshHost(hostname);
+
+  return (
+    <SettingsSection
+      title={t("settings.host.openInEditor.title")}
+      info={t("settings.host.openInEditor.info")}
+      testID="host-open-in-editor"
+    >
+      <View style={settingsStyles.card}>
+        <View style={settingsStyles.row}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>
+              {t("settings.host.openInEditor.sshHost.label")}
+            </Text>
+            <Text style={settingsStyles.rowHint}>
+              {t("settings.host.openInEditor.sshHost.hint")}
+            </Text>
+          </View>
+          <View style={styles.value}>
+            <Text style={styles.valueText} numberOfLines={1}>
+              {remoteDestination?.host ?? t("settings.host.openInEditor.sshHost.notSet")}
+            </Text>
+            <Pressable
+              onPress={openEditor}
+              hitSlop={8}
+              style={styles.iconButton}
+              accessibilityRole="button"
+              accessibilityLabel={t("settings.host.openInEditor.sshHost.editLabel")}
+              testID="host-open-in-editor-edit"
+            >
+              <ThemedPencil size={ICON_SIZE.sm} uniProps={mutedColorMapping} />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+
+      {isEditing ? (
+        <SshHostModal
+          initialValue={draft}
+          onClose={closeEditor}
+          onSubmit={updateRemoteDestination}
+        />
+      ) : null}
+    </SettingsSection>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  value: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    flexShrink: 1,
+  },
+  valueText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.base,
+    flexShrink: 1,
+  },
+  iconButton: {
+    padding: theme.spacing[1],
+    borderRadius: theme.borderRadius.md,
+  },
+  modalBody: {
+    gap: theme.spacing[3],
+    paddingBottom: theme.spacing[2],
+  },
+  modalInput: {
+    backgroundColor: theme.colors.surface0,
+    color: theme.colors.foreground,
+    paddingVertical: theme.spacing[3],
+    paddingHorizontal: theme.spacing[3],
+    borderRadius: theme.borderRadius.md,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    fontSize: theme.fontSize.base,
+  },
+  modalHint: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  modalError: {
+    color: theme.colors.statusDanger,
+    fontSize: theme.fontSize.sm,
+  },
+  modalActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  modalAction: {
+    flex: 1,
+  },
+}));

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -59,6 +59,7 @@ import { ProvidersSection } from "@/screens/settings/providers-section";
 import { ProviderUsageSettingsSection } from "@/provider-usage/settings-section";
 import { useProviderUsage } from "@/provider-usage/use-provider-usage";
 import { HostAppearanceSection } from "@/screens/settings/host-appearance-section";
+import { HostOpenInEditorSection } from "@/screens/settings/host-open-in-editor-section";
 import { SettingsSection } from "@/components/settings/headings/settings-section";
 import { useSessionStore } from "@/stores/session-store";
 import { settingsStyles } from "@/styles/settings";
@@ -371,6 +372,8 @@ export function HostSettingsPage({
       <HostStatusBadges serverId={serverId} />
 
       <HostAppearanceSection host={host} />
+
+      <HostOpenInEditorSection serverId={serverId} isLocalDaemon={isLocalDaemon} />
 
       {isLocalDaemon ? <LocalDaemonSection /> : null}
 

--- a/packages/app/src/workspace/desktop-open-targets.test.ts
+++ b/packages/app/src/workspace/desktop-open-targets.test.ts
@@ -1,20 +1,29 @@
 import { describe, expect, it } from "vitest";
 import { selectDesktopOpenTargets } from "./desktop-open-targets";
 
-const cachedTargets = [
-  {
-    id: "vscode",
-    label: "VS Code",
-    kind: "editor" as const,
-    icon: { kind: "symbol" as const, name: "terminal" as const },
-  },
-];
+const vscode = {
+  id: "vscode",
+  label: "VS Code",
+  kind: "editor" as const,
+  icon: { kind: "symbol" as const, name: "terminal" as const },
+  remoteDestinationKinds: ["ssh"] as const,
+};
+
+const finder = {
+  id: "finder",
+  label: "Finder",
+  kind: "file-manager" as const,
+  icon: { kind: "symbol" as const, name: "folder" as const },
+  remoteDestinationKinds: [] as const,
+};
+
+const cachedTargets = [vscode, finder];
 
 describe("selectDesktopOpenTargets", () => {
   it("hides cached targets when listing is unavailable", () => {
     expect(
       selectDesktopOpenTargets({
-        canListTargets: false,
+        execution: null,
         targets: cachedTargets,
       }),
     ).toEqual([]);
@@ -23,9 +32,34 @@ describe("selectDesktopOpenTargets", () => {
   it("returns cached targets when listing is available", () => {
     expect(
       selectDesktopOpenTargets({
-        canListTargets: true,
+        execution: { kind: "local" },
         targets: cachedTargets,
       }),
     ).toEqual(cachedTargets);
+  });
+
+  it("offers only remote-capable targets when the daemon is reached through an authority", () => {
+    expect(
+      selectDesktopOpenTargets({
+        execution: { kind: "remote", destination: { kind: "ssh", host: "dev" } },
+        targets: cachedTargets,
+      }),
+    ).toEqual([vscode]);
+  });
+
+  it("still reports remote-capable targets while no authority is configured", () => {
+    // The setup entry may only be offered when an editor that could use it is installed.
+    expect(
+      selectDesktopOpenTargets({
+        execution: { kind: "remote-unconfigured" },
+        targets: cachedTargets,
+      }),
+    ).toEqual([vscode]);
+    expect(
+      selectDesktopOpenTargets({
+        execution: { kind: "remote-unconfigured" },
+        targets: [finder],
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/app/src/workspace/desktop-open-targets.ts
+++ b/packages/app/src/workspace/desktop-open-targets.ts
@@ -6,11 +6,26 @@ export type DesktopOpenTargetIcon =
   | { kind: "image"; dataUrl: string }
   | { kind: "symbol"; name: "folder" | "terminal" };
 
+/**
+ * How an editor reaches another machine. Editors disagree on the syntax — VS Code wants a
+ * `vscode-remote://ssh-remote+<host>` authority, Zed wants an `ssh://` URL — so the client
+ * stores the destination and each target renders its own form. `wsl` and `dev-container`
+ * belong here as further kinds when they are supported.
+ */
+export type RemoteDestinationKind = "ssh";
+
+export interface RemoteDestination {
+  kind: "ssh";
+  /** An SSH destination: `[user@]host[:port]`, normally an alias from `~/.ssh/config`. */
+  host: string;
+}
+
 export interface DesktopOpenTarget {
   id: string;
   label: string;
   kind: DesktopOpenTargetKind;
   icon: DesktopOpenTargetIcon;
+  remoteDestinationKinds: readonly RemoteDestinationKind[];
 }
 
 export interface OpenDesktopTargetInput {
@@ -19,7 +34,24 @@ export interface OpenDesktopTargetInput {
   filePath?: string;
   line?: number;
   column?: number;
+  remoteDestination?: RemoteDestination;
 }
+
+/**
+ * Where the paths a desktop target is asked to open actually live. `remote` means the
+ * daemon runs on another machine the editor can reach; `remote-unconfigured` means it runs
+ * elsewhere and no destination is set yet, so nothing can be launched but the feature can
+ * still be offered as a setup step.
+ */
+export type DesktopOpenExecution =
+  | { kind: "local" }
+  | { kind: "remote"; destination: RemoteDestination }
+  | { kind: "remote-unconfigured" };
+
+export const LOCAL_DESKTOP_OPEN_EXECUTION: DesktopOpenExecution = { kind: "local" };
+export const REMOTE_UNCONFIGURED_DESKTOP_OPEN_EXECUTION: DesktopOpenExecution = {
+  kind: "remote-unconfigured",
+};
 
 interface AvailableDesktopEditorBridge {
   listTargets: NonNullable<DesktopEditorBridge["listTargets"]>;
@@ -27,18 +59,28 @@ interface AvailableDesktopEditorBridge {
 }
 
 interface SelectDesktopOpenTargetsInput {
-  canListTargets: boolean;
+  execution: DesktopOpenExecution | null;
   targets: DesktopOpenTarget[] | undefined;
 }
 
 export function selectDesktopOpenTargets({
-  canListTargets,
+  execution,
   targets,
 }: SelectDesktopOpenTargetsInput): DesktopOpenTarget[] {
-  if (!canListTargets) {
+  if (!execution) {
     return [];
   }
-  return targets ?? [];
+  const available = targets ?? [];
+  if (execution.kind === "local") {
+    return available;
+  }
+  // An unconfigured host has no destination yet, so any remote-capable target counts: the
+  // question there is only whether a setup entry could ever lead somewhere.
+  if (execution.kind === "remote-unconfigured") {
+    return available.filter((target) => target.remoteDestinationKinds.length > 0);
+  }
+  const { kind } = execution.destination;
+  return available.filter((target) => target.remoteDestinationKinds.includes(kind));
 }
 
 function getDesktopEditorBridge(): AvailableDesktopEditorBridge | null {
@@ -72,23 +114,23 @@ export async function openDesktopTarget(input: OpenDesktopTargetInput): Promise<
   await bridge.openTarget(input);
 }
 
-export function useDesktopOpenTargets(input: { isLocalExecution: boolean }) {
+export function useDesktopOpenTargets(input: { execution: DesktopOpenExecution | null }) {
   const hasBridge = hasDesktopOpenTargetsBridge();
-  const canListTargets = hasBridge && input.isLocalExecution;
+  const execution = hasBridge ? input.execution : null;
   const query = useQuery({
     queryKey: ["desktop-open-targets"],
-    enabled: canListTargets,
+    enabled: execution !== null,
     staleTime: 60_000,
     retry: false,
     queryFn: listDesktopOpenTargets,
   });
   const targets = selectDesktopOpenTargets({
-    canListTargets,
+    execution,
     targets: query.data,
   });
 
   return {
     targets,
-    isAvailable: canListTargets,
+    isAvailable: execution !== null,
   };
 }

--- a/packages/app/src/workspace/open-in-editor/button.tsx
+++ b/packages/app/src/workspace/open-in-editor/button.tsx
@@ -1,5 +1,6 @@
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { type ReactElement, useCallback, useMemo } from "react";
+import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { Pressable, Text, View, type PressableStateCallbackType } from "react-native";
 import { useMutation } from "@tanstack/react-query";
@@ -15,15 +16,17 @@ import {
 import { useToast } from "@/contexts/toast-context";
 import { useCheckoutStatusQuery } from "@/git/use-status-query";
 import { useCheckoutPrStatusQuery } from "@/git/use-pr-status-query";
-import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
-import { useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import { getHostRuntimeStore, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { resolvePreferredEditorId, usePreferredEditor } from "@/hooks/use-preferred-editor";
 import { openExternalUrl } from "@/utils/open-external-url";
 import { isAbsolutePath } from "@/utils/path";
 import { isWeb } from "@/constants/platform";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
 import { resolveWorkspaceFilePaths, type WorkspaceFileLocation } from "@/workspace/file-open";
+import { openHostOverview } from "@/navigation/settings-navigation";
 import { planWorkspaceOpenTargets } from "@/workspace/open-in-editor/planner";
+import { startRemoteHostEditorSetup } from "@/workspace/open-in-editor/setup";
+import { useDesktopOpenExecution } from "@/workspace/open-in-editor/remote-destination";
 import type { Theme } from "@/styles/theme";
 import { ForgeBrandIcon } from "@/git/forge-icon";
 import { getForgePresentation } from "@/git/forge";
@@ -39,9 +42,36 @@ interface WorkspaceOpenInEditorButtonProps {
 
 interface OpenTarget {
   id: string;
+  /** Dropdown label. */
   label: string;
+  /** Split-button label; "Open" for everything the button can actually open. */
+  primaryLabel: string;
+  accessibilityLabel: string;
   icon: ReactElement;
+  /** Setup entries are an action, not an editor choice: picking one runs it. */
+  isSetup: boolean;
   onOpen: () => Promise<void> | void;
+}
+
+/** The host's own name as the rest of the UI shows it, resolved when the entry is used. */
+function resolveHostLabel(serverId: string): string {
+  const host = getHostRuntimeStore()
+    .getHosts()
+    .find((candidate) => candidate.serverId === serverId);
+  return host?.label ?? serverId;
+}
+
+function formatOpenAccessibilityLabel(
+  t: TFunction,
+  input: { fileName: string | null; target: string },
+): string {
+  if (input.fileName) {
+    return t("workspace.git.openInEditor.openFileIn", {
+      fileName: input.fileName,
+      target: input.target,
+    });
+  }
+  return t("workspace.git.openInEditor.openIn", { target: input.target });
 }
 
 const ThemedLoadingSpinner = withUnistyles(LoadingSpinner);
@@ -89,12 +119,10 @@ export function WorkspaceOpenInEditorButton({
   const { t } = useTranslation();
   const toast = useToast();
   const isConnected = useHostRuntimeIsConnected(serverId);
-  const isLocalDaemon = useIsLocalDaemon(serverId);
+  const execution = useDesktopOpenExecution(serverId);
   const { preferredEditorId, updatePreferredEditor } = usePreferredEditor();
   const { targets: desktopOpenTargets, isAvailable: isDesktopOpenAvailable } =
-    useDesktopOpenTargets({
-      isLocalExecution: isLocalDaemon,
-    });
+    useDesktopOpenTargets({ execution });
 
   const resolvedFile = useMemo(
     () =>
@@ -126,37 +154,73 @@ export function WorkspaceOpenInEditorButton({
         resolvedActiveFile: resolvedFile,
         desktopTargets: desktopOpenTargets,
         canUseDesktopBridge: isDesktopOpenAvailable,
-        isLocalExecution: isLocalDaemon,
+        execution,
         checkoutStatus,
         forge: resolvedForge,
       }).map((target) => {
+        if (target.source === "desktop-setup") {
+          const label = t("workspace.git.openInEditor.setUp");
+          return {
+            id: target.id,
+            label,
+            primaryLabel: label,
+            accessibilityLabel: t("workspace.git.openInEditor.setUpRemoteHost"),
+            icon: (
+              <ThemedEditorTargetIcon icon={target.icon} size={16} uniProps={mutedColorMapping} />
+            ),
+            isSetup: true,
+            onOpen: () =>
+              startRemoteHostEditorSetup({
+                serverId,
+                hostLabel: resolveHostLabel(serverId),
+                toast,
+                t,
+                navigate: openHostOverview,
+              }),
+          };
+        }
+        const open = t("workspace.git.openInEditor.open");
+        const accessibilityLabel = formatOpenAccessibilityLabel(t, {
+          fileName: activeFileName,
+          target: target.label,
+        });
         if (target.source === "forge") {
           const presentation = getForgePresentation(target.forge);
           return {
             id: target.id,
             label: target.label,
+            primaryLabel: open,
+            accessibilityLabel,
             icon: renderForgeOpenTargetIcon(presentation.icon),
+            isSetup: false,
             onOpen: () => openExternalUrl(target.url),
           };
         }
         return {
           id: target.id,
           label: target.label,
+          primaryLabel: open,
+          accessibilityLabel,
           icon: (
             <ThemedEditorTargetIcon icon={target.icon} size={16} uniProps={mutedColorMapping} />
           ),
+          isSetup: false,
           onOpen: () => openDesktopTarget(target.openInput),
         };
       }),
     [
       activeFile,
+      activeFileName,
       checkoutStatus,
       cwd,
       desktopOpenTargets,
+      execution,
       resolvedForge,
       isDesktopOpenAvailable,
-      isLocalDaemon,
       resolvedFile,
+      serverId,
+      t,
+      toast,
     ],
   );
 
@@ -185,9 +249,13 @@ export function WorkspaceOpenInEditorButton({
 
   const handleSelectTarget = useCallback(
     (target: OpenTarget) => {
+      if (target.isSetup) {
+        handleOpenTarget(target);
+        return;
+      }
       void updatePreferredEditor(target.id).catch(() => undefined);
     },
-    [updatePreferredEditor],
+    [handleOpenTarget, updatePreferredEditor],
   );
 
   const primaryPressableStyle = useCallback(
@@ -226,16 +294,7 @@ export function WorkspaceOpenInEditorButton({
           onPress={handlePrimaryPress}
           disabled={openMutation.isPending}
           accessibilityRole="button"
-          accessibilityLabel={
-            activeFileName
-              ? t("workspace.git.openInEditor.openFileIn", {
-                  fileName: activeFileName,
-                  target: primaryOption.label,
-                })
-              : t("workspace.git.openInEditor.openIn", {
-                  target: primaryOption.label,
-                })
-          }
+          accessibilityLabel={primaryOption.accessibilityLabel}
         >
           {openMutation.isPending ? (
             <ThemedLoadingSpinner
@@ -247,7 +306,7 @@ export function WorkspaceOpenInEditorButton({
             <View style={styles.splitButtonContent}>
               {primaryOption.icon}
               {!hideLabels && (
-                <Text style={styles.splitButtonText}>{t("workspace.git.openInEditor.open")}</Text>
+                <Text style={styles.splitButtonText}>{primaryOption.primaryLabel}</Text>
               )}
             </View>
           )}

--- a/packages/app/src/workspace/open-in-editor/directory.ts
+++ b/packages/app/src/workspace/open-in-editor/directory.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useToast } from "@/contexts/toast-context";
-import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
 import { resolvePreferredEditorId, usePreferredEditor } from "@/hooks/use-preferred-editor";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
 import { planWorkspaceOpenTargets } from "@/workspace/open-in-editor/planner";
+import { useDesktopOpenExecution } from "@/workspace/open-in-editor/remote-destination";
 
 interface UseOpenDirectoryInEditorInput {
   serverId: string;
@@ -22,9 +22,13 @@ export function useOpenDirectoryInEditor({
 }: UseOpenDirectoryInEditorInput): OpenDirectoryInEditorAction | null {
   const { t } = useTranslation();
   const toast = useToast();
-  const isLocalExecution = useIsLocalDaemon(serverId);
+  const desktopOpenExecution = useDesktopOpenExecution(serverId);
+  // Opening a folder is a plain action with no room for a setup affordance, so an
+  // unconfigured remote host hides it exactly as it did before remote opens existed.
+  const execution =
+    desktopOpenExecution?.kind === "remote-unconfigured" ? null : desktopOpenExecution;
   const { preferredEditorId } = usePreferredEditor();
-  const { targets, isAvailable } = useDesktopOpenTargets({ isLocalExecution });
+  const { targets, isAvailable } = useDesktopOpenTargets({ execution });
   const editorTargets = useMemo(
     () => targets.filter((target) => target.kind === "editor"),
     [targets],
@@ -47,7 +51,7 @@ export function useOpenDirectoryInEditor({
         directoryPath,
         desktopTargets: [preferredTarget],
         canUseDesktopBridge: isAvailable,
-        isLocalExecution,
+        execution,
       }).find((candidate) => candidate.source === "desktop");
       if (!target) {
         return;
@@ -58,7 +62,7 @@ export function useOpenDirectoryInEditor({
         );
       });
     },
-    [isAvailable, isLocalExecution, preferredTarget, t, toast, workspaceDirectory],
+    [execution, isAvailable, preferredTarget, t, toast, workspaceDirectory],
   );
 
   return useMemo(

--- a/packages/app/src/workspace/open-in-editor/planner.test.ts
+++ b/packages/app/src/workspace/open-in-editor/planner.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
+import type { DesktopOpenExecution } from "@/workspace/desktop-open-targets";
 import { planWorkspaceOpenTargets } from "./planner";
+
+const localExecution: DesktopOpenExecution = { kind: "local" };
+const remoteExecution: DesktopOpenExecution = {
+  kind: "remote",
+  destination: { kind: "ssh", host: "dev" },
+};
+const unconfiguredExecution: DesktopOpenExecution = { kind: "remote-unconfigured" };
 
 const desktopTargets = [
   {
@@ -7,12 +15,14 @@ const desktopTargets = [
     label: "VS Code",
     kind: "editor" as const,
     icon: { kind: "symbol" as const, name: "terminal" as const },
+    remoteDestinationKinds: ["ssh"] as const,
   },
   {
     id: "finder",
     label: "Finder",
     kind: "file-manager" as const,
     icon: { kind: "symbol" as const, name: "folder" as const },
+    remoteDestinationKinds: [],
   },
 ];
 
@@ -29,7 +39,7 @@ describe("planWorkspaceOpenTargets", () => {
       activeFile: { path: "src/app.ts", lineStart: 3, lineEnd: 5 },
       desktopTargets,
       canUseDesktopBridge: true,
-      isLocalExecution: true,
+      execution: localExecution,
     });
 
     expect(targets[0]).toMatchObject({
@@ -50,7 +60,7 @@ describe("planWorkspaceOpenTargets", () => {
       activeFile: { path: "src/app.ts" },
       desktopTargets,
       canUseDesktopBridge: true,
-      isLocalExecution: true,
+      execution: localExecution,
     });
 
     expect(targets[1]).toMatchObject({
@@ -69,7 +79,7 @@ describe("planWorkspaceOpenTargets", () => {
       workspaceDirectory: "/repo",
       desktopTargets,
       canUseDesktopBridge: true,
-      isLocalExecution: true,
+      execution: localExecution,
     });
 
     expect(targets[0]).toMatchObject({
@@ -94,10 +104,11 @@ describe("planWorkspaceOpenTargets", () => {
           label: "Android Studio",
           kind: "editor",
           icon: { kind: "symbol", name: "terminal" },
+          remoteDestinationKinds: [],
         },
       ],
       canUseDesktopBridge: true,
-      isLocalExecution: true,
+      execution: localExecution,
     });
 
     expect(targets).toEqual([
@@ -125,10 +136,11 @@ describe("planWorkspaceOpenTargets", () => {
           label: "Open in Neovim",
           kind: "editor",
           icon: { kind: "symbol", name: "terminal" },
+          remoteDestinationKinds: [],
         },
       ],
       canUseDesktopBridge: true,
-      isLocalExecution: true,
+      execution: localExecution,
     });
 
     expect(targets).toEqual([
@@ -153,14 +165,14 @@ describe("planWorkspaceOpenTargets", () => {
       activeFile: { path: "src/app.ts", lineStart: 3, lineEnd: 5 },
       desktopTargets: [],
       canUseDesktopBridge: false,
-      isLocalExecution: false,
+      execution: null,
       checkoutStatus,
     });
     const treeTargets = planWorkspaceOpenTargets({
       workspaceDirectory: "/repo",
       desktopTargets: [],
       canUseDesktopBridge: false,
-      isLocalExecution: false,
+      execution: null,
       checkoutStatus,
     });
 
@@ -190,7 +202,7 @@ describe("planWorkspaceOpenTargets", () => {
       activeFile: { path: "src/app.ts", lineStart: 3, lineEnd: 5 },
       desktopTargets: [],
       canUseDesktopBridge: false,
-      isLocalExecution: false,
+      execution: null,
       checkoutStatus: {
         isGit: true,
         remoteUrl: "git@gitlab.com:group/project.git",
@@ -215,22 +227,117 @@ describe("planWorkspaceOpenTargets", () => {
       workspaceDirectory: "/repo",
       desktopTargets,
       canUseDesktopBridge: false,
-      isLocalExecution: true,
+      execution: localExecution,
       checkoutStatus,
     });
 
     expect(targets.map((target) => target.id)).toEqual(["github"]);
   });
 
-  it("suppresses desktop targets for remote execution paths", () => {
+  it("suppresses desktop targets when the daemon runs elsewhere and no authority is configured", () => {
     const targets = planWorkspaceOpenTargets({
       workspaceDirectory: "/repo",
       desktopTargets,
       canUseDesktopBridge: true,
-      isLocalExecution: false,
+      execution: null,
       checkoutStatus,
     });
 
     expect(targets.map((target) => target.id)).toEqual(["github"]);
+  });
+
+  it("carries the remote authority into every desktop open input", () => {
+    const targets = planWorkspaceOpenTargets({
+      workspaceDirectory: "/repo",
+      activeFile: { path: "src/app.ts", lineStart: 12 },
+      desktopTargets,
+      canUseDesktopBridge: true,
+      execution: remoteExecution,
+    });
+
+    expect(targets.map((target) => target.source === "desktop" && target.openInput)).toEqual([
+      {
+        editorId: "vscode",
+        workspacePath: "/repo",
+        filePath: "/repo/src/app.ts",
+        line: 12,
+        remoteDestination: { kind: "ssh", host: "dev" },
+      },
+      {
+        editorId: "finder",
+        workspacePath: "/repo",
+        filePath: "/repo/src/app.ts",
+        line: 12,
+        remoteDestination: { kind: "ssh", host: "dev" },
+      },
+    ]);
+  });
+
+  it("offers a single setup entry when the daemon is remote and no authority is configured", () => {
+    const targets = planWorkspaceOpenTargets({
+      workspaceDirectory: "/repo",
+      activeFile: { path: "src/app.ts", lineStart: 3 },
+      desktopTargets,
+      canUseDesktopBridge: true,
+      execution: unconfiguredExecution,
+      checkoutStatus,
+    });
+
+    expect(targets).toEqual([
+      {
+        source: "desktop-setup",
+        id: "open-in-editor-setup",
+        icon: { kind: "symbol", name: "terminal" },
+      },
+      {
+        source: "forge",
+        forge: "github",
+        id: "github",
+        label: "GitHub",
+        url: "https://github.com/getpaseo/paseo/blob/main/src/app.ts#L3",
+      },
+    ]);
+  });
+
+  it("offers no setup entry when no remote-capable editor is installed", () => {
+    const targets = planWorkspaceOpenTargets({
+      workspaceDirectory: "/repo",
+      desktopTargets: desktopTargets.filter((target) => target.remoteDestinationKinds.length === 0),
+      canUseDesktopBridge: true,
+      execution: unconfiguredExecution,
+      checkoutStatus,
+    });
+
+    expect(targets.map((target) => target.id)).toEqual(["github"]);
+  });
+
+  it("offers no setup entry when the desktop bridge is unavailable", () => {
+    const targets = planWorkspaceOpenTargets({
+      workspaceDirectory: "/repo",
+      desktopTargets,
+      canUseDesktopBridge: false,
+      execution: unconfiguredExecution,
+      checkoutStatus,
+    });
+
+    expect(targets.map((target) => target.id)).toEqual(["github"]);
+  });
+
+  it("carries the remote authority when opening a folder without an active file", () => {
+    const targets = planWorkspaceOpenTargets({
+      workspaceDirectory: "/repo",
+      desktopTargets,
+      canUseDesktopBridge: true,
+      execution: remoteExecution,
+    });
+
+    expect(targets[0]).toMatchObject({
+      source: "desktop",
+      openInput: {
+        editorId: "vscode",
+        workspacePath: "/repo",
+        remoteDestination: { kind: "ssh", host: "dev" },
+      },
+    });
   });
 });

--- a/packages/app/src/workspace/open-in-editor/planner.ts
+++ b/packages/app/src/workspace/open-in-editor/planner.ts
@@ -1,10 +1,16 @@
 import { type Forge, forgeFromRemoteUrl, getForgePresentation } from "@/git/forge";
-import type { DesktopOpenTarget, OpenDesktopTargetInput } from "@/workspace/desktop-open-targets";
+import type {
+  DesktopOpenExecution,
+  DesktopOpenTarget,
+  OpenDesktopTargetInput,
+} from "@/workspace/desktop-open-targets";
 import {
   type ResolvedWorkspaceFilePaths,
   resolveWorkspaceFilePaths,
   type WorkspaceFileLocation,
 } from "@/workspace/file-open";
+
+export const DESKTOP_SETUP_TARGET_ID = "open-in-editor-setup";
 
 interface CheckoutStatusForOpenTarget {
   isGit: boolean;
@@ -21,6 +27,18 @@ export interface PlannedDesktopOpenTarget {
   openInput: OpenDesktopTargetInput;
 }
 
+/**
+ * Offered when the daemon runs elsewhere and no remote authority is configured yet. It is
+ * the only way to find the feature without already knowing it exists, so it carries the
+ * icon of an installed remote-capable editor and routes to host settings instead of
+ * launching anything.
+ */
+export interface PlannedDesktopSetupTarget {
+  source: "desktop-setup";
+  id: typeof DESKTOP_SETUP_TARGET_ID;
+  icon: DesktopOpenTarget["icon"];
+}
+
 export interface PlannedForgeOpenTarget {
   source: "forge";
   forge: Forge;
@@ -29,7 +47,10 @@ export interface PlannedForgeOpenTarget {
   url: string;
 }
 
-export type PlannedWorkspaceOpenTarget = PlannedDesktopOpenTarget | PlannedForgeOpenTarget;
+export type PlannedWorkspaceOpenTarget =
+  | PlannedDesktopOpenTarget
+  | PlannedDesktopSetupTarget
+  | PlannedForgeOpenTarget;
 
 export interface PlanWorkspaceOpenTargetsInput {
   workspaceDirectory: string;
@@ -38,7 +59,7 @@ export interface PlanWorkspaceOpenTargetsInput {
   resolvedActiveFile?: ResolvedWorkspaceFilePaths | null;
   desktopTargets: readonly DesktopOpenTarget[];
   canUseDesktopBridge: boolean;
-  isLocalExecution: boolean;
+  execution: DesktopOpenExecution | null;
   checkoutStatus?: CheckoutStatusForOpenTarget | null;
   forge?: Forge | null;
 }
@@ -66,12 +87,10 @@ function planDesktopOpenTargets(input: {
   activeFile?: WorkspaceFileLocation | null;
   resolvedFile: ResolvedWorkspaceFilePaths | null;
   desktopTargets: readonly DesktopOpenTarget[];
-  canUseDesktopBridge: boolean;
-  isLocalExecution: boolean;
+  execution: Exclude<DesktopOpenExecution, { kind: "remote-unconfigured" }>;
 }): PlannedDesktopOpenTarget[] {
-  if (!input.canUseDesktopBridge || !input.isLocalExecution) {
-    return [];
-  }
+  const remote =
+    input.execution.kind === "remote" ? { remoteDestination: input.execution.destination } : {};
 
   const resolvedDirectory =
     input.directoryPath === undefined || input.directoryPath === null
@@ -95,7 +114,7 @@ function planDesktopOpenTargets(input: {
         label: target.label,
         editorId: target.id,
         icon: target.icon,
-        openInput: { editorId: target.id, workspacePath },
+        openInput: { editorId: target.id, workspacePath, ...remote },
       };
     }
     return {
@@ -109,6 +128,7 @@ function planDesktopOpenTargets(input: {
         workspacePath,
         filePath: input.resolvedFile.absolutePath,
         ...(input.activeFile?.lineStart ? { line: input.activeFile.lineStart } : {}),
+        ...remote,
       },
     };
   });
@@ -176,11 +196,36 @@ function planForgeOpenTarget(input: {
   };
 }
 
+function planDesktopSetupTarget(
+  desktopTargets: readonly DesktopOpenTarget[],
+): PlannedDesktopSetupTarget | null {
+  const editor = desktopTargets.find(
+    (target) => target.kind === "editor" && target.remoteDestinationKinds.length > 0,
+  );
+  if (!editor) {
+    return null;
+  }
+  return { source: "desktop-setup", id: DESKTOP_SETUP_TARGET_ID, icon: editor.icon };
+}
+
+function planDesktopTargets(
+  input: PlanWorkspaceOpenTargetsInput & { resolvedFile: ResolvedWorkspaceFilePaths | null },
+): (PlannedDesktopOpenTarget | PlannedDesktopSetupTarget)[] {
+  if (!input.canUseDesktopBridge || !input.execution) {
+    return [];
+  }
+  if (input.execution.kind === "remote-unconfigured") {
+    const setupTarget = planDesktopSetupTarget(input.desktopTargets);
+    return setupTarget ? [setupTarget] : [];
+  }
+  return planDesktopOpenTargets({ ...input, execution: input.execution });
+}
+
 export function planWorkspaceOpenTargets(
   input: PlanWorkspaceOpenTargetsInput,
 ): PlannedWorkspaceOpenTarget[] {
   const resolvedFile = resolveActiveFileForOpenTargets(input);
-  const desktopTargets = planDesktopOpenTargets({ ...input, resolvedFile });
+  const desktopTargets = planDesktopTargets({ ...input, resolvedFile });
   const forgeTarget = planForgeOpenTarget({ ...input, resolvedFile });
   return forgeTarget ? [...desktopTargets, forgeTarget] : desktopTargets;
 }

--- a/packages/app/src/workspace/open-in-editor/remote-destination.test.ts
+++ b/packages/app/src/workspace/open-in-editor/remote-destination.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storage = vi.hoisted(() => {
+  const entries = new Map<string, string>();
+  return {
+    entries,
+    default: {
+      getItem: async (key: string) => entries.get(key) ?? null,
+      setItem: async (key: string, value: string) => {
+        entries.set(key, value);
+      },
+      removeItem: async (key: string) => {
+        entries.delete(key);
+      },
+    },
+  };
+});
+
+vi.mock("@react-native-async-storage/async-storage", () => ({ default: storage.default }));
+
+import {
+  isSshHost,
+  loadEditorRemoteDestination,
+  sshDestination,
+  suggestSshHost,
+} from "./remote-destination";
+
+const DESTINATION_KEY = "@paseo:editor-remote-destination:srv-1";
+const LEGACY_AUTHORITY_KEY = "@paseo:editor-remote-authority:srv-1";
+
+describe("isSshHost", () => {
+  it("accepts the destination forms ssh understands", () => {
+    expect(isSshHost("dev")).toBe(true);
+    expect(isSshHost("my-dev-host")).toBe(true);
+    expect(isSshHost("build.example.com")).toBe(true);
+    expect(isSshHost("me@build.example.com")).toBe(true);
+    expect(isSshHost("me@build.example.com:2222")).toBe(true);
+  });
+
+  it("rejects anything that would break the URI each editor builds from it", () => {
+    expect(isSshHost("")).toBe(false);
+    expect(isSshHost("my host")).toBe(false);
+    expect(isSshHost("dev/repo")).toBe(false);
+    expect(isSshHost("ssh://dev")).toBe(false);
+    // The VS Code dialect is no longer what gets stored.
+    expect(isSshHost("ssh-remote+dev")).toBe(false);
+  });
+});
+
+describe("sshDestination", () => {
+  it("builds an ssh destination from a typed host", () => {
+    expect(sshDestination("dev")).toEqual({ kind: "ssh", host: "dev" });
+    expect(sshDestination("  me@build.example.com:2222  ")).toEqual({
+      kind: "ssh",
+      host: "me@build.example.com:2222",
+    });
+  });
+
+  it("accepts a pasted VS Code authority, since the field used to ask for one", () => {
+    expect(sshDestination("ssh-remote+dev")).toEqual({ kind: "ssh", host: "dev" });
+  });
+
+  it("rejects an empty or malformed host", () => {
+    expect(sshDestination("")).toBeNull();
+    expect(sshDestination("   ")).toBeNull();
+    expect(sshDestination("my host")).toBeNull();
+    expect(sshDestination("dev/repo")).toBeNull();
+    expect(sshDestination("ssh-remote+")).toBeNull();
+  });
+});
+
+describe("suggestSshHost", () => {
+  it("prefills the field with the hostname the daemon reports", () => {
+    expect(suggestSshHost("build-box")).toBe("build-box");
+    expect(suggestSshHost("  dev.local  ")).toBe("dev.local");
+  });
+
+  it("suggests nothing when the hostname cannot be an SSH destination", () => {
+    expect(suggestSshHost(null)).toBe("");
+    expect(suggestSshHost("")).toBe("");
+    expect(suggestSshHost("My MacBook Pro")).toBe("");
+  });
+});
+
+describe("loadEditorRemoteDestination", () => {
+  beforeEach(() => {
+    storage.entries.clear();
+  });
+
+  it("reads a stored destination", async () => {
+    storage.entries.set(DESTINATION_KEY, JSON.stringify({ kind: "ssh", host: "dev" }));
+
+    await expect(loadEditorRemoteDestination("srv-1")).resolves.toEqual({
+      kind: "ssh",
+      host: "dev",
+    });
+  });
+
+  it("returns nothing when the host has never been configured", async () => {
+    await expect(loadEditorRemoteDestination("srv-1")).resolves.toBeNull();
+  });
+
+  it("migrates a value stored as a VS Code authority instead of dropping it", async () => {
+    storage.entries.set(LEGACY_AUTHORITY_KEY, "ssh-remote+dev");
+
+    await expect(loadEditorRemoteDestination("srv-1")).resolves.toEqual({
+      kind: "ssh",
+      host: "dev",
+    });
+    expect(storage.entries.get(DESTINATION_KEY)).toBe('{"kind":"ssh","host":"dev"}');
+    expect(storage.entries.has(LEGACY_AUTHORITY_KEY)).toBe(false);
+  });
+
+  it("prefers a stored destination over a stale legacy authority", async () => {
+    storage.entries.set(DESTINATION_KEY, JSON.stringify({ kind: "ssh", host: "new-box" }));
+    storage.entries.set(LEGACY_AUTHORITY_KEY, "ssh-remote+old-box");
+
+    await expect(loadEditorRemoteDestination("srv-1")).resolves.toEqual({
+      kind: "ssh",
+      host: "new-box",
+    });
+  });
+
+  it("clears a legacy value it cannot migrate", async () => {
+    storage.entries.set(LEGACY_AUTHORITY_KEY, "wsl+Ubuntu-22.04");
+
+    await expect(loadEditorRemoteDestination("srv-1")).resolves.toBeNull();
+    expect(storage.entries.has(LEGACY_AUTHORITY_KEY)).toBe(false);
+  });
+});

--- a/packages/app/src/workspace/open-in-editor/remote-destination.test.ts
+++ b/packages/app/src/workspace/open-in-editor/remote-destination.test.ts
@@ -1,29 +1,28 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const storage = vi.hoisted(() => {
-  const entries = new Map<string, string>();
-  return {
-    entries,
-    default: {
-      getItem: async (key: string) => entries.get(key) ?? null,
-      setItem: async (key: string, value: string) => {
-        entries.set(key, value);
-      },
-      removeItem: async (key: string) => {
-        entries.delete(key);
-      },
-    },
-  };
-});
-
-vi.mock("@react-native-async-storage/async-storage", () => ({ default: storage.default }));
-
+import { describe, expect, it } from "vitest";
 import {
   isSshHost,
   loadEditorRemoteDestination,
+  saveEditorRemoteDestination,
   sshDestination,
   suggestSshHost,
+  type EditorRemoteDestinationStore,
 } from "./remote-destination";
+
+class MemoryStore implements EditorRemoteDestinationStore {
+  readonly values = new Map<string, string>();
+
+  async getItem(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null;
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async removeItem(key: string): Promise<void> {
+    this.values.delete(key);
+  }
+}
 
 const DESTINATION_KEY = "@paseo:editor-remote-destination:srv-1";
 const LEGACY_AUTHORITY_KEY = "@paseo:editor-remote-authority:srv-1";
@@ -83,48 +82,67 @@ describe("suggestSshHost", () => {
 });
 
 describe("loadEditorRemoteDestination", () => {
-  beforeEach(() => {
-    storage.entries.clear();
-  });
-
   it("reads a stored destination", async () => {
-    storage.entries.set(DESTINATION_KEY, JSON.stringify({ kind: "ssh", host: "dev" }));
+    const store = new MemoryStore();
+    store.values.set(DESTINATION_KEY, JSON.stringify({ kind: "ssh", host: "dev" }));
 
-    await expect(loadEditorRemoteDestination("srv-1")).resolves.toEqual({
+    await expect(loadEditorRemoteDestination("srv-1", store)).resolves.toEqual({
       kind: "ssh",
       host: "dev",
     });
   });
 
   it("returns nothing when the host has never been configured", async () => {
-    await expect(loadEditorRemoteDestination("srv-1")).resolves.toBeNull();
+    await expect(loadEditorRemoteDestination("srv-1", new MemoryStore())).resolves.toBeNull();
   });
 
   it("migrates a value stored as a VS Code authority instead of dropping it", async () => {
-    storage.entries.set(LEGACY_AUTHORITY_KEY, "ssh-remote+dev");
+    const store = new MemoryStore();
+    store.values.set(LEGACY_AUTHORITY_KEY, "ssh-remote+dev");
 
-    await expect(loadEditorRemoteDestination("srv-1")).resolves.toEqual({
+    await expect(loadEditorRemoteDestination("srv-1", store)).resolves.toEqual({
       kind: "ssh",
       host: "dev",
     });
-    expect(storage.entries.get(DESTINATION_KEY)).toBe('{"kind":"ssh","host":"dev"}');
-    expect(storage.entries.has(LEGACY_AUTHORITY_KEY)).toBe(false);
+    expect(store.values.get(DESTINATION_KEY)).toBe('{"kind":"ssh","host":"dev"}');
+    expect(store.values.has(LEGACY_AUTHORITY_KEY)).toBe(false);
   });
 
   it("prefers a stored destination over a stale legacy authority", async () => {
-    storage.entries.set(DESTINATION_KEY, JSON.stringify({ kind: "ssh", host: "new-box" }));
-    storage.entries.set(LEGACY_AUTHORITY_KEY, "ssh-remote+old-box");
+    const store = new MemoryStore();
+    store.values.set(DESTINATION_KEY, JSON.stringify({ kind: "ssh", host: "new-box" }));
+    store.values.set(LEGACY_AUTHORITY_KEY, "ssh-remote+old-box");
 
-    await expect(loadEditorRemoteDestination("srv-1")).resolves.toEqual({
+    await expect(loadEditorRemoteDestination("srv-1", store)).resolves.toEqual({
       kind: "ssh",
       host: "new-box",
     });
   });
 
   it("clears a legacy value it cannot migrate", async () => {
-    storage.entries.set(LEGACY_AUTHORITY_KEY, "wsl+Ubuntu-22.04");
+    const store = new MemoryStore();
+    store.values.set(LEGACY_AUTHORITY_KEY, "wsl+Ubuntu-22.04");
 
-    await expect(loadEditorRemoteDestination("srv-1")).resolves.toBeNull();
-    expect(storage.entries.has(LEGACY_AUTHORITY_KEY)).toBe(false);
+    await expect(loadEditorRemoteDestination("srv-1", store)).resolves.toBeNull();
+    expect(store.values.has(LEGACY_AUTHORITY_KEY)).toBe(false);
+  });
+});
+
+describe("saveEditorRemoteDestination", () => {
+  it("writes the destination under this host's key", async () => {
+    const store = new MemoryStore();
+
+    await saveEditorRemoteDestination("srv-1", { kind: "ssh", host: "dev" }, store);
+
+    expect(store.values.get(DESTINATION_KEY)).toBe('{"kind":"ssh","host":"dev"}');
+  });
+
+  it("removes the key when the destination is cleared", async () => {
+    const store = new MemoryStore();
+    store.values.set(DESTINATION_KEY, JSON.stringify({ kind: "ssh", host: "dev" }));
+
+    await saveEditorRemoteDestination("srv-1", null, store);
+
+    expect(store.values.has(DESTINATION_KEY)).toBe(false);
   });
 });

--- a/packages/app/src/workspace/open-in-editor/remote-destination.test.ts
+++ b/packages/app/src/workspace/open-in-editor/remote-destination.test.ts
@@ -145,4 +145,16 @@ describe("saveEditorRemoteDestination", () => {
 
     expect(store.values.has(DESTINATION_KEY)).toBe(false);
   });
+
+  it("rejects when the store rejects, so the caller cannot publish an unwritten value", async () => {
+    const store = new MemoryStore();
+    store.setItem = async () => {
+      throw new Error("quota exceeded");
+    };
+
+    await expect(
+      saveEditorRemoteDestination("srv-1", { kind: "ssh", host: "dev" }, store),
+    ).rejects.toThrow("quota exceeded");
+    expect(store.values.has(DESTINATION_KEY)).toBe(false);
+  });
 });

--- a/packages/app/src/workspace/open-in-editor/remote-destination.ts
+++ b/packages/app/src/workspace/open-in-editor/remote-destination.ts
@@ -1,0 +1,162 @@
+import { useCallback, useMemo } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { useFetchQuery } from "@/data/query";
+import { useLocalDaemonServerIdState } from "@/hooks/use-is-local-daemon";
+import { readValidatedJson, readValidatedString } from "@/storage/validated-storage";
+import {
+  LOCAL_DESKTOP_OPEN_EXECUTION,
+  REMOTE_UNCONFIGURED_DESKTOP_OPEN_EXECUTION,
+  type DesktopOpenExecution,
+  type RemoteDestination,
+} from "@/workspace/desktop-open-targets";
+
+/**
+ * An SSH destination: `[user@]host[:port]`, with nothing that would break the URI authority
+ * each editor builds from it. The Electron main process enforces the same shape at the IPC
+ * boundary; this copy exists so the settings form can reject a bad value as it is typed.
+ */
+const SSH_DESTINATION_PATTERN = /^[A-Za-z0-9._@:-]+$/u;
+
+const SshHostSchema = z.string().trim().regex(SSH_DESTINATION_PATTERN);
+
+const RemoteDestinationSchema = z.object({
+  kind: z.literal("ssh"),
+  host: SshHostSchema,
+});
+
+/** Device-local storage: the only writer is this client, so it can be re-read lazily. */
+const STALE_TIME_MS = 60_000;
+
+/**
+ * The binding lives on the client, never in the daemon config: the destination comes from
+ * this machine's own SSH config and its reachability is a client-side fact. Two clients on
+ * the same daemon can need different values, and the daemon can neither verify nor
+ * invalidate one.
+ */
+function storageKey(serverId: string): string {
+  return `@paseo:editor-remote-destination:${serverId}`;
+}
+
+/** Held only long enough to migrate; this key never shipped outside the feature branch. */
+function legacyAuthorityStorageKey(serverId: string): string {
+  return `@paseo:editor-remote-authority:${serverId}`;
+}
+
+function queryKey(serverId: string): readonly string[] {
+  return ["editor-remote-destination", serverId];
+}
+
+export function isSshHost(value: string): boolean {
+  return SshHostSchema.safeParse(value).success;
+}
+
+/**
+ * The destination to store for a typed host, or `null` when it is empty or malformed. A
+ * pasted `ssh-remote+dev` is accepted as `dev`: an earlier version of this field asked for
+ * the VS Code authority, so that is what some users will have to hand.
+ */
+export function sshDestination(host: string): RemoteDestination | null {
+  const trimmed = host.trim();
+  const value = trimmed.startsWith("ssh-remote+") ? trimmed.slice("ssh-remote+".length) : trimmed;
+  return isSshHost(value) ? { kind: "ssh", host: value } : null;
+}
+
+/** Prefill for the SSH host field, or `""` when the reported hostname cannot be one. */
+export function suggestSshHost(hostname: string | null): string {
+  const trimmed = hostname?.trim() ?? "";
+  return isSshHost(trimmed) ? trimmed : "";
+}
+
+async function migrateLegacyAuthority(serverId: string): Promise<RemoteDestination | null> {
+  const legacyKey = legacyAuthorityStorageKey(serverId);
+  const authority = await readValidatedString(AsyncStorage, legacyKey, z.string().trim().min(1));
+  if (!authority) {
+    return null;
+  }
+  await AsyncStorage.removeItem(legacyKey);
+  const destination = sshDestination(authority);
+  if (!destination) {
+    return null;
+  }
+  await AsyncStorage.setItem(storageKey(serverId), JSON.stringify(destination));
+  return destination;
+}
+
+/** The read path, including the one-way migration off the pre-release authority key. */
+export async function loadEditorRemoteDestination(
+  serverId: string,
+): Promise<RemoteDestination | null> {
+  const stored = await readValidatedJson(
+    AsyncStorage,
+    storageKey(serverId),
+    RemoteDestinationSchema,
+  );
+  return stored ?? (await migrateLegacyAuthority(serverId));
+}
+
+interface EditorRemoteDestination {
+  /** `undefined` while loading, `null` when this host has no destination configured. */
+  remoteDestination: RemoteDestination | null | undefined;
+  updateRemoteDestination: (destination: RemoteDestination | null) => Promise<void>;
+}
+
+export function useEditorRemoteDestination(serverId: string): EditorRemoteDestination {
+  const queryClient = useQueryClient();
+  const normalizedServerId = serverId.trim();
+  const { data, isPending } = useFetchQuery({
+    queryKey: queryKey(normalizedServerId),
+    queryFn: () => loadEditorRemoteDestination(normalizedServerId),
+    enabled: normalizedServerId.length > 0,
+    dataShape: "value",
+    staleTimeMs: STALE_TIME_MS,
+    gcTime: Infinity,
+  });
+
+  const updateRemoteDestination = useCallback(
+    async (destination: RemoteDestination | null) => {
+      const parsed = destination ? RemoteDestinationSchema.safeParse(destination) : null;
+      const stored = parsed?.success ? parsed.data : null;
+      queryClient.setQueryData(queryKey(normalizedServerId), stored);
+      if (stored) {
+        await AsyncStorage.setItem(storageKey(normalizedServerId), JSON.stringify(stored));
+        return;
+      }
+      await AsyncStorage.removeItem(storageKey(normalizedServerId));
+    },
+    [normalizedServerId, queryClient],
+  );
+
+  return {
+    remoteDestination: isPending && normalizedServerId.length > 0 ? undefined : (data ?? null),
+    updateRemoteDestination,
+  };
+}
+
+/**
+ * Where a desktop editor would have to look to open this host's files, or `null` when the
+ * answer is not known yet. Stays `null` until both the local daemon identity and the stored
+ * destination resolve, so a host is never treated as remote before we know whether it is
+ * this machine, and an unconfigured entry never flashes ahead of a configured one.
+ */
+export function useDesktopOpenExecution(serverId: string): DesktopOpenExecution | null {
+  const localDaemon = useLocalDaemonServerIdState();
+  const { remoteDestination } = useEditorRemoteDestination(serverId);
+  const normalizedServerId = serverId.trim();
+
+  return useMemo(() => {
+    if (localDaemon.status !== "resolved" || normalizedServerId.length === 0) {
+      return null;
+    }
+    if (localDaemon.serverId === normalizedServerId) {
+      return LOCAL_DESKTOP_OPEN_EXECUTION;
+    }
+    if (remoteDestination === undefined) {
+      return null;
+    }
+    return remoteDestination
+      ? { kind: "remote", destination: remoteDestination }
+      : REMOTE_UNCONFIGURED_DESKTOP_OPEN_EXECUTION;
+  }, [localDaemon, normalizedServerId, remoteDestination]);
+}

--- a/packages/app/src/workspace/open-in-editor/remote-destination.ts
+++ b/packages/app/src/workspace/open-in-editor/remote-destination.ts
@@ -4,7 +4,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import { useFetchQuery } from "@/data/query";
 import { useLocalDaemonServerIdState } from "@/hooks/use-is-local-daemon";
-import { readValidatedJson, readValidatedString } from "@/storage/validated-storage";
+import {
+  readValidatedJson,
+  readValidatedString,
+  type ValidatedStorage,
+} from "@/storage/validated-storage";
 import {
   LOCAL_DESKTOP_OPEN_EXECUTION,
   REMOTE_UNCONFIGURED_DESKTOP_OPEN_EXECUTION,
@@ -48,6 +52,15 @@ function queryKey(serverId: string): readonly string[] {
   return ["editor-remote-destination", serverId];
 }
 
+/**
+ * The device-local key/value store this setting lives in. Injected rather than imported so
+ * the read, write and migration paths can be exercised against an in-memory fake instead of
+ * a mocked AsyncStorage module (docs/testing.md).
+ */
+export interface EditorRemoteDestinationStore extends ValidatedStorage {
+  setItem(key: string, value: string): Promise<void>;
+}
+
 export function isSshHost(value: string): boolean {
   return SshHostSchema.safeParse(value).success;
 }
@@ -69,31 +82,44 @@ export function suggestSshHost(hostname: string | null): string {
   return isSshHost(trimmed) ? trimmed : "";
 }
 
-async function migrateLegacyAuthority(serverId: string): Promise<RemoteDestination | null> {
+async function migrateLegacyAuthority(
+  serverId: string,
+  store: EditorRemoteDestinationStore,
+): Promise<RemoteDestination | null> {
   const legacyKey = legacyAuthorityStorageKey(serverId);
-  const authority = await readValidatedString(AsyncStorage, legacyKey, z.string().trim().min(1));
+  const authority = await readValidatedString(store, legacyKey, z.string().trim().min(1));
   if (!authority) {
     return null;
   }
-  await AsyncStorage.removeItem(legacyKey);
+  await store.removeItem(legacyKey);
   const destination = sshDestination(authority);
   if (!destination) {
     return null;
   }
-  await AsyncStorage.setItem(storageKey(serverId), JSON.stringify(destination));
+  await store.setItem(storageKey(serverId), JSON.stringify(destination));
   return destination;
 }
 
 /** The read path, including the one-way migration off the pre-release authority key. */
 export async function loadEditorRemoteDestination(
   serverId: string,
+  store: EditorRemoteDestinationStore = AsyncStorage,
 ): Promise<RemoteDestination | null> {
-  const stored = await readValidatedJson(
-    AsyncStorage,
-    storageKey(serverId),
-    RemoteDestinationSchema,
-  );
-  return stored ?? (await migrateLegacyAuthority(serverId));
+  const stored = await readValidatedJson(store, storageKey(serverId), RemoteDestinationSchema);
+  return stored ?? (await migrateLegacyAuthority(serverId, store));
+}
+
+/** The write path. Clearing removes the key rather than storing an empty destination. */
+export async function saveEditorRemoteDestination(
+  serverId: string,
+  destination: RemoteDestination | null,
+  store: EditorRemoteDestinationStore = AsyncStorage,
+): Promise<void> {
+  if (destination) {
+    await store.setItem(storageKey(serverId), JSON.stringify(destination));
+    return;
+  }
+  await store.removeItem(storageKey(serverId));
 }
 
 interface EditorRemoteDestination {
@@ -119,11 +145,7 @@ export function useEditorRemoteDestination(serverId: string): EditorRemoteDestin
       const parsed = destination ? RemoteDestinationSchema.safeParse(destination) : null;
       const stored = parsed?.success ? parsed.data : null;
       queryClient.setQueryData(queryKey(normalizedServerId), stored);
-      if (stored) {
-        await AsyncStorage.setItem(storageKey(normalizedServerId), JSON.stringify(stored));
-        return;
-      }
-      await AsyncStorage.removeItem(storageKey(normalizedServerId));
+      await saveEditorRemoteDestination(normalizedServerId, stored);
     },
     [normalizedServerId, queryClient],
   );

--- a/packages/app/src/workspace/open-in-editor/remote-destination.ts
+++ b/packages/app/src/workspace/open-in-editor/remote-destination.ts
@@ -144,8 +144,11 @@ export function useEditorRemoteDestination(serverId: string): EditorRemoteDestin
     async (destination: RemoteDestination | null) => {
       const parsed = destination ? RemoteDestinationSchema.safeParse(destination) : null;
       const stored = parsed?.success ? parsed.data : null;
-      queryClient.setQueryData(queryKey(normalizedServerId), stored);
+      // Persist before publishing. Updating the cache first would leave every
+      // useDesktopOpenExecution consumer on a value that was never written, for the rest of
+      // the session, whenever storage rejects.
       await saveEditorRemoteDestination(normalizedServerId, stored);
+      queryClient.setQueryData(queryKey(normalizedServerId), stored);
     },
     [normalizedServerId, queryClient],
   );

--- a/packages/app/src/workspace/open-in-editor/setup.test.ts
+++ b/packages/app/src/workspace/open-in-editor/setup.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { TFunction } from "i18next";
+import type { ToastApi, ToastShowOptions } from "@/components/toast-host";
+import { buildSettingsHostSectionRoute } from "@/utils/host-routes";
+import { REMOTE_HOST_SETUP_TOAST_MS, startRemoteHostEditorSetup } from "./setup";
+
+interface ShownToast {
+  content: unknown;
+  options: ToastShowOptions | undefined;
+}
+
+function createToast(): { api: Pick<ToastApi, "show">; shown: ShownToast[] } {
+  const shown: ShownToast[] = [];
+  return {
+    api: {
+      show: (content, options) => {
+        shown.push({ content, options });
+      },
+    },
+    shown,
+  };
+}
+
+const t = ((key: string, values?: Record<string, unknown>) =>
+  `${key}:${JSON.stringify(values ?? {})}`) as unknown as TFunction;
+
+describe("startRemoteHostEditorSetup", () => {
+  it("navigates first, then names the host and the setting", () => {
+    const { api, shown } = createToast();
+    const order: string[] = [];
+
+    startRemoteHostEditorSetup({
+      serverId: "srv-1",
+      hostLabel: "build-box",
+      toast: {
+        show: (content, options) => {
+          order.push("toast");
+          api.show(content, options);
+        },
+      },
+      t,
+      navigate: (serverId) => order.push(`navigate:${serverId}`),
+    });
+
+    expect(order).toEqual(["navigate:srv-1", "toast"]);
+    expect(shown).toHaveLength(1);
+    expect(shown[0]?.content).toBe('workspace.git.openInEditor.setUpToast:{"host":"build-box"}');
+  });
+
+  it("reads as information rather than a failure", () => {
+    const { api, shown } = createToast();
+
+    startRemoteHostEditorSetup({
+      serverId: "srv-1",
+      hostLabel: "build-box",
+      toast: api,
+      t,
+      navigate: () => undefined,
+    });
+
+    expect(shown[0]?.options?.variant).toBe("info");
+  });
+
+  it("stays up long enough to act on, and still dismisses itself", () => {
+    const { api, shown } = createToast();
+
+    startRemoteHostEditorSetup({
+      serverId: "srv-1",
+      hostLabel: "build-box",
+      toast: api,
+      t,
+      navigate: () => undefined,
+    });
+
+    // `durationMs: null` schedules no timer and the toast has no dismiss control, so a
+    // pinned toast would never go away. It also has to outlast the 2200ms default.
+    expect(shown[0]?.options?.durationMs).toBe(REMOTE_HOST_SETUP_TOAST_MS);
+    expect(REMOTE_HOST_SETUP_TOAST_MS).toBeGreaterThan(2200);
+    expect(Number.isFinite(REMOTE_HOST_SETUP_TOAST_MS)).toBe(true);
+  });
+
+  it("names whatever label the caller resolved for the host", () => {
+    const { api, shown } = createToast();
+
+    startRemoteHostEditorSetup({
+      serverId: "srv-1",
+      hostLabel: "srv-1",
+      toast: api,
+      t,
+      navigate: () => undefined,
+    });
+
+    expect(shown[0]?.content).toBe('workspace.git.openInEditor.setUpToast:{"host":"srv-1"}');
+  });
+});
+
+describe("the route the setup entry lands on", () => {
+  it("is the host section that owns the Open in editor settings, not the settings root", () => {
+    // openHostOverview pushes this route; the setting lives on the "host" section page.
+    expect(buildSettingsHostSectionRoute("srv-1", "host")).toBe("/settings/hosts/srv-1/host");
+  });
+});

--- a/packages/app/src/workspace/open-in-editor/setup.ts
+++ b/packages/app/src/workspace/open-in-editor/setup.ts
@@ -1,0 +1,31 @@
+import type { TFunction } from "i18next";
+import type { ToastApi } from "@/components/toast-host";
+
+/**
+ * The toast has no dismiss control and `durationMs: null` schedules no timer at all, so a
+ * pinned toast would sit there for the rest of the session. This is long enough to read an
+ * instruction and act on it; hovering the toast on web pauses the countdown.
+ */
+export const REMOTE_HOST_SETUP_TOAST_MS = 8_000;
+
+interface RemoteHostSetupInput {
+  serverId: string;
+  hostLabel: string;
+  toast: Pick<ToastApi, "show">;
+  t: TFunction;
+  /** Injected so this module stays free of the router, and the ordering stays testable. */
+  navigate: (serverId: string) => void;
+}
+
+/**
+ * Landing on host settings is not enough — it is a page full of settings — so name the host
+ * and the setting once the route has changed. This is information, not a failure: the user
+ * asked for something this client cannot do until the SSH host is filled in.
+ */
+export function startRemoteHostEditorSetup(input: RemoteHostSetupInput): void {
+  input.navigate(input.serverId);
+  input.toast.show(input.t("workspace.git.openInEditor.setUpToast", { host: input.hostLabel }), {
+    variant: "info",
+    durationMs: REMOTE_HOST_SETUP_TOAST_MS,
+  });
+}

--- a/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
+++ b/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
@@ -7,7 +7,11 @@ import { ContextMenuItem } from "@/components/ui/context-menu";
 import { getIsElectron } from "@/constants/platform";
 import { useToast } from "@/contexts/toast-context";
 import type { Theme } from "@/styles/theme";
-import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
+import {
+  LOCAL_DESKTOP_OPEN_EXECUTION,
+  openDesktopTarget,
+  useDesktopOpenTargets,
+} from "@/workspace/desktop-open-targets";
 
 interface OpenInFileManagerMenuItemProps {
   path?: string | null;
@@ -33,7 +37,7 @@ export function OpenInFileManagerMenuItem({
   const isElectron = getIsElectron();
   const workspacePath = path?.trim() ?? "";
   const { targets } = useDesktopOpenTargets({
-    isLocalExecution: isElectron && workspacePath.length > 0,
+    execution: isElectron && workspacePath.length > 0 ? LOCAL_DESKTOP_OPEN_EXECUTION : null,
   });
   const fileManagerTarget = targets.find((target) => target.kind === "file-manager");
 

--- a/packages/desktop/src/features/editor-targets/ipc.ts
+++ b/packages/desktop/src/features/editor-targets/ipc.ts
@@ -9,12 +9,25 @@ interface IpcHandlerRegistry {
   handle(channel: string, listener: (event: unknown, ...args: unknown[]) => unknown): void;
 }
 
+/** An SSH destination: `[user@]host[:port]`, with nothing that would break a URI authority. */
+const SSH_DESTINATION_PATTERN = /^[A-Za-z0-9._@:-]+$/u;
+
+const RemoteDestinationSchema = z.object({
+  kind: z.literal("ssh"),
+  host: z
+    .string()
+    .trim()
+    .min(1)
+    .regex(SSH_DESTINATION_PATTERN, "SSH host must not contain spaces or slashes"),
+});
+
 const EditorTargetLaunchInputSchema = z.object({
   editorId: z.string().trim().min(1),
   workspacePath: z.string().trim().min(1),
   filePath: z.string().trim().min(1).optional(),
   line: z.number().int().positive().optional(),
   column: z.number().int().positive().optional(),
+  remoteDestination: RemoteDestinationSchema.optional(),
 });
 
 export function registerEditorTargetHandlers(

--- a/packages/desktop/src/features/editor-targets/registry.test.ts
+++ b/packages/desktop/src/features/editor-targets/registry.test.ts
@@ -7,6 +7,8 @@ import { explorerTarget, fileManagerTarget, finderTarget } from "./targets/file-
 import { intellijIdeaTarget } from "./targets/intellij-idea.js";
 import { pycharmTarget } from "./targets/pycharm.js";
 import { vscodeTarget } from "./targets/vscode.js";
+
+const sshDestination = { kind: "ssh", host: "dev" } as const;
 import { webstormTarget } from "./targets/webstorm.js";
 import { zedTarget } from "./targets/zed.js";
 
@@ -113,18 +115,21 @@ describe("editor target registry", () => {
         label: "VS Code",
         kind: "editor",
         icon: { kind: "image", dataUrl: "data:image/png;base64,vscode.png" },
+        remoteDestinationKinds: ["ssh"],
       },
       {
         id: "webstorm",
         label: "WebStorm",
         kind: "editor",
         icon: { kind: "image", dataUrl: "data:image/png;base64,webstorm.png" },
+        remoteDestinationKinds: [],
       },
       {
         id: "file-manager",
         label: "Files",
         kind: "file-manager",
         icon: { kind: "symbol", name: "folder" },
+        remoteDestinationKinds: [],
       },
     ]);
   });
@@ -247,6 +252,7 @@ describe("editor target registry", () => {
       label: "Android Studio",
       kind: "editor",
       icon: { kind: "image", dataUrl: "data:image/png;base64,android-studio.png" },
+      remoteDestinationKinds: [],
     });
 
     await openEditorTarget(
@@ -299,6 +305,7 @@ describe("editor target registry", () => {
       kind: "file-manager",
       icon: { kind: "symbol", name: "folder" },
     });
+    expect(explorerTarget.remoteDestinationKinds).toEqual([]);
     await explorerTarget.launch({ workspacePath: "C:/repo" }, runtime);
     await explorerTarget.launch(
       { workspacePath: "C:/repo", filePath: "C:/repo/src/app.ts" },
@@ -307,6 +314,177 @@ describe("editor target registry", () => {
 
     expect(runtime.openedPaths).toEqual(["C:/repo"]);
     expect(runtime.revealedPaths).toEqual(["C:/repo/src/app.ts"]);
+  });
+
+  it("opens a remote workspace through folder and file URIs instead of positional paths", async () => {
+    const runtime = new FakeEditorTargets();
+    runtime.installCommand("code");
+
+    await openEditorTarget(
+      {
+        editorId: "vscode",
+        workspacePath: "/home/user/my repo",
+        filePath: "/home/user/my repo/FILE.md",
+        line: 12,
+        remoteDestination: { kind: "ssh", host: "dev" },
+      },
+      runtime,
+      [vscodeTarget],
+    );
+
+    expect(runtime.launches).toEqual([
+      {
+        command: "/bin/code",
+        args: [
+          "--folder-uri",
+          "vscode-remote://ssh-remote+dev/home/user/my%20repo",
+          "--goto",
+          "--file-uri",
+          "vscode-remote://ssh-remote+dev/home/user/my%20repo/FILE.md:12",
+        ],
+      },
+    ]);
+  });
+
+  it("opens a remote folder, and a remote file without a line, without --goto", async () => {
+    const runtime = new FakeEditorTargets();
+    runtime.installCommand("code");
+
+    await openEditorTarget(
+      { editorId: "vscode", workspacePath: "/repo", remoteDestination: sshDestination },
+      runtime,
+      [vscodeTarget],
+    );
+    await openEditorTarget(
+      {
+        editorId: "vscode",
+        workspacePath: "/repo",
+        filePath: "/repo/src/app.ts",
+        remoteDestination: sshDestination,
+      },
+      runtime,
+      [vscodeTarget],
+    );
+
+    expect(runtime.launches).toEqual([
+      { command: "/bin/code", args: ["--folder-uri", "vscode-remote://ssh-remote+dev/repo"] },
+      {
+        command: "/bin/code",
+        args: [
+          "--folder-uri",
+          "vscode-remote://ssh-remote+dev/repo",
+          "--file-uri",
+          "vscode-remote://ssh-remote+dev/repo/src/app.ts",
+        ],
+      },
+    ]);
+  });
+
+  it("opens a remote workspace in Cursor with the same authority form as VS Code", async () => {
+    const runtime = new FakeEditorTargets();
+    runtime.installCommand("cursor");
+
+    await openEditorTarget(
+      {
+        editorId: "cursor",
+        workspacePath: "/repo",
+        filePath: "/repo/src/app.ts",
+        line: 9,
+        remoteDestination: sshDestination,
+      },
+      runtime,
+      [cursorTarget],
+    );
+
+    expect(runtime.launches).toEqual([
+      {
+        command: "/bin/cursor",
+        args: [
+          "--folder-uri",
+          "vscode-remote://ssh-remote+dev/repo",
+          "--goto",
+          "--file-uri",
+          "vscode-remote://ssh-remote+dev/repo/src/app.ts:9",
+        ],
+      },
+    ]);
+  });
+
+  it("opens a remote workspace in Zed as an ssh URL, folder only", async () => {
+    const runtime = new FakeEditorTargets();
+    runtime.installCommand("zeditor");
+
+    // Zed documents `zed ssh://[user@]host[:port]/<path>` for remote paths and `path:line`
+    // only for local ones, so the active file and line are dropped rather than guessed at.
+    await openEditorTarget(
+      {
+        editorId: "zed",
+        workspacePath: "/home/user/my repo",
+        filePath: "/home/user/my repo/src/app.ts",
+        line: 9,
+        remoteDestination: { kind: "ssh", host: "me@build.example.com:2222" },
+      },
+      runtime,
+      [zedTarget],
+    );
+
+    expect(runtime.launches).toEqual([
+      {
+        command: "/bin/zeditor",
+        args: ["ssh://me@build.example.com:2222/home/user/my%20repo"],
+      },
+    ]);
+  });
+
+  it("keeps opening local paths positionally for Zed", async () => {
+    const runtime = new FakeEditorTargets();
+    runtime.installCommand("zeditor");
+
+    await zedTarget.launch(
+      { workspacePath: "/repo", filePath: "/repo/src/app.ts", line: 7, column: 2 },
+      runtime,
+    );
+
+    expect(runtime.launches).toEqual([
+      { command: "/bin/zeditor", args: ["/repo", "/repo/src/app.ts:7:2"] },
+    ]);
+  });
+
+  it("refuses a remote open on a target that cannot reach another machine", async () => {
+    const runtime = new FakeEditorTargets();
+    runtime.addPath("/repo");
+
+    await expect(
+      openEditorTarget(
+        { editorId: "webstorm", workspacePath: "/repo", remoteDestination: sshDestination },
+        runtime,
+        [webstormTarget],
+      ),
+    ).rejects.toThrow("Editor target cannot open a ssh remote workspace: WebStorm");
+    expect(runtime.launches).toEqual([]);
+  });
+
+  it("refuses a remote open when only the macOS application is installed", async () => {
+    const runtime = new FakeEditorTargets("darwin");
+    runtime.installMacApplication("Visual Studio Code");
+
+    await expect(
+      openEditorTarget(
+        { editorId: "vscode", workspacePath: "/repo", remoteDestination: sshDestination },
+        runtime,
+        [vscodeTarget],
+      ),
+    ).rejects.toThrow("VS Code command line tools are required to open a remote workspace");
+    expect(runtime.openedMacApplications).toEqual([]);
+  });
+
+  it("keeps requiring a local path to exist when no destination is given", async () => {
+    const runtime = new FakeEditorTargets();
+    runtime.installCommand("code");
+
+    await expect(
+      openEditorTarget({ editorId: "vscode", workspacePath: "/repo" }, runtime, [vscodeTarget]),
+    ).rejects.toThrow("Path does not exist: /repo");
   });
 
   it("keeps the platform file-manager ids used by stored preferences", async () => {

--- a/packages/desktop/src/features/editor-targets/registry.test.ts
+++ b/packages/desktop/src/features/editor-targets/registry.test.ts
@@ -305,7 +305,7 @@ describe("editor target registry", () => {
       kind: "file-manager",
       icon: { kind: "symbol", name: "folder" },
     });
-    expect(explorerTarget.remoteDestinationKinds).toEqual([]);
+    expect(explorerTarget.remoteDestinationKinds(runtime)).toEqual([]);
     await explorerTarget.launch({ workspacePath: "C:/repo" }, runtime);
     await explorerTarget.launch(
       { workspacePath: "C:/repo", filePath: "C:/repo/src/app.ts" },
@@ -450,6 +450,47 @@ describe("editor target registry", () => {
     ]);
   });
 
+  it("does not offer SSH for an installed app whose CLI is missing, but still offers it locally", async () => {
+    // The common macOS shape: VS Code.app present, `code` never installed into PATH.
+    const runtime = new FakeEditorTargets("darwin");
+    runtime.installMacApplication("Visual Studio Code");
+    runtime.addPath("/repo");
+
+    const [descriptor] = await listAvailableEditorTargets(runtime, [vscodeTarget]);
+
+    expect(descriptor?.id).toBe("vscode");
+    expect(descriptor?.remoteDestinationKinds).toEqual([]);
+
+    await openEditorTarget({ editorId: "vscode", workspacePath: "/repo" }, runtime, [vscodeTarget]);
+    expect(runtime.openedMacApplications).toEqual([
+      { applicationName: "Visual Studio Code", paths: ["/repo"] },
+    ]);
+  });
+
+  it("offers SSH for the same app once its CLI resolves", async () => {
+    const runtime = new FakeEditorTargets("darwin");
+    runtime.installMacApplication("Visual Studio Code");
+    runtime.installCommand("code");
+
+    const [descriptor] = await listAvailableEditorTargets(runtime, [vscodeTarget]);
+
+    expect(descriptor?.remoteDestinationKinds).toEqual(["ssh"]);
+  });
+
+  it("refuses a remote open when the app is installed but its CLI is not", async () => {
+    const runtime = new FakeEditorTargets("darwin");
+    runtime.installMacApplication("Visual Studio Code");
+
+    await expect(
+      openEditorTarget(
+        { editorId: "vscode", workspacePath: "/repo", remoteDestination: sshDestination },
+        runtime,
+        [vscodeTarget],
+      ),
+    ).rejects.toThrow("Editor target cannot open a ssh remote workspace: VS Code");
+    expect(runtime.openedMacApplications).toEqual([]);
+  });
+
   it("refuses a remote open on a target that cannot reach another machine", async () => {
     const runtime = new FakeEditorTargets();
     runtime.addPath("/repo");
@@ -464,16 +505,12 @@ describe("editor target registry", () => {
     expect(runtime.launches).toEqual([]);
   });
 
-  it("refuses a remote open when only the macOS application is installed", async () => {
+  it("refuses a direct remote launch that bypasses the registry's capability check", async () => {
     const runtime = new FakeEditorTargets("darwin");
     runtime.installMacApplication("Visual Studio Code");
 
     await expect(
-      openEditorTarget(
-        { editorId: "vscode", workspacePath: "/repo", remoteDestination: sshDestination },
-        runtime,
-        [vscodeTarget],
-      ),
+      vscodeTarget.launch({ workspacePath: "/repo", remoteDestination: sshDestination }, runtime),
     ).rejects.toThrow("VS Code command line tools are required to open a remote workspace");
     expect(runtime.openedMacApplications).toEqual([]);
   });

--- a/packages/desktop/src/features/editor-targets/registry.test.ts
+++ b/packages/desktop/src/features/editor-targets/registry.test.ts
@@ -515,6 +515,45 @@ describe("editor target registry", () => {
     expect(runtime.openedMacApplications).toEqual([]);
   });
 
+  it("judges a remote path by POSIX rules, not by this desktop's platform", async () => {
+    // A macOS or Linux client must not reject a POSIX daemon path, and must not accept a
+    // Windows one it has no way to render. Windows daemons stay out of scope.
+    const runtime = new FakeEditorTargets("darwin");
+    runtime.installCommand("code");
+
+    await openEditorTarget(
+      { editorId: "vscode", workspacePath: "/home/user/repo", remoteDestination: sshDestination },
+      runtime,
+      [vscodeTarget],
+    );
+    expect(runtime.launches).toEqual([
+      {
+        command: "/bin/code",
+        args: ["--folder-uri", "vscode-remote://ssh-remote+dev/home/user/repo"],
+      },
+    ]);
+
+    await expect(
+      openEditorTarget(
+        { editorId: "vscode", workspacePath: "C:/repo", remoteDestination: sshDestination },
+        runtime,
+        [vscodeTarget],
+      ),
+    ).rejects.toThrow("Editor target workspace path must be an absolute path");
+  });
+
+  it("keeps judging local paths by this desktop's platform", async () => {
+    const runtime = new FakeEditorTargets("win32");
+    runtime.installCommand("code", "C:/Editors/code.cmd");
+    runtime.addPath("C:/repo");
+
+    await openEditorTarget({ editorId: "vscode", workspacePath: "C:/repo" }, runtime, [
+      vscodeTarget,
+    ]);
+
+    expect(runtime.launches).toEqual([{ command: "C:/Editors/code.cmd", args: ["C:/repo"] }]);
+  });
+
   it("keeps requiring a local path to exist when no destination is given", async () => {
     const runtime = new FakeEditorTargets();
     runtime.installCommand("code");

--- a/packages/desktop/src/features/editor-targets/registry.ts
+++ b/packages/desktop/src/features/editor-targets/registry.ts
@@ -61,7 +61,10 @@ export async function listAvailableEditorTargets(
   const descriptors: EditorTargetDescriptor[] = [];
   for (const target of targets) {
     if (await target.isInstalled(runtime)) {
-      descriptors.push(await target.describe(runtime));
+      descriptors.push({
+        ...(await target.describe(runtime)),
+        remoteDestinationKinds: target.remoteDestinationKinds,
+      });
     }
   }
   return descriptors;
@@ -81,22 +84,31 @@ export async function openEditorTarget(
   runtime: EditorTargetRuntime,
   targets: readonly EditorTarget[] = EDITOR_TARGETS,
 ): Promise<void> {
-  if (!runtime.isAbsolutePath(input.workspacePath)) {
-    throw new Error("Editor target workspace path must be an absolute local path");
+  const target = getEditorTarget(input.editorId, targets);
+  // Remote paths live on the daemon machine, so this process can only check their shape.
+  const remoteDestination = input.remoteDestination;
+  const isRemote = remoteDestination !== undefined;
+  if (remoteDestination && !target.remoteDestinationKinds.includes(remoteDestination.kind)) {
+    const descriptor = await target.describe(runtime);
+    throw new Error(
+      `Editor target cannot open a ${remoteDestination.kind} remote workspace: ${descriptor.label}`,
+    );
   }
-  if (!runtime.pathExists(input.workspacePath)) {
+  if (!runtime.isAbsolutePath(input.workspacePath)) {
+    throw new Error("Editor target workspace path must be an absolute path");
+  }
+  if (!isRemote && !runtime.pathExists(input.workspacePath)) {
     throw new Error(`Path does not exist: ${input.workspacePath}`);
   }
   if (input.filePath) {
     if (!runtime.isAbsolutePath(input.filePath)) {
-      throw new Error("Editor target file path must be an absolute local path");
+      throw new Error("Editor target file path must be an absolute path");
     }
-    if (!runtime.pathExists(input.filePath)) {
+    if (!isRemote && !runtime.pathExists(input.filePath)) {
       throw new Error(`Path does not exist: ${input.filePath}`);
     }
   }
 
-  const target = getEditorTarget(input.editorId, targets);
   if (!(await target.isInstalled(runtime))) {
     const descriptor = await target.describe(runtime);
     throw new Error(`Editor target unavailable: ${descriptor.label}`);

--- a/packages/desktop/src/features/editor-targets/registry.ts
+++ b/packages/desktop/src/features/editor-targets/registry.ts
@@ -1,3 +1,4 @@
+import { isAbsoluteRemotePath } from "./remote.js";
 import type {
   EditorTarget,
   EditorTargetDescriptor,
@@ -79,6 +80,18 @@ export function getEditorTarget(
   return target;
 }
 
+/** A remote path belongs to the daemon machine; a local one belongs to this machine. */
+function isAbsoluteLaunchPath(input: {
+  path: string;
+  isRemote: boolean;
+  runtime: EditorTargetRuntime;
+}): boolean {
+  if (input.isRemote) {
+    return isAbsoluteRemotePath(input.path);
+  }
+  return input.runtime.isAbsolutePath(input.path);
+}
+
 export async function openEditorTarget(
   input: EditorTargetLaunchInput & { editorId: string },
   runtime: EditorTargetRuntime,
@@ -97,14 +110,14 @@ export async function openEditorTarget(
       `Editor target cannot open a ${remoteDestination.kind} remote workspace: ${descriptor.label}`,
     );
   }
-  if (!runtime.isAbsolutePath(input.workspacePath)) {
+  if (!isAbsoluteLaunchPath({ path: input.workspacePath, isRemote, runtime })) {
     throw new Error("Editor target workspace path must be an absolute path");
   }
   if (!isRemote && !runtime.pathExists(input.workspacePath)) {
     throw new Error(`Path does not exist: ${input.workspacePath}`);
   }
   if (input.filePath) {
-    if (!runtime.isAbsolutePath(input.filePath)) {
+    if (!isAbsoluteLaunchPath({ path: input.filePath, isRemote, runtime })) {
       throw new Error("Editor target file path must be an absolute path");
     }
     if (!isRemote && !runtime.pathExists(input.filePath)) {

--- a/packages/desktop/src/features/editor-targets/registry.ts
+++ b/packages/desktop/src/features/editor-targets/registry.ts
@@ -63,7 +63,7 @@ export async function listAvailableEditorTargets(
     if (await target.isInstalled(runtime)) {
       descriptors.push({
         ...(await target.describe(runtime)),
-        remoteDestinationKinds: target.remoteDestinationKinds,
+        remoteDestinationKinds: target.remoteDestinationKinds(runtime),
       });
     }
   }
@@ -88,7 +88,10 @@ export async function openEditorTarget(
   // Remote paths live on the daemon machine, so this process can only check their shape.
   const remoteDestination = input.remoteDestination;
   const isRemote = remoteDestination !== undefined;
-  if (remoteDestination && !target.remoteDestinationKinds.includes(remoteDestination.kind)) {
+  if (
+    remoteDestination &&
+    !target.remoteDestinationKinds(runtime).includes(remoteDestination.kind)
+  ) {
     const descriptor = await target.describe(runtime);
     throw new Error(
       `Editor target cannot open a ${remoteDestination.kind} remote workspace: ${descriptor.label}`,

--- a/packages/desktop/src/features/editor-targets/remote.ts
+++ b/packages/desktop/src/features/editor-targets/remote.ts
@@ -1,15 +1,27 @@
+import { posix } from "node:path";
+
 import type { EditorTargetRuntime, RemoteDestinationKind } from "./target.js";
 
 const SSH_ONLY: readonly RemoteDestinationKind[] = ["ssh"];
 const LOCAL_ONLY: readonly RemoteDestinationKind[] = [];
 
 /**
+ * A remote path describes the daemon machine's filesystem, so it is judged by POSIX rules
+ * rather than this desktop's. `path.isAbsolute` follows the platform it runs on, which would
+ * make a macOS or Linux client reject a path its own daemon never produced.
+ */
+export function isAbsoluteRemotePath(path: string): boolean {
+  return posix.isAbsolute(path);
+}
+
+/**
  * Percent-encode a POSIX path for a remote URI. Each segment is encoded separately so the
  * separators and the leading slash survive, and so a space or `&` in a directory name never
- * reaches a shell as itself.
+ * reaches a shell as itself. Explicitly POSIX: the separator is the daemon's, not this
+ * machine's, and remote paths are validated as POSIX before they get here.
  */
 export function encodeRemotePath(path: string): string {
-  return path.split("/").map(encodeURIComponent).join("/");
+  return path.split(posix.sep).map(encodeURIComponent).join(posix.sep);
 }
 
 /**

--- a/packages/desktop/src/features/editor-targets/remote.ts
+++ b/packages/desktop/src/features/editor-targets/remote.ts
@@ -1,0 +1,27 @@
+import type { EditorTargetRuntime, RemoteDestinationKind } from "./target.js";
+
+const SSH_ONLY: readonly RemoteDestinationKind[] = ["ssh"];
+const LOCAL_ONLY: readonly RemoteDestinationKind[] = [];
+
+/**
+ * Percent-encode a POSIX path for a remote URI. Each segment is encoded separately so the
+ * separators and the leading slash survive, and so a space or `&` in a directory name never
+ * reaches a shell as itself.
+ */
+export function encodeRemotePath(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
+/**
+ * Remote opens go through the editor's CLI: `--folder-uri` and `ssh://` URLs have no
+ * `open -a` equivalent, so an installed application is not on its own enough. On macOS the
+ * app is commonly present without the shell command — VS Code ships it behind "Shell
+ * Command: Install 'code' command in PATH" — and advertising SSH there would offer an entry
+ * that can only fail once the user has configured a host and clicked it.
+ */
+export function cliRemoteDestinationKinds(
+  runtime: EditorTargetRuntime,
+  commands: readonly string[],
+): readonly RemoteDestinationKind[] {
+  return runtime.resolveCommand(commands) === null ? LOCAL_ONLY : SSH_ONLY;
+}

--- a/packages/desktop/src/features/editor-targets/runtime.test.ts
+++ b/packages/desktop/src/features/editor-targets/runtime.test.ts
@@ -57,4 +57,50 @@ describe("editor target runtime", () => {
       },
     ]);
   });
+
+  it("passes remote URIs to a Windows command script without extra quoting", async () => {
+    const records: SpawnRecord[] = [];
+    const runtime = createEditorTargetRuntime({
+      platform: "win32",
+      env: { PATH: "C:/Editors/bin" },
+      pathExists: (targetPath) => targetPath === "C:/Editors/bin/code.cmd",
+      spawn: (command, args, options) => {
+        const record = { command, args, options, unrefed: false };
+        records.push(record);
+        const child = {
+          once(event: "error" | "spawn", handler: (error?: Error) => void) {
+            if (event === "spawn") queueMicrotask(() => handler());
+            return child;
+          },
+          unref() {
+            record.unrefed = true;
+          },
+        };
+        return child;
+      },
+    });
+
+    const command = runtime.resolveCommand(["code"]);
+    if (!command) throw new Error("Expected the editor command to resolve");
+    // Percent-encoding happens before the shell sees the argument, so the characters the
+    // cmd escaper reacts to never reach it.
+    await runtime.spawnDetached({
+      command,
+      args: [
+        "--folder-uri",
+        "vscode-remote://ssh-remote+dev/home/me/repo%20%26%20tools",
+        "--goto",
+        "--file-uri",
+        "vscode-remote://ssh-remote+dev/home/me/repo%20%26%20tools/app.ts:12",
+      ],
+    });
+
+    expect(records[0]?.args).toEqual([
+      "--folder-uri",
+      "vscode-remote://ssh-remote+dev/home/me/repo%20%26%20tools",
+      "--goto",
+      "--file-uri",
+      "vscode-remote://ssh-remote+dev/home/me/repo%20%26%20tools/app.ts:12",
+    ]);
+  });
 });

--- a/packages/desktop/src/features/editor-targets/target.ts
+++ b/packages/desktop/src/features/editor-targets/target.ts
@@ -1,5 +1,19 @@
 export type EditorTargetKind = "editor" | "file-manager";
 
+/**
+ * How an editor is expected to reach another machine. Editors disagree on the syntax —
+ * VS Code wants a `vscode-remote://ssh-remote+<host>` authority, Zed wants an `ssh://` URL —
+ * so what gets stored is the destination itself and each target renders its own form.
+ * `wsl` and `dev-container` belong here as further kinds when they are supported.
+ */
+export type RemoteDestinationKind = "ssh";
+
+export interface RemoteDestination {
+  kind: "ssh";
+  /** An SSH destination: `[user@]host[:port]`, normally an alias from `~/.ssh/config`. */
+  host: string;
+}
+
 export type EditorTargetIcon =
   | { kind: "image"; dataUrl: string }
   | { kind: "symbol"; name: "folder" | "terminal" };
@@ -9,13 +23,22 @@ export interface EditorTargetDescriptor {
   label: string;
   kind: EditorTargetKind;
   icon: EditorTargetIcon;
+  remoteDestinationKinds: readonly RemoteDestinationKind[];
 }
+
+/** What a target reports about itself; the registry stamps on the static capabilities. */
+export type EditorTargetDescription = Omit<EditorTargetDescriptor, "remoteDestinationKinds">;
 
 export interface EditorTargetLaunchInput {
   workspacePath: string;
   filePath?: string;
   line?: number;
   column?: number;
+  /**
+   * When set, `workspacePath` and `filePath` name paths on that remote machine, not on
+   * this one, and the target renders them in whatever remote form it speaks.
+   */
+  remoteDestination?: RemoteDestination;
 }
 
 export interface EditorTargetRuntime {
@@ -35,8 +58,10 @@ export interface EditorTargetRuntime {
 
 export interface EditorTarget {
   readonly id: string;
+  /** Destination kinds `launch` can render. The registry refuses the rest. */
+  readonly remoteDestinationKinds: readonly RemoteDestinationKind[];
 
-  describe(runtime: EditorTargetRuntime): Promise<EditorTargetDescriptor>;
+  describe(runtime: EditorTargetRuntime): Promise<EditorTargetDescription>;
   isInstalled(runtime: EditorTargetRuntime): Promise<boolean>;
   launch(input: EditorTargetLaunchInput, runtime: EditorTargetRuntime): Promise<void>;
 }

--- a/packages/desktop/src/features/editor-targets/target.ts
+++ b/packages/desktop/src/features/editor-targets/target.ts
@@ -58,8 +58,12 @@ export interface EditorTargetRuntime {
 
 export interface EditorTarget {
   readonly id: string;
-  /** Destination kinds `launch` can render. The registry refuses the rest. */
-  readonly remoteDestinationKinds: readonly RemoteDestinationKind[];
+  /**
+   * Destination kinds `launch` can render *right now*. Runtime-derived, not static: a
+   * target whose CLI does not resolve is local-only even when the application is installed.
+   * The registry refuses every other kind.
+   */
+  remoteDestinationKinds(runtime: EditorTargetRuntime): readonly RemoteDestinationKind[];
 
   describe(runtime: EditorTargetRuntime): Promise<EditorTargetDescription>;
   isInstalled(runtime: EditorTargetRuntime): Promise<boolean>;

--- a/packages/desktop/src/features/editor-targets/targets/android-studio.ts
+++ b/packages/desktop/src/features/editor-targets/targets/android-studio.ts
@@ -22,6 +22,7 @@ function launchArgs(input: EditorTargetLaunchInput): string[] {
 
 export const androidStudioTarget: EditorTarget = {
   id: "android-studio",
+  remoteDestinationKinds: [],
   async describe(runtime) {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/android-studio.ts
+++ b/packages/desktop/src/features/editor-targets/targets/android-studio.ts
@@ -22,7 +22,7 @@ function launchArgs(input: EditorTargetLaunchInput): string[] {
 
 export const androidStudioTarget: EditorTarget = {
   id: "android-studio",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe(runtime) {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/antigravity.ts
+++ b/packages/desktop/src/features/editor-targets/targets/antigravity.ts
@@ -17,6 +17,7 @@ function launchArgs(input: EditorTargetLaunchInput): string[] {
 
 export const antigravityTarget: EditorTarget = {
   id: "antigravity",
+  remoteDestinationKinds: [],
   async describe(runtime) {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/antigravity.ts
+++ b/packages/desktop/src/features/editor-targets/targets/antigravity.ts
@@ -17,7 +17,7 @@ function launchArgs(input: EditorTargetLaunchInput): string[] {
 
 export const antigravityTarget: EditorTarget = {
   id: "antigravity",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe(runtime) {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/aqua.ts
+++ b/packages/desktop/src/features/editor-targets/targets/aqua.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["aqua", "aqua64"] as const;
 
 export const aquaTarget: EditorTarget = {
   id: "aqua",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/aqua.ts
+++ b/packages/desktop/src/features/editor-targets/targets/aqua.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["aqua", "aqua64"] as const;
 
 export const aquaTarget: EditorTarget = {
   id: "aqua",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/clion.ts
+++ b/packages/desktop/src/features/editor-targets/targets/clion.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["clion", "clion64"] as const;
 
 export const clionTarget: EditorTarget = {
   id: "clion",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/clion.ts
+++ b/packages/desktop/src/features/editor-targets/targets/clion.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["clion", "clion64"] as const;
 
 export const clionTarget: EditorTarget = {
   id: "clion",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/cursor.ts
+++ b/packages/desktop/src/features/editor-targets/targets/cursor.ts
@@ -1,4 +1,5 @@
-import type { EditorTarget, EditorTargetLaunchInput, EditorTargetRuntime } from "../target.js";
+import type { EditorTarget, EditorTargetRuntime } from "../target.js";
+import { vscodeLaunchArgs } from "./vscode-launch.js";
 
 function commands(runtime: EditorTargetRuntime): string[] {
   const candidates = ["cursor"];
@@ -23,21 +24,9 @@ function commands(runtime: EditorTargetRuntime): string[] {
   return candidates;
 }
 
-function location(input: EditorTargetLaunchInput): string {
-  if (!input.line) return input.filePath!;
-  return input.column
-    ? `${input.filePath}:${input.line}:${input.column}`
-    : `${input.filePath}:${input.line}`;
-}
-
-function launchArgs(input: EditorTargetLaunchInput): string[] {
-  if (!input.filePath) return [input.workspacePath];
-  if (!input.line) return [input.workspacePath, input.filePath];
-  return [input.workspacePath, "--goto", location(input)];
-}
-
 export const cursorTarget: EditorTarget = {
   id: "cursor",
+  remoteDestinationKinds: ["ssh"],
   async describe(runtime) {
     return {
       id: this.id,
@@ -54,8 +43,11 @@ export const cursorTarget: EditorTarget = {
   async launch(input, runtime) {
     const command = runtime.resolveCommand(commands(runtime));
     if (command) {
-      await runtime.spawnDetached({ command, args: launchArgs(input) });
+      await runtime.spawnDetached({ command, args: vscodeLaunchArgs(input) });
       return;
+    }
+    if (input.remoteDestination) {
+      throw new Error("Cursor command line tools are required to open a remote workspace");
     }
     if (runtime.hasMacApplication("Cursor")) {
       await runtime.openMacApplication({

--- a/packages/desktop/src/features/editor-targets/targets/cursor.ts
+++ b/packages/desktop/src/features/editor-targets/targets/cursor.ts
@@ -1,4 +1,5 @@
 import type { EditorTarget, EditorTargetRuntime } from "../target.js";
+import { cliRemoteDestinationKinds } from "../remote.js";
 import { vscodeLaunchArgs } from "./vscode-launch.js";
 
 function commands(runtime: EditorTargetRuntime): string[] {
@@ -26,7 +27,7 @@ function commands(runtime: EditorTargetRuntime): string[] {
 
 export const cursorTarget: EditorTarget = {
   id: "cursor",
-  remoteDestinationKinds: ["ssh"],
+  remoteDestinationKinds: (runtime) => cliRemoteDestinationKinds(runtime, commands(runtime)),
   async describe(runtime) {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/datagrip.ts
+++ b/packages/desktop/src/features/editor-targets/targets/datagrip.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["datagrip", "datagrip64"] as const;
 
 export const datagripTarget: EditorTarget = {
   id: "datagrip",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/datagrip.ts
+++ b/packages/desktop/src/features/editor-targets/targets/datagrip.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["datagrip", "datagrip64"] as const;
 
 export const datagripTarget: EditorTarget = {
   id: "datagrip",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/dataspell.ts
+++ b/packages/desktop/src/features/editor-targets/targets/dataspell.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["dataspell", "dataspell64"] as const;
 
 export const dataspellTarget: EditorTarget = {
   id: "dataspell",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/dataspell.ts
+++ b/packages/desktop/src/features/editor-targets/targets/dataspell.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["dataspell", "dataspell64"] as const;
 
 export const dataspellTarget: EditorTarget = {
   id: "dataspell",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/file-manager.ts
+++ b/packages/desktop/src/features/editor-targets/targets/file-manager.ts
@@ -10,6 +10,7 @@ const launchFileManager: EditorTarget["launch"] = async (input, runtime) => {
 
 export const finderTarget: EditorTarget = {
   id: "finder",
+  remoteDestinationKinds: [],
   async describe(runtime) {
     return {
       id: this.id,
@@ -26,6 +27,7 @@ export const finderTarget: EditorTarget = {
 
 export const explorerTarget: EditorTarget = {
   id: "explorer",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,
@@ -42,6 +44,7 @@ export const explorerTarget: EditorTarget = {
 
 export const fileManagerTarget: EditorTarget = {
   id: "file-manager",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/file-manager.ts
+++ b/packages/desktop/src/features/editor-targets/targets/file-manager.ts
@@ -10,7 +10,7 @@ const launchFileManager: EditorTarget["launch"] = async (input, runtime) => {
 
 export const finderTarget: EditorTarget = {
   id: "finder",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe(runtime) {
     return {
       id: this.id,
@@ -27,7 +27,7 @@ export const finderTarget: EditorTarget = {
 
 export const explorerTarget: EditorTarget = {
   id: "explorer",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,
@@ -44,7 +44,7 @@ export const explorerTarget: EditorTarget = {
 
 export const fileManagerTarget: EditorTarget = {
   id: "file-manager",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/goland.ts
+++ b/packages/desktop/src/features/editor-targets/targets/goland.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["goland", "goland64"] as const;
 
 export const golandTarget: EditorTarget = {
   id: "goland",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/goland.ts
+++ b/packages/desktop/src/features/editor-targets/targets/goland.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["goland", "goland64"] as const;
 
 export const golandTarget: EditorTarget = {
   id: "goland",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/intellij-idea.ts
+++ b/packages/desktop/src/features/editor-targets/targets/intellij-idea.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["idea", "idea64"] as const;
 
 export const intellijIdeaTarget: EditorTarget = {
   id: "intellij-idea",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/intellij-idea.ts
+++ b/packages/desktop/src/features/editor-targets/targets/intellij-idea.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["idea", "idea64"] as const;
 
 export const intellijIdeaTarget: EditorTarget = {
   id: "intellij-idea",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/kiro.ts
+++ b/packages/desktop/src/features/editor-targets/targets/kiro.ts
@@ -17,6 +17,7 @@ function launchArgs(input: EditorTargetLaunchInput): string[] {
 
 export const kiroTarget: EditorTarget = {
   id: "kiro",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/kiro.ts
+++ b/packages/desktop/src/features/editor-targets/targets/kiro.ts
@@ -17,7 +17,7 @@ function launchArgs(input: EditorTargetLaunchInput): string[] {
 
 export const kiroTarget: EditorTarget = {
   id: "kiro",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/phpstorm.ts
+++ b/packages/desktop/src/features/editor-targets/targets/phpstorm.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["phpstorm", "phpstorm64"] as const;
 
 export const phpstormTarget: EditorTarget = {
   id: "phpstorm",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/phpstorm.ts
+++ b/packages/desktop/src/features/editor-targets/targets/phpstorm.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["phpstorm", "phpstorm64"] as const;
 
 export const phpstormTarget: EditorTarget = {
   id: "phpstorm",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/pycharm.ts
+++ b/packages/desktop/src/features/editor-targets/targets/pycharm.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["pycharm", "pycharm64"] as const;
 
 export const pycharmTarget: EditorTarget = {
   id: "pycharm",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/pycharm.ts
+++ b/packages/desktop/src/features/editor-targets/targets/pycharm.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["pycharm", "pycharm64"] as const;
 
 export const pycharmTarget: EditorTarget = {
   id: "pycharm",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/remote-path.ts
+++ b/packages/desktop/src/features/editor-targets/targets/remote-path.ts
@@ -1,0 +1,8 @@
+/**
+ * Percent-encode a POSIX path for a remote URI. Each segment is encoded separately so the
+ * separators and the leading slash survive, and so a space or `&` in a directory name never
+ * reaches a shell as itself.
+ */
+export function encodeRemotePath(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/");
+}

--- a/packages/desktop/src/features/editor-targets/targets/remote-path.ts
+++ b/packages/desktop/src/features/editor-targets/targets/remote-path.ts
@@ -1,8 +1,0 @@
-/**
- * Percent-encode a POSIX path for a remote URI. Each segment is encoded separately so the
- * separators and the leading slash survive, and so a space or `&` in a directory name never
- * reaches a shell as itself.
- */
-export function encodeRemotePath(path: string): string {
-  return path.split("/").map(encodeURIComponent).join("/");
-}

--- a/packages/desktop/src/features/editor-targets/targets/rider.ts
+++ b/packages/desktop/src/features/editor-targets/targets/rider.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["rider", "rider64"] as const;
 
 export const riderTarget: EditorTarget = {
   id: "rider",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/rider.ts
+++ b/packages/desktop/src/features/editor-targets/targets/rider.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["rider", "rider64"] as const;
 
 export const riderTarget: EditorTarget = {
   id: "rider",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/rubymine.ts
+++ b/packages/desktop/src/features/editor-targets/targets/rubymine.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["rubymine", "rubymine64"] as const;
 
 export const rubymineTarget: EditorTarget = {
   id: "rubymine",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/rubymine.ts
+++ b/packages/desktop/src/features/editor-targets/targets/rubymine.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["rubymine", "rubymine64"] as const;
 
 export const rubymineTarget: EditorTarget = {
   id: "rubymine",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/rustrover.ts
+++ b/packages/desktop/src/features/editor-targets/targets/rustrover.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["rustrover", "rustrover64"] as const;
 
 export const rustroverTarget: EditorTarget = {
   id: "rustrover",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/rustrover.ts
+++ b/packages/desktop/src/features/editor-targets/targets/rustrover.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["rustrover", "rustrover64"] as const;
 
 export const rustroverTarget: EditorTarget = {
   id: "rustrover",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/trae.ts
+++ b/packages/desktop/src/features/editor-targets/targets/trae.ts
@@ -17,6 +17,7 @@ function launchArgs(input: EditorTargetLaunchInput): string[] {
 
 export const traeTarget: EditorTarget = {
   id: "trae",
+  remoteDestinationKinds: [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/trae.ts
+++ b/packages/desktop/src/features/editor-targets/targets/trae.ts
@@ -17,7 +17,7 @@ function launchArgs(input: EditorTargetLaunchInput): string[] {
 
 export const traeTarget: EditorTarget = {
   id: "trae",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/vscode-insiders.ts
+++ b/packages/desktop/src/features/editor-targets/targets/vscode-insiders.ts
@@ -1,4 +1,5 @@
-import type { EditorTarget, EditorTargetLaunchInput, EditorTargetRuntime } from "../target.js";
+import type { EditorTarget, EditorTargetRuntime } from "../target.js";
+import { vscodeLaunchArgs } from "./vscode-launch.js";
 
 function commands(runtime: EditorTargetRuntime): string[] {
   const candidates = ["code-insiders"];
@@ -27,21 +28,9 @@ function commands(runtime: EditorTargetRuntime): string[] {
   return candidates;
 }
 
-function location(input: EditorTargetLaunchInput): string {
-  if (!input.line) return input.filePath!;
-  return input.column
-    ? `${input.filePath}:${input.line}:${input.column}`
-    : `${input.filePath}:${input.line}`;
-}
-
-function launchArgs(input: EditorTargetLaunchInput): string[] {
-  if (!input.filePath) return [input.workspacePath];
-  if (!input.line) return [input.workspacePath, input.filePath];
-  return [input.workspacePath, "--goto", location(input)];
-}
-
 export const vscodeInsidersTarget: EditorTarget = {
   id: "vscode-insiders",
+  remoteDestinationKinds: ["ssh"],
   async describe() {
     return {
       id: this.id,
@@ -59,8 +48,13 @@ export const vscodeInsidersTarget: EditorTarget = {
   async launch(input, runtime) {
     const command = runtime.resolveCommand(commands(runtime));
     if (command) {
-      await runtime.spawnDetached({ command, args: launchArgs(input) });
+      await runtime.spawnDetached({ command, args: vscodeLaunchArgs(input) });
       return;
+    }
+    if (input.remoteDestination) {
+      throw new Error(
+        "VS Code Insiders command line tools are required to open a remote workspace",
+      );
     }
     if (runtime.hasMacApplication("Visual Studio Code - Insiders")) {
       await runtime.openMacApplication({

--- a/packages/desktop/src/features/editor-targets/targets/vscode-insiders.ts
+++ b/packages/desktop/src/features/editor-targets/targets/vscode-insiders.ts
@@ -1,4 +1,5 @@
 import type { EditorTarget, EditorTargetRuntime } from "../target.js";
+import { cliRemoteDestinationKinds } from "../remote.js";
 import { vscodeLaunchArgs } from "./vscode-launch.js";
 
 function commands(runtime: EditorTargetRuntime): string[] {
@@ -30,7 +31,7 @@ function commands(runtime: EditorTargetRuntime): string[] {
 
 export const vscodeInsidersTarget: EditorTarget = {
   id: "vscode-insiders",
-  remoteDestinationKinds: ["ssh"],
+  remoteDestinationKinds: (runtime) => cliRemoteDestinationKinds(runtime, commands(runtime)),
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/vscode-launch.ts
+++ b/packages/desktop/src/features/editor-targets/targets/vscode-launch.ts
@@ -1,0 +1,43 @@
+import type { EditorTargetLaunchInput, RemoteDestination } from "../target.js";
+import { encodeRemotePath } from "./remote-path.js";
+
+/** Adding a `RemoteDestinationKind` without an authority form here is a compile error. */
+function remoteAuthority(destination: RemoteDestination): string {
+  switch (destination.kind) {
+    case "ssh":
+      return `ssh-remote+${destination.host}`;
+  }
+}
+
+function remoteUri(destination: RemoteDestination, path: string): string {
+  return `vscode-remote://${remoteAuthority(destination)}${encodeRemotePath(path)}`;
+}
+
+function position(input: EditorTargetLaunchInput): string {
+  if (!input.line) return "";
+  return input.column ? `:${input.line}:${input.column}` : `:${input.line}`;
+}
+
+function localArgs(input: EditorTargetLaunchInput): string[] {
+  if (!input.filePath) return [input.workspacePath];
+  if (!input.line) return [input.workspacePath, input.filePath];
+  return [input.workspacePath, "--goto", `${input.filePath}${position(input)}`];
+}
+
+/**
+ * `--goto <path>:<line>` classifies positional paths with `stat()`, and the client cannot
+ * stat a remote filesystem: every path lands in `fileURIs` and the folder never opens.
+ * Explicit `--folder-uri` / `--file-uri` carry the authority inside the URI instead, so
+ * `--remote` is unnecessary and the line number rides inside the file URI path.
+ */
+function remoteArgs(input: EditorTargetLaunchInput, destination: RemoteDestination): string[] {
+  const folderArgs = ["--folder-uri", remoteUri(destination, input.workspacePath)];
+  if (!input.filePath) return folderArgs;
+  const fileUri = `${remoteUri(destination, input.filePath)}${position(input)}`;
+  if (!input.line) return [...folderArgs, "--file-uri", fileUri];
+  return [...folderArgs, "--goto", "--file-uri", fileUri];
+}
+
+export function vscodeLaunchArgs(input: EditorTargetLaunchInput): string[] {
+  return input.remoteDestination ? remoteArgs(input, input.remoteDestination) : localArgs(input);
+}

--- a/packages/desktop/src/features/editor-targets/targets/vscode-launch.ts
+++ b/packages/desktop/src/features/editor-targets/targets/vscode-launch.ts
@@ -1,5 +1,5 @@
 import type { EditorTargetLaunchInput, RemoteDestination } from "../target.js";
-import { encodeRemotePath } from "./remote-path.js";
+import { encodeRemotePath } from "../remote.js";
 
 /** Adding a `RemoteDestinationKind` without an authority form here is a compile error. */
 function remoteAuthority(destination: RemoteDestination): string {

--- a/packages/desktop/src/features/editor-targets/targets/vscode.ts
+++ b/packages/desktop/src/features/editor-targets/targets/vscode.ts
@@ -1,4 +1,5 @@
-import type { EditorTarget, EditorTargetLaunchInput, EditorTargetRuntime } from "../target.js";
+import type { EditorTarget, EditorTargetRuntime } from "../target.js";
+import { vscodeLaunchArgs } from "./vscode-launch.js";
 
 function commands(runtime: EditorTargetRuntime): string[] {
   const candidates = ["code"];
@@ -21,21 +22,9 @@ function commands(runtime: EditorTargetRuntime): string[] {
   return candidates;
 }
 
-function location(input: EditorTargetLaunchInput): string {
-  if (!input.line) return input.filePath!;
-  return input.column
-    ? `${input.filePath}:${input.line}:${input.column}`
-    : `${input.filePath}:${input.line}`;
-}
-
-function launchArgs(input: EditorTargetLaunchInput): string[] {
-  if (!input.filePath) return [input.workspacePath];
-  if (!input.line) return [input.workspacePath, input.filePath];
-  return [input.workspacePath, "--goto", location(input)];
-}
-
 export const vscodeTarget: EditorTarget = {
   id: "vscode",
+  remoteDestinationKinds: ["ssh"],
   async describe(runtime) {
     return {
       id: this.id,
@@ -53,8 +42,11 @@ export const vscodeTarget: EditorTarget = {
   async launch(input, runtime) {
     const command = runtime.resolveCommand(commands(runtime));
     if (command) {
-      await runtime.spawnDetached({ command, args: launchArgs(input) });
+      await runtime.spawnDetached({ command, args: vscodeLaunchArgs(input) });
       return;
+    }
+    if (input.remoteDestination) {
+      throw new Error("VS Code command line tools are required to open a remote workspace");
     }
     if (runtime.hasMacApplication("Visual Studio Code")) {
       await runtime.openMacApplication({

--- a/packages/desktop/src/features/editor-targets/targets/vscode.ts
+++ b/packages/desktop/src/features/editor-targets/targets/vscode.ts
@@ -1,4 +1,5 @@
 import type { EditorTarget, EditorTargetRuntime } from "../target.js";
+import { cliRemoteDestinationKinds } from "../remote.js";
 import { vscodeLaunchArgs } from "./vscode-launch.js";
 
 function commands(runtime: EditorTargetRuntime): string[] {
@@ -24,7 +25,7 @@ function commands(runtime: EditorTargetRuntime): string[] {
 
 export const vscodeTarget: EditorTarget = {
   id: "vscode",
-  remoteDestinationKinds: ["ssh"],
+  remoteDestinationKinds: (runtime) => cliRemoteDestinationKinds(runtime, commands(runtime)),
   async describe(runtime) {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/vscodium.ts
+++ b/packages/desktop/src/features/editor-targets/targets/vscodium.ts
@@ -1,4 +1,5 @@
-import type { EditorTarget, EditorTargetLaunchInput, EditorTargetRuntime } from "../target.js";
+import type { EditorTarget, EditorTargetRuntime } from "../target.js";
+import { vscodeLaunchArgs } from "./vscode-launch.js";
 
 function commands(runtime: EditorTargetRuntime): string[] {
   const candidates = ["codium"];
@@ -21,21 +22,9 @@ function commands(runtime: EditorTargetRuntime): string[] {
   return candidates;
 }
 
-function location(input: EditorTargetLaunchInput): string {
-  if (!input.line) return input.filePath!;
-  return input.column
-    ? `${input.filePath}:${input.line}:${input.column}`
-    : `${input.filePath}:${input.line}`;
-}
-
-function launchArgs(input: EditorTargetLaunchInput): string[] {
-  if (!input.filePath) return [input.workspacePath];
-  if (!input.line) return [input.workspacePath, input.filePath];
-  return [input.workspacePath, "--goto", location(input)];
-}
-
 export const vscodiumTarget: EditorTarget = {
   id: "vscodium",
+  remoteDestinationKinds: ["ssh"],
   async describe() {
     return {
       id: this.id,
@@ -52,8 +41,11 @@ export const vscodiumTarget: EditorTarget = {
   async launch(input, runtime) {
     const command = runtime.resolveCommand(commands(runtime));
     if (command) {
-      await runtime.spawnDetached({ command, args: launchArgs(input) });
+      await runtime.spawnDetached({ command, args: vscodeLaunchArgs(input) });
       return;
+    }
+    if (input.remoteDestination) {
+      throw new Error("VSCodium command line tools are required to open a remote workspace");
     }
     if (runtime.hasMacApplication("VSCodium")) {
       await runtime.openMacApplication({

--- a/packages/desktop/src/features/editor-targets/targets/vscodium.ts
+++ b/packages/desktop/src/features/editor-targets/targets/vscodium.ts
@@ -1,4 +1,5 @@
 import type { EditorTarget, EditorTargetRuntime } from "../target.js";
+import { cliRemoteDestinationKinds } from "../remote.js";
 import { vscodeLaunchArgs } from "./vscode-launch.js";
 
 function commands(runtime: EditorTargetRuntime): string[] {
@@ -24,7 +25,7 @@ function commands(runtime: EditorTargetRuntime): string[] {
 
 export const vscodiumTarget: EditorTarget = {
   id: "vscodium",
-  remoteDestinationKinds: ["ssh"],
+  remoteDestinationKinds: (runtime) => cliRemoteDestinationKinds(runtime, commands(runtime)),
   async describe() {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/webstorm.ts
+++ b/packages/desktop/src/features/editor-targets/targets/webstorm.ts
@@ -4,6 +4,7 @@ const COMMANDS = ["webstorm", "webstorm64"] as const;
 
 export const webstormTarget: EditorTarget = {
   id: "webstorm",
+  remoteDestinationKinds: [],
   async describe(runtime) {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/webstorm.ts
+++ b/packages/desktop/src/features/editor-targets/targets/webstorm.ts
@@ -4,7 +4,7 @@ const COMMANDS = ["webstorm", "webstorm64"] as const;
 
 export const webstormTarget: EditorTarget = {
   id: "webstorm",
-  remoteDestinationKinds: [],
+  remoteDestinationKinds: () => [],
   async describe(runtime) {
     return {
       id: this.id,

--- a/packages/desktop/src/features/editor-targets/targets/zed.ts
+++ b/packages/desktop/src/features/editor-targets/targets/zed.ts
@@ -1,4 +1,5 @@
-import type { EditorTarget, EditorTargetLaunchInput } from "../target.js";
+import type { EditorTarget, EditorTargetLaunchInput, RemoteDestination } from "../target.js";
+import { encodeRemotePath } from "./remote-path.js";
 
 const COMMANDS = ["zed", "zeditor"] as const;
 
@@ -9,8 +10,32 @@ function location(input: EditorTargetLaunchInput): string {
     : `${input.filePath}:${input.line}`;
 }
 
+/** Adding a `RemoteDestinationKind` without a URL form here is a compile error. */
+function remoteUrl(destination: RemoteDestination, path: string): string {
+  switch (destination.kind) {
+    case "ssh":
+      return `ssh://${destination.host}${encodeRemotePath(path)}`;
+  }
+}
+
+/**
+ * Zed opens a remote path as a URL rather than through an authority, so it needs no
+ * `--remote` equivalent. Its docs give `zed ssh://[<user>@]<host>[:<port>]/<path>` for
+ * remote paths and document `<path>:<line>[:<column>]` only for local ones; nothing
+ * documents a line suffix on an `ssh://` URL. So remote opens are folder-only here — the
+ * active file is dropped rather than appended in a syntax Zed may not parse.
+ */
+function launchArgs(input: EditorTargetLaunchInput): string[] {
+  if (input.remoteDestination) {
+    return [remoteUrl(input.remoteDestination, input.workspacePath)];
+  }
+  if (!input.filePath) return [input.workspacePath];
+  return [input.workspacePath, location(input)];
+}
+
 export const zedTarget: EditorTarget = {
   id: "zed",
+  remoteDestinationKinds: ["ssh"],
   async describe(runtime) {
     return { id: this.id, label: "Zed", kind: "editor", icon: await runtime.loadIcon("zed.png") };
   },
@@ -20,11 +45,11 @@ export const zedTarget: EditorTarget = {
   async launch(input, runtime) {
     const command = runtime.resolveCommand(COMMANDS);
     if (command) {
-      await runtime.spawnDetached({
-        command,
-        args: input.filePath ? [input.workspacePath, location(input)] : [input.workspacePath],
-      });
+      await runtime.spawnDetached({ command, args: launchArgs(input) });
       return;
+    }
+    if (input.remoteDestination) {
+      throw new Error("The Zed command line tool is required to open a remote workspace");
     }
     if (runtime.hasMacApplication("Zed")) {
       await runtime.openMacApplication({

--- a/packages/desktop/src/features/editor-targets/targets/zed.ts
+++ b/packages/desktop/src/features/editor-targets/targets/zed.ts
@@ -1,5 +1,5 @@
 import type { EditorTarget, EditorTargetLaunchInput, RemoteDestination } from "../target.js";
-import { encodeRemotePath } from "./remote-path.js";
+import { cliRemoteDestinationKinds, encodeRemotePath } from "../remote.js";
 
 const COMMANDS = ["zed", "zeditor"] as const;
 
@@ -35,7 +35,7 @@ function launchArgs(input: EditorTargetLaunchInput): string[] {
 
 export const zedTarget: EditorTarget = {
   id: "zed",
-  remoteDestinationKinds: ["ssh"],
+  remoteDestinationKinds: (runtime) => cliRemoteDestinationKinds(runtime, COMMANDS),
   async describe(runtime) {
     return { id: this.id, label: "Zed", kind: "editor", icon: await runtime.loadIcon("zed.png") };
   },

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -102,6 +102,7 @@ contextBridge.exposeInMainWorld("paseoDesktop", {
       filePath?: string;
       line?: number;
       column?: number;
+      remoteDestination?: { kind: "ssh"; host: string };
     }) => ipcRenderer.invoke("paseo:editor:openTarget", input),
   },
   webUtils: {


### PR DESCRIPTION
### Linked issue

No issue — feature requests aren't accepted as issues. The discussion behind this is #3344, where two people asked for this workflow.

### Type of change

- [x] New feature

### Reasoning

My daemons run on other machines. When an agent leaves work I want to continue by hand, the Open in editor button isn't there: it's gated to the local daemon, because the workspace path belongs to another machine and handing it to a local editor opens the wrong thing. So every handoff becomes copying a path and reconnecting by hand in the editor.

This makes the button work for a remote host by opening through the editor's own SSH remoting, using an SSH destination configured per host.

### Goals

- Open a workspace that lives on a remote daemon in a locally installed editor, over that editor's SSH remoting.
- The SSH destination is configured per host, on the client, and stays separate from how Paseo reaches the daemon.
- VS Code, Insiders, VSCodium and Cursor through `vscode-remote://ssh-remote+...`; Zed through `ssh://`.
- A host with no destination configured keeps the entry and routes to that host's settings, instead of hiding the feature from anyone who doesn't know it exists.
- Local-daemon workspaces behave exactly as before. Paseo stores no SSH credentials.

### Non-goals

- File-at-line for Zed. `path:line` is documented for local paths but not for `ssh://` URLs, so Zed opens folders only rather than guessing a syntax.
- Reading `~/.ssh/config` to detect the alias automatically. It came up in the discussion; left out on purpose.
- `wsl+` and `dev-container+`. The stored value is a destination with a kind, so they can be added without a rewrite, but only `ssh` exists here.
- JetBrains IDEs, which would need Gateway, and the VS Code forks I couldn't confirm ship a Remote-SSH implementation (Trae, Kiro, Antigravity). Each target declares what it supports.
- Mobile and web are untouched: no desktop bridge there, the entry stays hidden as today.
- Windows daemons. Remote paths are validated and encoded with POSIX rules; a Windows daemon would need the `/C:/...` form and isn't supported here.

### QA

Before writing any code I checked the obvious form by hand, and it doesn't work:

```
code --remote ssh-remote+dev /path/on/host --goto /path/on/host/FILE.md:12
```

That opens the file at the line but never the folder: with `--goto`, positional paths are classified by stat-ing them, and the client can't stat a remote filesystem. The form this PR implements is the one that behaves:

```
code --folder-uri "vscode-remote://ssh-remote+dev/path/on/host" \
     --goto --file-uri "vscode-remote://ssh-remote+dev/path/on/host/FILE.md:12"
```

Video on the desktop app: configuring the SSH destination for a host, then opening a workspace that lives on that remote daemon. It shows the folder case only — opening a file at a line is covered by the tests below, not by the video.

https://github.com/user-attachments/assets/904e824b-982a-4c5a-870f-1d27fa07d0c2

Automated tests, 7 files, 91 passed:

```
npx vitest run packages/app/src/workspace/open-in-editor \
  packages/app/src/workspace/desktop-open-targets.test.ts \
  packages/desktop/src/features/editor-targets
```

New cases cover the URI form with a space in the path, folder-only and file-without-line, refusal on a target that doesn't declare the destination kind, refusal when only the macOS `.app` is present, migration of the previously stored value, and that the local branch is unchanged when no destination is set.

`npm run typecheck` for `@getpaseo/app` and `@getpaseo/desktop`, `npm run lint` and `npm run format` all pass.

**Platforms.** Tested on the macOS desktop client against a Linux daemon reached over the relay, with VS Code. The Zed path was implemented from Zed's documentation and then tested and confirmed by @axsuul, who volunteered in #3344. Not tested: Windows and Linux desktop clients, and Cursor.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense


