### PR TITLE
fix(desktop): keep an externally managed daemon running across app updates

### DIFF
--- a/packages/desktop/src/daemon/daemon-manager.test.ts
+++ b/packages/desktop/src/daemon/daemon-manager.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     env: {},
   })),
   spawnProcess: vi.fn(),
+  downloadAndInstallUpdate: vi.fn(),
   logInfo: vi.fn(),
   logError: vi.fn(),
   appLogPath: "/tmp/paseo-desktop-daemon-manager-test-main.log",
@@ -77,6 +78,11 @@ vi.mock("./cli/external.js", () => ({
   runExternalCliTextCommand: mocks.runExternalCliTextCommand,
 }));
 
+vi.mock("../features/auto-updater.js", () => ({
+  checkForAppUpdate: vi.fn(),
+  downloadAndInstallUpdate: mocks.downloadAndInstallUpdate,
+}));
+
 function desktopSettingsWithManagement(enabled: boolean) {
   return {
     ...DEFAULT_DESKTOP_SETTINGS,
@@ -117,6 +123,13 @@ describe("daemon-manager commands", () => {
     mocks.createNodeEntrypointInvocation.mockReset();
     mocks.createNodeEntrypointInvocation.mockReturnValue({ command: "node", args: [], env: {} });
     mocks.spawnProcess.mockReset();
+    mocks.downloadAndInstallUpdate.mockReset();
+    mocks.downloadAndInstallUpdate.mockImplementation(
+      async (_options: unknown, onBeforeQuit?: () => Promise<void>) => {
+        await onBeforeQuit?.();
+        return { status: "installing" };
+      },
+    );
     mocks.logInfo.mockReset();
     mocks.logError.mockReset();
     mocks.getElectronLogFile.mockReset();
@@ -166,6 +179,61 @@ describe("daemon-manager commands", () => {
     });
 
     expect(mocks.runExternalCliJsonCommand).toHaveBeenCalledWith(["daemon", "status", "--json"]);
+  });
+
+  it("leaves an externally managed daemon running when installing an app update", async () => {
+    mocks.settings = desktopSettingsWithManagement(false);
+    mocks.runExternalCliJsonCommand.mockResolvedValueOnce({
+      localDaemon: "running",
+      serverId: "server-1",
+      pid: 4242,
+      listen: "127.0.0.1:6767",
+      desktopManaged: false,
+    });
+    const handlers = createDaemonCommandHandlers();
+
+    await handlers.install_app_update();
+
+    // Status is probed, but the daemon is never stopped: startDaemon() would refuse to
+    // bring an externally managed daemon back, leaving the user with no daemon at all.
+    expect(mocks.runExternalCliJsonCommand).toHaveBeenCalledTimes(1);
+    expect(mocks.runExternalCliJsonCommand).toHaveBeenCalledWith(["daemon", "status", "--json"]);
+    expect(mocks.logInfo).toHaveBeenCalledWith(
+      "[desktop daemon]",
+      "desktop daemon stop skipped",
+      expect.objectContaining({
+        reason: "app_update",
+        externallyManaged: true,
+        statusBefore: expect.objectContaining({ status: "running", desktopManaged: false }),
+      }),
+    );
+  });
+
+  it("stops the desktop-managed daemon when installing an app update", async () => {
+    mocks.runExternalCliJsonCommand
+      .mockResolvedValueOnce({
+        localDaemon: "running",
+        serverId: "server-1",
+        pid: 4242,
+        listen: "127.0.0.1:6767",
+        desktopManaged: true,
+      })
+      .mockResolvedValueOnce({ action: "stopped" })
+      .mockResolvedValueOnce({ localDaemon: "stopped", serverId: "" });
+    const handlers = createDaemonCommandHandlers();
+
+    await handlers.install_app_update();
+
+    expect(mocks.runExternalCliJsonCommand).toHaveBeenNthCalledWith(2, [
+      "daemon",
+      "stop",
+      "--json",
+      "--timeout",
+      "5",
+      "--force",
+      "--kill-timeout",
+      "5",
+    ]);
   });
 
   it("routes running desktop daemon stops through external CLI daemon stop", async () => {

--- a/packages/desktop/src/daemon/daemon-manager.ts
+++ b/packages/desktop/src/daemon/daemon-manager.ts
@@ -460,13 +460,20 @@ async function startDaemon(): Promise<DesktopDaemonStatus> {
   return pollForRunningDaemon();
 }
 
+// `onlyIfDesktopManaged` restricts the stop to a daemon this app started. Callers that
+// act on an explicit user gesture (the management toggle, host removal) leave it off and
+// stop whatever is running; callers acting on the app's own schedule set it, so a daemon
+// owned by systemd, a container, or a bare `paseo daemon start` is left alone.
 export async function stopDesktopDaemon(
   reason: DesktopDaemonStopReason = DEFAULT_DESKTOP_DAEMON_STOP_REASON,
+  { onlyIfDesktopManaged = false }: { onlyIfDesktopManaged?: boolean } = {},
 ): Promise<DesktopDaemonStatus> {
   const status = await resolveDesktopDaemonStatus();
-  if (status.status !== "running") {
+  const externallyManaged = onlyIfDesktopManaged && !status.desktopManaged;
+  if (status.status !== "running" || externallyManaged) {
     logDesktopDaemonLifecycle("desktop daemon stop skipped", {
       reason,
+      externallyManaged,
       statusBefore: summarizeDesktopDaemonStatus(status),
     });
     return status;
@@ -567,7 +574,11 @@ export function createDaemonCommandHandlers(): Record<string, DesktopCommandHand
       return downloadAndInstallUpdate(
         { currentVersion, releaseChannel: await resolveRequestedReleaseChannel(args) },
         async () => {
-          await stopDesktopDaemon("app_update");
+          // Only a desktop-managed daemon is ours to stop. An external one outlives the
+          // app, and startDaemon() refuses to bring it back while manageBuiltInDaemon is
+          // off, so stopping it here would leave the user with no daemon at all and no
+          // way for the app to restore it.
+          await stopDesktopDaemon("app_update", { onlyIfDesktopManaged: true });
         },
       );
     },


### PR DESCRIPTION
### Linked issue

Closes #<!-- not filed yet -->

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

If you run your own daemon and turn off **Manage built-in daemon**, installing a desktop app update kills that daemon permanently. Every client then shows "Transport not connected (status: disconnected)" and nothing points at the update as the cause.

`install_app_update` calls `stopDesktopDaemon("app_update")`, and `stopDesktopDaemon` only checks that *a* daemon is running — it never checks whether the desktop app owns it. But `startDaemon` and `restartDaemon` both call `assertBuiltInDaemonManagementEnabled`. So with `manageBuiltInDaemon: false` the app **can stop the daemon but is forbidden to start it again**: a one-way trip to no daemon at all.

The quit path already gets this right — `stopDesktopManagedDaemonOnQuitIfNeeded` bails on `!isDesktopManagedDaemonRunning()`. The update path is missing the same guard.

It also contradicts what the setting tells the user it does: *"Let Paseo start and stop the built-in daemon."* Turning that off reads as a promise not to touch a daemon they manage themselves.

### Goals

- An app update must not stop a daemon the desktop app does not own.
- Keep the existing behaviour for stops the user explicitly asked for (the management toggle, host removal).
- Make the skip visible in the desktop log, so this is diagnosable next time instead of silent.

### Non-goals

- The `version_mismatch` stop inside `startDaemon` is left alone. It sits behind `assertBuiltInDaemonManagementEnabled`, so it is only reachable while management is enabled. An externally owned daemon can still be stopped there if the toggle is on and versions differ; that felt like a separate decision rather than something to fold into this fix.
- No change to the default configuration. With `manageBuiltInDaemon: true` (the default) the app owns the daemon and the update still stops it exactly as before.

### QA

Linux only. This is a non-UI change in `packages/desktop`, so there is nothing to screenshot.

#### 1. The failure, from a real update

Logs from a packaged Linux build of this repo. The version numbers are my own fork's build numbering, but `packages/desktop/src/daemon/daemon-manager.ts` is unmodified from upstream on this path. Settings were `manageBuiltInDaemon: false`, with the daemon owned by a systemd user unit. Hostname redacted.

`~/.config/<app>/logs/main.log` — the app reads `desktopManaged: false` and stops it anyway:

```
[2026-09-07 09:45:37.621] [info]  [desktop daemon] desktop daemon stop requested {
  pid: 3745586,
  reason: 'app_update',
  statusBefore: {
    status: 'running',
    pid: 3427,
    listen: '0.0.0.0:6767',
    serverId: 'srv_...',
    version: null,
    desktopManaged: false,
    error: null
  }
}
[2026-09-07 09:45:39.785] [info]  [desktop daemon] desktop daemon stop completed {
  pid: 3745586,
  reason: 'app_update',
  cliResult: {
    action: 'stopped',
    home: '/home/<user>/.paseo',
    pid: '3427',
    forced: false,
    usedLifecycleRpc: false,
    reason: 'owner_pid_signal',
    message: 'daemon websocket at 0.0.0.0:6767 is not reachable, falling back to owner PID signal'
  }
}
[2026-09-07 09:45:39.786] [info]  [auto-updater] quitAndInstall requested { targetVersion: '<next>', isSilent: false, isForceRunAfter: true }
```

The daemon receives the signal and exits cleanly:

```
Sep 07 09:45:38 host zsh[3427]: [DaemonRunner] supervisor_received_SIGTERM. Stopping worker...
Sep 07 09:45:38 host zsh[3427]: {"msg":"SIGTERM received, shutting down gracefully..."}
Sep 07 09:45:38 host zsh[3427]: {"msg":"Server closed"}
```

```
$ systemctl --user status paseo-daemon
○ paseo-daemon.service - Paseo daemon (agent host for CLI, desktop, and mobile clients)
     Active: inactive (dead) since Mon 2026-09-07 09:45:39 EDT; 4min 20s ago
   Duration: 3d 2h 8min 55.556s
    Process: 3283 ExecStart=/usr/bin/zsh -c exec /home/<user>/.local/bin/paseo daemon start --foreground (code=exited, status=0/SUCCESS)
   Main PID: 3283 (code=exited, status=0/SUCCESS)
```

It never came back — the app cannot start it while management is off — and the desktop and CLI clients sat on "Transport not connected" until the unit was started by hand.

#### 2. Regression test fails on the old code, for the reported reason

`leaves an externally managed daemon running when installing an app update`, run against `main` with only the test file applied and the source fix reverted:

```
$ npx vitest run src/daemon/daemon-manager.test.ts
 × leaves an externally managed daemon running when installing an app update 3ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/daemon/daemon-manager.test.ts > daemon-manager commands > leaves an externally managed daemon running when installing an app update
AssertionError: expected "vi.fn()" to be called 1 times, but got 3 times

 Test Files  1 failed (1)
      Tests  1 failed | 13 passed (14)
```

Three CLI calls instead of one is the bug itself: `daemon status` → **`daemon stop`** → `daemon status`. With the fix it probes status and stops.

#### 3. With the fix

```
$ npx vitest run src/daemon/daemon-manager.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Whole desktop package, checking nothing else regressed:

```
$ npx vitest run --exclude "e2e/**"
 Test Files  50 passed (50)
      Tests  382 passed (382)
   Duration  51.87s
```

The second new test, `stops the desktop-managed daemon when installing an app update`, pins the unchanged behaviour for a daemon the app does own. The existing `keeps stop callable while built-in daemon management is disabled` still passes, which is why this is an option on the call rather than an assert inside `stopDesktopDaemon` — the management toggle has to keep being able to stop the daemon.

#### 4. End-to-end on a packaged build

Since opening this I have shipped the patch in a self-updating Linux build and taken a real in-app update through it — the app performing the update carries this fix, and the daemon is owned by a systemd user unit with `manageBuiltInDaemon: false`. From the desktop log:

```
[2026-09-07 11:55:43.177] [info]  [desktop daemon] desktop daemon stop skipped {
  pid: 139647,
  reason: 'app_update',
  externallyManaged: true,
  statusBefore: {
    status: 'running',
    pid: 3892513,
    listen: '0.0.0.0:6767',
    serverId: 'srv_...',
    version: null,
    desktopManaged: false,
    error: null
  }
}
[2026-09-07 11:55:43.177] [info]  [auto-updater] quitAndInstall requested { targetVersion: '...', isSilent: false, isForceRunAfter: true }
```

The daemon was untouched across the update:

```
$ systemctl --user status <daemon unit>
     Active: active (running) since Mon 2026-09-07 10:00:26 EDT; 1h 56min ago
   Main PID: 3892462
```

Same PID, uptime spanning 11:55 — it never went down, and the app reconnected to it after restarting.

This is a direct A/B against §1: same machine, same configuration, same code path, six hours apart. Before the patch the log read `reason: 'app_update'` with `desktopManaged: false` and stopped the daemon anyway, leaving it unrecoverable. After, the same inputs produce `externallyManaged: true` and a skip. The patch is the only variable.

#### 5. Checks

```
$ npm run lint
Found 0 warnings and 0 errors.
Finished in 966ms on 3838 files with 177 rules using 16 threads.

$ npm run format:check
(clean — the only files reported are untracked local notes outside the repo tree)

$ npm run typecheck --workspace @getpaseo/desktop
> tsgo --noEmit -p tsconfig.json
(clean)
```

One caveat, reported honestly: root `npm run typecheck` does **not** pass for me, but it also does not pass on a pristine checkout of `main` with zero changes applied — `packages/app` (`src/plugins/navigation.ts`, `src/plugins/settings/index.tsx`, expo-router route unions) and `packages/cli` (`src/commands/agent/logs.ts`, `AgentTimelineItem` drift between `protocol/dist` and `server/dist`). I verified that by stashing everything and re-running. Happy to be told it is a local build-state problem on my end.

#### 6. Platforms

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | n/a    | `packages/desktop`, Electron main process only |
| Android         | n/a    | same |
| Web             | n/a    | same |
| Desktop macOS   | no     | not tested |
| Desktop Windows | no     | not tested |
| Desktop Linux   | yes    | packaged AppImage, Arch Linux x86_64, Wayland |

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes — passes for `@getpaseo/desktop`; root fails on pristine `main`, see QA §5
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

