### PR TITLE
fix(server): decouple native Paseo tools from MCP injection

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -148,6 +148,7 @@ import {
 import { CheckoutDiffManager } from "./checkout-diff-manager.js";
 import { ScheduleService } from "./schedule/service.js";
 import { DaemonConfigStore, type MutableDaemonConfig } from "./daemon-config-store.js";
+import { isNativePaseoToolsEnabled } from "./native-tools-gate.js";
 import { createOrchestrationSkills } from "./orchestration-skills/index.js";
 import { resolveConfigFromPersisted, type CliConfigOverrides } from "./config.js";
 import { resolvePaseoToolPolicy } from "./agent/paseo-tool-policy.js";
@@ -1420,8 +1421,11 @@ export async function createPaseoDaemon(
     agentProviderRuntime.setPaseoToolCatalog(enabled ? createAgentToolCatalog({}) : null);
   };
   agentManager.setPaseoToolCatalogFactory(createAgentToolCatalog);
-  agentManager.setPaseoToolsEnabled(config.mcpInjectIntoAgents !== false);
-  setAgentProviderToolsEnabled(config.mcpEnabled !== false && config.mcpInjectIntoAgents !== false);
+  // Native Paseo tools follow the MCP stack being enabled, not MCP
+  // injection: caller-scoped deployments keep the catalog while injecting
+  // nothing (see native-tools-gate.ts).
+  agentManager.setPaseoToolsEnabled(isNativePaseoToolsEnabled(config.mcpEnabled));
+  setAgentProviderToolsEnabled(isNativePaseoToolsEnabled(config.mcpEnabled));
 
   let mcpEnabled = config.mcpEnabled ?? true;
   let agentMcpBaseUrl: string | null = null;
@@ -1593,18 +1597,18 @@ export async function createPaseoDaemon(
             agentMcpBaseUrl =
               !mcpEnabled || config.mcpInjectIntoAgents === false ? null : mcpBaseUrl;
             agentManager.setMcpBaseUrl(agentMcpBaseUrl);
-            agentManager.setPaseoToolsEnabled(mcpEnabled && config.mcpInjectIntoAgents !== false);
+            agentManager.setPaseoToolsEnabled(isNativePaseoToolsEnabled(mcpEnabled));
             daemonConfigStore.onFieldChange("mcp.enabled", (value) => {
               mcpEnabled = value !== false;
               const inject = daemonConfigStore.get().mcp.injectIntoAgents !== false;
               agentManager.setMcpBaseUrl(mcpEnabled && inject ? mcpBaseUrl : null);
-              agentManager.setPaseoToolsEnabled(mcpEnabled && inject);
-              setAgentProviderToolsEnabled(mcpEnabled && inject);
+              agentManager.setPaseoToolsEnabled(isNativePaseoToolsEnabled(mcpEnabled));
+              setAgentProviderToolsEnabled(isNativePaseoToolsEnabled(mcpEnabled));
             });
             daemonConfigStore.onFieldChange("mcp.injectIntoAgents", (value) => {
               agentManager.setMcpBaseUrl(mcpEnabled && value ? mcpBaseUrl : null);
-              agentManager.setPaseoToolsEnabled(mcpEnabled && value !== false);
-              setAgentProviderToolsEnabled(mcpEnabled && value !== false);
+              agentManager.setPaseoToolsEnabled(isNativePaseoToolsEnabled(mcpEnabled));
+              setAgentProviderToolsEnabled(isNativePaseoToolsEnabled(mcpEnabled));
             });
             daemonConfigStore.onFieldChange("appendSystemPrompt", (value) => {
               agentManager.setAppendSystemPrompt(typeof value === "string" ? value : "");

--- a/packages/server/src/server/native-tools-gate.test.ts
+++ b/packages/server/src/server/native-tools-gate.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "vitest";
+
+import { isNativePaseoToolsEnabled } from "./native-tools-gate.js";
+
+test("mcp enabled + injection off keeps the native catalog available", () => {
+  expect(isNativePaseoToolsEnabled(true)).toBe(true);
+});
+
+test("absent mcp.enabled defaults to enabled", () => {
+  expect(isNativePaseoToolsEnabled(undefined)).toBe(true);
+});
+
+test("mcp disabled disables the native catalog regardless of injection", () => {
+  expect(isNativePaseoToolsEnabled(false)).toBe(false);
+});

--- a/packages/server/src/server/native-tools-gate.ts
+++ b/packages/server/src/server/native-tools-gate.ts
@@ -1,0 +1,21 @@
+/**
+ * Whether the native Paseo tool catalog is available to a provider session,
+ * independent of whether the daemon injects its MCP server into agents.
+ *
+ * The native catalog is a separate delivery channel from daemon MCP injection.
+ * Deployments that serve MCP caller-scoped (each seat gets its own
+ * caller-scoped server, so daemon-wide injection is off) still need the native
+ * catalog for their coordinator seats — and, via the per-provider
+ * {@link ProviderPaseoToolsPolicy}, disabled for worker seats. Gating the
+ * catalog on `mcp.injectIntoAgents` makes the whole channel disappear for
+ * exactly those deployments.
+ *
+ * The master switch therefore follows the MCP stack being enabled
+ * (`daemon.mcp.enabled`), and injection controls only the injected MCP server.
+ * The per-provider policy remains the seat-level gate on top of this: an
+ * enabled stack plus an enabled policy is what delivers the catalog to a given
+ * provider session.
+ */
+export function isNativePaseoToolsEnabled(mcpEnabled: boolean | undefined): boolean {
+  return (mcpEnabled ?? true) !== false;
+}


### PR DESCRIPTION
After #4277 landed per-provider control of the Paseo tool catalog, disabling MCP injection also disables the native catalog, even where the provider policy is enabled:

```ts
// bootstrap.ts — startup and both live field-change handlers
agentManager.setPaseoToolsEnabled(mcpEnabled && mcp.injectIntoAgents !== false);
```

**Why it matters.** Deployments that serve MCP caller-scoped — each seat gets its own caller-scoped server, so daemon-wide injection is off — still need the native catalog for coordinator seats (and, via the per-provider `paseoTools` policy, none for worker seats). Gating the catalog on `injectIntoAgents` removes the whole channel for exactly those deployments; the per-provider policy from #4277 is a second gate on top of a switch that is already off.

**Fix.** Gate native availability on `mcp.enabled` at startup and on both `onFieldChange` handlers; injection keeps controlling only the injected MCP server URL (`setMcpBaseUrl`). The per-provider `paseoTools` policy remains the seat-level gate. Adds `native-tools-gate.ts` owning the decision, with its truth table (`native-tools-gate.test.ts`).

Default behaviour is unchanged where MCP is enabled and injection is on; the change is only for injection-off deployments, whose native tools previously disappeared as a side effect of a flag about something else. Server typecheck and the new tests pass.