### PR TITLE
chore(dev): rebuild client on change for desktop dev on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ tsconfig.tsbuildinfo
 .idea/
 *.sublime-*
 
+# Local, machine-specific lefthook overrides
+lefthook-local.yml
+
 # Testing
 coverage/
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,6 +23,22 @@ Desktop dev launches its desktop-managed daemon with `PASEO_NODE_ENV=development
 so development-only providers such as Mock Load Test are available. Packaged
 desktop launches always force the daemon to production mode.
 
+That daemon runs from `packages/server/dist` when the build output exists, so
+server edits need a rebuild. To iterate on server code without one, start a
+daemon yourself on the desktop dev port with the desktop dev home before
+launching desktop dev — it reuses a daemon that is already running at the
+configured `daemon.listen` instead of spawning its own, and `npm run dev:server:watch`
+runs the daemon from TypeScript source through tsx, so a `paseo daemon restart`
+picks up your changes.
+
+Desktop dev doesn't watch-build `@getpaseo/protocol`/`@getpaseo/client` the way
+`npm run dev` does. `packages/desktop/scripts/dev.ps1` instead fingerprints
+their sources (current `HEAD` plus a hash of the working-tree diff against it)
+against the fingerprint from the last desktop dev build, stored in
+`packages/desktop/.dev/build-client.fingerprint`, and only reruns `build:client`
+when that fingerprint changed — so a `git pull` that touches protocol picks up
+a rebuild automatically, and repeat restarts with no relevant changes skip it.
+
 The web and desktop dev launchers pass the current Git branch to Metro as
 `EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL`. The expanded desktop sidebar shows it in
 the titlebar row. Production builds leave the variable unset and show no label.
@@ -69,6 +85,15 @@ PASEO_DEV_RESET_HOME=1 npm run dev            # clear and reseed the derived wor
 - `npm run dev` (Windows): `localhost:6767` for the daemon.
 
 In Paseo-managed worktree services, use the injected service environment rather than hardcoded root checkout ports.
+
+On Windows, Hyper-V/WSL reserve blocks of TCP ports, and `8002-8101` is commonly
+one of them, so Metro can't bind `8081` and falls back to a random port every
+restart, breaking dev browser storage continuity. Check with
+`netsh interface ipv4 show excludedportrange protocol=tcp`. Plain `npm run dev`
+respects Expo's own `RCT_METRO_PORT` env var with no code changes needed.
+Desktop dev respects a preset `EXPO_PORT` instead of always auto-picking from
+`8081-8085`. Set whichever applies as a persistent user env var
+(`setx EXPO_PORT 8181`) to pin a port outside the reserved blocks.
 
 ### Expo Router
 

--- a/packages/desktop/scripts/dev.ps1
+++ b/packages/desktop/scripts/dev.ps1
@@ -8,25 +8,61 @@ $env:PATH = "$RootDir\node_modules\.bin;$env:PATH"
 
 # Build the Electron main process
 npm run build:main
+if ($LASTEXITCODE -ne 0) { throw "build:main failed with exit code $LASTEXITCODE" }
+
+# Desktop dev doesn't watch-build @getpaseo/protocol/@getpaseo/client like
+# `npm run dev` does, and their dist is consumed directly (see docs/development.md),
+# so rebuild them only when their sources changed since the last build here —
+# HEAD moving picks up pulled commits, the working-tree diff hash picks up
+# uncommitted edits.
+$ClientBuildPaths = @(
+    "packages/protocol/src",
+    "packages/protocol/codegen",
+    "packages/protocol/package.json",
+    "packages/protocol/tsconfig.json",
+    "packages/client/src",
+    "packages/client/package.json",
+    "packages/client/tsconfig.json"
+)
+$ClientBuildMarker = "$DesktopDir\.dev\build-client.fingerprint"
+$HeadSha = (git -C $RootDir rev-parse HEAD).Trim()
+$WorkingDiff = git -C $RootDir diff HEAD -- $ClientBuildPaths
+$WorkingDiffHash = if ($WorkingDiff) { ($WorkingDiff -join "`n" | git -C $RootDir hash-object --stdin).Trim() } else { "clean" }
+$CurrentFingerprint = "$HeadSha|$WorkingDiffHash"
+$PreviousFingerprint = if (Test-Path $ClientBuildMarker) { Get-Content $ClientBuildMarker -Raw } else { $null }
+
+if ($CurrentFingerprint -ne $PreviousFingerprint) {
+    Write-Host "[dev] packages/protocol or packages/client changed since the last desktop dev build, rebuilding..."
+    npm --prefix $RootDir run build:client
+    if ($LASTEXITCODE -ne 0) { throw "build:client failed with exit code $LASTEXITCODE" }
+    New-Item -ItemType Directory -Force -Path (Split-Path $ClientBuildMarker) | Out-Null
+    Set-Content -Path $ClientBuildMarker -Value $CurrentFingerprint -NoNewline
+} else {
+    Write-Host "[dev] packages/protocol and packages/client unchanged, skipping build:client"
+}
 
 # Prefer Metro's stable default port so dev browser storage keeps the same
