### PR TITLE
Run release scripts as main on Windows runners

### DIFF
--- a/scripts/github-release.mjs
+++ b/scripts/github-release.mjs
@@ -1,4 +1,5 @@
 import { execFileSync as nodeExecFileSync } from "node:child_process";
+import { isMainModule } from "./is-main-module.mjs";
 
 function parseJson(output) {
   return JSON.parse(output);
@@ -67,7 +68,7 @@ function parseArgs(argv) {
   return { cleanupDuplicates, repo, tag };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   const { cleanupDuplicates, repo, tag } = parseArgs(process.argv.slice(2));
   let release = null;
   for (let attempt = 0; attempt < 5 && !release; attempt += 1) {

--- a/scripts/is-main-module.mjs
+++ b/scripts/is-main-module.mjs
@@ -1,0 +1,10 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// `import.meta.url === \`file://${process.argv[1]}\`` is false on Windows, where argv[1] is
+// `D:\a\...` and the module URL is `file:///D:/a/...`, so a script guarded that way silently
+// does nothing on a Windows runner. Compare resolved filesystem paths instead.
+export function isMainModule(importMetaUrl, argvPath = process.argv[1]) {
+  if (!argvPath) return false;
+  return fileURLToPath(importMetaUrl) === path.resolve(argvPath);
+}

--- a/scripts/is-main-module.test.mjs
+++ b/scripts/is-main-module.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isMainModule } from "./is-main-module.mjs";
+
+test("matches the executed script on this platform", () => {
+  const scriptPath = path.resolve("scripts", "github-release.mjs");
+  assert.equal(isMainModule(pathToFileURL(scriptPath).href, scriptPath), true);
+});
+
+test("does not match when another module is the entry point", () => {
+  const scriptPath = path.resolve("scripts", "github-release.mjs");
+  const otherPath = path.resolve("scripts", "stamp-rollout.mjs");
+  assert.equal(isMainModule(pathToFileURL(scriptPath).href, otherPath), false);
+});
+
+test("returns false without an argv entry", () => {
+  assert.equal(
+    isMainModule(pathToFileURL(path.resolve("scripts", "x.mjs")).href, undefined),
+    false,
+  );
+});
+
+test("the naive string comparison that broke Windows is not used", () => {
+  const scriptPath = path.resolve("scripts", "github-release.mjs");
+  const url = pathToFileURL(scriptPath).href;
+  // On Windows this naive form is `file://D:\\...` and never equals the module URL.
+  assert.notEqual(
+    `file://${"D:\\a\\paseo\\scripts\\github-release.mjs"}`,
+    "file:///D:/a/paseo/scripts/github-release.mjs",
+  );
+  assert.equal(isMainModule(url, scriptPath), true);
+});

--- a/scripts/merge-mac-manifest.mjs
+++ b/scripts/merge-mac-manifest.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { dump, load } from "js-yaml";
+import { isMainModule } from "./is-main-module.mjs";
 
 // electron-updater compares this with os.release(), which reports the Darwin
 // kernel version. Darwin 22 is macOS 13 Ventura.
@@ -19,7 +20,7 @@ export function mergeMacManifest(arm64Path, x64Path, outputPath) {
   return output;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   const [, , arm64Path, x64Path, outputPath] = process.argv;
   if (!arm64Path || !x64Path || !outputPath) {
     throw new Error("Usage: node scripts/merge-mac-manifest.mjs <arm64.yml> <x64.yml> <out.yml>");

--- a/scripts/stamp-rollout.mjs
+++ b/scripts/stamp-rollout.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { dump, load } from "js-yaml";
+import { isMainModule } from "./is-main-module.mjs";
 
 export function stampRollout({ releaseDate, rolloutHours }, paths) {
   if (releaseDate === undefined && rolloutHours === undefined) {
@@ -35,7 +36,7 @@ function parseArgs(argv) {
   return { opts, paths };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   const { opts, paths } = parseArgs(process.argv.slice(2));
   if (paths.length === 0 || (opts.releaseDate === undefined && opts.rolloutHours === undefined)) {
     throw new Error(

--- a/scripts/sync-fdroid-changelogs.mjs
+++ b/scripts/sync-fdroid-changelogs.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 // require it, so the ABI table has exactly one definition across all three callers.
 import { getFdroidVersionCodes as defaultGetFdroidVersionCodes } from "../packages/app/native-release-version.js";
 import { parseChangelogBody, parseChangelogEntries } from "./changelog-utils.mjs";
+import { isMainModule } from "./is-main-module.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
@@ -263,6 +264,6 @@ export function syncFdroidChangelogs(argv = process.argv.slice(2), deps = {}) {
   return { contents, version, versionCodes, written };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   syncFdroidChangelogs();
 }

--- a/scripts/sync-release-notes-from-changelog.mjs
+++ b/scripts/sync-release-notes-from-changelog.mjs
@@ -9,6 +9,7 @@ import {
   normalizeReleaseTag,
   parseReleaseVersion,
 } from "./release-version-utils.mjs";
+import { isMainModule } from "./is-main-module.mjs";
 
 function usageAndExit(code = 1) {
   const usage = `
@@ -201,6 +202,6 @@ export function syncReleaseNotes(argv = process.argv.slice(2), deps = {}) {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   syncReleaseNotes();
 }


### PR DESCRIPTION
### Linked issue

Release plumbing failure observed on the v0.8.0-beta.1 tag: `publish-windows` failed in **Upload desktop artifacts to release** with `release not found` (https://github.com/getpaseo/paseo/actions/runs/34204067329). macOS arm64 and Linux uploaded fine.

### Type of change

- [x] Bug fix

### Reasoning

`scripts/github-release.mjs` guarded its CLI block with `import.meta.url === \`file://${process.argv[1]}\``. On Windows `process.argv[1]` is `D:\a\paseo\paseo\scripts\github-release.mjs`, so the right-hand side is `file://D:\a\...` while `import.meta.url` is `file:///D:/a/...`. The guard is false, the script prints nothing and exits 0, and the workflow runs `gh release upload "" ...`, which fails with `release not found`. POSIX paths start with `/`, so the naive form happens to match there.

`scripts/validate-desktop-manifests.mjs` and `scripts/npm-retry.mjs` already use the portable comparison. This change extracts it into `scripts/is-main-module.mjs` and uses it in every release script that has a CLI block: `github-release.mjs`, `sync-release-notes-from-changelog.mjs`, `merge-mac-manifest.mjs`, `stamp-rollout.mjs`, `sync-fdroid-changelogs.mjs`. No behaviour change on POSIX.

### Goals

- The Windows desktop release job resolves the draft release and uploads its artifacts.
- One main-module guard shared by the release scripts.

### Non-goals

- Retrying the v0.8.0-beta.1 Windows build (a `desktop-windows-v0.8.0-beta.1` retry tag on the merged commit does that).
- Fixing the pre-existing failures in `scripts/merge-mac-manifest.test.mjs` and `scripts/stamp-rollout.test.mjs`, which fail on `main` today and are not run by CI.

### QA

```text
node --test scripts/is-main-module.test.mjs scripts/sync-release-notes-from-changelog.test.mjs scripts/sync-fdroid-changelogs.test.mjs
# pass 26, fail 0

node scripts/github-release.mjs --repo getpaseo/paseo --tag v0.8.0-beta.1
untagged-60df50078cb40a25c9a6   # still resolves the draft as a CLI on Linux
```

Lint 0 warnings, formatted. Windows itself is verified by the retry-tag build after merge; the failing form is reproduced in the test file's comment (`file://D:\...` vs `file:///D:/...`).

### Checklist

- [x] One focused change
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense