### PR TITLE
feat(plugins): let plugin surfaces open a commit diff tab

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -279,9 +279,10 @@ existing agent-context instances, but it cannot create an agent panel without an
 
 Command Center callbacks use the selected host's existing `PaseoApi` for normal Paseo operations.
 They use typed plugin RPC only for plugin-specific backend work. Surface and panel props expose
-optional client-owned agent and workspace navigation; its absence is the compatibility gate for
-older clients. Other navigation remains limited to registered global surfaces and workspace panels.
-Plugins do not receive Expo Router or workspace-layout store access.
+optional client-owned agent, workspace, and commit-diff navigation; absence is the compatibility
+gate for older clients, and each capability added after the first is optional inside `navigation`
+for the same reason. Other navigation remains limited to registered global surfaces and workspace
+panels. Plugins do not receive Expo Router or workspace-layout store access.
 
 ## Lifecycle hooks
 

--- a/packages/app/e2e/browser/plugin-open-commit-diff.spec.ts
+++ b/packages/app/e2e/browser/plugin-open-commit-diff.spec.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Page, TestInfo } from "@playwright/test";
+import { expect, test } from "../support/fixtures";
+import { openCommandCenter } from "../support/helpers/command-center";
+import { gotoWorkspace } from "../support/helpers/launcher";
+import { connectNewWorkspaceDaemonClient } from "../support/helpers/new-workspace";
+import { pluginRequirements } from "../support/helpers/plugin-fixture";
+import { seedWorkspace } from "../support/helpers/seed-client";
+
+const PLUGIN_ID = "open-commit-diff-e2e";
+const COMMIT_SUBJECT = "Add feature from plugin";
+
+function pluginClientSource(sha: string): string {
+  return `import React from "react";
+import { Pressable, Text, View } from "react-native";
+
+function CommitPanel({ workspaceId, navigation }) {
+  const openCommitDiff = navigation?.openCommitDiff;
+  return <View>
+    <Text>{openCommitDiff ? "Plugin can open commit diffs" : "Plugin cannot open commit diffs"}</Text>
+    {openCommitDiff ? <Pressable accessibilityRole="button" onPress={() => openCommitDiff({ workspaceId, sha: ${JSON.stringify(sha)} })}><Text>Open commit from plugin</Text></Pressable> : null}
+  </View>;
+}
+
+export default function contribute(client) {
+  client.addWorkspacePanel({ id: "commit", title: "Commit panel", icon: "History", context: "workspace", Component: CommitPanel });
+  client.addCommandCenterItem({ id: "open-commit-panel", title: "Open plugin commit panel", icon: "History", context: "workspace", onSelect({ openPanel }) { openPanel("commit"); } });
+  return () => {};
+}`;
+}
+
+function commitFeatureFile(repoPath: string): string {
+  execFileSync("git", ["checkout", "-b", "feature"], { cwd: repoPath, stdio: "ignore" });
+  execFileSync("node", ["-e", "require('fs').writeFileSync('feature.txt', 'before\\nafter\\n')"], {
+    cwd: repoPath,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["add", "feature.txt"], { cwd: repoPath, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", COMMIT_SUBJECT], { cwd: repoPath, stdio: "ignore" });
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: repoPath, encoding: "utf8" }).trim();
+}
+
+async function runCommand(page: Page, title: string): Promise<void> {
+  const panel = await openCommandCenter(page);
+  await panel.getByTestId("command-center-input").fill(title);
+  await panel.getByRole("button", { name: title, exact: true }).click();
+  await expect(panel).not.toBeVisible();
+}
+
+async function capture(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  const screenshot = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ path: screenshot });
+  await testInfo.attach(name, { path: screenshot, contentType: "image/png" });
+}
+
+test.describe("plugin navigation.openCommitDiff", () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  test("opens the commit diff tab for a sha in the focused pane", async ({ page }, testInfo) => {
+    const directory = await mkdtemp(path.join(tmpdir(), "paseo-plugin-open-commit-diff-e2e-"));
+    const client = await connectNewWorkspaceDaemonClient({ ownProjects: false });
+    const previousConfig = await client.getDaemonConfig();
+    const workspace = await seedWorkspace({ repoPrefix: "plugin-open-commit-diff-" });
+    const sha = commitFeatureFile(workspace.repoPath);
+    await writeFile(
+      path.join(directory, "paseo-plugin.json"),
+      JSON.stringify({ id: PLUGIN_ID, requirements: pluginRequirements }),
+    );
+    await writeFile(path.join(directory, "index.client.tsx"), pluginClientSource(sha));
+
+    try {
+      await client.patchDaemonConfig({ pluginsEnabled: true });
+      await client.installDirectoryPlugin(directory);
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await gotoWorkspace(page, workspace.workspaceId);
+
+      await runCommand(page, "Open plugin commit panel");
+      await expect(page.getByText("Plugin can open commit diffs", { exact: true })).toBeVisible();
+      await page.getByRole("button", { name: "Open commit from plugin", exact: true }).click();
+
+      const tab = page.getByTestId(`workspace-tab-commit_diff_${sha}`).filter({ visible: true });
+      await expect(tab).toHaveAttribute("aria-selected", "true", { timeout: 30_000 });
+      const panel = page.getByTestId("commit-diff-panel").filter({ visible: true });
+      await expect(panel.getByTestId("commit-diff-toolbar")).toBeVisible({ timeout: 30_000 });
+      await expect(panel.getByTestId("diff-file-0")).toHaveAccessibleName("feature.txt, +2, -0");
+      await capture(page, testInfo, "plugin-open-commit-diff");
+    } finally {
+      await client.removePlugin(PLUGIN_ID);
+      await client.patchDaemonConfig({
+        pluginsEnabled: previousConfig.config.pluginsEnabled ?? false,
+      });
+      await client.close();
+      await workspace.cleanup();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/app/e2e/browser/plugin-open-commit-diff.spec.ts
+++ b/packages/app/e2e/browser/plugin-open-commit-diff.spec.ts
@@ -1,100 +1,15 @@
-import { execFileSync } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
-import type { Page, TestInfo } from "@playwright/test";
-import { expect, test } from "../support/fixtures";
-import { openCommandCenter } from "../support/helpers/command-center";
-import { gotoWorkspace } from "../support/helpers/launcher";
-import { connectNewWorkspaceDaemonClient } from "../support/helpers/new-workspace";
-import { pluginRequirements } from "../support/helpers/plugin-fixture";
-import { seedWorkspace } from "../support/helpers/seed-client";
+import { test } from "../support/fixtures";
+import {
+  expectSelectedCommitDiff,
+  openCommitFromPluginPanel,
+  withCommitDiffPlugin,
+} from "../support/helpers/plugin-commit-diff";
 
-const PLUGIN_ID = "open-commit-diff-e2e";
-const COMMIT_SUBJECT = "Add feature from plugin";
+test.describe.configure({ timeout: 180_000 });
 
-function pluginClientSource(sha: string): string {
-  return `import React from "react";
-import { Pressable, Text, View } from "react-native";
-
-function CommitPanel({ workspaceId, navigation }) {
-  const openCommitDiff = navigation?.openCommitDiff;
-  return <View>
-    <Text>{openCommitDiff ? "Plugin can open commit diffs" : "Plugin cannot open commit diffs"}</Text>
-    {openCommitDiff ? <Pressable accessibilityRole="button" onPress={() => openCommitDiff({ workspaceId, sha: ${JSON.stringify(sha)} })}><Text>Open commit from plugin</Text></Pressable> : null}
-  </View>;
-}
-
-export default function contribute(client) {
-  client.addWorkspacePanel({ id: "commit", title: "Commit panel", icon: "History", context: "workspace", Component: CommitPanel });
-  client.addCommandCenterItem({ id: "open-commit-panel", title: "Open plugin commit panel", icon: "History", context: "workspace", onSelect({ openPanel }) { openPanel("commit"); } });
-  return () => {};
-}`;
-}
-
-function commitFeatureFile(repoPath: string): string {
-  execFileSync("git", ["checkout", "-b", "feature"], { cwd: repoPath, stdio: "ignore" });
-  execFileSync("node", ["-e", "require('fs').writeFileSync('feature.txt', 'before\\nafter\\n')"], {
-    cwd: repoPath,
-    stdio: "ignore",
-  });
-  execFileSync("git", ["add", "feature.txt"], { cwd: repoPath, stdio: "ignore" });
-  execFileSync("git", ["commit", "-m", COMMIT_SUBJECT], { cwd: repoPath, stdio: "ignore" });
-  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: repoPath, encoding: "utf8" }).trim();
-}
-
-async function runCommand(page: Page, title: string): Promise<void> {
-  const panel = await openCommandCenter(page);
-  await panel.getByTestId("command-center-input").fill(title);
-  await panel.getByRole("button", { name: title, exact: true }).click();
-  await expect(panel).not.toBeVisible();
-}
-
-async function capture(page: Page, testInfo: TestInfo, name: string): Promise<void> {
-  const screenshot = testInfo.outputPath(`${name}.png`);
-  await page.screenshot({ path: screenshot });
-  await testInfo.attach(name, { path: screenshot, contentType: "image/png" });
-}
-
-test.describe("plugin navigation.openCommitDiff", () => {
-  test.describe.configure({ timeout: 180_000 });
-
-  test("opens the commit diff tab for a sha in the focused pane", async ({ page }, testInfo) => {
-    const directory = await mkdtemp(path.join(tmpdir(), "paseo-plugin-open-commit-diff-e2e-"));
-    const client = await connectNewWorkspaceDaemonClient({ ownProjects: false });
-    const previousConfig = await client.getDaemonConfig();
-    const workspace = await seedWorkspace({ repoPrefix: "plugin-open-commit-diff-" });
-    const sha = commitFeatureFile(workspace.repoPath);
-    await writeFile(
-      path.join(directory, "paseo-plugin.json"),
-      JSON.stringify({ id: PLUGIN_ID, requirements: pluginRequirements }),
-    );
-    await writeFile(path.join(directory, "index.client.tsx"), pluginClientSource(sha));
-
-    try {
-      await client.patchDaemonConfig({ pluginsEnabled: true });
-      await client.installDirectoryPlugin(directory);
-      await page.setViewportSize({ width: 1280, height: 900 });
-      await gotoWorkspace(page, workspace.workspaceId);
-
-      await runCommand(page, "Open plugin commit panel");
-      await expect(page.getByText("Plugin can open commit diffs", { exact: true })).toBeVisible();
-      await page.getByRole("button", { name: "Open commit from plugin", exact: true }).click();
-
-      const tab = page.getByTestId(`workspace-tab-commit_diff_${sha}`).filter({ visible: true });
-      await expect(tab).toHaveAttribute("aria-selected", "true", { timeout: 30_000 });
-      const panel = page.getByTestId("commit-diff-panel").filter({ visible: true });
-      await expect(panel.getByTestId("commit-diff-toolbar")).toBeVisible({ timeout: 30_000 });
-      await expect(panel.getByTestId("diff-file-0")).toHaveAccessibleName("feature.txt, +2, -0");
-      await capture(page, testInfo, "plugin-open-commit-diff");
-    } finally {
-      await client.removePlugin(PLUGIN_ID);
-      await client.patchDaemonConfig({
-        pluginsEnabled: previousConfig.config.pluginsEnabled ?? false,
-      });
-      await client.close();
-      await workspace.cleanup();
-      await rm(directory, { recursive: true, force: true });
-    }
+test("a plugin panel opens Paseo's commit diff for a sha", async ({ page }) => {
+  await withCommitDiffPlugin(page, async ({ sha }) => {
+    await openCommitFromPluginPanel(page);
+    await expectSelectedCommitDiff(page, { sha, file: "feature.txt, +2, -0" });
   });
 });

--- a/packages/app/e2e/support/helpers/plugin-commit-diff.ts
+++ b/packages/app/e2e/support/helpers/plugin-commit-diff.ts
@@ -1,0 +1,120 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, type Page } from "@playwright/test";
+import { openCommandCenter } from "./command-center";
+import { gotoWorkspace } from "./launcher";
+import { connectNewWorkspaceDaemonClient } from "./new-workspace";
+import { pluginRequirements } from "./plugin-fixture";
+import { seedWorkspace } from "./seed-client";
+
+const PLUGIN_ID = "open-commit-diff-e2e";
+const OPEN_PANEL_COMMAND = "Open plugin commit panel";
+const OPEN_COMMIT_BUTTON = "Open commit from plugin";
+export const COMMIT_SUBJECT = "Add feature from plugin";
+
+/** A workspace panel that forwards one row press to `navigation.openCommitDiff`. */
+function pluginClientSource(sha: string): string {
+  return `import React from "react";
+import { Pressable, Text, View } from "react-native";
+
+function CommitPanel({ workspaceId, navigation }) {
+  const openCommitDiff = navigation?.openCommitDiff;
+  return <View>
+    <Text>{openCommitDiff ? "Plugin can open commit diffs" : "Plugin cannot open commit diffs"}</Text>
+    {openCommitDiff ? <Pressable accessibilityRole="button" onPress={() => openCommitDiff({ workspaceId, sha: ${JSON.stringify(sha)} })}><Text>${OPEN_COMMIT_BUTTON}</Text></Pressable> : null}
+  </View>;
+}
+
+export default function contribute(client) {
+  client.addWorkspacePanel({ id: "commit", title: "Commit panel", icon: "History", context: "workspace", Component: CommitPanel });
+  client.addCommandCenterItem({ id: "open-commit-panel", title: ${JSON.stringify(OPEN_PANEL_COMMAND)}, icon: "History", context: "workspace", onSelect({ openPanel }) { openPanel("commit"); } });
+  return () => {};
+}`;
+}
+
+/** Commits a two-line file on a new branch and returns its sha. */
+function commitFeatureFile(repoPath: string): string {
+  const git = (args: string[]) => execFileSync("git", args, { cwd: repoPath, stdio: "ignore" });
+  git(["checkout", "-b", "feature"]);
+  execFileSync("node", ["-e", "require('fs').writeFileSync('feature.txt', 'before\\nafter\\n')"], {
+    cwd: repoPath,
+    stdio: "ignore",
+  });
+  git(["add", "feature.txt"]);
+  git(["commit", "-m", COMMIT_SUBJECT]);
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: repoPath, encoding: "utf8" }).trim();
+}
+
+export interface CommitDiffPluginWorkspace {
+  workspaceId: string;
+  /** The sha the contributed panel opens. */
+  sha: string;
+}
+
+/**
+ * Seeds a workspace with one commit, installs a plugin whose panel opens that
+ * commit, and navigates to the workspace. Every teardown step runs even when an
+ * earlier one rejects: browser specs share a daemon, so a half-restored
+ * `pluginsEnabled` or a leaked project contaminates later tests.
+ */
+export async function withCommitDiffPlugin(
+  page: Page,
+  run: (workspace: CommitDiffPluginWorkspace) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(path.join(tmpdir(), "paseo-plugin-open-commit-diff-e2e-"));
+  const client = await connectNewWorkspaceDaemonClient({ ownProjects: false });
+  const previousConfig = await client.getDaemonConfig();
+  const workspace = await seedWorkspace({ repoPrefix: "plugin-open-commit-diff-" });
+  const sha = commitFeatureFile(workspace.repoPath);
+  await writeFile(
+    path.join(directory, "paseo-plugin.json"),
+    JSON.stringify({ id: PLUGIN_ID, requirements: pluginRequirements }),
+  );
+  await writeFile(path.join(directory, "index.client.tsx"), pluginClientSource(sha));
+
+  try {
+    await client.patchDaemonConfig({ pluginsEnabled: true });
+    await client.installDirectoryPlugin(directory);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await gotoWorkspace(page, workspace.workspaceId);
+    await run({ workspaceId: workspace.workspaceId, sha });
+  } finally {
+    const restore: Array<() => Promise<unknown>> = [
+      () => client.removePlugin(PLUGIN_ID),
+      () =>
+        client.patchDaemonConfig({
+          pluginsEnabled: previousConfig.config.pluginsEnabled ?? false,
+        }),
+      () => client.close(),
+      () => workspace.cleanup(),
+      () => rm(directory, { recursive: true, force: true }),
+    ];
+    for (const step of restore) {
+      await step().catch(() => undefined);
+    }
+  }
+}
+
+/** Opens the contributed panel and presses its commit row. */
+export async function openCommitFromPluginPanel(page: Page): Promise<void> {
+  const commandCenter = await openCommandCenter(page);
+  await commandCenter.getByTestId("command-center-input").fill(OPEN_PANEL_COMMAND);
+  await commandCenter.getByRole("button", { name: OPEN_PANEL_COMMAND, exact: true }).click();
+  await expect(commandCenter).not.toBeVisible();
+  await expect(page.getByText("Plugin can open commit diffs", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: OPEN_COMMIT_BUTTON, exact: true }).click();
+}
+
+/** Asserts the focused pane shows Paseo's commit diff tab for `sha`. */
+export async function expectSelectedCommitDiff(
+  page: Page,
+  input: { sha: string; file: string },
+): Promise<void> {
+  const tab = page.getByTestId(`workspace-tab-commit_diff_${input.sha}`).filter({ visible: true });
+  await expect(tab).toHaveAttribute("aria-selected", "true", { timeout: 30_000 });
+  const panel = page.getByTestId("commit-diff-panel").filter({ visible: true });
+  await expect(panel.getByTestId("commit-diff-toolbar")).toBeVisible({ timeout: 30_000 });
+  await expect(panel.getByTestId("diff-file-0")).toHaveAccessibleName(input.file);
+}

--- a/packages/app/src/plugins/host-navigation.test.tsx
+++ b/packages/app/src/plugins/host-navigation.test.tsx
@@ -13,6 +13,9 @@ vi.mock("@/utils/navigate-to-agent", () => ({
 vi.mock("@/stores/navigation-active-workspace-store", () => ({
   navigateToWorkspace: vi.fn(),
 }));
+vi.mock("@/stores/workspace-layout-actions", () => ({
+  FOCUSED_PANE_PLACEMENT: { mode: "focused" },
+}));
 
 const navigateToAgentMock = vi.mocked(navigateToAgent);
 const navigateToWorkspaceMock = vi.mocked(navigateToWorkspace);
@@ -33,6 +36,19 @@ describe("usePluginHostNavigation", () => {
     expect(navigateToWorkspaceMock).toHaveBeenCalledWith({
       serverId: "host-1",
       workspaceId: "workspace-1",
+    });
+  });
+
+  it("opens a commit diff tab in the focused pane of the named workspace", () => {
+    const { result } = renderHook(() => usePluginHostNavigation("host-1"));
+
+    act(() => result.current.openCommitDiff?.({ workspaceId: "workspace-1", sha: "abc1234" }));
+
+    expect(navigateToWorkspaceMock).toHaveBeenCalledWith({
+      serverId: "host-1",
+      workspaceId: "workspace-1",
+      target: { kind: "commit_diff", sha: "abc1234" },
+      placement: { mode: "focused" },
     });
   });
 

--- a/packages/app/src/plugins/host-navigation.test.tsx
+++ b/packages/app/src/plugins/host-navigation.test.tsx
@@ -13,9 +13,6 @@ vi.mock("@/utils/navigate-to-agent", () => ({
 vi.mock("@/stores/navigation-active-workspace-store", () => ({
   navigateToWorkspace: vi.fn(),
 }));
-vi.mock("@/stores/workspace-layout-actions", () => ({
-  FOCUSED_PANE_PLACEMENT: { mode: "focused" },
-}));
 
 const navigateToAgentMock = vi.mocked(navigateToAgent);
 const navigateToWorkspaceMock = vi.mocked(navigateToWorkspace);
@@ -36,19 +33,6 @@ describe("usePluginHostNavigation", () => {
     expect(navigateToWorkspaceMock).toHaveBeenCalledWith({
       serverId: "host-1",
       workspaceId: "workspace-1",
-    });
-  });
-
-  it("opens a commit diff tab in the focused pane of the named workspace", () => {
-    const { result } = renderHook(() => usePluginHostNavigation("host-1"));
-
-    act(() => result.current.openCommitDiff?.({ workspaceId: "workspace-1", sha: "abc1234" }));
-
-    expect(navigateToWorkspaceMock).toHaveBeenCalledWith({
-      serverId: "host-1",
-      workspaceId: "workspace-1",
-      target: { kind: "commit_diff", sha: "abc1234" },
-      placement: { mode: "focused" },
     });
   });
 

--- a/packages/app/src/plugins/host-navigation.ts
+++ b/packages/app/src/plugins/host-navigation.ts
@@ -1,6 +1,7 @@
 import type { PluginSurfaceProps } from "@getpaseo/plugin/client";
 import { useMemo } from "react";
 import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store";
+import { FOCUSED_PANE_PLACEMENT } from "@/stores/workspace-layout-actions";
 import { navigateToAgent } from "@/utils/navigate-to-agent";
 
 export function usePluginHostNavigation(
@@ -10,6 +11,15 @@ export function usePluginHostNavigation(
     () => ({
       openAgent: ({ agentId }) => navigateToAgent({ serverId, agentId }),
       openWorkspace: ({ workspaceId }) => navigateToWorkspace({ serverId, workspaceId }),
+      // Same placement as the core Commits list: the user is working in the
+      // focused pane, so the diff lands there rather than beside the plugin panel.
+      openCommitDiff: ({ workspaceId, sha }) =>
+        navigateToWorkspace({
+          serverId,
+          workspaceId,
+          target: { kind: "commit_diff", sha },
+          placement: FOCUSED_PANE_PLACEMENT,
+        }),
     }),
     [serverId],
   );

--- a/packages/plugin/src/client/contracts.ts
+++ b/packages/plugin/src/client/contracts.ts
@@ -30,6 +30,14 @@ interface PluginNavigableHostProps extends PluginHostProps {
   readonly navigation?: {
     readonly openAgent: (input: { readonly agentId: string }) => void;
     readonly openWorkspace: (input: { readonly workspaceId: string }) => void;
+    /**
+     * Opens Paseo's commit diff tab for `sha` in `workspaceId`. Undefined on hosts
+     * that predate it; fall back or hide the affordance when absent.
+     */
+    readonly openCommitDiff?: (input: {
+      readonly workspaceId: string;
+      readonly sha: string;
+    }) => void;
   };
 }
 

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -614,12 +614,12 @@ export default function contribute(client: PluginClientContext) {
 
 `PluginSurfaceProps` contains:
 
-| Field        | Meaning                                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `theme`      | Typed `PluginTheme` color tokens for the active Paseo theme.                                                                 |
-| `host`       | Selected host `id` and display `label`.                                                                                      |
-| `layout`     | `compact` and the `ios`, `android`, or `web` platform.                                                                       |
-| `navigation` | Optional client navigation. `openAgent({ agentId })` and `openWorkspace({ workspaceId })` open targets on the selected host. |
+| Field        | Meaning                                                                                                                                                                                                                                            |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `theme`      | Typed `PluginTheme` color tokens for the active Paseo theme.                                                                                                                                                                                       |
+| `host`       | Selected host `id` and display `label`.                                                                                                                                                                                                            |
+| `layout`     | `compact` and the `ios`, `android`, or `web` platform.                                                                                                                                                                                             |
+| `navigation` | Optional client navigation. `openAgent({ agentId })` and `openWorkspace({ workspaceId })` open targets on the selected host. `openCommitDiff({ workspaceId, sha })` opens Paseo's commit diff tab; it is itself optional on hosts that predate it. |
 
 Paseo owns the route, header, close action, host picker, error boundary, and query client. The plugin owns the surface body.
 


### PR DESCRIPTION
### Linked issue

Follow-up to #4141 (closed in favour of a plugin workspace panel).

### Type of change

- [x] Enhancement

### Reasoning

#4141 was closed with the suggestion to ship commit history as a plugin workspace panel. Everything in that PR ports cleanly to a plugin except one thing: when the user selects a commit, the panel has nowhere to send them. Plugin `navigation` exposes `openAgent` and `openWorkspace` only, and the SDK has no diff renderer, so a plugin would have to re-implement the commit diff view to be useful. This adds the one capability that has to live in core: opening Paseo's existing commit diff tab for a SHA.

### Goals

- `navigation.openCommitDiff({ workspaceId, sha })` on surface and panel props opens the `commit_diff` target in the focused pane, the same placement the core Commits list uses.
- The new member is optional inside `navigation`, so a plugin compiled against this SDK keeps working on a host that predates it (`navigation` itself already carries that role for older hosts).
- Document it in the v0.8 plugin reference and `docs/plugins.md`.
- Browser E2E: install a plugin panel, press its row, land on the real commit diff panel.

### Non-goals

- No generic "open any workspace tab target" for plugins; the surface stays limited to product-level navigation like `openAgent` / `openWorkspace`.
- No diff components in the plugin SDK.
- The History panel itself lives outside core as a plugin. It uses this capability and falls back to copying the SHA on older hosts.

### QA

Windows 11, Chromium, isolated E2E daemon + Metro.

- `npx playwright test --project=browser e2e/browser/plugin-open-commit-diff.spec.ts` — 1 passed (52s). Installs a temp plugin whose panel calls `navigation.openCommitDiff`, presses the button, and asserts `workspace-tab-commit_diff_<sha>` is selected with `feature.txt, +2, -0` rendered in `commit-diff-panel`.

- Same capability driven through the real out-of-tree History plugin: panel in the Explorer with current-branch/all-branches scope, ref badges, then a row press opening the commit diff tab for that commit.
- `npx vitest run src/plugins/host-navigation.test.tsx` — 2 passed (the pre-existing cases; see below).
- `npm run typecheck`, `npm run lint`, `npm run format` pass on the branch.

Note on test shape, after review feedback: the first push added a hook unit test that mocked an internal navigation module and mounted the hook through Testing Library. `docs/testing.md` rules both out, so that case is gone and `host-navigation.test.tsx` is unchanged from `main`; the browser E2E is the coverage. The E2E's setup and interaction moved into `e2e/support/helpers/plugin-commit-diff.ts`, and each teardown step now runs independently so a failed `removePlugin` cannot leave `pluginsEnabled` flipped for later specs sharing the daemon.

### Checklist

- [x] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

