### PR TITLE
fix(server): scope OpenCode bridge manifest to agent-scoped definitions

### DIFF
--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -61,6 +61,7 @@ import { createWorkspaceProvisioningService } from "../session/workspace-provisi
 import { serializePaseoToolInputParameters } from "./tools/paseo-tool-serialization.js";
 import { createPaseoToolCatalog } from "./tools/paseo-tools.js";
 import type { PaseoToolCatalog } from "./tools/types.js";
+import { OpenCodeBridge } from "./providers/opencode/bridge.js";
 
 const REPO_CWD = resolvePath("/tmp/repo");
 const TARGET_CWD = resolvePath("/tmp/target");
@@ -157,6 +158,13 @@ function serializedInputSchema(catalog: PaseoToolCatalog, name: string): Seriali
   // OpenCodeBridge.serializeManifest), so asserting on it locks the advertised
   // contract, not just the zod validation behavior.
   return serializePaseoToolInputParameters(tool) as unknown as SerializedToolSchema;
+}
+
+function readBridgePluginOptions(bridge: OpenCodeBridge): { baseUrl: string; token: string } {
+  const config = JSON.parse(bridge.decorateServerEnv({}).OPENCODE_CONFIG_CONTENT as string) as {
+    plugin: Array<[string, { baseUrl: string; token: string }]>;
+  };
+  return config.plugin[0][1];
 }
 
 function agentsOf(response: {
@@ -3175,6 +3183,47 @@ describe("create_agent MCP tool", () => {
       workspace: { kind: "current" },
       notifyOnFinish: true,
     });
+  });
+
+  it("serves the agent-scoped manifest through the real bridge HTTP endpoint", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const providerSnapshotManager = createOpenCodeManager().manager;
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-bridge-manifest-"));
+    const bridge = new OpenCodeBridge({ paseoHome, logger: createTestLogger() });
+    await bridge.start();
+    try {
+      // Install the catalog exactly as bootstrap does for the bridge manifest.
+      bridge.setManifestCatalog(
+        createPaseoToolCatalog({
+          agentManager,
+          agentStorage,
+          providerSnapshotManager,
+          toolScope: "agent",
+          logger,
+        }),
+      );
+      const { baseUrl, token } = readBridgePluginOptions(bridge);
+      const manifest = (await (
+        await fetch(`${baseUrl}/_internal/opencode/tools`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+      ).json()) as { tools: Array<{ name: string; inputSchema: unknown }> };
+      const createAgent = manifest.tools.find((tool) => tool.name === "create_agent");
+      if (!createAgent) {
+        throw new Error("Bridge manifest is missing create_agent");
+      }
+      const properties = Object.keys(
+        ((createAgent.inputSchema ?? {}) as { properties?: Record<string, unknown> }).properties ??
+          {},
+      );
+      // The served manifest must not advertise keys that agent-scoped session
+      // bindings reject; `background` trapped models in a retry loop.
+      expect(properties).not.toContain("background");
+      expect(properties).toEqual(expect.arrayContaining(["title", "provider", "initialPrompt"]));
+    } finally {
+      await bridge.close();
+      await rm(paseoHome, { recursive: true, force: true });
+    }
   });
 
   it("advertises agent-scoped definitions from the caller-less bridge manifest scope", async () => {

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -3208,10 +3208,8 @@ describe("create_agent MCP tool", () => {
           headers: { Authorization: `Bearer ${token}` },
         })
       ).json()) as { tools: Array<{ name: string; inputSchema: unknown }> };
