### PR TITLE
Accept prerelease Paseo versions in plugin requirements and prepare plugin docs for the 0.8 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Run agents in parallel on your own machines. Ship from your phone or your desk.
 - **Cross-device:** iOS, Android, desktop, web, and CLI. Start work at your desk, check in from your phone, script it from the terminal.
 - **Privacy-first:** Paseo doesn't have any telemetry, tracking, or forced log-ins.
 
+## Plugins
+
+Add themes, workspace panels, commands, settings screens, and coding-agent providers with trusted
+TypeScript plugins. Install from a local directory or Git repository with `paseo plugin add <source>`.
+
+See the [plugin docs](https://paseo.sh/docs/plugins) for your Paseo version, or start with the
+[0.8 beta quickstart](https://paseo.sh/docs/plugins/v0.8). Plugins run with access to your daemon
+machine and inside connected clients; install only code you trust.
+
 ## Getting Started
 
 Paseo runs a local server called the daemon that manages your coding agents. Clients like the desktop app, mobile app, web app, and CLI connect to it.

--- a/packages/protocol/src/plugin-requirements.test.ts
+++ b/packages/protocol/src/plugin-requirements.test.ts
@@ -1,24 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { assertPluginCompatibility, validatePluginRequirements } from "./plugin-requirements.js";
 
-describe("plugin requirements", () => {
+describe.each(["daemon", "app"] as const)("plugin requirements on %s", (runtime) => {
   it("rejects legacy manifests on the first breaking release with migration instructions", () => {
-    expect(() =>
-      assertPluginCompatibility({ id: "legacy", version: "0.8.0", runtime: "daemon" }),
-    ).toThrow(/legacy.*<0\.8\.0.*0\.8\.0.*https:\/\/paseo.sh\/docs\/plugins\/v0.8\/migration/);
+    expect(() => assertPluginCompatibility({ id: "legacy", version: "0.8.0", runtime })).toThrow(
+      /legacy.*<0\.8\.0.*0\.8\.0.*https:\/\/paseo.sh\/docs\/plugins\/v0.8\/migration/,
+    );
   });
 
   it.each([
     [undefined, "0.7.2"],
     [">=0.8.0", "0.8.0"],
+    [">=0.8.0", "0.8.0-beta.1"],
     [">=0.8.0", "1.0.0"],
     ["^0.8.0", "0.8.4"],
     [">=0.8.0-beta.1", "0.8.0-beta.2"],
+    [">=0.8.0-beta.1", "0.8.0-beta.1"],
     [">=0.8.0-beta.1", "0.8.0"],
     ["^0.8.0 || ^0.9.0", "0.9.2+build.42"],
   ])("accepts %s on %s", (paseo, version) => {
     expect(() =>
-      assertPluginCompatibility({ id: "test", requirements: { paseo }, version, runtime: "app" }),
+      assertPluginCompatibility({ id: "test", requirements: { paseo }, version, runtime }),
     ).not.toThrow();
   });
 
@@ -27,11 +29,11 @@ describe("plugin requirements", () => {
     [undefined, "0.9.0"],
     [">=0.8.0", "0.7.2"],
     ["^0.8.0", "0.9.0"],
-    [">=0.8.0", "0.8.0-beta.1"],
+    ["<0.8.0", "0.8.0-beta.1"],
   ])("rejects %s on %s", (paseo, version) => {
     expect(() =>
-      assertPluginCompatibility({ id: "test", requirements: { paseo }, version, runtime: "app" }),
-    ).toThrow(`Your app is ${version}`);
+      assertPluginCompatibility({ id: "test", requirements: { paseo }, version, runtime }),
+    ).toThrow(`Your ${runtime} is ${version}`);
   });
 
   it.each(["", "   ", "latest", ">=potato", "0.8.0 nonsense"])(
@@ -47,8 +49,8 @@ describe("plugin requirements", () => {
         id: "test",
         requirements: { paseo: "*" },
         version,
-        runtime: "app",
+        runtime,
       }),
-    ).toThrow("Paseo app version is unknown");
+    ).toThrow(`Paseo ${runtime} version is unknown`);
   });
 });

--- a/packages/protocol/src/plugin-requirements.ts
+++ b/packages/protocol/src/plugin-requirements.ts
@@ -1,5 +1,5 @@
 import type { PluginRequirements } from "./messages.js";
