### PR TITLE
Keep 0.7.2 apps working with 0.8 daemons

### DIFF
--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -762,6 +762,8 @@ test("advertises client capabilities in hello", async () => {
       reasoning_merge_enum: true,
       terminal_reflowable_snapshot: true,
       timeline_notifications: true,
+      plugin_timeline_items: true,
+      workspace_setup_blocked: true,
       browser_host: {
         supportedCommands: ["list_tabs"],
         hostKind: "desktop app",

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -5681,6 +5681,8 @@ export class DaemonClient {
             ? { [CLIENT_CAPS.providerSnapshotReferences]: true }
             : {}),
           [CLIENT_CAPS.timelineNotifications]: true,
+          [CLIENT_CAPS.pluginTimelineItems]: true,
+          [CLIENT_CAPS.workspaceSetupBlocked]: true,
           ...this.config.capabilities,
         },
         ...(this.config.appVersion ? { appVersion: this.config.appVersion } : {}),

--- a/packages/protocol/src/client-capabilities.ts
+++ b/packages/protocol/src/client-capabilities.ts
@@ -34,6 +34,10 @@ export const CLIENT_CAPS = {
   // timeline items for older clients whose strict timeline union rejects them.
   // Remove after 2027-03-03 once the supported client floor is >= v0.7.2.
   timelineNotifications: "timeline_notifications",
+  // COMPAT(pluginTimelineItems): added in v0.8.0, remove after 2027-03-07 once client floor >= v0.8.0.
+  pluginTimelineItems: "plugin_timeline_items",
+  // COMPAT(workspaceSetupBlocked): added in v0.8.0, remove after 2027-03-07 once client floor >= v0.8.0.
+  workspaceSetupBlocked: "workspace_setup_blocked",
   browserHost: "browser_host",
 } as const;
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3404,9 +3404,9 @@ export const ServerInfoStatusPayloadSchema = z
     // COMPAT(providersSnapshot): added in v0.1.48, remove gating when all clients use snapshot
     features: z
       .object({
-        // COMPAT(agentRequestReceipts): added in v0.7.3; remove gate after 2027-03-05.
+        // COMPAT(agentRequestReceipts): added in v0.8.0; remove gate after 2027-03-05.
         agentRequestReceipts: z.boolean().optional(),
-        // COMPAT(hubAgentRpc): added in v0.7.3; remove gate after 2027-03-05.
+        // COMPAT(hubAgentRpc): added in v0.8.0; remove gate after 2027-03-05.
         hubAgentRpc: z.boolean().optional(),
         providersSnapshot: z.boolean().optional(),
         // COMPAT(providersSnapshotCwd): added in v0.3.2, remove gate after 2027-02-10.
@@ -3415,9 +3415,9 @@ export const ServerInfoStatusPayloadSchema = z
         directorySync: z.boolean().optional(),
         // COMPAT(workspaceLabels): added in v0.5.0, remove after 2027-08-14.
         workspaceLabels: z.boolean().optional(),
-        // COMPAT(workspaceSetupRun): added in v0.7.3, remove gate after 2027-09-02.
+        // COMPAT(workspaceSetupRun): added in v0.8.0, remove gate after 2027-09-02.
         workspaceSetupRun: z.boolean().optional(),
-        // COMPAT(workspaceTerminals): added in v0.7.3, remove gate after 2027-09-05.
+        // COMPAT(workspaceTerminals): added in v0.8.0, remove gate after 2027-09-05.
         workspaceTerminals: z.boolean().optional(),
         // COMPAT(checkoutForgeSetAutoMerge): added in v0.2.0-beta.1. Remove the
         // feature gate and checkoutGithubSetAutoMerge fallback after 2027-01-17
@@ -3527,7 +3527,7 @@ export const ServerInfoStatusPayloadSchema = z
         providerRemoval: z.boolean().optional(),
         // COMPAT(importSessionWorkspaceTarget): added in v0.1.110, remove gate after 2027-01-16.
         importSessionWorkspaceTarget: z.boolean().optional(),
-        // COMPAT(importSessionSearch): added in v0.7.3, remove gate after 2027-03-02.
+        // COMPAT(importSessionSearch): added in v0.8.0, remove gate after 2027-03-02.
         importSessionSearch: z.boolean().optional(),
         // COMPAT(forgeProviders): added in v0.2.0-beta.1. Drop the gate after
         // 2027-01-17 once the supported daemon floor is >= v0.2.0.

--- a/packages/protocol/src/messages.wire-compat.test.ts
+++ b/packages/protocol/src/messages.wire-compat.test.ts
@@ -6,6 +6,9 @@ import {
   ServerInfoStatusPayloadSchema,
   SessionOutboundMessageSchema,
   WSHelloMessageSchema,
+  WorkspaceSetupSnapshotSchema,
+  WorkspaceSetupProgressMessageSchema,
+  AgentTimelineEntryPayloadSchema,
 } from "./messages.js";
 
 test("terminal listings accept older rows and retain new per-terminal directories", () => {
@@ -301,4 +304,88 @@ describe("wire schema compatibility", () => {
       message: "Command blocked by user",
     });
   });
+});
+
+test("0.8 timeline and setup capabilities remain optional in the hello", () => {
+  const hello = { type: "hello", clientId: "compat", clientType: "mobile", protocolVersion: 1 };
+  expect(WSHelloMessageSchema.safeParse(hello).success).toBe(true);
+  expect(
+    WSHelloMessageSchema.parse({
+      ...hello,
+      capabilities: { plugin_timeline_items: true, workspace_setup_blocked: true },
+    }).capabilities,
+  ).toEqual({ plugin_timeline_items: true, workspace_setup_blocked: true });
+});
+
+test("plugin rows and identity merges require a capable receiver", () => {
+  const item = {
+    type: "plugin",
+    id: "task",
+    pluginId: "tasks",
+    kind: "tasks",
+    version: 1,
+    data: { text: "Working" },
+  };
+  expect(AgentTimelineItemPayloadSchema.parse(item)).toEqual(item);
+  const legacyItems = z.object({
+    type: z.enum([
+      "user_message",
+      "assistant_message",
+      "reasoning",
+      "tool_call",
+      "todo",
+      "error",
+      "notification",
+      "compaction",
+    ]),
+  });
+  expect(legacyItems.safeParse(item).success).toBe(false);
+  const entry = {
+    provider: "codex",
+    item,
+    timestamp: "2026-09-07T00:00:00.000Z",
+    seqStart: 1,
+    seqEnd: 2,
+    sourceSeqRanges: [{ startSeq: 1, endSeq: 2 }],
+    collapsed: ["identity"],
+  };
+  expect(AgentTimelineEntryPayloadSchema.parse(entry)).toEqual(entry);
+  const legacyCollapsed = z.array(z.enum(["assistant_merge", "reasoning_merge", "tool_lifecycle"]));
+  expect(legacyCollapsed.safeParse(entry.collapsed).success).toBe(false);
+});
+
+test("blocked setup preserves the legacy failed shape and optional provenance", () => {
+  const snapshot = {
+    status: "blocked",
+    error: null,
+    detail: {
+      type: "worktree_setup",
+      worktreePath: "/workspace",
+      branchName: "fork",
+      log: "",
+      commands: [],
+    },
+    blockedSource: {
+      kind: "change_request",
+      forge: "github",
+      number: 42,
+      headRepository: "contributor/project",
+    },
+  };
+  expect(WorkspaceSetupSnapshotSchema.parse(snapshot)).toEqual(snapshot);
+  const legacyStatus = z.enum(["running", "completed", "failed"]);
+  const legacySnapshot = WorkspaceSetupSnapshotSchema.omit({ blockedSource: true }).extend({
+    status: legacyStatus,
+  });
+  expect(legacySnapshot.safeParse(snapshot).success).toBe(false);
+  const failed = { ...snapshot, status: "failed", error: "Update Paseo to review and run setup." };
+  expect(legacySnapshot.safeParse(failed).success).toBe(true);
+  const progress = {
+    type: "workspace_setup_progress",
+    payload: { ...failed, workspaceId: "workspace" },
+  };
+  expect(WorkspaceSetupProgressMessageSchema.parse(progress)).toEqual(progress);
+  expect(WorkspaceSetupSnapshotSchema.parse(legacySnapshot.parse(failed))).toEqual(
+    legacySnapshot.parse(failed),
+  );
 });

--- a/packages/server/src/server/selective-timeline-delivery.e2e.test.ts
+++ b/packages/server/src/server/selective-timeline-delivery.e2e.test.ts
@@ -420,11 +420,7 @@ test("subscription acknowledgements stay on the requesting socket of a retained 
 test("real WebSocket sessions enforce selective delivery, retained resets, downgrade, and dedicated attention", async () => {
   const legacy = await connect({ clientId: "legacy-client", selective: false });
   let capable = await connect({ clientId: "capable-client", selective: true });
-  const workspace = await legacy.client.createWorkspace({
-    source: { kind: "directory", path: daemon.paseoHome },
-  });
-  if (!workspace.workspace) throw new Error(workspace.error ?? "Expected workspace");
-  const workspaceId = workspace.workspace.id;
+  const workspaceId = await createAttentionWorkspace(legacy.client);
   const agents = await Promise.all(
     ["A", "B", "C"].map((title) =>
       legacy.client.createAgent({
@@ -681,20 +677,24 @@ test("plugin items are gated in provider child streams, child fetches, and rewin
       item: { type: "assistant_message", text: "Child result" },
     },
   });
-  const childResult = (message: SessionOutboundMessage) =>
-    message.type === "agent.provider_subagents.update" &&
-    message.payload.kind === "timeline" &&
-    message.payload.item.type === "assistant_message";
+  function childResult(message: SessionOutboundMessage): boolean {
+    return (
+      message.type === "agent.provider_subagents.update" &&
+      message.payload.kind === "timeline" &&
+      message.payload.item.type === "assistant_message"
+    );
+  }
   await Promise.all([
     capable.next(childResult, "capable child result"),
     legacy.next(childResult, "legacy child result"),
   ]);
-  const childItems = (client: ConnectedClient) =>
-    client.messages.flatMap((message) =>
+  function childItems(client: ConnectedClient) {
+    return client.messages.flatMap((message) =>
       message.type === "agent.provider_subagents.update" && message.payload.kind === "timeline"
         ? [message.payload.item]
         : [],
     );
+  }
   expect(childItems(capable)).toContainEqual(plugin);
   expect(childItems(legacy)).toEqual([{ type: "assistant_message", text: "Child result" }]);
   const oldChild = await legacy.client.fetchProviderSubagentTimeline(agent.id, "child");
@@ -711,20 +711,36 @@ test("plugin items are gated in provider child streams, child fetches, and rewin
     direction: "tail",
     projection: "canonical",
   });
-  const target = timeline.entries.find((entry) => entry.item.type === "user_message");
-  if (target?.item.type !== "user_message" || !target.item.messageId)
-    throw new Error("Expected rewind target");
+  const targetMessageId = rewindMessageId(timeline);
   capable.clear();
   legacy.clear();
-  await capable.client.rewindAgent(agent.id, target.item.messageId, "conversation");
+  await capable.client.rewindAgent(agent.id, targetMessageId, "conversation");
   await Promise.all([capable.barrier("provider-rewind"), legacy.barrier("provider-rewind")]);
-  const replayItems = (client: ConnectedClient) =>
-    client.messages.flatMap((message) =>
+  function replayItems(client: ConnectedClient) {
+    return client.messages.flatMap((message) =>
       message.type === "agent_stream" && message.payload.event.type === "timeline"
         ? [message.payload.event.item]
         : [],
     );
+  }
   expect(replayItems(capable)).toContainEqual(plugin);
   expect(replayItems(legacy).some((item) => item.type === "plugin")).toBe(false);
   expect(replayItems(legacy)).toContainEqual(expect.objectContaining({ type: "user_message" }));
 });
+
+async function createAttentionWorkspace(client: DaemonClient): Promise<string> {
+  const result = await client.createWorkspace({
+    source: { kind: "directory", path: daemon.paseoHome },
+  });
+  if (!result.workspace) throw new Error(result.error ?? "Expected workspace");
+  return result.workspace.id;
+}
+
+function rewindMessageId(
+  timeline: Awaited<ReturnType<DaemonClient["fetchAgentTimeline"]>>,
+): string {
+  const target = timeline.entries.find((entry) => entry.item.type === "user_message");
+  if (target?.item.type !== "user_message" || !target.item.messageId)
+    throw new Error("Expected rewind target");
+  return target.item.messageId;
+}

--- a/packages/server/src/server/selective-timeline-delivery.e2e.test.ts
+++ b/packages/server/src/server/selective-timeline-delivery.e2e.test.ts
@@ -1,9 +1,17 @@
+import type { AgentStreamEvent, AgentSessionConfig } from "./agent/agent-sdk-types.js";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createPersistedWorkspaceRecord } from "./workspace-registry.js";
 import { afterEach, beforeEach, expect, test } from "vitest";
 import { CLIENT_CAPS } from "@getpaseo/protocol/client-capabilities";
 import type { SessionOutboundMessage } from "@getpaseo/protocol/messages";
 import { DaemonClient } from "./test-utils/daemon-client.js";
 import { createTestPaseoDaemon, type TestPaseoDaemon } from "./test-utils/paseo-daemon.js";
-import { MockLoadTestAgentClient } from "./agent/providers/mock-load-test-agent.js";
+import {
+  MockLoadTestAgentClient,
+  MockLoadTestAgentSession,
+} from "./agent/providers/mock-load-test-agent.js";
 
 interface MessageWaiter {
   predicate(message: SessionOutboundMessage): boolean;
@@ -130,12 +138,16 @@ async function connect(input: {
   selective: boolean;
   timelineReplacementInvalidation?: boolean;
   timelineNotifications?: boolean;
+  pluginTimelineItems?: boolean;
+  workspaceSetupBlocked?: boolean;
 }): Promise<ConnectedClient> {
   const client = new DaemonClient({
     url: `ws://127.0.0.1:${daemon.port}/ws`,
     clientId: input.clientId,
     capabilities: {
       [CLIENT_CAPS.selectiveAgentTimeline]: input.selective,
+      [CLIENT_CAPS.pluginTimelineItems]: input.pluginTimelineItems ?? false,
+      [CLIENT_CAPS.workspaceSetupBlocked]: input.workspaceSetupBlocked ?? false,
       ...(input.timelineNotifications === undefined
         ? {}
         : { [CLIENT_CAPS.timelineNotifications]: input.timelineNotifications }),
@@ -226,6 +238,94 @@ test("notification timeline items are sent only to clients that advertise suppor
   );
   expect(legacyTimeline.window).toEqual(capableTimeline.window);
   expect(legacyTimeline.endCursor).toEqual(capableTimeline.endCursor);
+});
+
+test("plugin timeline items are sent only to clients that advertise support", async () => {
+  await daemon.close();
+  daemon = await createTestPaseoDaemon({
+    isDev: true,
+    agentClients: { mock: new MockLoadTestAgentClient() },
+  });
+  const capable = await connect({
+    clientId: "plugin-shared",
+    selective: false,
+    pluginTimelineItems: true,
+  });
+  const legacy = await connect({
+    clientId: "plugin-shared",
+    selective: false,
+    pluginTimelineItems: false,
+  });
+  const agent = await capable.client.createAgent({
+    provider: "mock",
+    cwd: "/tmp",
+    title: "Plugin compatibility",
+    model: "ten-second-stream",
+  });
+  capable.clear();
+  legacy.clear();
+
+  await daemon.daemon.agentManager.appendTimelineItem(agent.id, {
+    type: "plugin",
+    id: "compat-row",
+    pluginId: "timeline-items",
+    kind: "notice",
+    version: 1,
+    data: { text: "Capable clients only" },
+  });
+  await daemon.daemon.agentManager.appendTimelineItem(agent.id, {
+    type: "plugin",
+    id: "compat-row",
+    pluginId: "timeline-items",
+    kind: "notice",
+    version: 1,
+    data: { text: "Updated" },
+  });
+  await daemon.daemon.agentManager.appendTimelineItem(agent.id, {
+    type: "assistant_message",
+    text: "Visible to every client",
+  });
+  await Promise.all([
+    capable.next(isAgentStream(agent.id), "capable timeline delivery"),
+    legacy.next(isAgentStream(agent.id), "legacy timeline delivery"),
+  ]);
+  await Promise.all([capable.barrier("plugin-capable"), legacy.barrier("plugin-legacy")]);
+
+  const capableLiveItems = capable.messages.flatMap((message) =>
+    message.type === "agent_stream" && message.payload.event.type === "timeline"
+      ? [message.payload.event.item]
+      : [],
+  );
+  const legacyLiveItems = legacy.messages.flatMap((message) =>
+    message.type === "agent_stream" && message.payload.event.type === "timeline"
+      ? [message.payload.event.item]
+      : [],
+  );
+  expect(capableLiveItems.some((item) => item.type === "plugin")).toBe(true);
+  expect(legacyLiveItems.some((item) => item.type === "plugin")).toBe(false);
+  expect(legacyLiveItems).toContainEqual(
+    expect.objectContaining({ type: "assistant_message", text: "Visible to every client" }),
+  );
+
+  for (const projection of ["canonical", "projected"] as const) {
+    const [capableTimeline, legacyTimeline] = await Promise.all([
+      capable.client.fetchAgentTimeline(agent.id, { direction: "tail", projection }),
+      legacy.client.fetchAgentTimeline(agent.id, { direction: "tail", projection }),
+    ]);
+    expect(capableTimeline.entries.some((entry) => entry.item.type === "plugin")).toBe(true);
+    expect(legacyTimeline.entries.some((entry) => entry.item.type === "plugin")).toBe(false);
+    expect(legacyTimeline.entries).toContainEqual(
+      expect.objectContaining({
+        item: expect.objectContaining({
+          type: "assistant_message",
+          text: "Visible to every client",
+        }),
+      }),
+    );
+    expect(legacyTimeline.window).toEqual(capableTimeline.window);
+    expect(legacyTimeline.endCursor).toEqual(capableTimeline.endCursor);
+    expect(legacyTimeline.entries.flatMap((entry) => entry.collapsed)).not.toContain("identity");
+  }
 });
 
 test("rewind routes replacement completion by source capability and subscription", async () => {
@@ -320,12 +420,18 @@ test("subscription acknowledgements stay on the requesting socket of a retained 
 test("real WebSocket sessions enforce selective delivery, retained resets, downgrade, and dedicated attention", async () => {
   const legacy = await connect({ clientId: "legacy-client", selective: false });
   let capable = await connect({ clientId: "capable-client", selective: true });
+  const workspace = await legacy.client.createWorkspace({
+    source: { kind: "directory", path: daemon.paseoHome },
+  });
+  if (!workspace.workspace) throw new Error(workspace.error ?? "Expected workspace");
+  const workspaceId = workspace.workspace.id;
   const agents = await Promise.all(
     ["A", "B", "C"].map((title) =>
       legacy.client.createAgent({
         provider: "codex",
-        cwd: "/tmp",
+        cwd: daemon.paseoHome,
         title: `Selective ${title}`,
+        workspaceId,
         modeId: "full-access",
       }),
     ),
@@ -397,6 +503,10 @@ test("real WebSocket sessions enforce selective delivery, retained resets, downg
   await capable.barrier("resumed-membership-reset");
   expect(capable.hasTimeline(agentB.id)).toBe(false);
 
+  await Promise.all([
+    legacy.client.fetchAgents({ subscribe: { subscriptionId: "legacy-directory" } }),
+    capable.client.fetchAgents({ subscribe: { subscriptionId: "capable-directory" } }),
+  ]);
   capable.client.sendHeartbeat({
     deviceType: "mobile",
     focusedAgentId: null,
@@ -451,3 +561,170 @@ test("real WebSocket sessions enforce selective delivery, retained resets, downg
 
   expect(downgradedDelivery.type).toBe("agent_stream");
 }, 30_000);
+
+test("blocked setup remains readable on mixed-capability sockets sharing a session", async () => {
+  await daemon.close();
+  const root = await mkdtemp(path.join(os.tmpdir(), "paseo-blocked-compat-"));
+  const projects = path.join(root, ".paseo", "projects");
+  await mkdir(projects, { recursive: true });
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "blocked-workspace",
+    projectId: "project",
+    cwd: root,
+    kind: "directory",
+    displayName: "Fork PR",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    untrustedSource: {
+      kind: "change_request",
+      forge: "github",
+      number: 42,
+      headRepository: "contributor/project",
+    },
+  });
+  await writeFile(path.join(projects, "workspaces.json"), JSON.stringify([workspace]));
+  daemon = await createTestPaseoDaemon({ paseoHomeRoot: root });
+  const legacy = await connect({ clientId: "setup-shared", selective: false });
+  const capable = await connect({
+    clientId: "setup-shared",
+    selective: false,
+    workspaceSetupBlocked: true,
+  });
+  const oldStatus = await legacy.client.fetchWorkspaceSetupStatus(workspace.workspaceId);
+  const newStatus = await capable.client.fetchWorkspaceSetupStatus(workspace.workspaceId);
+  expect(oldStatus.snapshot).toMatchObject({
+    status: "failed",
+    error:
+      "Workspace setup is blocked pending approval of code from a fork pull request. Update Paseo to review and run setup.",
+  });
+  expect(newStatus.snapshot).toMatchObject({
+    status: "blocked",
+    error: null,
+    blockedSource: workspace.untrustedSource,
+  });
+  expect(oldStatus.snapshot?.detail).toEqual(newStatus.snapshot?.detail);
+});
+
+// A provider adapter with controllable events and durable provider history.
+class CompatibilityProviderSession extends MockLoadTestAgentSession {
+  private readonly observers = new Set<(event: AgentStreamEvent) => void>();
+  private readonly injectedHistory: AgentStreamEvent[] = [];
+  override subscribe(callback: (event: AgentStreamEvent) => void): () => void {
+    const unsubscribe = super.subscribe(callback);
+    this.observers.add(callback);
+    return () => {
+      unsubscribe();
+      this.observers.delete(callback);
+    };
+  }
+  push(event: AgentStreamEvent): void {
+    this.injectedHistory.push(event);
+    for (const callback of this.observers) callback(event);
+  }
+  override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+    yield* this.injectedHistory;
+    yield* super.streamHistory();
+  }
+}
+
+class CompatibilityProvider extends MockLoadTestAgentClient {
+  session!: CompatibilityProviderSession;
+  override async createSession(config: AgentSessionConfig): Promise<CompatibilityProviderSession> {
+    this.session = new CompatibilityProviderSession({
+      config,
+      sessionId: "compat-provider-session",
+    });
+    return this.session;
+  }
+}
+
+test("plugin items are gated in provider child streams, child fetches, and rewind replay", async () => {
+  await daemon.close();
+  const provider = new CompatibilityProvider();
+  daemon = await createTestPaseoDaemon({ isDev: true, agentClients: { mock: provider } });
+  const legacy = await connect({ clientId: "provider-shared", selective: false });
+  const capable = await connect({
+    clientId: "provider-shared",
+    selective: false,
+    pluginTimelineItems: true,
+  });
+  const agent = await capable.client.createAgent({
+    provider: "mock",
+    cwd: "/tmp",
+    model: "ten-second-stream",
+  });
+  const plugin = {
+    type: "plugin" as const,
+    id: "provider-row",
+    pluginId: "provider",
+    kind: "notice",
+    version: 1,
+    data: { text: "Provider notice" },
+  };
+  provider.session.push({ type: "timeline", provider: "mock", item: plugin });
+  provider.session.push({
+    type: "provider_subagent",
+    provider: "mock",
+    event: { type: "upsert", id: "child", title: "Child", status: "running" },
+  });
+  provider.session.push({
+    type: "provider_subagent",
+    provider: "mock",
+    event: { type: "timeline", id: "child", item: plugin },
+  });
+  provider.session.push({
+    type: "provider_subagent",
+    provider: "mock",
+    event: {
+      type: "timeline",
+      id: "child",
+      item: { type: "assistant_message", text: "Child result" },
+    },
+  });
+  const childResult = (message: SessionOutboundMessage) =>
+    message.type === "agent.provider_subagents.update" &&
+    message.payload.kind === "timeline" &&
+    message.payload.item.type === "assistant_message";
+  await Promise.all([
+    capable.next(childResult, "capable child result"),
+    legacy.next(childResult, "legacy child result"),
+  ]);
+  const childItems = (client: ConnectedClient) =>
+    client.messages.flatMap((message) =>
+      message.type === "agent.provider_subagents.update" && message.payload.kind === "timeline"
+        ? [message.payload.item]
+        : [],
+    );
+  expect(childItems(capable)).toContainEqual(plugin);
+  expect(childItems(legacy)).toEqual([{ type: "assistant_message", text: "Child result" }]);
+  const oldChild = await legacy.client.fetchProviderSubagentTimeline(agent.id, "child");
+  const newChild = await capable.client.fetchProviderSubagentTimeline(agent.id, "child");
+  expect(newChild.rows.map((row) => row.item)).toContainEqual(plugin);
+  expect(oldChild.rows.map((row) => row.item)).toEqual([
+    { type: "assistant_message", text: "Child result" },
+  ]);
+  expect(oldChild.window).toEqual(newChild.window);
+
+  await capable.client.sendMessage(agent.id, "Rewind target");
+  await capable.client.cancelAgent(agent.id);
+  const timeline = await capable.client.fetchAgentTimeline(agent.id, {
+    direction: "tail",
+    projection: "canonical",
+  });
+  const target = timeline.entries.find((entry) => entry.item.type === "user_message");
+  if (target?.item.type !== "user_message" || !target.item.messageId)
+    throw new Error("Expected rewind target");
+  capable.clear();
+  legacy.clear();
+  await capable.client.rewindAgent(agent.id, target.item.messageId, "conversation");
+  await Promise.all([capable.barrier("provider-rewind"), legacy.barrier("provider-rewind")]);
+  const replayItems = (client: ConnectedClient) =>
+    client.messages.flatMap((message) =>
+      message.type === "agent_stream" && message.payload.event.type === "timeline"
+        ? [message.payload.event.item]
+        : [],
+    );
+  expect(replayItems(capable)).toContainEqual(plugin);
+  expect(replayItems(legacy).some((item) => item.type === "plugin")).toBe(false);
+  expect(replayItems(legacy)).toContainEqual(expect.objectContaining({ type: "user_message" }));
+});

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1175,20 +1175,23 @@ export class Session {
     return true;
   }
 
-  private supportsTimelineNotifications(source?: object): boolean {
-    return source
-      ? this.supportsForSource(CLIENT_CAPS.timelineNotifications, source)
-      : this.supports(CLIENT_CAPS.timelineNotifications);
+  // COMPAT(timelineItemCapabilities): plugin items added in v0.8.0, notifications in v0.7.2.
+  // Remove after 2027-03-07 once the supported client floor is >= v0.8.0.
+  private supportsTimelineItem(item: { type: string }, source?: object): boolean {
+    let capability: ClientCapability;
+    if (item.type === "notification") capability = CLIENT_CAPS.timelineNotifications;
+    else if (item.type === "plugin") capability = CLIENT_CAPS.pluginTimelineItems;
+    else return true;
+    return source ? this.supportsForSource(capability, source) : this.supports(capability);
   }
 
   private forwardAgentStream(
     event: Extract<AgentManagerEvent, { type: "agent_stream" }>,
     serializedEvent: Extract<SessionOutboundMessage, { type: "agent_stream" }>["payload"]["event"],
   ): void {
-    const isNotification =
-      serializedEvent.type === "timeline" && serializedEvent.item.type === "notification";
     if (this.clientCapabilitiesBySource.size === 0 || !this.onMessageToSource) {
-      if (isNotification && !this.supportsTimelineNotifications()) return;
+      if (serializedEvent.type === "timeline" && !this.supportsTimelineItem(serializedEvent.item))
+        return;
       if (this.usesSelectiveTimelineDelivery() && serializedEvent.type === "attention_required") {
         this.emit({
           type: "agent_attention_required",
@@ -1213,7 +1216,11 @@ export class Session {
     }
 
     for (const [source, capabilities] of this.clientCapabilitiesBySource) {
-      if (isNotification && !capabilities.has(CLIENT_CAPS.timelineNotifications)) continue;
+      if (
+        serializedEvent.type === "timeline" &&
+        !this.supportsTimelineItem(serializedEvent.item, source)
+      )
+        continue;
       const supportsSelectiveDelivery = capabilities.has(CLIENT_CAPS.selectiveAgentTimeline);
       if (supportsSelectiveDelivery && serializedEvent.type === "attention_required") {
         this.onMessageToSource(source, {
@@ -1679,11 +1686,10 @@ export class Session {
       };
     }
 
-    const isNotification = update.type === "timeline" && update.row.item.type === "notification";
     if (this.clientCapabilitiesBySource.size === 0 || !this.onMessageToSource) {
       if (
         this.supports(CLIENT_CAPS.providerSubagents) &&
-        (!isNotification || this.supportsTimelineNotifications())
+        (update.type !== "timeline" || this.supportsTimelineItem(update.row.item))
       ) {
         this.emit(message);
       }
@@ -1691,7 +1697,8 @@ export class Session {
     }
     for (const [source, capabilities] of this.clientCapabilitiesBySource) {
       if (!capabilities.has(CLIENT_CAPS.providerSubagents)) continue;
-      if (isNotification && !capabilities.has(CLIENT_CAPS.timelineNotifications)) continue;
+      if (update.type === "timeline" && !this.supportsTimelineItem(update.row.item, source))
+        continue;
       this.onMessageToSource(source, message);
     }
   }
@@ -4128,7 +4135,7 @@ export class Session {
     source?: object,
   ): void {
     for (const row of rows) {
-      if (row.item.type === "notification" && !this.supportsTimelineNotifications(source)) {
+      if (!this.supportsTimelineItem(row.item, source)) {
         continue;
       }
       const event = serializeAgentStreamEvent({
@@ -7175,9 +7182,9 @@ export class Session {
         selectedTimeline.endSeq !== null
           ? { epoch: selectedTimeline.timeline.epoch, seq: selectedTimeline.endSeq }
           : null;
-      const entries = this.supportsTimelineNotifications(source)
-        ? selectedTimeline.entries
-        : selectedTimeline.entries.filter((entry) => entry.item.type !== "notification");
+      const entries = selectedTimeline.entries.filter((entry) =>
+        this.supportsTimelineItem(entry.item, source),
+      );
 
       this.emitForSource(
         {
@@ -7376,9 +7383,7 @@ export class Session {
           limit: msg.limit ?? (direction === "after" ? 0 : 200),
         },
       );
-      const rows = this.supportsTimelineNotifications(source)
-        ? timeline.rows
-        : timeline.rows.filter((row) => row.item.type !== "notification");
+      const rows = timeline.rows.filter((row) => this.supportsTimelineItem(row.item, source));
       this.emitForSource(
         {
           type: "agent.provider_subagents.timeline.get.response",
@@ -7714,7 +7719,41 @@ export class Session {
         "agent.session.outbound",
       );
     }
+    if (msg.type === "workspace_setup_progress" || msg.type === "workspace_setup_status_response") {
+      if (this.clientCapabilitiesBySource.size > 0 && this.onMessageToSource) {
+        for (const [source] of this.clientCapabilitiesBySource) {
+          this.onMessageToSource(source, this.workspaceSetupMessageForClient(msg, source));
+        }
+        return;
+      }
+      msg = this.workspaceSetupMessageForClient(msg);
+    }
     this.onMessage(msg);
+  }
+
+  // COMPAT(workspaceSetupBlocked): added in v0.8.0, remove after 2027-03-07 once client floor >= v0.8.0.
+  private workspaceSetupMessageForClient(
+    message: Extract<
+      SessionOutboundMessage,
+      { type: "workspace_setup_progress" | "workspace_setup_status_response" }
+    >,
+    source?: object,
+  ): SessionOutboundMessage {
+    const supportsBlocked = source
+      ? this.supportsForSource(CLIENT_CAPS.workspaceSetupBlocked, source)
+      : this.supports(CLIENT_CAPS.workspaceSetupBlocked);
+    const snapshot =
+      message.type === "workspace_setup_progress" ? message.payload : message.payload.snapshot;
+    if (supportsBlocked || snapshot?.status !== "blocked") return message;
+    const legacySnapshot = {
+      ...snapshot,
+      status: "failed" as const,
+      error:
+        "Workspace setup is blocked pending approval of code from a fork pull request. Update Paseo to review and run setup.",
+    };
+    return message.type === "workspace_setup_progress"
+      ? { ...message, payload: { ...message.payload, ...legacySnapshot } }
+      : { ...message, payload: { ...message.payload, snapshot: legacySnapshot } };
   }
 
   private emitBinary(frame: Uint8Array): void {

--- a/packages/server/src/server/wire-compat.test.ts
+++ b/packages/server/src/server/wire-compat.test.ts
@@ -185,6 +185,7 @@ function createSessionForWireCompatTest(options?: {
   clientCapabilities?: Record<string, unknown> | null;
   directorySync?: DirectorySyncService;
   messages?: SessionOutboundMessage[];
+  onMessageToSource?: SessionOptions["onMessageToSource"];
   rows?: AgentTimelineRow[];
 }): Session {
   const messages = options?.messages ?? [];
@@ -212,6 +213,7 @@ function createSessionForWireCompatTest(options?: {
     permissions: OWNER_PERMISSIONS,
     clientCapabilities: options?.clientCapabilities ?? null,
     onMessage: (message) => messages.push(message),
+    onMessageToSource: options?.onMessageToSource,
     logger: pino({ level: "silent" }),
     downloadTokenStore: {} as SessionOptions["downloadTokenStore"],
     pushNotifications: {} as SessionOptions["pushNotifications"],
@@ -542,4 +544,52 @@ describe("wire compatibility", () => {
       paseoHome: "/tmp/paseo-home",
     });
   });
+});
+
+test("setup progress is adapted per socket without changing the canonical snapshot", async () => {
+  const legacy = {};
+  const capable = {};
+  const delivered = new Map<object, SessionOutboundMessage[]>();
+  const session = createSessionForWireCompatTest({
+    onMessageToSource: (source, message) =>
+      delivered.set(source, [...(delivered.get(source) ?? []), message]),
+  });
+  session.updateClientCapabilities({}, legacy);
+  session.updateClientCapabilities({ workspace_setup_blocked: true }, capable);
+  const message = {
+    type: "workspace_setup_progress" as const,
+    payload: {
+      workspaceId: "fork-workspace",
+      status: "blocked" as const,
+      error: null,
+      detail: {
+        type: "worktree_setup" as const,
+        worktreePath: "/workspace",
+        branchName: "fork",
+        log: "",
+        commands: [],
+      },
+      blockedSource: {
+        kind: "change_request" as const,
+        forge: "github",
+        number: 42,
+        headRepository: "contributor/project",
+      },
+    },
+  };
+  session.publish(message);
+  expect(delivered.get(capable)).toEqual([message]);
+  expect(delivered.get(legacy)).toEqual([
+    {
+      ...message,
+      payload: {
+        ...message.payload,
+        status: "failed",
+        error:
+          "Workspace setup is blocked pending approval of code from a fork pull request. Update Paseo to review and run setup.",
+      },
+    },
+  ]);
+  expect(message.payload.status).toBe("blocked");
+  await session.cleanup();
 });

--- a/public-docs/hub/security.md
+++ b/public-docs/hub/security.md
@@ -20,10 +20,11 @@ The host, provider credentials, filesystem, network, and resulting actions remai
 
 Connecting a daemon does not grant Hub permission to run agents. Grant `hub.execute` when you want
 Hub automations to use it. This permission allows Hub to create and continue agents, inspect their
-state and timelines, and archive or restore workspaces on that daemon. It also applies to existing
+state and timelines, configure their model, thinking, and provider permission mode, and archive or
+restore workspaces on that daemon. Provider modes can include bypassing approval prompts. It also applies to existing
 agents and workspaces; it is not an isolation boundary around Hub-created work.
 
-Daemon administration, terminal control, and permission management require separate permissions.
+Daemon administration, terminal control, and daemon credential permission management require separate permissions.
 You can revoke `hub.execute` without granting Hub the ability to change its own permissions.
 
 ## Treat requests as untrusted


### PR DESCRIPTION
### Linked issue

Pre-release compatibility review. Refs #3411, #4215, #4354, #4242, #4436.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

A phone app can remain on 0.7.2 for weeks after its desktop host updates to 0.8. Plugin timeline rows currently make that app reject timeline fetches and drop live events. Fork-PR setup also introduces a status that the old app cannot parse.

The daemon now checks `hello.capabilities.plugin_timeline_items` before delivering plugin rows through live streams, canonical/projected fetches, rewind replay, and provider-subagent streams/fetches. Filtering merged plugin rows also removes their new `collapsed: "identity"` value from old-client responses. Pagination windows and cursors remain canonical. Current clients advertise support.

`hello.capabilities.workspace_setup_blocked` preserves `blocked` for current clients and maps it to `failed` with update/approval guidance for old clients. Both setup progress and status responses are adapted per socket, including sockets sharing one retained session. Stored state stays unchanged. External agent-tool and MCP worktree broadcasts also enter this boundary: `emitExternalSessionMessage` → `wsServer.broadcast` → `Session.publish` → `Session.emit`.

The five incorrect `v0.7.3` feature tags present in this checkout now say `v0.8.0`. Review of #4354 and #4242 confirms that `hub.execute` intentionally has daemon-wide agent authority. Authorization remains unchanged; the public security guide explicitly includes model, thinking, and provider permission modes that bypass approval prompts, distinguishing those from daemon credential permissions.

### Goals

- Keep existing agents readable and live on a published 0.7.2 client against a 0.8 daemon.
- Preserve plugin rows and blocked setup state for capable clients.
- Keep compatibility adaptation at the daemon's client delivery boundary.

### Non-goals

- No persistence or replica-cache changes. `readTimeline` already deletes undecodable cache rows and returns a cache miss (#4436).
- No new Hub permission or restriction of its intended execution authority.
- Defer the optional unknown-item notice. A pure `z.union([knownItems, z.looseObject({type: z.string()})])` compiles with the pinned zod-aot, but also accepts malformed **known** items. Its overlapping string tag would spread loss of type narrowing across shared protocol consumers. Excluding known tags and introducing a separately normalized client wire type is larger than the small release fix requested here. Wire validation remains strict.

### QA

**CI passed on `5518eacab`:** [CI](https://github.com/getpaseo/paseo/actions/runs/34151676023) completed successfully with Linux/Windows server tests, SDK tests, all four Playwright shards, typecheck, lint, and formatting. [Docker](https://github.com/getpaseo/paseo/actions/runs/34151675889) and [Nix Linux/macOS builds](https://github.com/getpaseo/paseo/actions/runs/34151675876) also passed. All applicable checks are green; unrelated jobs were skipped by path filtering. Review threads are resolved.

**Failing first:** added the plugin mixed-socket repro, ran it before changing the gate, and observed:

```text
plugin timeline items are sent only to clients that advertise support
AssertionError: expected true to be false
expect(legacyLiveItems.some((item) => item.type === "plugin")).toBe(false)
```

Added the blocked-setup mixed-socket repro before implementing its gate:

```text
blocked setup remains readable on mixed-capability sockets sharing a session
Expected: { status: "failed", error: "Workspace setup is blocked ... Update Paseo ..." }
Received: { status: "blocked", error: null }
```

**Targeted automated checks:** only the four changed test files were run, never the full local suite.

```text
npx vitest run --config packages/server/vitest.config.ts packages/server/src/server/selective-timeline-delivery.e2e.test.ts --bail=1
Test Files  1 passed (1)
Tests       7 passed (7)

npx vitest run packages/server/src/server/wire-compat.test.ts --bail=1
Test Files  1 passed (1)
Tests       7 passed (7)

npx vitest run packages/protocol/src/messages.wire-compat.test.ts --bail=1
Test Files  1 passed (1)
Tests       13 passed (13)

npx vitest run packages/client/src/daemon-client.test.ts --bail=1
Test Files  1 passed (1)
Tests       120 passed (120)

npm run build:server  # exit 0
npm run typecheck    # exit 0, all workspaces
npm run lint
Found 0 warnings and 0 errors.
npm run format      # exit 0
```

The WebSocket coverage exercises persisted plugin appends, both timeline projections, mixed capabilities on a shared session in both connection orders, provider-child live delivery and fetches, and real rewind reconstruction from a controllable provider adapter. The setup progress test publishes through the public session boundary and verifies per-source adaptation without mutating the snapshot. The existing attention test needed workspace ownership and directory subscriptions added to its fixture to match the current delivery contract; it now passes without changing attention behavior.

**Manual published-client QA:** installed npm's `@getpaseo/client@0.7.2` into a separate temporary prefix, including its published 0.7.2 protocol dependency. A temporary source harness started `createTestPaseoDaemon` on `127.0.0.1:0`, with an isolated `PASEO_HOME`, daemon version `0.8.0-beta.1`, and a real Codex provider. Connected the published old client and current source client before creating the agent.

The current `plugin-examples/timeline-items` example is client-only. Copied it into the isolated directory and added this temporary server contribution so its rows were persisted through the actual plugin-session append RPC:

```ts
server.on("agent.created", async (event, context) => {
  const timeline = context.paseo.agents.ref(event.agent.id).timeline;
  for (const status of ["pending", "completed"] as const) {
    await timeline.append({
      type: "plugin", id: "compat-task", kind: "pi-task-list", version: 1,
      data: { tasks: [{ text: "Compatibility QA", status }] },
    });
  }
});
```

Installed that copy with `installDirectoryPlugin`. Its temporary manifest requirement was `>=0.8.0-beta.1`; the original example's stable `>=0.8.0` requirement correctly rejects the beta. No example files were changed in this PR. Sent the real agent: `Reply with exactly COMPAT_OK. Do not use any tools.`

Commands and observed output (temporary paths and the generated agent ID omitted):

```text
npm install --prefix <temporary-prefix> --no-audit --no-fund @getpaseo/client@0.7.2
added 7 packages in 1s

npx tsx packages/server/src/server/compat-072-qa.tmp.ts
Isolated daemon {"port":33109,"home":"<isolated-home>","version":"0.8.0-beta.1"}
Installed plugin {"id":"pi-tasks-timeline","path":"<isolated-plugin>","enabled":true,"status":"running"}
Real provider agent created <agent-id>
Fetch after persisted plugin append {"oldTypes":[],"currentTypes":["plugin"],"currentCollapsed":[["identity"]],"sameWindow":true}
Published 0.7.2 client live and fetch {"liveTypes":["user_message","assistant_message","assistant_message"],"fetchTypes":["user_message","assistant_message","assistant_message"],"error":null}
PASS: published 0.7.2 parses live assistant messages and timeline fetches while current client sees persisted plugin rows and identity merges.
Stopped isolated daemon
```

Also seeded persisted fork provenance before daemon startup, then fetched setup status through both real clients:

```json
{
  "old": {
    "status": "failed",
    "error": "Workspace setup is blocked pending approval of code from a fork pull request. Update Paseo to review and run setup."
  },
  "current": {
    "status": "blocked",
    "error": null,
    "blockedSource": {
      "kind": "change_request", "forge": "github", "number": 42,
      "headRepository": "contributor/project"
    }
  }
}
```

This verifies the restart/status path with fork provenance; an actual remote fork checkout and its live setup UI were not exercised. Live setup progress is covered at the session boundary. Only the isolated daemon was stopped; existing services were untouched. The temporary harness is not part of the diff.

Fallback compiler probe:

```text
AOT union + loose object compiled: 1
Unknown type accepted: true
Malformed known type also accepted: true
```

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Published client protocol exercised in Node; no device UI run |
| Android | No | Published client protocol exercised in Node; no device UI run |
| Web | CI | All four Playwright regression shards; no manual UI run |
| Desktop macOS | CI build | Desktop build passed; no manual macOS run |
| Desktop Windows | CI server tests | Server suite passed; no manual Windows run |
| Desktop Linux | Daemon/SDK and CI | Isolated source daemon, real provider, published old client, Ubuntu server suite and builds; no Electron UI run |

Compatibility in the other direction is unchanged: new clients only add optional hello capability keys, which older daemons already accept. No wire member becomes required, narrower, or removed. The remaining risk is another newly introduced union member elsewhere; this PR verifies the two release findings above, not an exhaustive historical protocol audit.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
