### PR TITLE
fix(server): skip cmd.exe for multi-line args on Windows

### DIFF
--- a/packages/server/src/utils/spawn.multiline-argument.test.ts
+++ b/packages/server/src/utils/spawn.multiline-argument.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { execCommand, spawnProcess } from "./spawn.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeEchoArgScript(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "paseo-multiline-argument-"));
+  tempDirs.push(dir);
+  const scriptPath = path.join(dir, "echo-arg.js");
+  writeFileSync(scriptPath, "process.stdout.write(process.argv[2] ?? '');\n");
+  return scriptPath;
+}
+
+// Use the bare command name "node" (no extension, no path separator) because
+// that is the shape `shouldUseWindowsShell` routes through cmd.exe, which drops
+// everything after the first newline in an argument. Using `process.execPath`
+// here would skip the shell path entirely and silently pass the test.
+const COMMAND = "node";
+
+const GRAPHQL_QUERY = "query PaseoBatchPullRequestStatus {\n  rateLimit {\n    remaining\n  }\n}";
+const COMMIT_MESSAGE = "subject line\r\n\r\nbody paragraph";
+
+describe("spawn argument delivery for multi-line arguments", () => {
+  test("delivers a multi-line gh graphql query to the child verbatim", async () => {
+    const scriptPath = writeEchoArgScript();
+
+    const { stdout } = await execCommand(COMMAND, [scriptPath, GRAPHQL_QUERY]);
+
+    expect(stdout).toBe(GRAPHQL_QUERY);
+  });
+
+  test("delivers a carriage-return commit message to the child verbatim", async () => {
+    const scriptPath = writeEchoArgScript();
+
+    const { stdout } = await execCommand(COMMAND, [scriptPath, COMMIT_MESSAGE]);
+
+    expect(stdout).toBe(COMMIT_MESSAGE);
+  });
+
+  test("spawnProcess delivers a multi-line argument to the child verbatim", async () => {
+    const scriptPath = writeEchoArgScript();
+    const child = spawnProcess(COMMAND, [scriptPath, GRAPHQL_QUERY]);
+
+    const chunks: Buffer[] = [];
+    child.stdout?.on("data", (chunk: Buffer) => chunks.push(chunk));
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.on("error", reject);
+      child.on("close", resolve);
+    });
+
+    expect(exitCode).toBe(0);
+    expect(Buffer.concat(chunks).toString()).toBe(GRAPHQL_QUERY);
+  });
+});

--- a/packages/server/src/utils/spawn.ts
+++ b/packages/server/src/utils/spawn.ts
@@ -39,8 +39,13 @@ function hasPathSeparator(value: string): boolean {
   return value.includes("/") || value.includes("\\");
 }
 
