### PR TITLE
feat(app): persist dismissed provider subagents across app restarts

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -184,7 +184,9 @@ Claude Code announces subagent lifecycle on the SDK stream (`task_started` / `ta
 
 Archived Paseo subagents disappear from the track, by design. To remove one from the track without closing its tab, use the **archive button** on the row — it opens a confirm dialog and archives the subagent on confirm. Provider-owned rows have no individual Paseo lifecycle controls.
 
-The **Archive finished** row at the foot of the panel covers every finished row. It archives idle or errored managed Paseo subagents one at a time, and hides completed, failed, or canceled provider-owned rows in the current app session. Native sessions and timelines are untouched. Running and initializing children remain in the track. If a hidden provider child starts running again, the app brings it back to the track.
+The **Archive finished** row at the foot of the panel covers every finished row. It archives idle or errored managed Paseo subagents one at a time, and hides completed, failed, or canceled provider-owned rows. Native sessions and timelines are untouched. Running and initializing children remain in the track. If a hidden provider child starts running again, the app brings it back to the track.
+
+Hiding a provider-owned row is client-local, not a daemon lifecycle action: it has no `archivedAt`, does not propagate to other clients, and is keyed by `serverId`/`parentAgentId`/`subagentId` in `useProviderSubagentStore`'s `hiddenFromTrack` set (`packages/app/src/subagents/provider-store.ts`). That set persists to the device's local storage so a dismissal survives an app restart, but it stays scoped to the device that dismissed it — another client, or the same client against another daemon, still shows the row.
 
 To keep the agent alive but remove it from the parent's track, use **detach**. The daemon clears the relationship lifecycle labels, emits the normal agent update, and every client reclassifies the agent from subagent to root/sibling from that updated snapshot.
 
@@ -204,7 +206,7 @@ We considered universal decoupling (no tab close ever archives, archive is alway
 
 ### Subagent accumulation under long-lived parents
 
-A parent that spawns many subagents will see the panel's list grow; the pill only counts them. Managed Paseo subagents can be archived individually or with **Archive finished**. That action hides finished provider-owned rows locally; this presentation state resets when the app restarts.
+A parent that spawns many subagents will see the panel's list grow; the pill only counts them. Managed Paseo subagents can be archived individually or with **Archive finished**. That action hides finished provider-owned rows locally and persists the dismissal on the device, but it is not a daemon-side archive: it does not propagate to other clients, and a dismissal made against one daemon does not follow the same subagent id if it is later seen through another. The dismissed-id set is never pruned against the current provider list, so it grows for as long as the device keeps dismissing rows.
 
 ### Cross-client tab dismissal
 

--- a/packages/app/src/subagents/hidden-track-persistence.test.ts
+++ b/packages/app/src/subagents/hidden-track-persistence.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeHiddenFromTrack,
+  resolveHiddenTrackStorage,
+  serializeHiddenFromTrack,
+} from "./hidden-track-persistence";
+
+describe("serializeHiddenFromTrack", () => {
+  it("converts the hidden set into a plain array for storage", () => {
+    expect(serializeHiddenFromTrack(new Set(["a", "b"]))).toEqual({
+      hiddenFromTrack: ["a", "b"],
+    });
+  });
+});
+
+describe("mergeHiddenFromTrack", () => {
+  it("restores a persisted hidden set", () => {
+    const current = { hiddenFromTrack: new Set<string>() };
+    const merged = mergeHiddenFromTrack({ hiddenFromTrack: ["a", "b"] }, current);
+    expect(Array.from(merged.hiddenFromTrack)).toEqual(["a", "b"]);
+  });
+
+  it("keeps the current state reference when nothing changed", () => {
+    const current = { hiddenFromTrack: new Set(["a"]) };
+    const merged = mergeHiddenFromTrack({ hiddenFromTrack: ["a"] }, current);
+    expect(merged).toBe(current);
+  });
+
+  it("falls back to the current state for malformed persisted data", () => {
+    const current = { hiddenFromTrack: new Set(["a"]) };
+    expect(mergeHiddenFromTrack({ hiddenFromTrack: [1, 2] }, current)).toBe(current);
+    expect(mergeHiddenFromTrack("not-an-object", current)).toBe(current);
+    expect(mergeHiddenFromTrack(null, current)).toBe(current);
+  });
+});
+
+describe("resolveHiddenTrackStorage", () => {
+  it("falls back to a no-op storage when evaluated web-side with no window", () => {
+    // The unit test project runs the web build in Node, so `window` is genuinely absent here —
+    // this exercises the exact crash this guard exists to avoid.
+    const asyncStorage = {
+      getItem: () => {
+        throw new Error("must not be called without a window");
+      },
+      setItem: () => {
+        throw new Error("must not be called without a window");
+      },
+      removeItem: () => {
+        throw new Error("must not be called without a window");
+      },
+    };
+
+    const storage = resolveHiddenTrackStorage(asyncStorage);
+
+    expect(storage.getItem("key")).toBeNull();
+    expect(() => storage.setItem("key", "value")).not.toThrow();
+    expect(() => storage.removeItem("key")).not.toThrow();
+  });
+});

--- a/packages/app/src/subagents/hidden-track-persistence.ts
+++ b/packages/app/src/subagents/hidden-track-persistence.ts
@@ -1,0 +1,61 @@
+import type { StateStorage } from "zustand/middleware";
+import { z } from "zod";
+import { isWeb } from "@/constants/platform";
+
+// The web build of @react-native-async-storage/async-storage reads window.localStorage
+// unconditionally. On native it never runs (a separate native module resolves instead), and in
+// a real browser window always exists; the only gap is a windowless web evaluation (SSR, or this
+// package's Node-environment unit tests), where calling it would throw. Fall back to a no-op
+// there so hydration silently skips instead of crashing.
+export function resolveHiddenTrackStorage(asyncStorage: StateStorage): StateStorage {
+  if (isWeb && typeof window === "undefined") {
+    return {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+  }
+  return asyncStorage;
+}
+
+export interface PersistedHiddenProviderSubagents {
+  hiddenFromTrack?: string[];
+}
+
+export const PersistedHiddenProviderSubagentsSchema: z.ZodType<PersistedHiddenProviderSubagents> =
+  z.strictObject({
+    hiddenFromTrack: z.array(z.string()).optional(),
+  });
+
+export function serializeHiddenFromTrack(hiddenFromTrack: Set<string>): {
+  hiddenFromTrack: string[];
+} {
+  return { hiddenFromTrack: Array.from(hiddenFromTrack) };
+}
+
+export function mergeHiddenFromTrack<S extends { hiddenFromTrack: Set<string> }>(
+  persistedValue: unknown,
+  current: S,
+): S {
+  const result = PersistedHiddenProviderSubagentsSchema.safeParse(persistedValue);
+  if (!result.success) {
+    return current;
+  }
+  const restored = new Set(result.data.hiddenFromTrack ?? current.hiddenFromTrack);
+  if (areSetsEqual(current.hiddenFromTrack, restored)) {
+    return current;
+  }
+  return { ...current, hiddenFromTrack: restored };
+}
+
+function areSetsEqual(left: Set<string>, right: Set<string>): boolean {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const key of left) {
+    if (!right.has(key)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/app/src/subagents/provider-store.test.ts
+++ b/packages/app/src/subagents/provider-store.test.ts
@@ -1,9 +1,27 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { providerSubagentKey, useProviderSubagentStore } from "./provider-store";
+import type { StateStorage } from "zustand/middleware";
+import {
+  createProviderSubagentStore,
+  providerSubagentKey,
+  useProviderSubagentStore,
+} from "./provider-store";
 
 const SERVER_ID = "server-1";
 const PARENT_ID = "parent-1";
 const SUBAGENT_ID = "child-1";
+
+function createMemoryStorage(): StateStorage {
+  const values = new Map<string, string>();
+  return {
+    getItem: async (name) => values.get(name) ?? null,
+    setItem: async (name, value) => {
+      values.set(name, value);
+    },
+    removeItem: async (name) => {
+      values.delete(name);
+    },
+  };
+}
 
 afterEach(() => {
   useProviderSubagentStore.setState({
@@ -479,5 +497,37 @@ describe("provider subagent client store", () => {
     expect(timeline?.head).toEqual([
       expect.objectContaining({ kind: "assistant_message", text: "Current tail output." }),
     ]);
+  });
+});
+
+describe("provider subagent hidden track persistence", () => {
+  test("survives an app restart instead of resetting Archive finished dismissals", async () => {
+    const storage = createMemoryStorage();
+    const first = createProviderSubagentStore(storage);
+    await first.persist.rehydrate();
+
+    const key = providerSubagentKey(SERVER_ID, PARENT_ID, SUBAGENT_ID);
+    first.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        id: SUBAGENT_ID,
+        parentAgentId: PARENT_ID,
+        provider: "codex",
+        title: "Finished child",
+        description: null,
+        status: "completed",
+        createdAt: "2026-07-12T10:00:00.000Z",
+        updatedAt: "2026-07-12T10:00:02.000Z",
+        toolCallId: "call-1",
+      },
+    });
+    first.getState().hideFromTrack(SERVER_ID, PARENT_ID, [SUBAGENT_ID]);
+    expect(first.getState().hiddenFromTrack.has(key)).toBe(true);
+
+    // Simulates the app restarting: a fresh store backed by the same disk storage.
+    const restored = createProviderSubagentStore(storage);
+    await restored.persist.rehydrate();
+
+    expect(restored.getState().hiddenFromTrack.has(key)).toBe(true);
   });
 });

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -4,10 +4,20 @@ import type {
   SessionOutboundMessage,
 } from "@getpaseo/protocol/messages";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
+import { persist, type StateStorage } from "zustand/middleware";
+import { createValidatedPersistStorage } from "@/storage/validated-persist-storage";
 import { applyStreamEvent } from "@/types/stream";
 import type { StreamItem } from "@/types/stream";
 import type { AgentLifecycleStatus } from "@getpaseo/protocol/agent-lifecycle";
+import {
+  mergeHiddenFromTrack,
+  PersistedHiddenProviderSubagentsSchema,
+  resolveHiddenTrackStorage,
+  serializeHiddenFromTrack,
+  type PersistedHiddenProviderSubagents,
+} from "./hidden-track-persistence";
 
 type ProviderSubagentTimelineItem = Extract<
   Extract<SessionOutboundMessage, { type: "agent.provider_subagents.update" }>["payload"],
@@ -192,135 +202,161 @@ function buildTimelineResponseRows(
   return rows;
 }
 
-export const useProviderSubagentStore = create<ProviderSubagentState>((set) => ({
-  descriptors: new Map(),
-  timelines: new Map(),
-  hiddenFromTrack: new Set(),
-  hideFromTrack(serverId, parentAgentId, subagentIds) {
-    set((state) => {
-      const hiddenFromTrack = new Set(state.hiddenFromTrack);
-      for (const subagentId of subagentIds) {
-        const key = providerSubagentKey(serverId, parentAgentId, subagentId);
-        if (state.descriptors.get(key)?.status !== "running") hiddenFromTrack.add(key);
-      }
-      return { hiddenFromTrack };
-    });
-  },
-  replaceList(serverId, parentAgentId, subagents) {
-    set((state) => {
-      const prefix = parentPrefix(serverId, parentAgentId);
-      const descriptors = new Map(
-        [...state.descriptors].filter(([key]) => !key.startsWith(prefix)),
-      );
-      const hiddenFromTrack = new Set(state.hiddenFromTrack);
-      for (const subagent of subagents) {
-        const key = providerSubagentKey(serverId, parentAgentId, subagent.id);
-        descriptors.set(key, subagent);
-        if (subagent.status === "running") {
-          hiddenFromTrack.delete(key);
-        }
-      }
-      const retainedKeys = new Set(descriptors.keys());
-      const timelines = new Map(
-        [...state.timelines].filter(([key]) => !key.startsWith(prefix) || retainedKeys.has(key)),
-      );
-      for (const subagent of subagents) {
-        const key = providerSubagentKey(serverId, parentAgentId, subagent.id);
-        const current = timelines.get(key);
-        const previous = state.descriptors.get(key);
-        if (current && previous?.status !== subagent.status) {
-          timelines.set(
-            key,
-            buildTimelineState(current.rows, current.epoch, subagent, current.hasOlder),
-          );
-        }
-      }
-      return { descriptors, timelines, hiddenFromTrack };
-    });
-  },
-  applyUpdate(serverId, payload) {
-    set((state) => {
-      if (payload.kind === "upsert") {
-        const key = providerSubagentKey(
-          serverId,
-          payload.subagent.parentAgentId,
-          payload.subagent.id,
-        );
-        const descriptors = new Map(state.descriptors);
-        const hiddenFromTrack = new Set(state.hiddenFromTrack);
-        const previous = descriptors.get(key);
-        descriptors.set(key, payload.subagent);
-        if (payload.subagent.status === "running") {
-          hiddenFromTrack.delete(key);
-        }
-        let timelines = state.timelines;
-        const current = state.timelines.get(key);
-        if (current && previous?.status !== payload.subagent.status) {
-          timelines = new Map(state.timelines);
-          timelines.set(
-            key,
-            buildTimelineState(current.rows, current.epoch, payload.subagent, current.hasOlder),
-          );
-        }
-        return { descriptors, timelines, hiddenFromTrack };
-      }
-      if (payload.kind === "remove") {
-        const key = providerSubagentKey(serverId, payload.parentAgentId, payload.subagentId);
-        const descriptors = new Map(state.descriptors);
-        descriptors.delete(key);
-        const timelines = new Map(state.timelines);
-        timelines.delete(key);
-        return { descriptors, timelines };
-      }
-      const key = providerSubagentKey(serverId, payload.parentAgentId, payload.subagentId);
-      const existing = state.timelines.get(key);
-      if (existing?.epoch && existing.epoch !== payload.epoch) {
-        return state;
-      }
-      const current = existing ?? EMPTY_TIMELINE;
-      if (payload.seq <= current.lastSeq) {
-        return state;
-      }
-      const rows = new Map(current.rows);
-      rows.set(payload.seq, {
-        provider: payload.provider,
-        item: payload.item,
-        timestamp: payload.timestamp,
-      });
-      const descriptor = state.descriptors.get(key);
-      const next =
-        descriptor && descriptor.status !== "running"
-          ? buildTimelineState(rows, payload.epoch, descriptor, current.hasOlder)
-          : applyStreamEvent({
-              tail: current.tail,
-              head: current.head,
-              event: { type: "timeline", provider: payload.provider, item: payload.item },
-              timestamp: new Date(payload.timestamp),
+export function createProviderSubagentStore(storage: StateStorage) {
+  return create<ProviderSubagentState>()(
+    persist<ProviderSubagentState, [], [], PersistedHiddenProviderSubagents>(
+      (set) => ({
+        descriptors: new Map(),
+        timelines: new Map(),
+        hiddenFromTrack: new Set(),
+        hideFromTrack(serverId, parentAgentId, subagentIds) {
+          set((state) => {
+            const hiddenFromTrack = new Set(state.hiddenFromTrack);
+            for (const subagentId of subagentIds) {
+              const key = providerSubagentKey(serverId, parentAgentId, subagentId);
+              if (state.descriptors.get(key)?.status !== "running") hiddenFromTrack.add(key);
+            }
+            return { hiddenFromTrack };
+          });
+        },
+        replaceList(serverId, parentAgentId, subagents) {
+          set((state) => {
+            const prefix = parentPrefix(serverId, parentAgentId);
+            const descriptors = new Map(
+              [...state.descriptors].filter(([key]) => !key.startsWith(prefix)),
+            );
+            const hiddenFromTrack = new Set(state.hiddenFromTrack);
+            for (const subagent of subagents) {
+              const key = providerSubagentKey(serverId, parentAgentId, subagent.id);
+              descriptors.set(key, subagent);
+              if (subagent.status === "running") {
+                hiddenFromTrack.delete(key);
+              }
+            }
+            const retainedKeys = new Set(descriptors.keys());
+            const timelines = new Map(
+              [...state.timelines].filter(
+                ([key]) => !key.startsWith(prefix) || retainedKeys.has(key),
+              ),
+            );
+            for (const subagent of subagents) {
+              const key = providerSubagentKey(serverId, parentAgentId, subagent.id);
+              const current = timelines.get(key);
+              const previous = state.descriptors.get(key);
+              if (current && previous?.status !== subagent.status) {
+                timelines.set(
+                  key,
+                  buildTimelineState(current.rows, current.epoch, subagent, current.hasOlder),
+                );
+              }
+            }
+            return { descriptors, timelines, hiddenFromTrack };
+          });
+        },
+        applyUpdate(serverId, payload) {
+          set((state) => {
+            if (payload.kind === "upsert") {
+              const key = providerSubagentKey(
+                serverId,
+                payload.subagent.parentAgentId,
+                payload.subagent.id,
+              );
+              const descriptors = new Map(state.descriptors);
+              const hiddenFromTrack = new Set(state.hiddenFromTrack);
+              const previous = descriptors.get(key);
+              descriptors.set(key, payload.subagent);
+              if (payload.subagent.status === "running") {
+                hiddenFromTrack.delete(key);
+              }
+              let timelines = state.timelines;
+              const current = state.timelines.get(key);
+              if (current && previous?.status !== payload.subagent.status) {
+                timelines = new Map(state.timelines);
+                timelines.set(
+                  key,
+                  buildTimelineState(
+                    current.rows,
+                    current.epoch,
+                    payload.subagent,
+                    current.hasOlder,
+                  ),
+                );
+              }
+              return { descriptors, timelines, hiddenFromTrack };
+            }
+            if (payload.kind === "remove") {
+              const key = providerSubagentKey(serverId, payload.parentAgentId, payload.subagentId);
+              const descriptors = new Map(state.descriptors);
+              descriptors.delete(key);
+              const timelines = new Map(state.timelines);
+              timelines.delete(key);
+              return { descriptors, timelines };
+            }
+            const key = providerSubagentKey(serverId, payload.parentAgentId, payload.subagentId);
+            const existing = state.timelines.get(key);
+            if (existing?.epoch && existing.epoch !== payload.epoch) {
+              return state;
+            }
+            const current = existing ?? EMPTY_TIMELINE;
+            if (payload.seq <= current.lastSeq) {
+              return state;
+            }
+            const rows = new Map(current.rows);
+            rows.set(payload.seq, {
+              provider: payload.provider,
+              item: payload.item,
+              timestamp: payload.timestamp,
             });
-      const timelines = new Map(state.timelines);
-      timelines.set(key, {
-        ...next,
-        epoch: payload.epoch,
-        lastSeq: payload.seq,
-        hasOlder: current.hasOlder,
-        rows,
-      });
-      return { timelines };
-    });
-  },
-  replaceTimeline(serverId, payload) {
-    const provider = payload.provider;
-    if (!provider) {
-      return;
-    }
-    set((state) => {
-      const key = providerSubagentKey(serverId, payload.parentAgentId, payload.subagentId);
-      const existing = state.timelines.get(key);
-      const rows = buildTimelineResponseRows(existing, payload, provider);
-      const descriptor = state.descriptors.get(key);
-      const timelines = new Map(state.timelines);
-      timelines.set(key, buildTimelineState(rows, payload.epoch, descriptor, payload.hasOlder));
-      return { timelines };
-    });
-  },
-}));
+            const descriptor = state.descriptors.get(key);
+            const next =
+              descriptor && descriptor.status !== "running"
+                ? buildTimelineState(rows, payload.epoch, descriptor, current.hasOlder)
+                : applyStreamEvent({
+                    tail: current.tail,
+                    head: current.head,
+                    event: { type: "timeline", provider: payload.provider, item: payload.item },
+                    timestamp: new Date(payload.timestamp),
+                  });
+            const timelines = new Map(state.timelines);
+            timelines.set(key, {
+              ...next,
+              epoch: payload.epoch,
+              lastSeq: payload.seq,
+              hasOlder: current.hasOlder,
+              rows,
+            });
+            return { timelines };
+          });
+        },
+        replaceTimeline(serverId, payload) {
+          const provider = payload.provider;
+          if (!provider) {
+            return;
+          }
+          set((state) => {
+            const key = providerSubagentKey(serverId, payload.parentAgentId, payload.subagentId);
+            const existing = state.timelines.get(key);
+            const rows = buildTimelineResponseRows(existing, payload, provider);
+            const descriptor = state.descriptors.get(key);
+            const timelines = new Map(state.timelines);
+            timelines.set(
+              key,
+              buildTimelineState(rows, payload.epoch, descriptor, payload.hasOlder),
+            );
+            return { timelines };
+          });
+        },
+      }),
+      {
+        name: "provider-subagents-hidden-track",
+        storage: createValidatedPersistStorage(storage, PersistedHiddenProviderSubagentsSchema),
+        partialize: (state) => serializeHiddenFromTrack(state.hiddenFromTrack),
+        merge: (persistedState, currentState) => mergeHiddenFromTrack(persistedState, currentState),
+      },
+    ),
+  );
+}
+
+export const useProviderSubagentStore = createProviderSubagentStore(
+  resolveHiddenTrackStorage(AsyncStorage),
+);


### PR DESCRIPTION
### Linked issue

Discussion: #4440 (this is a feature request, not a bug — no issue to close). Opening as a **draft** per the discussion until there's agreement this is the right shape; see CONTRIBUTING.md guidance on unsolicited PRs.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

"Archive finished" hides completed/failed/canceled provider-owned (Task-tool) subagent rows only in an in-memory `hiddenFromTrack` Set (`packages/app/src/subagents/provider-store.ts`), documented as intentional in `docs/agent-lifecycle.md`. Every reload or app restart wipes it, since `refreshProviderSubagents` refetches the full descriptor list from the daemon on mount and the daemon has no concept of a "dismissed" provider subagent to filter back out. On a long-running parent that fans out a lot of subagents, this means re-dismissing the same finished rows over and over across reconnects. See #4440 for the full framing.

This PR persists just the `hiddenFromTrack` set (not the much larger, non-serializable-safe `descriptors`/`timelines` maps) to the device's local storage, using the same `persist` + `createValidatedPersistStorage` + `AsyncStorage` pattern already used by `sidebar-collapsed-sections-store` and `workspace-service-route-preferences`. The store construction moves into an exported `createProviderSubagentStore(storage)` factory (matching `workspace-service-routes/store.ts`) so tests can inject an in-memory storage and exercise a real write → restart → read round trip.

### Goals

- A dismissal made via "Archive finished" for a provider-owned row survives a reload/app restart on the same device.
- No change to managed Paseo subagent archiving (already daemon-side and correct).
- No change to `descriptors`/`timelines` persistence — those stay in-memory only, refetched/rebuilt from the daemon as before.

### Non-goals

- Not adding a daemon-side "archived" concept for provider subagents — this stays a client-local presentation dismissal, exactly as documented today, just a durable one. It does not propagate to other clients, and does not survive the provider reporting the same subagent id through a different daemon.
- Not pruning `hiddenFromTrack` against the live provider list — an existing test (`keeps hidden state when a child temporarily disappears from the provider list`) already asserts a dismissal must survive a subagent temporarily vanishing from a `replaceList` response, so the set isn't safe to prune on absence; it only grows. Flagged explicitly in the doc update. A size-bounded eviction policy would need a design decision I didn't want to bundle into this PR.

### QA

Commands run:
```
npm run build:client && npm run build:server   # workspace declarations must be current, see CLAUDE.md
npx vitest run packages/app/src/subagents/provider-store.test.ts packages/app/src/subagents/select.test.ts packages/app/src/subagents/hidden-track-persistence.test.ts
# 28 passed, 0 unhandled rejections
npm run typecheck   # clean across all workspaces
npm run lint -- packages/app/src/subagents/provider-store.ts packages/app/src/subagents/provider-store.test.ts packages/app/src/subagents/hidden-track-persistence.ts packages/app/src/subagents/hidden-track-persistence.test.ts
# 0 warnings/errors
```

New test `survives an app restart instead of resetting Archive finished dismissals` (`provider-store.test.ts`) creates two separate store instances sharing one in-memory storage backend — the second simulates the app restarting — and asserts the dismissal from the first instance is visible in the second after `persist.rehydrate()`. Confirmed it fails (`createProviderSubagentStore is not a function`) against the pre-change code and passes after.

One thing I had to work around: `@react-native-async-storage/async-storage`'s web build reads `window.localStorage` unconditionally, which crashed as an unhandled rejection when the *existing* `provider-store.test.ts`/`select.test.ts` tests (which mutate the real exported singleton, not an injected instance) ran in this package's Node-environment unit test project. `resolveHiddenTrackStorage` swaps in a no-op storage specifically for that gap (web-targeted evaluation with no `window` — native and real-browser evaluation are unaffected); covered by `hidden-track-persistence.test.ts`.

I did not test this manually against a running app (web only, per my role in the linked discussion) — the QA here is the automated round-trip test above, which exercises the real persistence mechanism rather than a mock.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
