### PR TITLE
Add syntax highlighting for 8 common languages

### DIFF
--- a/packages/highlight/src/__tests__/highlighter.test.ts
+++ b/packages/highlight/src/__tests__/highlighter.test.ts
@@ -169,6 +169,83 @@ const title = "Hello";
     expect(stringToken?.style).toBe("string");
   });
 
+  it("highlights Shell code", () => {
+    const code = 'if true; then echo "hello"; fi';
+    const result = highlightCode(code, "test.sh");
+
+    const keywordToken = result[0].find((t) => t.text === "if");
+    expect(keywordToken?.style).toBe("keyword");
+
+    const stringToken = result[0].find((t) => t.text.includes("hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
+  it("highlights SQL code", () => {
+    const code = "SELECT 'hello';";
+    const result = highlightCode(code, "test.sql");
+
+    const keywordToken = result[0].find((t) => t.text === "SELECT");
+    expect(keywordToken?.style).toBe("keyword");
+
+    const stringToken = result[0].find((t) => t.text.includes("hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
+  it("highlights Ruby code", () => {
+    const code = 'puts "hello" if true';
+    const result = highlightCode(code, "test.rb");
+
+    const keywordToken = result[0].find((t) => t.text === "if");
+    expect(keywordToken?.style).toBe("keyword");
+
+    const stringToken = result[0].find((t) => t.text.includes("hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
+  it("highlights Kotlin code", () => {
+    const code = 'val message = "hello"';
+    const result = highlightCode(code, "test.kt");
+
+    const keywordToken = result[0].find((t) => t.text === "val");
+    expect(keywordToken?.style).toBe("keyword");
+
+    const stringToken = result[0].find((t) => t.text.includes("hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
+  it("highlights PowerShell code", () => {
+    const code = 'if ($true) { Write-Output "hello" }';
+    const result = highlightCode(code, "test.ps1");
+
+    const keywordToken = result[0].find((t) => t.text === "if");
+    expect(keywordToken?.style).toBe("keyword");
+
+    const stringToken = result[0].find((t) => t.text.includes("hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
+  it("highlights Lua code", () => {
+    const code = 'local message = "hello"';
+    const result = highlightCode(code, "test.lua");
+
+    const keywordToken = result[0].find((t) => t.text === "local");
+    expect(keywordToken?.style).toBe("keyword");
+
+    const stringToken = result[0].find((t) => t.text.includes("hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
+  it("highlights Protocol Buffers code", () => {
+    const code = 'syntax = "proto3";';
+    const result = highlightCode(code, "test.proto");
+
+    const keywordToken = result[0].find((t) => t.text === "syntax");
+    expect(keywordToken?.style).toBe("keyword");
+
+    const stringToken = result[0].find((t) => t.text.includes("proto3"));
+    expect(stringToken?.style).toBe("string");
+  });
+
   it("returns unhighlighted tokens for unsupported extensions", () => {
     const code = "hello world\nsecond line";
     const result = highlightCode(code, "test.xyz");

--- a/packages/highlight/src/__tests__/highlighter.test.ts
+++ b/packages/highlight/src/__tests__/highlighter.test.ts
@@ -2,25 +2,6 @@ import { describe, it, expect } from "vitest";
 import { highlightCode, highlightLine } from "../highlighter.js";
 
 describe("highlightCode", () => {
-  it("highlights TOML configuration files", () => {
-    const code = '# Project settings\n[project]\nname = "paseo"\nport = 6768';
-
-    expect(highlightCode(code, "pyproject.toml")).toEqual([
-      [{ text: "# Project settings", style: "comment" }],
-      [{ text: "[project]", style: "keyword" }],
-      [
-        { text: "name", style: "property" },
-        { text: " = ", style: null },
-        { text: '"paseo"', style: "string" },
-      ],
-      [
-        { text: "port", style: "property" },
-        { text: " = ", style: null },
-        { text: "6768", style: "number" },
-      ],
-    ]);
-  });
-
   it("highlights JavaScript code with correct token styles", () => {
     const code = "const x = 42;";
     const result = highlightCode(code, "test.js");
@@ -175,6 +156,17 @@ const title = "Hello";
 
     const tagToken = tokens.find((t) => t.text === "div");
     expect(tagToken).toBeDefined();
+  });
+
+  it("highlights TOML code", () => {
+    const code = 'name = "paseo"';
+    const result = highlightCode(code, "test.toml");
+
+    const propertyToken = result[0].find((t) => t.text === "name");
+    expect(propertyToken?.style).toBe("property");
+
+    const stringToken = result[0].find((t) => t.text.includes("paseo"));
+    expect(stringToken?.style).toBe("string");
   });
 
   it("returns unhighlighted tokens for unsupported extensions", () => {

--- a/packages/highlight/src/__tests__/highlighter.test.ts
+++ b/packages/highlight/src/__tests__/highlighter.test.ts
@@ -2,6 +2,50 @@ import { describe, it, expect } from "vitest";
 import { highlightCode, highlightLine } from "../highlighter.js";
 
 describe("highlightCode", () => {
+  it("highlights TOML configuration files", () => {
+    const code = ["# Project settings", "[project]", 'name = "paseo"', "ports = [6767, 6768]"].join(
+      "\n",
+    );
+    const result = highlightCode(code, "pyproject.toml");
+
+    expect(result).toHaveLength(4);
+    expect(result[0]).toEqual([{ text: "# Project settings", style: "comment" }]);
+    expect(result[1]).toEqual([{ text: "[project]", style: "keyword" }]);
+    expect(result[2]).toContainEqual({ text: "name", style: "property" });
+    expect(result[2]).toContainEqual({ text: '"paseo"', style: "string" });
+    expect(result[3]).toContainEqual({ text: "6767", style: "number" });
+    expect(result[3]).toContainEqual({ text: "6768", style: "number" });
+    const reconstructedLines: string[] = [];
+    for (const line of result) {
+      reconstructedLines.push(line.map((token) => token.text).join(""));
+    }
+    expect(reconstructedLines.join("\n")).toBe(code);
+  });
+
+  it("highlights TOML literals and preserves multiline string state", () => {
+    const code = [
+      "[[servers]]",
+      "enabled = true",
+      "disabled = false",
+      "created = 2026-09-07T12:00:00Z",
+      'description = """first line',
+      '# still a string"""',
+      "# back to a comment",
+      "path = 'local/path'",
+    ].join("\n");
+    const result = highlightCode(code, ".config/settings.TOML");
+
+    expect(result).toHaveLength(8);
+    expect(result[0]).toEqual([{ text: "[[servers]]", style: "keyword" }]);
+    expect(result[1]).toContainEqual({ text: "true", style: "keyword" });
+    expect(result[2]).toContainEqual({ text: "false", style: "keyword" });
+    expect(result[3]).toContainEqual({ text: "2026-09-07T12:00:00Z", style: "keyword" });
+    expect(result[4]).toContainEqual({ text: '"""first line', style: "string" });
+    expect(result[5]).toEqual([{ text: '# still a string"""', style: "string" }]);
+    expect(result[6]).toEqual([{ text: "# back to a comment", style: "comment" }]);
+    expect(result[7]).toContainEqual({ text: "'local/path'", style: "string" });
+  });
+
   it("highlights JavaScript code with correct token styles", () => {
     const code = "const x = 42;";
     const result = highlightCode(code, "test.js");

--- a/packages/highlight/src/__tests__/highlighter.test.ts
+++ b/packages/highlight/src/__tests__/highlighter.test.ts
@@ -3,47 +3,22 @@ import { highlightCode, highlightLine } from "../highlighter.js";
 
 describe("highlightCode", () => {
   it("highlights TOML configuration files", () => {
-    const code = ["# Project settings", "[project]", 'name = "paseo"', "ports = [6767, 6768]"].join(
-      "\n",
-    );
-    const result = highlightCode(code, "pyproject.toml");
+    const code = '# Project settings\n[project]\nname = "paseo"\nport = 6768';
 
-    expect(result).toHaveLength(4);
-    expect(result[0]).toEqual([{ text: "# Project settings", style: "comment" }]);
-    expect(result[1]).toEqual([{ text: "[project]", style: "keyword" }]);
-    expect(result[2]).toContainEqual({ text: "name", style: "property" });
-    expect(result[2]).toContainEqual({ text: '"paseo"', style: "string" });
-    expect(result[3]).toContainEqual({ text: "6767", style: "number" });
-    expect(result[3]).toContainEqual({ text: "6768", style: "number" });
-    const reconstructedLines: string[] = [];
-    for (const line of result) {
-      reconstructedLines.push(line.map((token) => token.text).join(""));
-    }
-    expect(reconstructedLines.join("\n")).toBe(code);
-  });
-
-  it("highlights TOML literals and preserves multiline string state", () => {
-    const code = [
-      "[[servers]]",
-      "enabled = true",
-      "disabled = false",
-      "created = 2026-09-07T12:00:00Z",
-      'description = """first line',
-      '# still a string"""',
-      "# back to a comment",
-      "path = 'local/path'",
-    ].join("\n");
-    const result = highlightCode(code, ".config/settings.TOML");
-
-    expect(result).toHaveLength(8);
-    expect(result[0]).toEqual([{ text: "[[servers]]", style: "keyword" }]);
-    expect(result[1]).toContainEqual({ text: "true", style: "keyword" });
-    expect(result[2]).toContainEqual({ text: "false", style: "keyword" });
-    expect(result[3]).toContainEqual({ text: "2026-09-07T12:00:00Z", style: "keyword" });
-    expect(result[4]).toContainEqual({ text: '"""first line', style: "string" });
-    expect(result[5]).toEqual([{ text: '# still a string"""', style: "string" }]);
-    expect(result[6]).toEqual([{ text: "# back to a comment", style: "comment" }]);
-    expect(result[7]).toContainEqual({ text: "'local/path'", style: "string" });
+    expect(highlightCode(code, "pyproject.toml")).toEqual([
+      [{ text: "# Project settings", style: "comment" }],
+      [{ text: "[project]", style: "keyword" }],
+      [
+        { text: "name", style: "property" },
+        { text: " = ", style: null },
+        { text: '"paseo"', style: "string" },
+      ],
+      [
+        { text: "port", style: "property" },
+        { text: " = ", style: null },
+        { text: "6768", style: "number" },
+      ],
+    ]);
   });
 
   it("highlights JavaScript code with correct token styles", () => {

--- a/packages/highlight/src/__tests__/parsers.test.ts
+++ b/packages/highlight/src/__tests__/parsers.test.ts
@@ -26,6 +26,17 @@ describe("isLanguageSupported", () => {
     expect(isLanguageSupported("test.ex")).toBe(true);
     expect(isLanguageSupported("Counter.svelte")).toBe(true);
     expect(isLanguageSupported("Page.astro")).toBe(true);
+    expect(isLanguageSupported("test.sh")).toBe(true);
+    expect(isLanguageSupported("test.bash")).toBe(true);
+    expect(isLanguageSupported("test.zsh")).toBe(true);
+    expect(isLanguageSupported("test.sql")).toBe(true);
+    expect(isLanguageSupported("test.rb")).toBe(true);
+    expect(isLanguageSupported("test.kt")).toBe(true);
+    expect(isLanguageSupported("test.kts")).toBe(true);
+    expect(isLanguageSupported("test.ps1")).toBe(true);
+    expect(isLanguageSupported("test.psm1")).toBe(true);
+    expect(isLanguageSupported("test.lua")).toBe(true);
+    expect(isLanguageSupported("test.proto")).toBe(true);
   });
 
   it("returns false for unsupported file extensions", () => {
@@ -69,6 +80,17 @@ describe("getSupportedExtensions", () => {
     expect(extensions).toContain("toml");
     expect(extensions).toContain("svelte");
     expect(extensions).toContain("astro");
+    expect(extensions).toContain("sh");
+    expect(extensions).toContain("bash");
+    expect(extensions).toContain("zsh");
+    expect(extensions).toContain("sql");
+    expect(extensions).toContain("rb");
+    expect(extensions).toContain("kt");
+    expect(extensions).toContain("kts");
+    expect(extensions).toContain("ps1");
+    expect(extensions).toContain("psm1");
+    expect(extensions).toContain("lua");
+    expect(extensions).toContain("proto");
   });
 });
 

--- a/packages/highlight/src/__tests__/parsers.test.ts
+++ b/packages/highlight/src/__tests__/parsers.test.ts
@@ -15,6 +15,7 @@ describe("isLanguageSupported", () => {
     expect(isLanguageSupported("test.go")).toBe(true);
     expect(isLanguageSupported("test.rs")).toBe(true);
     expect(isLanguageSupported("test.json")).toBe(true);
+    expect(isLanguageSupported("pyproject.toml")).toBe(true);
     expect(isLanguageSupported("test.css")).toBe(true);
     expect(isLanguageSupported("test.html")).toBe(true);
     expect(isLanguageSupported("test.java")).toBe(true);
@@ -65,6 +66,7 @@ describe("getSupportedExtensions", () => {
     expect(extensions).toContain("cs");
     expect(extensions).toContain("nix");
     expect(extensions).toContain("json");
+    expect(extensions).toContain("toml");
     expect(extensions).toContain("svelte");
     expect(extensions).toContain("astro");
   });

--- a/packages/highlight/src/parsers.ts
+++ b/packages/highlight/src/parsers.ts
@@ -1,6 +1,7 @@
 import { defineLanguageFacet, Language, StreamLanguage } from "@codemirror/language";
 import { dart } from "@codemirror/legacy-modes/mode/clike";
 import { swift } from "@codemirror/legacy-modes/mode/swift";
+import { toml } from "@codemirror/legacy-modes/mode/toml";
 import { parser as jsParser } from "@lezer/javascript";
 import { parser as jsonParser } from "@lezer/json";
 import { parser as cssParser } from "@lezer/css";
@@ -69,6 +70,8 @@ const languagesByExtension: Record<string, Language> = {
   // YAML
   yaml: language(yamlParser),
   yml: language(yamlParser),
+  // TOML
+  toml: StreamLanguage.define(toml),
   // Rust
   rs: language(rustParser),
   // Swift

--- a/packages/highlight/src/parsers.ts
+++ b/packages/highlight/src/parsers.ts
@@ -1,7 +1,13 @@
 import { defineLanguageFacet, Language, StreamLanguage } from "@codemirror/language";
-import { dart } from "@codemirror/legacy-modes/mode/clike";
+import { dart, kotlin } from "@codemirror/legacy-modes/mode/clike";
 import { swift } from "@codemirror/legacy-modes/mode/swift";
 import { toml } from "@codemirror/legacy-modes/mode/toml";
+import { protobuf } from "@codemirror/legacy-modes/mode/protobuf";
+import { lua } from "@codemirror/legacy-modes/mode/lua";
+import { powerShell } from "@codemirror/legacy-modes/mode/powershell";
+import { ruby } from "@codemirror/legacy-modes/mode/ruby";
+import { standardSQL } from "@codemirror/legacy-modes/mode/sql";
+import { shell } from "@codemirror/legacy-modes/mode/shell";
 import { parser as jsParser } from "@lezer/javascript";
 import { parser as jsonParser } from "@lezer/json";
 import { parser as cssParser } from "@lezer/css";
@@ -85,6 +91,24 @@ const languagesByExtension: Record<string, Language> = {
   // Elixir
   ex: language(elixirParser),
   exs: language(elixirParser),
+  // Shell
+  sh: StreamLanguage.define(shell),
+  bash: StreamLanguage.define(shell),
+  zsh: StreamLanguage.define(shell),
+  // SQL
+  sql: StreamLanguage.define(standardSQL),
+  // Ruby
+  rb: StreamLanguage.define(ruby),
+  // Kotlin
+  kt: StreamLanguage.define(kotlin),
+  kts: StreamLanguage.define(kotlin),
+  // PowerShell
+  ps1: StreamLanguage.define(powerShell),
+  psm1: StreamLanguage.define(powerShell),
+  // Lua
+  lua: StreamLanguage.define(lua),
+  // Protocol Buffers
+  proto: StreamLanguage.define(protobuf),
   // Markdown
   md: language(markdownParser),
   mdx: language(markdownParser),


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Configuration files, scripts, and queries in these languages currently appear without syntax highlighting. Registering the existing tokenizers makes them easier to read in Paseo’s editor, source viewer, and diffs.

### Goals

- Add highlighting for TOML, Shell, SQL, Ruby, Kotlin, PowerShell, Lua, and Protocol Buffers.
- Recognize `.toml`, `.sh`, `.bash`, `.zsh`, `.sql`, `.rb`, `.kt`, `.kts`, `.ps1`, `.psm1`, `.lua`, and `.proto`.
- Reuse existing dependencies and syntax colors.
- Follow the existing language registration and test patterns.

### Non-goals

- Validation, autocomplete, or formatting.
- Filename or shebang detection for extensionless scripts.
- Extending the bundled tokenizers’ syntax coverage.
- SQL dialect selection; `.sql` uses the standard SQL tokenizer.

### QA

Ran the focused highlighting and language registry tests:

```text
npx vitest run packages/highlight/src/__tests__/highlighter.test.ts packages/highlight/src/__tests__/parsers.test.ts --bail=1

Test Files  2 passed (2)
     Tests  35 passed (35)
```

Each new language has a smoke test exercising its actual tokenizer. Tests failed before registration and passed afterward. Kept per-language tests small and unspecific.

Also passed:

- `npm run build:server`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

The macOS dev desktop app launched successfully alongside the installed app using separate daemon ports and runtime state.

I then manually checked one representative fixture in `tmp/` for each extension: `.toml`, `.sh`, `.bash`, `.zsh`, `.sql`, `.rb`, `.kt`, `.kts`, `.ps1`, `.psm1`, `.lua`, and `.proto`. Highlighting worked in every file.

The fixtures exercise declarations, strings, functions, conditionals, shell variables, SQL statements, and protocol definitions. The Lua fixture also covers tables, locals, a function, a loop, conditionals, string formatting, and function calls.

During fixture preparation:

- `npm run format` completed without changing tracked files outside `tmp/`.
- `npm run lint` passed with 0 warnings and 0 errors.
- `npm run typecheck` was blocked by missing checkout dependencies or generated packages, including `zod-aot`, `@types/node`, and CodeMirror packages. The earlier implementation checks listed above passed; this later attempt did not complete.

A subsequent check in the implementation checkout passed both `npm run typecheck` and `npm run lint`. The fixture checks were performed by me, a human.

<img width="483" height="262" alt="image" src="https://github.com/user-attachments/assets/6309843a-3095-4655-a895-48a64ca2d9c9" />

Created a couple of files; all of them render correctly:

<img width="1794" height="1172" alt="92034" src="https://github.com/user-attachments/assets/9060122f-7a3f-48bc-9541-4663672392c1" />


### Checklist

- [x] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (if applicable) — N/A
- [x] One focused change
- [x] `npm run typecheck` passes — verified in the implementation checkout; fixture checkout limitation noted above
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence — automated results and human fixture checks documented, screenshots attached
- [x] Tests added or updated where it made sense