### PR TITLE
fix(omp): resolve session id to file on import so the session's model is preserved

### DIFF
--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -72,7 +72,11 @@ import { getUserMessageText } from "./message-history.js";
 import { mapOmpSystemNoticeToNotification } from "./system-notice.js";
 import { materializeProviderImage } from "../provider-image-output.js";
 import { OmpCliRuntime } from "./cli-runtime.js";
-import { listOmpImportableSessions, readOmpImportSessionConfig } from "./session-descriptor.js";
+import {
+  listOmpImportableSessions,
+  readOmpImportSessionConfig,
+  resolveOmpSessionFile,
+} from "./session-descriptor.js";
 import type { OmpRuntime, OmpRuntimeSession, OmpStartSessionInput } from "./runtime.js";
 import type {
   OmpAgentSessionEvent,
@@ -2365,7 +2369,18 @@ export class OmpAgentClient implements AgentClient {
   }
 
   async importSession(input: ImportProviderSessionInput, context: ImportProviderSessionContext) {
-    const importConfig = await readOmpImportSessionConfig(input.providerHandleId);
+    const descriptorOptions = {
+      sessionDir: this.providerParams.sessionDir,
+      runtimeSettings: this.runtimeSettings,
+    };
+    const sessionFile = await resolveOmpSessionFile(input.providerHandleId, descriptorOptions);
+    if (!sessionFile) {
+      this.logger.warn(
+        { providerHandleId: input.providerHandleId },
+        "OMP import could not locate the session file; model and thinking level will fall back to provider defaults",
+      );
+    }
+    const importConfig = sessionFile ? await readOmpImportSessionConfig(sessionFile) : {};
     return importSessionFromPersistence({
       provider: this.provider,
       request: input,

--- a/packages/server/src/server/agent/providers/omp/session-descriptor.test.ts
+++ b/packages/server/src/server/agent/providers/omp/session-descriptor.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
 
-import { listOmpImportableSessions, readOmpImportSessionConfig } from "./session-descriptor.js";
+import {
+  listOmpImportableSessions,
+  readOmpImportSessionConfig,
+  resolveOmpSessionFile,
+} from "./session-descriptor.js";
 
 async function writeSession(root: string, relativePath: string, lines: unknown[]): Promise<string> {
   const filePath = path.join(root, "sessions", relativePath);
@@ -93,6 +97,50 @@ describe("OMP session descriptor", () => {
     await expect(readOmpImportSessionConfig(sessionFile)).resolves.toEqual({
       model: "openai-codex/gpt-5.1",
     });
+  });
+
+  test("resolves a bare session id to its file and reads the same import config", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "paseo-omp-session-by-id-"));
+    const sessionDir = path.join(root, "sessions");
+    const cwd = path.join(root, "repo");
+    const sessionId = "01a03dc8-77bb-7000-b0a3-bb7d25477e81";
+    const sessionFile = await writeSession(
+      root,
+      `project/2026-08-26T11-15-43-163Z_${sessionId}.jsonl`,
+      [
+        { type: "title", v: 1, title: "", updatedAt: "2026-08-26T11:15:43.163Z" },
+        { type: "session", version: 3, id: sessionId, timestamp: "2026-08-26T11:15:43.163Z", cwd },
+        {
+          type: "model_change",
+          id: "model-1",
+          timestamp: "2026-08-26T11:15:43.200Z",
+          model: "anthropic/claude-opus-5",
+        },
+      ],
+    );
+    // A decoy whose filename does not follow the `<timestamp>_<id>` convention
+    // but whose header carries the id must still be found.
+    const oddlyNamedId = "renamed-session";
+    const oddlyNamed = await writeSession(root, "project/notes.jsonl", [
+      { type: "session", id: oddlyNamedId, timestamp: "2026-08-27T00:00:00.000Z", cwd },
+      {
+        type: "model_change",
+        id: "model-2",
+        timestamp: "2026-08-27T00:00:00.100Z",
+        model: "mimorouter/claude-fable-5-1",
+      },
+    ]);
+
+    await expect(resolveOmpSessionFile(sessionId, { sessionDir })).resolves.toBe(sessionFile);
+    await expect(resolveOmpSessionFile(sessionFile, { sessionDir })).resolves.toBe(sessionFile);
+    await expect(resolveOmpSessionFile(oddlyNamedId, { sessionDir })).resolves.toBe(oddlyNamed);
+    await expect(resolveOmpSessionFile("does-not-exist", { sessionDir })).resolves.toBeNull();
+
+    const byId = await readOmpImportSessionConfig(sessionId, { sessionDir });
+    const byPath = await readOmpImportSessionConfig(sessionFile, { sessionDir });
+    expect(byId).toEqual({ model: "anthropic/claude-opus-5" });
+    expect(byId).toEqual(byPath);
+    await expect(readOmpImportSessionConfig("does-not-exist", { sessionDir })).resolves.toEqual({});
   });
 
   test("keeps recent nested OMP subagent sessions importable", async () => {

--- a/packages/server/src/server/agent/providers/omp/session-descriptor.ts
+++ b/packages/server/src/server/agent/providers/omp/session-descriptor.ts
@@ -24,7 +24,7 @@ const FULL_SCAN_LINE_LIMIT = 2_000;
 const IMPORT_CANDIDATE_OVERSCAN = 40;
 const IMPORT_CANDIDATE_MIN = 400;
 
-interface OmpSessionDescriptorOptions extends ListImportableSessionsOptions {
+export interface OmpSessionDescriptorOptions extends ListImportableSessionsOptions {
   sessionDir?: string;
   runtimeSettings?: ProviderRuntimeSettings;
   env?: NodeJS.ProcessEnv;
@@ -102,12 +102,66 @@ export async function listOmpImportableSessions(
   );
 }
 
+/**
+ * Reads the model/thinking config of an OMP session for import.
+ *
+ * `handle` is either an absolute path to the session `.jsonl` (what the
+ * importable-sessions list hands back) or a bare OMP session id (what
+ * `paseo import <id>` supplies). Ids are resolved against the configured
+ * sessions directory; an unresolvable handle yields `{}`.
+ */
 export async function readOmpImportSessionConfig(
-  filePath: string,
+  handle: string,
+  options: OmpSessionDescriptorOptions = {},
 ): Promise<OmpImportSessionConfig> {
+  const filePath = await resolveOmpSessionFile(handle, options);
+  if (!filePath) return {};
   const descriptor = await readOmpSessionDescriptor(filePath);
   if (!descriptor) return {};
   return toOmpImportSessionConfig(descriptor);
+}
+
+/**
+ * Resolves an import handle to a session file path. Returns the handle itself
+ * when it already names a readable file; otherwise searches the sessions
+ * directory for a file whose header `id` matches.
+ */
+export async function resolveOmpSessionFile(
+  handle: string,
+  options: OmpSessionDescriptorOptions = {},
+): Promise<string | null> {
+  const trimmed = handle.trim();
+  if (!trimmed) return null;
+  if (await isReadableFile(trimmed)) return trimmed;
+
+  const sessionsDir = await resolveOmpSessionsDir(options);
+  const files = await walkJsonlFiles(sessionsDir);
+  // OMP names session files `<timestamp>_<id>.jsonl`; try those first so the
+  // common case opens a single file instead of scanning the directory.
+  const nameSuffix = `_${trimmed}.jsonl`;
+  const byName = files.filter((file) => path.basename(file).endsWith(nameSuffix));
+  for (const file of byName) {
+    if (await headerSessionIdMatches(file, trimmed)) return file;
+  }
+  const rest = byName.length > 0 ? files.filter((file) => !byName.includes(file)) : files;
+  for (const file of rest) {
+    if (await headerSessionIdMatches(file, trimmed)) return file;
+  }
+  return null;
+}
+
+async function isReadableFile(filePath: string): Promise<boolean> {
+  try {
+    return (await stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function headerSessionIdMatches(filePath: string, sessionId: string): Promise<boolean> {
+  const headChunk = await readHeadChunk(filePath);
+  if (!headChunk) return false;
+  return parseSessionHeaderFromChunk(headChunk)?.sessionId === sessionId;
 }
 
 async function resolveOmpSessionsDir(options: OmpSessionDescriptorOptions): Promise<string> {


### PR DESCRIPTION
Fixes #2727.

## Problem

`paseo import <session-id> --provider omp` passes the bare session id into `readOmpImportSessionConfig`, which expects a file path. The `open()` fails, the function returns `{}`, and the agent is created on the provider's default model instead of the one recorded in the session. The import still reports `created`, so nothing tells you the model was dropped.

I hit this bulk-importing ~90 OMP sessions on two hosts: 32/38 on macOS landed on `anthropic/claude-3-5-sonnet-20240620`, 40/40 on a Linux box landed on `ollama/deepseek-r1:32b` (a provider that host doesn't even have). Every continued conversation then went to the wrong model and looked like "no reply" in the app.

Importing by absolute `.jsonl` path already worked, which isolated the bug to the handle, not the extraction.

## Change

- `session-descriptor.ts`: new `resolveOmpSessionFile(handle, options)` — returns the handle when it is a readable file, otherwise looks it up in the configured sessions dir, preferring the `<timestamp>_<id>.jsonl` filename convention and falling back to matching the header `id`. `readOmpImportSessionConfig` now accepts either form.
- `agent.ts`: `importSession` resolves through the provider's `sessionDir` / runtime settings (so custom session dirs work) and logs a `warn` when the handle cannot be resolved, so the fallback is no longer silent.
- Test covering id → file, path → file, non-conventional filename, unknown id, and id/path producing identical import config.

## QA

Tests (only the changed file, per AGENTS.md):

```
$ npx vitest run src/server/agent/providers/omp/session-descriptor.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

`npm run typecheck` (server) and `npm run lint` on the three files: clean. `npm run format:files` applied.

End to end against the dev daemon from this branch (`npm run dev:server`, port 6768), importing a real session whose last `model_change` is `anthropic/claude-opus-5`:

```
$ npm run cli -- import --provider omp --cwd ~/Documents/interview 01a00ec6-499b-7000-a8fc-58eef9972c92 --json
{ "agentId": "7a301a8f-…", "status": "created", "provider": "omp", "cwd": "/Users/allo/Documents/interview", … }

$ npm run cli -- ls -a -g
AGENT ID   NAME                            PROVIDER                     THINKING  STATUS
7a301a8    看下这个ooboqoo/interview-coder-cn  omp/anthropic/claude-opus-5  max       idle
```

Before this change the same import produced `omp/anthropic/claude-3-5-sonnet-20240620 / auto` (see #2727 for the identical repro on 0.2.5; still reproduces on 0.7.2).

Unknown id still fails at resume as before, but now with a daemon log line first:

```
WARN: OMP import could not locate the session file; model and thinking level will fall back to provider defaults {"providerHandleId":"not-a-real-session"}
```

Tested on macOS 26.5 arm64 (omp 18.0.11). Not tested on Windows. No UI change.