-# localhost origin across restarts. Fall back only when earlier ports are busy.
-$PreviousNoColor = $env:NO_COLOR
-$PreviousForceColor = $env:FORCE_COLOR
-try {
-    $env:NO_COLOR = "1"
-    $env:FORCE_COLOR = "0"
-    $env:EXPO_PORT = (npx get-port-cli 8081 8082 8083 8084 8085).Trim()
-} finally {
-    if ($null -eq $PreviousNoColor) {
-        Remove-Item Env:\NO_COLOR -ErrorAction SilentlyContinue
-    } else {
-        $env:NO_COLOR = $PreviousNoColor
-    }
-    if ($null -eq $PreviousForceColor) {
-        Remove-Item Env:\FORCE_COLOR -ErrorAction SilentlyContinue
-    } else {
-        $env:FORCE_COLOR = $PreviousForceColor
+# localhost origin across restarts. Fall back only when earlier ports are busy,
+# and let a preset EXPO_PORT win so the origin can be pinned on machines where
+# 8081-8085 are unavailable.
+if (-not $env:EXPO_PORT) {
+    $PreviousNoColor = $env:NO_COLOR
+    $PreviousForceColor = $env:FORCE_COLOR
+    try {
+        $env:NO_COLOR = "1"
+        $env:FORCE_COLOR = "0"
+        $env:EXPO_PORT = (npx get-port-cli 8081 8082 8083 8084 8085).Trim()
+    } finally {
+        if ($null -eq $PreviousNoColor) {
+            Remove-Item Env:\NO_COLOR -ErrorAction SilentlyContinue
+        } else {
+            $env:NO_COLOR = $PreviousNoColor
+        }
+        if ($null -eq $PreviousForceColor) {
+            Remove-Item Env:\FORCE_COLOR -ErrorAction SilentlyContinue
+        } else {
+            $env:FORCE_COLOR = $PreviousForceColor
+        }
     }
 }
 

--- a/paseo.json
+++ b/paseo.json
@@ -21,6 +21,10 @@
       "type": "service",
       "command": "PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"${PASEO_WORKTREE_PATH:-$PWD}\" PASEO_HOME=\"${PASEO_WORKTREE_PATH:-$PWD}/.dev/paseo-home\" PASEO_LISTEN=0.0.0.0:${PASEO_SERVICE_DAEMON_PORT:-6768} PASEO_DEV_DAEMON_ENDPOINT=localhost:${PASEO_SERVICE_DAEMON_PORT:-6768} EXPO_PORT=${PASEO_PORT:-} exec ./packages/desktop/scripts/dev.sh"
     },
+    "desktop-win": {
+      "type": "service",
+      "command": "set \"EXPO_PORT=%PASEO_PORT%\" && npm run dev:win:desktop"
+    },
     "ios-simulator": {
       "type": "service",
       "command": "PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"$PWD\" PASEO_HOME=\"$PWD/.dev/paseo-home\" PASEO_LISTEN=0.0.0.0:${PASEO_SERVICE_DAEMON_PORT} PASEO_DEV_DAEMON_ENDPOINT=localhost:${PASEO_SERVICE_DAEMON_PORT} ./scripts/paseo-ios-simulator-service.sh"


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Enhancement

### Reasoning

`npm run dev` watch-builds `@getpaseo/protocol` and `@getpaseo/client`, but the Windows desktop dev launcher (`packages/desktop/scripts/dev.ps1`) never rebuilt them. After a `git pull` that touched the protocol, the desktop app ran against stale `dist` output and failed in ways that looked like app bugs. Separately, Hyper-V/WSL on Windows reserves TCP port blocks that commonly include 8081, so Metro fell back to a random port on every restart and dev browser storage (hosts, layout) was lost each time.

### Goals

- `dev.ps1` fingerprints protocol/client sources (`HEAD` plus a hash of the working-tree diff against it) against the last desktop dev build and reruns `build:client` only when that changed.
- `dev.ps1` honours a preset `EXPO_PORT` instead of always auto-picking from `8081-8085`.
- Document both behaviours and the reserved-port check (`netsh interface ipv4 show excludedportrange protocol=tcp`) in `docs/development.md`.
- Add a `desktop-win` service entry to `paseo.json` so Paseo-managed worktrees can launch Windows desktop dev.
- Ignore `lefthook-local.yml` (machine-specific hook overrides).

### Non-goals

- No change to `dev.sh` or the POSIX desktop dev flow.
- No live file watcher; the fingerprint is checked once per launch.

### QA

- Windows 11, `npm run dev:win:desktop`: first launch rebuilds `build:client` and writes `packages/desktop/.dev/build-client.fingerprint`; relaunching with no protocol/client changes prints the skip line; editing a file under `packages/protocol/src` triggers a rebuild on the next launch.
- `setx EXPO_PORT 8181` then relaunch: Metro binds 8181 across restarts.
- This PR is a rebase of a commit that was previously bundled into #4141 and is the launcher the author uses daily on Windows. It was not re-run end to end after the rebase; `npm run typecheck` and `npm run lint` pass on the rebased branch. `npm run format:check` reports only `AGENTS.md` / `packages/server/AGENTS.md`, which are unformatted on `main` and untouched here.

### Checklist

- [ ] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (n/a)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes (for the files in this PR)
- [x] QA evidence
- [ ] Tests added or updated where it made sense (shell launcher; no test harness)
