### PR TITLE
mark agents inside paseo-owned worktrees with PASEO_WORKTREE_PATH

### DIFF
--- a/packages/server/src/server/agent-worktree-env.test.ts
+++ b/packages/server/src/server/agent-worktree-env.test.ts
@@ -1,0 +1,110 @@
+import { join } from "node:path";
+
+import { describe, expect, test } from "vitest";
+
+import {
+  findPaseoOwnedWorktreeForCwd,
+  paseoWorktreeEnvForAgent,
+  resolveAgentWorktreeEnv,
+} from "./agent-worktree-env.js";
+import type { PersistedWorkspaceRecord } from "./workspace-registry.js";
+
+const WORKTREE_ROOT = "/home/user/.paseo/worktrees/082txh3s/odd-eel";
+const MAIN_REPO = "/home/user/src/example-app";
+
+function workspace(overrides: Partial<PersistedWorkspaceRecord>): PersistedWorkspaceRecord {
+  return {
+    workspaceId: "wks_test",
+    projectId: "prj_test",
+    cwd: WORKTREE_ROOT,
+    kind: "worktree",
+    displayName: "odd-eel",
+    title: null,
+    branch: "odd-eel",
+    worktreeRoot: WORKTREE_ROOT,
+    baseBranch: "main",
+    isPaseoOwnedWorktree: true,
+    mainRepoRoot: MAIN_REPO,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+describe("paseoWorktreeEnvForAgent", () => {
+  test("returns worktree markers only for a paseo-owned worktree", () => {
+    expect(paseoWorktreeEnvForAgent(workspace({}))).toEqual({
+      PASEO_WORKTREE_PATH: WORKTREE_ROOT,
+      PASEO_SOURCE_CHECKOUT_PATH: MAIN_REPO,
+      PASEO_ROOT_PATH: MAIN_REPO,
+      PASEO_BRANCH_NAME: "odd-eel",
+    });
+  });
+
+  test("returns null for a source checkout (local_checkout)", () => {
+    expect(
+      paseoWorktreeEnvForAgent(workspace({ kind: "local_checkout", isPaseoOwnedWorktree: false })),
+    ).toBeNull();
+  });
+
+  test("returns null for a worktree paseo does not own", () => {
+    expect(paseoWorktreeEnvForAgent(workspace({ isPaseoOwnedWorktree: false }))).toBeNull();
+  });
+
+  test("falls back to cwd when worktreeRoot is absent", () => {
+    const env = paseoWorktreeEnvForAgent(
+      workspace({ worktreeRoot: null, mainRepoRoot: null, branch: null }),
+    );
+    expect(env).toEqual({ PASEO_WORKTREE_PATH: WORKTREE_ROOT });
+  });
+});
+
+describe("findPaseoOwnedWorktreeForCwd", () => {
+  const records = [
+    workspace({ workspaceId: "wks_owned" }),
+    workspace({
+      workspaceId: "wks_checkout",
+      kind: "local_checkout",
+      isPaseoOwnedWorktree: false,
+      cwd: "/home/user/src/example-app",
+    }),
+  ];
+
+  test("matches the worktree root exactly", () => {
+    expect(findPaseoOwnedWorktreeForCwd(records, WORKTREE_ROOT)?.workspaceId).toBe("wks_owned");
+  });
+
+  test("matches a subdirectory inside the worktree", () => {
+    expect(
+      findPaseoOwnedWorktreeForCwd(records, join(WORKTREE_ROOT, "platform", "email"))?.workspaceId,
+    ).toBe("wks_owned");
+  });
+
+  test("returns null for a path outside any paseo-owned worktree", () => {
+    expect(findPaseoOwnedWorktreeForCwd(records, "/home/user/src/elsewhere")).toBeNull();
+  });
+
+  test("skips archived paseo-owned worktrees", () => {
+    const archived = [workspace({ archivedAt: "2026-02-01T00:00:00.000Z" })];
+    expect(findPaseoOwnedWorktreeForCwd(archived, WORKTREE_ROOT)).toBeNull();
+  });
+});
+
+describe("resolveAgentWorktreeEnv", () => {
+  test("projects env when cwd is inside a paseo-owned worktree", async () => {
+    const env = await resolveAgentWorktreeEnv(
+      async () => [workspace({})],
+      join(WORKTREE_ROOT, "platform"),
+    );
+    expect(env?.PASEO_WORKTREE_PATH).toBe(WORKTREE_ROOT);
+  });
+
+  test("returns null when cwd is not inside a paseo-owned worktree", async () => {
+    const env = await resolveAgentWorktreeEnv(
+      async () => [workspace({ kind: "local_checkout", isPaseoOwnedWorktree: false })],
+      "/home/user/src/example-app",
+    );
+    expect(env).toBeNull();
+  });
+});

--- a/packages/server/src/server/agent-worktree-env.ts
+++ b/packages/server/src/server/agent-worktree-env.ts
@@ -1,0 +1,86 @@
+import { resolve, sep } from "node:path";
+
+import type { PersistedWorkspaceRecord } from "./workspace-registry.js";
+
+// Maps a paseo-managed worktree workspace onto the process-env markers that let
+// a consumer distinguish "I am running inside a paseo worktree" from "I am
+// running against the shared/default resource".
+//
+// Agents are launched with only PASEO_AGENT_CWD (their working directory); the
+// daemon's service/terminal lifecycle instead exposes PASEO_WORKTREE_PATH for
+// processes it spawns inside a worktree, and consumers gate per-worktree
+// isolation on that variable (e.g. a per-worktree database or other isolated
+// resource). Without it an agent that shells out to a consumer's tooling is
+// treated as running outside any worktree and falls back to the shared
+// resource. This module projects the persisted worktree placement onto that
+// same variable so agents inherit it, keyed off workspace ownership rather than
+// directory heuristics.
+
+/**
+ * Returns the process-env markers for an agent running in a paseo-owned
+ * worktree, or null when `workspace` is not a paseo-owned worktree (a source
+ * checkout or a manual directory must keep running against the default
+ * resource). Mirrors the non-port fields of `resolveWorktreeRuntimeEnv`
+ * (`utils/worktree.ts`); the runtime worktree port is a service-routing concern
+ * and is intentionally not propagated to agent processes.
+ */
+export function paseoWorktreeEnvForAgent(
+  workspace: PersistedWorkspaceRecord,
+): Record<string, string> | null {
+  if (workspace.kind !== "worktree" || !workspace.isPaseoOwnedWorktree) {
+    return null;
+  }
+  const worktreeRoot = workspace.worktreeRoot ?? workspace.cwd;
+  const env: Record<string, string> = { PASEO_WORKTREE_PATH: worktreeRoot };
+  if (workspace.mainRepoRoot) {
+    // Source checkout is the original repo root shared across worktrees;
+    // PASEO_ROOT_PATH is its backward-compatible alias.
+    env.PASEO_SOURCE_CHECKOUT_PATH = workspace.mainRepoRoot;
+    env.PASEO_ROOT_PATH = workspace.mainRepoRoot;
+  }
+  if (workspace.branch) {
+    env.PASEO_BRANCH_NAME = workspace.branch;
+  }
+  return env;
+}
+
+/**
+ * Finds the paseo-owned worktree whose root contains `cwd`. The agent's cwd may
+ * be the worktree root itself or a subdirectory inside it; either way it is
+ * operating against that worktree's isolated resources, so the enclosing
+ * paseo-owned worktree wins. Returns null when `cwd` is not inside any
+ * paseo-owned worktree.
+ */
+export function findPaseoOwnedWorktreeForCwd(
+  workspaces: readonly PersistedWorkspaceRecord[],
+  cwd: string,
+): PersistedWorkspaceRecord | null {
+  const resolvedCwd = resolve(cwd);
+  let bestMatch: PersistedWorkspaceRecord | null = null;
+  let bestRootLength = -1;
+  for (const workspace of workspaces) {
+    if (workspace.archivedAt) continue;
+    if (workspace.kind !== "worktree" || !workspace.isPaseoOwnedWorktree) continue;
+    const root = resolve(workspace.worktreeRoot ?? workspace.cwd);
+    const isInside = resolvedCwd === root || resolvedCwd.startsWith(`${root}${sep}`);
+    if (!isInside) continue;
+    if (root.length > bestRootLength) {
+      bestRootLength = root.length;
+      bestMatch = workspace;
+    }
+  }
+  return bestMatch;
+}
+
+/**
+ * Resolves the worktree env markers to merge into an agent process about to be
+ * launched under `cwd`, or null when `cwd` is not inside a paseo-owned
+ * worktree.
+ */
+export async function resolveAgentWorktreeEnv(
+  listWorkspaces: () => Promise<readonly PersistedWorkspaceRecord[]>,
+  cwd: string,
+): Promise<Record<string, string> | null> {
+  const workspace = findPaseoOwnedWorktreeForCwd(await listWorkspaces(), cwd);
+  return workspace ? paseoWorktreeEnvForAgent(workspace) : null;
+}

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -1782,6 +1782,68 @@ test("createAgent forwards request env into the spawned provider process", async
   }
 });
 
