### PR TITLE
fix(app): drop stale loading compaction marker on canonical replacement

### DIFF
--- a/packages/app/src/types/stream.test.ts
+++ b/packages/app/src/types/stream.test.ts
@@ -10,8 +10,10 @@ import {
   mergeToolCallDetail,
   mergeCanonicalText,
   reduceStreamUpdate,
+  replaceWithCanonicalStream,
   streamTimelineItemIdentity,
   type AgentToolCallItem,
+  type CompactionItem,
   type StreamItem,
   isAgentToolCallItem,
   upsertUserMessage,
@@ -1487,6 +1489,50 @@ describe("stream reducer canonical tool calls", () => {
       state.some((item) => item.kind === "compaction" && item.status === "loading"),
       false,
     );
+  });
+
+  it("drops a stale loading compaction marker instead of leaving it stuck across a reload", () => {
+    // Reproduces a reload/reconnect: the live view had an unresolved "loading" compaction
+    // marker (no timelineCursor, since it is a synthetic status notice) sitting in `head` when
+    // the page refreshed. History hydration replays the boundary as a standalone "completed" row
+    // with a real cursor, since replay never reconstructs the transient "loading" phase. Without
+    // reconciliation, the stale marker used to survive in `head` forever with no event left that
+    // could ever resolve it.
+    const staleLoadingMarker: CompactionItem = {
+      kind: "compaction",
+      id: "compaction-loading-stale",
+      timestamp: new Date("2025-01-01T10:50:00Z"),
+      status: "loading",
+      trigger: "auto",
+    };
+    const canonicalCompleted: CompactionItem = {
+      kind: "compaction",
+      id: "compaction-completed-canonical",
+      timelineCursor: { epoch: "epoch-1", seq: 5 },
+      timestamp: new Date("2025-01-01T10:50:01Z"),
+      status: "completed",
+      trigger: "auto",
+    };
+
+    const result = replaceWithCanonicalStream({
+      canonical: [canonicalCompleted],
+      previousTail: [],
+      previousHead: [staleLoadingMarker],
+      sendingClientMessageIds: [],
+      preserveContinuity: true,
+      canonicalCoverage: { epoch: "epoch-1", endSeq: null },
+    });
+
+    const allItems = [...result.tail, ...result.head];
+    assert.strictEqual(
+      allItems.some((item) => item.kind === "compaction" && item.status === "loading"),
+      false,
+    );
+    const compactions = allItems.filter(
+      (item): item is CompactionItem => item.kind === "compaction",
+    );
+    assert.strictEqual(compactions.length, 1);
+    assert.strictEqual(compactions[0].status, "completed");
   });
 
   it("renders Claude TodoWrite as todo_list and suppresses tool call badge", () => {

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -476,6 +476,15 @@ function mergeRetainedLifecycleItem(tail: StreamItem[], retained: StreamItem): S
   if (retained.kind === "plugin") {
     return replaceTimelineIdentityItem(tail, retained);
   }
+  if (retained.kind === "compaction" && retained.status === "loading") {
+    // A "loading" compaction marker never carries a timelineCursor (it is a synthetic,
+    // unpositioned status notice), so it cannot be certified by canonical coverage and would
+    // otherwise survive every reload as a spinner that nothing ever resolves: the boundary event
+    // that would complete it, if it already happened, is replayed as a standalone "completed" row
+    // by history hydration rather than as an update to this row. Drop the stale marker instead;
+    // if the compaction is still genuinely in flight, the live stream will re-announce it.
+    return tail;
+  }
   if (!retained.timelineCursor) {
     return null;
   }


### PR DESCRIPTION
### Linked issue

Closes #4438

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A compaction "loading" status marker never carries a `timelineCursor` — it's a synthetic status notice, not a positioned transcript row. When a canonical stream replacement happens (page reload, websocket reconnect, catch-up), `mergeRetainedLifecycleItem` in `packages/app/src/types/stream.ts` had a branch to reconcile a retained **completed** compaction marker against a matching `loading` row in the fresh canonical tail, but no branch for a retained **loading** marker — it fell through to `return null`. History hydration never replays the loading phase either: it maps a `compact_boundary` entry straight to a standalone `completed` row (`convertClaudeHistoryEntryPreamble` in the Claude provider), never as an update to a prior `loading` row. So a `loading` marker retained across a reconnect had no code path left that could ever resolve or drop it — the "Compacting..." spinner got stuck forever, and could stack up across multiple compactions in the same session (see #4438 for the reported symptom).

This PR drops a retained `loading` compaction marker during reconciliation instead of silently re-adding it to `head` untouched. If the compaction is still genuinely in flight, the live stream re-announces its status, so nothing is lost — the only case this changes is the one where nothing was ever going to resolve the marker anyway.

### Goals

- A `loading` compaction marker retained across a canonical stream replacement (reload/reconnect/catch-up) no longer survives forever with no way to resolve.
- No change to the live, same-session compaction flow (`loading` → `completed` within one connection), which already worked and is covered by the existing `hydrateStreamState` test.

### Non-goals

- Not attempting to preserve a "still compacting" spinner across a reconnect for the rare case where compaction is genuinely still in flight at that exact moment — the live stream re-announces it if so, at the cost of a brief gap with no spinner instead of a stuck one.
- Not touching the daemon/provider side (`packages/server`) — the daemon's event shape (loading marker with no cursor, boundary replayed as a standalone completed row) is unchanged; this fixes the client-side reconciliation gap for it.

### QA

Reproduced the bug source-level rather than live (see #4438 for why I didn't have a live daemon.log capture: log rotation had already dropped the relevant window). I wrote a unit test (`packages/app/src/types/stream.test.ts`, "drops a stale loading compaction marker instead of leaving it stuck across a reload") that constructs exactly this scenario — a retained `loading` marker with no cursor in `head`, plus a canonical `completed` row with its own cursor in `tail` — and calls `replaceWithCanonicalStream` directly.

- Before the fix: confirmed the test fails (`assert.strictEqual` on "no loading marker remains" gets `true` instead of `false`) — i.e. it reproduces the bug.
- After the fix: test passes.

Commands run:
```
npm run build:client && npm run build:server   # workspace declarations must be current, see CLAUDE.md
npx vitest run packages/app/src/types/stream.test.ts   # 68 passed
npm run typecheck   # clean across all workspaces
npm run lint -- packages/app/src/types/stream.ts packages/app/src/types/stream.test.ts   # 0 warnings/errors
npm run format:files -- packages/app/src/types/stream.ts packages/app/src/types/stream.test.ts   # no changes needed
```

I did not reproduce this live in the running app (web only, per #4438) because I couldn't reliably trigger the reconnect-during-compaction race on demand; the unit test isolates the exact reconciliation path instead.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
