### PR TITLE
fix(app): collapse commit diff files from their header

### DIFF
--- a/packages/app/e2e/browser/commit-diff-panel.spec.ts
+++ b/packages/app/e2e/browser/commit-diff-panel.spec.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { Locator } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import { test, expect } from "../support/fixtures";
 import { openChangesTreePanel } from "../support/helpers/workspace-tabs";
 
@@ -86,6 +86,35 @@ test("commit history shows dates and shares diff layout preferences", async ({
   await expect(panel.getByTestId("commit-diff-toolbar")).toHaveCount(0);
   await expect(panel.getByTestId("git-diff-canvas")).toBeVisible();
 });
+
+test("a commit diff file collapses and expands from its header", async ({
+  page,
+  withWorkspace,
+}) => {
+  const workspace = await withWorkspace({ prefix: "commit-diff-collapse-" });
+  await createFeatureCommit(workspace.repoPath);
+  await page.setViewportSize({ width: 1400, height: 900 });
+  await workspace.navigateTo();
+
+  const panel = await openCommitDiff(page);
+  await panel.getByTestId("diff-file-0").click();
+  await expect(panel.getByTestId("diff-file-0-body")).not.toBeVisible();
+
+  await panel.getByTestId("diff-file-0").click();
+  await expect(panel.getByTestId("diff-file-0-body")).toBeVisible();
+});
+
+/** Opens the Commits section, selects the only commit, and returns its diff panel. */
+async function openCommitDiff(page: Page): Promise<Locator> {
+  await openChangesTreePanel(page);
+  const commitsSection = page.getByRole("button", { name: /Commits/i });
+  await expect(commitsSection).toBeVisible({ timeout: 30_000 });
+  await commitsSection.click();
+  await page.locator('[data-testid^="commit-row-"]').filter({ hasText: COMMIT_SUBJECT }).click();
+  const panel = page.getByTestId("commit-diff-panel").filter({ visible: true });
+  await expect(panel.getByTestId("git-diff-canvas")).toBeVisible({ timeout: 30_000 });
+  return panel;
+}
 
 async function createFeatureCommit(repoPath: string): Promise<void> {
   execFileSync("git", ["checkout", "-b", "feature"], { cwd: repoPath, stdio: "ignore" });

--- a/packages/app/src/components/ui/context-menu.tsx
+++ b/packages/app/src/components/ui/context-menu.tsx
@@ -169,6 +169,9 @@ export function ContextMenuTrigger({
   const handleContextMenu = useCallback(
     (event: unknown) => {
       if (isNative) return;
+      // A disabled trigger owns no menu, so it must let the event reach whatever
+      // encloses it instead of swallowing the right click and showing nothing.
+      if (!shouldEnableOnThisPlatform || disabled) return;
       if (typeof event === "object" && event !== null) {
         const preventDefault = Reflect.get(event, "preventDefault");
         const stopPropagation = Reflect.get(event, "stopPropagation");
@@ -178,7 +181,7 @@ export function ContextMenuTrigger({
       onContextMenu?.(event);
       openAtEvent(event);
     },
-    [onContextMenu, openAtEvent],
+    [disabled, onContextMenu, openAtEvent, shouldEnableOnThisPlatform],
   );
 
   const resolveDynamicStyle = useCallback(

--- a/packages/app/src/git/diff-document/document-file-header.tsx
+++ b/packages/app/src/git/diff-document/document-file-header.tsx
@@ -24,8 +24,7 @@ export const DocumentFileHeader = memo(function DocumentFileHeader({
 }: DocumentFileHeaderProps) {
   const activate = useCallback(
     (path: string) => {
-      if (mode.kind !== "working") return;
-      mode.onFilePress?.(path);
+      if (mode.kind === "working") mode.onFilePress?.(path);
       onToggleFile(path);
     },
     [mode, onToggleFile],

--- a/packages/app/src/git/diff-document/index.tsx
+++ b/packages/app/src/git/diff-document/index.tsx
@@ -12,19 +12,16 @@ type ThemedDiffDocumentProps = DiffDocumentProps & {
   headerTypography: DiffHeaderTypography;
 };
 
-const EMPTY_PATHS: string[] = [];
-
 function ThemedDiffDocument(props: ThemedDiffDocumentProps) {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const paletteRef = useRef(props.palette);
   paletteRef.current = retainDiffPalette(paletteRef.current, props.palette);
   const palette = paletteRef.current;
-  const collapseState = props.mode.kind === "working" ? props.collapseState : null;
-  const paths = collapseState?.paths ?? EMPTY_PATHS;
+  const collapseState = props.collapseState;
+  const paths = collapseState.paths;
   const collapsedFilePaths = useMemo(() => new Set(paths), [paths]);
   const toggleFile = useCallback(
     (path: string) => {
-      if (!collapseState) return;
       const next = collapsedFilePaths.has(path)
         ? paths.filter((entry) => entry !== path)
         : [...paths, path];

--- a/packages/app/src/git/diff-document/types.ts
+++ b/packages/app/src/git/diff-document/types.ts
@@ -2,8 +2,15 @@ import type { ParsedDiffFile } from "@getpaseo/protocol/messages";
 import type { InlineReviewActions } from "@/review";
 import type { ReviewableDiffTarget } from "@/utils/diff-layout";
 
+export interface DiffCollapseState {
+  paths: readonly string[];
+  onChange: (paths: string[]) => void;
+}
+
 interface DiffDocumentBaseProps {
   files: ParsedDiffFile[];
+  /** Collapsed file paths and the sink that persists them. Every mode collapses. */
+  collapseState: DiffCollapseState;
   displayPreferences: {
     layout: "unified" | "split";
     wrapLines: boolean;
@@ -31,17 +38,9 @@ export interface WorkingDiffMode {
   onRevert?: (path: string, oldPath?: string) => void;
 }
 
-export type DiffDocumentProps = DiffDocumentBaseProps &
-  (
-    | {
-        mode: WorkingDiffMode;
-        collapseState: {
-          paths: readonly string[];
-          onChange: (paths: string[]) => void;
-        };
-      }
-    | { mode: { kind: "commit" }; collapseState?: never }
-  );
+export type DiffDocumentProps = DiffDocumentBaseProps & {
+  mode: WorkingDiffMode | { kind: "commit" };
+};
 
 export interface DiffTypography {
   family: string;

--- a/packages/app/src/git/file-header.tsx
+++ b/packages/app/src/git/file-header.tsx
@@ -130,6 +130,10 @@ function fileHeaderNameStyle(showsBodyState: boolean, isHovered: boolean) {
   ];
 }
 
+function childTestID(testID: string | undefined, suffix: string): string | undefined {
+  return testID ? `${testID}-${suffix}` : undefined;
+}
+
 function fileChange(file: ParsedDiffFile): "added" | "deleted" | "modified" {
   return diffFileChangeKind(file);
 }
@@ -199,7 +203,11 @@ export const FileHeader = memo(function FileHeader({
   onActiveChange,
   ...actions
 }: FileHeaderProps) {
-  const hover = useFileHeaderHover(interactive, onActiveChange);
+  // A commit diff header collapses on press but owns no working-tree actions, so
+  // press and hover follow `onActivate` while the drag source and the actions menu
+  // stay behind `interactive`.
+  const pressable = interactive || Boolean(onActivate);
+  const hover = useFileHeaderHover(pressable, onActiveChange);
   const dragSourceRef = useWorkspaceFileDragSource({
     enabled: interactive,
     disabled: file.isDeleted,
@@ -209,7 +217,7 @@ export const FileHeader = memo(function FileHeader({
   });
   const interaction = useFileHeaderInteraction({
     path: file.path,
-    enabled: interactive,
+    enabled: pressable,
     onSelect,
     onActivate,
     onLayout: useCallback(
@@ -253,7 +261,7 @@ export const FileHeader = memo(function FileHeader({
   const content = (
     <View
       style={[styles.content, showsBodyState && styles.documentContent]}
-      testID={testID ? `${testID}-header-content` : undefined}
+      testID={childTestID(testID, "header-content")}
     >
       <View ref={dragSourceRef} style={showDir ? styles.left : [styles.left, styles.leftTree]}>
         {showDir ? null : (
@@ -261,7 +269,7 @@ export const FileHeader = memo(function FileHeader({
             <MaterialFileIcon fileName={fileName} size={WORKSPACE_TREE_ICON_SIZE} />
           </View>
         )}
-        <Text style={nameStyle} numberOfLines={1} testID={testID ? `${testID}-name` : undefined}>
+        <Text style={nameStyle} numberOfLines={1} testID={childTestID(testID, "name")}>
           {fileName}
         </Text>
         {showDir ? (
@@ -276,7 +284,7 @@ export const FileHeader = memo(function FileHeader({
         <DiffStat
           additions={file.additions}
           deletions={file.deletions}
-          testID={testID ? `${testID}-stat` : undefined}
+          testID={childTestID(testID, "stat")}
         />
         {changeIcon}
       </View>
@@ -302,10 +310,11 @@ export const FileHeader = memo(function FileHeader({
     [onActiveChange],
   );
   let trigger: ReactElement;
-  if (interactive) {
+  if (pressable) {
     trigger = (
       <ContextMenuTrigger
-        testID={testID ? `${testID}-toggle` : undefined}
+        enabled={interactive}
+        testID={childTestID(testID, "toggle")}
         style={canvasPressableStyle}
         highlightStyle={fileHeaderPressFeedbackStyle(showsBodyState, canvasRendered)}
         onPressIn={handlePressIn}

--- a/packages/app/src/panels/commit-diff/state.ts
+++ b/packages/app/src/panels/commit-diff/state.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const commitDiffStateSchema = z.strictObject({
+  collapsedFilePaths: z.array(z.string()),
+});
+
+export type CommitDiffState = z.infer<typeof commitDiffStateSchema>;
+
+export const defaultCommitDiffState: CommitDiffState = { collapsedFilePaths: [] };

--- a/packages/app/src/panels/diff-panel.tsx
+++ b/packages/app/src/panels/diff-panel.tsx
@@ -19,6 +19,7 @@ import { useAddFileToChat } from "@/panels/use-add-file-to-chat";
 import { useWorkspaceDirectory } from "@/stores/session-store-hooks";
 import type { WorkspaceTabTarget } from "@/workspace-tabs/model";
 import { defaultChangesState, changesStateSchema } from "@/panels/changes/state";
+import { commitDiffStateSchema, defaultCommitDiffState } from "@/panels/commit-diff/state";
 import { usePanelState } from "@/panels/use-panel-state";
 import { RenderProfile } from "@/utils/render-profiler";
 
@@ -162,6 +163,18 @@ function CommitDiffPanel() {
     enabled: Boolean(cwd),
   });
   const mode = useMemo(() => ({ kind: "commit" as const }), []);
+  const [commitDiffState, setCommitDiffState] = usePanelState(
+    commitDiffStateSchema,
+    defaultCommitDiffState,
+  );
+  const setCollapsedFilePaths = useCallback(
+    (collapsedFilePaths: string[]) => setCommitDiffState({ collapsedFilePaths }),
+    [setCommitDiffState],
+  );
+  const collapseState = useMemo(
+    () => ({ paths: commitDiffState.collapsedFilePaths, onChange: setCollapsedFilePaths }),
+    [commitDiffState.collapsedFilePaths, setCollapsedFilePaths],
+  );
 
   let body: ReactNode;
   if (!cwd) {
@@ -185,6 +198,7 @@ function CommitDiffPanel() {
     body = (
       <DiffDocument
         files={files}
+        collapseState={collapseState}
         displayPreferences={panelPreferences.displayPreferences}
         mode={mode}
       />


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [x] Bug fix

### Reasoning

Clicking a file header in the working diff collapses that file. The same header in a commit diff does nothing — it is not even pressable. Nothing about collapsing is specific to the working tree; a commit that touches twenty files is exactly where you want to fold away the ones you have already read.

The reason it was missing is structural: `collapseState` was declared on the working branch of the `DiffDocumentProps` union, so the commit panel had no way to pass one, and `DocumentFileHeader` returned early on any non-working mode.

### Goals

- A commit diff file header collapses and expands on press, like the working diff.
- Collapsed paths persist per tab, like the Changes panel.
- Right click on a commit diff header does not regress.

### Non-goals

- No file-actions menu (Open file, Revert, Add to chat) on commit diff headers. Those are working-tree actions and the commit panel owns none of them.

### Implementation notes

`collapseState` moves onto the document's base props so both modes toggle.

`FileHeader` separates the two things `interactive` used to mean. Press and hover now follow `onActivate`; the drag source and the file-actions menu stay behind `interactive`, which the commit diff does not set. Without that split a commit header would mount a `ContextMenu` whose content renders `null`, and right click would be swallowed for a menu that never appears.

That is also why `ContextMenuTrigger` changes: a trigger with `enabled={false}` still called `preventDefault`/`stopPropagation`, so it ate the right click and showed nothing. It now lets the event through, and the diff surface's own Copy / Copy line / Select all menu still opens over a commit diff header. No existing caller passes `enabled={false}`, so nothing else changes.

### QA

Automated, on this branch:

```
$ npm run typecheck
(all workspaces, no errors)

$ npm run lint
Found 0 warnings and 0 errors.

$ npx vitest run src/components/ui/context-menu.test.tsx src/git/use-diff-files.test.ts --bail=1
 Test Files  2 passed (2)
      Tests  3 passed (3)
```

New browser coverage in `packages/app/e2e/browser/commit-diff-panel.spec.ts`:

```ts
test("a commit diff file collapses and expands from its header", ...)
  await panel.getByTestId("diff-file-0").click();
  await expect(panel.getByTestId("diff-file-0-body")).not.toBeVisible();
  await panel.getByTestId("diff-file-0").click();
  await expect(panel.getByTestId("diff-file-0-body")).toBeVisible();
```

Manual, Windows desktop, against a real daemon in a real browser, through the same steps the spec runs (Changes → Commits → commit row):

Expanded:

![expanded](https://raw.githubusercontent.com/CN-liuzhiyang/paseo/qa-evidence/qa/qa-collapse-expanded.png)

After pressing the `feature.txt` header:

![collapsed](https://raw.githubusercontent.com/CN-liuzhiyang/paseo/qa-evidence/qa/qa-collapse-collapsed.png)

Pressing again restores the body. Right clicking the header still opens the diff Copy / Copy line / Select all menu.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             |        | Shares the `DocumentFileHeader` path with web; not run on device |
| Android         |        | Same |
| Web             | yes    | Playwright browser project |
| Desktop macOS   |        |       |
| Desktop Windows | yes    | Electron dev build |
| Desktop Linux   |        |       |

`commit-diff-panel.spec.ts` could not be run locally: on this machine the `withWorkspace` fixture never gets past "No projects yet", and it fails the same way on a clean checkout of `main`, so it is an environment problem rather than something this branch introduced. The collapse behaviour above was verified through a `seedWorkspace`-based run of the identical steps. CI covers the committed spec.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
