### PR TITLE
Keep ACP configuration notifications atomic

### DIFF
--- a/packages/plugin/src/server/acp-internal/connection.ts
+++ b/packages/plugin/src/server/acp-internal/connection.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { Readable, Writable } from "node:stream";
 import {
   ClientSideConnection,
+  CLIENT_METHODS,
   PROTOCOL_VERSION,
   ndJsonStream,
   type Client,
@@ -427,10 +428,11 @@ class AcpRuntime {
       requestPermission: (request) => this.requestPermission(request),
       sessionUpdate: (notification) =>
         this.enqueueNotification(() => this.sessionUpdate(notification)),
-      extNotification: (method, params) =>
-        this.enqueueNotification(() => this.vendorNotification(method, params)),
     };
-    this.connection = new ClientSideConnection(() => client, stream);
+    this.connection = new ClientSideConnection(
+      () => client,
+      routeVendorNotifications(stream, (method, params) => this.vendorNotification(method, params)),
+    );
     if (!child) void this.connection.closed.then(() => this.handleUnexpectedTransportClose());
     child?.on("error", (error) => {
       this.processFailed = true;
@@ -997,7 +999,7 @@ class AcpRuntime {
     });
   }
 
-  private vendorNotification(method: string, params: Record<string, unknown>): void {
+  private vendorNotification(method: string, params: unknown): void {
     const notification = { method, params: jsonValue(params) };
     const context = { sessionId: this.options.boundarySessionId };
     for (const transformer of this.transformers) {
@@ -1084,6 +1086,31 @@ class AcpRuntime {
       this.commandWaiter = null;
     });
   }
+}
+
+function routeVendorNotifications(
+  stream: Stream,
+  receive: (method: string, params: unknown) => void,
+): Stream {
+  const clientMethods = new Set<string>(Object.values(CLIENT_METHODS));
+  return {
+    writable: stream.writable,
+    readable: stream.readable.pipeThrough(
+      new TransformStream({
+        transform(message, controller) {
+          if ("method" in message && !("id" in message) && !clientMethods.has(message.method)) {
+            // The SDK dispatches extensions asynchronously and can resolve a later response first.
+            // Run synchronous vendor transforms in wire order, inside the configuration transaction.
+            try {
+              receive(message.method, message.params);
+            } catch (error) {
+              console.error("Error handling ACP vendor notification", error);
+            }
+          } else controller.enqueue(message);
+        },
+      }),
+    ),
+  };
 }
 
 function selectPermissionOption(

--- a/packages/plugin/src/server/acp.test.ts
+++ b/packages/plugin/src/server/acp.test.ts
@@ -823,10 +823,12 @@ lines.on("line", (line) => {
     await connection.close();
   });
 
-  it("commits transformer config notifications once and discards them on rollback", async () => {
-    const executable = await fakeAcp(`const readline = require("node:readline");
+  it.each([1, 64])(
+    "commits transformer config notifications once and discards them on rollback (%i per response)",
+    async (notificationCount) => {
+      const executable = await fakeAcp(`const readline = require("node:readline");
 const lines = readline.createInterface({ input: process.stdin });
-const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+const send = (...messages) => process.stdout.write(messages.map((message) => JSON.stringify(message) + "\\n").join(""));
 let model = "a";
 const options = () => [
   { id: "model", name: "Model", category: "model", type: "select", currentValue: model, options: [{ name: "A", value: "a" }, { name: "B", value: "b" }] },
@@ -839,66 +841,84 @@ lines.on("line", (line) => {
   else if (message.method === "session/set_config_option" && message.params.configId === "late") send({ jsonrpc: "2.0", id: message.id, error: { code: -32602, message: "late rejected" } });
   else if (message.method === "session/set_config_option") {
     model = message.params.value;
-    send({ jsonrpc: "2.0", method: "vendor/config", params: { model } });
-    send({ jsonrpc: "2.0", id: message.id, result: { configOptions: options() } });
+    send(
+      ...Array.from({ length: ${notificationCount} }, () => ({ jsonrpc: "2.0", method: "vendor/config", params: { model } })),
+      { jsonrpc: "2.0", id: message.id, result: { configOptions: options() } },
+    );
   }
 });`);
-    const transformer = {
-      notification(notification: { method: string; params: unknown }) {
-        if (notification.method !== "vendor/config") return null;
-        const params = notification.params as { model: string };
-        return {
-          type: "config" as const,
-          config: {
-            model: params.model,
-            models: [{ id: params.model, label: `Transformer ${params.model}` }],
-            modes: [],
-            thinkingOptions: [],
-            settings: [],
-          },
-        };
-      },
-    };
-    const { connection, events } = await connect(
-      executable,
-      ["prompt.message", "session.configure"],
-      [transformer],
-    );
-    await connection.send(openInput());
-    await waitForEvent(events, (event) => event.type === "session.ready");
-    const initialConfigCount = events.filter((event) => event.type === "session.config").length;
+      const transformer = {
+        notification(notification: { method: string; params: unknown }) {
+          if (notification.method !== "vendor/config") return null;
+          const params = notification.params as { model: string };
+          return {
+            type: "config" as const,
+            config: {
+              model: params.model,
+              models: [{ id: params.model, label: `Transformer ${params.model}` }],
+              modes: [],
+              thinkingOptions: [],
+              settings: [],
+            },
+          };
+        },
+      };
+      const { connection, events } = await connect(
+        executable,
+        ["prompt.message", "session.configure"],
+        [transformer],
+      );
+      await connection.send(openInput());
+      await waitForEvent(events, (event) => event.type === "session.ready");
+      const initialConfigCount = events.filter((event) => event.type === "session.config").length;
 
-    await connection.send({
-      type: "session.configure",
-      requestId: "transformer-success",
-      sessionId: "session-1",
-      changes: { model: "b" },
-    });
-    await waitForEvent(
-      events,
-      (event) => event.type === "request.completed" && event.requestId === "transformer-success",
-    );
-    let configs = events.filter((event) => event.type === "session.config");
-    expect(configs).toHaveLength(initialConfigCount + 1);
-    expect(configs.at(-1)).toMatchObject({
-      config: { model: "b", models: [{ label: "Transformer b" }] },
-    });
+      await connection.send({
+        type: "session.configure",
+        requestId: "transformer-initial-failure",
+        sessionId: "session-1",
+        changes: { model: "b", settings: { late: "fail" } },
+      });
+      await waitForEvent(
+        events,
+        (event) =>
+          event.type === "request.failed" && event.requestId === "transformer-initial-failure",
+      );
+      expect(events.filter((event) => event.type === "session.config")).toHaveLength(
+        initialConfigCount,
+      );
 
-    await connection.send({
-      type: "session.configure",
-      requestId: "transformer-failure",
-      sessionId: "session-1",
-      changes: { model: "a", settings: { late: "fail" } },
-    });
-    await waitForEvent(
-      events,
-      (event) => event.type === "request.failed" && event.requestId === "transformer-failure",
-    );
-    configs = events.filter((event) => event.type === "session.config");
-    expect(configs).toHaveLength(initialConfigCount + 1);
-    expect(configs.at(-1)).toMatchObject({ config: { model: "b" } });
-    await connection.close();
-  });
+      await connection.send({
+        type: "session.configure",
+        requestId: "transformer-success",
+        sessionId: "session-1",
+        changes: { model: "b" },
+      });
+      await waitForEvent(
+        events,
+        (event) => event.type === "request.completed" && event.requestId === "transformer-success",
+      );
+      let configs = events.filter((event) => event.type === "session.config");
+      expect(configs).toHaveLength(initialConfigCount + 1);
+      expect(configs.at(-1)).toMatchObject({
+        config: { model: "b", models: [{ label: "Transformer b" }] },
+      });
+
+      await connection.send({
+        type: "session.configure",
+        requestId: "transformer-failure",
+        sessionId: "session-1",
+        changes: { model: "a", settings: { late: "fail" } },
+      });
+      await waitForEvent(
+        events,
+        (event) => event.type === "request.failed" && event.requestId === "transformer-failure",
+      );
+      configs = events.filter((event) => event.type === "session.config");
+      expect(configs).toHaveLength(initialConfigCount + 1);
+      expect(configs.at(-1)).toMatchObject({ config: { model: "b" } });
+      await connection.close();
+    },
+  );
 
   it("gives discovery transformers the discovered session configuration facade", async () => {
     const executable = await fakeAcp(`const readline = require("node:readline");


### PR DESCRIPTION
Keep plugin ACP configuration changes atomic when an agent sends vendor notifications alongside its configuration response. Successful changes publish one final snapshot; failed changes publish none.

### Linked issue

Fixes the [SDK test failure on main](https://github.com/getpaseo/paseo/actions/runs/34208232113/job/102002975911). No matching open issue or superseded PR found.

### Type of change

- [x] Bug fix

### Reasoning

ACP SDK 1.4 dispatches extension notifications through an asynchronous handler chain while resolving responses independently. If a notification and response arrive together, the response can close our configuration transaction before the SDK invokes the notification callback. The resulting `session.config` event escapes rollback or duplicates a successful commit. Separate subprocess writes made this depend on pipe chunking.

```text
Wire:   vendor/config → configuration response
Before: response → commit/rollback → vendor/config → extra snapshot
After:  vendor/config → response → commit/rollback
```

The adapter now consumes synchronous vendor transforms at its input stream boundary. Built-in ACP methods and all requests/responses still go through the SDK. This removes the deferred extension callback path; no sleeps, retries, or notification-count suppression are needed. Waiting for the existing notification queue would miss callbacks the SDK has not invoked yet.

### Goals

- Publish exactly one transformer-derived snapshot for a successful configuration change.
- Discard notifications from both the failed change and its rollback.
- Verify single notifications and bursts coalesced with the response in one subprocess write.

### Non-goals

- Change the public plugin API, configuration rollback policy, or ACP SDK version.
- Modify the built-in provider backend.

### QA

Linux, Node 22.20.0, installed ACP SDK 1.4.0. Reproduction uses a real Node subprocess and SDK connection through `runAcpProvider`, without mocks.

- Repeated the original single-notification journey: reproduced an extra snapshot after initially passing runs. Temporary tracing showed the transaction closing before the SDK invoked the vendor callback.
- Strengthened the fixture to write notifications and their response together. Against unmodified main `47171b4`, the initial rollback assertion failed **10/10 runs**: `expected ... length of 1 but got 2`.
- With the fix, the targeted regression passed **20 consecutive runs / 40 cases**, covering 1 and 64 notifications per response. Each case checks initial rollback, successful commit, and subsequent rollback.
- `npx vitest run src/server/acp.test.ts --bail=1` in `packages/plugin`: **21 passed**.
- `npx vitest run src/boundaries.test.ts --bail=1` in `packages/plugin`: **44 passed**.
- `npx vitest run src/server/agent/plugin-provider.test.ts --bail=1` in `packages/server`: **3 passed**.
- `npm run build:server`, `npm run typecheck`, `npm run lint`, and `npm run format`: **passed**.

Risk surface: delivery timing of vendor notifications in the plugin ACP adapter, shared by subprocess and connector transports. Existing ACP tests also cover SDK connectors, permission requests, configuration serialization, disconnects, and process shutdown. No live vendor session or macOS/Windows runtime was exercised locally.

### Checklist

- [x] Plugin changes follow the SDK import boundaries
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