+test("buildLaunchContext merges worktree env for an agent in a paseo worktree", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-worktree-env-"));
+  const captured: Record<string, string | undefined> = {};
+  class WorktreeEnvCapturingClient extends TestAgentClient {
+    override async createSession(
+      config: AgentSessionConfig,
+      launchContext?: AgentLaunchContext,
+    ): Promise<AgentSession> {
+      Object.assign(captured, launchContext?.env);
+      return new TestAgentSession(config);
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new WorktreeEnvCapturingClient() },
+    logger,
+    resolveAgentWorktreeEnv: async (cwd) =>
+      cwd === workdir ? { PASEO_WORKTREE_PATH: workdir, PASEO_BRANCH_NAME: "odd-eel" } : null,
+  });
+
+  try {
+    await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+
+  expect(captured.PASEO_WORKTREE_PATH).toBe(workdir);
+  expect(captured.PASEO_BRANCH_NAME).toBe("odd-eel");
+  expect(captured.PASEO_AGENT_CWD).toBe(workdir);
+});
+
+test("buildLaunchContext injects no worktree env outside a paseo worktree", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-no-worktree-env-"));
+  const captured: Record<string, string | undefined> = {};
+  class NoWorktreeEnvCapturingClient extends TestAgentClient {
+    override async createSession(
+      config: AgentSessionConfig,
+      launchContext?: AgentLaunchContext,
+    ): Promise<AgentSession> {
+      Object.assign(captured, launchContext?.env);
+      return new TestAgentSession(config);
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new NoWorktreeEnvCapturingClient() },
+    logger,
+    resolveAgentWorktreeEnv: async () => null,
+  });
+
+  try {
+    await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+
+  expect(captured.PASEO_WORKTREE_PATH).toBeUndefined();
+  expect(captured.PASEO_AGENT_CWD).toBe(workdir);
+});
+
 test("normalizeConfig strips legacy 'default' model id", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -310,6 +310,16 @@ export interface AgentManagerOptions {
     agentId: string;
     expectedTurnId: string;
   }) => Promise<void>;
