### PR TITLE
refactor(server): separate provider history reads from interactive resume

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -113,17 +113,25 @@ History navigation preserves the selected agent as an explicit recovery target. 
 and its workspace are archived, the workspace recovery action restores the workspace and unarchives
 the selected agent as one user action. Other archived agents in the restored workspace remain
 recoverable from History. Opening one pins its tab and renders the archived-agent callout. Authoritative
-timeline catch-up may load provider history with a runtime-only `history` resume purpose, which must
-leave both Paseo's `archivedAt` and the provider's native archive state unchanged. **Unarchive** remains
-the only transition back to an interactive runtime: it runs the provider's native unarchive hook
-(including Codex `thread/unarchive`) before the normal agent resume and timeline hydration flow. A
-provider session can be archived outside Paseo while its Paseo agent remains active. Interactive
-resume repairs that drift through the provider's native unarchive hook; history resume does not.
+timeline catch-up uses the provider's dedicated history-read operation, which materializes history
+without registering an interactive runtime and must leave both Paseo's `archivedAt` and the provider's
+native archive state unchanged. The result hydrates only the retained in-memory timeline; it does not
+seed or commit a durable timeline cache. **Unarchive** remains the only transition back to an interactive
+runtime: it runs the provider's native unarchive hook (including Codex `thread/unarchive`) before the
+normal agent resume and timeline hydration flow. A provider session can also be archived outside
+Paseo while its Paseo agent remains active. Interactive resume repairs that drift through the
+provider's native unarchive path; dedicated history reads never do.
+
+Closed history snapshots retain visibility metadata such as the persisted `internal` flag. Public
+timeline and provider-subagent reads must apply the same visibility boundary to a history snapshot as
+they do to a live agent, including when a concurrent unarchive promotes that snapshot to a live
+runtime.
 
 Provider session connection owns every process it spawns until the session is registered with
