### PR TITLE
feat(omp/pi): expose native Fast mode

### DIFF
--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -119,6 +119,101 @@ function createToolCatalog(): PaseoToolCatalog {
 }
 
 describe("OMP agent client and session", () => {
+  test("advertises Fast only for supported provider-qualified Codex models", async () => {
+    const supported = new OmpHarness();
+    await supported.start({
+      model: "openai-codex/gpt-5.6-luna",
+      featureValues: { fast_mode: true },
+    });
+    expect(supported.features()).toEqual([
+      expect.objectContaining({ id: "fast_mode", type: "toggle", value: true }),
+    ]);
+
+    const unsupported = new OmpHarness();
+    await unsupported.start({ model: "openai-completions/gpt-5.6-luna" });
+    expect(unsupported.features()).toEqual([]);
+
+    const client = new OmpHarness();
+    await expect(client.clientFeatures({ model: "openai-codex/gpt-5.6-luna" })).resolves.toEqual([
+      expect.objectContaining({ id: "fast_mode", value: false }),
+    ]);
+  });
+
+  test("applies Fast through native RPC without relaunch and keeps active separate", async () => {
+    const omp = new OmpHarness();
+    await omp.start({ model: "openai-codex/gpt-5.6-luna" });
+    const runtime = omp.runtime();
+    runtime.setFastModeResult = { enabled: true, active: false };
+
+    await omp.setFeature("fast_mode", true);
+
+    expect(runtime.setFastModeRequests).toEqual([true]);
+    expect(runtime.state).toMatchObject({ fastModeEnabled: true, fastModeActive: false });
+    expect(omp.features()).toEqual([expect.objectContaining({ id: "fast_mode", value: true })]);
+    expect(runtime.setFastModeRequests).toHaveLength(1);
+  });
+
+  test("does not advertise Fast when an older OMP state omits its state fields", async () => {
+    const omp = new OmpHarness();
+    await omp.start({ model: "openai-codex/gpt-5.6-luna" });
+    const runtime = omp.runtime();
+    delete runtime.state.fastModeEnabled;
+    delete runtime.state.fastModeActive;
+
+    expect(omp.features()).toEqual([]);
+    runtime.setFastModeError = new Error("set_fast_mode is not supported");
+    await expect(omp.setFeature("fast_mode", true)).rejects.toThrow(
+      "set_fast_mode is not supported",
+    );
+  });
+
+  test("applies persisted Fast values before the initial state read on create and resume", async () => {
+    const created = new OmpHarness();
+    await created.start({
+      model: "openai-codex/gpt-5.6-luna",
+      featureValues: { fast_mode: true },
+    });
+    expect(created.runtime().setFastModeRequests).toEqual([true]);
+    expect(created.runtime().getStateRequestCount).toBe(1);
+
+    const resumed = new OmpHarness();
+    await resumed.resume(
+      { user: { id: "u1", text: "hello" }, assistant: { id: "a1", text: "hi" } },
+      { model: "openai-codex/gpt-5.6-luna", featureValues: { fast_mode: false } },
+    );
+    expect(resumed.runtime().setFastModeRequests).toEqual([false]);
+    expect(resumed.runtime().getStateRequestCount).toBe(1);
+  });
+
+  test("refreshes state and removes stale Fast values after switching models", async () => {
+    const omp = new OmpHarness();
+    await omp.start({
+      model: "openai-codex/gpt-5.6-luna",
+      featureValues: { fast_mode: true },
+    });
+    const runtime = omp.runtime();
+    runtime.setModelResult = {
+      provider: "nvidia",
+      id: "minimaxai/minimax-m3",
+    };
+    runtime.state = { ...runtime.state, model: runtime.setModelResult };
+
+    await omp.setModel("nvidia/minimaxai/minimax-m3");
+
+    expect(runtime.getStateRequestCount).toBe(2);
+    expect(omp.features()).toEqual([]);
+  });
+
+  test("surfaces native Fast RPC failures", async () => {
+    const omp = new OmpHarness();
+    await omp.start({ model: "openai-codex/gpt-5.6-luna" });
+    const error = new Error("set_fast_mode is not supported");
+    omp.runtime().setFastModeError = error;
+
+    await expect(omp.setFeature("fast_mode", true)).rejects.toThrow(error.message);
+    expect(omp.runtime().setFastModeRequests).toEqual([true]);
+  });
+
   test("owns launch configuration and registers native host tools", async () => {
     const omp = new OmpHarness();
     await omp.start({ modeId: "ask" }, createToolCatalog());

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -1,3 +1,6 @@
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 import { setImmediate as waitForImmediate } from "node:timers/promises";
 
@@ -6,6 +9,14 @@ import type { OmpNoTurnScheduler, OmpProviderIdleScheduler } from "./agent.js";
 import type { OmpUsagePollScheduler } from "./usage-poller.js";
 import { resolveOmpProviderParams } from "./provider-config.js";
 import { OmpHarness } from "./test-utils/omp-harness.js";
+
+async function createOmpVersionShim(script: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "paseo-omp-version-"));
+  const shim = join(directory, "omp-shim");
+  await writeFile(shim, `#!/bin/sh\n${script}\n`, "utf8");
+  await chmod(shim, 0o755);
+  return shim;
+}
 
 test("OMP ready timeout defaults to 20 seconds and RPC timeout overrides both", () => {
   expect(resolveOmpProviderParams({}).runtimeProviderParams).toMatchObject({
@@ -167,14 +178,14 @@ describe("OMP agent client and session", () => {
     );
   });
 
-  test("applies persisted Fast values before the initial state read on create and resume", async () => {
+  test("restores persisted Fast values from the effective model on create and resume", async () => {
     const created = new OmpHarness();
     await created.start({
       model: "openai-codex/gpt-5.6-luna",
       featureValues: { fast_mode: true },
     });
     expect(created.runtime().setFastModeRequests).toEqual([true]);
-    expect(created.runtime().getStateRequestCount).toBe(1);
+    expect(created.runtime().getStateRequestCount).toBe(2);
 
     const resumed = new OmpHarness();
     await resumed.resume(
@@ -182,7 +193,105 @@ describe("OMP agent client and session", () => {
       { model: "openai-codex/gpt-5.6-luna", featureValues: { fast_mode: false } },
     );
     expect(resumed.runtime().setFastModeRequests).toEqual([false]);
-    expect(resumed.runtime().getStateRequestCount).toBe(1);
+    expect(resumed.runtime().getStateRequestCount).toBe(2);
+  });
+
+  test("restores persisted Fast from the runtime effective model when config model is omitted", async () => {
+    const created = new OmpHarness();
+    created.queueInitialState({ model: { provider: "openai-codex", id: "gpt-5.6-luna" } });
+    await created.start({ featureValues: { fast_mode: true } });
+    expect(created.runtime().setFastModeRequests).toEqual([true]);
+    expect(created.features()).toEqual([expect.objectContaining({ id: "fast_mode", value: true })]);
+
+    const resumed = new OmpHarness();
+    resumed.queueInitialState({ model: { provider: "openai-codex", id: "gpt-5.6-luna" } });
+    await resumed.resume(
+      { user: { id: "u1", text: "hello" }, assistant: { id: "a1", text: "hi" } },
+      { featureValues: { fast_mode: false } },
+    );
+    expect(resumed.runtime().setFastModeRequests).toEqual([false]);
+    expect(resumed.features()).toEqual([
+      expect.objectContaining({ id: "fast_mode", value: false }),
+    ]);
+  });
+
+  test("lets startup succeed without claiming Fast when it is configured but unsupported", async () => {
+    const unsupportedModel = new OmpHarness();
+    await unsupportedModel.start({
+      model: "openai-completions/gpt-5.6-luna",
+      featureValues: { fast_mode: true },
+    });
+    expect(unsupportedModel.runtime().setFastModeRequests).toEqual([]);
+    expect(unsupportedModel.runtime().getStateRequestCount).toBe(1);
+    expect(unsupportedModel.features()).toEqual([]);
+
+    const oldBinary = await createOmpVersionShim('echo "omp 16.3.9"');
+    const oldOmp = new OmpHarness({
+      runtimeSettings: { command: { mode: "replace", argv: [oldBinary] } },
+    });
+    await oldOmp.start({
+      model: "openai-codex/gpt-5.6-luna",
+      featureValues: { fast_mode: true },
+    });
+    expect(oldOmp.runtime().setFastModeRequests).toEqual([]);
+    expect(oldOmp.runtime().getStateRequestCount).toBe(1);
+    delete oldOmp.runtime().state.fastModeEnabled;
+    delete oldOmp.runtime().state.fastModeActive;
+    expect(oldOmp.features()).toEqual([]);
+  });
+  test("hides draft Fast features on old or unknown OMP versions", async () => {
+    const oldBinary = await createOmpVersionShim('echo "omp 16.3.9"');
+    const oldOmp = new OmpHarness({
+      runtimeSettings: { command: { mode: "replace", argv: [oldBinary] } },
+    });
+    await expect(oldOmp.clientFeatures({ model: "openai-codex/gpt-5.6-luna" })).resolves.toEqual(
+      [],
+    );
+
+    const missing = new OmpHarness({
+      runtimeSettings: { command: { mode: "replace", argv: ["/definitely-not-here/omp"] } },
+    });
+    await expect(missing.clientFeatures({ model: "openai-codex/gpt-5.6-luna" })).resolves.toEqual(
+      [],
+    );
+
+    const currentBinary = await createOmpVersionShim('echo "omp 18.1.13"');
+    const current = new OmpHarness({
+      runtimeSettings: { command: { mode: "replace", argv: [currentBinary] } },
+    });
+    await expect(current.clientFeatures({ model: "openai-codex/gpt-5.6-luna" })).resolves.toEqual([
+      expect.objectContaining({ id: "fast_mode", value: false }),
+    ]);
+  });
+
+  test("probes custom replacement commands with their configured argv", async () => {
+    const shim = await createOmpVersionShim(
+      'if [ "$1" = "--profile" ]; then echo "omp 18.1.13"; else echo "omp 0.0.0"; fi',
+    );
+    const custom = new OmpHarness({
+      runtimeSettings: { command: { mode: "replace", argv: [shim, "--profile", "work"] } },
+    });
+    await expect(custom.clientFeatures({ model: "openai-codex/gpt-5.6-luna" })).resolves.toEqual([
+      expect.objectContaining({ id: "fast_mode" }),
+    ]);
+
+    const unforwarded = new OmpHarness({
+      runtimeSettings: { command: { mode: "replace", argv: [shim] } },
+    });
+    await expect(
+      unforwarded.clientFeatures({ model: "openai-codex/gpt-5.6-luna" }),
+    ).resolves.toEqual([]);
+  });
+
+  test("rejects non-boolean Fast values before any RPC or config mutation", async () => {
+    const omp = new OmpHarness();
+    await omp.start({ model: "openai-codex/gpt-5.6-luna" });
+
+    await expect(omp.setFeature("fast_mode", "true")).rejects.toThrow("boolean");
+    await expect(omp.setFeature("fast_mode", 1)).rejects.toThrow("boolean");
+    await expect(omp.setFeature("fast_mode", null)).rejects.toThrow("boolean");
+    expect(omp.runtime().setFastModeRequests).toEqual([]);
+    expect(omp.features()).toEqual([expect.objectContaining({ id: "fast_mode", value: false })]);
   });
 
   test("refreshes state and removes stale Fast values after switching models", async () => {
@@ -200,7 +309,7 @@ describe("OMP agent client and session", () => {
 
     await omp.setModel("nvidia/minimaxai/minimax-m3");
 
-    expect(runtime.getStateRequestCount).toBe(2);
+    expect(runtime.getStateRequestCount).toBe(3);
     expect(omp.features()).toEqual([]);
   });
 

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -235,8 +235,6 @@ describe("OMP agent client and session", () => {
     });
     expect(oldOmp.runtime().setFastModeRequests).toEqual([]);
     expect(oldOmp.runtime().getStateRequestCount).toBe(1);
-    delete oldOmp.runtime().state.fastModeEnabled;
-    delete oldOmp.runtime().state.fastModeActive;
     expect(oldOmp.features()).toEqual([]);
   });
   test("hides draft Fast features on old or unknown OMP versions", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -1309,7 +1309,7 @@ export class OmpAgentSession implements AgentSession {
       throw new Error(`Unknown OMP feature: ${featureId}`);
     }
     const modelId = modelToId(this.state.model) ?? this.config.model ?? null;
-    if (!ompFastModeSupportedForModelId(modelId)) {
+    if (Boolean(value) && !ompFastModeSupportedForModelId(modelId)) {
       throw new Error(`OMP fast mode is not available for model '${modelId ?? "default"}'`);
     }
 

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -42,6 +42,7 @@ import { runProviderRefreshActivity } from "../../provider-refresh-deadline.js";
 import { runProviderTurn } from "../provider-runner.js";
 import {
   checkProviderLaunchAvailable,
+  createProviderEnvSpec,
   resolveProviderLaunch,
   type ProviderRuntimeSettings,
   type ResolvedProviderLaunch,
@@ -58,6 +59,7 @@ import {
 import {
   formatOmpVersionSupport,
   mergeOmpRuntimeSettings,
+  ompVersionSupportsFastMode,
   resolveOmpDiagnosticPaths,
   resolveOmpLaunchMode,
   resolveOmpProviderParams,
@@ -71,6 +73,7 @@ import { shouldDisplayOmpCustomMessage } from "./custom-message.js";
 import { getUserMessageText } from "./message-history.js";
 import { mapOmpSystemNoticeToNotification } from "./system-notice.js";
 import { materializeProviderImage } from "../provider-image-output.js";
+import { execCommand } from "../../../../utils/spawn.js";
 import { OmpCliRuntime } from "./cli-runtime.js";
 import { listOmpImportableSessions, readOmpImportSessionConfig } from "./session-descriptor.js";
 import type { OmpRuntime, OmpRuntimeSession, OmpStartSessionInput } from "./runtime.js";
@@ -1308,12 +1311,15 @@ export class OmpAgentSession implements AgentSession {
     if (featureId !== "fast_mode") {
       throw new Error(`Unknown OMP feature: ${featureId}`);
     }
+    if (typeof value !== "boolean") {
+      throw new Error(`OMP fast mode requires a boolean value, received ${typeof value}`);
+    }
     const modelId = modelToId(this.state.model) ?? this.config.model ?? null;
-    if (Boolean(value) && !ompFastModeSupportedForModelId(modelId)) {
+    if (value && !ompFastModeSupportedForModelId(modelId)) {
       throw new Error(`OMP fast mode is not available for model '${modelId ?? "default"}'`);
     }
 
-    const result = await this.runtimeSession.setFastMode(Boolean(value));
+    const result = await this.runtimeSession.setFastMode(value);
     await this.refreshState();
     this.state = {
       ...this.state,
@@ -2254,6 +2260,7 @@ export class OmpAgentClient implements AgentClient {
   private readonly noTurnScheduler?: OmpNoTurnScheduler;
   private readonly usagePollScheduler?: OmpUsagePollScheduler;
   private readonly runtime: OmpRuntime;
+  private nativeFastModeSupport: Promise<boolean> | null = null;
 
   constructor(options: OmpAgentClientOptions) {
     const { runtimeProviderParams, modelRoleParams } = resolveOmpProviderParams(
@@ -2308,18 +2315,30 @@ export class OmpAgentClient implements AgentClient {
     });
     try {
       await this.configureNativePaseoTools(runtimeSession, launchContext?.paseoTools);
+      const reportedState = await runtimeSession.getState();
+      const effectiveModel = modelToId(reportedState.model) ?? config.model ?? null;
       const configuredFastMode = config.featureValues?.fast_mode;
-      const fastModeResult =
-        typeof configuredFastMode === "boolean" && ompFastModeSupportedForModelId(config.model)
-          ? await runtimeSession.setFastMode(configuredFastMode)
-          : undefined;
-      const initialState = await runtimeSession.getState();
-      if (fastModeResult && config.featureValues) {
-        config.featureValues = {
-          ...config.featureValues,
-          fast_mode: fastModeResult.enabled,
-        };
+      let fastModeApplied = false;
+      if (
+        typeof configuredFastMode === "boolean" &&
+        ompFastModeSupportedForModelId(effectiveModel) &&
+        (await this.supportsNativeFastMode())
+      ) {
+        try {
+          const fastModeResult = await runtimeSession.setFastMode(configuredFastMode);
+          config.featureValues = {
+            ...config.featureValues,
+            fast_mode: fastModeResult.enabled,
+          };
+          fastModeApplied = true;
+        } catch (error) {
+          this.logger.debug(
+            { err: error },
+            "OMP fast mode restore failed; continuing without Fast",
+          );
+        }
       }
+      const initialState = fastModeApplied ? await runtimeSession.getState() : reportedState;
       return new OmpAgentSession({
         runtimeSession,
         config,
@@ -2362,19 +2381,30 @@ export class OmpAgentClient implements AgentClient {
     );
     try {
       await this.configureNativePaseoTools(runtimeSession, launchContext?.paseoTools);
+      const reportedState = await runtimeSession.getState();
+      const effectiveModel = modelToId(reportedState.model) ?? resumeConfig.config.model ?? null;
       const configuredFastMode = resumeConfig.config.featureValues?.fast_mode;
-      const fastModeResult =
+      let fastModeApplied = false;
+      if (
         typeof configuredFastMode === "boolean" &&
-        ompFastModeSupportedForModelId(resumeConfig.config.model)
-          ? await runtimeSession.setFastMode(configuredFastMode)
-          : undefined;
-      const initialState = await runtimeSession.getState();
-      if (fastModeResult && resumeConfig.config.featureValues) {
-        resumeConfig.config.featureValues = {
-          ...resumeConfig.config.featureValues,
-          fast_mode: fastModeResult.enabled,
-        };
+        ompFastModeSupportedForModelId(effectiveModel) &&
+        (await this.supportsNativeFastMode())
+      ) {
+        try {
+          const fastModeResult = await runtimeSession.setFastMode(configuredFastMode);
+          resumeConfig.config.featureValues = {
+            ...resumeConfig.config.featureValues,
+            fast_mode: fastModeResult.enabled,
+          };
+          fastModeApplied = true;
+        } catch (error) {
+          this.logger.debug(
+            { err: error },
+            "OMP fast mode restore failed; continuing without Fast",
+          );
+        }
       }
+      const initialState = fastModeApplied ? await runtimeSession.getState() : reportedState;
       return new OmpAgentSession({
         runtimeSession,
         config: resumeConfig.config,
@@ -2437,6 +2467,9 @@ export class OmpAgentClient implements AgentClient {
 
   async listFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {
     if (!ompFastModeSupportedForModelId(config.model)) {
+      return [];
+    }
+    if (!(await this.supportsNativeFastMode())) {
       return [];
     }
     return [
@@ -2539,5 +2572,28 @@ export class OmpAgentClient implements AgentClient {
       commandConfig: this.runtimeSettings?.command,
       defaultBinary: "omp",
     });
+  }
+
+  private supportsNativeFastMode(): Promise<boolean> {
+    this.nativeFastModeSupport ??= this.probeNativeFastMode();
+    return this.nativeFastModeSupport;
+  }
+
+  private async probeNativeFastMode(): Promise<boolean> {
+    try {
+      const launch = await this.resolveOmpLaunch();
+      const availability = await checkProviderLaunchAvailable(launch);
+      if (availability.available) {
+        const executable = availability.resolvedPath ?? launch.command;
+        const { stdout, stderr } = await execCommand(executable, [...launch.args, "--version"], {
+          ...createProviderEnvSpec({ runtimeSettings: this.runtimeSettings }),
+          timeout: 5_000,
+        });
+        return ompVersionSupportsFastMode(`${stdout}\n${stderr}`);
+      }
+    } catch (error) {
+      this.logger.debug({ err: error }, "OMP fast mode version probe failed");
+    }
+    return false;
   }
 }

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -108,6 +108,10 @@ import {
   mapOmpRpcUiPermissionRequest,
 } from "./rpc-ui-permission-mapper.js";
 import { DEFAULT_OMP_THINKING_LEVEL, mapOmpModel } from "./map-omp-model.js";
+import {
+  CODEX_FAST_MODE_FEATURE,
+  codexModelSupportsFastMode,
+} from "../codex-feature-definitions.js";
 
 const OMP_PROVIDER = "omp";
 const QUESTION_RESPONSE_HEADER = "Response";
@@ -384,6 +388,14 @@ function parseModelReference(modelId: string | null): OmpModelReference | null {
     }
   }
   return { id: modelId };
+}
+
+function ompFastModeSupportedForModelId(modelId: string | null | undefined): boolean {
+  if (typeof modelId !== "string" || modelId.trim().length === 0) {
+    return false;
+  }
+  const reference = parseModelReference(modelId);
+  return reference?.provider === "openai-codex" && codexModelSupportsFastMode(reference.id);
 }
 
 function parsePersistenceMetadata(metadata: AgentMetadata | undefined): OmpPersistenceMetadata {
@@ -938,6 +950,17 @@ export class OmpAgentSession implements AgentSession {
     return this.state.sessionId;
   }
 
+  get features(): AgentFeature[] {
+    const modelId = modelToId(this.state.model) ?? this.config.model ?? null;
+    if (!ompFastModeSupportedForModelId(modelId)) {
+      return [];
+    }
+    if (typeof this.state.fastModeEnabled !== "boolean") {
+      return [];
+    }
+    return [{ ...CODEX_FAST_MODE_FEATURE, value: this.state.fastModeEnabled }];
+  }
+
   async run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult> {
     return runProviderTurn({
       prompt,
@@ -1264,6 +1287,43 @@ export class OmpAgentSession implements AgentSession {
       model,
     };
     this.config.model = `${model.provider}/${model.id}`;
+    await this.refreshState();
+    if (!ompFastModeSupportedForModelId(this.config.model)) {
+      const featureValues = this.config.featureValues;
+      if (featureValues && "fast_mode" in featureValues) {
+        const nextFeatureValues = { ...featureValues };
+        delete nextFeatureValues.fast_mode;
+        this.config.featureValues =
+          Object.keys(nextFeatureValues).length > 0 ? nextFeatureValues : undefined;
+      }
+    } else if (typeof this.state.fastModeEnabled === "boolean") {
+      this.config.featureValues = {
+        ...this.config.featureValues,
+        fast_mode: this.state.fastModeEnabled,
+      };
+    }
+  }
+
+  async setFeature(featureId: string, value: unknown): Promise<void> {
+    if (featureId !== "fast_mode") {
+      throw new Error(`Unknown OMP feature: ${featureId}`);
+    }
+    const modelId = modelToId(this.state.model) ?? this.config.model ?? null;
+    if (!ompFastModeSupportedForModelId(modelId)) {
+      throw new Error(`OMP fast mode is not available for model '${modelId ?? "default"}'`);
+    }
+
+    const result = await this.runtimeSession.setFastMode(Boolean(value));
+    await this.refreshState();
+    this.state = {
+      ...this.state,
+      fastModeEnabled: result.enabled,
+      fastModeActive: result.active,
+    };
+    this.config.featureValues = {
+      ...this.config.featureValues,
+      fast_mode: result.enabled,
+    };
   }
 
   async setThinkingOption(thinkingOptionId: string | null): Promise<void> {
@@ -2248,10 +2308,22 @@ export class OmpAgentClient implements AgentClient {
     });
     try {
       await this.configureNativePaseoTools(runtimeSession, launchContext?.paseoTools);
+      const configuredFastMode = config.featureValues?.fast_mode;
+      const fastModeResult =
+        typeof configuredFastMode === "boolean" && ompFastModeSupportedForModelId(config.model)
+          ? await runtimeSession.setFastMode(configuredFastMode)
+          : undefined;
+      const initialState = await runtimeSession.getState();
+      if (fastModeResult && config.featureValues) {
+        config.featureValues = {
+          ...config.featureValues,
+          fast_mode: fastModeResult.enabled,
+        };
+      }
       return new OmpAgentSession({
         runtimeSession,
         config,
-        initialState: await runtimeSession.getState(),
+        initialState,
         currentModeId: launchMode.modeId,
         logger: this.logger,
         subagentCardScheduler: this.subagentCardScheduler,
@@ -2290,10 +2362,23 @@ export class OmpAgentClient implements AgentClient {
     );
     try {
       await this.configureNativePaseoTools(runtimeSession, launchContext?.paseoTools);
+      const configuredFastMode = resumeConfig.config.featureValues?.fast_mode;
+      const fastModeResult =
+        typeof configuredFastMode === "boolean" &&
+        ompFastModeSupportedForModelId(resumeConfig.config.model)
+          ? await runtimeSession.setFastMode(configuredFastMode)
+          : undefined;
+      const initialState = await runtimeSession.getState();
+      if (fastModeResult && resumeConfig.config.featureValues) {
+        resumeConfig.config.featureValues = {
+          ...resumeConfig.config.featureValues,
+          fast_mode: fastModeResult.enabled,
+        };
+      }
       return new OmpAgentSession({
         runtimeSession,
         config: resumeConfig.config,
-        initialState: await runtimeSession.getState(),
+        initialState,
         currentModeId: launchMode.modeId,
         logger: this.logger,
         subagentCardScheduler: this.subagentCardScheduler,
@@ -2350,8 +2435,16 @@ export class OmpAgentClient implements AgentClient {
     }
   }
 
-  async listFeatures(_config: AgentSessionConfig): Promise<AgentFeature[]> {
-    return [];
+  async listFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {
+    if (!ompFastModeSupportedForModelId(config.model)) {
+      return [];
+    }
+    return [
+      {
+        ...CODEX_FAST_MODE_FEATURE,
+        value: config.featureValues?.fast_mode === true,
+      },
+    ];
   }
 
   async listImportableSessions(

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -193,6 +193,7 @@ interface OmpAgentSessionOptions {
   noTurnScheduler?: OmpNoTurnScheduler;
   usagePollScheduler?: OmpUsagePollScheduler;
   paseoTools?: PaseoToolCatalog;
+  nativeFastModeSupported: boolean;
   /**
    * When false (resumed sessions), replayed session events are dropped until
    * the first prompt or agent_start so history is not re-emitted as live
@@ -414,6 +415,16 @@ function parsePersistenceMetadata(metadata: AgentMetadata | undefined): OmpPersi
     ...(typeof metadata.modeId === "string" ? { modeId: metadata.modeId } : {}),
     ...(typeof metadata.systemPrompt === "string" ? { systemPrompt: metadata.systemPrompt } : {}),
   };
+}
+
+function clearConfiguredFastMode(config: AgentSessionConfig): void {
+  const featureValues = config.featureValues;
+  if (!featureValues || !("fast_mode" in featureValues)) {
+    return;
+  }
+  const nextFeatureValues = { ...featureValues };
+  delete nextFeatureValues.fast_mode;
+  config.featureValues = Object.keys(nextFeatureValues).length > 0 ? nextFeatureValues : undefined;
 }
 
 function buildResumeConfig(
@@ -889,6 +900,7 @@ export class OmpAgentSession implements AgentSession {
   private readonly providerIdleScheduler: OmpProviderIdleScheduler;
   private readonly noTurnScheduler: OmpNoTurnScheduler;
   private readonly usagePoller: OmpUsagePoller;
+  private readonly nativeFastModeSupported: boolean;
   private closed = false;
   private live: boolean;
   private readonly emittedUserMessageIds = new Set<string>();
@@ -900,6 +912,7 @@ export class OmpAgentSession implements AgentSession {
     this.currentModeId = options.currentModeId ?? null;
     this.logger = options.logger;
     this.paseoTools = options.paseoTools;
+    this.nativeFastModeSupported = options.nativeFastModeSupported;
     this.live = options.live ?? true;
     this.providerIdleScheduler = options.providerIdleScheduler ?? createOmpProviderIdleScheduler();
     this.noTurnScheduler = options.noTurnScheduler ?? createOmpNoTurnScheduler();
@@ -954,6 +967,9 @@ export class OmpAgentSession implements AgentSession {
   }
 
   get features(): AgentFeature[] {
+    if (!this.nativeFastModeSupported) {
+      return [];
+    }
     const modelId = modelToId(this.state.model) ?? this.config.model ?? null;
     if (!ompFastModeSupportedForModelId(modelId)) {
       return [];
@@ -2318,11 +2334,12 @@ export class OmpAgentClient implements AgentClient {
       const reportedState = await runtimeSession.getState();
       const effectiveModel = modelToId(reportedState.model) ?? config.model ?? null;
       const configuredFastMode = config.featureValues?.fast_mode;
+      const nativeFastModeSupported = await this.supportsNativeFastMode();
       let fastModeApplied = false;
       if (
         typeof configuredFastMode === "boolean" &&
         ompFastModeSupportedForModelId(effectiveModel) &&
-        (await this.supportsNativeFastMode())
+        nativeFastModeSupported
       ) {
         try {
           const fastModeResult = await runtimeSession.setFastMode(configuredFastMode);
@@ -2336,7 +2353,10 @@ export class OmpAgentClient implements AgentClient {
             { err: error },
             "OMP fast mode restore failed; continuing without Fast",
           );
+          clearConfiguredFastMode(config);
         }
+      } else if (typeof configuredFastMode === "boolean") {
+        clearConfiguredFastMode(config);
       }
       const initialState = fastModeApplied ? await runtimeSession.getState() : reportedState;
       return new OmpAgentSession({
@@ -2350,6 +2370,7 @@ export class OmpAgentClient implements AgentClient {
         noTurnScheduler: this.noTurnScheduler,
         usagePollScheduler: this.usagePollScheduler,
         paseoTools: launchContext?.paseoTools,
+        nativeFastModeSupported,
       });
     } catch (error) {
       await runtimeSession.close().catch(() => undefined);
@@ -2384,11 +2405,12 @@ export class OmpAgentClient implements AgentClient {
       const reportedState = await runtimeSession.getState();
       const effectiveModel = modelToId(reportedState.model) ?? resumeConfig.config.model ?? null;
       const configuredFastMode = resumeConfig.config.featureValues?.fast_mode;
+      const nativeFastModeSupported = await this.supportsNativeFastMode();
       let fastModeApplied = false;
       if (
         typeof configuredFastMode === "boolean" &&
         ompFastModeSupportedForModelId(effectiveModel) &&
-        (await this.supportsNativeFastMode())
+        nativeFastModeSupported
       ) {
         try {
           const fastModeResult = await runtimeSession.setFastMode(configuredFastMode);
@@ -2402,7 +2424,10 @@ export class OmpAgentClient implements AgentClient {
             { err: error },
             "OMP fast mode restore failed; continuing without Fast",
           );
+          clearConfiguredFastMode(resumeConfig.config);
         }
+      } else if (typeof configuredFastMode === "boolean") {
+        clearConfiguredFastMode(resumeConfig.config);
       }
       const initialState = fastModeApplied ? await runtimeSession.getState() : reportedState;
       return new OmpAgentSession({
@@ -2416,6 +2441,7 @@ export class OmpAgentClient implements AgentClient {
         noTurnScheduler: this.noTurnScheduler,
         usagePollScheduler: this.usagePollScheduler,
         paseoTools: launchContext?.paseoTools,
+        nativeFastModeSupported,
         live: false,
       });
     } catch (error) {

--- a/packages/server/src/server/agent/providers/omp/cli-runtime.test.ts
+++ b/packages/server/src/server/agent/providers/omp/cli-runtime.test.ts
@@ -263,6 +263,19 @@ describe("OMP CLI runtime", () => {
     ]);
   });
 
+  test("sends the native set_fast_mode RPC and parses enabled and active", async () => {
+    const child = createOmpChild();
+    const commands: Record<string, unknown>[] = [];
+    replyToCommands(child, (command) => {
+      commands.push(command);
+      return command.type === "set_fast_mode" ? { enabled: true, active: false } : {};
+    });
+    const session = await createRuntime(child).startSession({ cwd: "/workspace/project" });
+
+    await expect(session.setFastMode(true)).resolves.toEqual({ enabled: true, active: false });
+    expect(commands.map(withoutRequestId)).toEqual([{ type: "set_fast_mode", enabled: true }]);
+  });
+
   test("wraps OMP subagent RPC commands", async () => {
     const child = createOmpChild();
     const commands: Record<string, unknown>[] = [];

--- a/packages/server/src/server/agent/providers/omp/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/omp/cli-runtime.ts
@@ -24,6 +24,7 @@ import {
   OmpRuntimeEventSchema,
   OmpSessionStateSchema,
   OmpSessionStatsSchema,
+  OmpSetFastModeResultSchema,
   type OmpThinkingLevel,
   type OmpAgentMessage,
   type OmpModel,
@@ -36,6 +37,7 @@ import {
   type OmpRuntimeEvent,
   type OmpSessionState,
   type OmpSessionStats,
+  type OmpSetFastModeResult,
   type OmpSubagentSubscriptionLevel,
 } from "./rpc-types.js";
 
@@ -180,6 +182,10 @@ class OmpCliRuntimeSession implements OmpRuntimeSession {
 
   async setThinkingLevel(level: OmpThinkingLevel): Promise<void> {
     await this.request({ type: "set_thinking_level", level });
+  }
+
+  async setFastMode(enabled: boolean): Promise<OmpSetFastModeResult> {
+    return OmpSetFastModeResultSchema.parse(await this.request({ type: "set_fast_mode", enabled }));
   }
 
   async getSessionStats(): Promise<OmpSessionStats> {

--- a/packages/server/src/server/agent/providers/omp/provider-config.ts
+++ b/packages/server/src/server/agent/providers/omp/provider-config.ts
@@ -12,6 +12,42 @@ const DEFAULT_OMP_READY_TIMEOUT_MS = 20_000;
 const DEFAULT_OMP_RPC_TIMEOUT_MS = 60_000;
 
 export const MIN_SUPPORTED_OMP_VERSION = "16.3.9";
+
+/**
+ * First tagged OMP release containing native `set_fast_mode` (landed upstream
+ * in commit abc2159). Fast stays hidden on older installs even though the
+ * general minimum below them is lower.
+ */
+export const MIN_FAST_MODE_OMP_VERSION = "18.1.0";
+
+export function parseOmpVersion(versionOutput: string): [number, number, number] | null {
+  const match = versionOutput.match(/(\d+)\.(\d+)\.(\d+)\b/);
+  if (!match) {
+    return null;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function isOmpVersionAtLeast(versionOutput: string, minimum: string): boolean {
+  const installed = parseOmpVersion(versionOutput);
+  const floor = parseOmpVersion(minimum);
+  if (!installed || !floor) {
+    return false;
+  }
+  for (let index = 0; index < 3; index += 1) {
+    if (installed[index]! > floor[index]!) {
+      return true;
+    }
+    if (installed[index]! < floor[index]!) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function ompVersionSupportsFastMode(versionOutput: string): boolean {
+  return isOmpVersionAtLeast(versionOutput, MIN_FAST_MODE_OMP_VERSION);
+}
 export { OMP_MODES };
 
 export const OmpProviderParamsSchema = z
@@ -117,16 +153,10 @@ export function resolveOmpDiagnosticPaths(
 }
 
 export function formatOmpVersionSupport(versionOutput: string): string {
-  const match = versionOutput.match(/(\d+)\.(\d+)\.(\d+)\b/);
-  if (!match) return `unknown (minimum ${MIN_SUPPORTED_OMP_VERSION})`;
-  const installed = [Number(match[1]), Number(match[2]), Number(match[3])];
-  const minimum = MIN_SUPPORTED_OMP_VERSION.split(".").map(Number);
-  const supported =
-    installed[0]! > minimum[0]! ||
-    (installed[0] === minimum[0] &&
-      (installed[1]! > minimum[1]! ||
-        (installed[1] === minimum[1]! && installed[2]! >= minimum[2]!)));
-  return `${match[1]}.${match[2]}.${match[3]} (${supported ? "supported" : "unsupported"}; minimum ${MIN_SUPPORTED_OMP_VERSION})`;
+  const installed = parseOmpVersion(versionOutput);
+  if (!installed) return `unknown (minimum ${MIN_SUPPORTED_OMP_VERSION})`;
+  const supported = isOmpVersionAtLeast(versionOutput, MIN_SUPPORTED_OMP_VERSION);
+  return `${installed[0]}.${installed[1]}.${installed[2]} (${supported ? "supported" : "unsupported"}; minimum ${MIN_SUPPORTED_OMP_VERSION})`;
 }
 
 export function resolveOmpProviderParams(providerParams: unknown): {

--- a/packages/server/src/server/agent/providers/omp/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/omp/rpc-types.ts
@@ -128,6 +128,8 @@ export const OmpSessionStateSchema = z
     isStreaming: z.boolean(),
     isCompacting: z.boolean(),
     autoCompactionEnabled: z.boolean().optional(),
+    fastModeEnabled: z.boolean().optional(),
+    fastModeActive: z.boolean().optional(),
     sessionFile: z.string().optional(),
     sessionId: z.string(),
     sessionName: z.string().optional(),
@@ -544,6 +546,7 @@ export const OmpRpcCommandSchema = z.discriminatedUnion("type", [
     type: z.literal("handoff"),
     customInstructions: z.string().optional(),
   }),
+  z.object({ ...OmpCommandBase, type: z.literal("set_fast_mode"), enabled: z.boolean() }),
 ]);
 
 export const OmpPromptAckSchema = z
@@ -570,6 +573,9 @@ export const OmpBranchMessagesResultSchema = z
     messages: z.array(z.object({ entryId: z.string(), text: z.string() }).passthrough()).optional(),
   })
   .passthrough();
+export const OmpSetFastModeResultSchema = z
+  .object({ enabled: z.boolean(), active: z.boolean() })
+  .passthrough();
 
 export type OmpThinkingLevel = z.infer<typeof OmpThinkingLevelSchema>;
 export type OmpImageContent = z.infer<typeof OmpImageContentSchema>;
@@ -582,6 +588,7 @@ export type OmpModel = z.infer<typeof OmpModelSchema>;
 export type OmpModelThinking = z.infer<typeof OmpModelThinkingSchema>;
 export type OmpSessionState = z.infer<typeof OmpSessionStateSchema>;
 export type OmpSessionStats = z.infer<typeof OmpSessionStatsSchema>;
+export type OmpSetFastModeResult = z.infer<typeof OmpSetFastModeResultSchema>;
 export type OmpRpcSlashCommand = z.infer<typeof OmpRpcSlashCommandSchema>;
 export type OmpAgentToolResult = z.infer<typeof OmpAgentToolResultSchema>;
 export type OmpRpcHostToolDefinition = z.infer<typeof OmpRpcHostToolDefinitionSchema>;

--- a/packages/server/src/server/agent/providers/omp/runtime.ts
+++ b/packages/server/src/server/agent/providers/omp/runtime.ts
@@ -9,6 +9,7 @@ import type {
   OmpRuntimeEvent,
   OmpSessionState,
   OmpSessionStats,
+  OmpSetFastModeResult,
   OmpSubagentSubscriptionLevel,
   OmpThinkingLevel,
 } from "./rpc-types.js";
@@ -56,6 +57,7 @@ export interface OmpRuntimeSession {
   getAvailableModels(timeoutMs?: number | null): Promise<OmpModel[]>;
   setModel(provider: string, modelId: string): Promise<OmpModel>;
   setThinkingLevel(level: OmpThinkingLevel): Promise<void>;
+  setFastMode(enabled: boolean): Promise<OmpSetFastModeResult>;
   getSessionStats(): Promise<OmpSessionStats>;
   getCommands(): Promise<OmpRpcSlashCommand[]>;
   setSubagentSubscription(level: OmpSubagentSubscriptionLevel): Promise<void>;

--- a/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
@@ -59,11 +59,11 @@ export class FakeOmp implements OmpRuntime {
     FakeOmpSubagentSubscriptionLevel,
     Error
   >();
+  private readonly initialStatePatches: Array<Partial<OmpSessionState>> = [];
 
   constructor(command: [string, ...string[]] = ["omp"]) {
     this.command = command;
   }
-
   async startSession(input: OmpStartSessionInput): Promise<FakeOmpSession> {
     const launch = buildOmpLaunch({
       command: this.command,
@@ -71,6 +71,10 @@ export class FakeOmp implements OmpRuntime {
     });
     this.recordedLaunches.push(launch);
     const session = new FakeOmpSession(launch);
+    const initialStatePatch = this.initialStatePatches.shift();
+    if (initialStatePatch) {
+      session.state = { ...session.state, ...initialStatePatch };
+    }
     session.commands = this.queuedCommands.shift() ?? [];
     for (const [level, error] of this.queuedSubagentSubscriptionErrors) {
       session.subagentSubscriptionErrors.set(level, error);
@@ -82,6 +86,9 @@ export class FakeOmp implements OmpRuntime {
 
   queueCommands(commands: OmpRpcSlashCommand[]): void {
     this.queuedCommands.push(commands);
+  }
+  queueInitialStatePatch(patch: Partial<OmpSessionState>): void {
+    this.initialStatePatches.push(patch);
   }
 
   failNextSubagentSubscription(level: FakeOmpSubagentSubscriptionLevel, error: Error): void {

--- a/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
@@ -15,6 +15,7 @@ import type {
   OmpRuntimeEvent,
   OmpSessionState,
   OmpSessionStats,
+  OmpSetFastModeResult,
   OmpThinkingLevel,
 } from "../rpc-types.js";
 import { buildOmpLaunch } from "../runtime.js";
@@ -104,6 +105,7 @@ export class FakeOmpSession implements OmpRuntimeSession {
   readonly subagentMessageRequests: FakeOmpSubagentMessagesSelector[] = [];
   readonly setModelRequests: Array<{ provider: string; modelId: string }> = [];
   readonly setThinkingLevelRequests: OmpThinkingLevel[] = [];
+  readonly setFastModeRequests: boolean[] = [];
   readonly handoffRequests: Array<{ customInstructions?: string }> = [];
   readonly steerRequests: Array<{ message: string; imageCount: number }> = [];
   readonly followUpRequests: Array<{ message: string; imageCount: number }> = [];
@@ -119,6 +121,8 @@ export class FakeOmpSession implements OmpRuntimeSession {
     response: { value?: string; confirmed?: boolean; cancelled?: boolean };
   }> = [];
   setModelResult: OmpModel | null = null;
+  setFastModeResult: OmpSetFastModeResult | null = null;
+  setFastModeError: Error | null = null;
   models: OmpModel[] = [];
   messages: OmpAgentMessage[] = [];
   stats: OmpSessionStats = {
@@ -157,6 +161,8 @@ export class FakeOmpSession implements OmpRuntimeSession {
       isStreaming: false,
       isCompacting: false,
       autoCompactionEnabled: true,
+      fastModeEnabled: false,
+      fastModeActive: false,
       sessionFile: launch.session ?? "/tmp/omp-session",
       sessionId: "omp-session-1",
       messageCount: 0,
@@ -288,6 +294,20 @@ export class FakeOmpSession implements OmpRuntimeSession {
 
   async setThinkingLevel(level: OmpThinkingLevel): Promise<void> {
     this.setThinkingLevelRequests.push(level);
+  }
+
+  async setFastMode(enabled: boolean): Promise<OmpSetFastModeResult> {
+    this.setFastModeRequests.push(enabled);
+    if (this.setFastModeError) {
+      throw this.setFastModeError;
+    }
+    const result = this.setFastModeResult ?? { enabled, active: enabled };
+    this.state = {
+      ...this.state,
+      fastModeEnabled: result.enabled,
+      fastModeActive: result.active,
+    };
+    return result;
   }
 
   async getSessionStats(): Promise<OmpSessionStats> {

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -11,7 +11,7 @@ import type {
   AgentStreamEvent,
   AgentTimelineItem,
 } from "../../../agent-sdk-types.js";
-import type { PaseoToolCatalog } from "../../../tools/types.js";
+import type { ProviderRuntimeSettings } from "../../../provider-launch-config.js";
 import {
   OmpAgentClient,
   OmpAgentSession,
@@ -20,7 +20,7 @@ import {
 } from "../agent.js";
 import type { OmpUsagePollScheduler } from "../usage-poller.js";
 import type { AgentFeature } from "../../../agent-sdk-types.js";
-import type { OmpAgentMessage, OmpRpcSlashCommand } from "../rpc-types.js";
+import type { OmpAgentMessage, OmpRpcSlashCommand, OmpSessionState } from "../rpc-types.js";
 import { FakeOmp } from "./fake-omp.js";
 
 const CWD = "/tmp/paseo-omp-agent-test";
@@ -72,11 +72,13 @@ export class OmpHarness {
       providerIdleScheduler?: OmpProviderIdleScheduler;
       noTurnScheduler?: OmpNoTurnScheduler;
       usagePollScheduler?: OmpUsagePollScheduler;
+      runtimeSettings?: ProviderRuntimeSettings;
     } = {},
   ) {
     this.client = new OmpAgentClient({
       logger: pino({ level: "silent" }),
       runtime: this.omp,
+      runtimeSettings: options.runtimeSettings,
       providerIdleScheduler: options.providerIdleScheduler,
       noTurnScheduler: options.noTurnScheduler,
       usagePollScheduler: options.usagePollScheduler,
@@ -85,6 +87,10 @@ export class OmpHarness {
 
   queueCommands(commands: OmpRpcSlashCommand[]): void {
     this.omp.queueCommands(commands);
+  }
+
+  queueInitialState(patch: Partial<OmpSessionState>): void {
+    this.omp.queueInitialStatePatch(patch);
   }
 
   failEventSubscription(error: Error): void {

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -19,6 +19,7 @@ import {
   type OmpProviderIdleScheduler,
 } from "../agent.js";
 import type { OmpUsagePollScheduler } from "../usage-poller.js";
+import type { AgentFeature } from "../../../agent-sdk-types.js";
 import type { OmpAgentMessage, OmpRpcSlashCommand } from "../rpc-types.js";
 import { FakeOmp } from "./fake-omp.js";
 
@@ -444,6 +445,22 @@ export class OmpHarness {
 
   async setMode(modeId: string) {
     return await this.requireSession().setMode(modeId);
+  }
+
+  features(): AgentFeature[] {
+    return this.requireSession().features ?? [];
+  }
+
+  async clientFeatures(config: Partial<AgentSessionConfig> = {}): Promise<AgentFeature[]> {
+    return await this.client.listFeatures({ provider: "omp", cwd: CWD, ...config });
+  }
+
+  async setFeature(featureId: string, value: unknown): Promise<void> {
+    await this.requireSession().setFeature?.(featureId, value);
+  }
+
+  async setModel(modelId: string | null): Promise<void> {
+    await this.requireSession().setModel?.(modelId);
   }
 
   async rewind(messageId: string, restoredPrompt: string): Promise<void> {

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -1507,6 +1507,36 @@ describe("PiRpcAgentSession", () => {
     expect(fakeSession.setThinkingLevelRequests).toEqual(["high"]);
   });
 
+  test("clears requested Fast when switching to an ineligible model", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const session = (await client.createSession(
+      createConfig({
+        model: "openai-codex/gpt-5.6-luna",
+        featureValues: { fast_mode: true },
+      }),
+    )) as PiRpcAgentSession;
+    const fakeSession = pi.latestSession();
+
+    await session.setFeature("fast_mode", true);
+    expect(fakeSession.fastModeRequested).toBe(true);
+
+    fakeSession.setModelResult = { provider: "openrouter", id: "model-a", name: "Model A" };
+    await session.setModel("openrouter/model-a");
+    expect(fakeSession.fastModeRequests).toContainEqual({ enabled: false, eligible: false });
+    expect(fakeSession.fastModeRequested).toBe(false);
+
+    fakeSession.setModelResult = {
+      provider: "openai-codex",
+      id: "gpt-5.6-luna",
+      name: "GPT-5.6 Luna",
+    };
+    await session.setModel("openai-codex/gpt-5.6-luna");
+    expect(fakeSession.fastModeRequested).toBe(false);
+    expect(session.features).toEqual([expect.objectContaining({ id: "fast_mode", value: false })]);
+    await session.close();
+  });
+
   test("materializes image prompts as text hints for text-only Pi models", async () => {
     const { pi, session } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -87,6 +87,10 @@ import {
   type PiToolResult,
   type PiTrackedToolCall,
 } from "./tool-call-mapper.js";
+import {
+  CODEX_FAST_MODE_FEATURE,
+  codexModelSupportsFastMode,
+} from "../codex-feature-definitions.js";
 
 const PI_PROVIDER = "pi";
 const DEFAULT_PI_THINKING_LEVEL: PiThinkingLevel = "medium";
@@ -96,6 +100,7 @@ const PASEO_PI_CAPTURE_EXTENSION_COMMAND = "paseo_capture_entries";
 const PASEO_PI_ENTRY_CAPTURE_MARKER = "PASEO_ENTRY_CAPTURE";
 const PASEO_PI_SUBMITTED_USER_ENTRY_MARKER = "PASEO_SUBMITTED_USER_ENTRY";
 const PASEO_PI_COMMAND_RESULT_MARKER = "PASEO_COMMAND_RESULT";
+const PASEO_PI_FAST_MODE_EXTENSION_COMMAND = "paseo_fast_mode";
 const DEFAULT_PI_EXTENSION_RESULT_TIMEOUT_MS = 30_000;
 const DEFAULT_PI_RPC_TIMEOUT_MS = 60_000;
 const QUESTION_RESPONSE_HEADER = "Response";
@@ -614,7 +619,10 @@ function createPiMcpConfigFile(
   };
 }
 
-function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
+function createPiPaseoExtensionFile(
+  systemPrompt?: string,
+  options?: { fastModeEnabled?: boolean; fastModeEligible?: boolean },
+): PiTempFile {
   const dir = mkdtempSync(join(tmpdir(), "paseo-pi-extension-"));
   const filePath = join(dir, "paseo-integration.mjs");
   writeFileSync(
@@ -669,6 +677,34 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 
 	export default function paseoIntegration(pi) {
 	  const submittedUserMessages = [];
+	  let fastModeRequested = ${options?.fastModeEnabled === true ? "true" : "false"};
+	  let fastModeEligible = ${options?.fastModeEligible === true ? "true" : "false"};
+	  let fastModeEnabled = fastModeRequested && fastModeEligible;
+
+	  pi.on("before_provider_request", (event) => {
+	    if (
+	      !fastModeEnabled ||
+	      !fastModeEligible ||
+	      !event.payload ||
+	      typeof event.payload !== "object" ||
+	      Array.isArray(event.payload)
+	    ) {
+	      return event.payload;
+	    }
+	    return { ...event.payload, service_tier: "priority" };
+	  });
+
+	  pi.on("model_select", (event) => {
+	    const provider = event?.model?.provider;
+	    const modelId = event?.model?.id;
+	    fastModeEligible =
+	      provider === "openai-codex" &&
+	      typeof modelId === "string" &&
+	      ["gpt-5", "gpt-4.1", "o3", "o4-mini"].some(
+	        (prefix) => modelId === prefix || modelId.startsWith(prefix),
+	      );
+	    fastModeEnabled = fastModeRequested && fastModeEligible;
+	  });
 
 	  function emitSubmittedUserEntries(ctx) {
 	    const entries = ctx.sessionManager.getEntries();
@@ -744,6 +780,36 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 	      }
 	    },
 	  });
+
+	  pi.registerCommand("${PASEO_PI_FAST_MODE_EXTENSION_COMMAND}", {
+	    description: "Internal Paseo Fast-mode bridge",
+	    handler: async (args, ctx) => {
+	      const payload = decodePayload(args.trim());
+	      if (payload.setRequested !== false) {
+	        if (typeof payload.enabled !== "boolean") {
+	          emitCommandResult(ctx, payload.requestId, {
+	            ok: false,
+	            error: "Pi Fast mode requires a boolean enabled value",
+	          });
+	          return;
+	        }
+	        fastModeRequested = payload.enabled;
+	      }
+	      if (typeof payload.eligible !== "boolean") {
+	        emitCommandResult(ctx, payload.requestId, {
+	          ok: false,
+	          error: "Pi Fast mode requires a boolean eligible value",
+	        });
+	        return;
+	      }
+	      fastModeEligible = payload.eligible;
+	      fastModeEnabled = fastModeRequested && fastModeEligible;
+	      emitCommandResult(ctx, payload.requestId, {
+	        ok: true,
+	        result: { enabled: fastModeEnabled, eligible: fastModeEligible },
+	      });
+	    },
+	  });
 	}
 `.trimStart(),
     "utf8",
@@ -801,6 +867,14 @@ function resolveThinkingOptionId(
 
 function modelToId(model: PiModel | null | undefined): string | null {
   return model?.provider && model.id ? `${model.provider}/${model.id}` : null;
+}
+
+function piFastModeSupportedForModelId(modelId: string | null | undefined): boolean {
+  if (typeof modelId !== "string" || modelId.trim().length === 0) {
+    return false;
+  }
+  const reference = parseModelReference(modelId);
+  return reference?.provider === "openai-codex" && codexModelSupportsFastMode(reference.id);
 }
 
 function piAssistantText(message: Extract<PiAgentMessage, { role: "assistant" }>): string | null {
@@ -1306,6 +1380,19 @@ export class PiRpcAgentSession implements AgentSession {
     return this.state.sessionId;
   }
 
+  get features(): AgentFeature[] {
+    const modelId = modelToId(this.state.model) ?? this.config.model ?? null;
+    if (!piFastModeSupportedForModelId(modelId)) {
+      return [];
+    }
+    return [
+      {
+        ...CODEX_FAST_MODE_FEATURE,
+        value: this.config.featureValues?.fast_mode === true,
+      },
+    ];
+  }
+
   async run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult> {
     return runProviderTurn({
       prompt,
@@ -1694,6 +1781,41 @@ export class PiRpcAgentSession implements AgentSession {
       model,
     };
     this.config.model = `${model.provider}/${model.id}`;
+    const fastModeEligible = piFastModeSupportedForModelId(modelToId(model));
+    if (typeof this.config.featureValues?.fast_mode === "boolean") {
+      await this.updateFastModeEligibility(fastModeEligible);
+    }
+    if (!fastModeEligible) {
+      const featureValues = this.config.featureValues;
+      if (featureValues && "fast_mode" in featureValues) {
+        const nextFeatureValues = { ...featureValues };
+        delete nextFeatureValues.fast_mode;
+        this.config.featureValues =
+          Object.keys(nextFeatureValues).length > 0 ? nextFeatureValues : undefined;
+      }
+    }
+  }
+
+  async setFeature(featureId: string, value: unknown): Promise<void> {
+    if (featureId !== "fast_mode") {
+      throw new Error(`Unknown Pi feature: ${featureId}`);
+    }
+    if (typeof value !== "boolean") {
+      throw new Error(`Pi fast mode requires a boolean value, received ${typeof value}`);
+    }
+    const modelId = modelToId(this.state.model) ?? this.config.model ?? null;
+    const fastModeEligible = piFastModeSupportedForModelId(modelId);
+    if (value && !fastModeEligible) {
+      throw new Error(`Pi fast mode is not available for model '${modelId ?? "default"}'`);
+    }
+    const result = await this.sendFastModeCommand({
+      enabled: value,
+      eligible: fastModeEligible,
+    });
+    this.config.featureValues = {
+      ...this.config.featureValues,
+      fast_mode: result.enabled,
+    };
   }
 
   async setThinkingOption(thinkingOptionId: string | null): Promise<void> {
@@ -1922,6 +2044,45 @@ export class PiRpcAgentSession implements AgentSession {
     const payload = Buffer.from(JSON.stringify({ requestId, reason })).toString("base64url");
     await this.runtimeSession.prompt(`/${PASEO_PI_CAPTURE_EXTENSION_COMMAND} ${payload}`);
     await resultPromise;
+  }
+
+  private async updateFastModeEligibility(eligible: boolean): Promise<void> {
+    await this.sendFastModeCommand({ setRequested: false, eligible });
+  }
+
+  private async sendFastModeCommand(input: {
+    enabled?: boolean;
+    eligible: boolean;
+    setRequested?: boolean;
+  }): Promise<{ enabled: boolean; eligible: boolean }> {
+    const requestId = randomUUID();
+    const resultPromise = this.waitForExtensionResult(requestId);
+    const payload = Buffer.from(
+      JSON.stringify({
+        requestId,
+        eligible: input.eligible,
+        ...(input.setRequested === false ? { setRequested: false } : { enabled: input.enabled }),
+      }),
+    ).toString("base64url");
+    try {
+      await this.runtimeSession.prompt(`/${PASEO_PI_FAST_MODE_EXTENSION_COMMAND} ${payload}`);
+    } catch (error) {
+      this.rejectExtensionResult(
+        requestId,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      throw error;
+    }
+    const result = await resultPromise;
+    if (
+      !result ||
+      typeof result !== "object" ||
+      typeof (result as { enabled?: unknown }).enabled !== "boolean" ||
+      typeof (result as { eligible?: unknown }).eligible !== "boolean"
+    ) {
+      throw new Error("Pi fast mode returned an invalid extension result");
+    }
+    return result as { enabled: boolean; eligible: boolean };
   }
 
   private waitForExtensionResult(requestId: string): Promise<unknown> {
@@ -2536,6 +2697,10 @@ export class PiRpcAgentClient implements AgentClient {
     const mcpConfig = await this.prepareMcpConfig(config.cwd, config.mcpServers, mcpEnv);
     const paseoExtension = createPiPaseoExtensionFile(
       composeSystemPromptParts(config.systemPrompt, config.daemonAppendSystemPrompt),
+      {
+        fastModeEnabled: config.featureValues?.fast_mode === true,
+        fastModeEligible: piFastModeSupportedForModelId(config.model),
+      },
     );
     let runtimeSession: PiRuntimeSession;
     try {
@@ -2600,6 +2765,10 @@ export class PiRpcAgentClient implements AgentClient {
         resumeConfig.config.systemPrompt,
         resumeConfig.config.daemonAppendSystemPrompt,
       ),
+      {
+        fastModeEnabled: resumeConfig.config.featureValues?.fast_mode === true,
+        fastModeEligible: piFastModeSupportedForModelId(resumeConfig.config.model),
+      },
     );
     let runtimeSession: PiRuntimeSession;
     try {
@@ -2673,8 +2842,16 @@ export class PiRpcAgentClient implements AgentClient {
     }
   }
 
-  async listFeatures(_config: AgentSessionConfig): Promise<AgentFeature[]> {
-    return [];
+  async listFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {
+    if (!piFastModeSupportedForModelId(config.model)) {
+      return [];
+    }
+    return [
+      {
+        ...CODEX_FAST_MODE_FEATURE,
+        value: config.featureValues?.fast_mode === true,
+      },
+    ];
   }
 
   async listImportableSessions(

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2047,7 +2047,11 @@ export class PiRpcAgentSession implements AgentSession {
   }
 
   private async updateFastModeEligibility(eligible: boolean): Promise<void> {
-    await this.sendFastModeCommand({ setRequested: false, eligible });
+    if (!eligible) {
+      await this.sendFastModeCommand({ enabled: false, eligible: false });
+      return;
+    }
+    await this.sendFastModeCommand({ setRequested: false, eligible: true });
   }
 
   private async sendFastModeCommand(input: {

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -103,6 +103,12 @@ export class FakePiSession implements PiRuntimeSession {
   readonly subagentSubscriptionRequests: FakePiSubagentSubscriptionLevel[] = [];
   readonly subagentMessageRequests: FakePiSubagentMessagesSelector[] = [];
   readonly setModelRequests: Array<{ provider: string; modelId: string }> = [];
+  readonly fastModeRequests: Array<{
+    enabled?: boolean;
+    eligible: boolean;
+    setRequested?: boolean;
+  }> = [];
+  fastModeEnabled = false;
   readonly setThinkingLevelRequests: string[] = [];
   readonly treeNavigationRequests: string[] = [];
   readonly handoffRequests: Array<{ customInstructions?: string }> = [];
@@ -181,6 +187,7 @@ export class FakePiSession implements PiRuntimeSession {
     }
     this.handleTreeNavigationCommand(message);
     this.handleEntryCaptureCommand(message);
+    this.handleFastModeCommand(message);
     return this.promptAck;
   }
 
@@ -443,6 +450,41 @@ export class FakePiSession implements PiRuntimeSession {
       payload.requestId,
       typeof payload.reason === "string" ? payload.reason : "command",
     );
+  }
+
+  private handleFastModeCommand(message: string): void {
+    const prefix = "/paseo_fast_mode ";
+    if (!message.startsWith(prefix)) {
+      return;
+    }
+    const payload = JSON.parse(
+      Buffer.from(message.slice(prefix.length), "base64url").toString("utf8"),
+    ) as {
+      requestId?: unknown;
+      enabled?: unknown;
+      eligible?: unknown;
+      setRequested?: unknown;
+    };
+    if (typeof payload.requestId !== "string" || typeof payload.eligible !== "boolean") {
+      return;
+    }
+    this.fastModeRequests.push({
+      ...(typeof payload.enabled === "boolean" ? { enabled: payload.enabled } : {}),
+      eligible: payload.eligible,
+      ...(payload.setRequested === false ? { setRequested: false } : {}),
+    });
+    if (payload.setRequested !== false) {
+      this.fastModeEnabled = payload.enabled === true && payload.eligible;
+    } else if (!payload.eligible) {
+      this.fastModeEnabled = false;
+    }
+    this.emitExtensionCommandResult(payload.requestId, {
+      ok: true,
+      result: {
+        enabled: this.fastModeEnabled,
+        eligible: payload.eligible,
+      },
+    });
   }
 
   emitEntryCapture(requestId?: string, reason = "test"): void {

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -108,6 +108,7 @@ export class FakePiSession implements PiRuntimeSession {
     eligible: boolean;
     setRequested?: boolean;
   }> = [];
+  fastModeRequested = false;
   fastModeEnabled = false;
   readonly setThinkingLevelRequests: string[] = [];
   readonly treeNavigationRequests: string[] = [];
@@ -474,10 +475,9 @@ export class FakePiSession implements PiRuntimeSession {
       ...(payload.setRequested === false ? { setRequested: false } : {}),
     });
     if (payload.setRequested !== false) {
-      this.fastModeEnabled = payload.enabled === true && payload.eligible;
-    } else if (!payload.eligible) {
-      this.fastModeEnabled = false;
+      this.fastModeRequested = payload.enabled === true;
     }
+    this.fastModeEnabled = this.fastModeRequested && payload.eligible;
     this.emitExtensionCommandResult(payload.requestId, {
       ok: true,
       result: {


### PR DESCRIPTION
## Summary

Expose Paseo's Fast/lightning control for OpenAI Codex models through both the OMP adapter's native RPC and the local Pi adapter's session extension bridge.

The OMP path uses native `set_fast_mode` state/control. The Pi path uses Pi's `before_provider_request` hook to add `service_tier: "priority"` only for an explicitly enabled, eligible `openai-codex/*` session. Neither path uses model aliases, gateway rewrites, or global provider configuration changes.

## Changes

### OMP

- Add optional `fastModeEnabled` / `fastModeActive` state fields and typed `set_fast_mode` RPC schemas.
- Implement `OmpCliRuntimeSession.setFastMode()` with strict response parsing.
- Advertise Fast only for supported `openai-codex/*` models and OMP runtimes known to support native Fast (OMP >= 18.1.0).
- Probe the configured OMP command's `--version` once per adapter instance, sharing concurrent in-flight checks; custom replacement commands use their configured argv.
- Validate `fast_mode` values as booleans before any RPC or config mutation.
- On create/resume, read native state first and derive the effective model from that state, then restore persisted `featureValues.fast_mode` when supported. A failed or unavailable restore does not prevent startup.
- Refresh native state after live toggles and model changes; keep requested/enabled state separate from native active state.
- Keep unsupported-model, old-OMP, and unknown-OMP behavior explicit: no fallback or alias path.

### Pi

- Add the same `fast_mode` feature to `PiRpcAgentSession` for eligible `openai-codex/*` models.
- Extend the existing generated `paseo-integration.mjs` session extension with session-local Fast state and an internal `paseo_fast_mode` command.
- Rewrite eligible Pi provider payloads with `service_tier: "priority"` only while Fast is enabled; preserve all other request fields.
- Recompute eligibility after Pi model/provider changes and clear stale Fast state when a fallback is unsupported.
- Keep the bridge adapter-owned and local to the session. It does not change Pi authentication, `end-pi-multi-pass` pools, `.pi/multi-pass.json`, OMP configuration, or provider routing.
- `end-pi-multi-pass@0.0.8` is compatible: it handles subscription/session/model failover but does not register `before_provider_request`, so there is no hook collision.

## Verification

- OMP focused Vitest: `agent.test.ts`, `agent.diagnostic.test.ts`, and `cli-runtime.test.ts` — 3 files, 61/61 tests passed.
- Pi focused Vitest: 3 Pi files — 110/110 tests passed.
- `oxfmt` checks passed on the changed source files; `oxlint` reported 0 warnings and 0 errors on the OMP changes.
- Server typecheck/build reports only the same 3 pre-existing `src/server/session.ts` protocol-drift errors (`pluginTimelineItems` / `workspaceSetupBlocked`); no changed OMP/Pi-file diagnostics.
- Live desktop-managed Paseo smoke passed after restart with provider `pi`, model `openai-codex/gpt-5.6-luna`, thinking `low`, `fast_mode: true`, and exact output `OK`; the agent ended `idle` and loopback health returned `200`.
- Installed Pi is `0.85.1`; installed `end-pi-multi-pass` is `0.0.8`.

## Scope and non-goals

- Do not create custom “Fast” model aliases.
- Do not change OMP's global `tier.openai` configuration semantics.
- Do not make Pi or OMP wrappers rewrite service-tier arguments outside an explicitly enabled eligible session.
- Do not change the direct Codex provider's existing Fast behavior.
- Do not modify `end-pi-multi-pass` itself.

Closes #4437