-import valid from "semver/functions/valid.js";
+import parse from "semver/functions/parse.js";
 import validRange from "semver/ranges/valid.js";
 import satisfies from "semver/functions/satisfies.js";
 
@@ -21,14 +21,16 @@ interface PluginCompatibilityInput {
 
 export function assertPluginCompatibility(input: PluginCompatibilityInput): void {
   validatePluginRequirements(input.requirements);
-  // COMPAT(plugin-requirements): added in v0.8.0; remove after 2027-03-07 once pre-0.8 plugins and catalogs are unsupported.
+  // COMPAT(plugin-requirements): added in v0.8.0-beta.1; remove after 2027-03-07 once pre-0.8 plugins and catalogs are unsupported. The legacy range excludes 0.8 prereleases and their stable core.
   const range = input.requirements?.paseo ?? "<0.8.0";
-  if (!input.version || !valid(input.version)) {
+  const version = input.version ? parse(input.version) : null;
+  if (!version) {
     throw new Error(
       `Cannot check plugin "${input.id}" requirements: Paseo ${input.runtime} version is unknown. Update the ${input.runtime}.`,
     );
   }
-  if (satisfies(input.version, range)) return;
+  const stableCore = `${version.major}.${version.minor}.${version.patch}`;
+  if (satisfies(version, range) || satisfies(stableCore, range)) return;
   const action =
     input.requirements?.paseo === undefined
       ? "This plugin has no requirements.paseo and targets Paseo before 0.8. Ask its author to migrate it: https://paseo.sh/docs/plugins/v0.8/migration"

--- a/packages/server/src/server/plugins/manifest.test.ts
+++ b/packages/server/src/server/plugins/manifest.test.ts
@@ -1,16 +1,29 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { readPluginManifest } from "./manifest.js";
 
 const directories: string[] = [];
+const examplesDirectory = fileURLToPath(
+  new URL("../../../../../plugin-examples/", import.meta.url),
+);
+const examples = (await readdir(examplesDirectory, { withFileTypes: true }))
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
 
 afterEach(async () => {
   await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
 });
 
 describe("plugin manifest", () => {
+  it.each(examples)("validates the %s example manifest", async (name) => {
+    await expect(readPluginManifest(path.join(examplesDirectory, name))).resolves.toMatchObject({
+      id: expect.any(String),
+    });
+  });
+
   it("reads and validates requirements before any plugin code runs", async () => {
     const directory = await mkdtemp(path.join(tmpdir(), "paseo-plugin-manifest-"));
     directories.push(directory);

--- a/packages/website/src/plugin-docs-navigation.test.ts
+++ b/packages/website/src/plugin-docs-navigation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildDocsNavTree, getDocs, getLegacyDocsRedirect } from "./docs";
 
 describe("versioned plugin documentation", () => {
-  it("keeps current and preview releases together in the Plugins navigation", () => {
+  it("keeps stable and beta releases together in the Plugins navigation", () => {
     const plugins = buildDocsNavTree(getDocs()).find(
       (node) => node.type === "category" && node.label === "Plugins",
     );
@@ -19,11 +19,12 @@ describe("versioned plugin documentation", () => {
         },
         {
           type: "group",
-          label: "Paseo v0.8 — Preview",
+          label: "Paseo v0.8 — Beta",
           href: "/docs/plugins/v0.8",
           children: [
-            { type: "page", label: "Reference", href: "/docs/plugins/v0.8/reference" },
+            { type: "page", label: "Provider plugins", href: "/docs/plugins/v0.8/providers" },
             { type: "page", label: "Migration", href: "/docs/plugins/v0.8/migration" },
+            { type: "page", label: "Reference", href: "/docs/plugins/v0.8/reference" },
           ],
         },
       ],

--- a/plugin-examples/lifecycle-actions/README.md
+++ b/plugin-examples/lifecycle-actions/README.md
@@ -17,6 +17,10 @@ paseo plugin install /absolute/path/to/plugin-examples/lifecycle-logger
 paseo plugin logs lifecycle-logger
 ```
 
+Outside the Paseo repository, `server/inspect.ts` needs `@getpaseo/protocol` installed for its
+type imports. Add it to your plugin development dependencies at the same version as
+`@getpaseo/plugin` before installing this example.
+
 Copy the callbacks you need into your own plugin. The follow-up example sends a new message; it does
 not replay attachments or undo previous tool effects. If the provider keeps returning the matching
 phrase, it keeps sending follow-ups. Add limits or delay in your plugin when your workflow needs them.

--- a/plugin-examples/linear/README.md
+++ b/plugin-examples/linear/README.md
@@ -9,21 +9,16 @@ Set a personal API key in the daemon environment:
 export LINEAR_API_KEY="lin_api_..."
 ```
 
-Register the extension in `$PASEO_HOME/config.json`:
+Start your daemon with that environment variable set. Then turn on **Enable plugins** in
+**Settings → Plugins** and install the example:
 
-```json
-{
-  "pluginsEnabled": true,
-  "plugins": {
-    "linear": {
-      "source": "directory",
-      "path": "/absolute/path/to/paseo/plugin-examples/linear"
-    }
-  }
-}
+```bash
+paseo plugin add /absolute/path/to/paseo/plugin-examples/linear
+paseo plugin ls linear
 ```
 
-Restart the development daemon after changing its environment or plugin configuration.
+Use `paseo plugin reload linear` after source edits. Changing the API key requires restarting the
+daemon with the new environment; installing or reloading plugin source does not.
 
 The split entry point demonstrates the complete attachment-source pattern:
 

--- a/plugin-examples/provider-acp-transformer/paseo-plugin.json
+++ b/plugin-examples/provider-acp-transformer/paseo-plugin.json
@@ -1,8 +1,5 @@
 {
   "id": "provider-acp-transformer-example",
-  "name": "ACP provider transformer example",
-  "version": "1.0.0",
-  "description": "Wraps an ACP command and normalizes one vendor file-edit shape.",
   "requirements": {
     "paseo": ">=0.8.0"
   }

--- a/public-docs/plugins/index.md
+++ b/public-docs/plugins/index.md
@@ -15,7 +15,7 @@ change between releases.
 
 Build and maintain plugins for the latest stable Paseo release.
 
-## [Paseo v0.8 — Preview](/docs/plugins/v0.8)
+## [Paseo v0.8 — Beta](/docs/plugins/v0.8)
 
-Prepare plugins for the upcoming client and server entry layout. Existing plugin authors should
+Build plugins for Paseo 0.8 beta, with separate client and server entries. Existing plugin authors should
 follow the [v0.8 migration guide](/docs/plugins/v0.8/migration).

--- a/public-docs/plugins/v0.8/index.md
+++ b/public-docs/plugins/v0.8/index.md
@@ -1,15 +1,15 @@
 ---
 title: Plugin quickstart
 description: Build, install, share, and update a trusted Paseo plugin.
-nav: Paseo v0.8 — Preview
+nav: Paseo v0.8 — Beta
 order: 46
 category: Plugins
 ---
 
 # Plugin quickstart
 
-> **For the upcoming Paseo v0.8 release.** Use the [current v0.7 docs](/docs/plugins/v0.7)
-> unless you are preparing a plugin for v0.8.
+> **For Paseo v0.8 beta.** Use the [v0.7 docs](/docs/plugins/v0.7)
+> if you run the stable release.
 
 > **Experimental:** The plugin API is still evolving, so expect breaking changes and updates to
 > your plugins as Paseo evolves. See the [plugin roadmap](https://github.com/getpaseo/paseo/labels/plugins)

--- a/public-docs/plugins/v0.8/migration.md
+++ b/public-docs/plugins/v0.8/migration.md
@@ -8,7 +8,7 @@ category: Plugins
 
 # Migrate a plugin to runtime entries
 
-> **For the upcoming Paseo v0.8 release.** This migration is not required for Paseo v0.7.
+> **For Paseo v0.8 beta.** This migration is not required for Paseo v0.7.
 
 Give this page to a coding agent with the plugin directory as its working directory. Execute the
 steps in order. Do not keep a compatibility entry.
@@ -246,7 +246,7 @@ After migrating the entries and imports, add the minimum runtime version to `pas
 ```json
 {
   "id": "my-plugin",
-  "requirements": { "paseo": ">=0.8.0" }
+  "requirements": { "paseo": ">=0.8.0-beta.1" }
 }
 ```
 

--- a/public-docs/plugins/v0.8/migration.md
+++ b/public-docs/plugins/v0.8/migration.md
@@ -246,7 +246,7 @@ After migrating the entries and imports, add the minimum runtime version to `pas
 ```json
 {
   "id": "my-plugin",
-  "requirements": { "paseo": ">=0.8.0-beta.1" }
+  "requirements": { "paseo": ">=0.8.0" }
 }
 ```
 
@@ -255,8 +255,8 @@ rejects the plugin even if its files have been moved. Adding the field alone doe
 code. Update the local `@getpaseo/plugin` development dependency to the version you target and
 reinstall dependencies before typechecking.
 
-For a 0.8 beta, use its explicit version in both the SDK dependency and range, for example
-`>=0.8.0-beta.1`. See [requirements](reference#requirements) for range and prerelease semantics.
+For a 0.8 beta, use its explicit version in the SDK dependency and `>=0.8.0` in the manifest.
+See [requirements](reference#requirements) for range and prerelease semantics.
 
 ## 8. Verify the migration
 

--- a/public-docs/plugins/v0.8/providers.md
+++ b/public-docs/plugins/v0.8/providers.md
@@ -8,7 +8,7 @@ category: Plugins
 
 # Build a provider plugin
 
-> **For the upcoming Paseo v0.8 release.** Start with the
+> **For Paseo v0.8 beta.** Start with the
 > [plugin quickstart](/docs/plugins/v0.8) if you have not built a Paseo plugin before.
 
 A provider plugin connects a coding agent to Paseo without adding it to Paseo core. Publish the
@@ -22,10 +22,10 @@ Choose one implementation path:
 | It already implements ACP                                         | Register it with `runAcpProvider()` and add only narrow vendor transformers. |
 | It has a TypeScript SDK, JSON-RPC API, or custom process protocol | Implement `ProviderRegistration` directly.                                   |
 
-The complete examples are:
+The examples are:
 
 - [`provider-direct`](https://github.com/getpaseo/paseo/tree/main/plugin-examples/provider-direct): sessions, settings, prompts, persistence, child sessions, and a provider-owned timeline renderer;
-- [`provider-acp-transformer`](https://github.com/getpaseo/paseo/tree/main/plugin-examples/provider-acp-transformer): an ACP command with a Zod-validated vendor edit transformer;
+- [`provider-acp-transformer`](https://github.com/getpaseo/paseo/tree/main/plugin-examples/provider-acp-transformer): an ACP command template with a Zod-validated vendor edit transformer. Replace `example-acp --stdio` with an installed ACP agent before loading it;
 - [`inline-thinking`](https://github.com/getpaseo/paseo/tree/main/plugin-examples/inline-thinking): a renderer-only plugin that does not implement a provider.
 
 ## Register a direct provider

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -8,7 +8,7 @@ category: Plugins
 
 # Plugin reference
 
-> **For the upcoming Paseo v0.8 release.** Return to the [v0.8 quickstart](/docs/plugins/v0.8).
+> **For Paseo v0.8 beta.** Return to the [v0.8 quickstart](/docs/plugins/v0.8).
 
 Migrating an existing plugin? Follow the standalone [runtime-entry migration guide](/docs/plugins/v0.8/migration).
 
@@ -45,7 +45,7 @@ my-plugin/
 The required root manifest is `paseo-plugin.json`. It contains the default plugin ID and supported Paseo versions:
 
 ```json
-{ "id": "my-plugin", "requirements": { "paseo": ">=0.8.0" } }
+{ "id": "my-plugin", "requirements": { "paseo": ">=0.8.0-beta.1" } }
 ```
 
 ### Requirements
@@ -81,10 +81,10 @@ and cannot show this new diagnostic.
 
 ### Runtime entries
 
-| Entry              | Runtime               | Receives              | Required                                                          |
-| ------------------ | --------------------- | --------------------- | ----------------------------------------------------------------- |
-| `index.client.tsx` | Paseo app, per client | `PluginClientContext` | When the plugin has any UI, callback, theme, or attachment source |
-| `index.server.ts`  | Daemon subprocess     | `PluginServerContext` | When the plugin handles RPCs                                      |
+| Entry              | Runtime               | Receives              | Required                                                                        |
+| ------------------ | --------------------- | --------------------- | ------------------------------------------------------------------------------- |
+| `index.client.tsx` | Paseo app, per client | `PluginClientContext` | When the plugin has any UI, callback, theme, or attachment source               |
+| `index.server.ts`  | Daemon subprocess     | `PluginServerContext` | When the plugin contributes handlers, hooks, settings persistence, or providers |
 
 At least one entry is required; both accept `.ts` or `.tsx`. A directory that still has only the
 old `index.ts` fails to load and points at the [migration guide](/docs/plugins/v0.8/migration).
@@ -346,7 +346,9 @@ and directory lookup/import operations are unaffected.
 ### Send a follow-up when a turn ends
 
 Copy [server/inspect.ts](https://github.com/getpaseo/paseo/blob/main/plugin-examples/lifecycle-actions/server/inspect.ts)
-into your plugin. `latestOutputText` joins text chunks after the latest user message.
+into your plugin. The helper imports types from `@getpaseo/protocol/agent-types`; add
+`@getpaseo/protocol` at the same version as your plugin SDK to your development dependencies
+and install them before loading the plugin. `latestOutputText` joins text chunks after the latest user message.
 
 ```ts
 import type { PluginServerContext } from "@getpaseo/plugin/server";
@@ -1215,7 +1217,7 @@ import { z } from "zod";
 
 const refreshReview = defineRpc({
   name: "review.refresh",
-  input: z.object({ agentId: z.string() }),
+  input: z.object({ agentId: z.string(), scope: z.string().optional() }),
   output: z.object({ refreshed: z.boolean() }),
 });
 
@@ -1376,10 +1378,10 @@ registered by the same plugin.
 Use `usePaseo()` for ordinary Paseo operations from a surface. It borrows the selected host's existing connection; do not create another client.
 
 ```tsx
-import { usePaseo } from "@getpaseo/plugin/client";
+import { type PluginSurfaceProps, usePaseo } from "@getpaseo/plugin/client";
 import { Pressable, Text } from "react-native";
 
-function PullRequestAction() {
+function PullRequestAction({ theme }: PluginSurfaceProps) {
   const paseo = usePaseo();
 
   async function createReviewWorkspace() {
@@ -1400,7 +1402,7 @@ function PullRequestAction() {
 
   return (
     <Pressable accessibilityRole="button" onPress={() => void createReviewWorkspace()}>
-      <Text>Create review workspace</Text>
+      <Text style={{ color: theme.colors.foreground }}>Create review workspace</Text>
     </Pressable>
   );
 }
@@ -1644,7 +1646,7 @@ step:
 ```json
 {
   "id": "review",
-  "requirements": { "paseo": ">=0.8.0" },
+  "requirements": { "paseo": ">=0.8.0-beta.1" },
   "build": [
     ["npm", "ci"],
     ["npm", "run", "build"]
@@ -1659,7 +1661,7 @@ compilation, activation, or replacement. A failing command reports its output, d
 candidate, and leaves the installed/running version intact. The daemon log records each command and
 output; with the global `--host` option, execution is on that daemon host.
 
-Run `npm run typecheck` before install or reload. Never edit the daemon config directly.
+Run `npm run typecheck` before install or reload. Manage plugin source entries with the CLI or Settings.
 
 The daemon-wide **Enable plugins** switch lives under **Settings → Plugins**. A configured plugin remains `disabled` until that switch and the plugin's own enabled state are both on.
 
@@ -1673,8 +1675,8 @@ Use `paseo plugin ls` to read the current status and error.
 | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `This plugin was made for an older version of Paseo`                  | The directory has only an `index.ts` entry. Follow the [migration guide](/docs/plugins/v0.8/migration).                                 |
 | `Plugin entry points are missing`                                     | Neither `index.client.tsx` nor `index.server.ts` exists with that exact name.                                                           |
-| `server-only module cannot be imported into the plugin client bundle` | Client code imports `server/` or a `*.server.*` file. Move the work behind an RPC and import its contract from `shared/`.               |
-| `client-only module cannot be imported into the plugin server bundle` | Server code imports `client/` or a `*.client.*` file. Register that contribution from `index.client.tsx` instead.                       |
+| `server-only module cannot be imported into the plugin client bundle` | Client code imports `server/`. Move the work behind an RPC and import its contract from `shared/`.                                      |
+| `client-only module cannot be imported into the plugin server bundle` | Server code imports `client/`. Register that contribution from `index.client.tsx` instead.                                              |
 | `Node module cannot be imported into the plugin client bundle`        | Client code imports `node:*`. Move the operation to `server/` and call it through an RPC.                                               |
 | Sidebar item is missing                                               | The plugin is `running`, the item references an existing surface, the icon name is valid, and the client is on the installation's host. |
 | Client module is unavailable                                          | Import only the host-provided client modules listed above.                                                                              |

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -45,7 +45,7 @@ my-plugin/
 The required root manifest is `paseo-plugin.json`. It contains the default plugin ID and supported Paseo versions:
 
 ```json
-{ "id": "my-plugin", "requirements": { "paseo": ">=0.8.0-beta.1" } }
+{ "id": "my-plugin", "requirements": { "paseo": ">=0.8.0" } }
 ```
 
 ### Requirements
@@ -55,15 +55,13 @@ range. An omitted `requirements.paseo` means `<0.8.0`: the plugin predates the f
 plugin release. Paseo 0.8 and later reject it with a link to the [migration guide](migration).
 Empty strings, invalid ranges, and unknown manifest requirement keys are rejected.
 
-| Range            | Compatible releases                                                 |
-| ---------------- | ------------------------------------------------------------------- |
-| `>=0.8.0`        | 0.8.0 and later stable releases, including future breaking releases |
-| `^0.8.0`         | 0.8.x stable releases only                                          |
-| `>=0.8.3 <0.9.0` | 0.8.3 through the last 0.8 patch                                    |
-| `>=0.8.0-beta.1` | Betas from 0.8.0-beta.1, then 0.8.0 and later stable releases       |
+| Range            | Compatible releases                                                          |
+| ---------------- | ---------------------------------------------------------------------------- |
+| `>=0.8.0`        | 0.8.0 and later releases, including prereleases and future breaking releases |
+| `^0.8.0`         | 0.8.x releases, including prereleases                                        |
+| `>=0.8.3 <0.9.0` | 0.8.3 through the last 0.8 patch, including prereleases                      |
 
-Standard npm prerelease rules apply: `>=0.8.0` excludes `0.8.0-beta.1`. A prerelease must be
-explicitly included for its major/minor/patch tuple; no version tags are stripped.
+Prerelease Paseo versions also satisfy a range their stable core (`major.minor.patch`) satisfies, so `0.8.0-beta.1` satisfies `>=0.8.0` but not `<0.8.0`.
 
 `paseo plugin init` writes `>=` followed by the current CLI version and pins the matching SDK
 for typechecking. Raise the minimum when adopting a newer API. Add an upper bound when a later
@@ -1646,7 +1644,7 @@ step:
 ```json
 {
   "id": "review",
-  "requirements": { "paseo": ">=0.8.0-beta.1" },
+  "requirements": { "paseo": ">=0.8.0" },
   "build": [
     ["npm", "ci"],
     ["npm", "run", "build"]


### PR DESCRIPTION
### Linked issue

Refs #4206, #4347, #4430, #4265, #4314, #4357, #4435, #4392, #4431, #4358, #4203, #4446, #3983, #3985.

### Type of change

- [x] Bug fix
- [x] Docs

### Reasoning

Plugins declaring `requirements.paseo: ">=0.8.0"` were rejected by Paseo `0.8.0-beta.1`, so the release examples could not install on the beta. Match the running version or its stable core against the range in the shared compatibility function. Both the daemon and app use this function; legacy `<0.8.0` plugins remain rejected by beta.1, and 0.7.2 remains rejected by `>=0.8.0`. Explicit prerelease ranges still work.

The ACP example also had unsupported `name`, `version`, and `description` manifest fields. Remove them and validate every checked-in example through the production manifest reader in a parameterized test.

Prepare the plugin guides for the beta: label v0.8 Beta while retaining stable v0.7 navigation; use `>=0.8.0` in copyable manifests and explain stable-core matching; correct the slash-command RPC schema and stale runtime-boundary/config-edit guidance; clarify ACP and lifecycle-helper prerequisites; add README plugin discovery and trust guidance. The documentation-navigation assertion follows the Beta label and existing Providers page. The scaffold still generates the current CLI version as its minimum.

### Compatibility and scope

No wire schema or RPC shape changes. Old messages still parse unchanged; this changes only local plugin version eligibility in the shared app/daemon helper. An older app still checks its own version and does not become compatible merely because its daemon is compatible. Stable-core matching intentionally treats a prerelease as eligible wherever its stable release is eligible.

Two commits on the branch: the existing docs commit `1766217a8`, followed by the code fix `5de2122a7`. No evidence files are committed. No release version bump, SDK publish, or provider implementation change.

### Test-first evidence

Before the fix, the new compatibility case failed with:

```text
FAIL plugin requirements on daemon > accepts >=0.8.0 on 0.8.0-beta.1
Plugin "test" requires Paseo >=0.8.0. Your daemon is 0.8.0-beta.1.
```

Before removing the ACP metadata, the new example-validation case failed with:

```text
FAIL plugin manifest > validates the provider-acp-transformer example manifest
Unrecognized keys: "name", "version", "description"
```

After the fixes:

```text
npx vitest run packages/protocol/src/plugin-requirements.test.ts --bail=1
44 passed — both app and daemon, stable-core acceptance, legacy rejection,
0.7.2 rejection, explicit beta range acceptance, invalid/unknown versions

npx vitest run packages/server/src/server/plugins/manifest.test.ts --bail=1
14 passed — all 12 example manifests plus existing validation tests

npm run build:client   exit 0
npm run typecheck      exit 0
npm run lint           0 warnings, 0 errors
npm run format         exit 0
git diff --check       exit 0
```

Checked all 12 example manifests and seven manifest JSON snippets across public/internal/example docs: no unsupported top-level metadata fields found. `packages/app/src/plugins/registry.ts` imports and calls the same `assertPluginCompatibility` before evaluating client bundles. No app-specific fallback was added.

### CLI integration verification

Used this checkout's built CLI against two isolated in-process daemons, each with its own temporary PASEO_HOME and OS-assigned port. The daemon code is the built release source with the rebuilt protocol package; the harness sets only the reported version to beta.1 or 0.7.2. Installed directly from checked-in example directories, with no temporary requirement rewrites or ACP command substitution. All 12 plugins reached running on beta.1, and all 12 were rejected on 0.7.2. Both daemons stopped in `finally`; existing daemons were untouched.

ACP's `example-acp` command remains a documented placeholder; installation/running does not establish that command can complete a prompt. Prior UI/provider QA used an installed OpenCode ACP command explicitly, as recorded below.

| Example | beta.1 add | 0.7.2 add |
| --- | --- | --- |
| agent-configuration | exit 0, running | exit 1, incompatible |
| catppuccin | exit 0, running | exit 1, incompatible |
| inline-thinking | exit 0, running | exit 1, incompatible |
| lifecycle-actions | exit 0, running | exit 1, incompatible |
| lifecycle-logger | exit 0, running | exit 1, incompatible |
| linear | exit 0, running | exit 1, incompatible |
| local-plugin | exit 0, running | exit 1, incompatible |
| modal-ui | exit 0, running | exit 1, incompatible |
| provider-acp-transformer | exit 0, running | exit 1, incompatible |
| provider-direct | exit 0, running | exit 1, incompatible |
| settings | exit 0, running | exit 1, incompatible |
| timeline-items | exit 0, running | exit 1, incompatible |

<details>
<summary>Exact CLI commands and output (trust notice / Node warning omitted)</summary>

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/agent-configuration --json
```

```json
{
  "id": "agent-configuration",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/agent-configuration",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/catppuccin --json
```

```json
{
  "id": "catppuccin",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/catppuccin",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/inline-thinking --json
```

```json
{
  "id": "inline-thinking",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/inline-thinking",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/lifecycle-actions --json
```

```json
{
  "id": "lifecycle-actions",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/lifecycle-actions",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/lifecycle-logger --json
```

```json
{
  "id": "lifecycle-logger",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/lifecycle-logger",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/linear --json
```

```json
{
  "id": "linear",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/linear",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/local-plugin --json
```

```json
{
  "id": "local-example",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/local-plugin",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/modal-ui --json
```

```json
{
  "id": "modal-ui-example",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/modal-ui",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/provider-acp-transformer --json
```

```json
{
  "id": "provider-acp-transformer-example",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/provider-acp-transformer",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/provider-direct --json
```

```json
{
  "id": "provider-direct-example",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/provider-direct",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/settings --json
```

```json
{
  "id": "settings-example",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/settings",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.8.0-beta.1`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:43461 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/timeline-items --json
```

```json
{
  "id": "pi-tasks-timeline",
  "path": "/home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/timeline-items",
  "enabled": true,
  "status": "running"
}
```

Exit: 0

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/agent-configuration --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "6221835a-0854-4a2c-a865-54a2d02d9da2",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"agent-configuration\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/catppuccin --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "3d515126-92b3-4ef6-9aa1-71df3e1daab5",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"catppuccin\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/inline-thinking --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "21a0c4ab-f688-4aa9-a61d-8b554a51e55e",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"inline-thinking\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/lifecycle-actions --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "7a9f81a2-2da0-40ab-afba-9d115764a59f",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"lifecycle-actions\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/lifecycle-logger --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "962a07a9-18de-4469-aaa6-d4476e9f6742",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"lifecycle-logger\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/linear --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "8e76cd71-6e02-428e-943f-d39635cc1acc",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"linear\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/local-plugin --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "f673a478-1949-48e5-9346-3ca38b1596dd",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"local-example\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/modal-ui --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "38b35634-e1d9-4ce0-916e-d05267bb9ced",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"modal-ui-example\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/provider-acp-transformer --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "1bae68ad-e001-451a-917c-39d207d624c4",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"provider-acp-transformer-example\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/provider-direct --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "be67d89d-d8cf-4716-a4f7-a55d2797885a",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"provider-direct-example\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/settings --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "47a8ab9d-b5c0-43ee-b00c-4ec96d0d55f3",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"settings-example\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

Reported daemon version: `0.7.2`

```sh
node /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/packages/cli/dist/index.js --host 127.0.0.1:41625 plugin add /home/moboudra/dev/paseo/.dev/paseo-home/worktrees/04qpit1r/qa-0-8-beta1-plugins-docs/plugin-examples/timeline-items --json
```

```json
{
  "error": {
    "name": "DaemonRpcError",
    "requestId": "100c356f-564d-4ca6-91c8-6213eb87dc11",
    "requestType": "plugin.directory.install.request",
    "code": "handler_error",
    "message": "Request failed: Plugin \"pi-tasks-timeline\" requires Paseo >=0.8.0. Your daemon is 0.7.2. Use a compatible plugin version or update the daemon. requestType=plugin.directory.install.request code=handler_error"
  }
}
```

Exit: 1

</details>

### Prior browser and SDK QA retained

Linux/Chromium at 1440×1000 and 390×844 against an isolated built daemon: settings save/validation/reload persistence; Catppuccin theme; sidebar item visibility/order; workspace and Explorer panels; composer pills and slash command; timeline renderer rows; modal clipboard/list behavior; direct-provider and configured ACP prompts; all 11 lifecycle hook types; public SDK project subscription, permission response and workspace-owned terminal operations; Git update rejection preserving the running revision. Those earlier UI checks used disclosed temporary example adaptations before the compatibility fix. This follow-up independently verifies unmodified checked-in example installation after the fix.

Prior local SDK/runtime/docs checks: 44 SDK boundaries, 1 plugin process, 31 client loader, 1 migration documentation, 2 documentation navigation; 52 current TypeScript snippets typechecked with typed surrounding context, and 46 Markdown links resolved (11 unique external URLs fetched). No complete local suite was run.

Remaining release QA notes outside this fix: the 0.7.2-versioned scaffold selects the old published SDK while emitting newer imports; a version-bumped/published beta scaffold still needs verification. Appending a plugin row after a completed provider turn extended its displayed duration in prior QA. Successful authenticated Linear search, live Pi integration, native platforms/gestures and every lifecycle policy branch remain untested. These are not claimed as fixed or green by this PR.

Final CI on `5de2122a78155bf4fec5bed6d696d364b38a6dae` is green: SDK tests (including ACP), Linux and Windows server tests, typecheck, lint, formatting, Docker, Linux Nix and macOS desktop builds, and Greptile review all passed. Unaffected jobs were skipped by CI filters. The ACP failure did not recur; no rerun or assertion change was needed. All review threads are resolved; the stable-core behavior for explicit prerelease ranges was confirmed as intentional and the reviewer withdrew that finding.

### Checklist

- [x] Failing-first regressions for both reported blockers
- [x] Shared app/daemon behavior; no wire compatibility changes
- [x] All 12 checked-in examples install on beta.1 and reject 0.7.2
- [x] Build client, typecheck, lint, format
- [x] Copyable docs ranges and README updated
- [x] Evidence stays outside the repository