-`AgentManager`. If initialization, persisted-session resume, or initial history hydration fails,
-`connect()` must dispose that process before rethrowing; the manager cannot clean up a session it never
-received.
+`AgentManager`. Dedicated history reads own their temporary process for the entire operation and close
+it before resolving or rejecting. If initialization or persisted-session resume fails, the provider
+must also dispose the unregistered process before rethrowing; the manager cannot clean up a session it
+never received.
 
 ## Tabs vs archive
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -458,6 +458,10 @@ interface AgentClient {
   fetchCatalog(options: FetchCatalogOptions): Promise<ProviderCatalog>;
   isAvailable(): Promise<boolean>;
   // Optional:
+  readSessionHistory(
+    handle: AgentPersistenceHandle,
+    context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult>;
   listImportableSessions(
     options?: ListImportableSessionsOptions,
   ): Promise<ImportableProviderSession[]>;
@@ -506,6 +510,8 @@ interface AgentSession {
 ```
 
 `setMode` and `setThinkingOption` may return an `AgentProviderNotice` when the provider knows the change needs user-facing context. For example, providers that stage changes until the next turn should return an `info` notice while a turn is already running. The app renders the notice generically as a toast; provider-specific lifecycle behavior stays in the provider implementation.
+
+Persistent providers should implement `readSessionHistory` as a distinct read contract rather than forwarding to the public interactive `resumeSession` path. It returns events with explicit coverage; current readers return `{ kind: "complete" }`, leaving the result shape extensible without adding pagination here. Its narrow `AgentHistoryReadContext` exposes only the working directory, provider environment, and agent identity; interactive configuration such as MCP servers, native Paseo tools, prompts, modes, models, and feature flags is deliberately unavailable. Prefer direct transcript files or provider SDK history endpoints. If the provider requires a temporary runtime, start only the minimum history runtime, avoid interactive subscriptions, host-tool/MCP setup, prompts, aborts, or native archive mutations, and close the runtime before the method resolves or rejects. Tests must cover both successful and failed reads and assert resource release; providers with native archive state must also prove that history reads leave it unchanged.
 
 ### Steps
 

--- a/packages/server/src/server/agent/agent-loading.test.ts
+++ b/packages/server/src/server/agent/agent-loading.test.ts
@@ -1,24 +1,42 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { expect, test } from "vitest";
+import { expect, onTestFinished, test } from "vitest";
 
 import { createTestLogger } from "../../test-utils/test-logger.js";
-import { AgentManager } from "./agent-manager.js";
+import { AgentManager, type AgentManagerEvent } from "./agent-manager.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
 import { AgentStorage } from "./agent-storage.js";
 import type {
   AgentClient,
-  AgentLaunchContext,
+  AgentHistoryReadContext,
   AgentPersistenceHandle,
-  AgentResumeSessionOptions,
-  AgentSession,
-  AgentSessionConfig,
+  AgentStreamEvent,
 } from "./agent-sdk-types.js";
 import { createTestAgentClients } from "../test-utils/fake-agent-client.js";
 
-test("loads archived records for history and active records with the interactive default", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-purpose-"));
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+function completeHistory(events: AgentStreamEvent[]) {
+  return { events, coverage: { kind: "complete" as const } };
+}
+
+type HistoryReader = NonNullable<AgentClient["readSessionHistory"]>;
+
+interface LoaderHarnessOptions {
+  readSessionHistory?: HistoryReader;
+  archiveNativeSession?: (handle: AgentPersistenceHandle) => Promise<void>;
+  unarchiveNativeSession?: (handle: AgentPersistenceHandle) => Promise<void>;
+}
+
+async function createLoaderHarness(options: LoaderHarnessOptions = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-history-"));
   const logger = createTestLogger();
   const storage = new AgentStorage(path.join(root, "agents"), logger);
   const baseClient = createTestAgentClients().codex;
@@ -26,57 +44,317 @@ test("loads archived records for history and active records with the interactive
     throw new Error("expected Codex test client");
   }
 
-  const resumeOptions: Array<AgentResumeSessionOptions | undefined> = [];
+  const calls = {
+    createCount: 0,
+    resumeSessionIds: [] as string[],
+    history: [] as Array<{
+      handle: AgentPersistenceHandle;
+      context: AgentHistoryReadContext | undefined;
+    }>,
+  };
   const client: AgentClient = {
     provider: baseClient.provider,
     capabilities: baseClient.capabilities,
-    createSession: async (
-      config: AgentSessionConfig,
-      launchContext?: AgentLaunchContext,
-    ): Promise<AgentSession> => await baseClient.createSession(config, launchContext),
-    resumeSession: async (
-      handle: AgentPersistenceHandle,
-      overrides?: Partial<AgentSessionConfig>,
-      launchContext?: AgentLaunchContext,
-      options?: AgentResumeSessionOptions,
-    ): Promise<AgentSession> => {
-      resumeOptions.push(options);
+    createSession: async (config, launchContext) => {
+      calls.createCount += 1;
+      return await baseClient.createSession(config, launchContext);
+    },
+    resumeSession: async (handle, overrides, launchContext) => {
+      calls.resumeSessionIds.push(handle.sessionId);
       return await baseClient.resumeSession(handle, overrides, launchContext);
     },
-    fetchCatalog: async (options) => await baseClient.fetchCatalog(options),
+    readSessionHistory: async (handle, context) => {
+      calls.history.push({ handle, context });
+      return (await options.readSessionHistory?.(handle, context)) ?? completeHistory([]);
+    },
+    archiveNativeSession: options.archiveNativeSession,
+    unarchiveNativeSession: options.unarchiveNativeSession,
+    fetchCatalog: async (catalogOptions) => await baseClient.fetchCatalog(catalogOptions),
     isAvailable: async () => await baseClient.isAvailable(),
   };
-  const manager = new AgentManager({
-    clients: { codex: client },
-    registry: storage,
-    logger,
-  });
+  const manager = new AgentManager({ clients: { codex: client }, registry: storage, logger });
 
-  const archivedId = "00000000-0000-4000-8000-000000000301";
-  const activeId = "00000000-0000-4000-8000-000000000302";
-
-  try {
-    const archived = await manager.createAgent({ provider: "codex", cwd: root }, archivedId, {
-      workspaceId: "workspace-archived",
-    });
-    await manager.archiveAgent(archived.id);
-
-    const active = await manager.createAgent({ provider: "codex", cwd: root }, activeId, {
-      workspaceId: "workspace-active",
-    });
-    await manager.closeAgent(active.id);
-
-    await ensureAgentLoaded(archived.id, { agentManager: manager, agentStorage: storage, logger });
-    await ensureAgentLoaded(active.id, { agentManager: manager, agentStorage: storage, logger });
-
-    expect(resumeOptions).toEqual([{ purpose: "history" }, undefined]);
-  } finally {
-    await Promise.all([
-      manager.closeAgent(archivedId).catch(() => undefined),
-      manager.closeAgent(activeId).catch(() => undefined),
-    ]);
+  onTestFinished(async () => {
+    for (const agent of manager.listAgents()) {
+      await manager.closeAgent(agent.id).catch(() => undefined);
+    }
     await manager.flush().catch(() => undefined);
     await storage.flush().catch(() => undefined);
     await rm(root, { recursive: true, force: true });
+  });
+
+  return {
+    root,
+    logger,
+    storage,
+    manager,
+    calls,
+    load: async (agentId: string, broadcastTimeline = false) =>
+      await ensureAgentLoaded(agentId, {
+        agentManager: manager,
+        agentStorage: storage,
+        ...(broadcastTimeline ? { broadcastTimeline: true } : {}),
+        logger,
+      }),
+    createArchived: async (agentId: string, archiveOptions?: { internal?: boolean }) => {
+      const agent = await manager.createAgent(
+        {
+          provider: "codex",
+          cwd: root,
+          ...(archiveOptions?.internal === undefined ? {} : { internal: archiveOptions.internal }),
+        },
+        agentId,
+        {
+          workspaceId: "workspace-archived",
+        },
+      );
+      await manager.archiveAgent(agent.id);
+      return agent;
+    },
+  };
+}
+
+test("loads archived history without interactive resume or archive-state changes", async () => {
+  let nativeArchived = false;
+  let nativeUnarchiveCount = 0;
+  const harness = await createLoaderHarness({
+    readSessionHistory: async () => {
+      expect(nativeArchived).toBe(true);
+      return completeHistory([
+        {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "assistant_message", text: "Archived provider history" },
+        },
+      ]);
+    },
+    archiveNativeSession: async () => {
+      nativeArchived = true;
+    },
+    unarchiveNativeSession: async () => {
+      nativeArchived = false;
+      nativeUnarchiveCount += 1;
+    },
+  });
+  const archivedId = "00000000-0000-4000-8000-000000000301";
+  const activeId = "00000000-0000-4000-8000-000000000302";
+  const archived = await harness.createArchived(archivedId);
+  const archivedAt = (await harness.storage.get(archived.id))?.archivedAt;
+  const active = await harness.manager.createAgent(
+    { provider: "codex", cwd: harness.root },
+    activeId,
+    { workspaceId: "workspace-active" },
+  );
+  await harness.manager.closeAgent(active.id);
+
+  const archivedSnapshot = await harness.load(archived.id);
+  const activeSnapshot = await harness.load(active.id);
+
+  expect(archivedSnapshot.lifecycle).toBe("closed");
+  expect(activeSnapshot.lifecycle).toBe("idle");
+  expect(harness.manager.getAgent(archived.id)).toBeNull();
+  expect(harness.manager.getTimeline(archived.id)).toContainEqual({
+    type: "assistant_message",
+    text: "Archived provider history",
+  });
+  expect(harness.calls.history).toEqual([
+    {
+      handle: expect.objectContaining({ sessionId: archived.persistence?.sessionId }),
+      context: { agentId: archived.id, cwd: harness.root },
+    },
+  ]);
+  expect(harness.calls.resumeSessionIds).toEqual([active.persistence?.sessionId]);
+  expect((await harness.storage.get(archived.id))?.archivedAt).toBe(archivedAt);
+  expect(nativeArchived).toBe(true);
+  expect(nativeUnarchiveCount).toBe(0);
+});
+
+test("keeps archived internal history hidden from public provider-subagent reads", async () => {
+  const agentId = "00000000-0000-4000-8000-000000000307";
+  const subagentId = "hidden-archived-child";
+  const harness = await createLoaderHarness({
+    readSessionHistory: async () =>
+      completeHistory([
+        {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "upsert",
+            id: subagentId,
+            title: "Hidden archived child",
+            status: "completed",
+          },
+        },
+      ]),
+  });
+  await harness.createArchived(agentId, { internal: true });
+  expect((await harness.storage.get(agentId))?.internal).toBe(true);
+
+  const snapshot = await harness.load(agentId);
+
+  expect(snapshot.internal).toBe(true);
+  expect(() => harness.manager.getTimeline(agentId)).toThrow(`Unknown agent '${agentId}'`);
+  expect(() => harness.manager.fetchPublicTimeline(agentId)).toThrow(`Unknown agent '${agentId}'`);
+  expect(() => harness.manager.listProviderSubagents(agentId)).toThrow(
+    `Unknown agent '${agentId}'`,
+  );
+  expect(() => harness.manager.getProviderSubagent(agentId, subagentId)).toThrow(
+    `Unknown agent '${agentId}'`,
+  );
+  expect(() => harness.manager.fetchProviderSubagentTimeline(agentId, subagentId)).toThrow(
+    `Unknown agent '${agentId}'`,
+  );
+});
+
+test("shares archived history reads and upgrades deferred timeline broadcast", async () => {
+  const historyStarted = deferred();
+  const historyAllowed = deferred();
+  onTestFinished(() => historyAllowed.resolve());
+  const harness = await createLoaderHarness({
+    readSessionHistory: async () => {
+      historyStarted.resolve();
+      await historyAllowed.promise;
+      return completeHistory([
+        {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "assistant_message", text: "Shared archived history" },
+        },
+      ]);
+    },
+  });
+  const agentId = "00000000-0000-4000-8000-000000000303";
+  await harness.createArchived(agentId);
+  const events: AgentManagerEvent[] = [];
+  harness.manager.subscribe((event) => events.push(event), { agentId, replayState: false });
+
+  const quietLoad = harness.load(agentId);
+  await historyStarted.promise;
+  const broadcastingLoad = harness.load(agentId, true);
+  historyAllowed.resolve();
+
+  const [quietSnapshot, broadcastingSnapshot] = await Promise.all([quietLoad, broadcastingLoad]);
+  const cachedSnapshot = await harness.load(agentId);
+  expect([quietSnapshot.id, broadcastingSnapshot.id, cachedSnapshot.id]).toEqual([
+    agentId,
+    agentId,
+    agentId,
+  ]);
+  expect(harness.calls.history).toHaveLength(1);
+  expect(events).toContainEqual(
+    expect.objectContaining({
+      type: "agent_stream",
+      agentId,
+      event: expect.objectContaining({
+        type: "timeline",
+        item: { type: "assistant_message", text: "Shared archived history" },
+      }),
+    }),
+  );
+});
+
+async function runConcurrentUnarchiveScenario(
+  historyFails: boolean,
+  scenarioOptions?: { internal?: boolean },
+) {
+  const historyStarted = deferred();
+  const historyAllowed = deferred();
+  onTestFinished(() => historyAllowed.resolve());
+  const harness = await createLoaderHarness({
+    readSessionHistory: async () => {
+      historyStarted.resolve();
+      await historyAllowed.promise;
+      if (historyFails) {
+        throw new Error("archived history became unavailable");
+      }
+      return completeHistory([
+        {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "assistant_message", text: "History before unarchive" },
+        },
+      ]);
+    },
+    archiveNativeSession: async () => undefined,
+    unarchiveNativeSession: async () => undefined,
+  });
+  let agentId = "00000000-0000-4000-8000-000000000304";
+  if (historyFails) {
+    agentId = "00000000-0000-4000-8000-000000000305";
   }
+  if (scenarioOptions?.internal) {
+    agentId = "00000000-0000-4000-8000-000000000308";
+  }
+  await harness.createArchived(agentId, scenarioOptions);
+
+  const archivedLoad = harness.load(agentId);
+  await historyStarted.promise;
+  await harness.manager.unarchiveSnapshot(agentId);
+  const interactiveLoad = harness.load(agentId);
+  historyAllowed.resolve();
+  const [first, second] = await Promise.all([archivedLoad, interactiveLoad]);
+
+  expect(first.lifecycle).toBe("idle");
+  expect(second.lifecycle).toBe("idle");
+  expect(harness.manager.getAgent(agentId)?.lifecycle).toBe("idle");
+  expect(harness.calls.history).toHaveLength(1);
+  expect(harness.calls.resumeSessionIds).toHaveLength(1);
+  return { harness, agentId };
+}
+
+test("promotes a shared archived history read to interactive resume after unarchive", async () => {
+  const { harness, agentId } = await runConcurrentUnarchiveScenario(false);
+  expect(harness.manager.getTimeline(agentId)).toContainEqual({
+    type: "assistant_message",
+    text: "History before unarchive",
+  });
+});
+
+test("promotes to interactive resume when archived history fails after unarchive", async () => {
+  await runConcurrentUnarchiveScenario(true);
+});
+
+test("does not retain archived history state when the provider read fails", async () => {
+  const harness = await createLoaderHarness({
+    readSessionHistory: async () => {
+      throw new Error("archived history is unavailable");
+    },
+  });
+  const agentId = "00000000-0000-4000-8000-000000000309";
+  await harness.createArchived(agentId);
+
+  await expect(harness.load(agentId)).rejects.toThrow("archived history is unavailable");
+
+  expect(harness.manager.getHistorySnapshot(agentId)).toBeNull();
+  expect(() => harness.manager.fetchTimeline(agentId)).toThrow(`Unknown agent '${agentId}'`);
+  expect(harness.manager.getAgent(agentId)).toBeNull();
+});
+
+test("preserves internal visibility when archived history is promoted after unarchive", async () => {
+  const { harness, agentId } = await runConcurrentUnarchiveScenario(false, { internal: true });
+
+  expect(harness.manager.getAgent(agentId)?.internal).toBe(true);
+  expect(harness.manager.listAgents().map((agent) => agent.id)).not.toContain(agentId);
+
+  await harness.manager.closeAgent(agentId);
+});
+
+test("does not create an interactive session for an archived record without persistence", async () => {
+  const harness = await createLoaderHarness({ archiveNativeSession: async () => undefined });
+  const agentId = "00000000-0000-4000-8000-000000000306";
+  await harness.createArchived(agentId);
+  const archivedRecord = await harness.storage.get(agentId);
+  if (!archivedRecord) {
+    throw new Error("expected archived record");
+  }
+  await harness.storage.upsert({ ...archivedRecord, persistence: undefined });
+  const createCountBeforeLoad = harness.calls.createCount;
+
+  await expect(harness.load(agentId)).rejects.toThrow(
+    `Archived agent history is unavailable without persistence: ${agentId}`,
+  );
+  expect(harness.calls.createCount).toBe(createCountBeforeLoad);
+  expect(harness.calls.resumeSessionIds).toEqual([]);
+  expect(harness.calls.history).toEqual([]);
+  expect(harness.manager.getAgent(agentId)).toBeNull();
 });

--- a/packages/server/src/server/agent/agent-loading.test.ts
+++ b/packages/server/src/server/agent/agent-loading.test.ts
@@ -330,6 +330,39 @@ test("does not retain archived history state when the provider read fails", asyn
   expect(harness.manager.getAgent(agentId)).toBeNull();
 });
 
+test("discards archived history state when the record is deleted during the read", async () => {
+  const historyStarted = deferred();
+  const historyAllowed = deferred();
+  onTestFinished(() => historyAllowed.resolve());
+  const harness = await createLoaderHarness({
+    readSessionHistory: async () => {
+      historyStarted.resolve();
+      await historyAllowed.promise;
+      return completeHistory([
+        {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "assistant_message", text: "History deleted during read" },
+        },
+      ]);
+    },
+  });
+  const agentId = "00000000-0000-4000-8000-000000000310";
+  await harness.createArchived(agentId);
+
+  const load = harness.load(agentId);
+  await historyStarted.promise;
+  await harness.storage.remove(agentId);
+  await harness.manager.deleteAgentState(agentId);
+  historyAllowed.resolve();
+
+  await expect(load).rejects.toThrow(`Agent not found: ${agentId}`);
+  expect(harness.manager.getHistorySnapshot(agentId)).toBeNull();
+  expect(harness.manager.getAgent(agentId)).toBeNull();
+  expect(() => harness.manager.fetchTimeline(agentId)).toThrow(`Unknown agent '${agentId}'`);
+  await expect(harness.load(agentId)).rejects.toThrow(`Agent not found: ${agentId}`);
+});
+
 test("preserves internal visibility when archived history is promoted after unarchive", async () => {
   const { harness, agentId } = await runConcurrentUnarchiveScenario(false, { internal: true });
 

--- a/packages/server/src/server/agent/agent-loading.test.ts
+++ b/packages/server/src/server/agent/agent-loading.test.ts
@@ -89,6 +89,13 @@ async function createLoaderHarness(options: LoaderHarnessOptions = {}) {
     storage,
     manager,
     calls,
+    requireRecord: async (agentId: string) => {
+      const record = await storage.get(agentId);
+      if (!record) {
+        throw new Error(`expected a stored record for ${agentId}`);
+      }
+      return record;
+    },
     load: async (agentId: string, broadcastTimeline = false) =>
       await ensureAgentLoaded(agentId, {
         agentManager: manager,
@@ -376,10 +383,7 @@ test("does not create an interactive session for an archived record without pers
   const harness = await createLoaderHarness({ archiveNativeSession: async () => undefined });
   const agentId = "00000000-0000-4000-8000-000000000306";
   await harness.createArchived(agentId);
-  const archivedRecord = await harness.storage.get(agentId);
-  if (!archivedRecord) {
-    throw new Error("expected archived record");
-  }
+  const archivedRecord = await harness.requireRecord(agentId);
   await harness.storage.upsert({ ...archivedRecord, persistence: undefined });
   const createCountBeforeLoad = harness.calls.createCount;
 

--- a/packages/server/src/server/agent/agent-loading.ts
+++ b/packages/server/src/server/agent/agent-loading.ts
@@ -26,7 +26,15 @@ export type AgentLoaderManager = Pick<
   | "hydrateTimelineFromProvider"
   | "resumeAgentFromPersistence"
 > &
-  Partial<Pick<AgentManager, "waitForAgentClose">>;
+  Partial<
+    Pick<
+      AgentManager,
+      | "getHistorySnapshot"
+      | "readAgentHistoryFromPersistence"
+      | "releaseHistorySnapshot"
+      | "waitForAgentClose"
+    >
+  >;
 
 export interface EnsureAgentLoadedDeps {
   agentManager: AgentLoaderManager;
@@ -75,6 +83,10 @@ export async function ensureAgentLoaded(
   if (existing) {
     return existing;
   }
+  const historySnapshot = deps.agentManager.getHistorySnapshot?.(agentId);
+  if (historySnapshot) {
+    return historySnapshot;
+  }
 
   // A close may have started after the first barrier observed no in-flight
   // work. Once the live lookup is empty, this second barrier closes that gap
@@ -104,13 +116,71 @@ export async function ensureAgentLoaded(
     const handle = toAgentPersistenceHandle(validProviders, record.persistence);
 
     let snapshot: ManagedAgent;
-    if (handle) {
+    if (record.archivedAt) {
+      if (!handle) {
+        throw new Error(`Archived agent history is unavailable without persistence: ${agentId}`);
+      }
+      if (!deps.agentManager.readAgentHistoryFromPersistence) {
+        throw new Error(`Agent manager cannot read archived provider history for ${agentId}`);
+      }
+
+      let loadedHistorySnapshot: ManagedAgent | null = null;
+      let historyReadFailed = false;
+      let historyReadError: unknown;
+      try {
+        loadedHistorySnapshot = await deps.agentManager.readAgentHistoryFromPersistence(
+          handle,
+          buildConfigOverrides(record),
+          agentId,
+          extractTimestamps(record),
+          { broadcast: () => pendingOptions.broadcastTimeline },
+        );
+        deps.logger.info(
+          { agentId, provider: record.provider },
+          "Agent history read from persistence",
+        );
+      } catch (error) {
+        historyReadFailed = true;
+        historyReadError = error;
+      }
+
+      const latestRecord = await deps.agentStorage.get(agentId);
+      if (!latestRecord) {
+        throw new Error(`Agent not found: ${agentId}`);
+      }
+      if (latestRecord.archivedAt) {
+        if (historyReadFailed) {
+          throw historyReadError;
+        }
+        if (!loadedHistorySnapshot) {
+          throw new Error(`Archived agent history read returned no snapshot: ${agentId}`);
+        }
+        return loadedHistorySnapshot;
+      }
+
+      deps.agentManager.releaseHistorySnapshot?.(agentId);
+      if (historyReadFailed) {
+        deps.logger.info(
+          { agentId, provider: latestRecord.provider, err: historyReadError },
+          "Archived history read failed after concurrent unarchive; resuming interactively",
+        );
+      }
+      snapshot = await deps.agentManager.resumeAgentFromPersistence(
+        handle,
+        buildConfigOverrides(latestRecord),
+        agentId,
+        extractTimestamps(latestRecord),
+      );
+      deps.logger.info(
+        { agentId, provider: latestRecord.provider },
+        "Agent resumed after concurrent unarchive",
+      );
+    } else if (handle) {
       snapshot = await deps.agentManager.resumeAgentFromPersistence(
         handle,
         buildConfigOverrides(record),
         agentId,
         extractTimestamps(record),
-        record.archivedAt ? { purpose: "history" } : undefined,
       );
       deps.logger.info({ agentId, provider: record.provider }, "Agent resumed from persistence");
     } else {

--- a/packages/server/src/server/agent/agent-loading.ts
+++ b/packages/server/src/server/agent/agent-loading.ts
@@ -32,6 +32,7 @@ export type AgentLoaderManager = Pick<
       | "getHistorySnapshot"
       | "readAgentHistoryFromPersistence"
       | "releaseHistorySnapshot"
+      | "discardHistoryState"
       | "waitForAgentClose"
     >
   >;
@@ -146,6 +147,7 @@ export async function ensureAgentLoaded(
 
       const latestRecord = await deps.agentStorage.get(agentId);
       if (!latestRecord) {
+        deps.agentManager.discardHistoryState?.(agentId);
         throw new Error(`Agent not found: ${agentId}`);
       }
       if (latestRecord.archivedAt) {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7224,6 +7224,86 @@ test("getAgent returns internal agents by ID", async () => {
   expect(agent?.internal).toBe(true);
 });
 
+test("getTimelineRows rejects internal history snapshots", async () => {
+  const agentId = "00000000-0000-4000-8000-000000000118";
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-internal-history-"));
+  const client = new (class extends TestAgentClient {
+    async readSessionHistory() {
+      return {
+        events: [
+          {
+            type: "timeline" as const,
+            provider: "codex" as const,
+            item: { type: "user_message" as const, text: "internal prompt" },
+          },
+        ],
+        coverage: { kind: "complete" as const },
+      };
+    }
+  })();
+  const manager = new AgentManager({ clients: { codex: client }, logger });
+
+  try {
+    await manager.readAgentHistoryFromPersistence(
+      { provider: "codex", sessionId: "internal-history", metadata: { cwd: workdir } },
+      { cwd: workdir },
+      agentId,
+      { internal: true },
+    );
+
+    await expect(manager.getTimelineRows(agentId)).rejects.toThrow(`Unknown agent '${agentId}'`);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("dedicated history reads use only the in-memory timeline", async () => {
+  const agentId = "00000000-0000-4000-8000-000000000119";
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-memory-history-"));
+  const durableTimelineStore = new RecordingTimelineStore();
+  const getLatestCommittedSeq = vi.spyOn(durableTimelineStore, "getLatestCommittedSeq");
+  const getCommittedRows = vi.spyOn(durableTimelineStore, "getCommittedRows");
+  const bulkInsert = vi.spyOn(durableTimelineStore, "bulkInsert");
+  const client = new (class extends TestAgentClient {
+    async readSessionHistory() {
+      return {
+        events: [
+          {
+            type: "timeline" as const,
+            provider: "codex" as const,
+            item: { type: "assistant_message" as const, text: "memory-only history" },
+          },
+        ],
+        coverage: { kind: "complete" as const },
+      };
+    }
+  })();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    durableTimelineStore,
+    logger,
+  });
+
+  try {
+    await manager.readAgentHistoryFromPersistence(
+      { provider: "codex", sessionId: "memory-history", metadata: { cwd: workdir } },
+      { cwd: workdir },
+      agentId,
+      {},
+    );
+
+    expect(await manager.getTimelineRows(agentId)).toMatchObject([
+      { item: { type: "assistant_message", text: "memory-only history" } },
+    ]);
+    await manager.flush();
+    expect(getLatestCommittedSeq).not.toHaveBeenCalled();
+    expect(getCommittedRows).not.toHaveBeenCalled();
+    expect(bulkInsert).not.toHaveBeenCalled();
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("subscribe does not emit state events for internal agents to global subscribers", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7304,6 +7304,64 @@ test("dedicated history reads use only the in-memory timeline", async () => {
   }
 });
 
+test("clearAgentAttention publishes archived attention changes without loading history", async () => {
+  const agentId = "00000000-0000-4000-8000-000000000132";
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-unloaded-attention-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const client = new TestAgentClient();
+  const manager = new AgentManager({ clients: { codex: client }, registry: storage, logger });
+  const before: StoredAgentRecord = {
+    id: agentId,
+    provider: "codex",
+    cwd: workdir,
+    createdAt: "2026-08-30T00:00:00.000Z",
+    updatedAt: "2026-08-30T00:00:01.000Z",
+    labels: {},
+    lastStatus: "closed",
+    config: null,
+    persistence: {
+      provider: "codex",
+      sessionId: "unloaded-attention-session",
+      metadata: { cwd: workdir },
+    },
+    requiresAttention: true,
+    attentionReason: "error",
+    attentionTimestamp: "2026-08-30T00:00:01.000Z",
+    archivedAt: "2026-08-30T00:00:02.000Z",
+  };
+  const stateEvents: AgentManagerEvent[] = [];
+  const unsubscribe = manager.subscribe((event) => stateEvents.push(event), {
+    agentId,
+    replayState: false,
+  });
+
+  try {
+    await storage.upsert(before);
+    await manager.clearAgentAttention(agentId);
+
+    const stored = await storage.get(agentId);
+    expectArchivedAgentRecord(stored, "closed");
+    expect(stored?.archivedAt).toBe(before.archivedAt);
+    expect(manager.getAgent(agentId)).toBeNull();
+    expect(manager.getHistorySnapshot(agentId)).toBeNull();
+    expect(stateEvents).toEqual([
+      expect.objectContaining({
+        type: "agent_state",
+        agent: expect.objectContaining({
+          id: agentId,
+          lifecycle: "closed",
+          attention: { requiresAttention: false },
+        }),
+      }),
+    ]);
+    expect(client.createdConfigs).toEqual([]);
+    expect(client.resumeOverrides).toEqual([]);
+  } finally {
+    unsubscribe();
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("clearAgentAttention clears archived history snapshots without resuming a provider runtime", async () => {
   const agentId = "00000000-0000-4000-8000-000000000131";
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-archived-attention-"));

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7304,6 +7304,104 @@ test("dedicated history reads use only the in-memory timeline", async () => {
   }
 });
 
+test("clearAgentAttention clears archived history snapshots without resuming a provider runtime", async () => {
+  const agentId = "00000000-0000-4000-8000-000000000131";
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-archived-attention-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const historyReads: string[] = [];
+  const client = new (class extends TestAgentClient {
+    async readSessionHistory(handle: AgentPersistenceHandle) {
+      historyReads.push(handle.sessionId);
+      return {
+        events: [
+          {
+            type: "timeline" as const,
+            provider: "codex" as const,
+            item: { type: "assistant_message" as const, text: "archived result" },
+          },
+        ],
+        coverage: { kind: "complete" as const },
+      };
+    }
+  })();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+  const before: StoredAgentRecord = {
+    id: agentId,
+    provider: "codex",
+    cwd: workdir,
+    createdAt: "2026-08-30T00:00:00.000Z",
+    updatedAt: "2026-08-30T00:00:01.000Z",
+    labels: {},
+    lastStatus: "closed",
+    config: null,
+    persistence: {
+      provider: "codex",
+      sessionId: "archived-attention-session",
+      metadata: { cwd: workdir },
+    },
+    requiresAttention: true,
+    attentionReason: "error",
+    attentionTimestamp: "2026-08-30T00:00:01.000Z",
+    archivedAt: "2026-08-30T00:00:02.000Z",
+  };
+  await storage.upsert(before);
+
+  try {
+    const historySnapshot = await ensureAgentLoaded(agentId, {
+      agentManager: manager,
+      agentStorage: storage,
+      logger,
+    });
+    expect(historySnapshot.lifecycle).toBe("closed");
+    expect(manager.getAgent(agentId)).toBeNull();
+    expect(historyReads).toEqual(["archived-attention-session"]);
+    expect(client.createdConfigs).toEqual([]);
+    expect(client.resumeOverrides).toEqual([]);
+
+    const stateEvents: AgentManagerEvent[] = [];
+    const unsubscribe = manager.subscribe((event) => stateEvents.push(event), {
+      agentId,
+      replayState: false,
+    });
+    await manager.clearAgentAttention(agentId);
+    unsubscribe();
+
+    const stored = await storage.get(agentId);
+    expect(stored).toMatchObject({
+      archivedAt: "2026-08-30T00:00:02.000Z",
+      requiresAttention: false,
+      attentionReason: null,
+      attentionTimestamp: null,
+    });
+    expect(Date.parse(stored!.updatedAt)).toBeGreaterThan(Date.parse(before.updatedAt));
+    expect(manager.getAgent(agentId)).toBeNull();
+    expect(manager.getHistorySnapshot(agentId)).toMatchObject({
+      lifecycle: "closed",
+      attention: { requiresAttention: false },
+      updatedAt: new Date(stored!.updatedAt),
+    });
+    expect(stateEvents).toEqual([
+      expect.objectContaining({
+        type: "agent_state",
+        agent: expect.objectContaining({
+          id: agentId,
+          lifecycle: "closed",
+          attention: { requiresAttention: false },
+        }),
+      }),
+    ]);
+    expect(historyReads).toEqual(["archived-attention-session"]);
+    expect(client.createdConfigs).toEqual([]);
+    expect(client.resumeOverrides).toEqual([]);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("subscribe does not emit state events for internal agents to global subscribers", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -8007,6 +8007,18 @@ test("native archive and restore release the loaded session writer", async () =>
     ): Promise<AgentSession> {
       return this.createSession({ provider: "codex", cwd: workdir, ...config });
     }
+    override async readSessionHistory() {
+      return {
+        events: [
+          {
+            type: "timeline" as const,
+            provider: "codex" as const,
+            item: { type: "assistant_message" as const, text: "Archived provider history" },
+          },
+        ],
+        coverage: { kind: "complete" as const },
+      };
+    }
     override async archiveNativeSession(handle: AgentPersistenceHandle): Promise<void> {
       if (!this.session?.closed) throw new Error("native thread has an active writer");
       await super.archiveNativeSession(handle);
@@ -8025,9 +8037,14 @@ test("native archive and restore release the loaded session writer", async () =>
     });
     await manager.archiveAgent(agent.id);
     expect(client.archivedHandles).toHaveLength(1);
-    // Opening archived history can retain a writer, including records archived by older daemons.
-    await ensureAgentLoaded(agent.id, { agentManager: manager, agentStorage: storage, logger });
-    expect(client.session?.closed).toBe(false);
+    const archivedSnapshot = await ensureAgentLoaded(agent.id, {
+      agentManager: manager,
+      agentStorage: storage,
+      logger,
+    });
+    expect(archivedSnapshot.lifecycle).toBe("closed");
+    expect(manager.getAgent(agent.id)).toBeNull();
+    expect(client.session?.closed).toBe(true);
     await manager.unarchiveSnapshot(agent.id);
     expect(client.unarchivedHandles).toHaveLength(1);
     expect((await storage.get(agent.id))?.archivedAt).toBeNull();

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -26,7 +26,6 @@ import {
   type AgentCapabilityFlags,
   type AgentClient,
   type AgentCreateSessionOptions,
-  type AgentResumeSessionOptions,
   type AgentFeature,
   type AgentLaunchContext,
   type AgentSlashCommand,
@@ -151,6 +150,13 @@ interface TimeoutOptions {
   operation: Promise<void>;
   timeoutMs: number;
   onLateError?: (error: unknown) => void;
+}
+
+function resolveInternalVisibility(
+  persisted: boolean | undefined,
+  configured: boolean | undefined,
+): boolean {
+  return persisted ?? configured ?? false;
 }
 
 function formatProviderList(providers: readonly string[]): string {
@@ -694,6 +700,7 @@ export class AgentManager {
   private readonly providerEnabled = new Map<AgentProvider, boolean>();
   private readonly providerDefinitions = new Map<AgentProvider, ProviderEnabledFlag>();
   private readonly agents = new Map<string, LiveManagedAgent>();
+  private readonly historySnapshots = new Map<string, ManagedAgentClosed>();
   private readonly timelineStore = new InMemoryAgentTimelineStore();
   private readonly providerSubagents = new ProviderSubagentStore();
   private readonly agentsAwaitingInitialSnapshotPersist = new Set<string>();
@@ -1126,6 +1133,16 @@ export class AgentManager {
     return agent ? { ...agent } : null;
   }
 
+  getHistorySnapshot(id: string): ManagedAgent | null {
+    const snapshot = this.historySnapshots.get(id);
+    return snapshot ? { ...snapshot } : null;
+  }
+
+  releaseHistorySnapshot(id: string): void {
+    const normalizedId = validateAgentId(id, "releaseHistorySnapshot");
+    this.historySnapshots.delete(normalizedId);
+  }
+
   async waitForAgentClose(agentId: string): Promise<void> {
     // Loading during reload must wait for the replacement, not resume another writer.
     await this.lifecycleMutationTails.get(agentId);
@@ -1133,12 +1150,15 @@ export class AgentManager {
   }
 
   getTimeline(id: string): AgentTimelineItem[] {
-    this.requireAgent(id);
+    this.requirePublicReadableAgent(id);
     return this.timelineStore.getItems(id);
   }
 
   async getTimelineRows(id: string): Promise<AgentTimelineRow[]> {
-    this.requireAgent(id);
+    const agent = this.requirePublicReadableAgent(id);
+    if (this.historySnapshots.has(agent.id)) {
+      return this.timelineStore.getRows(agent.id);
+    }
     if (this.durableTimelineStore) {
       return await this.durableTimelineStore.getCommittedRows(id);
     }
@@ -1146,12 +1166,17 @@ export class AgentManager {
   }
 
   fetchTimeline(id: string, options?: AgentTimelineFetchOptions): AgentTimelineFetchResult {
-    this.requireAgent(id);
+    this.requireReadableAgent(id);
+    return this.timelineStore.fetch(id, options);
+  }
+
+  fetchPublicTimeline(id: string, options?: AgentTimelineFetchOptions): AgentTimelineFetchResult {
+    this.requirePublicReadableAgent(id);
     return this.timelineStore.fetch(id, options);
   }
 
   listProviderSubagents(parentAgentId: string): ProviderSubagentDescriptor[] {
-    this.requirePublicAgent(parentAgentId);
+    this.requirePublicReadableAgent(parentAgentId);
     return this.providerSubagents.list(parentAgentId);
   }
 
@@ -1170,7 +1195,7 @@ export class AgentManager {
     parentAgentId: string,
     subagentId: string,
   ): ProviderSubagentDescriptor | null {
-    this.requirePublicAgent(parentAgentId);
+    this.requirePublicReadableAgent(parentAgentId);
     return this.providerSubagents.get(parentAgentId, subagentId);
   }
 
@@ -1179,7 +1204,7 @@ export class AgentManager {
     subagentId: string,
     options?: AgentTimelineFetchOptions,
   ): AgentTimelineFetchResult {
-    this.requirePublicAgent(parentAgentId);
+    this.requirePublicReadableAgent(parentAgentId);
     return this.providerSubagents.fetchTimeline(parentAgentId, subagentId, options);
   }
 
@@ -1262,14 +1287,14 @@ export class AgentManager {
       createdAt?: Date;
       updatedAt?: Date;
       lastUserMessageAt?: Date | null;
+      internal?: boolean;
       labels?: Record<string, string>;
       workspaceId?: string;
       owner?: AgentOwner;
     },
-    resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
-      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
+      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options),
     );
   }
 
@@ -1281,11 +1306,11 @@ export class AgentManager {
       createdAt?: Date;
       updatedAt?: Date;
       lastUserMessageAt?: Date | null;
+      internal?: boolean;
       labels?: Record<string, string>;
       workspaceId?: string;
       owner?: AgentOwner;
     },
-    resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
     this.assertAcceptingAgentRegistrations();
     const resolvedAgentId = validateAgentId(
@@ -1319,22 +1344,116 @@ export class AgentManager {
       undefined,
       {
         reason: "resume",
-        purpose: resumeOptions?.purpose ?? "interactive",
+        purpose: "interactive",
         workspaceId: options?.workspaceId ?? null,
       },
     );
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
-    const session = await client.resumeSession(
-      handle,
-      providerLaunchConfig,
-      launchContext,
-      resumeOptions,
-    );
+    this.historySnapshots.delete(resolvedAgentId);
+    const session = await client.resumeSession(handle, providerLaunchConfig, launchContext);
     await this.requireExternalMcpSupport(session, storedConfig);
     return this.registerSession(session, storedConfig, resolvedAgentId, {
       ...options,
       persistence: handle,
     });
+  }
+
+  readAgentHistoryFromPersistence(
+    handle: AgentPersistenceHandle,
+    overrides: Partial<AgentSessionConfig> | undefined,
+    agentId: string,
+    options: {
+      createdAt?: Date;
+      updatedAt?: Date;
+      lastUserMessageAt?: Date | null;
+      internal?: boolean;
+      labels?: Record<string, string>;
+      workspaceId?: string;
+      owner?: AgentOwner;
+    },
+    hydrateOptions?: HydrateTimelineOptions,
+  ): Promise<ManagedAgent> {
+    return this.trackAgentRegistrationOperation(
+      this.readAgentHistoryFromPersistenceInternal(
+        handle,
+        overrides,
+        agentId,
+        options,
+        hydrateOptions,
+      ),
+    );
+  }
+
+  private async readAgentHistoryFromPersistenceInternal(
+    handle: AgentPersistenceHandle,
+    overrides: Partial<AgentSessionConfig> | undefined,
+    agentId: string,
+    options: {
+      createdAt?: Date;
+      updatedAt?: Date;
+      lastUserMessageAt?: Date | null;
+      internal?: boolean;
+      labels?: Record<string, string>;
+      workspaceId?: string;
+      owner?: AgentOwner;
+    },
+    hydrateOptions?: HydrateTimelineOptions,
+  ): Promise<ManagedAgent> {
+    this.assertAcceptingAgentRegistrations();
+    const resolvedAgentId = validateAgentId(agentId, "readAgentHistoryFromPersistence");
+    const metadata = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
+    const mergedConfig = {
+      ...metadata,
+      ...overrides,
+      provider: handle.provider,
+    } as AgentSessionConfig;
+    const storedConfig = await this.normalizeConfig(stripInternalPaseoMcpServer(mergedConfig), {
+      resolveDefaultModel: false,
+    });
+
+    const client = this.requireClient(handle.provider);
+    const available = await client.isAvailable();
+    if (!available) {
+      throw new Error(
+        `Provider '${handle.provider}' is not available. Please ensure the CLI is installed.`,
+      );
+    }
+    if (!client.readSessionHistory) {
+      throw new Error(`Provider '${handle.provider}' does not support reading session history`);
+    }
+
+    const history = await client.readSessionHistory(handle, {
+      agentId: resolvedAgentId,
+      cwd: storedConfig.cwd,
+    });
+    this.assertAcceptingAgentRegistrations();
+
+    const now = new Date();
+    if (!this.timelineStore.has(resolvedAgentId)) {
+      this.timelineStore.initialize(resolvedAgentId, { timestamp: now.toISOString() });
+    }
+    const snapshot = this.buildHistorySnapshot({
+      resolvedAgentId,
+      client,
+      config: storedConfig,
+      handle,
+      now,
+      options,
+    });
+    try {
+      await this.primeTimelineFromProviderEvents(
+        snapshot,
+        history.events,
+        hydrateOptions?.broadcast ?? false,
+        { writeDurableTimeline: false },
+      );
+    } catch (error) {
+      this.timelineStore.delete(resolvedAgentId);
+      this.providerSubagents.deleteParent(resolvedAgentId);
+      throw error;
+    }
+    this.historySnapshots.set(resolvedAgentId, snapshot);
+    return { ...snapshot };
   }
 
   importProviderSession(input: {
@@ -2149,6 +2268,7 @@ export class AgentManager {
       updatedAt: new Date().toISOString(),
     });
 
+    this.historySnapshots.delete(agentId);
     if (this.getAgent(agentId)) {
       this.notifyAgentState(agentId);
     }
@@ -3348,6 +3468,7 @@ export class AgentManager {
       createdAt?: Date;
       updatedAt?: Date;
       lastUserMessageAt?: Date | null;
+      internal?: boolean;
       labels?: Record<string, string>;
       timeline?: AgentTimelineItem[];
       timelineRows?: AgentTimelineRow[];
@@ -3367,6 +3488,7 @@ export class AgentManager {
     try {
       this.assertAcceptingAgentRegistrations();
       const resolvedAgentId = validateAgentId(agentId, "registerSession");
+      this.historySnapshots.delete(resolvedAgentId);
       if (this.agents.has(resolvedAgentId)) {
         throw new Error(`Agent with id ${resolvedAgentId} already exists`);
       }
@@ -3504,6 +3626,7 @@ export class AgentManager {
           createdAt?: Date;
           updatedAt?: Date;
           lastUserMessageAt?: Date | null;
+          internal?: boolean;
           labels?: Record<string, string>;
           historyPrimed?: boolean;
           lastUsage?: AgentUsage;
@@ -3550,9 +3673,66 @@ export class AgentManager {
       lastUsage: options?.lastUsage,
       lastError: options?.lastError,
       attention: resolveInitialAttention(options?.attention),
-      internal: config.internal ?? false,
+      internal: resolveInternalVisibility(options?.internal, config.internal),
       labels: options?.labels ?? {},
     } as ActiveManagedAgent;
+  }
+
+  private buildHistorySnapshot(params: {
+    resolvedAgentId: string;
+    client: AgentClient;
+    config: AgentSessionConfig;
+    handle: AgentPersistenceHandle;
+    now: Date;
+    options: {
+      createdAt?: Date;
+      updatedAt?: Date;
+      lastUserMessageAt?: Date | null;
+      internal?: boolean;
+      labels?: Record<string, string>;
+      workspaceId?: string;
+      owner?: AgentOwner;
+    };
+  }): ManagedAgentClosed {
+    const { resolvedAgentId, client, config, handle, now, options } = params;
+    return {
+      id: resolvedAgentId,
+      provider: config.provider,
+      cwd: config.cwd,
+      workspaceId: options.workspaceId,
+      owner: options.owner,
+      session: null,
+      capabilities: client.capabilities,
+      config,
+      runtimeInfo: {
+        provider: config.provider,
+        sessionId: handle.sessionId,
+        model: config.model ?? null,
+        thinkingOptionId: config.thinkingOptionId ?? null,
+        modeId: config.modeId ?? null,
+      },
+      lifecycle: "closed",
+      createdAt: options.createdAt ?? now,
+      updatedAt: options.updatedAt ?? now,
+      availableModes: [],
+      currentModeId: config.modeId ?? null,
+      pendingPermissions: new Map(),
+      bufferedPermissionResolutions: new Map(),
+      inFlightPermissionResponses: new Set(),
+      pendingReplacement: false,
+      activeForegroundTurnId: null,
+      activeTurnId: null,
+      activeTurnStartedAt: null,
+      foregroundTurnWaiters: new Set(),
+      finalizedForegroundTurnIds: new Set(),
+      unsubscribeSession: null,
+      persistence: attachPersistenceCwd(handle, config.cwd),
+      historyPrimed: false,
+      lastUserMessageAt: options.lastUserMessageAt ?? null,
+      attention: { requiresAttention: false },
+      internal: resolveInternalVisibility(options.internal, config.internal),
+      labels: options.labels ?? {},
+    };
   }
 
   private async loadCommittedTimelineSeed(
@@ -3604,6 +3784,7 @@ export class AgentManager {
   }
 
   private discardRetainedAgentState(agentId: string): void {
+    this.historySnapshots.delete(agentId);
     this.timelineStore.delete(agentId);
     this.paseoToolPolicies.delete(agentId);
     for (const event of this.providerSubagents.deleteParent(agentId)) {
@@ -3923,6 +4104,18 @@ export class AgentManager {
     agent: ActiveManagedAgent,
     broadcast: boolean | (() => boolean),
   ): Promise<void> {
+    await this.primeTimelineFromProviderEvents(agent, agent.session.streamHistory(), broadcast);
+  }
+
+  private async primeTimelineFromProviderEvents(
+    agent: Pick<ManagedAgentBase, "id" | "historyPrimed">,
+    events: AsyncIterable<AgentStreamEvent> | Iterable<AgentStreamEvent>,
+    broadcast: boolean | (() => boolean),
+    options?: { writeDurableTimeline?: boolean },
+  ): Promise<void> {
+    if (agent.historyPrimed) {
+      return;
+    }
     const deferredBroadcast = typeof broadcast === "function";
     const timelineEvents: Array<{
       event: Extract<AgentStreamEvent, { type: "timeline" }>;
@@ -3931,7 +4124,7 @@ export class AgentManager {
     const providerSubagentEvents: AgentManagerEvent[] = [];
     agent.historyPrimed = false;
     try {
-      for await (const rawEvent of agent.session.streamHistory()) {
+      for await (const rawEvent of events) {
         const event = limitAgentStreamEventContent(rawEvent);
         if (event.type === "provider_subagent") {
           const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
@@ -3949,11 +4142,11 @@ export class AgentManager {
         if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
           continue;
         }
-        const row = this.recordTimeline(
-          agent.id,
-          event.item,
-          event.timestamp ? { timestamp: event.timestamp } : undefined,
-        );
+        const timelineOptions = event.timestamp ? { timestamp: event.timestamp } : undefined;
+        const row =
+          options?.writeDurableTimeline === false
+            ? this.timelineStore.append(agent.id, event.item, timelineOptions)
+            : this.recordTimeline(agent.id, event.item, timelineOptions);
         if (deferredBroadcast) {
           timelineEvents.push({ event, row });
         } else if (broadcast) {
@@ -5176,6 +5369,23 @@ export class AgentManager {
     }
   }
 
+  private requireReadableAgent(id: string): LiveManagedAgent | ManagedAgentClosed {
+    const normalizedId = validateAgentId(id, "requireReadableAgent");
+    const agent = this.agents.get(normalizedId) ?? this.historySnapshots.get(normalizedId);
+    if (!agent) {
+      throw new Error(`Unknown agent '${normalizedId}'`);
+    }
+    return agent;
+  }
+
+  private requirePublicReadableAgent(id: string): LiveManagedAgent | ManagedAgentClosed {
+    const agent = this.requireReadableAgent(id);
+    if (agent.internal) {
+      throw new Error(`Unknown agent '${agent.id}'`);
+    }
+    return agent;
+  }
+
   private requireAgent(id: string): LiveManagedAgent {
     const normalizedId = validateAgentId(id, "requireAgent");
     const agent = this.agents.get(normalizedId);
@@ -5189,14 +5399,6 @@ export class AgentManager {
     const agent = this.requireAgent(id);
     if (agent.session === null) {
       throw new Error(`Agent '${agent.id}' has no managed session`);
-    }
-    return agent;
-  }
-
-  private requirePublicAgent(id: string): LiveManagedAgent {
-    const agent = this.requireAgent(id);
-    if (agent.internal) {
-      throw new Error(`Unknown agent '${agent.id}'`);
     }
     return agent;
   }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1422,9 +1422,16 @@ export class AgentManager {
       throw new Error(`Provider '${handle.provider}' does not support reading session history`);
     }
 
+    const historyEnv = await this.resolveHistoryReadEnv(
+      resolvedAgentId,
+      client,
+      storedConfig.cwd,
+      options.workspaceId ?? null,
+    );
     const history = await client.readSessionHistory(handle, {
       agentId: resolvedAgentId,
       cwd: storedConfig.cwd,
+      ...(historyEnv ? { env: historyEnv } : {}),
     });
     this.assertAcceptingAgentRegistrations();
 
@@ -5240,6 +5247,33 @@ export class AgentManager {
           daemonAppendSystemPrompt,
         }
       : next;
+  }
+
+  /**
+   * A history read opens no interactive session, so it must not build a Paseo tool
+   * catalog the way `buildLaunchContext` does. Plugins still observe the open with
+   * `purpose: "history"` and may rewrite the environment the provider reads under.
+   * Without a plugin there is nothing to apply, so providers keep their default
+   * environment rather than being handed a synthetic one.
+   */
+  private async resolveHistoryReadEnv(
+    agentId: string,
+    client: AgentClient,
+    cwd: string,
+    workspaceId: string | null,
+  ): Promise<Record<string, string> | undefined> {
+    if (!this.pluginLifecycle) return undefined;
+    const request: PluginSessionOpenRequest = {
+      agentId,
+      provider: client.provider,
+      cwd,
+      workspaceId,
+      reason: "resume",
+      purpose: "history",
+      env: {},
+    };
+    const transformed = await this.pluginLifecycle.before("agent.session_open", request);
+    return transformed.env;
   }
 
   private async buildLaunchContext(

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2177,11 +2177,49 @@ export class AgentManager {
   }
 
   async clearAgentAttention(agentId: string): Promise<void> {
-    const agent = this.requireAgent(agentId);
-    if (agent.attention.requiresAttention) {
-      agent.attention = { requiresAttention: false };
-      await this.persistSnapshot(agent);
-      this.emitState(agent, { persist: false });
+    const normalizedAgentId = validateAgentId(agentId, "clearAgentAttention");
+    const liveAgent = this.agents.get(normalizedAgentId);
+    if (liveAgent) {
+      if (liveAgent.attention.requiresAttention) {
+        liveAgent.attention = { requiresAttention: false };
+        await this.persistSnapshot(liveAgent);
+        this.emitState(liveAgent, { persist: false });
+      }
+      return;
+    }
+
+    const registry = this.requireRegistry();
+    const record = await registry.get(normalizedAgentId);
+    if (!record) {
+      throw new Error(`Unknown agent '${normalizedAgentId}'`);
+    }
+
+    const shouldPersist =
+      record.requiresAttention === true ||
+      record.attentionReason != null ||
+      record.attentionTimestamp != null;
+    const nextRecord = shouldPersist
+      ? {
+          ...record,
+          updatedAt: this.nextStoredUpdatedAt(record),
+          requiresAttention: false,
+          attentionReason: null,
+          attentionTimestamp: null,
+        }
+      : record;
+    if (shouldPersist) {
+      await registry.upsert(nextRecord);
+    }
+
+    const historySnapshot = this.historySnapshots.get(normalizedAgentId);
+    if (historySnapshot) {
+      historySnapshot.attention = { requiresAttention: false };
+      historySnapshot.updatedAt = new Date(nextRecord.updatedAt);
+      if (!historySnapshot.internal) {
+        this.emitState(historySnapshot, { persist: false });
+      }
+    } else if (shouldPersist && !nextRecord.internal) {
+      this.dispatchArchivedStoredAgent(nextRecord);
     }
   }
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1143,6 +1143,11 @@ export class AgentManager {
     this.historySnapshots.delete(normalizedId);
   }
 
+  discardHistoryState(id: string): void {
+    const normalizedId = validateAgentId(id, "discardHistoryState");
+    this.discardRetainedAgentState(normalizedId);
+  }
+
   async waitForAgentClose(agentId: string): Promise<void> {
     // Loading during reload must wait for the replacement, not resume another writer.
     await this.lifecycleMutationTails.get(agentId);

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2219,7 +2219,7 @@ export class AgentManager {
         this.emitState(historySnapshot, { persist: false });
       }
     } else if (shouldPersist && !nextRecord.internal) {
-      this.dispatchArchivedStoredAgent(nextRecord);
+      this.dispatchStoredAgentState(nextRecord);
     }
   }
 

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -635,18 +635,33 @@ export interface AgentLaunchContext {
   paseoTools?: PaseoToolCatalog;
 }
 
+/**
+ * Narrow context for read-only provider history access. It intentionally omits
+ * interactive configuration such as MCP servers, native Paseo tools, prompts,
+ * modes, models, and feature flags.
+ */
+export interface AgentHistoryReadContext {
+  cwd: string;
+  agentId?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * Complete provider history returned by the dedicated read-only path.
+ * The coverage envelope leaves room for a future paged result without
+ * coupling archived reads to a live provider session.
+ */
+export interface AgentHistoryReadResult {
+  events: AgentStreamEvent[];
+  coverage: { kind: "complete" };
+}
+
 export interface AgentCreateSessionOptions {
   /**
    * Whether the provider should leave a durable native session behind.
    * Defaults to true. Providers that cannot honor false should no-op.
    */
   persistSession?: boolean;
-}
-
-/** Runtime-only intent for a persisted-session resume. Never persist this option. */
-export interface AgentResumeSessionOptions {
-  /** Defaults to interactive. History loading may be read-only for archived native sessions. */
-  purpose?: "interactive" | "history";
 }
 
 /**
@@ -746,12 +761,19 @@ export interface AgentClient {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
-    options?: AgentResumeSessionOptions,
   ): Promise<AgentSession>;
   /** Equal keys share availability and catalogue discovery within this configured client.
    * Include the execution environment and effective configuration; omit to use target identity.
    * force must not affect identity. Resolve before every cache lookup. */
   getCatalogCacheKey?(options: FetchCatalogOptions): Promise<string | undefined>;
+  /**
+   * Read persisted provider history without leaving an interactive runtime open.
+   * Implementations own and close any temporary resources before this resolves or rejects.
+   */
+  readSessionHistory?(
+    handle: AgentPersistenceHandle,
+    context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult>;
   /**
    * Discover models and modes together. Implementations may use one upstream
    * process, separate upstream calls, static modes, or private helpers; callers

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -212,9 +212,12 @@ function buildAgentManagerSpies() {
     archiveAgent: vi.fn().mockResolvedValue({ archivedAt: new Date().toISOString() }),
     notifyAgentState: vi.fn(),
     getAgent: vi.fn(),
+    getHistorySnapshot: vi.fn(),
+    releaseHistorySnapshot: vi.fn(),
     listAgents: vi.fn().mockReturnValue([]),
     getTimeline: vi.fn().mockReturnValue([]),
     resumeAgentFromPersistence: vi.fn(),
+    readAgentHistoryFromPersistence: vi.fn(),
     hydrateTimelineFromProvider: vi.fn().mockResolvedValue(undefined),
     appendTimelineItem: vi.fn().mockResolvedValue(undefined),
     emitLiveTimelineItem: vi.fn().mockResolvedValue(undefined),
@@ -5812,12 +5815,10 @@ describe("agent snapshot MCP serialization", () => {
       id: "archived-activity-agent",
       currentModeId: "default",
     } as ManagedAgent;
-    spies.agentManager.getAgent
-      .mockReturnValueOnce(null)
-      .mockReturnValue(snapshot)
-      .mockReturnValue(snapshot);
+    spies.agentManager.getAgent.mockReturnValue(null);
+    spies.agentManager.getHistorySnapshot.mockReturnValueOnce(null).mockReturnValue(snapshot);
     spies.agentStorage.get.mockResolvedValue(record);
-    spies.agentManager.resumeAgentFromPersistence.mockResolvedValue(snapshot);
+    spies.agentManager.readAgentHistoryFromPersistence.mockResolvedValue(snapshot);
     spies.agentManager.getTimeline.mockReturnValue([
       {
         kind: "status",
@@ -5842,10 +5843,42 @@ describe("agent snapshot MCP serialization", () => {
         currentModeId: "default",
       }),
     );
-    expect(spies.agentManager.resumeAgentFromPersistence).toHaveBeenCalled();
-    expect(spies.agentManager.hydrateTimelineFromProvider).toHaveBeenCalledWith(
+    expect(spies.agentManager.readAgentHistoryFromPersistence).toHaveBeenCalledWith(
+      record.persistence,
+      expect.objectContaining({ provider: "claude", cwd: record.cwd }),
       "archived-activity-agent",
+      expect.objectContaining({ workspaceId: record.workspaceId }),
       { broadcast: expect.any(Function) },
+    );
+    expect(spies.agentManager.resumeAgentFromPersistence).not.toHaveBeenCalled();
+  });
+
+  it("does not expose archived internal agents from get_agent_activity", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const record = createStoredRecord({ id: "internal-activity-agent", internal: true });
+    const snapshot = createManagedAgent({
+      id: "internal-activity-agent",
+      internal: true,
+      lifecycle: "closed",
+    });
+    spies.agentManager.getAgent.mockReturnValue(null);
+    spies.agentManager.getHistorySnapshot.mockReturnValueOnce(null);
+    spies.agentStorage.get.mockResolvedValue(record);
+    spies.agentManager.readAgentHistoryFromPersistence.mockResolvedValue(snapshot);
+    spies.agentManager.getTimeline.mockImplementation(() => {
+      throw new Error("Unknown agent 'internal-activity-agent'");
+    });
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      logger,
+      providerSnapshotManager: createClaudeOnlyManager(),
+    });
+    const tool = registeredTool(server, "get_agent_activity");
+
+    await expect(tool.handler({ agentId: "internal-activity-agent" })).rejects.toThrow(
+      "Unknown agent 'internal-activity-agent'",
     );
   });
 

--- a/packages/server/src/server/agent/mcp-shared.test.ts
+++ b/packages/server/src/server/agent/mcp-shared.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+import { AGENT_WAIT_TIMEOUT_MS, waitForAgentWithTimeout } from "./mcp-shared.js";
+import type { AgentManager, ManagedAgent } from "./agent-manager.js";
+import type { AgentTimelineItem } from "./agent-sdk-types.js";
+
+interface StubManagerOptions {
+  snapshot: ManagedAgent | null;
+  getTimeline: () => AgentTimelineItem[];
+}
+
+function createStubManager(options: StubManagerOptions): AgentManager {
+  return {
+    waitForAgentEvent: (_agentId: string, waitOptions: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        waitOptions.signal?.addEventListener(
+          "abort",
+          () => reject(waitOptions.signal?.reason as Error),
+          { once: true },
+        );
+      }),
+    getAgent: () => options.snapshot,
+    getTimeline: options.getTimeline,
+  } as unknown as AgentManager;
+}
+
+function createSnapshot(overrides: Partial<ManagedAgent>): ManagedAgent {
+  return { id: "agent-1", lifecycle: "running", ...overrides } as unknown as ManagedAgent;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("wait timeout returns the friendly message when the timeline is not publicly readable", async () => {
+  vi.useFakeTimers();
+  const manager = createStubManager({
+    snapshot: createSnapshot({ internal: true }),
+    getTimeline: () => {
+      throw new Error("Unknown agent 'agent-1'");
+    },
+  });
+
+  const pending = waitForAgentWithTimeout(manager, "agent-1");
+  await vi.advanceTimersByTimeAsync(AGENT_WAIT_TIMEOUT_MS);
+  const result = await pending;
+
+  expect(result.status).toBe("running");
+  expect(result.lastMessage).toContain("timed out after 30s");
+});
+
+test("wait timeout still reports recent activity for readable agents", async () => {
+  vi.useFakeTimers();
+  const manager = createStubManager({
+    snapshot: createSnapshot({}),
+    getTimeline: () => [{ type: "assistant_message", text: "building the thing" }],
+  });
+
+  const pending = waitForAgentWithTimeout(manager, "agent-1");
+  await vi.advanceTimersByTimeAsync(AGENT_WAIT_TIMEOUT_MS);
+  const result = await pending;
+
+  expect(result.lastMessage).toContain("building the thing");
+});

--- a/packages/server/src/server/agent/mcp-shared.ts
+++ b/packages/server/src/server/agent/mcp-shared.ts
@@ -87,6 +87,24 @@ export function resolveRequiredProviderModel(
 }
 
 /**
+ * Timeline reads are best-effort here: the timeout message is the whole point of the
+ * fallback, so it must survive an unreadable timeline. `getTimeline` rejects agents that
+ * are not publicly readable — internal agents, and agents that went away while we waited.
+ */
+function readRecentActivity(agentManager: AgentManager, agentId: string): string {
+  try {
+    const recent = selectItemsByProjectedLimit({
+      items: agentManager.getTimeline(agentId),
+      direction: "tail",
+      limit: 5,
+    });
+    return curateAgentActivity(recent.items);
+  } catch {
+    return curateAgentActivity([]);
+  }
+}
+
+/**
  * Wraps agentManager.waitForAgentEvent with a self-imposed timeout.
  * Returns a friendly message when timeout occurs, rather than letting
  * the SDK tool timeout trigger a generic "tool failed" error.
@@ -137,13 +155,7 @@ export async function waitForAgentWithTimeout(
   } catch (error) {
     if (error instanceof Error && error.message === "wait timeout") {
       const snapshot = agentManager.getAgent(agentId);
-      const timeline = agentManager.getTimeline(agentId);
-      const recent = selectItemsByProjectedLimit({
-        items: timeline,
-        direction: "tail",
-        limit: 5,
-      });
-      const recentActivity = curateAgentActivity(recent.items);
+      const recentActivity = readRecentActivity(agentManager, agentId);
       const waitedSeconds = Math.round(AGENT_WAIT_TIMEOUT_MS / 1000);
       const message = `Awaiting the agent timed out after ${waitedSeconds}s. This does not mean the agent failed - it is still running. Call get_agent_status to check on it, or continue with other work if you will receive a finish notification.\n\nRecent activity:\n${recentActivity}`;
       return {

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -5,8 +5,10 @@ import { createTestLogger } from "../../test-utils/test-logger.js";
 import type {
   AgentClient,
   AgentFeature,
+  AgentHistoryReadContext,
   AgentModelDefinition,
   AgentMode,
+  AgentPersistenceHandle,
   AgentSessionConfig,
   ProviderCatalog,
 } from "./agent-sdk-types.js";
@@ -60,6 +62,10 @@ const mockState = vi.hoisted(() => {
     isCommandAvailable: vi.fn(async (_command: string) => false),
     runtimeModels: new Map<string, AgentModelDefinition[]>(),
     cursorListFeaturesConfigs: [] as AgentSessionConfig[],
+    historyReads: [] as Array<{
+      handle: AgentPersistenceHandle;
+      context?: AgentHistoryReadContext;
+    }>,
     reset() {
       this.constructorArgs.claude = [];
       this.constructorArgs.codex = [];
@@ -73,6 +79,7 @@ const mockState = vi.hoisted(() => {
       this.isCommandAvailable.mockImplementation(async (_command: string) => false);
       this.runtimeModels.clear();
       this.cursorListFeaturesConfigs = [];
+      this.historyReads = [];
     },
   };
 });
@@ -109,6 +116,20 @@ vi.mock("./providers/claude/agent.js", async () => {
 
       async resumeSession(): Promise<never> {
         throw new Error("not implemented");
+      }
+
+      async readSessionHistory(handle: AgentPersistenceHandle, context?: AgentHistoryReadContext) {
+        mockState.historyReads.push({ handle, context });
+        return {
+          events: [
+            {
+              type: "timeline" as const,
+              provider: "claude",
+              item: { type: "assistant_message" as const, text: "derived history" },
+            },
+          ],
+          coverage: { kind: "complete" as const },
+        };
       }
 
       async fetchCatalog(): Promise<ProviderCatalog> {
@@ -649,6 +670,52 @@ test("new provider extending claude appears in registry", () => {
   expect(registry.zai.label).toBe("ZAI");
   expect(registry.zai.description).toBe("Claude with ZAI defaults");
   expect(registry.zai.createClient(logger).provider).toBe("zai");
+});
+
+test("derived provider maps dedicated history reads through the base provider", async () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      zai: {
+        extends: "claude",
+        label: "ZAI",
+      },
+    },
+  });
+  const client = registry.zai.createClient(logger);
+  const context: AgentHistoryReadContext = {
+    agentId: "00000000-0000-4000-8000-000000000401",
+    cwd: "/workspace/zai",
+  };
+
+  await expect(
+    client.readSessionHistory?.(
+      {
+        provider: "zai",
+        sessionId: "zai-session",
+        metadata: { cwd: context.cwd },
+      },
+      context,
+    ),
+  ).resolves.toEqual({
+    events: [
+      {
+        type: "timeline",
+        provider: "zai",
+        item: { type: "assistant_message", text: "derived history" },
+      },
+    ],
+    coverage: { kind: "complete" },
+  });
+  expect(mockState.historyReads).toEqual([
+    {
+      handle: {
+        provider: "claude",
+        sessionId: "zai-session",
+        metadata: { cwd: context.cwd },
+      },
+      context,
+    },
+  ]);
 });
 
 test("built-in OMP override keeps the real OMP adapter enabled and launchable", async () => {

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -487,6 +487,7 @@ function wrapClientProvider(
   const listImportableSessions = inner.listImportableSessions?.bind(inner);
   const importSession = inner.importSession?.bind(inner);
   const listFeatures = inner.listFeatures?.bind(inner);
+  const readSessionHistory = inner.readSessionHistory?.bind(inner);
 
   return {
     provider,
@@ -502,7 +503,7 @@ function wrapClientProvider(
           launchContext,
         ),
       ),
-    resumeSession: async (handle, overrides, launchContext, options) =>
+    resumeSession: async (handle, overrides, launchContext) =>
       wrapSessionProvider(
         provider,
         await inner.resumeSession(
@@ -517,9 +518,23 @@ function wrapClientProvider(
               }
             : undefined,
           launchContext,
-          options,
         ),
       ),
+    readSessionHistory: readSessionHistory
+      ? async (handle, context) => {
+          const result = await readSessionHistory(
+            {
+              ...handle,
+              provider: inner.provider,
+            },
+            context,
+          );
+          return {
+            ...result,
+            events: result.events.map((event) => mapStreamEvent(provider, event)),
+          };
+        }
+      : undefined,
     fetchCatalog: async (options, context) => {
       const catalog = await inner.fetchCatalog(options, context);
       return {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -3480,6 +3480,116 @@ describe("ACPAgentSession initialization cleanup", () => {
   });
 });
 
+describe("ACPAgentClient history cleanup", () => {
+  function createHistoryClient(args: {
+    child: ChildProcessWithoutNullStreams;
+    loadSession?: ReturnType<typeof vi.fn>;
+    unstableResumeSession?: ReturnType<typeof vi.fn>;
+    capabilities?: AgentCapabilityFlags;
+    terminator: FakeTerminator;
+  }): ACPAgentClient {
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override createSessionInstance(
+        ...sessionArgs: ConstructorParameters<typeof ACPAgentSession>
+      ): ACPAgentSession {
+        return new (class extends ACPAgentSession {
+          protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+            return {
+              child: args.child,
+              connection: {
+                prompt: vi.fn(),
+                loadSession: args.loadSession,
+                unstable_resumeSession: args.unstableResumeSession,
+              } as unknown as ClientSideConnection,
+              initialize: {
+                agentCapabilities: args.capabilities ?? { loadSession: true },
+              },
+            } as SpawnedACPProcess;
+          }
+        })(...sessionArgs);
+      }
+    }
+
+    return new TestACPAgentClient({
+      provider: "claude-acp",
+      logger: createTestLogger(),
+      defaultCommand: ["claude", "--acp"],
+      defaultModes: [],
+      terminateProcess: args.terminator.terminate,
+    });
+  }
+
+  const handle: AgentPersistenceHandle = {
+    provider: "claude-acp",
+    sessionId: "session-history",
+    metadata: {
+      cwd: "/tmp/paseo-acp-history",
+      mcpServers: {
+        paseo: { type: "http", url: "http://127.0.0.1:6767/mcp/agents" },
+      },
+    },
+  };
+
+  test("terminates the temporary process after a successful history read", async () => {
+    const child = createProbeChildStub();
+    const terminator = new FakeTerminator();
+    const loadSession = vi.fn().mockResolvedValue({
+      sessionId: "session-history",
+      modes: null,
+      models: null,
+      configOptions: [],
+    });
+    const client = createHistoryClient({ child, loadSession, terminator });
+
+    await expect(client.readSessionHistory(handle)).resolves.toEqual({
+      events: [],
+      coverage: { kind: "complete" },
+    });
+
+    expect(loadSession).toHaveBeenCalledWith({
+      sessionId: "session-history",
+      cwd: "/tmp/paseo-acp-history",
+      mcpServers: [],
+    });
+    expect(terminator.terminated).toEqual([child]);
+  });
+
+  test("rejects a resume-only history read without invoking interactive resume", async () => {
+    const child = createProbeChildStub();
+    const terminator = new FakeTerminator();
+    const unstableResumeSession = vi.fn().mockResolvedValue({
+      sessionId: "session-history",
+      modes: null,
+      models: null,
+      configOptions: [],
+    });
+    const client = createHistoryClient({
+      child,
+      unstableResumeSession,
+      capabilities: { sessionCapabilities: { resume: {} } },
+      terminator,
+    });
+
+    await expect(client.readSessionHistory(handle)).rejects.toThrow(
+      "claude-acp does not support ACP session/load history reads",
+    );
+
+    expect(unstableResumeSession).not.toHaveBeenCalled();
+    expect(terminator.terminated).toEqual([child]);
+  });
+
+  test("terminates the temporary process when history loading fails", async () => {
+    const child = createProbeChildStub();
+    const terminator = new FakeTerminator();
+    const loadSession = vi.fn().mockRejectedValue(new Error("session/load failed"));
+    const client = createHistoryClient({ child, loadSession, terminator });
+
+    await expect(client.readSessionHistory(handle)).rejects.toThrow("session/load failed");
+
+    expect(terminator.terminated).toEqual([child]);
+  });
+});
+
 describe("ACPAgentClient probe cleanup", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -65,6 +65,8 @@ import {
   type AgentClient,
   type AgentCreateConfigUnattendedInput,
   type AgentFeature,
+  type AgentHistoryReadContext,
+  type AgentHistoryReadResult,
   type AgentLaunchContext,
   type AgentMetadata,
   type AgentMode,
@@ -935,37 +937,52 @@ export class ACPAgentClient implements AgentClient {
     this.now = options.now ?? Date.now;
   }
 
+  protected createSessionInstance(
+    ...args: ConstructorParameters<typeof ACPAgentSession>
+  ): ACPAgentSession {
+    return new ACPAgentSession(...args);
+  }
+
+  private sessionOptions(
+    launchContext: AgentLaunchContext | undefined,
+    handle?: AgentPersistenceHandle,
+  ): ACPAgentSessionOptions {
+    return {
+      provider: this.provider,
+      logger: this.logger,
+      runtimeSettings: this.runtimeSettings,
+      defaultCommand: this.defaultCommand,
+      defaultModes: this.defaultModes,
+      modelTransformer: this.modelTransformer,
+      sessionResponseTransformer: this.sessionResponseTransformer,
+      configOptionsTransformer: this.configOptionsTransformer,
+      configFeatureOptions: this.configFeatureOptions,
+      clientCapabilities: this.clientCapabilities,
+      clientCapabilityMeta: this.clientCapabilityMeta,
+      modeIdTransformer: this.modeIdTransformer,
+      toolSnapshotTransformer: this.toolSnapshotTransformer,
+      providerModeWriter: this.providerModeWriter,
+      beforeModeWriter: this.beforeModeWriter,
+      thinkingOptionWriter: this.thinkingOptionWriter,
+      capabilities: this.capabilities,
+      handle,
+      agentId: launchContext?.agentId,
+      launchEnv: launchContext?.env,
+      extensionCommandsParser: this.extensionCommandsParser,
+      waitForInitialCommands: this.waitForInitialCommands,
+      initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
+      terminateProcess: this.terminateProcess,
+    };
+  }
+
   async createSession(
     config: AgentSessionConfig,
     launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
     this.assertProvider(config);
-    const session = new ACPAgentSession(
+    const session = this.createSessionInstance(
       { ...config, provider: this.provider },
-      {
-        provider: this.provider,
-        logger: this.logger,
-        runtimeSettings: this.runtimeSettings,
-        defaultCommand: this.defaultCommand,
-        defaultModes: this.defaultModes,
-        modelTransformer: this.modelTransformer,
-        sessionResponseTransformer: this.sessionResponseTransformer,
-        configOptionsTransformer: this.configOptionsTransformer,
-        configFeatureOptions: this.configFeatureOptions,
-        clientCapabilities: this.clientCapabilities,
-        clientCapabilityMeta: this.clientCapabilityMeta,
-        modeIdTransformer: this.modeIdTransformer,
-        toolSnapshotTransformer: this.toolSnapshotTransformer,
-        providerModeWriter: this.providerModeWriter,
-        beforeModeWriter: this.beforeModeWriter,
-        thinkingOptionWriter: this.thinkingOptionWriter,
-        capabilities: this.capabilities,
-        agentId: launchContext?.agentId,
-        launchEnv: launchContext?.env,
-        extensionCommandsParser: this.extensionCommandsParser,
-        waitForInitialCommands: this.waitForInitialCommands,
-        initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
-      },
+      this.sessionOptions(launchContext),
     );
     await session.initializeNewSession();
     return session;
@@ -992,33 +1009,42 @@ export class ACPAgentClient implements AgentClient {
       provider: this.provider,
       cwd,
     };
-    const session = new ACPAgentSession(mergedConfig, {
-      provider: this.provider,
-      logger: this.logger,
-      runtimeSettings: this.runtimeSettings,
-      defaultCommand: this.defaultCommand,
-      defaultModes: this.defaultModes,
-      modelTransformer: this.modelTransformer,
-      sessionResponseTransformer: this.sessionResponseTransformer,
-      configOptionsTransformer: this.configOptionsTransformer,
-      configFeatureOptions: this.configFeatureOptions,
-      clientCapabilities: this.clientCapabilities,
-      clientCapabilityMeta: this.clientCapabilityMeta,
-      modeIdTransformer: this.modeIdTransformer,
-      toolSnapshotTransformer: this.toolSnapshotTransformer,
-      providerModeWriter: this.providerModeWriter,
-      beforeModeWriter: this.beforeModeWriter,
-      thinkingOptionWriter: this.thinkingOptionWriter,
-      capabilities: this.capabilities,
-      handle,
-      agentId: launchContext?.agentId,
-      launchEnv: launchContext?.env,
-      extensionCommandsParser: this.extensionCommandsParser,
-      waitForInitialCommands: this.waitForInitialCommands,
-      initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
-    });
+    const session = this.createSessionInstance(
+      mergedConfig,
+      this.sessionOptions(launchContext, handle),
+    );
     await session.initializeResumedSession();
     return session;
+  }
+
+  async readSessionHistory(
+    handle: AgentPersistenceHandle,
+    context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult> {
+    if (handle.provider !== this.provider) {
+      throw new Error(`Cannot read ${handle.provider} history with ${this.provider} provider`);
+    }
+
+    const storedConfig = coerceSessionConfigMetadata(handle.metadata);
+    const cwd = context?.cwd ?? storedConfig.cwd;
+    if (!cwd) {
+      throw new Error(`${this.provider} history read requires the original working directory`);
+    }
+
+    const session = this.createSessionInstance(
+      { provider: this.provider, cwd },
+      this.sessionOptions(context, handle),
+    );
+    try {
+      await session.initializeHistorySession();
+      const events: AgentStreamEvent[] = [];
+      for await (const event of session.streamHistory()) {
+        events.push(event);
+      }
+      return { events, coverage: { kind: "complete" } };
+    } finally {
+      await session.close();
+    }
   }
 
   async fetchCatalog(
@@ -1758,41 +1784,11 @@ export class ACPAgentSession implements AgentSession, ACPClient {
    */
   async initializeResumedSession(): Promise<void> {
     try {
-      const handle = this.initialHandle;
-      if (!handle) {
-        throw new Error("Resume requested without persistence handle");
-      }
-
-      const spawned = await this.spawnProcess();
-      this.child = spawned.child;
-      this.connection = spawned.connection;
-      this.agentCapabilities = spawned.initialize.agentCapabilities ?? null;
-      this.sessionId = handle.sessionId;
-      this.bootstrapThreadEventPending = true;
-
-      const sessionCapabilities = this.agentCapabilities?.sessionCapabilities;
+      const { handle, sessionCapabilities } = await this.initializePersistedProcess();
       if (this.agentCapabilities?.loadSession) {
-        this.replayingHistory = true;
-        const response = await this.runACPRequest(() =>
-          this.connection!.loadSession({
-            sessionId: handle.sessionId,
-            cwd: this.config.cwd,
-            mcpServers: this.acpMcpServers(),
-          }),
-        );
-        this.deliverTranslatedEvents(this.flushPendingUserMessage());
-        this.replayingHistory = false;
-        this.historyPending = this.persistedHistory.length > 0;
-        this.applySessionState(response);
+        await this.loadPersistedSession(handle);
       } else if (sessionCapabilities?.resume) {
-        const response = await this.runACPRequest(() =>
-          this.connection!.unstable_resumeSession({
-            sessionId: handle.sessionId,
-            cwd: this.config.cwd,
-            mcpServers: this.acpMcpServers(),
-          }),
-        );
-        this.applySessionState(response);
+        await this.resumePersistedSession(handle);
       } else {
         throw new Error(`${this.provider} does not support ACP session resume`);
       }
@@ -1801,6 +1797,75 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     } catch (error) {
       await this.closeAfterInitializationFailure(error);
     }
+  }
+
+  async initializeHistorySession(): Promise<void> {
+    try {
+      const { handle } = await this.initializePersistedProcess();
+      if (this.agentCapabilities?.loadSession) {
+        await this.loadPersistedSession(handle, []);
+      } else {
+        throw new Error(`${this.provider} does not support ACP session/load history reads`);
+      }
+    } catch (error) {
+      await this.closeAfterInitializationFailure(error);
+    }
+  }
+
+  private async initializePersistedProcess(): Promise<{
+    handle: AgentPersistenceHandle;
+    sessionCapabilities: ACPAgentCapabilities["sessionCapabilities"];
+  }> {
+    const handle = this.initialHandle;
+    if (!handle) {
+      throw new Error("Persisted session requested without persistence handle");
+    }
+
+    const spawned = await this.spawnProcess();
+    this.child = spawned.child;
+    this.connection = spawned.connection;
+    this.agentCapabilities = spawned.initialize.agentCapabilities ?? null;
+    this.sessionId = handle.sessionId;
+    this.bootstrapThreadEventPending = true;
+    return {
+      handle,
+      sessionCapabilities: this.agentCapabilities?.sessionCapabilities,
+    };
+  }
+
+  private async loadPersistedSession(
+    handle: AgentPersistenceHandle,
+    mcpServers: McpServer[] = this.acpMcpServers(),
+  ): Promise<void> {
+    this.replayingHistory = true;
+    try {
+      const response = await this.runACPRequest(() =>
+        this.connection!.loadSession({
+          sessionId: handle.sessionId,
+          cwd: this.config.cwd,
+          mcpServers,
+        }),
+      );
+      this.deliverTranslatedEvents(this.flushPendingUserMessage());
+      this.historyPending = this.persistedHistory.length > 0;
+      this.applySessionState(response);
+    } finally {
+      this.replayingHistory = false;
+    }
+  }
+
+  private async resumePersistedSession(
+    handle: AgentPersistenceHandle,
+    mcpServers: McpServer[] = this.acpMcpServers(),
+  ): Promise<void> {
+    const response = await this.runACPRequest(() =>
+      this.connection!.unstable_resumeSession({
+        sessionId: handle.sessionId,
+        cwd: this.config.cwd,
+        mcpServers,
+      }),
+    );
+    this.applySessionState(response);
   }
 
   private async closeAfterInitializationFailure(error: unknown): Promise<never> {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -411,6 +411,7 @@ interface ClaudeAgentClientOptions {
 interface ClaudeAgentSessionOptions {
   defaults?: { agents?: Record<string, AgentDefinition> };
   runtimeSettings?: ProviderRuntimeSettings;
+  configDir?: string;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -1527,6 +1528,7 @@ export class ClaudeAgentClient implements AgentClient {
     return new ClaudeAgentSession(claudeConfig, {
       defaults: this.defaults,
       runtimeSettings: this.runtimeSettings,
+      configDir: this.configDir,
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       persistSession: options?.persistSession,
@@ -1556,6 +1558,7 @@ export class ClaudeAgentClient implements AgentClient {
     const session = new ClaudeAgentSession(this.assertConfig({ provider: "claude", cwd }), {
       defaults: this.defaults,
       runtimeSettings: this.runtimeSettings,
+      configDir: this.configDir,
       handle,
       agentId: context?.agentId,
       launchEnv: context?.env,
@@ -1593,6 +1596,7 @@ export class ClaudeAgentClient implements AgentClient {
     return new ClaudeAgentSession(claudeConfig, {
       defaults: this.defaults,
       runtimeSettings: this.runtimeSettings,
+      configDir: this.configDir,
       handle,
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
@@ -2144,6 +2148,7 @@ class ClaudeAgentSession implements AgentSession {
   private foregroundHasVisibleActivity = false;
   private activeTurnHasAssistantText = false;
   private readonly contextUsage: ClaudeContextUsageState;
+  private readonly configDir?: string;
   private userMessageIds: string[] = [];
   private readonly emittedUserMessageIds = new Set<string>();
   private readonly rewindTurnAnchors: ClaudeRewindTurnAnchor[] = [];
@@ -2158,6 +2163,7 @@ class ClaudeAgentSession implements AgentSession {
     this.agentId = options.agentId;
     this.defaults = options.defaults;
     this.runtimeSettings = options.runtimeSettings;
+    this.configDir = options.configDir;
     this.persistSession = options.persistSession;
     this.logger = options.logger.child({ agentId: this.agentId });
     this.queryFactory = options.queryFactory;
@@ -5063,7 +5069,10 @@ class ClaudeAgentSession implements AgentSession {
   private resolveHistoryPath(sessionId: string): string | null {
     const cwd = this.config.cwd;
     if (!cwd) return null;
-    const configDir = resolveClaudeConfigDir({ runtimeSettings: this.runtimeSettings });
+    const configDir = resolveClaudeConfigDir({
+      configDir: this.configDir,
+      runtimeSettings: this.runtimeSettings,
+    });
     const candidates = [cwd];
     try {
       const realCwd = fs.realpathSync(cwd);

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -5072,6 +5072,7 @@ class ClaudeAgentSession implements AgentSession {
     const configDir = resolveClaudeConfigDir({
       configDir: this.configDir,
       runtimeSettings: this.runtimeSettings,
+      launchEnv: this.launchEnv,
     });
     const candidates = [cwd];
     try {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -2,7 +2,6 @@ import type { ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { promises } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   type AgentDefinition,
@@ -78,7 +77,7 @@ import { renderPromptAttachmentAsText } from "../../prompt-attachments.js";
 import { claudeQuery, type ClaudeOptions, type ClaudeQueryFactory } from "./query.js";
 import { realClaudeRewindSdk, revertClaudeConversation, revertClaudeFiles } from "./rewind.js";
 import { normalizeProviderReplayTimestamp } from "../../provider-history-timestamps.js";
-import { claudeProjectDirSync } from "./project-dir.js";
+import { claudeProjectDirSync, resolveClaudeConfigDir } from "./project-dir.js";
 import { THINKING_APPLIES_NEXT_TURN_NOTICE } from "../../provider-notices.js";
 import {
   isProviderImageMarkdown,
@@ -94,6 +93,8 @@ import {
   type AgentClient,
   type AgentCreateSessionOptions,
   type AgentFeature,
+  type AgentHistoryReadContext,
+  type AgentHistoryReadResult,
   type AgentLaunchContext,
   type AgentMetadata,
   type AgentMode,
@@ -1540,6 +1541,44 @@ export class ClaudeAgentClient implements AgentClient {
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
+    return this.createPersistedSession(handle, overrides, launchContext);
+  }
+
+  async readSessionHistory(
+    handle: AgentPersistenceHandle,
+    context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult> {
+    const metadata = coerceSessionMetadata(handle.metadata);
+    const cwd = context?.cwd ?? metadata.cwd;
+    if (!cwd) {
+      throw new Error("Claude history read requires the original working directory in metadata");
+    }
+    const session = new ClaudeAgentSession(this.assertConfig({ provider: "claude", cwd }), {
+      defaults: this.defaults,
+      runtimeSettings: this.runtimeSettings,
+      handle,
+      agentId: context?.agentId,
+      launchEnv: context?.env,
+      logger: this.logger,
+      queryFactory: this.queryFactory,
+      resolveBinary: this.resolveBinary,
+    });
+    try {
+      const events: AgentStreamEvent[] = [];
+      for await (const event of session.streamHistory()) {
+        events.push(event);
+      }
+      return { events, coverage: { kind: "complete" } };
+    } finally {
+      await session.close();
+    }
+  }
+
+  private createPersistedSession(
+    handle: AgentPersistenceHandle,
+    overrides?: Partial<AgentSessionConfig>,
+    launchContext?: AgentLaunchContext,
+  ): ClaudeAgentSession {
     const metadata = coerceSessionMetadata(handle.metadata);
     const merged: Partial<AgentSessionConfig> = { ...metadata, ...overrides };
     if (!merged.cwd) {
@@ -1613,7 +1652,10 @@ export class ClaudeAgentClient implements AgentClient {
   async listImportableSessions(
     options?: ListImportableSessionsOptions,
   ): Promise<ImportableProviderSession[]> {
-    const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+    const configDir = resolveClaudeConfigDir({
+      configDir: this.configDir,
+      runtimeSettings: this.runtimeSettings,
+    });
     const sessionsRoot = options?.cwd
       ? claudeProjectDirSync(options.cwd, { configDir })
       : path.join(configDir, "projects");
@@ -5021,7 +5063,7 @@ class ClaudeAgentSession implements AgentSession {
   private resolveHistoryPath(sessionId: string): string | null {
     const cwd = this.config.cwd;
     if (!cwd) return null;
-    const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+    const configDir = resolveClaudeConfigDir({ runtimeSettings: this.runtimeSettings });
     const candidates = [cwd];
     try {
       const realCwd = fs.realpathSync(cwd);

--- a/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
@@ -270,6 +270,55 @@ describe("ClaudeAgentSession history replay regression", () => {
     expect(timelineText).toContain(HISTORY_ASSISTANT_MARKER);
   });
 
+  test("reads persisted history without starting a Claude SDK query", async () => {
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    queryFactory.mockClear();
+
+    const historyEvents = await client.readSessionHistory(
+      {
+        provider: "claude",
+        sessionId: "history-session",
+        nativeHandle: "history-session",
+        metadata: { provider: "claude", cwd },
+      },
+      { cwd },
+    );
+
+    expect(historyEvents.coverage).toEqual({ kind: "complete" });
+    expect(collectTimelineText(historyEvents.events)).toContain(HISTORY_USER_MARKER);
+    expect(collectTimelineText(historyEvents.events)).toContain(HISTORY_ASSISTANT_MARKER);
+    expect(queryFactory).not.toHaveBeenCalled();
+    expect(lastQuery).toBeNull();
+  });
+
+  test("reads persisted history from the provider profile's CLAUDE_CONFIG_DIR", async () => {
+    process.env.CLAUDE_CONFIG_DIR = path.join(tempRoot, "daemon-claude-config");
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory,
+      runtimeSettings: { env: { CLAUDE_CONFIG_DIR: configDir } },
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    queryFactory.mockClear();
+
+    const history = await client.readSessionHistory(
+      {
+        provider: "claude",
+        sessionId: "history-session",
+        nativeHandle: "history-session",
+        metadata: { provider: "claude", cwd },
+      },
+      { cwd },
+    );
+
+    expect(collectTimelineText(history.events)).toContain(HISTORY_ASSISTANT_MARKER);
+    expect(queryFactory).not.toHaveBeenCalled();
+  });
+
   test("replays persisted sidechains as provider subagent timelines", async () => {
     const client = new ClaudeAgentClient({
       logger: createTestLogger(),

--- a/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
@@ -319,6 +319,33 @@ describe("ClaudeAgentSession history replay regression", () => {
     expect(queryFactory).not.toHaveBeenCalled();
   });
 
+  test("prefers the explicit config directory when reading persisted history", async () => {
+    process.env.CLAUDE_CONFIG_DIR = path.join(tempRoot, "daemon-claude-config");
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory,
+      configDir,
+      runtimeSettings: {
+        env: { CLAUDE_CONFIG_DIR: path.join(tempRoot, "profile-claude-config") },
+      },
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    queryFactory.mockClear();
+
+    const history = await client.readSessionHistory(
+      {
+        provider: "claude",
+        sessionId: "history-session",
+        nativeHandle: "history-session",
+        metadata: { provider: "claude", cwd },
+      },
+      { cwd },
+    );
+
+    expect(collectTimelineText(history.events)).toContain(HISTORY_ASSISTANT_MARKER);
+    expect(queryFactory).not.toHaveBeenCalled();
+  });
+
   test("replays persisted sidechains as provider subagent timelines", async () => {
     const client = new ClaudeAgentClient({
       logger: createTestLogger(),

--- a/packages/server/src/server/agent/providers/claude/project-dir.test.ts
+++ b/packages/server/src/server/agent/providers/claude/project-dir.test.ts
@@ -5,9 +5,9 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { claudeProjectDir, claudeProjectDirSync } from "./project-dir.js";
+import { claudeProjectDir, claudeProjectDirSync, resolveClaudeConfigDir } from "./project-dir.js";
 
 // Parity oracle: the Claude SDK's getSessionInfo({ dir }) canonicalizes the
 // given dir with the SDK's own encoder and looks for `<sessionId>.jsonl` under
@@ -106,6 +106,58 @@ describe("claudeProjectDir parity with Claude Agent SDK", () => {
     const cwd = await ensureDir(join(workspaceRoot, "sync path with spaces"));
 
     await expect(claudeProjectDir(cwd)).resolves.toBe(claudeProjectDirSync(cwd));
+  });
+});
+
+describe("resolveClaudeConfigDir", () => {
+  const daemonConfigDir = join(tmpdir(), "paseo-claude-config-daemon");
+  const profileConfigDir = join(tmpdir(), "paseo-claude-config-profile");
+
+  beforeEach(() => {
+    vi.stubEnv("CLAUDE_CONFIG_DIR", daemonConfigDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("prefers a provider profile's CLAUDE_CONFIG_DIR over the daemon environment", () => {
+    expect(
+      resolveClaudeConfigDir({
+        runtimeSettings: { env: { CLAUDE_CONFIG_DIR: profileConfigDir } },
+      }),
+    ).toBe(profileConfigDir);
+  });
+
+  test("falls back to the daemon environment when the profile sets no directory", () => {
+    expect(resolveClaudeConfigDir({ runtimeSettings: { env: {} } })).toBe(daemonConfigDir);
+    expect(resolveClaudeConfigDir()).toBe(daemonConfigDir);
+  });
+
+  test("keeps an explicit config directory as the highest precedence", () => {
+    const explicit = join(tmpdir(), "paseo-claude-config-explicit");
+
+    expect(
+      resolveClaudeConfigDir({
+        configDir: explicit,
+        runtimeSettings: { env: { CLAUDE_CONFIG_DIR: profileConfigDir } },
+      }),
+    ).toBe(explicit);
+  });
+
+  test("defaults to ~/.claude when no directory is configured", () => {
+    vi.stubEnv("CLAUDE_CONFIG_DIR", undefined);
+
+    expect(resolveClaudeConfigDir()).toBe(join(homedir(), ".claude"));
+  });
+
+  test("resolves session transcripts under the profile directory", () => {
+    const cwd = join(tmpdir(), "paseo-profile-project");
+    const configDir = resolveClaudeConfigDir({
+      runtimeSettings: { env: { CLAUDE_CONFIG_DIR: profileConfigDir } },
+    });
+
+    expect(claudeProjectDirSync(cwd, { configDir })).toContain(profileConfigDir);
   });
 });
 

--- a/packages/server/src/server/agent/providers/claude/project-dir.test.ts
+++ b/packages/server/src/server/agent/providers/claude/project-dir.test.ts
@@ -121,6 +121,29 @@ describe("resolveClaudeConfigDir", () => {
     vi.unstubAllEnvs();
   });
 
+  test("prefers a launch environment's CLAUDE_CONFIG_DIR over the provider profile", () => {
+    // `createProviderEnv` overlays launchEnv on top of the profile settings, so a
+    // plugin that redirects CLAUDE_CONFIG_DIR for one open must win here too, or
+    // the transcript lookup resolves a different directory than the session ran in.
+    const launchConfigDir = join(tmpdir(), "paseo-claude-config-launch");
+    expect(
+      resolveClaudeConfigDir({
+        runtimeSettings: { env: { CLAUDE_CONFIG_DIR: profileConfigDir } },
+        launchEnv: { CLAUDE_CONFIG_DIR: launchConfigDir },
+      }),
+    ).toBe(launchConfigDir);
+  });
+
+  test("prefers an explicit config directory over the launch environment", () => {
+    const explicitConfigDir = join(tmpdir(), "paseo-claude-config-explicit");
+    expect(
+      resolveClaudeConfigDir({
+        configDir: explicitConfigDir,
+        launchEnv: { CLAUDE_CONFIG_DIR: join(tmpdir(), "paseo-claude-config-launch") },
+      }),
+    ).toBe(explicitConfigDir);
+  });
+
   test("prefers a provider profile's CLAUDE_CONFIG_DIR over the daemon environment", () => {
     expect(
       resolveClaudeConfigDir({

--- a/packages/server/src/server/agent/providers/claude/project-dir.ts
+++ b/packages/server/src/server/agent/providers/claude/project-dir.ts
@@ -13,6 +13,7 @@ const PROJECT_DIR_LENGTH_CAP = 200;
 
 export interface ClaudeProjectDirOptions {
   configDir?: string;
+  runtimeSettings?: { env?: Record<string, string> };
 }
 
 export async function claudeProjectDir(
@@ -66,6 +67,15 @@ function hashSuffix(input: string): string {
   return Math.abs(hash).toString(36);
 }
 
+export function resolveClaudeConfigDir(options?: ClaudeProjectDirOptions): string {
+  return (
+    options?.configDir ??
+    options?.runtimeSettings?.env?.CLAUDE_CONFIG_DIR ??
+    process.env.CLAUDE_CONFIG_DIR ??
+    join(homedir(), ".claude")
+  );
+}
+
 function resolveConfigDir(options?: ClaudeProjectDirOptions): string {
-  return options?.configDir ?? process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude");
+  return resolveClaudeConfigDir(options);
 }

--- a/packages/server/src/server/agent/providers/claude/project-dir.ts
+++ b/packages/server/src/server/agent/providers/claude/project-dir.ts
@@ -14,6 +14,13 @@ const PROJECT_DIR_LENGTH_CAP = 200;
 export interface ClaudeProjectDirOptions {
   configDir?: string;
   runtimeSettings?: { env?: Record<string, string> };
+  /**
+   * Per-launch environment, including anything a plugin rewrote for this open.
+   * `createProviderEnv` overlays it on top of the profile settings, so config-dir
+   * resolution has to prefer it the same way or a transcript read lands in a
+   * different directory than the session it belongs to.
+   */
+  launchEnv?: Record<string, string>;
 }
 
 export async function claudeProjectDir(
@@ -70,6 +77,7 @@ function hashSuffix(input: string): string {
 export function resolveClaudeConfigDir(options?: ClaudeProjectDirOptions): string {
   return (
     options?.configDir ??
+    options?.launchEnv?.CLAUDE_CONFIG_DIR ??
     options?.runtimeSettings?.env?.CLAUDE_CONFIG_DIR ??
     process.env.CLAUDE_CONFIG_DIR ??
     join(homedir(), ".claude")

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -1413,30 +1413,40 @@ describe("Codex app-server provider", () => {
     await session.close();
   });
 
-  test("loads archived Codex history without resuming the native thread", async () => {
+  test("reads archived Codex history without resuming an unarchived native thread", async () => {
     const threadRequests: string[] = [];
     const appServer = createFakeCodexAppServer({
+      "collaborationMode/list": () => {
+        threadRequests.push("collaborationMode/list");
+        return { data: [] };
+      },
+      "skills/list": () => {
+        threadRequests.push("skills/list");
+        return { data: [] };
+      },
       "thread/loaded/list": () => {
         threadRequests.push("thread/loaded/list");
         return { data: [] };
       },
       "thread/resume": () => {
         threadRequests.push("thread/resume");
-        return Promise.reject(new Error(archivedThreadErrorMessage("archived-thread-id")));
+        return { thread: { id: "archived-thread-id" } };
       },
       "thread/read": () => {
         threadRequests.push("thread/read");
         return { thread: { turns: [] } };
       },
     });
+    const killSpy = vi.spyOn(appServer.child, "kill");
     const provider = createProviderWithFakeAppServer(appServer);
 
-    const session = await provider.resumeSession(archivedThreadHandle(), undefined, undefined, {
-      purpose: "history",
+    await expect(provider.readSessionHistory(archivedThreadHandle())).resolves.toEqual({
+      events: [],
+      coverage: { kind: "complete" },
     });
 
-    expect(threadRequests).toEqual(["thread/loaded/list", "thread/resume", "thread/read"]);
-    await session.close();
+    expect(threadRequests).toEqual(["thread/read"]);
+    expect(killSpy).toHaveBeenCalledWith("SIGTERM");
     appServer.assertNoErrors();
   });
 
@@ -1504,9 +1514,9 @@ describe("Codex app-server provider", () => {
     const killSpy = vi.spyOn(appServer.child, "kill");
     const provider = createProviderWithFakeAppServer(appServer);
 
-    await expect(
-      provider.resumeSession(archivedThreadHandle(), undefined, undefined, { purpose: "history" }),
-    ).rejects.toThrow("thread history is unavailable");
+    await expect(provider.readSessionHistory(archivedThreadHandle())).rejects.toThrow(
+      "thread history is unavailable",
+    );
 
     expect(killSpy).toHaveBeenCalledWith("SIGTERM");
     appServer.assertNoErrors();
@@ -3991,6 +4001,175 @@ describe("Codex app-server provider", () => {
       index: 0,
       turnId: "native-turn-1",
     });
+  });
+
+  test("loads independent persisted sub-agent histories with bounded deterministic concurrency", async () => {
+    const session = createSession();
+    const childThreadIds = Array.from({ length: 10 }, (_, index) => `child-thread-${index}`);
+    const childStartedItems = childThreadIds.map((childThreadId, index) => ({
+      type: "subAgentActivity",
+      id: `child-started-${index}`,
+      kind: "started",
+      agentThreadId: childThreadId,
+      agentPath: `/root/child-${index}`,
+    }));
+    const childReadGates = new Map(childThreadIds.map((threadId) => [threadId, deferred<void>()]));
+    const requestedChildThreadIds = new Set<string>();
+    let activeChildReads = 0;
+    let peakChildReads = 0;
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "test-thread") {
+          return {
+            thread: {
+              turns: [
+                {
+                  items: childStartedItems,
+                },
+              ],
+            },
+          };
+        }
+        if (!threadId) {
+          throw new Error("Expected a child thread id");
+        }
+
+        const gate = childReadGates.get(threadId);
+        if (!gate) {
+          throw new Error(`Unexpected child thread id: ${threadId}`);
+        }
+        requestedChildThreadIds.add(threadId);
+        activeChildReads += 1;
+        peakChildReads = Math.max(peakChildReads, activeChildReads);
+        try {
+          await gate.promise;
+          return {
+            thread: {
+              turns: [
+                {
+                  items: [
+                    {
+                      type: "agentMessage",
+                      id: `message-${threadId}`,
+                      text: `History from ${threadId}`,
+                    },
+                  ],
+                },
+              ],
+            },
+          };
+        } finally {
+          activeChildReads -= 1;
+        }
+      }),
+    };
+
+    const historyLoad = asInternals(session).loadPersistedHistory();
+    try {
+      await vi.waitFor(() => {
+        expect(peakChildReads).toBe(8);
+        expect(requestedChildThreadIds.size).toBe(8);
+      });
+      for (const threadId of childThreadIds.slice(0, 8).toReversed()) {
+        childReadGates.get(threadId)?.resolve(undefined);
+      }
+      await vi.waitFor(() => {
+        expect(requestedChildThreadIds.size).toBe(10);
+      });
+      for (const threadId of childThreadIds.slice(8).toReversed()) {
+        childReadGates.get(threadId)?.resolve(undefined);
+      }
+      await historyLoad;
+    } finally {
+      for (const gate of childReadGates.values()) {
+        gate.resolve(undefined);
+      }
+    }
+
+    const history: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      history.push(event);
+    }
+    const childTimelineOrder = history.flatMap((event) =>
+      event.type === "provider_subagent" && event.event.type === "timeline" ? [event.event.id] : [],
+    );
+
+    expect(peakChildReads).toBe(8);
+    expect(requestedChildThreadIds).toEqual(new Set(childThreadIds));
+    expect(activeChildReads).toBe(0);
+    expect(childTimelineOrder).toEqual(childThreadIds);
+  });
+
+  test("isolates a failed persisted sub-agent history read", async () => {
+    const session = createSession();
+    const requestedChildThreadIds: string[] = [];
+    const childStartedItems = ["failing-child", "successful-child"].map((childThreadId) => ({
+      type: "subAgentActivity",
+      id: `started-${childThreadId}`,
+      kind: "started",
+      agentThreadId: childThreadId,
+      agentPath: `/root/${childThreadId}`,
+    }));
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "test-thread") {
+          return {
+            thread: {
+              turns: [
+                {
+                  items: childStartedItems,
+                },
+              ],
+            },
+          };
+        }
+        if (!threadId) {
+          throw new Error("Expected a child thread id");
+        }
+        requestedChildThreadIds.push(threadId);
+        if (threadId === "failing-child") {
+          throw new Error("child history unavailable");
+        }
+        return {
+          thread: {
+            turns: [
+              {
+                items: [
+                  {
+                    type: "agentMessage",
+                    id: "successful-child-message",
+                    text: "Successful child history",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }),
+    };
+
+    await expect(asInternals(session).loadPersistedHistory()).resolves.toBeUndefined();
+
+    const history: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      history.push(event);
+    }
+    expect(requestedChildThreadIds).toEqual(["failing-child", "successful-child"]);
+    expect(
+      history.flatMap((event) =>
+        event.type === "provider_subagent" && event.event.type === "timeline"
+          ? [event.event.id]
+          : [],
+      ),
+    ).toEqual(["successful-child"]);
   });
 
   test("loads mixed legacy and MultiAgentV2 sub-agent history", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -5,8 +5,9 @@ import {
   type AgentClient,
   type AgentCreateSessionOptions,
   type AgentFeature,
+  type AgentHistoryReadContext,
+  type AgentHistoryReadResult,
   type AgentLaunchContext,
-  type AgentResumeSessionOptions,
   type AgentMode,
   type AgentModelDefinition,
   type McpServerConfig,
@@ -138,6 +139,7 @@ function isCodexAlreadyUnarchivedError(error: unknown, threadId: string): boolea
 
 const TURN_START_TIMEOUT_MS = 90 * 1000;
 const INTERRUPT_TIMEOUT_MS = 2_000;
+const PERSISTED_SUBAGENT_HISTORY_CONCURRENCY = 8;
 const CODEX_PROVIDER = "codex" as const;
 // Codex treats most app-server client names as the model-request originator.
 // This reserved Codex name is non-originating, so requests keep Codex's default
@@ -3398,7 +3400,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     private readonly goalsEnabled: boolean = false,
     private readonly autoReviewEnabled: boolean = false,
     private readonly agentId?: string,
-    private readonly initialResumePurpose: "interactive" | "history" = "interactive",
   ) {
     this.logger = logger.child({
       module: "agent",
@@ -3490,9 +3491,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       await this.loadSkills();
 
       if (this.currentThreadId) {
-        await this.ensureThreadLoaded({
-          allowArchivedHistory: this.initialResumePurpose === "history",
-        });
+        await this.ensureThreadLoaded();
         await this.loadPersistedHistory();
       }
 
@@ -3535,6 +3534,33 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.resolvedSandboxPolicy = sandbox ?? null;
     if (sandbox?.type !== "workspaceWrite") return;
     this.resolvedWorkspaceWrite = readSandboxWorkspaceWrite(sandbox);
+  }
+
+  async connectForHistory(): Promise<void> {
+    if (this.connected) return;
+    const child = await this.spawnAppServer();
+    this.client = new CodexAppServerClient(child, this.logger, () => this.traceContext());
+
+    try {
+      await this.client.request("initialize", buildCodexAppServerInitializeParams());
+      this.client.notify("initialized", {});
+      await this.loadPersistedHistory();
+      this.connected = true;
+    } catch (error) {
+      await this.closeAfterConnectFailure(error);
+    }
+  }
+
+  private async closeAfterConnectFailure(error: unknown): Promise<never> {
+    try {
+      await this.close();
+    } catch (closeError) {
+      this.logger.warn(
+        { err: closeError, connectError: error },
+        "Failed to close Codex app-server after connection failure",
+      );
+    }
+    throw error;
   }
 
   private createClosedError(): Error {
@@ -3829,23 +3855,56 @@ export class CodexAppServerAgentSession implements AgentSession {
     }));
     const visitedThreadIds = new Set(this.currentThreadId ? [this.currentThreadId] : []);
     while (queue.length > 0 && visitedThreadIds.size < 100) {
-      const next = queue.shift();
-      if (!next || visitedThreadIds.has(next.route.childThreadId)) {
-        continue;
-      }
-      visitedThreadIds.add(next.route.childThreadId);
-      this.registerSubAgentToolCall({
-        timelineItem: next.route.toolCall,
-        rawItem: { agentThreadId: next.route.childThreadId },
-        parentCallId: next.parentCallId,
-        parentSubagentId: next.parentSubagentId,
-      });
-      try {
-        const childHistory = await loadCodexThreadHistoryTimeline({
-          threadId: next.route.childThreadId,
-          cwd: this.config.cwd ?? null,
-          requestThread: (childThreadId) => readCodexThread(client, childThreadId),
+      const batch: Array<{
+        route: PersistedSubAgentRoute;
+        parentCallId: string | null;
+        parentSubagentId: string | null;
+      }> = [];
+      while (
+        batch.length < PERSISTED_SUBAGENT_HISTORY_CONCURRENCY &&
+        queue.length > 0 &&
+        visitedThreadIds.size < 100
+      ) {
+        const next = queue.shift();
+        if (!next || visitedThreadIds.has(next.route.childThreadId)) {
+          continue;
+        }
+        visitedThreadIds.add(next.route.childThreadId);
+        this.registerSubAgentToolCall({
+          timelineItem: next.route.toolCall,
+          rawItem: { agentThreadId: next.route.childThreadId },
+          parentCallId: next.parentCallId,
+          parentSubagentId: next.parentSubagentId,
         });
+        batch.push(next);
+      }
+
+      const results = await Promise.all(
+        batch.map(async (next) => {
+          try {
+            return {
+              next,
+              childHistory: await loadCodexThreadHistoryTimeline({
+                threadId: next.route.childThreadId,
+                cwd: this.config.cwd ?? null,
+                requestThread: (childThreadId) => readCodexThread(client, childThreadId),
+              }),
+              error: null,
+            };
+          } catch (error) {
+            return { next, childHistory: null, error };
+          }
+        }),
+      );
+
+      for (const { next, childHistory, error } of results) {
+        if (error || !childHistory) {
+          this.logger.trace(
+            { err: error, childThreadId: next.route.childThreadId },
+            "Failed to load persisted Codex child history",
+          );
+          continue;
+        }
         for (const entry of childHistory.timeline) {
           this.emitProviderSubagentTimeline(next.route.childThreadId, entry.item, entry.timestamp);
         }
@@ -3856,18 +3915,11 @@ export class CodexAppServerAgentSession implements AgentSession {
             parentSubagentId: next.route.childThreadId,
           });
         }
-      } catch (error) {
-        this.logger.trace(
-          { err: error, childThreadId: next.route.childThreadId },
-          "Failed to load persisted Codex child history",
-        );
       }
     }
   }
 
-  private async ensureThreadLoaded(
-    options: { allowArchivedHistory?: boolean } = {},
-  ): Promise<void> {
+  private async ensureThreadLoaded(): Promise<void> {
     if (!this.client || !this.currentThreadId) return;
     const params: Record<string, unknown> = { threadId: this.currentThreadId };
     const developerInstructions = composeSystemPromptParts(
@@ -3892,16 +3944,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     } catch (error) {
       const threadId = this.currentThreadId;
       const message = error instanceof Error ? error.message : String(error);
-      if (
-        options.allowArchivedHistory === true &&
-        isArchivedCodexThreadResumeError(error, threadId)
-      ) {
-        this.logger.info(
-          { threadId },
-          "Loading archived Codex thread history without resuming the native session",
-        );
-        return;
-      }
       if (isArchivedCodexThreadResumeError(error, threadId)) {
         try {
           await this.client.request("thread/unarchive", { threadId });
@@ -7078,8 +7120,53 @@ export class CodexAppServerAgentClient implements AgentClient {
     handle: { sessionId: string; metadata?: Record<string, unknown> },
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
-    options?: AgentResumeSessionOptions,
   ): Promise<AgentSession> {
+    const session = await this.createPersistedSession(handle, overrides, launchContext);
+    await session.connect();
+    return session;
+  }
+
+  async readSessionHistory(
+    handle: { sessionId: string; metadata?: Record<string, unknown> },
+    context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult> {
+    const metadata = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
+    const session = new CodexAppServerAgentSession(
+      {
+        provider: CODEX_PROVIDER,
+        cwd: context?.cwd ?? metadata.cwd ?? process.cwd(),
+        modeId: DEFAULT_CODEX_MODE_ID,
+      },
+      handle,
+      this.logger,
+      () =>
+        this.spawnAppServer(context?.env, {
+          goalsEnabled: false,
+          agentId: context?.agentId,
+        }),
+      this.sessionDeps(),
+      false,
+      false,
+      false,
+      context?.agentId,
+    );
+    try {
+      await session.connectForHistory();
+      const events: AgentStreamEvent[] = [];
+      for await (const event of session.streamHistory()) {
+        events.push(event);
+      }
+      return { events, coverage: { kind: "complete" } };
+    } finally {
+      await session.close();
+    }
+  }
+
+  private async createPersistedSession(
+    handle: { sessionId: string; metadata?: Record<string, unknown> },
+    overrides?: Partial<AgentSessionConfig>,
+    launchContext?: AgentLaunchContext,
+  ): Promise<CodexAppServerAgentSession> {
     const storedConfig = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
     const merged: AgentSessionConfig = {
       ...storedConfig,
@@ -7089,7 +7176,7 @@ export class CodexAppServerAgentClient implements AgentClient {
     };
     const goalsEnabled = await this.resolveGoalsEnabled();
     const autoReviewEnabled = await this.resolveAutoReviewEnabled();
-    const session = new CodexAppServerAgentSession(
+    return new CodexAppServerAgentSession(
       merged,
       handle,
       this.logger,
@@ -7100,10 +7187,7 @@ export class CodexAppServerAgentClient implements AgentClient {
       goalsEnabled,
       autoReviewEnabled,
       launchContext?.agentId,
-      options?.purpose ?? "interactive",
     );
-    await session.connect();
-    return session;
   }
 
   async listImportableSessions(

--- a/packages/server/src/server/agent/providers/codex-archived-history-read.local.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/codex-archived-history-read.local.e2e.test.ts
@@ -1,0 +1,297 @@
+import { execFileSync } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import { ensureAgentLoaded } from "../agent-loading.js";
+import { AgentManager } from "../agent-manager.js";
+import { AgentStorage } from "../agent-storage.js";
+import { CodexAppServerAgentClient } from "./codex-app-server-agent.js";
+
+function isCodexInstalled(): boolean {
+  try {
+    return execFileSync("which", ["codex"], { encoding: "utf8" }).trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function sse(events: unknown[]): string {
+  return events
+    .map((event) => {
+      const type =
+        typeof event === "object" && event !== null && "type" in event
+          ? String((event as { type: unknown }).type)
+          : "message";
+      return `event: ${type}\ndata: ${JSON.stringify(event)}\n\n`;
+    })
+    .join("");
+}
+
+function assistantMessageSse(text: string): string {
+  return sse([
+    { type: "response.created", response: { id: "resp-1" } },
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "message",
+        role: "assistant",
+        id: "msg-1",
+        content: [{ type: "output_text", text }],
+      },
+    },
+    { type: "response.completed", response: { id: "resp-1" } },
+  ]);
+}
+
+async function startMockResponsesServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((req, res) => {
+    req.on("data", () => {});
+    req.on("end", () => {
+      if (req.method !== "POST" || req.url !== "/v1/responses") {
+        res.statusCode = 404;
+        res.end("not found");
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader("content-type", "text/event-stream");
+      res.setHeader("cache-control", "no-cache");
+      res.end(assistantMessageSse("archived turn"));
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP address for mock responses server");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+  };
+}
+
+function writeMockCodexConfig(codexHome: string, serverUrl: string): void {
+  writeFileSync(
+    path.join(codexHome, "config.toml"),
+    `
+model = "mock-model"
+approval_policy = "on-request"
+sandbox_mode = "read-only"
+
+model_provider = "mock_provider"
+
+[model_providers.mock_provider]
+name = "Mock provider for test"
+base_url = "${serverUrl}/v1"
+wire_api = "responses"
+request_max_retries = 0
+stream_max_retries = 0
+`,
+  );
+}
+
+/**
+ * Codex app-servers this test process spawned. `spawnProcess` detaches them, so
+ * the parent link is the only handle back: a released app-server leaves this
+ * list empty, a retained one keeps its pid in it.
+ */
+function listOwnedAppServers(): number[] {
+  const out = execFileSync("ps", ["-eo", "pid=,ppid=,args="], { encoding: "utf8" });
+  const owned: number[] = [];
+  for (const line of out.split("\n")) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/);
+    if (!match) continue;
+    const [, pid, ppid, args] = match;
+    if (Number(ppid) === process.pid && /\bapp-server\b/.test(args)) {
+      owned.push(Number(pid));
+    }
+  }
+  return owned;
+}
+
+async function settledAppServers(timeoutMs = 10_000): Promise<number[]> {
+  const deadline = Date.now() + timeoutMs;
+  let owned = listOwnedAppServers();
+  while (owned.length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    owned = listOwnedAppServers();
+  }
+  return owned;
+}
+
+describe("Codex archived history read (local e2e)", () => {
+  test.runIf(isCodexInstalled())(
+    "leaves the archived native thread untouched and releases the temporary app-server",
+    async () => {
+      const cwd = mkdtempSync(path.join(os.tmpdir(), "codex-archived-history-cwd-"));
+      const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-archived-history-home-"));
+      const mockServer = await startMockResponsesServer();
+      const logger = createTestLogger();
+      const storage = new AgentStorage(path.join(cwd, "agents"), logger);
+      const client = new CodexAppServerAgentClient(logger);
+      const manager = new AgentManager({
+        clients: { codex: client },
+        registry: storage,
+        logger,
+      });
+      const listNativeThreads = async () =>
+        (await client.listImportableSessions({ limit: 20 })).map(
+          (session) => session.providerHandleId,
+        );
+
+      try {
+        writeMockCodexConfig(codexHome, mockServer.url);
+        vi.stubEnv("CODEX_HOME", codexHome);
+
+        // A real Codex thread carrying real persisted history.
+        const created = await manager.createAgent(
+          { provider: "codex", cwd, modeId: "auto", model: "mock-model" },
+          undefined,
+          { workspaceId: undefined },
+        );
+        const agentId = created.id;
+        await manager.runAgent(agentId, "remember this turn");
+        const handle = manager.getAgent(agentId)?.persistence;
+        const threadId = handle?.sessionId;
+        expect(threadId).toBeTruthy();
+        expect(await listNativeThreads()).toContain(threadId);
+
+        await manager.archiveAgent(agentId);
+        // `archiveAgentUnlocked` syncs the native archive before it closes the
+        // runtime, so `thread/archive` loses to the thread's own writer lock and
+        // the best-effort sync swallows it. Archive again now that the runtime is
+        // gone, so this test observes a genuinely archived native thread.
+        await client.archiveNativeSession(handle!);
+        expect(await listNativeThreads()).not.toContain(threadId);
+        expect(await settledAppServers()).toEqual([]);
+
+        const snapshot = await ensureAgentLoaded(agentId, {
+          agentManager: manager,
+          agentStorage: storage,
+          logger,
+        });
+
+        // The history really was read...
+        expect(snapshot.id).toBe(agentId);
+        expect(manager.getTimeline(agentId).length).toBeGreaterThan(0);
+
+        // ...the temporary app-server it used is gone...
+        expect(await settledAppServers(), "a history read must not retain its app-server").toEqual(
+          [],
+        );
+
+        // ...and the native thread is still archived, never resumed or unarchived.
+        expect(
+          await listNativeThreads(),
+          "a history read must leave the native thread archived",
+        ).not.toContain(threadId);
+        await settledAppServers();
+      } finally {
+        for (const pid of listOwnedAppServers()) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // already gone
+          }
+        }
+        await storage.flush();
+        vi.unstubAllEnvs();
+        await mockServer.close();
+        rmSync(cwd, { recursive: true, force: true });
+        rmSync(codexHome, { recursive: true, force: true });
+      }
+    },
+    120_000,
+  );
+  test.runIf(isCodexInstalled())(
+    "does not resume a native thread the Paseo archive left active",
+    async () => {
+      const cwd = mkdtempSync(path.join(os.tmpdir(), "codex-active-history-cwd-"));
+      const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-active-history-home-"));
+      const mockServer = await startMockResponsesServer();
+      const logger = createTestLogger();
+      const storage = new AgentStorage(path.join(cwd, "agents"), logger);
+      const client = new CodexAppServerAgentClient(logger);
+      const manager = new AgentManager({
+        clients: { codex: client },
+        registry: storage,
+        logger,
+      });
+      const listNativeThreads = async () =>
+        (await client.listImportableSessions({ limit: 20 })).map(
+          (session) => session.providerHandleId,
+        );
+
+      try {
+        writeMockCodexConfig(codexHome, mockServer.url);
+        vi.stubEnv("CODEX_HOME", codexHome);
+
+        const created = await manager.createAgent(
+          { provider: "codex", cwd, modeId: "auto", model: "mock-model" },
+          undefined,
+          { workspaceId: undefined },
+        );
+        const agentId = created.id;
+        await manager.runAgent(agentId, "remember this turn");
+        const handle = manager.getAgent(agentId)?.persistence;
+        const threadId = handle?.sessionId;
+        expect(threadId).toBeTruthy();
+
+        // The ordinary archive path syncs the native archive while the runtime
+        // still owns the thread's writer, so `thread/archive` loses and the
+        // best-effort sync swallows it. The Paseo record is archived while the
+        // native thread stays active — the state a history read actually meets.
+        await manager.archiveAgent(agentId);
+        expect(await listNativeThreads()).toContain(threadId);
+        expect(await settledAppServers()).toEqual([]);
+
+        await ensureAgentLoaded(agentId, {
+          agentManager: manager,
+          agentStorage: storage,
+          logger,
+        });
+        expect(manager.getTimeline(agentId).length).toBeGreaterThan(0);
+
+        // Codex refuses to archive a thread that has an active writer. A read-only
+        // history pass takes no writer, so this succeeds; a `thread/resume` would
+        // have claimed one and made it fail.
+        await expect(
+          client.archiveNativeSession(handle!),
+          "a history read must not claim the native thread's writer",
+        ).resolves.toBeUndefined();
+
+        expect(await settledAppServers(), "a history read must not retain its app-server").toEqual(
+          [],
+        );
+      } finally {
+        for (const pid of listOwnedAppServers()) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // already gone
+          }
+        }
+        await storage.flush();
+        vi.unstubAllEnvs();
+        await mockServer.close();
+        rmSync(cwd, { recursive: true, force: true });
+        rmSync(codexHome, { recursive: true, force: true });
+      }
+    },
+    120_000,
+  );
+});

--- a/packages/server/src/server/agent/providers/mock-load-test-agent.ts
+++ b/packages/server/src/server/agent/providers/mock-load-test-agent.ts
@@ -4,6 +4,8 @@ import type {
   AgentCapabilityFlags,
   AgentClient,
   AgentFeature,
+  AgentHistoryReadContext,
+  AgentHistoryReadResult,
   AgentLaunchContext,
   AgentMode,
   AgentModelDefinition,
@@ -681,6 +683,26 @@ export class MockLoadTestAgentClient implements AgentClient {
       sessionId: handle.sessionId,
       logger: this.logger,
     });
+  }
+
+  async readSessionHistory(
+    handle: AgentPersistenceHandle,
+    context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult> {
+    const session = await this.resumeSession(
+      handle,
+      context ? { cwd: context.cwd } : undefined,
+      context ? { agentId: context.agentId, env: context.env } : undefined,
+    );
+    try {
+      const events: AgentStreamEvent[] = [];
+      for await (const event of session.streamHistory()) {
+        events.push(event);
+      }
+      return { events, coverage: { kind: "complete" } };
+    } finally {
+      await session.close();
+    }
   }
 
   async fetchCatalog(_options: FetchCatalogOptions): Promise<ProviderCatalog> {

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -486,6 +486,58 @@ describe("OMP agent client and session", () => {
     });
   });
 
+  test("reads OMP history with a temporary runtime but no interactive session setup", async () => {
+    const omp = new OmpHarness();
+
+    const history = await omp.readPersistedHistory(
+      {
+        user: { id: "user-history", text: "continue the audit" },
+        assistant: { id: "assistant-history", text: "audit context restored" },
+      },
+      { cwd: "/workspace/resumed", modeId: "ask", thinkingOptionId: "high" },
+      createToolCatalog(),
+    );
+
+    expect(history.flatMap((event) => (event.type === "timeline" ? [event.item] : []))).toEqual([
+      { type: "user_message", text: "continue the audit", messageId: "user-history" },
+      {
+        type: "assistant_message",
+        text: "audit context restored",
+        messageId: "assistant-history",
+      },
+    ]);
+    expect(omp.launchConfiguration()).toMatchObject({
+      cwd: "/workspace/resumed",
+      protocolMode: "rpc-ui",
+      session: expect.stringMatching(/[\\/]paseo-omp-resume-.*[\\/]session\.jsonl$/),
+    });
+    const historyLaunch = omp.launchConfiguration();
+    expect(historyLaunch.modeId).toBeUndefined();
+    expect(historyLaunch.argv).not.toContain("--approval-mode");
+    expect(historyLaunch.argv).not.toContain("--model");
+    expect(historyLaunch.argv).not.toContain("--thinking");
+    expect(historyLaunch.argv).not.toContain("--append-system-prompt");
+    expect(omp.registeredHostTools()).toEqual([]);
+    expect(omp.subagentSubscriptionRequests()).toEqual([]);
+    expect(omp.runtimeClosed()).toBe(true);
+  });
+
+  test("closes the temporary OMP runtime when history state loading fails", async () => {
+    const omp = new OmpHarness();
+    omp.failNextHistoryStateRead(new Error("OMP history state unavailable"));
+
+    await expect(
+      omp.readPersistedHistory({
+        user: { id: "user-history", text: "continue the audit" },
+        assistant: { id: "assistant-history", text: "audit context restored" },
+      }),
+    ).rejects.toThrow("OMP history state unavailable");
+
+    expect(omp.runtimeClosed()).toBe(true);
+    expect(omp.registeredHostTools()).toEqual([]);
+    expect(omp.subagentSubscriptionRequests()).toEqual([]);
+  });
+
   test("resumes an OMP session and replays its history", async () => {
     const omp = new OmpHarness();
     await omp.resume(

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -9,6 +9,8 @@ import {
   type AgentCapabilityFlags,
   type AgentClient,
   type AgentFeature,
+  type AgentHistoryReadContext,
+  type AgentHistoryReadResult,
   type AgentLaunchContext,
   type AgentMetadata,
   type AgentMode,
@@ -2306,6 +2308,42 @@ export class OmpAgentClient implements AgentClient {
     } catch (error) {
       await runtimeSession.close().catch(() => undefined);
       throw error;
+    }
+  }
+
+  async readSessionHistory(
+    handle: AgentPersistenceHandle,
+    context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult> {
+    const sessionFile = handle.nativeHandle;
+    if (!sessionFile) {
+      throw new Error("OMP history read requires a native session file handle");
+    }
+
+    const persistenceMetadata = parsePersistenceMetadata(handle.metadata);
+    const cwd = context?.cwd ?? persistenceMetadata.cwd ?? process.cwd();
+    const runtimeSession = await this.runtime.startSession({
+      cwd,
+      protocolMode: "rpc-ui",
+      env: context?.env,
+      session: sessionFile,
+    });
+    try {
+      const state = await runtimeSession.getState();
+      const events: AgentStreamEvent[] = [];
+      for await (const event of streamOmpHistory({
+        sessionFile: state.sessionFile ?? sessionFile,
+        runtimeSession,
+        provider: this.provider,
+      })) {
+        events.push(event);
+      }
+      for (const item of mapOmpTodoState(state)) {
+        events.push({ type: "timeline", provider: this.provider, item });
+      }
+      return { events, coverage: { kind: "complete" } };
+    } finally {
+      await runtimeSession.close();
     }
   }
 

--- a/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
@@ -54,6 +54,7 @@ export class FakeOmp implements OmpRuntime {
   private readonly sessions: FakeOmpSession[] = [];
   private readonly command: [string, ...string[]];
   private readonly queuedCommands: OmpRpcSlashCommand[][] = [];
+  private readonly queuedSessionSetups: Array<(session: FakeOmpSession) => void> = [];
   private readonly queuedSubagentSubscriptionErrors = new Map<
     FakeOmpSubagentSubscriptionLevel,
     Error
@@ -71,6 +72,7 @@ export class FakeOmp implements OmpRuntime {
     this.recordedLaunches.push(launch);
     const session = new FakeOmpSession(launch);
     session.commands = this.queuedCommands.shift() ?? [];
+    this.queuedSessionSetups.shift()?.(session);
     for (const [level, error] of this.queuedSubagentSubscriptionErrors) {
       session.subagentSubscriptionErrors.set(level, error);
     }
@@ -81,6 +83,10 @@ export class FakeOmp implements OmpRuntime {
 
   queueCommands(commands: OmpRpcSlashCommand[]): void {
     this.queuedCommands.push(commands);
+  }
+
+  queueSessionSetup(setup: (session: FakeOmpSession) => void): void {
+    this.queuedSessionSetups.push(setup);
   }
 
   failNextSubagentSubscription(level: FakeOmpSubagentSubscriptionLevel, error: Error): void {

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -90,6 +90,12 @@ export class OmpHarness {
     this.omp.failNextSubagentSubscription("events", error);
   }
 
+  failNextHistoryStateRead(error: Error): void {
+    this.omp.queueSessionSetup((session) => {
+      session.getStateError = error;
+    });
+  }
+
   async start(
     config: Partial<AgentSessionConfig> = {},
     paseoTools?: PaseoToolCatalog,
@@ -103,6 +109,24 @@ export class OmpHarness {
     }
     this.session = session;
     this.session.subscribe((event) => this.events.push(event));
+  }
+
+  async readPersistedHistory(
+    history: OmpResumeHistory,
+    overrides: Partial<AgentSessionConfig> = {},
+    _paseoTools?: PaseoToolCatalog,
+  ): Promise<AgentStreamEvent[]> {
+    const sessionFile = await writeOmpHistory(history);
+    const result = await this.client.readSessionHistory(
+      {
+        provider: "omp",
+        sessionId: "omp-session-history",
+        nativeHandle: sessionFile,
+        metadata: { cwd: CWD },
+      },
+      { cwd: overrides.cwd ?? CWD },
+    );
+    return result.events;
   }
 
   async resume(
@@ -144,6 +168,14 @@ export class OmpHarness {
 
   registeredHostTools() {
     return this.omp.latestSession().hostToolSetRequests;
+  }
+
+  subagentSubscriptionRequests() {
+    return this.omp.latestSession().subagentSubscriptionRequests;
+  }
+
+  runtimeClosed(): boolean {
+    return this.omp.latestSession().closed;
   }
 
   capabilities() {

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -4001,6 +4001,31 @@ describe("OpenCode persisted sessions", () => {
     expect(runtime.acquisitions).toEqual([{ kind: "current", releaseCount: 1 }]);
   });
 
+  test("rejects structured session metadata errors without reading messages", async () => {
+    const sdkClient = new TestOpenCodeClient();
+    sdkClient.sessionGetResponse = { error: { name: "NotFoundError", message: "missing session" } };
+    const { runtime, read } = createHistoryHarness({ sdkClient });
+
+    await expect(read()).rejects.toThrow(
+      'Failed to read OpenCode session metadata: {"name":"NotFoundError","message":"missing session"}',
+    );
+    expect(sdkClient.calls.sessionMessages).toEqual([]);
+    expect(runtime.acquisitions).toEqual([{ kind: "current", releaseCount: 1 }]);
+  });
+
+  test("rejects structured session message errors instead of completing empty history", async () => {
+    const sdkClient = new TestOpenCodeClient();
+    sdkClient.sessionMessagesResponse = {
+      error: { name: "InternalServerError", message: "messages unavailable" },
+    };
+    const { runtime, read } = createHistoryHarness({ sdkClient });
+
+    await expect(read()).rejects.toThrow(
+      'Failed to read OpenCode session messages: {"name":"InternalServerError","message":"messages unavailable"}',
+    );
+    expect(runtime.acquisitions).toEqual([{ kind: "current", releaseCount: 1 }]);
+  });
+
   test("releases the server acquisition when history client construction fails", async () => {
     const { runtime, read } = createHistoryHarness({ failClientCreation: true });
 

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -3895,6 +3895,119 @@ describe("OpenCodeAgentClient env", () => {
 });
 
 describe("OpenCode persisted sessions", () => {
+  const historyHandle = {
+    provider: "opencode" as const,
+    sessionId: "ses_history",
+    metadata: { cwd: "/workspace/repo" },
+  };
+
+  function createHistoryHarness(
+    options: {
+      sdkClient?: TestOpenCodeClient;
+      failClientCreation?: boolean;
+    } = {},
+  ) {
+    const runtime = new TestOpenCodeHarness();
+    const sdkClient = options.sdkClient ?? new TestOpenCodeClient();
+    if (!options.failClientCreation) {
+      runtime.enqueueClient(sdkClient);
+    }
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: options.failClientCreation
+        ? () => {
+            throw new Error("OpenCode client construction failed");
+          }
+        : runtime.createClient,
+    });
+    return {
+      runtime,
+      sdkClient,
+      read: async () => await client.readSessionHistory(historyHandle),
+    };
+  }
+
+  test("reads history without starting an event stream or aborting the native session", async () => {
+    const { runtime, sdkClient, read } = createHistoryHarness();
+    sdkClient.sessionGetResponse = {
+      data: {
+        id: "ses_history",
+        directory: historyHandle.metadata.cwd,
+        title: null,
+        time: { archived: 123 },
+      },
+    };
+    sdkClient.sessionMessagesResponse = {
+      data: [
+        {
+          info: {
+            id: "msg_user",
+            sessionID: "ses_history",
+            role: "user",
+            time: { created: 1000 },
+            agent: "build",
+            model: { providerID: "opencode", modelID: "big-pickle" },
+          },
+          parts: [
+            {
+              id: "prt_user",
+              sessionID: "ses_history",
+              messageID: "msg_user",
+              type: "text",
+              text: "read archived history",
+            },
+          ],
+        },
+      ],
+    };
+
+    await expect(read()).resolves.toEqual({
+      events: [
+        {
+          type: "timeline",
+          provider: "opencode",
+          item: {
+            type: "user_message",
+            text: "read archived history",
+            messageId: "msg_user",
+          },
+          timestamp: "1970-01-01T00:16:40.000Z",
+        },
+      ],
+      coverage: { kind: "complete" },
+    });
+    expect(sdkClient.calls.sessionGet).toEqual([
+      { sessionID: "ses_history", directory: historyHandle.metadata.cwd },
+    ]);
+    expect(sdkClient.calls.sessionMessages).toEqual([
+      { sessionID: "ses_history", directory: historyHandle.metadata.cwd },
+    ]);
+    expect(sdkClient.calls.globalEvent).toEqual([]);
+    expect(sdkClient.calls.eventSubscribe).toEqual([]);
+    expect(sdkClient.calls.sessionAbort).toEqual([]);
+    expect(sdkClient.calls.sessionUpdate).toEqual([]);
+    expect(runtime.acquisitions).toEqual([{ kind: "current", releaseCount: 1 }]);
+  });
+
+  test("releases the server acquisition when direct history loading fails", async () => {
+    const sdkClient = new TestOpenCodeClient();
+    sdkClient.sessionMessagesImplementation = async () => {
+      throw new Error("session messages unavailable");
+    };
+    const { runtime, read } = createHistoryHarness({ sdkClient });
+
+    await expect(read()).rejects.toThrow("session messages unavailable");
+    expect(sdkClient.calls.sessionAbort).toEqual([]);
+    expect(runtime.acquisitions).toEqual([{ kind: "current", releaseCount: 1 }]);
+  });
+
+  test("releases the server acquisition when history client construction fails", async () => {
+    const { runtime, read } = createHistoryHarness({ failClientCreation: true });
+
+    await expect(read()).rejects.toThrow("OpenCode client construction failed");
+    expect(runtime.acquisitions).toEqual([{ kind: "current", releaseCount: 1 }]);
+  });
+
   test("replay hides summaries produced by manual compact", () => {
     const timeline = __openCodeInternals.buildOpenCodeSessionTimeline([
       {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1601,17 +1601,28 @@ export class OpenCodeAgentClient implements AgentClient {
         sessionID: handle.sessionId,
         directory: cwd,
       });
+      if (sessionResponse.error || !sessionResponse.data) {
+        let detail = "response did not include session data";
+        if (sessionResponse.error) {
+          detail = toDiagnosticErrorMessage(sessionResponse.error);
+        }
+        throw new Error(`Failed to read OpenCode session metadata: ${detail}`);
+      }
       const messagesResponse = await client.session.messages({
         sessionID: handle.sessionId,
         directory: cwd,
       });
       if (messagesResponse.error || !messagesResponse.data) {
-        return { events: [], coverage: { kind: "complete" } };
+        let detail = "response did not include session messages";
+        if (messagesResponse.error) {
+          detail = toDiagnosticErrorMessage(messagesResponse.error);
+        }
+        throw new Error(`Failed to read OpenCode session messages: ${detail}`);
       }
 
       const messages = filterOpenCodeRevertedMessages(
         messagesResponse.data,
-        sessionResponse.error ? null : sessionResponse.data?.revert,
+        sessionResponse.data.revert,
       );
       return {
         events: messages.flatMap(buildOpenCodeReplayTimelineEvents),

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -25,6 +25,8 @@ import {
   type AgentClient,
   type AgentCreateSessionOptions,
   type AgentFeature,
+  type AgentHistoryReadContext,
+  type AgentHistoryReadResult,
   type AgentLaunchContext,
   type AgentMode,
   type AgentModelDefinition,
@@ -1569,6 +1571,55 @@ export class OpenCodeAgentClient implements AgentClient {
       env: launchContext.env ?? {},
       tools: launchContext.paseoTools,
     });
+  }
+
+  async readSessionHistory(
+    handle: AgentPersistenceHandle,
+    context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult> {
+    const metadata = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
+    const cwd = context?.cwd ?? metadata.cwd;
+    if (!cwd) {
+      throw new Error("OpenCode history read requires the original working directory");
+    }
+
+    const registeredServerUrl = getOpenCodeChildSessionServerUrl(handle.sessionId);
+    const registeredAcquisition = registeredServerUrl
+      ? this.serverManager.acquireExisting(registeredServerUrl)
+      : null;
+    const acquisition =
+      registeredAcquisition ??
+      (context?.env
+        ? await this.serverManager.acquireDedicated(context.env)
+        : await this.serverManager.acquireCurrent());
+    try {
+      const client = this.createOpenCodeClient({
+        baseUrl: acquisition.server.url,
+        directory: cwd,
+      });
+      const sessionResponse = await client.session.get({
+        sessionID: handle.sessionId,
+        directory: cwd,
+      });
+      const messagesResponse = await client.session.messages({
+        sessionID: handle.sessionId,
+        directory: cwd,
+      });
+      if (messagesResponse.error || !messagesResponse.data) {
+        return { events: [], coverage: { kind: "complete" } };
+      }
+
+      const messages = filterOpenCodeRevertedMessages(
+        messagesResponse.data,
+        sessionResponse.error ? null : sessionResponse.data?.revert,
+      );
+      return {
+        events: messages.flatMap(buildOpenCodeReplayTimelineEvents),
+        coverage: { kind: "complete" },
+      };
+    } finally {
+      await acquisition.release();
+    }
   }
 
   async fetchCatalog(

--- a/packages/server/src/server/agent/providers/opencode-archived-history-read.real.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-archived-history-read.real.e2e.test.ts
@@ -1,0 +1,272 @@
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, request as httpRequest } from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { ensureAgentLoaded } from "../agent-loading.js";
+import { AgentManager } from "../agent-manager.js";
+import { AgentStorage } from "../agent-storage.js";
+import { OpenCodeAgentClient } from "./opencode-agent.js";
+import { OpenCodeServerManager } from "./opencode/server-manager.js";
+
+const SENTINEL = "PASEO_OPENCODE_HISTORY_4B71";
+const TIMEOUT_MS = 300_000;
+
+/**
+ * Any OpenAI-compatible endpoint drives this test. OpenRouter's compatibility
+ * layer is the zero-config default; PASEO_TEST_OPENAI_* points it at a local
+ * gateway instead.
+ */
+function resolveModelBackend(): { baseURL: string; apiKey: string; model: string } | null {
+  const baseURL = process.env.PASEO_TEST_OPENAI_BASE_URL?.trim();
+  const apiKey = process.env.PASEO_TEST_OPENAI_API_KEY?.trim();
+  const model = process.env.PASEO_TEST_OPENAI_MODEL?.trim();
+  if (baseURL && apiKey && model) {
+    return { baseURL, apiKey, model };
+  }
+  const openRouterKey = process.env.OPENROUTER_API_KEY?.trim();
+  if (openRouterKey) {
+    return {
+      baseURL: "https://openrouter.ai/api/v1",
+      apiKey: openRouterKey,
+      model: "google/gemini-2.5-flash-lite",
+    };
+  }
+  return null;
+}
+
+function isOpenCodeInstalled(): boolean {
+  try {
+    return execFileSync("which", ["opencode"], { encoding: "utf8" }).trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function reservePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Port reservation failed");
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return address.port;
+}
+
+/**
+ * Every OpenCode request Paseo makes passes through here. `session.abort` is
+ * OpenCode's only way to interrupt a session, and it is session-scoped rather
+ * than turn-scoped, so an abort issued on behalf of a history read cancels
+ * whatever that session happens to be running. A global event subscription is
+ * the other thing an interactive resume drags in that a read has no use for.
+ */
+async function createRecordingProxy(upstreamPort: number) {
+  const requests: Array<{ method: string; url: string }> = [];
+  const server = createServer((incoming, outgoing) => {
+    requests.push({ method: incoming.method ?? "", url: incoming.url ?? "" });
+    const upstream = httpRequest(
+      {
+        host: "127.0.0.1",
+        port: upstreamPort,
+        method: incoming.method,
+        path: incoming.url,
+        headers: incoming.headers,
+      },
+      (response) => {
+        outgoing.writeHead(response.statusCode ?? 502, response.headers);
+        response.pipe(outgoing);
+      },
+    );
+    upstream.on("error", () => outgoing.destroy());
+    incoming.pipe(upstream);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Proxy did not bind");
+  return {
+    port: address.port,
+    aborts(sessionId: string): number {
+      return requests.filter(
+        (entry) => entry.method === "POST" && entry.url.includes(`/session/${sessionId}/abort`),
+      ).length;
+    },
+    globalEventConnections(): number {
+      return requests.filter((entry) => entry.url.startsWith("/global/event")).length;
+    },
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function writeOpenCodeConfig(
+  xdgConfig: string,
+  backend: { baseURL: string; apiKey: string; model: string },
+): void {
+  const providerDir = path.join(xdgConfig, "opencode");
+  mkdirSync(providerDir, { recursive: true });
+  writeFileSync(
+    path.join(providerDir, "opencode.json"),
+    JSON.stringify(
+      {
+        $schema: "https://opencode.ai/config.json",
+        provider: {
+          harness: {
+            npm: "@ai-sdk/openai-compatible",
+            name: "harness",
+            options: { baseURL: backend.baseURL, apiKey: backend.apiKey },
+            models: { [backend.model]: { name: backend.model } },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+const backend = resolveModelBackend();
+
+describe.sequential("OpenCode archived history read (real)", () => {
+  let harness: Awaited<ReturnType<typeof createHarness>> | null = null;
+
+  beforeAll(async () => {
+    if (!backend || !isOpenCodeInstalled()) return;
+    harness = await createHarness(backend);
+  }, 120_000);
+
+  afterAll(async () => {
+    await harness?.close();
+  }, 60_000);
+
+  test(
+    "never aborts the native session and attaches to no event stream",
+    async (context) => {
+      if (!harness) {
+        context.skip();
+        return;
+      }
+      const { manager, storage, workspace, model, proxy, logger } = harness;
+
+      // A real OpenCode session carrying real history.
+      const created = await manager.createAgent(
+        { provider: "opencode", cwd: workspace, model, modeId: "build" },
+        undefined,
+        { workspaceId: undefined },
+      );
+      const agentId = created.id;
+      await manager.runAgent(agentId, `Reply with exactly ${SENTINEL} and no other text.`);
+      const sessionId = manager.getAgent(agentId)?.persistence?.sessionId;
+      expect(sessionId).toBeTruthy();
+
+      await manager.archiveAgent(agentId);
+
+      const abortsBefore = proxy.aborts(sessionId!);
+      const eventStreamsBefore = proxy.globalEventConnections();
+
+      // The history read, then the close that closing a tab would trigger.
+      await ensureAgentLoaded(agentId, { agentManager: manager, agentStorage: storage, logger });
+      expect(manager.getTimeline(agentId).length).toBeGreaterThan(0);
+      if (manager.getAgent(agentId)) {
+        await manager.closeAgent(agentId);
+      }
+
+      expect(
+        proxy.aborts(sessionId!) - abortsBefore,
+        "a history read must not abort the native session",
+      ).toBe(0);
+
+      expect(
+        proxy.globalEventConnections() - eventStreamsBefore,
+        "a history read must not attach to the global event stream",
+      ).toBe(0);
+    },
+    TIMEOUT_MS,
+  );
+});
+
+async function createHarness(modelBackend: { baseURL: string; apiKey: string; model: string }) {
+  const runtimeDir = mkdtempSync(path.join(os.tmpdir(), "paseo-opencode-history-"));
+  const home = path.join(runtimeDir, "home");
+  const xdgConfig = path.join(runtimeDir, "xdg-config");
+  const xdgData = path.join(runtimeDir, "xdg-data");
+  const xdgCache = path.join(runtimeDir, "xdg-cache");
+  const xdgState = path.join(runtimeDir, "xdg-state");
+  const workspace = path.join(runtimeDir, "workspace");
+  for (const directory of [home, xdgConfig, xdgData, xdgCache, xdgState, workspace]) {
+    mkdirSync(directory, { recursive: true });
+  }
+  writeOpenCodeConfig(xdgConfig, modelBackend);
+  // OpenCode keys a session to its project, which it resolves from the git root.
+  execFileSync("git", ["init", "-q"], { cwd: workspace });
+
+  const isolatedEnv = {
+    ...process.env,
+    HOME: home,
+    XDG_CONFIG_HOME: xdgConfig,
+    XDG_DATA_HOME: xdgData,
+    XDG_CACHE_HOME: xdgCache,
+    XDG_STATE_HOME: xdgState,
+    OPENCODE_DISABLE_AUTOUPDATE: "1",
+    OPENCODE_DISABLE_AUTO_UPDATE: "1",
+  };
+
+  const upstreamPort = await reservePort();
+  const proxy = await createRecordingProxy(upstreamPort);
+  const logger = pino({ level: "silent" });
+  let child: ChildProcess | null = null;
+  const placeholders: ChildProcess[] = [];
+  const serverManager = new OpenCodeServerManager({
+    logger,
+    portAllocator: async () => proxy.port,
+    resolveCommandPrefix: async () => ({ command: "opencode", args: [] }),
+    resolveHomeDir: () => home,
+    // Without a bridge every acquisition asks for a dedicated server. One real
+    // OpenCode process backs them all, so every request still lands on the same
+    // session; later acquisitions get a live placeholder that announces the
+    // readiness line the manager waits for.
+    spawnServerProcess: () => {
+      if (child) {
+        const placeholder = spawn(
+          "sh",
+          ["-c", `echo "listening on 127.0.0.1:${upstreamPort}"; sleep 100000`],
+          { stdio: ["ignore", "pipe", "pipe"] },
+        );
+        placeholders.push(placeholder);
+        return placeholder;
+      }
+      child = spawn("opencode", ["serve", "--port", String(upstreamPort)], {
+        cwd: workspace,
+        env: isolatedEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      return child;
+    },
+  });
+  const lease = await serverManager.acquireCurrent();
+  const client = new OpenCodeAgentClient(logger, undefined, { serverManager });
+  const storage = new AgentStorage(path.join(runtimeDir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { opencode: client },
+    registry: storage,
+    logger,
+  });
+
+  return {
+    manager,
+    storage,
+    workspace,
+    logger,
+    proxy,
+    model: `harness/${modelBackend.model}`,
+    async close() {
+      await storage.flush();
+      await lease.release();
+      await proxy.close();
+      child?.kill("SIGKILL");
+      for (const placeholder of placeholders) placeholder.kill("SIGKILL");
+      rmSync(runtimeDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   mkdtempSync,
   openSync,
+  readFileSync,
   readSync,
   rmSync,
   writeFileSync,
@@ -2106,6 +2107,117 @@ describe("PiRpcAgentSession steering", () => {
 });
 
 describe("PiRpcAgentClient", () => {
+  test("reads history directly from JSONL without launching a Pi runtime", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "paseo-pi-history-read-"));
+    onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+    const sessionFile = path.join(root, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "pi-history-session",
+          cwd: "/workspace/project",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "entry-user-1",
+          parentId: "pi-history-session",
+          message: { role: "user", content: "first prompt" },
+        }),
+        "{malformed-jsonl-entry",
+        JSON.stringify({
+          type: "message",
+          id: "entry-stale-branch",
+          parentId: "entry-user-1",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "stale branch response" }],
+            responseId: "assistant-stale-branch",
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "entry-assistant-1",
+          parentId: "entry-user-1",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "history response" }],
+            responseId: "assistant-history-1",
+          },
+        }),
+        JSON.stringify({
+          type: "custom_message",
+          id: "entry-custom-1",
+          parentId: "entry-assistant-1",
+          customType: "extension-output",
+          content: "persisted extension output",
+          display: true,
+        }),
+        JSON.stringify({
+          type: "session_info",
+          id: "session-info-after-history",
+          name: "Archived history",
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const before = readFileSync(sessionFile, "utf8");
+    const pi = new FakePi();
+    const client = createClient(pi);
+
+    const history = await client.readSessionHistory({
+      provider: "pi",
+      sessionId: "pi-history-session",
+      nativeHandle: sessionFile,
+      metadata: { cwd: "/workspace/project" },
+    });
+
+    expect(history).toEqual({
+      events: [
+        {
+          type: "timeline",
+          provider: "pi",
+          item: { type: "user_message", text: "first prompt", messageId: "entry-user-1" },
+        },
+        {
+          type: "timeline",
+          provider: "pi",
+          item: {
+            type: "assistant_message",
+            text: "history response",
+            messageId: "assistant-history-1",
+          },
+        },
+        {
+          type: "timeline",
+          provider: "pi",
+          item: { type: "assistant_message", text: "persisted extension output" },
+        },
+      ],
+      coverage: { kind: "complete" },
+    });
+    expect(pi.recordedLaunches).toEqual([]);
+    expect(readFileSync(sessionFile, "utf8")).toBe(before);
+  });
+
+  test("returns empty history for a missing Pi transcript without launching a runtime", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+
+    await expect(
+      client.readSessionHistory({
+        provider: "pi",
+        sessionId: "pi-history-session",
+        nativeHandle: path.join(tmpdir(), "missing-pi-history-session.jsonl"),
+        metadata: { cwd: "/workspace/project" },
+      }),
+    ).resolves.toEqual({ events: [], coverage: { kind: "complete" } });
+
+    expect(pi.recordedLaunches).toEqual([]);
+  });
+
   test("lists JSONL persisted sessions from configured provider params", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "paseo-pi-sessions-"));
     const cwd = path.join(root, "workspace");

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 import type { Logger } from "pino";
@@ -10,6 +11,8 @@ import {
   type AgentCapabilityFlags,
   type AgentClient,
   type AgentFeature,
+  type AgentHistoryReadContext,
+  type AgentHistoryReadResult,
   type AgentLaunchContext,
   type AgentMetadata,
   type AgentMode,
@@ -508,6 +511,104 @@ function buildResumeConfig(
       systemPrompt: overrideConfig.systemPrompt ?? metadata.systemPrompt,
     },
   };
+}
+
+interface PiPersistedSessionEntry {
+  type?: string;
+  id?: string;
+  parentId?: string | null;
+  message?: unknown;
+  content?: unknown;
+}
+
+function isPiAgentMessage(value: unknown): value is PiAgentMessage {
+  if (!isRecord(value) || typeof value.role !== "string") {
+    return false;
+  }
+  return ["user", "custom", "assistant", "toolResult", "bashExecution"].includes(value.role);
+}
+
+function isPiCustomMessageContent(
+  value: unknown,
+): value is Extract<PiAgentMessage, { role: "custom" }>["content"] {
+  return typeof value === "string" || Array.isArray(value);
+}
+
+async function readPersistedPiHistory(sessionFile: string): Promise<{
+  messages: PiAgentMessage[];
+  userEntries: PiCapturedUserMessageEntry[];
+}> {
+  let content: string;
+  try {
+    content = await readFile(sessionFile, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { messages: [], userEntries: [] };
+    }
+    throw error;
+  }
+
+  const entries = content.split(/\r?\n/).flatMap((line): PiPersistedSessionEntry[] => {
+    if (!line.trim()) {
+      return [];
+    }
+    try {
+      const entry = JSON.parse(line) as unknown;
+      return isRecord(entry) ? [entry as PiPersistedSessionEntry] : [];
+    } catch {
+      return [];
+    }
+  });
+  const activeEntries = selectActivePiEntryChain(entries);
+  const messages: PiAgentMessage[] = [];
+  const userEntries: PiCapturedUserMessageEntry[] = [];
+  for (const entry of activeEntries) {
+    let message: PiAgentMessage | null = null;
+    if (entry.type === "message" && isPiAgentMessage(entry.message)) {
+      message = entry.message;
+    } else if (entry.type === "custom_message" && isPiCustomMessageContent(entry.content)) {
+      message = { role: "custom", content: entry.content };
+    }
+    if (!message) {
+      continue;
+    }
+    messages.push(message);
+    if (message.role === "user" && entry.id) {
+      const text = getUserMessageText(message.content);
+      if (text) {
+        userEntries.push({ id: entry.id, text });
+      }
+    }
+  }
+  return { messages, userEntries };
+}
+
+function selectActivePiEntryChain(
+  entries: readonly PiPersistedSessionEntry[],
+): PiPersistedSessionEntry[] {
+  const indexedEntries = entries.filter(
+    (entry): entry is PiPersistedSessionEntry & { id: string } => typeof entry.id === "string",
+  );
+  if (!indexedEntries.some((entry) => typeof entry.parentId === "string")) {
+    return [...entries];
+  }
+
+  const byId = new Map(indexedEntries.map((entry) => [entry.id, entry]));
+  const parentIds = new Set(
+    indexedEntries.flatMap((entry) => (typeof entry.parentId === "string" ? [entry.parentId] : [])),
+  );
+  const branchEntries = indexedEntries.filter(
+    (entry) => typeof entry.parentId === "string" || parentIds.has(entry.id),
+  );
+  let current = branchEntries.findLast((entry) => !parentIds.has(entry.id)) ?? branchEntries.at(-1);
+  const chain: PiPersistedSessionEntry[] = [];
+  const seen = new Set<string>();
+  while (current && !seen.has(current.id)) {
+    chain.push(current);
+    seen.add(current.id);
+    current = typeof current.parentId === "string" ? byId.get(current.parentId) : undefined;
+  }
+  return chain.toReversed();
 }
 
 function buildResumeStartInput(input: {
@@ -2634,6 +2735,23 @@ export class PiRpcAgentClient implements AgentClient {
       paseoExtension?.cleanup();
       throw error;
     }
+  }
+
+  async readSessionHistory(
+    handle: AgentPersistenceHandle,
+    _context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult> {
+    const sessionFile = handle.nativeHandle;
+    if (!sessionFile) {
+      throw new Error("Pi history read requires a native session file handle");
+    }
+
+    const { messages, userEntries } = await readPersistedPiHistory(sessionFile);
+    const events: AgentStreamEvent[] = [];
+    for await (const event of streamPiHistory(this.provider, messages, userEntries)) {
+      events.push(event);
+    }
+    return { events, coverage: { kind: "complete" } };
   }
 
   async fetchCatalog(

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -3041,7 +3041,8 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         logger: childLogger,
       });
       const timeline = agentManager.getTimeline(agentId);
-      const snapshot = agentManager.getAgent(agentId);
+      const snapshot =
+        agentManager.getAgent(agentId) ?? agentManager.getHistorySnapshot?.(agentId) ?? null;
 
       const selection = selectItemsByProjectedLimit({
         items: timeline,

--- a/packages/server/src/server/persistence-hooks.ts
+++ b/packages/server/src/server/persistence-hooks.ts
@@ -110,6 +110,7 @@ export function extractTimestamps(record: StoredAgentRecord): {
   createdAt: Date;
   updatedAt: Date;
   lastUserMessageAt: Date | null;
+  internal?: boolean;
   labels?: Record<string, string>;
   workspaceId?: string;
   owner?: StoredAgentRecord["owner"];
@@ -118,6 +119,7 @@ export function extractTimestamps(record: StoredAgentRecord): {
     createdAt: new Date(record.createdAt),
     updatedAt: new Date(record.lastActivityAt ?? record.updatedAt),
     lastUserMessageAt: record.lastUserMessageAt ? new Date(record.lastUserMessageAt) : null,
+    internal: record.internal,
     labels: record.labels,
     workspaceId: record.workspaceId,
     owner: record.owner,

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -24,7 +24,7 @@ import { OWNER_PERMISSIONS, type DaemonPermission } from "./authorization/index.
 import { DownloadTokenStore } from "./file-download/token-store.js";
 import { StructuredAgentFallbackError } from "./agent/agent-response-loop.js";
 import type { StoredAgentRecord } from "./agent/agent-storage.js";
-import type { AgentManagerEvent } from "./agent/agent-manager.js";
+import type { AgentManagerEvent, ManagedAgent } from "./agent/agent-manager.js";
 import type { ProviderSnapshotManager } from "./agent/provider-snapshot-manager.js";
 import { WorkspaceLabelError, type WorkspaceLabelService } from "./workspace-labels/index.js";
 import { createPersistedProjectRecord } from "./workspace-registry.js";
@@ -5151,6 +5151,166 @@ describe("schedule dispatch routing", () => {
     expect(routed, `${msg.type} did not route to a handler (silent no-op)`).toBeDefined();
     expect(routed?.payload.code).toBe(code);
   });
+});
+
+test("fetches a closed history snapshot with authoritative stored agent metadata", async () => {
+  const agentId = "00000000-0000-4000-8000-000000000402";
+  const archivedAt = "2026-07-20T12:00:00.000Z";
+  const record = createStoredAgentRecord({
+    id: agentId,
+    cwd: "/workspace/archived-agent",
+    title: "Archived investigation",
+    updatedAt: "2026-07-21T13:00:00.000Z",
+    lastStatus: "idle",
+    labels: { purpose: "audit" },
+    archivedAt,
+    persistence: {
+      provider: "codex",
+      sessionId: "archived-thread",
+      metadata: { cwd: "/workspace/archived-agent" },
+    },
+  });
+  const snapshot = {
+    id: agentId,
+    provider: "codex",
+    lifecycle: "closed",
+  } as ManagedAgent;
+  const messages: SessionOutboundMessage[] = [];
+  const providerSnapshot = createProviderSnapshotManagerStub();
+  providerSnapshot.listRegisteredProviderIds.mockReturnValue(["codex"]);
+  const session = createSessionForTest({
+    messages,
+    providerSnapshotManager: providerSnapshot.manager,
+    agentStorage: { get: vi.fn().mockResolvedValue(record) },
+    agentManager: {
+      waitForAgentClose: vi.fn().mockResolvedValue(undefined),
+      getAgent: vi.fn(() => null),
+      getHistorySnapshot: vi.fn(() => snapshot),
+      fetchPublicTimeline: vi.fn(() => ({
+        epoch: "archived-history-epoch",
+        direction: "tail" as const,
+        reset: false,
+        staleCursor: false,
+        gap: false,
+        window: { minSeq: 0, maxSeq: 0, nextSeq: 0 },
+        hasOlder: false,
+        hasNewer: false,
+        rows: [],
+      })),
+    },
+  });
+
+  await session.handleMessage({
+    type: "fetch_agent_timeline_request",
+    agentId,
+    requestId: "archived-history-request",
+    projection: "canonical",
+  });
+
+  const response = messages.find(
+    (
+      message,
+    ): message is Extract<SessionOutboundMessage, { type: "fetch_agent_timeline_response" }> =>
+      message.type === "fetch_agent_timeline_response",
+  );
+  expect(response?.payload.error).toBeNull();
+  expect(response?.payload.agent).toMatchObject({
+    id: agentId,
+    title: "Archived investigation",
+    status: "idle",
+    archivedAt,
+    labels: { purpose: "audit" },
+    persistence: {
+      provider: "codex",
+      sessionId: "archived-thread",
+    },
+  });
+});
+
+test("public timeline, prompt index, and fork-context requests reject archived internal agents", async () => {
+  const agentId = "00000000-0000-4000-8000-000000000403";
+  const record = createStoredAgentRecord({
+    id: agentId,
+    cwd: "/workspace/internal-archived-agent",
+    title: "Internal archived investigation",
+    internal: true,
+    archivedAt: "2026-07-20T12:00:00.000Z",
+    persistence: {
+      provider: "codex",
+      sessionId: "internal-archived-thread",
+      metadata: { cwd: "/workspace/internal-archived-agent" },
+    },
+  });
+  const snapshot = {
+    id: agentId,
+    provider: "codex",
+    lifecycle: "closed",
+    internal: true,
+  } as ManagedAgent;
+  const messages: SessionOutboundMessage[] = [];
+  const providerSnapshot = createProviderSnapshotManagerStub();
+  providerSnapshot.listRegisteredProviderIds.mockReturnValue(["codex"]);
+  const fetchPublicTimeline = vi.fn(() => {
+    throw new Error(`Unknown agent '${agentId}'`);
+  });
+  const getTimelineRows = vi.fn(async () => {
+    throw new Error(`Unknown agent '${agentId}'`);
+  });
+  const session = createSessionForTest({
+    messages,
+    providerSnapshotManager: providerSnapshot.manager,
+    agentStorage: { get: vi.fn().mockResolvedValue(record) },
+    agentManager: {
+      waitForAgentClose: vi.fn().mockResolvedValue(undefined),
+      getAgent: vi.fn(() => null),
+      getHistorySnapshot: vi.fn(() => snapshot),
+      getTimelineRows,
+      fetchPublicTimeline,
+    },
+  });
+
+  await session.handleMessage({
+    type: "fetch_agent_timeline_request",
+    agentId,
+    requestId: "internal-archived-timeline",
+    projection: "canonical",
+  });
+  await session.handleMessage({
+    type: "agent.fork_context.request",
+    agentId,
+    requestId: "internal-archived-fork-context",
+  });
+  await session.handleMessage({
+    type: "agent.timeline.list_prompts.request",
+    agentId,
+    requestId: "internal-archived-prompts",
+  });
+
+  expect(findByType(messages, "fetch_agent_timeline_response")?.payload).toMatchObject({
+    requestId: "internal-archived-timeline",
+    agentId,
+    agent: null,
+    entries: [],
+    error: `Unknown agent '${agentId}'`,
+  });
+  expect(findByType(messages, "agent.fork_context.response")?.payload).toEqual({
+    requestId: "internal-archived-fork-context",
+    agentId,
+    attachment: null,
+    itemCount: 0,
+    boundaryCursor: null,
+    boundaryMessageId: null,
+    error: `Unknown agent '${agentId}'`,
+  });
+  expect(findByType(messages, "agent.timeline.list_prompts.response")?.payload).toEqual({
+    requestId: "internal-archived-prompts",
+    agentId,
+    epoch: "",
+    prompts: [],
+    error: `Unknown agent '${agentId}'`,
+  });
+  expect(getTimelineRows).toHaveBeenCalledOnce();
+  expect(fetchPublicTimeline).toHaveBeenCalledTimes(2);
 });
 
 test("replaces a capable session's complete viewed timeline set", async () => {

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -1384,6 +1384,79 @@ function createStoredAgentRecord(
   };
 }
 
+test("clear_agent_attention returns the updated archived history snapshot", async () => {
+  const messages: SessionOutboundMessage[] = [];
+  const before = createStoredAgentRecord({
+    id: "archived-attention-agent",
+    cwd: "/tmp/archived-attention-agent",
+    updatedAt: "2026-08-30T00:00:01.000Z",
+    lastStatus: "closed",
+    persistence: {
+      provider: "codex",
+      sessionId: "archived-attention-session",
+    },
+    requiresAttention: true,
+    attentionReason: "error",
+    attentionTimestamp: "2026-08-30T00:00:01.000Z",
+    archivedAt: "2026-08-30T00:00:02.000Z",
+  });
+  const after = createStoredAgentRecord({
+    ...before,
+    updatedAt: "2026-08-30T00:00:03.000Z",
+    requiresAttention: false,
+    attentionReason: null,
+    attentionTimestamp: null,
+  });
+  let storedRecord = before;
+  const getAgent = vi.fn(() => null);
+  const getHistorySnapshot = vi.fn(() => ({
+    id: storedRecord.id,
+    lifecycle: "closed" as const,
+  }));
+  const clearAgentAttention = vi.fn(async () => {
+    storedRecord = after;
+  });
+  const session = createSessionForTest({
+    messages,
+    agentManager: {
+      getAgent,
+      getHistorySnapshot,
+      waitForAgentClose: vi.fn(async () => {}),
+      clearAgentAttention,
+    },
+    agentStorage: {
+      get: vi.fn(async () => storedRecord),
+    },
+  });
+
+  await session.handleMessage({
+    type: "clear_agent_attention",
+    agentId: before.id,
+    requestId: "clear-archived-attention",
+  });
+
+  expect(clearAgentAttention).toHaveBeenCalledWith(before.id);
+  expect(getAgent).toHaveBeenCalledTimes(2);
+  expect(getHistorySnapshot).toHaveBeenCalledTimes(2);
+  expect(findByType(messages, "clear_agent_attention_response")).toMatchObject({
+    payload: {
+      requestId: "clear-archived-attention",
+      agentId: before.id,
+      agents: [
+        {
+          id: before.id,
+          status: "closed",
+          archivedAt: "2026-08-30T00:00:02.000Z",
+          updatedAt: "2026-08-30T00:00:03.000Z",
+          requiresAttention: false,
+          attentionReason: null,
+          attentionTimestamp: null,
+        },
+      ],
+    },
+  });
+});
+
 describe("plugin timeline append RPC", () => {
   test("stamps the plugin identity and returns the timeline position", async () => {
     const messages: SessionOutboundMessage[] = [];

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4269,7 +4269,8 @@ export class Session {
         const agents = (
           await Promise.all(
             agentIds.map(async (id) => {
-              const agent = this.agentManager.getAgent(id);
+              const agent =
+                this.agentManager.getAgent(id) ?? this.agentManager.getHistorySnapshot(id);
               return agent ? this.buildAgentPayload(agent) : null;
             }),
           )

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1840,8 +1840,23 @@ export class Session {
     return payload;
   }
 
-  private buildAgentPayload(agent: ManagedAgent): Promise<AgentSnapshotPayload> {
-    return this.enrichAgentPayload(toAgentPayload(agent));
+  private async buildAgentPayload(agent: ManagedAgent): Promise<AgentSnapshotPayload> {
+    const storedRecord = await this.agentStorage.get(agent.id);
+    if (agent.lifecycle === "closed" && storedRecord) {
+      return this.buildStoredAgentPayload(storedRecord);
+    }
+    const title = storedRecord?.title ?? null;
+    const payload = toAgentPayload(agent, { title });
+    const storedUpdatedAt = storedRecord ? resolveStoredAgentPayloadUpdatedAt(storedRecord) : null;
+    if (storedUpdatedAt) {
+      const liveUpdatedAt = Date.parse(payload.updatedAt);
+      const persistedUpdatedAt = Date.parse(storedUpdatedAt);
+      if (Number.isNaN(liveUpdatedAt) || persistedUpdatedAt > liveUpdatedAt) {
+        payload.updatedAt = storedUpdatedAt;
+      }
+    }
+    payload.archivedAt = storedRecord?.archivedAt ?? null;
+    return payload;
   }
 
   private buildStoredAgentPayload(
@@ -7176,7 +7191,7 @@ export class Session {
       pageLimit: input.pageLimit,
     })
       ? (input.fullTimeline ??
-        this.agentManager.fetchTimeline(input.agentId, { direction: "tail", limit: 0 }))
+        this.agentManager.fetchPublicTimeline(input.agentId, { direction: "tail", limit: 0 }))
       : input.controlTimeline;
     const page = selectProjectedTimelinePage({
       rows: selectedTimeline.rows,
@@ -7236,7 +7251,7 @@ export class Session {
       });
       const agentPayload = await this.buildAgentPayload(snapshot);
 
-      const fetchedControlTimeline = this.agentManager.fetchTimeline(msg.agentId, {
+      const fetchedControlTimeline = this.agentManager.fetchPublicTimeline(msg.agentId, {
         direction,
         cursor,
         limit: pageLimit,
@@ -7365,7 +7380,7 @@ export class Session {
         logger: this.sessionLogger,
       });
       const rows = await this.agentManager.getTimelineRows(msg.agentId);
-      const timeline = this.agentManager.fetchTimeline(msg.agentId, {
+      const timeline = this.agentManager.fetchPublicTimeline(msg.agentId, {
         direction: "tail",
         limit: 1,
       });
@@ -7521,7 +7536,7 @@ export class Session {
         logger: this.sessionLogger,
       });
       const agentPayload = await this.buildAgentPayload(snapshot);
-      const timeline = this.agentManager.fetchTimeline(msg.agentId, {
+      const timeline = this.agentManager.fetchPublicTimeline(msg.agentId, {
         direction: "tail",
         limit: 0,
       });

--- a/packages/server/src/server/test-utils/fake-agent-client.ts
+++ b/packages/server/src/server/test-utils/fake-agent-client.ts
@@ -7,6 +7,8 @@ import type {
   AgentCapabilityFlags,
   AgentClient,
   AgentFeature,
+  AgentHistoryReadContext,
+  AgentHistoryReadResult,
   AgentLaunchContext,
   AgentMode,
   AgentModelDefinition,
@@ -1234,6 +1236,26 @@ class FakeAgentClient implements AgentClient {
       closeSession: this.options.closeSession,
       onStartTurn: this.options.onStartTurn,
     });
+  }
+
+  async readSessionHistory(
+    handle: AgentPersistenceHandle,
+    context?: AgentHistoryReadContext,
+  ): Promise<AgentHistoryReadResult> {
+    const session = await this.resumeSession(
+      handle,
+      context ? { cwd: context.cwd } : undefined,
+      context ? { agentId: context.agentId, env: context.env } : undefined,
+    );
+    try {
+      const events: AgentStreamEvent[] = [];
+      for await (const event of session.streamHistory()) {
+        events.push(event);
+      }
+      return { events, coverage: { kind: "complete" } };
+    } finally {
+      await session.close();
+    }
   }
 
   async fetchCatalog(

--- a/packages/server/src/server/wire-compat.test.ts
+++ b/packages/server/src/server/wire-compat.test.ts
@@ -112,6 +112,10 @@ class InMemoryAgentManager {
     return this.timeline.fetch("agent-1", options);
   }
 
+  fetchPublicTimeline() {
+    return this.fetchTimeline();
+  }
+
   listAgents() {
     return [];
   }


### PR DESCRIPTION
Replaces #2388, which cannot be reopened: the branch was rebased onto current `main`, and GitHub refuses to reopen a closed PR whose head was force-pushed. Same branch, same work, plus the real-provider evidence @boudra asked for.

Rebased onto `1f5b6143d`. #4353, #4283, #4300 and #4314 all landed in the meantime and touch the same files.

## Summary

Separates read-only provider history access from interactive session resume:

- adds optional `AgentClient.readSessionHistory()` with a narrow history context;
- returns `{ events, coverage: { kind: "complete" } }`, leaving an internal result seam for future coverage variants without implementing pagination;
- removes `AgentResumeSessionOptions` and all `purpose: "history"` plumbing;
- hydrates archived records into retained closed snapshots without registering an interactive provider session;
- shares concurrent archived reads, upgrades deferred broadcast requests, and preserves concurrent unarchive promotion;
- migrates Codex, ACP-based providers, Claude, OpenCode, OMP, and Pi to provider-owned history readers;
- forwards the contract through derived/custom providers while remapping event provider IDs.

Closed history hydration is memory-only. It does not restore file timeline persistence, seed or commit the injectable durable timeline store, or reintroduce history reconciliation.

## Real-provider evidence

Two suites drive the real binaries. Both were run on `upstream/main` and on this branch; the `main` failures are the behaviour this PR fixes.

### Codex — `codex-archived-history-read.local.e2e.test.ts`

Real `codex` 0.153.4 against a local stub model backend, following the existing `codex-app-server-agent.local.e2e.test.ts` pattern, so it needs no credentials to reproduce.

| Case | `upstream/main` | This PR |
| --- | --- | --- |
| Native thread genuinely archived | ❌ `a history read must not retain its app-server: expected [ 647875 ] to deeply equal []` | ✅ |
| Native thread left active by the Paseo archive | ❌ `CodexAppServerRpcError: thread 01a07fed-… already has an active writer` | ✅ |

The second case is the direct answer to "leaves the native thread untouched". After the history read it archives the thread again; Codex rejects that while a writer is held, so on `main` the read demonstrably resumed the thread and claimed its writer. This PR's read only issues `thread/read`, takes no writer, and the archive succeeds.

The first case answers "release temporary resources": the test lists `codex app-server` processes this test process spawned (they are detached, so the parent link is the handle). On `main` one stays alive after the read because the archived record is registered as a live interactive session and nothing ever closes it — `ensureAgentLoaded` has no close on the archived path and there is no idle reclamation.

### OpenCode — `opencode-archived-history-read.real.e2e.test.ts`

Real `opencode serve` 1.14.46 behind a recording proxy, so every request Paseo issues is observable.

| Assertion | `upstream/main` | This PR |
| --- | --- | --- |
| Issues no `session.abort` | ❌ `expected 1 to be +0` | ✅ |
| Opens no global event stream | — | ✅ |

A history read followed by the close a tab teardown triggers sends exactly one session-scoped abort on `main`. `abortOpenCodeSession` is unconditional in `close()`, and OpenCode's abort is session-scoped rather than turn-scoped, so it cancels whatever that session is running. OpenCode's native archive is only a numeric field and does not stop a session from running, so an archived session can legitimately be busy.

The suite takes any OpenAI-compatible endpoint and defaults to OpenRouter's, so it needs no new credential type.

Both suites skip when the provider binary is missing, matching the other `*.local.e2e` / `*.real.e2e` files. Neither runs in the default `test:e2e` sweep.

## A neighbouring bug this surfaced

`archiveAgentUnlocked` syncs the native archive **before** it closes the runtime, so `thread/archive` loses to the thread's own writer lock and `syncNativeArchiveState`'s best-effort `catch` swallows it. A Paseo-archived Codex agent therefore usually leaves its native thread active — which is exactly the state the second Codex case covers, and why `allowArchivedHistory` on `main` rarely engages: `thread/resume` succeeds instead of raising the archived error the guard keys off.

Not fixed here; it belongs in its own change. The tests document the current behaviour rather than working around it.

## Rebase note

#4435 added `PluginSessionOpenRequest.purpose: "interactive" | "history"` to the public plugin SDK, populated from the `resumeOptions` this PR removes. Rather than drop the field's only producer and leave `"history"` unreachable, interactive resume now pins `purpose: "interactive"` and the history path reports `purpose: "history"` through a narrow `resolveHistoryReadEnv`. It deliberately does not reuse `buildLaunchContext`: `isPaseoToolPolicyEnabled(undefined)` returns `true`, so that path would build a Paseo tool catalog for a read — the opposite of what this PR is for. With no plugin installed it returns `undefined`, leaving provider behaviour unchanged.

## Provider behavior

| Provider | Read-only history path |
| --- | --- |
| Codex | Initialize a temporary app-server and call `thread/read` directly; no loaded-list, resume, unarchive, skills, collaboration modes, or interactive tool setup |
| ACP | Initialize a temporary process and call `session/load` with `mcpServers: []`; resume-only providers return an unsupported error |
| Claude | Read the persisted transcript without starting an SDK query; resolve `CLAUDE_CONFIG_DIR` from explicit config, provider profile env, daemon env, then `~/.claude` |
| OpenCode | Call session metadata/messages directly; no global event attachment or native abort; release every acquisition on success and failure |
| OMP | Start only the minimal history RPC runtime; no model, mode, prompt, host-tool, or subagent subscription setup |
| Pi | Parse the persisted JSONL directly without starting a runtime or installing temporary MCP/extensions |

Codex persisted child histories are loaded with a maximum concurrency of 8 and the existing 100-thread cap, deduplication, nested traversal, and per-child failure isolation. Results are applied in batch route order so completion timing cannot reorder the restored timeline.

## Archive behavior

- A history read leaves Paseo `archivedAt` and provider-native archive state unchanged.
- The snapshot is published only after provider resources are released and all events are applied.
- A failed read leaves no partial timeline, provider-subagent state, or closed snapshot.
- A concurrent unarchive releases the closed snapshot and runs normal interactive resume.
- Successful history is reused during that promotion; failed history is hydrated normally by the interactive session.
- Closed responses use the stored agent record as authority for title, status, archive timestamp, labels, owner, attention, persistence metadata, and internal visibility.
- Registering a live session, deleting the agent, or discarding retained state removes the closed snapshot.

## Scope guard

This PR does not include:

- #3261 pagination, `thread/turns/list`, timeline cursors, or CLI tail changes;
- app, protocol, CLI, or wire-schema changes;
- file timeline persistence, SQLite, append-only caches, durable history snapshots, or old reconciliation;
- the broader live/history hydration transaction from #2722;
- archive/resume lifecycle-lock expansion from #3544;
- unrelated provider or timeline cleanup.

37 files, +3393/-272 — of which tests are +2305 and the two evidence suites are 569. Implementation is +1065/-196 across 16 files, limited to `packages/server` plus the two owning docs.

## Verification

Focused Vitest files passed on the rebased branch: archived loader, AgentManager (182), session (151), Codex/OpenCode/ACP (387), Pi/OMP/Claude/MCP/wire-compat (268), provider registry.

`npm run build:server`, `npm run lint`, `npm run format:check` and `npm run typecheck --workspace=@getpaseo/server` all pass. Repo-wide `npm run typecheck` reports two pre-existing `packages/app/src/plugins/*` errors identical on `upstream/main`; they come from a stale generated `.expo/types/router.d.ts` and are untouched by this branch.

The full test suite was not run locally per repository guidance.

Closes #2364.