+  /**
+   * Resolves the worktree env markers (at minimum `PASEO_WORKTREE_PATH`) to
+   * merge into an agent process about to be launched under `cwd`, or null when
+   * `cwd` is not inside a paseo-managed worktree (source checkout / manual
+   * directory — those keep running against the default resource). Wired by the
+   * daemon from the workspace registry so consumers can tell an agent it is
+   * operating inside a paseo worktree and route it to the worktree's isolated
+   * resources. When omitted, no worktree env is injected.
+   */
+  resolveAgentWorktreeEnv?: (cwd: string) => Promise<Record<string, string> | null>;
   logger: Logger;
 }
 
@@ -726,6 +736,9 @@ export class AgentManager {
   private onWorkspaceStateMayHaveChanged?: (params: { cwd: string }) => void;
   private logger: Logger;
   private readonly rescueTimeouts: Required<AgentManagerRescueTimeouts>;
+  private readonly resolveAgentWorktreeEnv?: (
+    cwd: string,
+  ) => Promise<Record<string, string> | null>;
   private readonly beforeSteerUnavailableFallback?: AgentManagerOptions["beforeSteerUnavailableFallback"];
   private acceptingAgentRegistrations = true;
 
@@ -749,6 +762,7 @@ export class AgentManager {
         options.rescueTimeouts?.interruptSessionMs ?? INTERRUPT_SESSION_TIMEOUT_MS,
     };
     this.beforeSteerUnavailableFallback = options.beforeSteerUnavailableFallback;
+    this.resolveAgentWorktreeEnv = options.resolveAgentWorktreeEnv;
     this.agentStreamCoalescer = new AgentStreamCoalescer({
       windowMs: options.agentStreamCoalesceWindowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
       timers: { setTimeout, clearTimeout },
@@ -5013,10 +5027,18 @@ export class AgentManager {
       const transformed = await this.pluginLifecycle.before("agent.session_open", request);
       env = transformed.env;
     }
+    const worktreeEnv = this.resolveAgentWorktreeEnv
+      ? await this.resolveAgentWorktreeEnv(cwd)
+      : null;
     const context: AgentLaunchContext = {
       agentId,
       env: {
         ...env,
+        // When the agent runs inside a paseo-owned worktree, carry the worktree
+        // markers (PASEO_WORKTREE_PATH et al.) so processes the agent spawns are
+        // routed to the worktree's isolated resources instead of the
+        // shared/default ones.
+        ...worktreeEnv,
         PASEO_AGENT_ID: agentId,
         PASEO_AGENT_CWD: cwd,
       },

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -140,6 +140,7 @@ import {
 import type { PaseoToolRuntimeContext } from "./agent/tools/types.js";
 import { createAgentProviderRuntime } from "./agent/provider-runtime.js";
 import { bootstrapWorkspaceRegistries } from "./workspace-registry-bootstrap.js";
+import { resolveAgentWorktreeEnv as resolveAgentWorktreeEnvForCwd } from "./agent-worktree-env.js";
 import { WorkspaceReconciliationService } from "./workspace-reconciliation-service.js";
 import {
   FileBackedProjectRegistry,
@@ -928,6 +929,11 @@ export async function createPaseoDaemon(
     onWorkspaceStateMayHaveChanged: ({ cwd }) => {
       workspaceGitService.onWorkspaceStateMayHaveChanged(cwd);
     },
+    // Mark agents launched inside a paseo-owned worktree with PASEO_WORKTREE_PATH
+    // so processes they spawn use the worktree's isolated resources rather than
+    // the shared/default ones.
+    resolveAgentWorktreeEnv: (cwd) =>
+      resolveAgentWorktreeEnvForCwd(() => workspaceRegistry.list(), cwd),
     mcpAuthToken: agentMcpAuthToken,
     resolvePaseoToolPolicy: (provider) =>
       resolvePaseoToolPolicy(provider, daemonConfigStore.get().providers),


### PR DESCRIPTION
The daemon already exposes PASEO_WORKTREE_PATH, PASEO_SOURCE_CHECKOUT_PATH, PASEO_ROOT_PATH, and PASEO_BRANCH_NAME to service/terminal processes it spawns inside a worktree (see resolveWorktreeRuntimeEnv). Agents, however, are launched with only PASEO_AGENT_CWD, so tooling they shell out to cannot tell a paseo-owned worktree apart from the shared/default checkout and ends up using the shared resource.

When an agent's cwd falls inside a paseo-owned worktree, merge those markers into the launch env so spawned processes are routed to the worktree's isolated resources. Wired through a new optional resolveAgentWorktreeEnv option on AgentManager; the daemon resolves it from the workspace registry, keyed on workspace ownership rather than directory heuristics, and the runtime worktree port stays a service-routing concern.

### Linked issue

NA

### Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

I was getting different behavior in my scripts based on whether an agent started the process or the paseo UI did because there are inconsistencies in the environment variables.

### Goals

Add PASEO_WORKTREE_PATH to any environment for a subprocess, no matter how it's started.

### Non-goals

Solve world hunger, achieve AGI. ASI is probably fine, what could go wrong?

### QA

 - Started a process via agent and via web UI. Saw environment differed. Made change. Saw they were the same.
 - 
### Checklist

- [ ] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (if applicable)
- [X] One focused change
- [X] `npm run typecheck` passes
- [X] `npm run lint` passes
- [X] `npm run format` passes
- [X] QA evidence
- [X] Tests added or updated where it made sense
