### PR TITLE
Fix context usage for Anthropic-compatible providers

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -2182,6 +2182,84 @@ describe("ClaudeAgentSession context window usage", () => {
     }
   });
 
+  test("assistant usage corrects incomplete Anthropic-compatible stream usage", async () => {
+    const session = await createSessionForTurns(
+      [
+        [
+          createInitMessage(),
+          createMessageStartEvent({
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          }),
+          createMessageDeltaEvent(799),
+          {
+            type: "assistant",
+            parent_tool_use_id: null,
+            message: {
+              id: "assistant-compatible-provider-1",
+              role: "assistant",
+              content: [{ type: "text", text: "Continuing with a tool call." }],
+              usage: {
+                input_tokens: 1_514,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 178_752,
+                output_tokens: 799,
+              },
+            },
+            uuid: "assistant-compatible-provider-event-1",
+            session_id: "session-1",
+          },
+          createSuccessResult({
+            usage: {
+              input_tokens: 1_514,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 178_752,
+              output_tokens: 799,
+              iterations: [],
+            },
+            modelUsage: {
+              "glm-5.2": { contextWindow: 1_000_000 },
+            },
+          }),
+        ],
+      ],
+      { model: "claude-sonnet-5[1m]" },
+    );
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      expect(
+        events.some(
+          (event) => event.type === "usage_updated" && event.usage.contextWindowUsedTokens === 799,
+        ),
+      ).toBe(false);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "usage_updated",
+          provider: "claude",
+          usage: {
+            contextWindowMaxTokens: 1_000_000,
+            contextWindowUsedTokens: 181_065,
+          },
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "turn_completed",
+          provider: "claude",
+          usage: expect.objectContaining({
+            contextWindowMaxTokens: 1_000_000,
+            contextWindowUsedTokens: 181_065,
+          }),
+        }),
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
   test("per-request stream usage is not cumulative across API calls in a turn", async () => {
     const session = await createSessionForTurns([
       [

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -1439,13 +1439,15 @@ describe("ClaudeAgentSession context window usage", () => {
   }
 
   function createMessageDeltaEvent(outputTokens: number): Record<string, unknown> {
+    return createMessageDeltaUsageEvent({ output_tokens: outputTokens });
+  }
+
+  function createMessageDeltaUsageEvent(usage: Record<string, unknown>): Record<string, unknown> {
     return {
       type: "stream_event",
       event: {
         type: "message_delta",
-        usage: {
-          output_tokens: outputTokens,
-        },
+        usage,
       },
       session_id: "session-1",
     };
@@ -2252,6 +2254,291 @@ describe("ClaudeAgentSession context window usage", () => {
           usage: expect.objectContaining({
             contextWindowMaxTokens: 1_000_000,
             contextWindowUsedTokens: 181_065,
+          }),
+        }),
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("terminal message_delta usage corrects zeroed Anthropic-compatible stream usage", async () => {
+    // Mirrors a captured GLM (open.bigmodel.cn /api/anthropic) stream in SDK order
+    // (stream events first, completed assistant message last): message_start and the
+    // completed assistant frame both carry zeroed usage; only the terminal message_delta
+    // reports accurate per-request input, cache-read, and output tokens.
+    const session = await createSessionForTurns(
+      [
+        [
+          createInitMessage(),
+          createMessageStartEvent({
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          }),
+          createMessageDeltaUsageEvent({
+            input_tokens: 38_917,
+            output_tokens: 205,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          }),
+          {
+            type: "assistant",
+            parent_tool_use_id: null,
+            message: {
+              id: "assistant-zero-usage-1",
+              role: "assistant",
+              content: [{ type: "text", text: "OK" }],
+              usage: {
+                input_tokens: 0,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                output_tokens: 0,
+              },
+            },
+            uuid: "assistant-zero-usage-event-1",
+            session_id: "session-1",
+          },
+          createSuccessResult({
+            usage: {
+              input_tokens: 38_917,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+              output_tokens: 205,
+              iterations: [],
+            },
+            modelUsage: {
+              "glm-5.3-flash": { contextWindow: 1_000_000 },
+            },
+          }),
+        ],
+      ],
+      { model: "claude-sonnet-5[1m]" },
+    );
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      expect(
+        events.some(
+          (event) => event.type === "usage_updated" && event.usage.contextWindowUsedTokens === 205,
+        ),
+      ).toBe(false);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "usage_updated",
+          provider: "claude",
+          usage: {
+            contextWindowMaxTokens: 1_000_000,
+            contextWindowUsedTokens: 39_122,
+          },
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "turn_completed",
+          provider: "claude",
+          usage: expect.objectContaining({
+            contextWindowMaxTokens: 1_000_000,
+            contextWindowUsedTokens: 39_122,
+          }),
+        }),
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("assistant frame cannot regress delta-reconciled stream usage", async () => {
+    // A partially-populated assistant frame (raw input without cache fields) must not
+    // overwrite input already reconciled from an accurate terminal message_delta.
+    const session = await createSessionForTurns(
+      [
+        [
+          createInitMessage(),
+          createMessageStartEvent({
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          }),
+          createMessageDeltaUsageEvent({
+            input_tokens: 38_917,
+            output_tokens: 205,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          }),
+          {
+            type: "assistant",
+            parent_tool_use_id: null,
+            message: {
+              id: "assistant-partial-usage-1",
+              role: "assistant",
+              content: [{ type: "text", text: "OK" }],
+              usage: {
+                input_tokens: 1_514,
+                output_tokens: 205,
+              },
+            },
+            uuid: "assistant-partial-usage-event-1",
+            session_id: "session-1",
+          },
+          createSuccessResult({
+            usage: {
+              input_tokens: 38_917,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+              output_tokens: 205,
+              iterations: [],
+            },
+            modelUsage: {
+              "glm-5.3-flash": { contextWindow: 1_000_000 },
+            },
+          }),
+        ],
+      ],
+      { model: "claude-sonnet-5[1m]" },
+    );
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      expect(
+        events.some(
+          (event) =>
+            event.type === "usage_updated" &&
+            event.usage.contextWindowUsedTokens !== undefined &&
+            event.usage.contextWindowUsedTokens < 39_122,
+        ),
+      ).toBe(false);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "turn_completed",
+          provider: "claude",
+          usage: expect.objectContaining({
+            contextWindowUsedTokens: 39_122,
+          }),
+        }),
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("delta input tokens never downgrade an accurate message_start", async () => {
+    // A delta carrying raw input_tokens without cache fields totals less than the
+    // message_start observation; the smaller total must not replace it.
+    const session = await createSessionForTurns(
+      [
+        [
+          createInitMessage(),
+          createMessageStartEvent({
+            input_tokens: 1_514,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 178_752,
+          }),
+          createMessageDeltaUsageEvent({
+            input_tokens: 1_514,
+            output_tokens: 799,
+          }),
+          createSuccessResult({
+            usage: {
+              input_tokens: 1_514,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 178_752,
+              output_tokens: 799,
+              iterations: [],
+            },
+          }),
+        ],
+      ],
+      { model: "claude-sonnet-5[1m]" },
+    );
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      expect(
+        events.some(
+          (event) =>
+            event.type === "usage_updated" &&
+            event.usage.contextWindowUsedTokens !== undefined &&
+            event.usage.contextWindowUsedTokens < 180_266,
+        ),
+      ).toBe(false);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "usage_updated",
+          provider: "claude",
+          usage: expect.objectContaining({
+            contextWindowUsedTokens: 181_065,
+          }),
+        }),
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("straggler delta without a request start cannot seed usage", async () => {
+    // After a canceled request, the pump can still deliver that request's terminal delta
+    // once the next turn has already begun, before the new request's message_start. The
+    // adoption requires the current request's message_start, so the stale total stays inert.
+    const session = await createSessionForTurns([
+      [
+        createInitMessage(),
+        createMessageDeltaUsageEvent({
+          input_tokens: 38_917,
+          output_tokens: 205,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        }),
+        createMessageStartEvent({
+          input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        }),
+        createMessageDeltaUsageEvent({
+          input_tokens: 30_000,
+          output_tokens: 10,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        }),
+        createSuccessResult({
+          usage: {
+            input_tokens: 30_000,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 10,
+            iterations: [],
+          },
+        }),
+      ],
+    ]);
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      expect(
+        events.some(
+          (event) =>
+            event.type === "usage_updated" && event.usage.contextWindowUsedTokens === 39_122,
+        ),
+      ).toBe(false);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "usage_updated",
+          provider: "claude",
+          usage: expect.objectContaining({
+            contextWindowUsedTokens: 30_010,
+          }),
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "turn_completed",
+          provider: "claude",
+          usage: expect.objectContaining({
+            contextWindowUsedTokens: 30_010,
           }),
         }),
       );

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1733,38 +1733,46 @@ function extractContextWindowSize(modelUsage: unknown): number | undefined {
   return maxContextWindow;
 }
 
-function readStreamRequestInputTokens(event: Record<string, unknown>): number | undefined {
-  const messageUsage = toObjectRecord(toObjectRecord(event.message)?.usage);
-  if (!messageUsage) {
+function readRequestInputTokens(usage: unknown): number | undefined {
+  const usageRecord = toObjectRecord(usage);
+  if (!usageRecord) {
     return undefined;
   }
-  const usage = messageUsage;
   const inputTokens =
-    typeof usage.input_tokens === "number" && Number.isFinite(usage.input_tokens)
-      ? usage.input_tokens
+    typeof usageRecord.input_tokens === "number" && Number.isFinite(usageRecord.input_tokens)
+      ? usageRecord.input_tokens
       : undefined;
   const cacheCreationInputTokens =
-    typeof usage.cache_creation_input_tokens === "number" &&
-    Number.isFinite(usage.cache_creation_input_tokens)
-      ? usage.cache_creation_input_tokens
+    typeof usageRecord.cache_creation_input_tokens === "number" &&
+    Number.isFinite(usageRecord.cache_creation_input_tokens)
+      ? usageRecord.cache_creation_input_tokens
       : 0;
   const cacheReadInputTokens =
-    typeof usage.cache_read_input_tokens === "number" &&
-    Number.isFinite(usage.cache_read_input_tokens)
-      ? usage.cache_read_input_tokens
+    typeof usageRecord.cache_read_input_tokens === "number" &&
+    Number.isFinite(usageRecord.cache_read_input_tokens)
+      ? usageRecord.cache_read_input_tokens
       : 0;
   if (typeof inputTokens !== "number" || inputTokens < 0) {
     return undefined;
   }
-  return inputTokens + cacheCreationInputTokens + cacheReadInputTokens;
+  const total = inputTokens + cacheCreationInputTokens + cacheReadInputTokens;
+  return total > 0 ? total : undefined;
 }
 
-function readStreamRequestOutputTokens(event: Record<string, unknown>): number | undefined {
-  const outputTokens = toObjectRecord(event.usage)?.output_tokens;
+function readStreamRequestInputTokens(event: Record<string, unknown>): number | undefined {
+  return readRequestInputTokens(toObjectRecord(event.message)?.usage);
+}
+
+function readRequestOutputTokens(usage: unknown): number | undefined {
+  const outputTokens = toObjectRecord(usage)?.output_tokens;
   if (typeof outputTokens !== "number" || !Number.isFinite(outputTokens) || outputTokens < 0) {
     return undefined;
   }
   return outputTokens;
+}
+
+function readStreamRequestOutputTokens(event: Record<string, unknown>): number | undefined {
+  return readRequestOutputTokens(event.usage);
 }
 
 function readLastUsageIteration(usage: unknown): Record<string, unknown> | undefined {
@@ -1866,11 +1874,11 @@ class ClaudeContextUsageState {
     const eventType = readTrimmedString(streamEvent.type);
     if (eventType === "message_start") {
       const inputTokens = readStreamRequestInputTokens(streamEvent);
+      this.streamRequestInputTokens = inputTokens;
+      this.streamRequestOutputTokens = inputTokens === undefined ? undefined : 0;
       if (typeof inputTokens !== "number") {
         return null;
       }
-      this.streamRequestInputTokens = inputTokens;
-      this.streamRequestOutputTokens = 0;
     } else if (eventType === "message_delta") {
       const outputTokens = readStreamRequestOutputTokens(streamEvent);
       if (typeof outputTokens !== "number") {
@@ -1883,6 +1891,25 @@ class ClaudeContextUsageState {
 
     const usedTokens = this.streamUsedTokens();
     if (usedTokens === undefined) {
+      return null;
+    }
+    return this.createUsageUpdatedEvent(usedTokens);
+  }
+
+  buildAssistantUsageEvent(usage: unknown): AgentStreamEvent | null {
+    // Anthropic-compatible gateways can zero the message_start usage while keeping the completed
+    // assistant frame accurate. Reconcile from that per-request frame before the result aggregate.
+    const inputTokens = readRequestInputTokens(usage);
+    const outputTokens = readRequestOutputTokens(usage);
+    if (inputTokens === undefined || outputTokens === undefined) {
+      return null;
+    }
+
+    const previousUsedTokens = this.streamUsedTokens();
+    this.streamRequestInputTokens = inputTokens;
+    this.streamRequestOutputTokens = outputTokens;
+    const usedTokens = this.streamUsedTokens();
+    if (usedTokens === undefined || usedTokens === previousUsedTokens) {
       return null;
     }
     return this.createUsageUpdatedEvent(usedTokens);
@@ -3782,6 +3809,10 @@ class ClaudeAgentSession implements AgentSession {
         this.appendSidechainResultEvents(message, events);
         break;
       case "assistant": {
+        const usageUpdatedEvent = this.contextUsage.buildAssistantUsageEvent(message.message.usage);
+        if (usageUpdatedEvent) {
+          events.push(usageUpdatedEvent);
+        }
         const timelineItems = this.mapBlocksToTimeline(message.message.content, {
           suppressAssistantText: options?.suppressAssistantText ?? false,
           suppressReasoning: options?.suppressReasoning ?? false,

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1775,6 +1775,10 @@ function readStreamRequestOutputTokens(event: Record<string, unknown>): number |
   return readRequestOutputTokens(event.usage);
 }
 
+function readStreamDeltaInputTokens(event: Record<string, unknown>): number | undefined {
+  return readRequestInputTokens(event.usage);
+}
+
 function readLastUsageIteration(usage: unknown): Record<string, unknown> | undefined {
   const iterations = toObjectRecord(usage)?.iterations;
   if (!Array.isArray(iterations)) {
@@ -1843,6 +1847,7 @@ class ClaudeContextUsageState {
   private streamRequestOutputTokens: number | undefined;
   private compactedContextWindowUsedTokens: number | undefined;
   private completedResultTurns = 0;
+  private sawRequestStart = false;
 
   constructor(initialContextWindowMaxTokens?: number) {
     this.contextWindowMaxTokens = initialContextWindowMaxTokens;
@@ -1852,6 +1857,7 @@ class ClaudeContextUsageState {
     this.streamRequestInputTokens = undefined;
     this.streamRequestOutputTokens = undefined;
     this.compactedContextWindowUsedTokens = undefined;
+    this.sawRequestStart = false;
   }
 
   setInitialContextWindowMaxTokens(contextWindowMaxTokens: number | undefined): void {
@@ -1874,6 +1880,7 @@ class ClaudeContextUsageState {
     const eventType = readTrimmedString(streamEvent.type);
     if (eventType === "message_start") {
       const inputTokens = readStreamRequestInputTokens(streamEvent);
+      this.sawRequestStart = true;
       this.streamRequestInputTokens = inputTokens;
       this.streamRequestOutputTokens = inputTokens === undefined ? undefined : 0;
       if (typeof inputTokens !== "number") {
@@ -1885,6 +1892,18 @@ class ClaudeContextUsageState {
         return null;
       }
       this.streamRequestOutputTokens = outputTokens;
+      // Zero-usage gateways can also zero the completed assistant frame's usage and publish
+      // accurate per-request usage only on the terminal message_delta. A request's input total
+      // is constant, so the largest nonzero observation wins; stragglers from a canceled
+      // request never see a start here and stay inert.
+      const deltaInputTokens = readStreamDeltaInputTokens(streamEvent);
+      if (
+        this.sawRequestStart &&
+        typeof deltaInputTokens === "number" &&
+        deltaInputTokens > (this.streamRequestInputTokens ?? 0)
+      ) {
+        this.streamRequestInputTokens = deltaInputTokens;
+      }
     } else {
       return null;
     }
@@ -1901,12 +1920,15 @@ class ClaudeContextUsageState {
     // assistant frame accurate. Reconcile from that per-request frame before the result aggregate.
     const inputTokens = readRequestInputTokens(usage);
     const outputTokens = readRequestOutputTokens(usage);
-    if (inputTokens === undefined || outputTokens === undefined) {
+    if (inputTokens === undefined || outputTokens === undefined || !this.sawRequestStart) {
       return null;
     }
 
     const previousUsedTokens = this.streamUsedTokens();
-    this.streamRequestInputTokens = inputTokens;
+    // Same merge policy as the terminal message_delta: a request's input total is constant,
+    // so keep the largest nonzero observation instead of letting a partially-populated frame
+    // regress a value already reconciled from the delta.
+    this.streamRequestInputTokens = Math.max(inputTokens, this.streamRequestInputTokens ?? 0);
     this.streamRequestOutputTokens = outputTokens;
     const usedTokens = this.streamUsedTokens();
     if (usedTokens === undefined || usedTokens === previousUsedTokens) {
@@ -1977,6 +1999,7 @@ class ClaudeContextUsageState {
   buildCompactionUsageEvent(postTokens: number | undefined): AgentStreamEvent {
     this.streamRequestInputTokens = undefined;
     this.streamRequestOutputTokens = undefined;
+    this.sawRequestStart = false;
     this.compactedContextWindowUsedTokens = postTokens;
     const usage: AgentUsage = {};
     if (this.contextWindowMaxTokens !== undefined) {


### PR DESCRIPTION
Follow-up to #2903, reopened as a new PR because author-side reopen is not permitted after the close. The evidence @boudra asked for is below and in the new commit.

## Summary

- Treat zero-token `message_start` usage as incomplete so output deltas cannot replace the context meter with an output-only value.
- Reconcile each parent assistant frame's per-request input, cache-read, cache-creation, and output usage into live and completed context usage.
- Keep subagent usage excluded through the existing parent-frame routing.

## Root cause

Some Anthropic-compatible gateways emit a zeroed `message_start` usage object. Paseo accepted the zero input as authoritative, added the later output delta, and displayed only that output count (for example, `799 / 1m`; on a captured real session the meter read **22 / 1M** while the turn actually consumed 38,917 input tokens).

## Evidence from an affected gateway

GLM Coding Plan via `open.bigmodel.cn/api/anthropic`, reached through a local CLIProxyAPI that only maps `glm-5.3-flash[1m]` → `glm-5.3-flash`. Synthetic prompt, response bodies only, credentials stripped.

`message_start` (line 2):

```json
data: {"type": "message_start", "message": {..., "usage": {"input_tokens": 0, "output_tokens": 0}}}
```

Terminal `message_delta` (line 89 direct, line 98 via the proxy):

```json
data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", ...}, "usage": {"input_tokens": 818, "output_tokens": 25, "cache_read_input_tokens": 0, ...}}
```

Direct and proxied captures are identical in shape: the zeroing originates at the vendor endpoint; the proxy passes it through unchanged.

### Before/after context-meter readings (real sessions through the production wrapper)

- **main (`1f5b6143d`)** — turn consumed input 38,917 + output 22; meter showed **22 / 1M**, `turn_completed` also carrying `contextWindowUsedTokens: 22`.
- **this branch (`196681a65`)** — meter showed the correct total after the turn (38,935 / 1M that run), but no live `usage_updated` events.

## What the traces added in `a11e45513`

Instrumenting the SDK stream showed the completed **assistant frames also carry zeroed usage** on this gateway (`{"input_tokens":0,"output_tokens":0}`); accurate per-request input/cache/output is published only on the terminal `message_delta`. The assistant-frame reconcile alone therefore never fired live. The follow-up commit:

- adopts `message_delta` input tokens (incl. cache fields) when they improve on the current per-request value, gated on the current request's `message_start` so a straggler terminal delta from a canceled request cannot seed usage for the next turn;
- applies the same non-regressing merge to `buildAssistantUsageEvent` so a partially-populated assistant frame cannot undo the reconciled value;
- adds four regression tests mirroring the captured trace and these orderings, each mutation-verified.

Reading with the commit on the same chain: live `usage_updated: used=38957` (input 31,621 + cache_read 7,296 + output 40), meter **38,957 / 1M** mid-turn, `turn_completed` matching.

## Validation

- `npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts --bail=1` (66 passed)
- `npm run lint` and format check clean on changed files
- repo-wide typecheck: no new errors versus the branch baseline (this checkout predates current main and lacks `@/partial/watcher` native builds, so a fixed set of pre-existing errors remains in untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)