### PR TITLE
fix(terminal): fix Chinese Pinyin input on iOS

### DIFF
--- a/docs/mobile-testing.md
+++ b/docs/mobile-testing.md
@@ -448,6 +448,33 @@ RN init; anything about on-screen behavior needs a human holding the phone.
 
 ## iOS Simulator
 
+### Terminal IME input
+
+Terminal composition uses the iOS Fabric TextInput patch in
+`patches/react-native+0.81.5.patch`. Rebuild the native app after changing it;
+Metro reloads do not update native events. Keep `buildReactNativeFromSource`
+enabled in the iOS build properties so Expo does not bypass the patch with a
+prebuilt React Native binary.
+
+Use the onscreen keyboard for this check. Pasting Chinese text or using an
+automation tool's text injection does not exercise marked-text composition.
+
+1. Open a terminal and select the Simplified Chinese Pinyin keyboard.
+2. Type `nihao`, edit the reading with Backspace, and select a Chinese candidate.
+   Only the confirmed candidate should reach the terminal.
+3. Start another reading and use Return to confirm it. It must not submit the
+   terminal line. Press Return again to submit.
+4. Delete the confirmed Chinese characters, including the final character.
+   Each deletion should reach the terminal once. Also try deleting the reading
+   completely before choosing a candidate.
+5. Repeat with WeChat Pinyin, then switch to English and check typing, Return,
+   repeated Backspace on an empty input, emoji deletion, and focus changes.
+
+Record the keyboard interaction and terminal output on the device. Also check
+composition in an ordinary chat input because the native patch is shared.
+
+### Simulator commands
+
 ```bash
 # Screenshot
 xcrun simctl io booted screenshot /tmp/screenshot.png

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -167,6 +167,10 @@ export default {
       [
         "expo-build-properties",
         {
+          ios: {
+            // The terminal needs the patched Fabric TextInput composition events.
+            buildReactNativeFromSource: true,
+          },
           android: {
             minSdkVersion: 29,
             kotlinVersion: "2.1.20",

--- a/packages/app/src/terminal/native-renderer/terminal-input-state.ios.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-input-state.ios.ts
@@ -1,0 +1,68 @@
+import type { TextInputChangeEventData, TextInputKeyPressEventData } from "react-native";
+import { resolveNativeTerminalKey } from "./terminal-key-events";
+import type { TerminalTextInputChange } from "./terminal-input.native";
+
+// Composition metadata comes from patches/react-native+0.81.5.patch. Text changes
+// own printable input and deletion; keypresses run before UIKit applies the edit.
+export function createIosTerminalTextInputState() {
+  let committedText = "";
+  let submittedText: string | null = null;
+
+  return {
+    receiveKeyPress(event: TextInputKeyPressEventData): TerminalTextInputChange {
+      if (event.isComposing) {
+        return { data: "", shouldClear: false };
+      }
+
+      const terminalKey = resolveNativeTerminalKey(event.key);
+      if (terminalKey) {
+        return { data: "", key: terminalKey, shouldClear: true };
+      }
+      if (event.key === "Backspace" && event.isTextEmpty) {
+        // An empty native buffer has no text-change event, but the terminal
+        // may still contain text from history, completion, or an earlier focus.
+        return { data: "\x7f", shouldClear: false };
+      }
+      if (event.key === "Enter" || event.key === "Return" || event.key === "return") {
+        submittedText = committedText;
+        return { data: "\r", shouldClear: true };
+      }
+      return { data: "", shouldClear: false };
+    },
+    receiveChange(event: TextInputChangeEventData): TerminalTextInputChange {
+      if (event.isComposing) {
+        return { data: "", shouldClear: false };
+      }
+
+      const text = event.text;
+      if (submittedText !== null) {
+        const lateSubmitText = `${submittedText}\n`;
+        submittedText = null;
+        if (text === lateSubmitText) {
+          return { data: "", shouldClear: false };
+        }
+      }
+      if (text.includes("\n") || text.includes("\r")) {
+        return { data: "", shouldClear: true };
+      }
+
+      if (text.startsWith(committedText)) {
+        const data = text.slice(committedText.length);
+        committedText = text;
+        return { data, shouldClear: false };
+      }
+      if (committedText.startsWith(text)) {
+        const removed = Array.from(committedText.slice(text.length)).length;
+        committedText = text;
+        return { data: "\x7f".repeat(removed), shouldClear: false };
+      }
+
+      // An unrelated replacement cannot safely rewrite a PTY. Discard the
+      // native editing context so it cannot disable subsequent Backspace.
+      return { data: "", shouldClear: true };
+    },
+    reset(): void {
+      committedText = "";
+    },
+  };
+}

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
@@ -1,8 +1,10 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from "react";
 import {
+  Platform,
   StyleSheet,
   type NativeSyntheticEvent,
   type StyleProp,
+  type TextInputChangeEventData,
   type TextInputKeyPressEventData,
   type TextStyle,
 } from "react-native";
@@ -11,6 +13,7 @@ import {
   type EditingTextInputHandle,
 } from "@/components/ui/text-input";
 import { resolveNativeTerminalKey, type NativeTerminalKey } from "./terminal-key-events";
+import { createIosTerminalTextInputState } from "./terminal-input-state.ios";
 
 export const TERMINAL_INPUT_CONTEXT_MENU_HIDDEN = true;
 export const TERMINAL_INPUT_HITBOX_SIZE = 1;
@@ -44,8 +47,8 @@ interface TerminalInputProps {
 }
 
 // Scripts produced by CJK IMEs when they commit or update a candidate. The
-// native input does not expose marked-text ranges, so the committed script is
-// the only reliable distinction between composition and ordinary autocorrect.
+// Android input does not expose marked-text ranges, so this path distinguishes
+// composition from ordinary autocorrect by script. iOS uses native metadata.
 const CJK_COMPOSITION_PATTERN =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Bopomofo}]/u;
 
@@ -187,7 +190,17 @@ export const TerminalInput = forwardRef<TerminalInputHandle, TerminalInputProps>
     const inputRef = useRef<EditingTextInputHandle>(null);
     const isFocusedRef = useRef(false);
     const pendingFocusFrameRef = useRef<number | null>(null);
-    const inputState = useMemo(() => createTerminalTextInputState(), []);
+    const inputState = useMemo(() => {
+      if (Platform.OS === "ios") {
+        return createIosTerminalTextInputState();
+      }
+      const state = createTerminalTextInputState();
+      return {
+        receiveKeyPress: (event: TextInputKeyPressEventData) => state.receiveKeyPress(event.key),
+        receiveChange: (event: TextInputChangeEventData) => state.receiveTextChange(event.text),
+        reset: state.reset,
+      };
+    }, []);
     const inputStyle = useMemo(() => [styles.input, style], [style]);
 
     const clearPendingFocus = useCallback(() => {
@@ -276,9 +289,9 @@ export const TerminalInput = forwardRef<TerminalInputHandle, TerminalInputProps>
       resetNativeInput();
     }, [resetNativeInput]);
 
-    const handleChangeText = useCallback(
-      (text: string) => {
-        const change = inputState.receiveTextChange(text);
+    const handleChange = useCallback(
+      (event: NativeSyntheticEvent<TextInputChangeEventData>) => {
+        const change = inputState.receiveChange(event.nativeEvent);
         if (change.data.length > 0) {
           onInput?.(change.data);
         }
@@ -291,7 +304,7 @@ export const TerminalInput = forwardRef<TerminalInputHandle, TerminalInputProps>
 
     const handleKeyPress = useCallback(
       (event: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
-        const change = inputState.receiveKeyPress(event.nativeEvent.key);
+        const change = inputState.receiveKeyPress(event.nativeEvent);
         if (change.key) {
           onTerminalKey?.(change.key);
         }
@@ -321,7 +334,7 @@ export const TerminalInput = forwardRef<TerminalInputHandle, TerminalInputProps>
         blurOnSubmit={false}
         importantForAutofill="no"
         multiline={true}
-        onChangeText={handleChangeText}
+        onChange={handleChange}
         onBlur={handleBlur}
         onFocus={handleFocus}
         onKeyPress={handleKeyPress}

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -35,3 +35,225 @@ index f708543..26df5e0 100644
    private int getScrollDelta(View descendent) {
      descendent.getDrawingRect(mTempRect);
      offsetDescendantRectToMyCoords(descendent, mTempRect);
+diff --git a/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts b/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts
+--- a/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts
++++ b/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts
+@@ -504,6 +504,9 @@
+  */
+ export interface TextInputKeyPressEventData {
+   key: string;
++  /** Paseo iOS Fabric patch: native state before the edit. */
++  isComposing?: boolean;
++  isTextEmpty?: boolean;
+ }
+
+ /**
+@@ -518,6 +521,8 @@
+ export interface TextInputChangeEventData extends TargetedEvent {
+   eventCount: number;
+   text: string;
++  /** Paseo iOS Fabric patch: includes in-progress marked-text updates. */
++  isComposing?: boolean;
+ }
+
+ /**
+diff --git a/node_modules/react-native/Libraries/Components/TextInput/TextInput.flow.js b/node_modules/react-native/Libraries/Components/TextInput/TextInput.flow.js
+--- a/node_modules/react-native/Libraries/Components/TextInput/TextInput.flow.js
++++ b/node_modules/react-native/Libraries/Components/TextInput/TextInput.flow.js
+@@ -28,6 +28,7 @@
+   eventCount: number,
+   target: number,
+   text: string,
++  isComposing?: boolean,
+ }>;
+
+ export type TextInputChangeEvent =
+@@ -97,6 +98,8 @@
+ type TextInputKeyPressEventData = $ReadOnly<{
+   ...TargetEvent,
+   key: string,
++  isComposing?: boolean,
++  isTextEmpty?: boolean,
+   target?: ?number,
+   eventCount: number,
+   ...
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+--- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
++++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+@@ -22,6 +22,10 @@
+
+ @property (nonatomic, weak) id<RCTBackedTextInputDelegate> textInputDelegate;
+
++// Includes callbacks inside setMarkedText:, before UIKit installs markedTextRange.
++@property (nonatomic, assign, readonly) BOOL paseoIsComposing;
++@property (nonatomic, assign, readonly) BOOL paseoIsUpdatingText;
++
+ @property (nonatomic, assign) BOOL contextMenuHidden;
+ @property (nonatomic, assign, readonly) BOOL textWasPasted;
+ @property (nonatomic, assign, readonly) BOOL dictationRecognizing;
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+--- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+@@ -14,6 +14,8 @@
+ #import <React/RCTTextAttributes.h>
+
+ @implementation RCTUITextView {
++  NSUInteger _paseoMarkedTextDepth;
++  NSUInteger _paseoTextMutationDepth;
+   UILabel *_placeholderView;
+   UITextView *_detachedTextView;
+   RCTBackedTextViewDelegateAdapter *_textInputDelegateAdapter;
+@@ -60,6 +62,48 @@
+   }
+
+   return self;
++}
++
++- (BOOL)paseoIsComposing
++{
++  return _paseoMarkedTextDepth > 0 || self.markedTextRange != nil;
++}
++
++- (BOOL)paseoIsUpdatingText
++{
++  return _paseoTextMutationDepth > 0;
++}
++
++- (void)setMarkedText:(NSString *)markedText selectedRange:(NSRange)selectedRange
++{
++  _paseoTextMutationDepth += 1;
++  _paseoMarkedTextDepth += 1;
++  [super setMarkedText:markedText selectedRange:selectedRange];
++  _paseoMarkedTextDepth -= 1;
++  _paseoTextMutationDepth -= 1;
++  [self.textInputDelegate textInputDidChange];
++}
++
++- (void)unmarkText
++{
++  const BOOL wasComposing = self.paseoIsComposing;
++  _paseoTextMutationDepth += 1;
++  [super unmarkText];
++  _paseoTextMutationDepth -= 1;
++  // Committing an unchanged candidate does not necessarily change the string.
++  if (wasComposing) {
++    [self.textInputDelegate textInputDidChange];
++  }
++}
++
++- (void)insertText:(NSString *)text
++{
++  // UIKit can unmark the old reading before replacing it with the candidate.
++  // Publish only the snapshot after the outer edit has completed.
++  _paseoTextMutationDepth += 1;
++  [super insertText:text];
++  _paseoTextMutationDepth -= 1;
++  [self.textInputDelegate textInputDidChange];
+ }
+
+ - (void)setDelegate:(id<UITextViewDelegate>)delegate
+diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+--- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
++++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+@@ -55,6 +55,7 @@
+    * textInputDidChange]` call.
+    */
+   BOOL _ignoreNextTextInputCall;
++  BOOL _paseoLastIsComposing;
+
+   /*
+    * A flag that when set to true, `_mostRecentEventCount` won't be incremented when `[self _updateState]`
+@@ -444,6 +445,8 @@
+       textInputEventEmitter.onKeyPress({
+           .text = RCTStringFromNSString(text),
+           .eventCount = static_cast<int>(_mostRecentEventCount),
++          .isComposing = [self _paseoIsComposing],
++          .isTextEmpty = _backedTextInputView.attributedText.length == 0,
+       });
+     }
+   }
+@@ -477,15 +480,22 @@
+
+ - (void)textInputDidChange
+ {
++  if ([_backedTextInputView isKindOfClass:RCTUITextView.class] &&
++      ((RCTUITextView *)_backedTextInputView).paseoIsUpdatingText) {
++    return;
++  }
+   if (_comingFromJS) {
+     return;
+   }
+
+-  if (_ignoreNextTextInputCall && [_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
++  const BOOL isComposing = [self _paseoIsComposing];
++  if (_ignoreNextTextInputCall && _paseoLastIsComposing == isComposing &&
++      [_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+     _ignoreNextTextInputCall = NO;
+     return;
+   }
+
++  _paseoLastIsComposing = isComposing;
+   [self _updateState];
+
+   if (_eventEmitter) {
+@@ -696,6 +706,14 @@
+
+ #pragma mark - Other
+
++- (BOOL)_paseoIsComposing
++{
++  if ([_backedTextInputView isKindOfClass:RCTUITextView.class]) {
++    return ((RCTUITextView *)_backedTextInputView).paseoIsComposing;
++  }
++  return _backedTextInputView.markedTextRange != nil;
++}
++
+ - (TextInputEventEmitter::Metrics)_textInputMetrics
+ {
+   return {
+@@ -707,6 +725,7 @@
+       .contentSize = RCTSizeFromCGSize(_backedTextInputView.contentSize),
+       .layoutMeasurement = RCTSizeFromCGSize(_backedTextInputView.bounds.size),
+       .zoomScale = _backedTextInputView.zoomScale,
++      .isComposing = [self _paseoIsComposing],
+   };
+ }
+
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.cpp b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.cpp
+--- a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.cpp
++++ b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.cpp
+@@ -23,6 +23,7 @@
+   payload.setProperty(runtime, "target", textInputMetrics.target);
+
+   payload.setProperty(runtime, "eventCount", textInputMetrics.eventCount);
++  payload.setProperty(runtime, "isComposing", textInputMetrics.isComposing);
+
+   if (includeSelectionState) {
+     auto selection = jsi::Object(runtime);
+@@ -111,6 +112,8 @@
+     const TextInputEventEmitter::KeyPressMetrics& keyPressMetrics) {
+   auto payload = jsi::Object(runtime);
+   payload.setProperty(runtime, "eventCount", keyPressMetrics.eventCount);
++  payload.setProperty(runtime, "isComposing", keyPressMetrics.isComposing);
++  payload.setProperty(runtime, "isTextEmpty", keyPressMetrics.isTextEmpty);
+
+   std::string key;
+   if (keyPressMetrics.text.empty()) {
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h
+--- a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h
++++ b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h
+@@ -28,11 +28,14 @@
+     Size layoutMeasurement;
+     Float zoomScale;
+     Tag target;
++    bool isComposing{false};
+   };
+
+   struct KeyPressMetrics {
+     std::string text;
+     int eventCount;
++    bool isComposing{false};
++    bool isTextEmpty{false};
+   };
+
+   void onFocus(const Metrics& textInputMetrics) const;


### PR DESCRIPTION
Chinese Pinyin input on iOS sends Latin letters before the confirmed Chinese text and can break Backspace. Reported with both Apple and WeChat keyboards on iOS 26.6.

Use native IME composition state to send only confirmed text, handle deletion once, and keep Backspace/Return inside the IME while composing.

Validation: typecheck, lint, formatting, and 39 existing tests pass. Manual event replay covers composition and deletion.

**Draft:** native iOS build and real-device keyboard testing are still pending.