-      const createAgent = manifest.tools.find((tool) => tool.name === "create_agent");
-      if (!createAgent) {
-        throw new Error("Bridge manifest is missing create_agent");
-      }
+      expect(manifest.tools.map((tool) => tool.name)).toContain("create_agent");
+      const createAgent = manifest.tools.find((tool) => tool.name === "create_agent")!;
       const properties = Object.keys(
         ((createAgent.inputSchema ?? {}) as { properties?: Record<string, unknown> }).properties ??
           {},

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -58,6 +58,9 @@ import type { BrowserToolsBroker, BrowserToolsExecuteInput } from "../browser-to
 import type { BrowserToolsResponsePayload } from "../browser-tools/errors.js";
 import { readPaseoWorktreeMetadata } from "../../utils/worktree-metadata.js";
 import { createWorkspaceProvisioningService } from "../session/workspace-provisioning/workspace-provisioning-service.js";
+import { serializePaseoToolInputParameters } from "./tools/paseo-tool-serialization.js";
+import { createPaseoToolCatalog } from "./tools/paseo-tools.js";
+import type { PaseoToolCatalog } from "./tools/types.js";
 
 const REPO_CWD = resolvePath("/tmp/repo");
 const TARGET_CWD = resolvePath("/tmp/target");
@@ -138,6 +141,22 @@ async function invokeToolWithParsedInput(
   const parsed = await tool.inputSchema.safeParseAsync(input);
   expect(parsed.success).toBe(true);
   return tool.handler(parsed.data);
+}
+
+interface SerializedToolSchema {
+  properties?: Record<string, { description?: string }>;
+  required?: string[];
+}
+
+function serializedInputSchema(catalog: PaseoToolCatalog, name: string): SerializedToolSchema {
+  const tool = catalog.getTool(name);
+  if (!tool) {
+    throw new Error(`Paseo tool not registered: ${name}`);
+  }
+  // The OpenCode bridge advertises this exact serialization (see
+  // OpenCodeBridge.serializeManifest), so asserting on it locks the advertised
+  // contract, not just the zod validation behavior.
+  return serializePaseoToolInputParameters(tool) as unknown as SerializedToolSchema;
 }
 
 function agentsOf(response: {
@@ -3156,6 +3175,79 @@ describe("create_agent MCP tool", () => {
       workspace: { kind: "current" },
       notifyOnFinish: true,
     });
+  });
+
+  it("advertises agent-scoped definitions from the caller-less bridge manifest scope", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const providerSnapshotManager = createOpenCodeManager().manager;
+    // The OpenCode bridge manifest is built without a callerAgentId but serves
+    // only agent-bound sessions, which validate against agent-scoped schemas.
+    // A top-level manifest advertises keys (e.g. create_agent.background) that
+    // execution rejects with "Unrecognized key", trapping models in a retry loop.
+    // Build the catalogs exactly as bootstrap (manifest) and agent-manager
+    // (per-session execution bindings) do.
+    const manifestCatalog = createPaseoToolCatalog({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager,
+      toolScope: "agent",
+      logger,
+    });
+    const executionCatalog = createPaseoToolCatalog({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+    const topLevelCatalog = createPaseoToolCatalog({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager,
+      logger,
+    });
+
+    const manifestCreateAgent = serializedInputSchema(manifestCatalog, "create_agent");
+    const executionCreateAgent = serializedInputSchema(executionCatalog, "create_agent");
+    const topLevelCreateAgent = serializedInputSchema(topLevelCatalog, "create_agent");
+
+    // Advertise == validate: the manifest offers exactly the keys execution accepts.
+    expect(Object.keys(manifestCreateAgent.properties ?? {}).sort()).toEqual(
+      Object.keys(executionCreateAgent.properties ?? {}).sort(),
+    );
+    expect(manifestCreateAgent.properties).not.toHaveProperty("background");
+    // Top-level callers keep the background knob.
+    expect(topLevelCreateAgent.properties).toHaveProperty("background");
+
+    // The scope override covers the other caller-varying definitions too.
+    const manifestPrompt = serializedInputSchema(manifestCatalog, "send_agent_prompt");
+    expect(manifestPrompt.properties?.background?.description).toContain(
+      "Agent-scoped default is true",
+    );
+    const manifestSchedule = serializedInputSchema(manifestCatalog, "create_schedule");
+    expect(manifestSchedule.required ?? []).not.toContain("provider");
+    const topLevelSchedule = serializedInputSchema(topLevelCatalog, "create_schedule");
+    expect(topLevelSchedule.required ?? []).toContain("provider");
+
+    // The advertised manifest input parses through execution validation.
+    const executionTool = registeredTool(
+      await createAgentMcpServer({
+        agentManager,
+        agentStorage,
+        providerSnapshotManager,
+        callerAgentId: "parent-agent",
+        logger,
+      }),
+      "create_agent",
+    );
+    const parsed = await executionTool.inputSchema.safeParseAsync({
+      title: "Child",
+      provider: "codex/gpt-5.4",
+      initialPrompt: "Do work",
+      workspaceId: "wks_parent",
+      notifyOnFinish: true,
+    });
+    expect(parsed.success).toBe(true);
   });
 
   it("returns notify-on-finish guidance for caller-created agents", async () => {

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -139,6 +139,15 @@ export interface PaseoToolHostDependencies {
    */
   callerAgentId?: string;
   /**
+   * Schema scope for advertised tool definitions. Defaults to "agent" when
+   * callerAgentId is set, "top-level" otherwise. The OpenCode bridge manifest
+   * sets this to "agent" explicitly: the manifest is served globally without a
+   * caller, but every session that executes bridge tools is bound to one, so a
+   * top-level manifest advertises keys (e.g. create_agent.background) that
+   * agent-scoped validation rejects.
+   */
+  toolScope?: "agent" | "top-level";
+  /**
    * Optional resolver for session-bound speak handlers.
    * Used by hidden voice agents to narrate through daemon-managed TTS.
    */
@@ -557,6 +566,11 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
   } = options;
   const childLogger = logger.child({ module: "agent", component: "paseo-tool-catalog" });
   const callerContext = callerAgentId ? (resolveCallerContext?.(callerAgentId) ?? null) : null;
+  // Schema scope drives advertised definitions only; handlers keep using
+  // callerAgentId directly. Scope defaults from caller identity, but the
+  // OpenCode bridge manifest overrides it to "agent" (see toolScope docs).
+  const isAgentScope =
+    options.toolScope !== undefined ? options.toolScope === "agent" : callerAgentId !== undefined;
 
   const parseToolInput = async (tool: PaseoToolDefinition, input: unknown): Promise<unknown> => {
     const inputSchema = tool.inputSchema;
@@ -1095,7 +1109,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       .describe("Legacy GitHub PR number. Prefer workspace.source.target.githubPrNumber."),
   };
   const createAgentInputSchema = z
-    .object(callerAgentId ? agentToAgentInputSchema : canonicalTopLevelInputSchema)
+    .object(isAgentScope ? agentToAgentInputSchema : canonicalTopLevelInputSchema)
     .passthrough();
   const agentToAgentCreateAgentArgsSchema = z.object(agentToAgentInputSchema).strict();
   const legacyAgentToAgentCreateAgentArgsSchema = z.object(legacyAgentToAgentInputSchema).strict();
@@ -1142,7 +1156,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         "Agent-scoped only: get notified when the prompted agent finishes, errors, or needs permission.",
       ),
   };
-  const sendAgentPromptInputSchema = callerAgentId
+  const sendAgentPromptInputSchema = isAgentScope
     ? agentToAgentSendAgentPromptInputSchema
     : topLevelSendAgentPromptInputSchema;
   const inspectProviderInputSchema = {
@@ -2530,7 +2544,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
           .optional()
           .describe("IANA time zone for the cron cadence. For example: America/New_York."),
         name: z.string().optional(),
-        provider: (callerAgentId ? AgentProviderEnum.optional() : AgentProviderEnum).describe(
+        provider: (isAgentScope ? AgentProviderEnum.optional() : AgentProviderEnum).describe(
           "Provider, or provider/model (for example: codex or codex/gpt-5.4). Defaults to the caller's provider in an agent-scoped session.",
         ),
         cwd: z.string().optional(),

--- a/packages/server/src/server/agent/tools/types.ts
+++ b/packages/server/src/server/agent/tools/types.ts
@@ -40,6 +40,13 @@ export interface PaseoToolRuntimeContext {
   paseoToolPolicy?: ProviderPaseoToolsPolicy;
   enableVoiceTools?: boolean;
   voiceOnly?: boolean;
+  /**
+   * Schema scope for advertised tool definitions. Defaults to "agent" when a
+   * callerAgentId is set, "top-level" otherwise. The OpenCode bridge manifest
+   * sets this to "agent" explicitly: the manifest is served globally without a
+   * caller, but every session that executes bridge tools is bound to one.
+   */
+  toolScope?: "agent" | "top-level";
 }
 
 export type PaseoToolCatalogFactory = (

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -1408,6 +1408,7 @@ export async function createPaseoDaemon(
     paseoHome: config.paseoHome,
     worktreesRoot: config.worktreesRoot,
     callerAgentId: runtime.callerAgentId,
+    ...(runtime.toolScope !== undefined ? { toolScope: runtime.toolScope } : {}),
     enableVoiceTools: runtime.enableVoiceTools,
     voiceOnly: runtime.voiceOnly,
     resolveSpeakHandler: (agentId) => wsServer?.resolveVoiceSpeakHandler(agentId) ?? null,
@@ -1417,7 +1418,14 @@ export async function createPaseoDaemon(
   const createAgentToolCatalog = (runtime: PaseoToolRuntimeContext) =>
     createPaseoToolCatalog(createAgentToolHostDependencies(runtime));
   const setAgentProviderToolsEnabled = (enabled: boolean) => {
-    agentProviderRuntime.setPaseoToolCatalog(enabled ? createAgentToolCatalog({}) : null);
+    // The bridge manifest is served globally without a caller, but every session
+    // that executes bridge tools is bound to one. Advertise agent-scoped
+    // definitions so the manifest matches agent-scoped validation; a top-level
+    // manifest advertises keys (e.g. create_agent.background) that execution
+    // rejects with "Unrecognized key".
+    agentProviderRuntime.setPaseoToolCatalog(
+      enabled ? createAgentToolCatalog({ toolScope: "agent" }) : null,
+    );
   };
   agentManager.setPaseoToolCatalogFactory(createAgentToolCatalog);
   agentManager.setPaseoToolsEnabled(config.mcpInjectIntoAgents !== false);


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

An OpenCode agent asked to delegate research via `create_agent` looped ~12 times sending a `background` key the daemon rejects with `Unrecognized key: "background"`. The agent was doing exactly what our tool definition told it to: the OpenCode bridge serves one global tool manifest built from a top-level catalog, but executes every call against per-session agent-scoped bindings whose strict schemas have no `background` key. The raw Zod error gives the model no recovery path, so it cycled through `true`/`false`/omitted and burned ~25k tokens going nowhere. Agent-scoped creation is always async anyway, so the advertised knob could never have worked.

### Goals

- Advertise == validate for every bridge consumer: build the OpenCode bridge manifest with explicit agent scope so `create_agent` no longer advertises `background` to agents.
- Fix the same advertise/validate split for the other caller-varying definitions (`send_agent_prompt` defaults/descriptions, `create_schedule.provider` requiredness).
- Lock the invariant with a regression test that asserts on the exact serialization the bridge serves.

### Non-goals

- No behavior change: agent-scoped validation stays strict, execution paths untouched. Top-level callers (CLI, MCP without caller) keep the `background` knob.
- Not accepting-and-ignoring `background` (considered and rejected: it would bless calls whose advertised description promises synchronous execution we don't perform).

### QA

- Reproduced from a real agent debug trace: `transformedRequest.tools` showed `paseo_create_agent` advertising `background`, and the timeline showed every call failing with `unrecognized_keys: ["background"]`.
- New test `advertises agent-scoped definitions from the caller-less bridge manifest scope` fails without the fix and passes with it.
- `mcp-server.test.ts` 120/120; `bridge.test.ts`, `provider-runtime.test.ts`, `agent-manager.test.ts` 185/185.
- `npm run lint` clean on all touched files; `npm run format` applied. Server `typecheck` shows only the 9 pre-existing `plugins/*` errors, byte-identical on the clean tree.

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes (pre-existing `plugins/*` failures, unrelated — verified identical on clean tree)
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
