### PR TITLE
Add generic ACP active-turn steering

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -503,6 +503,17 @@ Paseo tools such as subagent creation come from the shared internal tool catalog
 }
 ```
 
+ACP does not define native active-turn steering. Agents that expose steering through a slash
+command can opt in without changing the fallback for other ACP providers:
+
+```json
+"params": { "activeTurnSteerCommand": "/steer" }
+```
+
+Paseo sends that command as a concurrent ACP prompt while preserving the foreground turn. Use this
+only when the ACP agent explicitly handles the command as in-place steering; otherwise Paseo keeps
+its normal interrupt-and-replace behavior.
+
 ACP agents execute filesystem operations in their own environment by default,
 while terminal operations run through Paseo on the host. To customize which
 operations Paseo handles, configure client capabilities in provider params:

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -128,6 +128,19 @@ interface ACPConfiguredOverrideInternals {
   applyConfiguredOverrides(): Promise<void>;
 }
 
+interface ACPSteerInternals {
+  sessionId: string | null;
+  connection: {
+    prompt: (input: {
+      sessionId: string;
+      messageId: string;
+      prompt: Array<{ type: "text"; text: string }>;
+    }) => Promise<unknown>;
+  };
+  activeForegroundTurnId: string | null;
+  activeTurnSteerCommand?: string;
+}
+
 function createSession(terminateProcess?: ProcessTerminator): ACPAgentSession {
   return new ACPAgentSession(
     {
@@ -151,6 +164,29 @@ function createSession(terminateProcess?: ProcessTerminator): ACPAgentSession {
     },
   );
 }
+
+test("ACP forwards an opted-in active-turn steer without replacing the turn", async () => {
+  const session = createSession();
+  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+  const internals = asInternals<ACPSteerInternals>(session);
+  internals.sessionId = "session-1";
+  internals.activeForegroundTurnId = "turn-1";
+  internals.activeTurnSteerCommand = "/steer";
+  internals.connection = { prompt };
+
+  await expect(
+    session.steerActiveTurn?.("change course", {
+      expectedTurnId: "turn-1",
+      clientMessageId: "steer-message-1",
+    }),
+  ).resolves.toEqual({ status: "accepted" });
+  expect(prompt).toHaveBeenCalledWith({
+    sessionId: "session-1",
+    messageId: "steer-message-1",
+    prompt: [{ type: "text", text: "/steer change course" }],
+  });
+  expect(internals.activeForegroundTurnId).toBe("turn-1");
+});
 
 // Typed substitute for the real tree-kill terminator. Records which child
 // processes it was asked to terminate, so tests assert on observable state

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -84,6 +84,8 @@ import {
   type AgentStreamEvent,
   type AgentTimelineItem,
   type AgentUsage,
+  type SteerActiveTurnOptions,
+  type SteerResult,
   type FetchCatalogOptions,
   type ProviderRefreshContext,
   type ImportableProviderSession,
@@ -443,6 +445,7 @@ interface ACPAgentClientOptions {
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
   now?: () => number;
+  activeTurnSteerCommand?: string;
 }
 
 interface ACPAgentSessionOptions {
@@ -476,6 +479,7 @@ interface ACPAgentSessionOptions {
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
+  activeTurnSteerCommand?: string;
 }
 
 export interface SpawnedACPProcess {
@@ -905,6 +909,7 @@ export class ACPAgentClient implements AgentClient {
   private readonly importPromptCache = new Map<string, ACPImportPromptCacheEntry>();
   private readonly now: () => number;
   protected readonly terminateProcess: ProcessTerminator;
+  private readonly activeTurnSteerCommand?: string;
 
   constructor(options: ACPAgentClientOptions) {
     this.provider = options.provider;
@@ -933,6 +938,7 @@ export class ACPAgentClient implements AgentClient {
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
     this.now = options.now ?? Date.now;
+    this.activeTurnSteerCommand = options.activeTurnSteerCommand;
   }
 
   async createSession(
@@ -965,6 +971,7 @@ export class ACPAgentClient implements AgentClient {
         extensionCommandsParser: this.extensionCommandsParser,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
+        activeTurnSteerCommand: this.activeTurnSteerCommand,
       },
     );
     await session.initializeNewSession();
@@ -1016,6 +1023,7 @@ export class ACPAgentClient implements AgentClient {
       extensionCommandsParser: this.extensionCommandsParser,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
+      activeTurnSteerCommand: this.activeTurnSteerCommand,
     });
     await session.initializeResumedSession();
     return session;
@@ -1689,6 +1697,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private replayingHistory = false;
   private bootstrapThreadEventPending = false;
   private readonly terminateProcess: ProcessTerminator;
+  private readonly activeTurnSteerCommand?: string;
 
   constructor(config: AgentSessionConfig, options: ACPAgentSessionOptions) {
     this.provider = options.provider;
@@ -1721,6 +1730,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.activeTurnSteerCommand = options.activeTurnSteerCommand;
   }
 
   get id(): string | null {
@@ -1879,6 +1889,37 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       });
 
     return { turnId };
+  }
+
+  async steerActiveTurn(
+    prompt: AgentPromptInput,
+    options: SteerActiveTurnOptions,
+  ): Promise<SteerResult> {
+    if (
+      !this.activeTurnSteerCommand ||
+      !this.connection ||
+      !this.sessionId ||
+      this.activeForegroundTurnId !== options.expectedTurnId ||
+      typeof prompt !== "string"
+    ) {
+      return { status: "unavailable" };
+    }
+
+    if (options.clearPendingPermissions) {
+      for (const pending of this.pendingPermissions.values()) {
+        pending.resolve({ outcome: { outcome: "cancelled" } });
+      }
+      this.pendingPermissions.clear();
+    }
+
+    await this.runACPRequest(() =>
+      this.connection!.prompt({
+        sessionId: this.sessionId!,
+        messageId: options.clientMessageId ?? randomUUID(),
+        prompt: [{ type: "text", text: `${this.activeTurnSteerCommand} ${prompt}` }],
+      }),
+    );
+    return { status: "accepted" };
   }
 
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -21,6 +21,7 @@ import {
 export const GenericACPProviderParamsSchema = z
   .object({
     supportsMcpServers: z.boolean().optional(),
+    activeTurnSteerCommand: z.string().trim().min(1).optional(),
     clientCapabilities: z
       .object({
         fs: z
@@ -77,6 +78,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
       catalogModelResolver: options.catalogModelResolver,
+      activeTurnSteerCommand: providerParams.activeTurnSteerCommand,
       now: options.now,
     });
 


### PR DESCRIPTION
## Summary

- add opt-in active-turn steering for generic ACP providers through `params.activeTurnSteerCommand`
- forward accepted steering as a concurrent ACP prompt without canceling the foreground turn
- preserve interrupt-and-replace fallback for providers that do not opt in, stale turns, and structured prompts
- document the custom-provider setting

## Root cause

Paseo's provider-neutral manager supports `steerActiveTurn`, but the generic ACP adapter did not implement it because standard ACP has no steering method. Hermes exposes in-place steering through `/steer`, so Paseo unnecessarily canceled and replaced Hermes turns.

## Configuration

```json
"params": { "activeTurnSteerCommand": "/steer" }
```

## Verification

- focused ACP suites: 105 passed
- clean `npm run build:server`
- full workspace typecheck through pre-commit: passed
- lint and format checks: passed
- isolated daemon on port `16767`: a Hermes turn running `sleep 20` accepted a mid-turn correction, preserved the tool call, emitted the correction once, and finished with `STEERED DONE`

Production Paseo on port `6767` was not modified or restarted.