+function hasLineBreak(value: string): boolean {
+  return value.includes("\n") || value.includes("\r");
+}
+
 function shouldUseWindowsShell(
   command: string,
+  args: string[],
   requestedShell?: boolean | string,
 ): boolean | string {
   if (isWindowsCommandScript(command)) {
@@ -49,7 +54,12 @@ function shouldUseWindowsShell(
   if (requestedShell !== undefined) {
     return requestedShell;
   }
-  return process.platform === "win32" && !hasPathSeparator(command) && !extname(command);
+  return (
+    process.platform === "win32" &&
+    !hasPathSeparator(command) &&
+    !extname(command) &&
+    !args.some(hasLineBreak)
+  );
 }
 
 export function spawnProcess(
@@ -60,7 +70,7 @@ export function spawnProcess(
   const { baseEnv, env, envOverlay, ...spawnOptions } = options ?? {};
   const resolvedBaseEnv = env ?? baseEnv ?? process.env;
   const isWindows = process.platform === "win32";
-  const shell = shouldUseWindowsShell(command, spawnOptions.shell);
+  const shell = shouldUseWindowsShell(command, args, spawnOptions.shell);
 
   const shouldQuoteForShell = isWindows && shell !== false;
   const resolvedCommand = shouldQuoteForShell ? quoteWindowsCommand(command) : command;
@@ -91,7 +101,7 @@ export async function execCommand(
   const { baseEnv, env, envOverlay } = options ?? {};
   const resolvedBaseEnv = env ?? baseEnv ?? process.env;
   const isWindows = process.platform === "win32";
-  const shell = shouldUseWindowsShell(command, options?.shell);
+  const shell = shouldUseWindowsShell(command, args, options?.shell);
   const shouldQuoteForShell = isWindows && shell !== false;
   const resolvedCommand = shouldQuoteForShell ? quoteWindowsCommand(command) : command;
   const resolvedArgs = shouldQuoteForShell ? args.map(quoteWindowsArgument) : args;


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

<!-- A short description of the reasoning of this change in your own words. What was wrong, and how do you hope this PR fixes it. If you can't explain this briefly, the PR is probably too big. This description must be grounded in real user flows and framed as value provided to Paseo users. -->

On Windows every `gh api graphql` call the daemon makes fails, so anything backed by GraphQL is quietly missing from the changes pane - merge state, auto merge facts, PR timeline and comments, and the batched PR status poll.
Nothing surfaces in the UI because `loadPullRequestGithubFacts` catches `GitHubCommandError` and returns `null`, so the pane just renders less than it should and you have no idea why.

I found this on my own machine after a separate `gh` problem sent me into `C:\Users\<USER>\.paseo\daemon.log`, which was full of:

```
GitHub CLI command failed: gh api graphql -f query=query PaseoBatchPullRequestStatus {...}
stderr: gh: Expected NAME, actual: (none) ("") at [1, 35]
```

Column 35 is the end of `query PaseoBatchPullRequestStatus {`, so GitHub only ever received the first line of the query.

Timeline is basically:

1. `createForgeCliRunner` calls `execCommand("gh", ...)` with the bare binary name
2. `shouldUseWindowsShell` returns true on `win32` for a command with no path separator and no extension, so the spawn goes through `cmd.exe /d /s /c`
3. `cmd.exe` can't carry a line break inside an argument. It drops everything after a `\n` and silently swallows a lone `\r`. `quoteWindowsArgument` handles `& | ^ < > ( ) !` but has nothing for line breaks
4. `gh` gets a one-line query, GitHub's parser hits EOF where it wants a field, and the whole poll fails

Single line calls like `gh pr view --json ...` are fine which is what makes this hard to spot - PR status half works, so it shows as flaky instead of broken.

The bare name shell routing only exists so `PATHEXT` resolution finds `gh.exe`. `libuv` does that itself, so skipping the shell when an argument spans lines costs nothing.

### Goals

<!-- A bullet list of what this PR wants to accomplish, include requirements and acceptance criteria. This helps lock down the scope of the PR and prevent expanding scope over the intended goal. -->

- `gh api graphql` reaches the CLI intact on Windows, and the same for the `glab` / `tea` runners that share `createForgeCliRunner`
- Batch PR status polling, merge and auto merge facts, and PR timeline and comments work on Windows again
- No behavior change on macOS or Linux

### Non-goals

<!-- A bullet list of what this PR does not want to accomplish. Add any intentional trade offs taken. This helps lock down the scope of the PR and prevent expanding scope over the intended goal. -->

- Not changing how `.cmd` or `.bat` launch - they can't run without the shell, so they keep it, and a multi line argument to one of those stays unsupported
- Not overriding an explicit `shell:` from a caller
- Not touching `runGitCommand`, as it already passes `shell: false`, so it was never affected. I checked because I assumed multi line commit messages were broken too and they aren't
- Not resolving forge binaries to absolute paths. That fixes the same symptom for `gh` / `glab` / `tea` only and leaves the trap in place for whoever passes a multiline argument next

### QA

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.
-->

IN PROGRESS
I'll undraft the PR when this section is ready 🙂

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense