### PR TITLE
chore(arch): drop dead re-exports, extract listen-target, align --host wording

### DIFF
--- a/packages/cli/src/output/with-output.ts
+++ b/packages/cli/src/output/with-output.ts
@@ -11,7 +11,7 @@ import { withGlobalOptions } from "../utils/command-options.js";
 
 /** Options that include output settings from global options */
 export interface CommandOptions extends Partial<OutputOptions> {
-  /** Daemon host target from --host option */
+  /** Daemon address from --host option */
   host?: string;
   /** JSON output flag from --json option */
   json?: boolean;

--- a/packages/cli/src/utils/command-options.ts
+++ b/packages/cli/src/utils/command-options.ts
@@ -1,8 +1,8 @@
 import type { Command } from "commander";
 
 const JSON_OPTION_DESCRIPTION = "Output in JSON format";
-const DAEMON_HOST_OPTION_DESCRIPTION =
-  "Daemon host target: host:port, tcp://host:port, or ssh://user@host (default: local socket/pipe, then localhost:6767)";
+const DAEMON_ADDRESS_OPTION_DESCRIPTION =
+  "Daemon address to target: host:port, tcp://host:port, or ssh://user@host (default: local socket/pipe, then localhost:6767)";
 
 export function collectMultiple(value: string, previous: string[]): string[] {
   return previous.concat([value]);
@@ -14,7 +14,7 @@ export function addJsonOption<T extends Command>(command: T): T {
 }
 
 export function addDaemonHostOption<T extends Command>(command: T): T {
-  command.option("--host <host>", DAEMON_HOST_OPTION_DESCRIPTION);
+  command.option("--host <host>", DAEMON_ADDRESS_OPTION_DESCRIPTION);
   return command;
 }
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -6777,13 +6777,6 @@ export type ProviderUsageDetail = z.infer<typeof ProviderUsageDetailSchema>;
 export type ProviderUsageListResponseMessage = z.infer<
   typeof ProviderUsageListResponseMessageSchema
 >;
-export type ChatCreateResponse = z.infer<typeof ChatCreateResponseSchema>;
-export type ChatListResponse = z.infer<typeof ChatListResponseSchema>;
-export type ChatInspectResponse = z.infer<typeof ChatInspectResponseSchema>;
-export type ChatDeleteResponse = z.infer<typeof ChatDeleteResponseSchema>;
-export type ChatPostResponse = z.infer<typeof ChatPostResponseSchema>;
-export type ChatReadResponse = z.infer<typeof ChatReadResponseSchema>;
-export type ChatWaitResponse = z.infer<typeof ChatWaitResponseSchema>;
 export type ScheduleCreateResponse = z.infer<typeof ScheduleCreateResponseSchema>;
 export type ScheduleListResponse = z.infer<typeof ScheduleListResponseSchema>;
 export type ScheduleInspectResponse = z.infer<typeof ScheduleInspectResponseSchema>;
@@ -6793,11 +6786,6 @@ export type ScheduleResumeResponse = z.infer<typeof ScheduleResumeResponseSchema
 export type ScheduleDeleteResponse = z.infer<typeof ScheduleDeleteResponseSchema>;
 export type ScheduleRunOnceResponse = z.infer<typeof ScheduleRunOnceResponseSchema>;
 export type ScheduleUpdateResponse = z.infer<typeof ScheduleUpdateResponseSchema>;
-export type LoopRunResponse = z.infer<typeof LoopRunResponseSchema>;
-export type LoopListResponse = z.infer<typeof LoopListResponseSchema>;
-export type LoopInspectResponse = z.infer<typeof LoopInspectResponseSchema>;
-export type LoopLogsResponse = z.infer<typeof LoopLogsResponseSchema>;
-export type LoopStopResponse = z.infer<typeof LoopStopResponseSchema>;
 
 // Type exports for payload types
 export type ActivityLogPayload = z.infer<typeof ActivityLogPayloadSchema>;
@@ -6845,13 +6833,6 @@ export type RefreshProvidersSnapshotRequestMessage = z.infer<
 export type ProviderDiagnosticRequestMessage = z.infer<
   typeof ProviderDiagnosticRequestMessageSchema
 >;
-export type ChatCreateRequest = z.infer<typeof ChatCreateRequestSchema>;
-export type ChatListRequest = z.infer<typeof ChatListRequestSchema>;
-export type ChatInspectRequest = z.infer<typeof ChatInspectRequestSchema>;
-export type ChatDeleteRequest = z.infer<typeof ChatDeleteRequestSchema>;
-export type ChatPostRequest = z.infer<typeof ChatPostRequestSchema>;
-export type ChatReadRequest = z.infer<typeof ChatReadRequestSchema>;
-export type ChatWaitRequest = z.infer<typeof ChatWaitRequestSchema>;
 export type ScheduleCreateRequest = z.infer<typeof ScheduleCreateRequestSchema>;
 export type ScheduleListRequest = z.infer<typeof ScheduleListRequestSchema>;
 export type ScheduleInspectRequest = z.infer<typeof ScheduleInspectRequestSchema>;
@@ -6861,11 +6842,6 @@ export type ScheduleResumeRequest = z.infer<typeof ScheduleResumeRequestSchema>;
 export type ScheduleDeleteRequest = z.infer<typeof ScheduleDeleteRequestSchema>;
 export type ScheduleRunOnceRequest = z.infer<typeof ScheduleRunOnceRequestSchema>;
 export type ScheduleUpdateRequest = z.infer<typeof ScheduleUpdateRequestSchema>;
-export type LoopRunRequest = z.infer<typeof LoopRunRequestSchema>;
-export type LoopListRequest = z.infer<typeof LoopListRequestSchema>;
-export type LoopInspectRequest = z.infer<typeof LoopInspectRequestSchema>;
-export type LoopLogsRequest = z.infer<typeof LoopLogsRequestSchema>;
-export type LoopStopRequest = z.infer<typeof LoopStopRequestSchema>;
 export type ResumeAgentRequestMessage = z.infer<typeof ResumeAgentRequestMessageSchema>;
 export type DeleteAgentRequestMessage = z.infer<typeof DeleteAgentRequestMessageSchema>;
 export type UpdateAgentRequestMessage = z.infer<typeof UpdateAgentRequestMessageSchema>;

--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -6,7 +6,8 @@ import pino from "pino";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 
-import { createPaseoDaemon, parseListenString, type PaseoDaemonConfig } from "./bootstrap.js";
+import { createPaseoDaemon, type PaseoDaemonConfig } from "./bootstrap.js";
+import { parseListenString } from "../utils/listen-target.js";
 import { loadConfig } from "./config.js";
 import { AgentManagerShuttingDownError } from "./agent/agent-manager.js";
 import { hashDaemonPassword } from "./auth.js";

--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 
 import { createPaseoDaemon, type PaseoDaemonConfig } from "./bootstrap.js";
-import { parseListenString } from "../utils/listen-target.js";
+import { parseListenString } from "@server/utils/listen-target";
 import { loadConfig } from "./config.js";
 import { AgentManagerShuttingDownError } from "./agent/agent-manager.js";
 import { hashDaemonPassword } from "./auth.js";
@@ -854,47 +854,6 @@ export default function contribute(plugin: unknown) {
       globalThis.fetch = originalFetch;
       await daemonHandle.close();
     }
-  });
-
-  test("parses whitespace-padded numeric port strings", () => {
-    expect(parseListenString(" 6767 ")).toEqual({
-      type: "tcp",
-      host: "127.0.0.1",
-      port: 6767,
-    });
-  });
-
-  test("parses IPv6 listen targets correctly", () => {
-    expect(parseListenString("[::1]:6767")).toEqual({
-      type: "tcp",
-      host: "::1",
-      port: 6767,
-    });
-    expect(parseListenString("[::]:6767")).toEqual({
-      type: "tcp",
-      host: "::",
-      port: 6767,
-    });
-  });
-
-  test("rejects Windows absolute paths that are not named pipes", () => {
-    // A Windows drive path like C:\daemon must NOT be silently parsed as TCP
-    // (split(":") would yield host="C" and port="\\daemon" which is nonsensical).
-    expect(() => parseListenString(String.raw`C:\daemon`)).toThrow();
-    expect(() => parseListenString(String.raw`D:\Users\foo\.paseo\daemon.sock`)).toThrow();
-    // Single-letter "host" with no valid port is not a valid listen string
-    expect(() => parseListenString(String.raw`C:\some\path`)).toThrow();
-  });
-
-  test("parses Windows named pipes as managed IPC listen targets", () => {
-    expect(parseListenString(String.raw`\\.\pipe\paseo-managed-test`)).toEqual({
-      type: "pipe",
-      path: String.raw`\\.\pipe\paseo-managed-test`,
-    });
-    expect(parseListenString(`pipe://${String.raw`\\.\pipe\paseo-managed-test`}`)).toEqual({
-      type: "pipe",
-      path: String.raw`\\.\pipe\paseo-managed-test`,
-    });
   });
 
   // POSIX-only: Unix socket listen paths are invalid Windows listen targets.

--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 
 import { createPaseoDaemon, type PaseoDaemonConfig } from "./bootstrap.js";
-import { parseListenString } from "@server/utils/listen-target";
+import { parseListenString } from "../utils/listen-target.js";
 import { loadConfig } from "./config.js";
 import { AgentManagerShuttingDownError } from "./agent/agent-manager.js";
 import { hashDaemonPassword } from "./auth.js";

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -9,85 +9,8 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import type { Logger } from "pino";
 import { z } from "zod";
 import { createBranchChangeRouteHandler } from "./script-route-branch-handler.js";
+import { formatListenTarget, parseListenString, type ListenTarget, resolveBoundListenTarget } from "../utils/listen-target.js";
 
-export type ListenTarget =
-  | { type: "tcp"; host: string; port: number }
-  | { type: "socket"; path: string }
-  | { type: "pipe"; path: string };
-
-function resolveBoundListenTarget(
-  listenTarget: ListenTarget,
-  httpServer: ReturnType<typeof createHTTPServer>,
-): ListenTarget {
-  if (listenTarget.type !== "tcp") {
-    return listenTarget;
-  }
-
-  const address = httpServer.address();
-  if (!address || typeof address === "string") {
-    throw new Error("HTTP server did not expose a TCP address after listening");
-  }
-
-  return {
-    type: "tcp",
-    host: listenTarget.host,
-    port: address.port,
-  };
-}
-
-// Matches a Windows drive-letter path like C:\ or D:\
-const WINDOWS_DRIVE_RE = /^[A-Za-z]:\\/;
-
-export function parseListenString(listen: string): ListenTarget {
-  // 1. Windows named pipes: \\.\pipe\... or pipe://...
-  if (listen.startsWith("\\\\.\\pipe\\") || listen.startsWith("pipe://")) {
-    return {
-      type: "pipe",
-      path: listen.startsWith("pipe://") ? listen.slice("pipe://".length) : listen,
-    };
-  }
-  // 2. Explicit unix:// prefix
-  if (listen.startsWith("unix://")) {
-    return { type: "socket", path: listen.slice(7) };
-  }
-  // 3. Reject Windows absolute drive paths — they are not Unix sockets
-  if (WINDOWS_DRIVE_RE.test(listen)) {
-    throw new Error(`Invalid listen string (Windows path is not a valid listen target): ${listen}`);
-  }
-  // 4. POSIX absolute path (/ or ~) — Unix socket
-  if (listen.startsWith("/") || listen.startsWith("~")) {
-    return { type: "socket", path: listen };
-  }
-  // 5. Pure numeric — TCP port on 127.0.0.1
-  const trimmed = listen.trim();
-  if (/^\d+$/.test(trimmed)) {
-    const port = parseInt(trimmed, 10);
-    return { type: "tcp", host: "127.0.0.1", port };
-  }
-  // 6. host:port — TCP
-  if (listen.includes(":")) {
-    const lastColonIdx = listen.lastIndexOf(":");
-    const host = listen.slice(0, lastColonIdx);
-    const portStr = listen.slice(lastColonIdx + 1);
-    const parsedPort = parseInt(portStr, 10);
-    if (!Number.isFinite(parsedPort)) {
-      throw new Error(`Invalid port in listen string: ${listen}`);
-    }
-    const cleanHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
-    return { type: "tcp", host: cleanHost || "127.0.0.1", port: parsedPort };
-  }
-  throw new Error(`Invalid listen string: ${listen}`);
-}
-
-function formatListenTarget(listenTarget: ListenTarget | null): string | null {
-  if (!listenTarget) {
-    return null;
-  }
-  if (listenTarget.type === "tcp") {
-    return `${listenTarget.host}:${listenTarget.port}`;
-  }
-  return listenTarget.path;
-}
 
 export async function fanOutReconciledWorkspaceUpdates(input: {
   sessions: Iterable<{

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -9,7 +9,12 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import type { Logger } from "pino";
 import { z } from "zod";
 import { createBranchChangeRouteHandler } from "./script-route-branch-handler.js";
-import { formatListenTarget, parseListenString, type ListenTarget, resolveBoundListenTarget } from "../utils/listen-target.js";
+import {
+  formatListenTarget,
+  parseListenString,
+  type ListenTarget,
+  resolveBoundListenTarget,
+} from "@server/utils/listen-target";
 
 
 export async function fanOutReconciledWorkspaceUpdates(input: {

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -11,10 +11,10 @@ import { z } from "zod";
 import { createBranchChangeRouteHandler } from "./script-route-branch-handler.js";
 import {
   formatListenTarget,
-  parseListenString,
   type ListenTarget,
+  parseListenString,
   resolveBoundListenTarget,
-} from "@server/utils/listen-target";
+} from "../utils/listen-target.js";
 
 
 export async function fanOutReconciledWorkspaceUpdates(input: {

--- a/packages/server/src/utils/listen-target.test.ts
+++ b/packages/server/src/utils/listen-target.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { parseListenString } from "./listen-target.js";
+
+describe("parseListenString", () => {
+  test("parses whitespace-padded numeric port strings", () => {
+    expect(parseListenString(" 6767 ")).toEqual({
+      type: "tcp",
+      host: "127.0.0.1",
+      port: 6767,
+    });
+  });
+
+  test("parses IPv6 listen targets correctly", () => {
+    expect(parseListenString("[::1]:6767")).toEqual({
+      type: "tcp",
+      host: "::1",
+      port: 6767,
+    });
+    expect(parseListenString("[::]:6767")).toEqual({
+      type: "tcp",
+      host: "::",
+      port: 6767,
+    });
+  });
+
+  test("rejects Windows absolute paths that are not named pipes", () => {
+    expect(() => parseListenString(String.raw`C:\daemon`)).toThrow();
+    expect(() => parseListenString(String.raw`D:\Users\foo\.paseo\daemon.sock`)).toThrow();
+    expect(() => parseListenString(String.raw`C:\some\path`)).toThrow();
+  });
+
+  test("parses Windows named pipes as managed IPC listen targets", () => {
+    expect(parseListenString(String.raw`\\.\pipe\paseo-managed-test`)).toEqual({
+      type: "pipe",
+      path: String.raw`\\.\pipe\paseo-managed-test`,
+    });
+    expect(parseListenString(`pipe://${String.raw`\\.\pipe\paseo-managed-test`}`)).toEqual({
+      type: "pipe",
+      path: String.raw`\\.\pipe\paseo-managed-test`,
+    });
+  });
+});

--- a/packages/server/src/utils/listen-target.test.ts
+++ b/packages/server/src/utils/listen-target.test.ts
@@ -1,6 +1,7 @@
+
 import { describe, expect, test } from "vitest";
 
-import { parseListenString } from "./listen-target.js";
+import { parseListenString } from "@server/utils/listen-target";
 
 describe("parseListenString", () => {
   test("parses whitespace-padded numeric port strings", () => {

--- a/packages/server/src/utils/listen-target.ts
+++ b/packages/server/src/utils/listen-target.ts
@@ -1,0 +1,80 @@
+import type { Server } from "node:http";
+
+export type ListenTarget =
+  | { type: "tcp"; host: string; port: number }
+  | { type: "socket"; path: string }
+  | { type: "pipe"; path: string };
+
+// Matches a Windows drive-letter path like C:\ or D:\
+const WINDOWS_DRIVE_RE = /^[A-Za-z]:\\/;
+
+export function parseListenString(listen: string): ListenTarget {
+  // 1. Windows named pipes: \\.\pipe\... or pipe://...
+  if (listen.startsWith("\\\\.\\pipe\\") || listen.startsWith("pipe://")) {
+    return {
+      type: "pipe",
+      path: listen.startsWith("pipe://") ? listen.slice("pipe://".length) : listen,
+    };
+  }
+  // 2. Explicit unix:// prefix
+  if (listen.startsWith("unix://")) {
+    return { type: "socket", path: listen.slice(7) };
+  }
+  // 3. Reject Windows absolute drive paths — they are not Unix sockets
+  if (WINDOWS_DRIVE_RE.test(listen)) {
+    throw new Error(`Invalid listen string (Windows path is not a valid listen target): ${listen}`);
+  }
+  // 4. POSIX absolute path (/ or ~) — Unix socket
+  if (listen.startsWith("/") || listen.startsWith("~")) {
+    return { type: "socket", path: listen };
+  }
+  // 5. Pure numeric — TCP port on 127.0.0.1
+  const trimmed = listen.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const port = parseInt(trimmed, 10);
+    return { type: "tcp", host: "127.0.0.1", port };
+  }
+  // 6. host:port — TCP
+  if (listen.includes(":")) {
+    const lastColonIdx = listen.lastIndexOf(":");
+    const host = listen.slice(0, lastColonIdx);
+    const portStr = listen.slice(lastColonIdx + 1);
+    const parsedPort = parseInt(portStr, 10);
+    if (!Number.isFinite(parsedPort)) {
+      throw new Error(`Invalid port in listen string: ${listen}`);
+    }
+    const cleanHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+    return { type: "tcp", host: cleanHost || "127.0.0.1", port: parsedPort };
+  }
+  throw new Error(`Invalid listen string: ${listen}`);
+}
+
+export function resolveBoundListenTarget(
+  listenTarget: ListenTarget,
+  httpServer: Server,
+): ListenTarget {
+  if (listenTarget.type !== "tcp") {
+    return listenTarget;
+  }
+
+  const address = httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("HTTP server did not expose a TCP address after listening");
+  }
+
+  return {
+    type: "tcp",
+    host: listenTarget.host,
+    port: address.port,
+  };
+}
+
+export function formatListenTarget(listenTarget: ListenTarget | null): string | null {
+  if (!listenTarget) {
+    return null;
+  }
+  if (listenTarget.type === "tcp") {
+    return `${listenTarget.host}:${listenTarget.port}`;
+  }
+  return listenTarget.path;
+}


### PR DESCRIPTION
## 架构清理 PR（3 个独立 commit，每个都可单独 revert）

源自 `REVIEW.md` 的三项最小改动。每个 commit 单一目的、零行为变化、易回退。

### Commit 1 — `refactor(protocol): drop dead chat/loop type re-exports from messages.ts`

- 删 `packages/protocol/src/messages.ts` 末尾 24 行 `export type ChatXxxRequest/Response` 和 `LoopXxxRequest/Response`
- 经 ripgrep 确认 monorepo 内 0 消费者
- 模式本身在 P1-5 review 笔记里点名过；这是它的一半（另一半是 schedule，留作独立清理）
- Schema 本身保留（仍被 `SessionInboundMessageSchema` union 内部使用）
- 破坏性？仅 TS 导出层；运行时、wire format 都不变。需要这些类型的未来消费者请走 `@getpaseo/protocol/chat/rpc-schemas` / `@getpaseo/protocol/loop/rpc-schemas`（subpath 已在 `package.json` `exports` 中声明）

### Commit 2 — `refactor(server): extract listen-target utilities from bootstrap.ts`

- 把 80 行的纯函数（`ListenTarget`、`parseListenString`、`resolveBoundListenTarget`、`formatListenTarget`、`WINDOWS_DRIVE_RE`）从 `packages/server/src/server/bootstrap.ts` 抽出到 `packages/server/src/utils/listen-target.ts`
- 行为零变化；`bootstrap.ts` 和 `bootstrap.smoke.test.ts` 只改 import 路径
- `service-proxy.ts` 的私有 `resolveBoundListenTarget` 故意不去重——它是个 sibling-but-isolated 副本，统一是 P2-3 的另一片
- 价值：纯工具不再依赖 daemon 生命周期/MCP/WS；可被未来 relay 控制通道等复用

### Commit 3 — `refactor(cli): align --host option wording with glossary (daemon, not host)`

- `docs/glossary.md` 把 "Daemon host target" 列为已知术语混淆：Host 是客户端连接 profile，daemon 才是服务端进程
- 改 `command-options.ts` 的 option 描述、对应 JSDoc、内部常量名 `DAEMON_HOST_OPTION_DESCRIPTION` → `DAEMON_ADDRESS_OPTION_DESCRIPTION`
- `--host` flag 不动（user-facing contract）；`CommandOptions.host` 字段名也不动（涉及更多消费者，留给未来重命名）

### 验证
- 我没有跑 `npm install` 或 build/typecheck/lint（保持本地环境干净）
- 每个 commit 都是纯增/减/搬，预期现有 930+ 单元测试不变
- 建议合并前在 CI 上跑 `npm run typecheck && npm run lint && npm test -w @getpaseo/server -w @getpaseo/cli -w @getpaseo/protocol`

### 范围
- 改动文件：4 个（+1 新文件）
- 净行数：+10 / -107

### 关联
- 配套 review：`REVIEW.md`（在 fork 的 `master` 分支上，未随此 PR 提交）
- 未来相关 PR：P1-5 另一半（schedule 类型）、P0-2 server-utils 抽取、P0-3 跨包 `internal/*` 边界
