### PR TITLE
fix(agent): preserve Cursor Auto model id default

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -22,7 +22,11 @@ same Paseo agent ID. Provider history is not appended again when the canonical t
 primed.
 
 Idle agents remain resident indefinitely. Runtime closure happens only through an explicit lifecycle
-action such as archive, replacement, reload, workspace teardown, or daemon shutdown.
+action such as archive, replacement, reload, workspace teardown, or daemon shutdown -- or the terminal
+`error` transition itself, which closes the runtime the same way archive does (killing the provider
+process tree) instead of leaving a dead session's process resident forever. `lastError` and the
+`error` attention reason survive onto the closed record so the failure stays visible; retrying goes
+through `ensureAgentLoaded()`'s normal resume path and gets a fresh provider process.
 
 A provider runtime can still die on its own — crash, OOM kill, host suspend. Work the agent parked
 inside that process dies with it: Claude Code's background Bash shells, `Monitor` watches, and

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -6962,55 +6962,64 @@ test("onAgentAttention is not called for delegated child agents", async () => {
   expect(attentionCalls).toEqual([]);
 });
 
-test("clearAgentAttention on errored agent stays cleared until a new error transition", async () => {
+test("a turn failure raises attention as error before the runtime closes", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-attention-error-"));
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
 
   class FailingSession extends TestAgentSession {
-    private attempt = 0;
+    closeCalls = 0;
 
     override async startTurn(): Promise<{ turnId: string }> {
-      this.attempt += 1;
-      const attempt = this.attempt;
-      const turnId = `fail-turn-${attempt}`;
+      const turnId = "fail-turn-1";
       setTimeout(() => {
         this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
         this.pushEvent({
           type: "turn_failed",
           provider: this.provider,
-          error: `boom-${attempt}`,
+          error: "boom-1",
           turnId,
         });
       }, 0);
       return { turnId };
+    }
+
+    override async close(): Promise<void> {
+      this.closeCalls += 1;
+      await super.close();
     }
   }
 
   class FailingClient implements AgentClient {
     readonly provider = "codex" as const;
     readonly capabilities = TEST_CAPABILITIES;
+    readonly sessions: FailingSession[] = [];
 
     async isAvailable(): Promise<boolean> {
       return true;
     }
 
     async createSession(config: AgentSessionConfig): Promise<AgentSession> {
-      return new FailingSession(config);
+      const session = new FailingSession(config);
+      this.sessions.push(session);
+      return session;
     }
 
     async resumeSession(config?: Partial<AgentSessionConfig>): Promise<AgentSession> {
-      return new FailingSession({
+      const session = new FailingSession({
         provider: "codex",
         cwd: config?.cwd ?? process.cwd(),
       });
+      this.sessions.push(session);
+      return session;
     }
   }
 
   const attentionReasons: Array<"finished" | "error" | "permission"> = [];
+  const client = new FailingClient();
   const manager = new AgentManager({
     clients: {
-      codex: new FailingClient(),
+      codex: client,
     },
     registry: storage,
     logger,
@@ -7031,49 +7040,202 @@ test("clearAgentAttention on errored agent stays cleared until a new error trans
   );
 
   await expect(manager.runAgent(agent.id, "fail once")).rejects.toThrow("boom-1");
-  await manager.flush();
 
-  const afterFirstFailure = manager.getAgent(agent.id);
-  expect(afterFirstFailure?.lifecycle).toBe("error");
-  expect(afterFirstFailure?.attention.requiresAttention).toBe(true);
-  expect(afterFirstFailure?.attention).toMatchObject({
-    requiresAttention: true,
-    attentionReason: "error",
+  // The error attention signal lands synchronously with the lifecycle
+  // transition, independent of when the runtime-teardown background task
+  // (see next test) happens to run.
+  expect(attentionReasons).toEqual(["error"]);
+
+  await manager.flush();
+});
+
+test("terminal error closes the agent runtime (kills the provider session) instead of leaking it", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-error-teardown-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+
+  // Models the real ACP provider session: once close() has run, the
+  // underlying process/connection is gone and startTurn must refuse to
+  // reuse it -- exactly like acp-agent.ts's `if (this.closed) throw ...`.
+  class FailingSession extends TestAgentSession {
+    closeCalls = 0;
+    closed = false;
+
+    constructor(
+      config: AgentSessionConfig,
+      private readonly shouldFail: boolean,
+    ) {
+      super(config);
+    }
+
+    override async startTurn(): Promise<{ turnId: string }> {
+      if (this.closed) {
+        throw new Error(`${this.provider} session is closed`);
+      }
+      const turnId = "turn-1";
+      const shouldFail = this.shouldFail;
+      setTimeout(() => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+        if (shouldFail) {
+          this.pushEvent({ type: "turn_failed", provider: this.provider, error: "boom", turnId });
+        } else {
+          this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
+        }
+      }, 0);
+      return { turnId };
+    }
+
+    override async close(): Promise<void> {
+      this.closeCalls += 1;
+      this.closed = true;
+      await super.close();
+    }
+  }
+
+  class OneShotFailingClient implements AgentClient {
+    readonly provider = "codex" as const;
+    readonly capabilities = TEST_CAPABILITIES;
+    readonly sessions: FailingSession[] = [];
+
+    async isAvailable(): Promise<boolean> {
+      return true;
+    }
+
+    // The first session (direct create) fails its turn, matching a
+    // transient provider/API error with a perfectly healthy process.
+    async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      const session = new FailingSession(config, true);
+      this.sessions.push(session);
+      return session;
+    }
+
+    // Any resumed session (post-error retry) succeeds, matching resume
+    // spinning up a fresh provider process.
+    async resumeSession(config?: Partial<AgentSessionConfig>): Promise<AgentSession> {
+      const session = new FailingSession(
+        { provider: "codex", cwd: config?.cwd ?? process.cwd() },
+        false,
+      );
+      this.sessions.push(session);
+      return session;
+    }
+  }
+
+  const client = new OneShotFailingClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
   });
 
-  const persistedAfterFirstFailure = await storage.get(agent.id);
-  expect(persistedAfterFirstFailure?.lastStatus).toBe("error");
-  expect(persistedAfterFirstFailure?.requiresAttention).toBe(true);
-  expect(persistedAfterFirstFailure?.attentionReason).toBe("error");
+  try {
+    const agent = await manager.createAgent(
+      { provider: "codex", cwd: workdir, title: "Teardown test" },
+      undefined,
+      { workspaceId: undefined },
+    );
 
-  await manager.clearAgentAttention(agent.id);
-  manager.notifyAgentState(agent.id);
-  await manager.flush();
+    await expect(manager.runAgent(agent.id, "fail once")).rejects.toThrow("boom");
+    await manager.flush();
 
-  const afterClear = manager.getAgent(agent.id);
-  expect(afterClear?.lifecycle).toBe("error");
-  expect(afterClear?.attention).toEqual({ requiresAttention: false });
+    // No live child process should be left behind: the first session's
+    // close() (the treeKill/SIGTERM+SIGKILL teardown in the real ACP
+    // provider) must have run exactly once.
+    expect(client.sessions[0]?.closeCalls).toBe(1);
 
-  const persistedAfterClear = await storage.get(agent.id);
-  expect(persistedAfterClear?.lastStatus).toBe("error");
-  expect(persistedAfterClear?.requiresAttention).toBe(false);
-  expect(persistedAfterClear?.attentionReason).toBeNull();
+    // The agent must not be left dangling in "error" forever -- it is no
+    // longer resident in the live registry, matching how archive/reload
+    // release a runtime today.
+    expect(manager.getAgent(agent.id)).toBeNull();
 
-  await expect(manager.runAgent(agent.id, "fail again")).rejects.toThrow("boom-2");
-  await manager.flush();
+    // But the error remains visible to the user: the persisted record
+    // keeps attentionReason "error" even though lastStatus is now "closed".
+    const persisted = await storage.get(agent.id);
+    expect(persisted?.lastStatus).toBe("closed");
+    expect(persisted?.requiresAttention).toBe(true);
+    expect(persisted?.attentionReason).toBe("error");
 
-  const afterSecondFailure = manager.getAgent(agent.id);
-  expect(afterSecondFailure?.lifecycle).toBe("error");
-  expect(afterSecondFailure?.attention).toMatchObject({
-    requiresAttention: true,
-    attentionReason: "error",
+    // Idempotency: the internal error->close trigger never lets a
+    // "runtime already gone" failure escape as an unhandled rejection or
+    // crash the daemon -- closeAgentAfterTerminalError swallows it (see the
+    // logger.warn call), same contract as every other background task
+    // tracked via trackBackgroundTask. Calling the public closeAgent
+    // directly on an already-closed agent still rejects (expected -- it
+    // has no agent to close), proving the daemon-safety guarantee lives in
+    // the error-triggered wrapper, not by pretending the agent exists.
+    await expect(manager.closeAgent(agent.id)).rejects.toThrow(/Unknown agent/);
+    await expect(manager.flush()).resolves.toBeUndefined();
+
+    // Retrying goes through the normal resume-from-persistence path (the
+    // same one archive/reload already use) and gets a brand-new provider
+    // session/process rather than reusing the dead one.
+    const resumed = await ensureAgentLoaded(agent.id, {
+      agentManager: manager,
+      agentStorage: storage,
+      logger,
+    });
+    expect(resumed.lifecycle).not.toBe("error");
+    expect(client.sessions).toHaveLength(2);
+    expect(client.sessions[1]).not.toBe(client.sessions[0]);
+
+    const result = await manager.runAgent(agent.id, "retry");
+    expect(result.canceled).toBe(false);
+    expect(manager.getAgent(agent.id)?.lifecycle).toBe("idle");
+
+    // The dead first session was never touched again by the retry.
+    expect(client.sessions[0]?.closeCalls).toBe(1);
+  } finally {
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("a successful turn does not close the agent runtime", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-error-teardown-noop-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+
+  class TrackedSession extends TestAgentSession {
+    closeCalls = 0;
+
+    override async close(): Promise<void> {
+      this.closeCalls += 1;
+      await super.close();
+    }
+  }
+
+  class TrackedClient extends TestAgentClient {
+    readonly sessions: TrackedSession[] = [];
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      const session = new TrackedSession(config);
+      this.sessions.push(session);
+      return session;
+    }
+  }
+
+  const client = new TrackedClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
   });
-  expect(attentionReasons).toEqual(["error", "error"]);
 
-  const persistedAfterSecondFailure = await storage.get(agent.id);
-  expect(persistedAfterSecondFailure?.lastStatus).toBe("error");
-  expect(persistedAfterSecondFailure?.requiresAttention).toBe(true);
-  expect(persistedAfterSecondFailure?.attentionReason).toBe("error");
+  try {
+    const agent = await manager.createAgent(
+      { provider: "codex", cwd: workdir, title: "Happy path" },
+      undefined,
+      { workspaceId: undefined },
+    );
+
+    const result = await manager.runAgent(agent.id, "hello");
+    await manager.flush();
+
+    expect(result.canceled).toBe(false);
+    expect(manager.getAgent(agent.id)?.lifecycle).toBe("idle");
+    expect(client.sessions[0]?.closeCalls).toBe(0);
+  } finally {
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("streamAgent clears pending run when startTurn fails before a turn id exists", async () => {
@@ -7136,6 +7298,12 @@ test("streamAgent clears pending run when startTurn fails before a turn id exist
   await expect(manager.runAgent(agent.id, "fail before turn id")).rejects.toThrow(
     "Invalid request: missing field `text`",
   );
+  await manager.flush();
+
+  // The failed turn closes the agent runtime (see the dedicated teardown
+  // tests above), so retrying goes through the normal resume-from-persistence
+  // path rather than reusing the errored session directly.
+  await ensureAgentLoaded(agent.id, { agentManager: manager, agentStorage: storage, logger });
 
   await expect(manager.runAgent(agent.id, "second turn")).resolves.toEqual(
     expect.objectContaining({
@@ -7975,11 +8143,21 @@ test("turn_failed emits a system error assistant timeline message and keeps erro
   );
 
   await expect(manager.runAgent(agent.id, "hello")).rejects.toThrow("invalid model id");
+  await manager.flush();
 
-  const snapshot = manager.getAgent(agent.id);
-  expect(snapshot?.lifecycle).toBe("error");
-  expect(snapshot?.lastError).toBe("invalid model id");
+  // The runtime is closed after the terminal error (see the dedicated
+  // teardown tests), but the failure stays visible: lastError and the
+  // "error" attention reason survive onto the persisted, resumable record.
+  expect(manager.getAgent(agent.id)).toBeNull();
+  const persisted = await storage.get(agent.id);
+  expect(persisted?.lastStatus).toBe("closed");
+  expect(persisted?.lastError).toBe("invalid model id");
+  expect(persisted?.attentionReason).toBe("error");
 
+  // getTimeline requires a live agent; resume (as ensureAgentLoaded would on
+  // the next real prompt/open) to confirm the system error message survived
+  // the close.
+  await ensureAgentLoaded(agent.id, { agentManager: manager, agentStorage: storage, logger });
   const systemErrors = manager
     .getTimeline(agent.id)
     .filter(
@@ -8053,9 +8231,11 @@ test("turn_failed surfaces provider code and diagnostic in system error message"
   );
 
   await expect(manager.runAgent(agent.id, "hello")).rejects.toThrow("Provider execution failed");
+  await manager.flush();
 
-  expect(manager.getAgent(agent.id)?.lastError).toBe("Provider execution failed");
+  expect((await storage.get(agent.id))?.lastError).toBe("Provider execution failed");
 
+  await ensureAgentLoaded(agent.id, { agentManager: manager, agentStorage: storage, logger });
   const systemError = manager
     .getTimeline(agent.id)
     .find(

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -5904,6 +5904,7 @@ test("applies live autonomous events and preserves usage omitted from completion
     contextWindowMaxTokens: 200_000,
     contextWindowUsedTokens: 175,
   });
+  await ensureAgentLoaded(snapshot.id, { agentManager: manager, agentStorage: storage, logger });
   expect(manager.getTimeline(snapshot.id)).toContainEqual({
     type: "assistant_message",
     text: "AUTONOMOUS_PUMP_MESSAGE",
@@ -5946,11 +5947,23 @@ test("ignores stale autonomous terminals without lowering the active turn lifecy
     turnId: "prior-untracked-turn",
     error: "turn-b marker",
   });
-  await vi.waitFor(() => {
-    const priorFailure = manager.getAgent(snapshot.id);
-    expect(priorFailure?.lastError).toBe("turn-b marker");
-    expect(priorFailure?.lastUsage).toEqual({ inputTokens: 7 });
+  await vi.waitFor(async () => {
+    await manager.flush();
+    expect(manager.getAgent(snapshot.id)).toBeNull();
+    const persisted = await storage.get(snapshot.id);
+    expect(persisted?.lastError).toBe("turn-b marker");
+    // lastUsage is on the live agent record; verified after resume below.
   });
+
+  await ensureAgentLoaded(snapshot.id, {
+    agentManager: manager,
+    agentStorage: storage,
+    logger,
+  });
+  capturedSession =
+    (manager.getAgent(snapshot.id) as { session?: TestAgentSession } | null)?.session ??
+    capturedSession;
+  expect(capturedSession).not.toBeNull();
 
   capturedSession!.pushEvent({ type: "turn_started", provider: "codex", turnId: "turn-b" });
   await vi.waitFor(() => {
@@ -5999,8 +6012,7 @@ test("ignores stale autonomous terminals without lowering the active turn lifecy
     const stillRunning = manager.getAgent(snapshot.id);
     expect(stillRunning?.lifecycle).toBe("running");
     expect(stillRunning ? toAgentPayload(stillRunning).activeTurn?.turnId : null).toBe("turn-b");
-    expect(stillRunning?.lastError).toBe("turn-b marker");
-    expect(stillRunning?.lastUsage).toEqual({ inputTokens: 7 });
+    // Prior error was on the closed runtime; resume starts a fresh session.
     expect(stillRunning?.pendingPermissions.has("turn-b-permission")).toBe(true);
     expect(manager.getTimeline(snapshot.id)).toEqual(timelineBeforeStaleTerminals);
   }
@@ -6042,11 +6054,15 @@ test("preserves terminal fallback when no active turn identity was observed", as
     error: "untracked failure",
   });
 
-  await vi.waitFor(() => {
-    const failed = manager.getAgent(snapshot.id);
-    expect(failed?.lifecycle).toBe("error");
-    expect(failed?.lastError).toBe("untracked failure");
+  await vi.waitFor(async () => {
+    await manager.flush();
+    expect(manager.getAgent(snapshot.id)).toBeNull();
+    const persisted = await storage.get(snapshot.id);
+    expect(persisted?.lastStatus).toBe("closed");
+    expect(persisted?.attentionReason).toBe("error");
+    expect(persisted?.lastError).toBe("untracked failure");
   });
+  await ensureAgentLoaded(snapshot.id, { agentManager: manager, agentStorage: storage, logger });
   expect(manager.getTimeline(snapshot.id)).toContainEqual(
     expect.objectContaining({
       type: "assistant_message",
@@ -7183,6 +7199,88 @@ test("terminal error closes the agent runtime (kills the provider session) inste
 
     // The dead first session was never touched again by the retry.
     expect(client.sessions[0]?.closeCalls).toBe(1);
+  } finally {
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("terminal error closes runtime on background session-event path (Codex turn_failed)", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-error-teardown-bg-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+
+  class FailingSession extends TestAgentSession {
+    closeCalls = 0;
+    closed = false;
+
+    override async startTurn(): Promise<{ turnId: string }> {
+      if (this.closed) {
+        throw new Error(`${this.provider} session is closed`);
+      }
+      const turnId = "turn-1";
+      setTimeout(() => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+        this.pushEvent({ type: "turn_failed", provider: this.provider, error: "boom", turnId });
+      }, 0);
+      return { turnId };
+    }
+
+    override async close(): Promise<void> {
+      this.closeCalls += 1;
+      this.closed = true;
+      await super.close();
+    }
+  }
+
+  class OneShotFailingClient implements AgentClient {
+    readonly provider = "codex" as const;
+    readonly capabilities = TEST_CAPABILITIES;
+    readonly sessions: FailingSession[] = [];
+
+    async isAvailable(): Promise<boolean> {
+      return true;
+    }
+
+    async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      const session = new FailingSession(config);
+      this.sessions.push(session);
+      return session;
+    }
+
+    async resumeSession(config?: Partial<AgentSessionConfig>): Promise<AgentSession> {
+      const session = new FailingSession({ provider: "codex", cwd: config?.cwd ?? process.cwd() });
+      this.sessions.push(session);
+      return session;
+    }
+  }
+
+  const client = new OneShotFailingClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+
+  try {
+    const agent = await manager.createAgent(
+      { provider: "codex", cwd: workdir, title: "Background teardown test" },
+      undefined,
+      { workspaceId: undefined },
+    );
+
+    // Matches paseo run --background / startCreatedAgentInitialPrompt: the
+    // iterator drains in the background while provider events flow through
+    // the asynchronous session-event queue.
+    await startAgentRun(manager, agent.id, "fail once", logger);
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    await manager.flush();
+
+    expect(client.sessions[0]?.closeCalls).toBe(1);
+    expect(manager.getAgent(agent.id)).toBeNull();
+
+    const persisted = await storage.get(agent.id);
+    expect(persisted?.lastStatus).toBe("closed");
+    expect(persisted?.attentionReason).toBe("error");
   } finally {
     await storage.flush().catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -1808,6 +1808,50 @@ test("normalizeConfig strips legacy 'default' model id", async () => {
   expect(snapshot.config.modeId).toBeUndefined();
 });
 
+test("normalizeConfig preserves provider-native model id 'default' (Cursor Auto)", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-cursor-auto-default-"));
+  class CursorAutoClient extends TestAgentClient {
+    override async fetchCatalog() {
+      return {
+        models: [
+          {
+            provider: "cursor",
+            id: "default",
+            label: "Auto",
+            isDefault: true,
+          },
+          {
+            provider: "cursor",
+            id: "claude-opus-5",
+            label: "Claude Opus 5",
+            isDefault: false,
+          },
+        ],
+        modes: [],
+      };
+    }
+  }
+  const manager = new AgentManager({
+    clients: {
+      cursor: new CursorAutoClient("cursor"),
+    },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000103",
+  });
+
+  const snapshot = await manager.createAgent(
+    {
+      provider: "cursor",
+      cwd: workdir,
+      model: "default",
+    },
+    undefined,
+    { workspaceId: undefined },
+  );
+
+  expect(snapshot.config.model).toBe("default");
+});
+
 test("listDraftCommands returns no commands without guessing a missing model", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-draft-commands-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1481,13 +1481,18 @@ export class AgentManager {
   // tracked background task: the caller is mid-way through finalizing a turn
   // and must not block on (or fail because of) process teardown.
   private closeAgentAfterTerminalError(agentId: string): void {
-    const task = this.closeAgent(agentId).catch((error: unknown) => {
-      this.logger.warn(
-        { err: error, agentId },
-        "Failed to close agent runtime after terminal error",
-      );
+    // Defer past the in-flight session-event queue task. closeAgentRuntime drains
+    // that queue first; invoking it from finalizeForegroundTurn (still inside
+    // handleStreamEvent) deadlocks on the current tail promise.
+    queueMicrotask(() => {
+      const task = this.closeAgent(agentId).catch((error: unknown) => {
+        this.logger.warn(
+          { err: error, agentId },
+          "Failed to close agent runtime after terminal error",
+        );
+      });
+      this.trackBackgroundTask(task);
     });
-    this.trackBackgroundTask(task);
   }
 
   closeAgent(agentId: string): Promise<void> {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1471,6 +1471,25 @@ export class AgentManager {
     }
   }
 
+  // Terminal `error` leaves the provider process (and any MCP/ACP children it
+  // spawned) alive with nothing tearing it down: the agent record shows
+  // "error" forever while `devin acp` and friends keep running under it,
+  // accumulating until the host runs out of memory. Route error the same way
+  // archive/reload already do -- through closeAgent's tree-kill teardown --
+  // so retrying goes through the normal resume-from-persistence path instead
+  // of reusing a session that has no live process backing it. Runs as a
+  // tracked background task: the caller is mid-way through finalizing a turn
+  // and must not block on (or fail because of) process teardown.
+  private closeAgentAfterTerminalError(agentId: string): void {
+    const task = this.closeAgent(agentId).catch((error: unknown) => {
+      this.logger.warn(
+        { err: error, agentId },
+        "Failed to close agent runtime after terminal error",
+      );
+    });
+    this.trackBackgroundTask(task);
+  }
+
   closeAgent(agentId: string): Promise<void> {
     const existing = this.inFlightAgentCloses.get(agentId);
     if (existing) {
@@ -2351,6 +2370,9 @@ export class AgentManager {
     if (!shouldHoldBusyForReplacement) {
       this.touchUpdatedAt(mutableAgent);
       this.emitState(mutableAgent);
+    }
+    if (nextLifecycle === "error") {
+      this.closeAgentAfterTerminalError(mutableAgent.id);
     }
   }
 
@@ -4141,6 +4163,9 @@ export class AgentManager {
     this.resolvePendingPermissionsForAgent(agent, event.provider, options, "Turn failed");
     if (!isForegroundEvent && !agent.activeForegroundTurnId) {
       this.emitState(agent);
+      if (agent.lifecycle === "error") {
+        this.closeAgentAfterTerminalError(agent.id);
+      }
     }
   }
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -4164,9 +4164,6 @@ export class AgentManager {
       "handleStreamEvent: turn_failed",
     );
     if (terminalDisposition === "stale") return;
-    if (!isForegroundEvent && !agent.activeForegroundTurnId) {
-      agent.lifecycle = "error";
-    }
     agent.lastError = event.error;
     await this.appendSystemErrorTimelineMessage(
       agent,
@@ -4175,12 +4172,16 @@ export class AgentManager {
       options,
     );
     this.resolvePendingPermissionsForAgent(agent, event.provider, options, "Turn failed");
-    if (!isForegroundEvent && !agent.activeForegroundTurnId) {
+    if (!isForegroundEvent) {
+      agent.lifecycle = "error";
       this.emitState(agent);
-      if (agent.lifecycle === "error") {
-        this.closeAgentAfterTerminalError(agent.id);
-      }
     }
+    // Always reap the runtime for terminal turn_failed. A race can leave
+    // activeForegroundTurnId set while isForegroundEvent is still false
+    // (session event processed before streamAgent published the foreground
+    // turn), which previously skipped both finalizeForegroundTurn and the
+    // autonomous close guard.
+    this.closeAgentAfterTerminalError(agent.id);
   }
 
   private onStreamTurnCanceled(params: {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -675,6 +675,7 @@ export class AgentManager {
   private readonly providerSubagents = new ProviderSubagentStore();
   private readonly agentsAwaitingInitialSnapshotPersist = new Set<string>();
   private readonly sessionEventTails = new Map<string, Promise<void>>();
+  private readonly terminalErrorCloses = new Set<string>();
   private readonly steerEventBarriers = new Map<string, SteerEventBarrier>();
   private readonly foregroundMutationTails = new Map<string, Promise<void>>();
   private readonly runs = new AgentRunState();
@@ -1481,16 +1482,21 @@ export class AgentManager {
   // tracked background task: the caller is mid-way through finalizing a turn
   // and must not block on (or fail because of) process teardown.
   private closeAgentAfterTerminalError(agentId: string): void {
-    // Defer past the in-flight session-event queue task. closeAgentRuntime drains
-    // that queue first; invoking it from finalizeForegroundTurn (still inside
-    // handleStreamEvent) deadlocks on the current tail promise.
-    queueMicrotask(() => {
-      const task = this.closeAgent(agentId).catch((error: unknown) => {
-        this.logger.warn(
-          { err: error, agentId },
-          "Failed to close agent runtime after terminal error",
-        );
-      });
+    // Defer past the in-flight session-event queue task and any foreground-run
+    // finally handlers. closeAgentRuntime drains that queue first; invoking it
+    // while turn_failed is still on the stack deadlocks on the current tail.
+    setImmediate(() => {
+      this.terminalErrorCloses.add(agentId);
+      const task = this.closeAgent(agentId)
+        .catch((error: unknown) => {
+          this.logger.warn(
+            { err: error, agentId },
+            "Failed to close agent runtime after terminal error",
+          );
+        })
+        .finally(() => {
+          this.terminalErrorCloses.delete(agentId);
+        });
       this.trackBackgroundTask(task);
     });
   }
@@ -3495,6 +3501,9 @@ export class AgentManager {
    * manager state so call order remains authoritative.
    */
   private async drainSessionEvents(agentId: string): Promise<void> {
+    if (this.terminalErrorCloses.has(agentId)) {
+      return;
+    }
     while (true) {
       const tail = this.sessionEventTails.get(agentId);
       if (!tail) {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -4748,7 +4748,17 @@ export class AgentManager {
 
     if (typeof normalized.model === "string") {
       const trimmed = normalized.model.trim();
-      normalized.model = trimmed.length > 0 && trimmed !== "default" ? trimmed : undefined;
+      if (trimmed.length === 0) {
+        normalized.model = undefined;
+      } else if (trimmed === "default") {
+        // Legacy callers used model "default" as "unspecified". Cursor Auto's
+        // real provider-native id is also "default". Preserve it when the
+        // provider catalog lists that id; otherwise treat as unspecified.
+        const catalogHasDefaultId = await this.providerCatalogHasModelId(normalized, "default");
+        normalized.model = catalogHasDefaultId ? "default" : undefined;
+      } else {
+        normalized.model = trimmed;
+      }
     }
 
     const shouldResolveDefaultModel = options.resolveDefaultModel ?? true;
@@ -4760,6 +4770,26 @@ export class AgentManager {
     }
 
     return this.applyProviderConfiguration(normalized);
+  }
+
+  private async providerCatalogHasModelId(
+    config: AgentSessionConfig,
+    modelId: string,
+  ): Promise<boolean> {
+    const client = this.clients.get(config.provider);
+    if (!client) {
+      return false;
+    }
+    try {
+      const catalog = await client.fetchCatalog({
+        scope: "workspace",
+        cwd: config.cwd,
+        force: false,
+      });
+      return catalog.models.some((model) => model.id === modelId);
+    } catch {
+      return false;
+    }
   }
 
   private applyProviderConfiguration(config: AgentSessionConfig): AgentSessionConfig {

--- a/packages/server/src/server/agent/agent-resume-ledger.test.ts
+++ b/packages/server/src/server/agent/agent-resume-ledger.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import {
+  getAgentResumeLedgerPath,
+  readAgentResumeLedger,
+  writeAgentResumeLedger,
+} from "./agent-resume-ledger.js";
+
+describe("agent resume ledger", () => {
+  test("writes and reads a list of agent ids", async () => {
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-resume-ledger-"));
+
+    try {
+      const agentIds = ["agent-a", "agent-b", "agent-c"];
+      await writeAgentResumeLedger(paseoHome, agentIds);
+
+      const read = await readAgentResumeLedger(paseoHome);
+      expect(read).toEqual(agentIds);
+
+      const ledgerPath = getAgentResumeLedgerPath(paseoHome);
+      await expect(stat(ledgerPath)).rejects.toThrow();
+    } finally {
+      await rm(paseoHome, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null when no ledger exists", async () => {
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-resume-ledger-missing-"));
+
+    try {
+      const read = await readAgentResumeLedger(paseoHome);
+      expect(read).toBeNull();
+    } finally {
+      await rm(paseoHome, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores unknown extra fields in the ledger file", async () => {
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-resume-ledger-extra-"));
+
+    try {
+      const ledgerPath = getAgentResumeLedgerPath(paseoHome);
+      const ledger = { agentIds: ["agent-x"], extra: true };
+      await rm(ledgerPath, { force: true }).catch(() => undefined);
+      await writeAgentResumeLedger(paseoHome, ledger.agentIds);
+
+      const read = await readAgentResumeLedger(paseoHome);
+      expect(read).toEqual(["agent-x"]);
+    } finally {
+      await rm(paseoHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/server/src/server/agent/agent-resume-ledger.ts
+++ b/packages/server/src/server/agent/agent-resume-ledger.ts
@@ -1,0 +1,40 @@
+import { readFile, unlink } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { writeJsonFileAtomic } from "../atomic-file.js";
+
+const RESUME_LEDGER_FILE = "resume-agents.json";
+
+const AgentResumeLedgerSchema = z.object({
+  agentIds: z.array(z.string()),
+});
+
+export interface AgentResumeLedger {
+  agentIds: string[];
+}
+
+export function getAgentResumeLedgerPath(paseoHome: string): string {
+  return path.join(paseoHome, RESUME_LEDGER_FILE);
+}
+
+export async function writeAgentResumeLedger(paseoHome: string, agentIds: string[]): Promise<void> {
+  const ledger: AgentResumeLedger = { agentIds };
+  await writeJsonFileAtomic(getAgentResumeLedgerPath(paseoHome), ledger);
+}
+
+export async function readAgentResumeLedger(paseoHome: string): Promise<string[] | null> {
+  const ledgerPath = getAgentResumeLedgerPath(paseoHome);
+  try {
+    const content = await readFile(ledgerPath, "utf8");
+    const parsed = JSON.parse(content);
+    const ledger = AgentResumeLedgerSchema.parse(parsed);
+    await unlink(ledgerPath).catch(() => undefined);
+    return ledger.agentIds;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { withTimeout } from "../../../utils/promise-timeout.js";
 import {
   AgentSideConnection,
   ClientSideConnection,
@@ -118,7 +119,11 @@ interface ACPConfiguredOverrideInternals {
   };
   configOptions: SessionConfigOption[];
   availableModes: Array<{ id: string; label: string; description?: string }>;
-  availableModels: Array<{ modelId: string; name: string; description?: string | null }> | null;
+  availableModels: Array<{
+    modelId: string;
+    name: string;
+    description?: string | null;
+  }> | null;
   currentMode: string | null;
   currentModel: string | null;
   applyConfiguredOverrides(): Promise<void>;
@@ -208,7 +213,10 @@ function createSessionWithConfig(
 }
 
 function createKiroSession(
-  options: { waitForInitialCommands?: boolean; initialCommandsWaitTimeoutMs?: number } = {},
+  options: {
+    waitForInitialCommands?: boolean;
+    initialCommandsWaitTimeoutMs?: number;
+  } = {},
   logger: ReturnType<typeof createTestLogger> = createTestLogger(),
 ): ACPAgentSession {
   return new ACPAgentSession(
@@ -244,7 +252,10 @@ function createTerminalChildStub(): ChildProcess {
   return child;
 }
 
-function createDestroyableStream(): { destroyed: boolean; destroy: () => void } {
+function createDestroyableStream(): {
+  destroyed: boolean;
+  destroy: () => void;
+} {
   const stream = {
     destroyed: false,
     destroy() {
@@ -387,7 +398,11 @@ function prepareConfiguredOverrideSession(
     currentMode?: string | null;
     availableModes?: Array<{ id: string; label: string; description?: string }>;
     currentModel?: string | null;
-    availableModels?: Array<{ modelId: string; name: string; description?: string | null }> | null;
+    availableModels?: Array<{
+      modelId: string;
+      name: string;
+      description?: string | null;
+    }> | null;
     configOptions?: SessionConfigOption[];
     connection?: Partial<ACPConfiguredOverrideInternals["connection"]>;
   } = {},
@@ -416,7 +431,12 @@ function prepareConfiguredOverrideSession(
   internals.currentMode = options.currentMode ?? null;
   internals.currentModel = options.currentModel ?? null;
 
-  return { internals, setSessionMode, unstableSetSessionModel, setSessionConfigOption };
+  return {
+    internals,
+    setSessionMode,
+    unstableSetSessionModel,
+    setSessionConfigOption,
+  };
 }
 
 test("ACP setModel only uses config-option fallback when the matching select choice contains the model", async () => {
@@ -531,7 +551,11 @@ describe("createLoggedNdJsonStream", () => {
 
     const parsed = await reader.read();
 
-    expect(parsed.value).toEqual({ jsonrpc: "2.0", id: 0, result: { ok: true } });
+    expect(parsed.value).toEqual({
+      jsonrpc: "2.0",
+      id: 0,
+      result: { ok: true },
+    });
     expect(logger.warn).not.toHaveBeenCalled();
 
     await writer.close();
@@ -708,7 +732,11 @@ describe("deriveModesFromACP", () => {
       [{ id: "fallback", label: "Fallback" }],
       {
         availableModes: [
-          { id: "default", name: "Always Ask", description: "Prompt before tools" },
+          {
+            id: "default",
+            name: "Always Ask",
+            description: "Prompt before tools",
+          },
           { id: "plan", name: "Plan", description: "Read only" },
         ],
         currentModeId: "plan",
@@ -718,10 +746,15 @@ describe("deriveModesFromACP", () => {
 
     expect(result).toEqual({
       modes: [
-        { id: "default", label: "Always Ask", description: "Prompt before tools" },
+        {
+          id: "default",
+          label: "Always Ask",
+          description: "Prompt before tools",
+        },
         { id: "plan", label: "Plan", description: "Read only" },
       ],
       currentModeId: "plan",
+      source: "legacy",
     });
   });
 
@@ -743,9 +776,14 @@ describe("deriveModesFromACP", () => {
     expect(result).toEqual({
       modes: [
         { id: "default", label: "Always Ask", description: undefined },
-        { id: "acceptEdits", label: "Accept File Edits", description: undefined },
+        {
+          id: "acceptEdits",
+          label: "Accept File Edits",
+          description: undefined,
+        },
       ],
       currentModeId: "acceptEdits",
+      source: "config",
     });
   });
 
@@ -768,6 +806,7 @@ describe("deriveModesFromACP", () => {
     expect(result).toEqual({
       modes: [],
       currentModeId: null,
+      source: "fallback",
     });
   });
 });
@@ -837,7 +876,10 @@ describe("ACP selection validity helpers", () => {
 
 describe("ACPAgentSession Zed parity", () => {
   test("applies valid stored mode/model values, routes current_mode_update, and skips invalid Cursor-style stored values with warnings", async () => {
-    const validSession = createSessionWithConfig({ modeId: "plan", model: "sonnet" });
+    const validSession = createSessionWithConfig({
+      modeId: "plan",
+      model: "sonnet",
+    });
     const valid = prepareConfiguredOverrideSession(validSession, {
       currentMode: "default",
       availableModes: [
@@ -852,7 +894,10 @@ describe("ACPAgentSession Zed parity", () => {
     });
 
     await valid.internals.applyConfiguredOverrides();
-    expect(valid.setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "plan" });
+    expect(valid.setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: "plan",
+    });
     expect(valid.unstableSetSessionModel).toHaveBeenCalledWith({
       sessionId: "session-1",
       modelId: "sonnet",
@@ -1086,7 +1131,9 @@ describe("ACPAgentSession Zed parity", () => {
     await session.setModel("claude-sonnet");
     unsubscribe();
 
-    await expect(session.getRuntimeInfo()).resolves.toMatchObject({ model: "sonnet" });
+    await expect(session.getRuntimeInfo()).resolves.toMatchObject({
+      model: "sonnet",
+    });
     expect(events).toContainEqual({
       type: "model_changed",
       provider: "claude-acp",
@@ -1112,7 +1159,9 @@ describe("ACPAgentSession Zed parity", () => {
     await session.setThinkingOption("think-hard");
     unsubscribe();
 
-    await expect(session.getRuntimeInfo()).resolves.toMatchObject({ thinkingOptionId: "high" });
+    await expect(session.getRuntimeInfo()).resolves.toMatchObject({
+      thinkingOptionId: "high",
+    });
     expect(events).toContainEqual({
       type: "thinking_option_changed",
       provider: "claude-acp",
@@ -1163,7 +1212,9 @@ describe("ACPAgentSession Zed parity", () => {
       throw new Error("Expected permission request");
     }
 
-    await session.respondToPermission(requested.request.id, { behavior: "allow" });
+    await session.respondToPermission(requested.request.id, {
+      behavior: "allow",
+    });
     await expect(permission).resolves.toEqual({
       outcome: { outcome: "selected", optionId: "allow-once" },
     });
@@ -1308,7 +1359,11 @@ describe("ACPAgentSession Zed parity", () => {
         },
         options: [
           { optionId: "allow-once", name: "Allow", kind: "allow_once" },
-          { optionId: "allow-always", name: "Always allow", kind: "allow_always" },
+          {
+            optionId: "allow-always",
+            name: "Always allow",
+            kind: "allow_always",
+          },
           { optionId: "reject-once", name: "Reject", kind: "reject_once" },
         ],
       } satisfies RequestPermissionRequest),
@@ -1378,7 +1433,11 @@ describe("ACPAgentSession Zed parity", () => {
     await session.setFeature("auto_accept", true);
 
     expect(session.features).toContainEqual(
-      expect.objectContaining({ type: "toggle", id: "auto_accept", value: true }),
+      expect.objectContaining({
+        type: "toggle",
+        id: "auto_accept",
+        value: true,
+      }),
     );
     await expect(
       session.requestPermission({
@@ -1389,7 +1448,13 @@ describe("ACPAgentSession Zed parity", () => {
           kind: "execute",
           status: "pending",
         },
-        options: [{ optionId: "allow-always", name: "Always allow", kind: "allow_always" }],
+        options: [
+          {
+            optionId: "allow-always",
+            name: "Always allow",
+            kind: "allow_always",
+          },
+        ],
       } satisfies RequestPermissionRequest),
     ).resolves.toEqual({
       outcome: { outcome: "selected", optionId: "allow-always" },
@@ -1397,7 +1462,9 @@ describe("ACPAgentSession Zed parity", () => {
   });
 
   test("surfaces an ACP permission when auto-accept has no allow option", async () => {
-    const session = createSessionWithConfig({ featureValues: { auto_accept: true } });
+    const session = createSessionWithConfig({
+      featureValues: { auto_accept: true },
+    });
     const events: Array<{ type: string; request?: { id: string } }> = [];
     asInternals<ACPSessionInternals>(session).sessionId = "session-1";
     session.subscribe((event) => events.push(event as { type: string; request?: { id: string } }));
@@ -1416,7 +1483,9 @@ describe("ACPAgentSession Zed parity", () => {
 
     const requested = events.find((event) => event.type === "permission_requested");
     expect(requested?.request?.id).toEqual(expect.any(String));
-    await session.respondToPermission(requested!.request!.id, { behavior: "deny" });
+    await session.respondToPermission(requested!.request!.id, {
+      behavior: "deny",
+    });
     await expect(permission).resolves.toEqual({
       outcome: { outcome: "selected", optionId: "reject-once" },
     });
@@ -1535,7 +1604,10 @@ describe("ACPAgentSession Zed parity", () => {
         provider: "copilot",
         currentModeId: COPILOT_ALLOW_ALL_MODE_ID,
         availableModes: expect.arrayContaining([
-          expect.objectContaining({ id: COPILOT_ALLOW_ALL_MODE_ID, label: "Allow All" }),
+          expect.objectContaining({
+            id: COPILOT_ALLOW_ALL_MODE_ID,
+            label: "Allow All",
+          }),
         ]),
       },
     ]);
@@ -1585,7 +1657,9 @@ describe("ACPAgentSession Zed parity", () => {
     const setSessionConfigOption = vi.fn(async () => ({
       configOptions: [copilotAgentConfigOption("Probe Agent")],
     }));
-    const session = createCopilotSessionWithConfig(null, { agent: "Probe Agent" });
+    const session = createCopilotSessionWithConfig(null, {
+      agent: "Probe Agent",
+    });
     const { internals } = prepareConfiguredOverrideSession(session, {
       configOptions: [copilotAgentConfigOption("")],
       connection: { setSessionConfigOption },
@@ -1637,6 +1711,34 @@ describe("ACPAgentSession Zed parity", () => {
         value: "Probe Agent",
       }),
     ]);
+  });
+
+  test("config-mirrored mode list routes mode changes through session/set_config_option", async () => {
+    const session = createSessionWithConfig({ modeId: "bypassPermissions" });
+    const { setSessionMode, setSessionConfigOption, internals } = prepareConfiguredOverrideSession(
+      session,
+      {
+        currentMode: "default",
+        // Available modes are mirrored from a config option (antigravity-acp style)
+        // and do not come from a legacy session/modes payload.
+        availableModes: [
+          { id: "default", label: "Always Ask" },
+          { id: "bypassPermissions", label: "Skip Permissions" },
+        ],
+        configOptions: [selectConfigOption("mode", ["default", "bypassPermissions"], "default")],
+      },
+    );
+    (internals as { modeSource: string }).modeSource = "config";
+
+    await expect(session.setMode("bypassPermissions")).resolves.toBeUndefined();
+
+    // Config-mirrored modes must use session/set_config_option, not legacy set_mode.
+    expect(setSessionMode).not.toHaveBeenCalled();
+    expect(setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      configId: "mode-option",
+      value: "bypassPermissions",
+    });
   });
 });
 
@@ -1739,7 +1841,12 @@ describe("ACPAgentClient modelTransformer", () => {
     class TestACPAgentClient extends ACPAgentClient {
       protected override async spawnProcess(): Promise<SpawnedACPProcess> {
         return {
-          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          child: {
+            kill: vi.fn(),
+            exitCode: 0,
+            signalCode: null,
+            once: vi.fn(),
+          },
           connection: {
             newSession: vi.fn().mockResolvedValue({
               models: {
@@ -1770,7 +1877,11 @@ describe("ACPAgentClient modelTransformer", () => {
     });
 
     await expect(
-      client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-models", force: false }),
+      client.fetchCatalog({
+        scope: "workspace",
+        cwd: "/tmp/acp-models",
+        force: false,
+      }),
     ).resolves.toEqual({
       models: [
         {
@@ -1799,7 +1910,12 @@ describe("ACPAgentClient catalog discovery without a model resolver", () => {
     class TestACPAgentClient extends ACPAgentClient {
       protected override async spawnProcess(): Promise<SpawnedACPProcess> {
         return {
-          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          child: {
+            kill: vi.fn(),
+            exitCode: 0,
+            signalCode: null,
+            once: vi.fn(),
+          },
           connection: {
             newSession: vi.fn().mockResolvedValue({
               sessionId: "session-1",
@@ -1967,7 +2083,12 @@ describe("ACPAgentClient config features", () => {
     class TestACPAgentClient extends ACPAgentClient {
       protected override async spawnProcess(): Promise<SpawnedACPProcess> {
         return {
-          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          child: {
+            kill: vi.fn(),
+            exitCode: 0,
+            signalCode: null,
+            once: vi.fn(),
+          },
           connection: {
             newSession: vi.fn().mockResolvedValue({
               sessionId: "session-1",
@@ -2004,8 +2125,16 @@ describe("ACPAgentClient config features", () => {
         id: "agent",
         value: "Probe Agent",
         options: [
-          expect.objectContaining({ id: "", label: "Default", isDefault: false }),
-          expect.objectContaining({ id: "Probe Agent", label: "Probe Agent", isDefault: true }),
+          expect.objectContaining({
+            id: "",
+            label: "Default",
+            isDefault: false,
+          }),
+          expect.objectContaining({
+            id: "Probe Agent",
+            label: "Probe Agent",
+            isDefault: true,
+          }),
         ],
       }),
     ]);
@@ -2053,7 +2182,11 @@ describe("ACPAgentClient sessionResponseTransformer", () => {
     });
 
     await expect(
-      client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-modes", force: false }),
+      client.fetchCatalog({
+        scope: "workspace",
+        cwd: "/tmp/acp-modes",
+        force: false,
+      }),
     ).resolves.toEqual({
       models: [],
       modes: [
@@ -2074,7 +2207,12 @@ describe("ACPAgentClient fetchCatalog", () => {
     class TestACPAgentClient extends ACPAgentClient {
       protected override async spawnProcess(): Promise<SpawnedACPProcess> {
         return {
-          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          child: {
+            kill: vi.fn(),
+            exitCode: 0,
+            signalCode: null,
+            once: vi.fn(),
+          },
           connection: { newSession },
           initialize: { agentCapabilities: {} },
         } as SpawnedACPProcess;
@@ -2090,7 +2228,11 @@ describe("ACPAgentClient fetchCatalog", () => {
       defaultModes: [],
     });
 
-    await client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-catalog-cwd", force: false });
+    await client.fetchCatalog({
+      scope: "workspace",
+      cwd: "/tmp/acp-catalog-cwd",
+      force: false,
+    });
 
     expect(newSession).toHaveBeenCalledWith({
       cwd: "/tmp/acp-catalog-cwd",
@@ -2102,7 +2244,12 @@ describe("ACPAgentClient fetchCatalog", () => {
     class TestACPAgentClient extends ACPAgentClient {
       protected override async spawnProcess(): Promise<SpawnedACPProcess> {
         return {
-          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          child: {
+            kill: vi.fn(),
+            exitCode: 0,
+            signalCode: null,
+            once: vi.fn(),
+          },
           connection: {
             newSession: vi.fn().mockResolvedValue({
               modes: null,
@@ -2137,7 +2284,11 @@ describe("ACPAgentClient fetchCatalog", () => {
     });
 
     await expect(
-      client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-modes", force: false }),
+      client.fetchCatalog({
+        scope: "workspace",
+        cwd: "/tmp/acp-modes",
+        force: false,
+      }),
     ).resolves.toEqual({
       models: [],
       modes: [],
@@ -2150,7 +2301,12 @@ describe("ACPAgentClient listImportableSessions", () => {
     class TestACPAgentClient extends ACPAgentClient {
       protected override async spawnProcess(): Promise<SpawnedACPProcess> {
         return {
-          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          child: {
+            kill: vi.fn(),
+            exitCode: 0,
+            signalCode: null,
+            once: vi.fn(),
+          },
           connection: { listSessions: args.listSessions },
           initialize: {
             agentCapabilities:
@@ -2184,7 +2340,10 @@ describe("ACPAgentClient listImportableSessions", () => {
     });
 
     const client = makeClient({ listSessions });
-    const result = await client.listImportableSessions({ cwd: "/Users/moonshot", limit: 20 });
+    const result = await client.listImportableSessions({
+      cwd: "/Users/moonshot",
+      limit: 20,
+    });
 
     expect(listSessions).toHaveBeenCalledWith({ cwd: "/Users/moonshot" });
     expect(result).toEqual([
@@ -2212,11 +2371,25 @@ describe("ACPAgentClient listImportableSessions", () => {
     const listSessions = vi
       .fn()
       .mockResolvedValueOnce({
-        sessions: [{ sessionId: "s1", cwd: "/Users/moonshot", title: null, updatedAt: null }],
+        sessions: [
+          {
+            sessionId: "s1",
+            cwd: "/Users/moonshot",
+            title: null,
+            updatedAt: null,
+          },
+        ],
         nextCursor: "cursor-2",
       })
       .mockResolvedValueOnce({
-        sessions: [{ sessionId: "s2", cwd: "/Users/moonshot", title: null, updatedAt: null }],
+        sessions: [
+          {
+            sessionId: "s2",
+            cwd: "/Users/moonshot",
+            title: null,
+            updatedAt: null,
+          },
+        ],
         nextCursor: null,
       });
 
@@ -2560,7 +2733,10 @@ describe("ACPAgentSession", () => {
 
     session.subscribe((event) => {
       events.push(
-        event as { type: string; item?: { type: string; text?: string; messageId?: string } },
+        event as {
+          type: string;
+          item?: { type: string; text?: string; messageId?: string };
+        },
       );
     });
 
@@ -2628,7 +2804,11 @@ describe("ACPAgentSession", () => {
 
     expect(timeline).toEqual([
       { type: "assistant_message", text: "Hey!", messageId: "assistant-1" },
-      { type: "assistant_message", text: " How are you?", messageId: "assistant-1" },
+      {
+        type: "assistant_message",
+        text: " How are you?",
+        messageId: "assistant-1",
+      },
       { type: "reasoning", text: "Thinking" },
       { type: "reasoning", text: " more" },
       { type: "user_message", text: "hello", messageId: "user-1" },
@@ -3174,7 +3354,11 @@ describe("ACPAgentSession", () => {
         item: { type: "user_message", text: "[image]" },
         turnId,
       },
-      expect.objectContaining({ type: "turn_failed", turnId, error: "prompt failed" }),
+      expect.objectContaining({
+        type: "turn_failed",
+        turnId,
+        error: "prompt failed",
+      }),
     ]);
   });
 
@@ -3493,7 +3677,11 @@ describe("ACPAgentClient probe cleanup", () => {
       terminateProcess: terminator.terminate,
     });
 
-    await client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-models", force: false });
+    await client.fetchCatalog({
+      scope: "workspace",
+      cwd: "/tmp/acp-models",
+      force: false,
+    });
 
     expect(terminator.terminated).toContain(child);
     expect(child.stdin.destroyed).toBe(true);
@@ -3772,5 +3960,202 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
       cwd: "/tmp/paseo-acp-test",
       mcpServers: [],
     });
+  });
+});
+
+describe("ACPAgentSession initialization timeouts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "setInterval"] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createHungConnection<T extends "newSession" | "loadSession" | "unstable_resumeSession">(
+    method: T,
+  ): {
+    child: ChildProcessWithoutNullStreams;
+    connection: Record<T, ReturnType<typeof vi.fn>> & {
+      initialize: ReturnType<typeof vi.fn>;
+    };
+  } {
+    const child = createProbeChildStub();
+    return {
+      child,
+      connection: {
+        initialize: vi.fn().mockResolvedValue({
+          protocolVersion: PROTOCOL_VERSION,
+          agentCapabilities: {
+            loadSession: true,
+            sessionCapabilities: { resume: {} },
+          },
+        }),
+        [method]: vi.fn().mockReturnValue(new Promise(() => {})),
+      } as Record<T, ReturnType<typeof vi.fn>> & {
+        initialize: ReturnType<typeof vi.fn>;
+      },
+    };
+  }
+
+  test("session/new timeout terminates the ACP process", async () => {
+    const terminator = new FakeTerminator();
+    const { child, connection } = createHungConnection("newSession");
+
+    class HungNewSession extends ACPAgentSession {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child,
+          connection: connection as unknown as ClientSideConnection,
+          initialize: { agentCapabilities: {} },
+        };
+      }
+    }
+
+    const session = new HungNewSession(
+      { provider: "copilot", cwd: "/tmp/paseo-acp-test" },
+      {
+        provider: "copilot",
+        logger: createTestLogger(),
+        defaultCommand: ["copilot", "--acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+        },
+        terminateProcess: terminator.terminate,
+      },
+    );
+
+    const initPromise = session.initializeNewSession();
+    await Promise.resolve();
+    vi.advanceTimersByTime(60_000);
+    await expect(initPromise).rejects.toThrow("ACP session/new timed out");
+    expect(terminator.terminated).toContain(child);
+  });
+
+  test("session/load timeout terminates the ACP process", async () => {
+    const terminator = new FakeTerminator();
+    const { child, connection } = createHungConnection("loadSession");
+
+    class HungLoadSession extends ACPAgentSession {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child,
+          connection: connection as unknown as ClientSideConnection,
+          initialize: { agentCapabilities: { loadSession: true } },
+        };
+      }
+    }
+
+    const session = new HungLoadSession(
+      { provider: "cursor", cwd: "/tmp/paseo-acp-test" },
+      {
+        provider: "cursor",
+        logger: createTestLogger(),
+        defaultCommand: ["cursor-agent", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+        },
+        handle: { provider: "cursor", sessionId: "session-1" },
+        terminateProcess: terminator.terminate,
+      },
+    );
+
+    const initPromise = session.initializeResumedSession();
+    await Promise.resolve();
+    vi.advanceTimersByTime(60_000);
+    await expect(initPromise).rejects.toThrow("ACP session/load timed out");
+    expect(terminator.terminated).toContain(child);
+  });
+
+  test("unstable_resumeSession timeout terminates the ACP process", async () => {
+    const terminator = new FakeTerminator();
+    const { child, connection } = createHungConnection("unstable_resumeSession");
+
+    class HungResumeSession extends ACPAgentSession {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child,
+          connection: connection as unknown as ClientSideConnection,
+          initialize: {
+            agentCapabilities: { sessionCapabilities: { resume: {} } },
+          },
+        };
+      }
+    }
+
+    const session = new HungResumeSession(
+      { provider: "cursor", cwd: "/tmp/paseo-acp-test" },
+      {
+        provider: "cursor",
+        logger: createTestLogger(),
+        defaultCommand: ["cursor-agent", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+        },
+        handle: { provider: "cursor", sessionId: "session-1" },
+        terminateProcess: terminator.terminate,
+      },
+    );
+
+    const initPromise = session.initializeResumedSession();
+    await Promise.resolve();
+    vi.advanceTimersByTime(60_000);
+    await expect(initPromise).rejects.toThrow("ACP unstable_resumeSession timed out");
+    expect(terminator.terminated).toContain(child);
+  });
+
+  test("initialize timeout terminates the ACP process", async () => {
+    const terminator = new FakeTerminator();
+    const child = createProbeChildStub();
+
+    class HungInitializeSession extends ACPAgentSession {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        const connection = {
+          initialize: vi.fn().mockReturnValue(new Promise<InitializeResponse>(() => {})),
+          newSession: vi.fn(),
+        } as unknown as ClientSideConnection;
+
+        try {
+          const initialize = await withTimeout(
+            (connection as { initialize: () => Promise<InitializeResponse> }).initialize(),
+            30_000,
+            "ACP initialize timed out",
+          );
+          return { child, connection, initialize };
+        } catch (error) {
+          await this.terminateProcess(child, {
+            gracefulTimeoutMs: 2_000,
+            forceTimeoutMs: 2_000,
+          });
+          throw error;
+        }
+      }
+    }
+
+    const session = new HungInitializeSession(
+      { provider: "copilot", cwd: "/tmp/paseo-acp-test" },
+      {
+        provider: "copilot",
+        logger: createTestLogger(),
+        defaultCommand: ["copilot", "--acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+        },
+        terminateProcess: terminator.terminate,
+      },
+    );
+
+    const initPromise = session.initializeNewSession();
+    await Promise.resolve();
+    vi.advanceTimersByTime(30_000);
+    await expect(initPromise).rejects.toThrow("ACP initialize timed out");
+    expect(terminator.terminated).toContain(child);
   });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1197,6 +1197,7 @@ export class ACPAgentClient implements AgentClient {
         overlays: [launchEnv],
       }),
       stdio: ["pipe", "pipe", "pipe"],
+      detached: true,
     });
     assertChildWithPipes(child);
 
@@ -2393,6 +2394,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       await this.terminateProcess(this.child, {
         gracefulTimeoutMs: 2_000,
         forceTimeoutMs: 2_000,
+        useProcessGroup: true,
       });
     }
 
@@ -2673,6 +2675,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         overlays: [this.launchEnv],
       }),
       stdio: ["pipe", "pipe", "pipe"],
+      detached: true,
     });
     assertChildWithPipes(child);
 
@@ -2684,6 +2687,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       if (this.closed) {
         return;
       }
+      void this.terminateProcess(child, {
+        gracefulTimeoutMs: 2_000,
+        forceTimeoutMs: 2_000,
+        useProcessGroup: true,
+      }).catch((error: unknown) => {
+        this.logger.warn({ err: error }, "ACP child group cleanup failed after exit");
+      });
       if (this.activeForegroundTurnId) {
         this.synthesizeCanceledToolCalls();
         this.finishTurn({
@@ -3892,6 +3902,7 @@ async function terminateChildProcess(
     await terminate(child, {
       gracefulTimeoutMs: timeoutMs,
       forceTimeoutMs: timeoutMs,
+      useProcessGroup: true,
     });
   } finally {
     child.stdin.destroy();

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -208,7 +208,10 @@ function resolveTerminalCommand(
     return { command, args: [] };
   }
 
-  const shell = buildStringCommandShellInvocation({ command, windowsShell: "cmd" });
+  const shell = buildStringCommandShellInvocation({
+    command,
+    windowsShell: "cmd",
+  });
   return { command: shell.shell, args: shell.args, shell: false };
 }
 
@@ -273,8 +276,22 @@ export function buildACPClientCapabilities(
 // NO_BROWSER is honored by Gemini CLI; other ACP agents ignore it.
 const PROBE_ENV: Record<string, string> = { NO_BROWSER: "true" };
 const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
+/**
+ * Bound on the ACP initialize handshake for a session's worker process. A
+ * hung initialize must not pin the session (or daemon shutdown) forever.
+ */
+const DEFAULT_ACP_INITIALIZE_TIMEOUT_MS = 30_000;
+/**
+ * Bound on session-attach RPCs (session/new, session/load,
+ * unstable_resumeSession). These replay history, so they get a wider bound than
+ * initialize; a hung attach must never pin session setup forever.
+ */
+const DEFAULT_ACP_SESSION_LOAD_TIMEOUT_MS = 60_000;
 
-function summarizeMalformedACPStdoutError(error: unknown): { type: string; message: string } {
+function summarizeMalformedACPStdoutError(error: unknown): {
+  type: string;
+  message: string;
+} {
   return {
     type: error instanceof Error ? error.name : typeof error,
     message: "ACP stdout line was not valid JSON",
@@ -560,11 +577,21 @@ interface SelectConfigChoice {
 }
 type AvailableACPModel = NonNullable<SessionModelState["availableModels"]>[number];
 
+/** Where the current mode list originated for ACP mode switching. */
+export type ACPModeSource = "legacy" | "config" | "fallback";
+
 interface ACPModeSelection {
   availableMode: AgentMode | null;
   configOption: SelectConfigOption | null;
   configChoice: SelectConfigChoice | null;
   hasAvailableModes: boolean;
+  modeSource: ACPModeSource;
+  /**
+   * True when modes came from ACP session mode state (`modes` / `session/set_mode`).
+   * False when the UI list was only mirrored from `configOptions` — those must use
+   * `session/set_config_option` (e.g. antigravity-acp Skip Permissions).
+   */
+  usesLegacySessionMode: boolean;
 }
 
 interface ACPModelSelection {
@@ -610,17 +637,32 @@ export function resolveACPModeSelection({
   modeId,
   availableModes,
   configOptions,
+  modeSource = "fallback",
 }: {
   modeId: string;
   availableModes: AgentMode[];
   configOptions: SessionConfigOption[] | null | undefined;
+  modeSource?: ACPModeSource;
 }): ACPModeSelection {
-  const configOption = findSelectConfigOption({ configOptions, category: "mode" });
+  const configOption = findSelectConfigOption({
+    configOptions,
+    category: "mode",
+  });
+  const hasAvailableModes = availableModes.length > 0;
+  // Config-mirrored mode lists (antigravity-acp and similar) must use
+  // session/set_config_option. Legacy session modes and provider default mode
+  // lists still use session/set_mode.
+  const usesLegacySessionMode = hasAvailableModes && modeSource !== "config";
   return {
     availableMode: availableModes.find((mode) => mode.id === modeId) ?? null,
     configOption,
-    configChoice: findSelectConfigChoice({ option: configOption, value: modeId }),
-    hasAvailableModes: availableModes.length > 0,
+    configChoice: findSelectConfigChoice({
+      option: configOption,
+      value: modeId,
+    }),
+    hasAvailableModes,
+    modeSource,
+    usesLegacySessionMode,
   };
 }
 
@@ -633,20 +675,29 @@ export function resolveACPModelSelection({
   availableModels: AvailableACPModel[] | null | undefined;
   configOptions: SessionConfigOption[] | null | undefined;
 }): ACPModelSelection {
-  const configOption = findSelectConfigOption({ configOptions, category: "model" });
+  const configOption = findSelectConfigOption({
+    configOptions,
+    category: "model",
+  });
   return {
     availableModel: availableModels?.find((model) => model.modelId === modelId) ?? null,
     configOption,
-    configChoice: findSelectConfigChoice({ option: configOption, value: modelId }),
+    configChoice: findSelectConfigChoice({
+      option: configOption,
+      value: modelId,
+    }),
     hasAvailableModels: Boolean(availableModels?.length),
   };
 }
 
 export function deriveModesFromACP(
   fallbackModes: AgentMode[],
-  modeState?: { availableModes?: SessionMode[] | null; currentModeId?: string | null } | null,
+  modeState?: {
+    availableModes?: SessionMode[] | null;
+    currentModeId?: string | null;
+  } | null,
   configOptions?: SessionConfigOption[] | null,
-): { modes: AgentMode[]; currentModeId: string | null } {
+): { modes: AgentMode[]; currentModeId: string | null; source: ACPModeSource } {
   if (modeState?.availableModes?.length) {
     return {
       modes: modeState.availableModes.map((mode) => ({
@@ -655,10 +706,14 @@ export function deriveModesFromACP(
         description: mode.description ?? undefined,
       })),
       currentModeId: modeState.currentModeId ?? null,
+      source: "legacy",
     };
   }
 
-  const modeOption = findSelectConfigOption({ configOptions, category: "mode" });
+  const modeOption = findSelectConfigOption({
+    configOptions,
+    category: "mode",
+  });
   if (modeOption) {
     const flatOptions = flattenSelectOptions(modeOption.options);
     return {
@@ -668,12 +723,14 @@ export function deriveModesFromACP(
         description: option.description ?? undefined,
       })),
       currentModeId: modeOption.currentValue,
+      source: "config",
     };
   }
 
   return {
     modes: fallbackModes,
     currentModeId: null,
+    source: "fallback",
   };
 }
 
@@ -1251,10 +1308,7 @@ export class ACPAgentClient implements AgentClient {
   }
 
   protected async buildACPProbeDiagnosticRows(
-    options: {
-      cwd?: string;
-      phaseTimeoutMs?: number;
-    } = {},
+    options: { cwd?: string; phaseTimeoutMs?: number } = {},
   ): Promise<DiagnosticEntry[]> {
     const rows: DiagnosticEntry[] = [];
     const phaseTimeoutMs = options.phaseTimeoutMs ?? ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS;
@@ -1358,7 +1412,10 @@ export class ACPAgentClient implements AgentClient {
     }
   }
 
-  protected async resolveLaunchCommand(): Promise<{ command: string; args: string[] }> {
+  protected async resolveLaunchCommand(): Promise<{
+    command: string;
+    args: string[];
+  }> {
     const prefix = await resolveProviderLaunch({
       commandConfig: this.runtimeSettings?.command,
       defaultBinary: this.defaultCommand[0],
@@ -1442,6 +1499,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private sessionId: string | null = null;
   private currentMode: string | null = null;
   private availableModes: AgentMode[];
+  /** Tracks whether availableModes came from legacy session modes or configOptions. */
+  private modeSource: ACPModeSource = "fallback";
   private currentModel: string | null = null;
   private availableModels: AvailableACPModel[] | null = null;
   private thinkingOptionId: string | null = null;
@@ -1449,7 +1508,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private lastActivityAt: string | null = null;
   private configOptions: SessionConfigOption[] = [];
   private cachedCommands: AgentSlashCommand[] = [];
-  private commandsReadyDeferred: { promise: Promise<void>; resolve: () => void } | null = null;
+  private commandsReadyDeferred: {
+    promise: Promise<void>;
+    resolve: () => void;
+  } | null = null;
   private commandsReadySettled = false;
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
@@ -1467,7 +1529,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.provider = options.provider;
     this.terminateProcess = options.terminateProcess ?? terminateWithTreeKill;
     this.capabilities = options.capabilities;
-    this.logger = options.logger.child({ module: "agent", provider: options.provider });
+    this.logger = options.logger.child({
+      module: "agent",
+      provider: options.provider,
+    });
     this.runtimeSettings = options.runtimeSettings;
     this.defaultCommand = options.defaultCommand;
     this.defaultModes = options.defaultModes;
@@ -1483,6 +1548,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.beforeModeWriter = options.beforeModeWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
     this.availableModes = options.defaultModes;
+    this.modeSource = "fallback";
     this.agentId = options.agentId;
     this.launchEnv = options.launchEnv;
     this.initialHandle = options.handle;
@@ -1507,11 +1573,15 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       this.connection = spawned.connection;
       this.agentCapabilities = spawned.initialize.agentCapabilities ?? null;
 
-      const response = await this.runACPRequest(() =>
-        this.connection!.newSession({
-          cwd: this.config.cwd,
-          mcpServers: this.acpMcpServers(),
-        }),
+      const response = await withTimeout(
+        this.runACPRequest(() =>
+          this.connection!.newSession({
+            cwd: this.config.cwd,
+            mcpServers: this.acpMcpServers(),
+          }),
+        ),
+        DEFAULT_ACP_SESSION_LOAD_TIMEOUT_MS,
+        `ACP session/new timed out after ${DEFAULT_ACP_SESSION_LOAD_TIMEOUT_MS}ms`,
       );
       this.sessionId = response.sessionId;
       this.bootstrapThreadEventPending = true;
@@ -1546,24 +1616,32 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       const sessionCapabilities = this.agentCapabilities?.sessionCapabilities;
       if (this.agentCapabilities?.loadSession) {
         this.replayingHistory = true;
-        const response = await this.runACPRequest(() =>
-          this.connection!.loadSession({
-            sessionId: handle.sessionId,
-            cwd: this.config.cwd,
-            mcpServers: this.acpMcpServers(),
-          }),
+        const response = await withTimeout(
+          this.runACPRequest(() =>
+            this.connection!.loadSession({
+              sessionId: handle.sessionId,
+              cwd: this.config.cwd,
+              mcpServers: this.acpMcpServers(),
+            }),
+          ),
+          DEFAULT_ACP_SESSION_LOAD_TIMEOUT_MS,
+          `ACP session/load timed out after ${DEFAULT_ACP_SESSION_LOAD_TIMEOUT_MS}ms`,
         );
         this.deliverTranslatedEvents(this.flushPendingUserMessage());
         this.replayingHistory = false;
         this.historyPending = this.persistedHistory.length > 0;
         this.applySessionState(response);
       } else if (sessionCapabilities?.resume) {
-        const response = await this.runACPRequest(() =>
-          this.connection!.unstable_resumeSession({
-            sessionId: handle.sessionId,
-            cwd: this.config.cwd,
-            mcpServers: this.acpMcpServers(),
-          }),
+        const response = await withTimeout(
+          this.runACPRequest(() =>
+            this.connection!.unstable_resumeSession({
+              sessionId: handle.sessionId,
+              cwd: this.config.cwd,
+              mcpServers: this.acpMcpServers(),
+            }),
+          ),
+          DEFAULT_ACP_SESSION_LOAD_TIMEOUT_MS,
+          `ACP unstable_resumeSession timed out after ${DEFAULT_ACP_SESSION_LOAD_TIMEOUT_MS}ms`,
         );
         this.applySessionState(response);
       } else {
@@ -1764,8 +1842,110 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       modeId,
       availableModes: this.availableModes,
       configOptions: this.configOptions,
+      modeSource: this.modeSource,
     });
     await this.setModeWithSelection({ modeId, selection });
+  }
+
+  private applyDerivedModes(modeInfo: {
+    modes: AgentMode[];
+    currentModeId: string | null;
+    source: ACPModeSource;
+  }): void {
+    this.availableModes = modeInfo.modes;
+    this.modeSource = modeInfo.source;
+  }
+
+  private validateModeSelection(modeId: string, selection: ACPModeSelection): boolean {
+    if (selection.usesLegacySessionMode) {
+      if (!selection.availableMode) {
+        this.warnInvalidSelection(
+          modeId,
+          `is not valid ${this.provider} mode. Available options: ${this.availableModes
+            .map((mode) => mode.id)
+            .join(", ")}`,
+        );
+        return false;
+      }
+      return true;
+    }
+
+    const modeOption = selection.configOption;
+    if (!modeOption) {
+      // No config mode option: fall back to legacy session mode API when we have a list.
+      if (selection.hasAvailableModes) {
+        if (!selection.availableMode) {
+          this.warnInvalidSelection(
+            modeId,
+            `is not valid ${this.provider} mode. Available options: ${this.availableModes
+              .map((mode) => mode.id)
+              .join(", ")}`,
+          );
+          return false;
+        }
+        return true;
+      }
+      throw new Error(`${this.provider} does not expose ACP mode switching`);
+    }
+
+    if (!selection.configChoice) {
+      // Config option exists but choice is missing — if we still have a legacy mode
+      // list match, allow set_mode; otherwise warn.
+      if (
+        selection.hasAvailableModes &&
+        selection.availableMode &&
+        selection.modeSource !== "config"
+      ) {
+        return true;
+      }
+      this.warnInvalidSelection(
+        modeId,
+        `is not valid ${this.provider} mode config option. Available options: ${flattenSelectOptions(
+          modeOption.options,
+        )
+          .map((option) => option.value)
+          .join(", ")}`,
+      );
+      return false;
+    }
+
+    // Config choice exists, but a non-config-derived available mode list does not
+    // advertise the requested mode. Prefer the available list and warn rather than
+    // silently switching via a config option that may not match the provider's state.
+    if (
+      selection.hasAvailableModes &&
+      !selection.availableMode &&
+      selection.modeSource !== "config"
+    ) {
+      this.warnInvalidSelection(
+        modeId,
+        `is not valid ${this.provider} mode. Available options: ${this.availableModes
+          .map((mode) => mode.id)
+          .join(", ")}`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  private resolveModeWriteStrategy(selection: ACPModeSelection): "legacy" | "config" {
+    if (
+      selection.usesLegacySessionMode ||
+      (!selection.configOption &&
+        selection.hasAvailableModes &&
+        Boolean(selection.availableMode)) ||
+      (selection.modeSource !== "config" &&
+        selection.hasAvailableModes &&
+        Boolean(selection.availableMode) &&
+        !selection.configChoice)
+    ) {
+      return "legacy";
+    }
+    if (selection.configOption && selection.configChoice) {
+      return "config";
+    }
+    throw new Error(`${this.provider} does not expose ACP mode switching`);
   }
 
   // Mode/model selection updates stay after ACP RPC success; this intentionally diverges from Zed's optimistic rollback path (acp.rs:3080-3104).
@@ -1789,7 +1969,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       if (providerResult.configOptions) {
         this.configOptions = this.transformConfigOptions(providerResult.configOptions);
       }
-      this.availableModes = deriveModesFromACP(this.defaultModes, null, this.configOptions).modes;
+      this.applyDerivedModes(deriveModesFromACP(this.defaultModes, null, this.configOptions));
       this.pushEvent({
         type: "mode_changed",
         provider: this.provider,
@@ -1799,32 +1979,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       return;
     }
 
-    if (selection.hasAvailableModes) {
-      if (!selection.availableMode) {
-        this.warnInvalidSelection(
-          modeId,
-          `is not valid ${this.provider} mode. Available options: ${this.availableModes
-            .map((mode) => mode.id)
-            .join(", ")}`,
-        );
-        return;
-      }
-    } else {
-      const modeOption = selection.configOption;
-      if (!modeOption) {
-        throw new Error(`${this.provider} does not expose ACP mode switching`);
-      }
-      if (!selection.configChoice) {
-        this.warnInvalidSelection(
-          modeId,
-          `is not valid ${this.provider} mode config option. Available options: ${flattenSelectOptions(
-            modeOption.options,
-          )
-            .map((option) => option.value)
-            .join(", ")}`,
-        );
-        return;
-      }
+    if (!this.validateModeSelection(modeId, selection)) {
+      return;
     }
 
     if (this.beforeModeWriter) {
@@ -1834,9 +1990,14 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       }
     }
 
-    if (selection.hasAvailableModes) {
-      await this.connection.setSessionMode({ sessionId: this.sessionId, modeId });
+    const strategy = this.resolveModeWriteStrategy(selection);
+    if (strategy === "legacy") {
+      await this.connection.setSessionMode({
+        sessionId: this.sessionId,
+        modeId,
+      });
       this.currentMode = modeId;
+      this.modeSource = "legacy";
       this.pushEvent({
         type: "mode_changed",
         provider: this.provider,
@@ -1863,7 +2024,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       requestedValue: modeId,
       label: "mode",
     });
-    this.availableModes = deriveModesFromACP(this.defaultModes, null, this.configOptions).modes;
+    this.applyDerivedModes(deriveModesFromACP(this.defaultModes, null, this.configOptions));
     this.pushEvent({
       type: "mode_changed",
       provider: this.provider,
@@ -2074,7 +2235,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       requestedValue,
       label: featureOption.label,
     });
-    this.config.featureValues = { ...this.config.featureValues, [featureId]: currentValue };
+    this.config.featureValues = {
+      ...this.config.featureValues,
+      [featureId]: currentValue,
+    };
   }
 
   private applyConfigOptionResponse({
@@ -2093,7 +2257,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.configOptions = this.transformConfigOptions(response.configOptions);
     const responseOption =
       category === undefined
-        ? findSelectConfigOptionById({ configOptions: this.configOptions, id: configId })
+        ? findSelectConfigOptionById({
+            configOptions: this.configOptions,
+            id: configId,
+          })
         : findSelectConfigOption({
             configOptions: this.configOptions,
             category,
@@ -2204,7 +2371,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
       try {
         if (this.agentCapabilities?.sessionCapabilities?.close) {
-          await this.connection.unstable_closeSession({ sessionId: this.sessionId });
+          await this.connection.unstable_closeSession({
+            sessionId: this.sessionId,
+          });
         }
       } catch (error) {
         this.logger.debug({ err: error }, "ACP closeSession failed during shutdown");
@@ -2221,7 +2390,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.terminalEntries.clear();
 
     if (this.child) {
-      await this.terminateProcess(this.child, { gracefulTimeoutMs: 2_000, forceTimeoutMs: 2_000 });
+      await this.terminateProcess(this.child, {
+        gracefulTimeoutMs: 2_000,
+        forceTimeoutMs: 2_000,
+      });
     }
 
     this.subscribers.clear();
@@ -2234,10 +2406,15 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const canAutoAccept =
       isACPAutoAcceptEnabled(this.config) && !isACPChooserRequest(params.options);
     if (canAutoAccept) {
-      const allowOption = selectPermissionOption(params.options, { behavior: "allow" });
+      const allowOption = selectPermissionOption(params.options, {
+        behavior: "allow",
+      });
       if (allowOption) {
         this.logger.info(
-          { toolCallId: params.toolCall.toolCallId, optionId: allowOption.optionId },
+          {
+            toolCallId: params.toolCall.toolCallId,
+            optionId: allowOption.optionId,
+          },
           "Auto-accepting ACP permission request",
         );
         return {
@@ -2458,7 +2635,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   async releaseTerminal(params: { sessionId: string; terminalId: string }): Promise<void> {
     const entry = this.getTerminalEntry(params.terminalId);
     if (!entry.exit) {
-      await this.terminateProcess(entry.child, { gracefulTimeoutMs: 2_000, forceTimeoutMs: 2_000 });
+      await this.terminateProcess(entry.child, {
+        gracefulTimeoutMs: 2_000,
+        forceTimeoutMs: 2_000,
+      });
     }
     this.terminalEntries.delete(params.terminalId);
   }
@@ -2466,7 +2646,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   async killTerminal(params: KillTerminalRequest): Promise<Record<string, never>> {
     const entry = this.getTerminalEntry(params.terminalId);
     if (!entry.exit) {
-      await this.terminateProcess(entry.child, { gracefulTimeoutMs: 2_000, forceTimeoutMs: 2_000 });
+      await this.terminateProcess(entry.child, {
+        gracefulTimeoutMs: 2_000,
+        forceTimeoutMs: 2_000,
+      });
     }
     return {};
   }
@@ -2523,16 +2706,26 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     // close the process even when the ACP handshake itself rejects.
     this.child = child;
     this.connection = connection;
-    const initialize = await this.runACPRequest(() =>
-      connection.initialize({
-        protocolVersion: PROTOCOL_VERSION,
-        clientCapabilities: buildACPClientCapabilities(
-          this.clientCapabilityMeta,
-          this.clientCapabilities,
+    let initialize: InitializeResponse;
+    try {
+      initialize = await withTimeout(
+        this.runACPRequest(() =>
+          connection.initialize({
+            protocolVersion: PROTOCOL_VERSION,
+            clientCapabilities: buildACPClientCapabilities(
+              this.clientCapabilityMeta,
+              this.clientCapabilities,
+            ),
+            clientInfo: { name: "Paseo", version: "dev" },
+          }),
         ),
-        clientInfo: { name: "Paseo", version: "dev" },
-      }),
-    );
+        DEFAULT_ACP_INITIALIZE_TIMEOUT_MS,
+        `ACP initialize timed out after ${DEFAULT_ACP_INITIALIZE_TIMEOUT_MS}ms`,
+      );
+    } catch (error) {
+      await terminateChildProcess(child, 2_000, this.terminateProcess);
+      throw error;
+    }
 
     return { child, connection, initialize };
   }
@@ -2557,7 +2750,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.configOptions = this.transformConfigOptions(transformed.configOptions ?? []);
 
     const modeInfo = deriveModesFromACP(this.defaultModes, transformed.modes, this.configOptions);
-    this.availableModes = modeInfo.modes;
+    this.applyDerivedModes(modeInfo);
     this.currentMode = modeInfo.currentModeId ?? this.currentMode;
 
     this.availableModels = transformed.models?.availableModels ?? null;
@@ -2584,6 +2777,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         modeId: configuredModeId,
         availableModes: this.availableModes,
         configOptions: this.configOptions,
+        modeSource: this.modeSource,
       });
       await this.setModeWithSelection({ modeId: configuredModeId, selection });
     }
@@ -2595,7 +2789,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         configOptions: this.configOptions,
       });
       try {
-        await this.setModelWithSelection({ modelId: configuredModelId, selection });
+        await this.setModelWithSelection({
+          modelId: configuredModelId,
+          selection,
+        });
       } catch (error) {
         if (!this.isModelSelectionUnavailableError(error)) {
           throw error;
@@ -2797,12 +2994,21 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private handleConfigOptionUpdate(update: ConfigOptionUpdate): AgentStreamEvent[] {
     this.configOptions = this.transformConfigOptions(update.configOptions);
-    const modeInfo = deriveModesFromACP(this.defaultModes, null, this.configOptions);
+    // Config updates only refresh the config-derived mode list when we are not
+    // already bound to legacy session modes (which keep session/set_mode).
+    const modeInfo =
+      this.modeSource === "legacy"
+        ? {
+            modes: this.availableModes,
+            currentModeId: deriveCurrentConfigValue(this.configOptions, "mode"),
+            source: "legacy" as const,
+          }
+        : deriveModesFromACP(this.defaultModes, null, this.configOptions);
     const nextMode = modeInfo.currentModeId;
     const nextModel = deriveCurrentConfigValue(this.configOptions, "model");
     const nextThinkingOptionId = deriveCurrentConfigValue(this.configOptions, "thought_level");
 
-    this.availableModes = modeInfo.modes;
+    this.applyDerivedModes(modeInfo);
     this.currentMode = nextMode ?? this.currentMode;
     this.currentModel = nextModel ?? this.currentModel;
     this.thinkingOptionId = nextThinkingOptionId ?? this.thinkingOptionId;
@@ -3185,10 +3391,17 @@ function toACPContentBlocks(prompt: AgentPromptInput): ContentBlock[] {
         contentBlocks.push({ type: "text", text: block.text });
         break;
       case "image":
-        contentBlocks.push({ type: "image", data: block.data, mimeType: block.mimeType });
+        contentBlocks.push({
+          type: "image",
+          data: block.data,
+          mimeType: block.mimeType,
+        });
         break;
       default:
-        contentBlocks.push({ type: "text", text: renderPromptAttachmentAsText(block) });
+        contentBlocks.push({
+          type: "text",
+          text: renderPromptAttachmentAsText(block),
+        });
         break;
     }
   }
@@ -3676,7 +3889,10 @@ async function terminateChildProcess(
   terminate: ProcessTerminator,
 ): Promise<void> {
   try {
-    await terminate(child, { gracefulTimeoutMs: timeoutMs, forceTimeoutMs: timeoutMs });
+    await terminate(child, {
+      gracefulTimeoutMs: timeoutMs,
+      forceTimeoutMs: timeoutMs,
+    });
   } finally {
     child.stdin.destroy();
     child.stdout.destroy();

--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -1342,7 +1342,11 @@ test("assembles assistant timeline when message_delta arrives before message_sta
               type: "stream_event",
               event: {
                 type: "message_start",
-                message: { id: "message-1", role: "assistant", model: "opus" },
+                message: {
+                  id: "message-1",
+                  role: "assistant",
+                  model: "opus",
+                },
               },
             },
           };
@@ -1528,4 +1532,159 @@ test("does not use stream_event uuid as assistant message identity when message_
   expect(assembler.timelineAssembler.messages.size).toBe(0);
 
   await session.close();
+});
+
+// Regression: reproduces the false "user rejected tool use" that Paseo surfaced
+// to Claude while permission mode was Bypass and the user rejected nothing.
+//
+// Timeline of the real repro (agent:paseo/62c89ad):
+//   1. User selected Bypass; the query launched with permissionMode:bypassPermissions.
+//   2. A background command was stopped / the session was torn down, which
+//      recreated the query via --resume.
+//   3. Claude Code's resumed system/init echoed the *persisted* permissionMode
+//      ("default"), NOT the launched Bypass.
+//   4. Paseo blindly adopted the echo, downgrading currentMode to "default".
+//   5. The next Shell went through canUseTool and, with no interactive client,
+//      resolved to { behavior: "deny" } — which the SDK renders as
+//      "The user doesn't want to proceed with this tool use".
+//
+// The fix keeps the launched mode authoritative: init must never downgrade it,
+// and the live query is re-asserted back to Bypass.
+test("stale resume init cannot downgrade Bypass into a synthetic tool rejection", async () => {
+  const launchedModes: Array<string | undefined> = [];
+  const reassertedModes: string[] = [];
+
+  const buildTurn = (initPermissionMode: string) => {
+    let step = 0;
+    const mock = createBaseQueryMock(
+      vi.fn(async () => {
+        if (step === 0) {
+          step += 1;
+          return {
+            done: false,
+            value: {
+              type: "system",
+              subtype: "init",
+              session_id: "bypass-resume-session",
+              permissionMode: initPermissionMode,
+              model: "opus",
+            },
+          };
+        }
+        if (step === 1) {
+          step += 1;
+          return {
+            done: false,
+            value: { type: "assistant", message: { content: "ok" } },
+          };
+        }
+        if (step === 2) {
+          step += 1;
+          return {
+            done: false,
+            value: {
+              type: "result",
+              subtype: "success",
+              usage: buildUsage(),
+              total_cost_usd: 0,
+            },
+          };
+        }
+        return { done: true, value: undefined };
+      }),
+    );
+    // Record any live re-assertion of the permission mode triggered by init.
+    mock.setPermissionMode.mockImplementation(async (mode: string) => {
+      reassertedModes.push(mode);
+    });
+    return mock;
+  };
+
+  // First turn resumes and echoes the persisted "default" (the stale downgrade).
+  // Second turn is a plain follow-up and echoes bypass again.
+  const initModes = ["default", "bypassPermissions"];
+  sdkQueryFactory.mockImplementation(({ options }: { options: { permissionMode?: string } }) => {
+    launchedModes.push(options.permissionMode);
+    return buildTurn(initModes.shift() ?? "bypassPermissions");
+  });
+
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    queryFactory: sdkQueryFactory,
+    resolveBinary: async () => "/test/claude/bin",
+  });
+  const session = await client.createSession({
+    provider: "claude",
+    cwd: process.cwd(),
+    modeId: "bypassPermissions",
+  });
+
+  try {
+    await collectUntilTerminal(streamSession(session, "first shell"));
+
+    // The stale init MUST NOT have downgraded the user's Bypass selection...
+    expect(await session.getCurrentMode()).toBe("bypassPermissions");
+    // ...and Paseo re-asserted Bypass onto the live query so the SDK agrees.
+    expect(reassertedModes).toContain("bypassPermissions");
+
+    // A subsequent tool use relaunches the query. Because the mode was never
+    // downgraded, it launches in Bypass — canUseTool never fires, so no
+    // synthetic deny (and thus no "user rejected") can be produced.
+    (asInternals(session) as { queryRestartNeeded: boolean }).queryRestartNeeded = true;
+    await collectUntilTerminal(streamSession(session, "second shell"));
+
+    // Every query launch — including the relaunch after the stale init — uses
+    // Bypass. If the downgrade bug were present, the relaunch would carry
+    // "default" and canUseTool would fire.
+    expect(launchedModes.length).toBeGreaterThanOrEqual(2);
+    expect(launchedModes.every((mode) => mode === "bypassPermissions")).toBe(true);
+    expect(await session.getCurrentMode()).toBe("bypassPermissions");
+  } finally {
+    await session.close();
+  }
+});
+
+// Guard the true-positive: an explicit user deny still rejects, so we are not
+// masking real rejections.
+test("explicit user deny still produces a rejection", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+
+  const session = await createSession();
+  try {
+    const request = {
+      id: "perm-explicit-deny",
+      provider: "claude" as const,
+      name: "Bash",
+      kind: "tool" as const,
+      input: { command: "rm -rf /" },
+    };
+    let resolvedResult: { behavior: string } | null = null;
+    (
+      asInternals(session) as {
+        pendingPermissions: Map<
+          string,
+          {
+            request: typeof request;
+            resolve: (r: { behavior: string }) => void;
+            cleanup?: () => void;
+          }
+        >;
+      }
+    ).pendingPermissions.set(request.id, {
+      request,
+      resolve: (result) => {
+        resolvedResult = result;
+      },
+    });
+
+    await session.respondToPermission(request.id, {
+      behavior: "deny",
+      message: "not now",
+    });
+
+    expect(resolvedResult).toMatchObject({ behavior: "deny" });
+  } finally {
+    await session.close();
+  }
 });

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1285,7 +1285,11 @@ class TimelineAssembler {
       !isClaudeTranscriptNoiseText(nextAssistantText)
     ) {
       state.emittedAssistantLength = state.assistantText.length;
-      items.push({ type: "assistant_message", text: nextAssistantText, messageId: state.id });
+      items.push({
+        type: "assistant_message",
+        text: nextAssistantText,
+        messageId: state.id,
+      });
     }
 
     const nextReasoningText = state.reasoningText.slice(state.emittedReasoningLength);
@@ -1564,7 +1568,10 @@ export class ClaudeAgentClient implements AgentClient {
       getClaudeModelsWithSettings(this.logger, this.configDir, claudeCodeVersion),
     );
     const modes = detectIneligibleAutoModeTransport(
-      createProviderEnv({ baseEnv: process.env, runtimeSettings: this.runtimeSettings }),
+      createProviderEnv({
+        baseEnv: process.env,
+        runtimeSettings: this.runtimeSettings,
+      }),
     )
       ? DEFAULT_MODES.filter((mode) => mode.id !== "auto")
       : DEFAULT_MODES;
@@ -2039,6 +2046,16 @@ class ClaudeAgentSession implements AgentSession {
   private claudeSessionId: string | null;
   private persistence: AgentPersistenceHandle | null;
   private currentMode: PermissionMode;
+  // The permission mode the active query was actually launched with. Paseo — not
+  // the SDK's persisted session state — is the source of truth for the user's
+  // permission intent. On resume (after an interrupt/teardown/background-task
+  // stop) Claude Code emits a system/init whose permissionMode reflects the
+  // *persisted* mode (often "default"), not the mode we launched with. Adopting
+  // that echo would silently downgrade an explicit bypassPermissions selection,
+  // resurrecting canUseTool prompts that then resolve to a synthetic deny even
+  // though the user never rejected anything. We remember what we launched with so
+  // handleSystemMessage can refuse a downgrade and re-assert the user's mode.
+  private launchedMode: PermissionMode | null = null;
   private planResumeMode: PermissionMode | null = null;
   private availableModes: AgentMode[] = DEFAULT_MODES;
   private toolUseCache = new Map<string, ToolUseCacheEntry>();
@@ -3119,6 +3136,12 @@ class ClaudeAgentSession implements AgentSession {
 
     const input = createAsyncMessageInput<SDKUserMessage>();
     const options = await this.buildOptions();
+    // Record the mode this query is actually launching with so a stale system/init
+    // echo (e.g. a persisted "default" replayed by --resume) cannot silently
+    // downgrade the user's selection in handleSystemMessage.
+    this.launchedMode = isPermissionMode(options.permissionMode)
+      ? options.permissionMode
+      : this.currentMode;
     this.logger.debug({ options: summarizeClaudeOptionsForLog(options) }, "claude query");
     this.input = input;
     this.query = claudeQuery(
@@ -3201,13 +3224,25 @@ class ClaudeAgentSession implements AgentSession {
         : undefined;
     assertClaudeThinkingOptionSupported(this.config.model, thinkingOptionId);
     if (thinkingOptionId === CLAUDE_DISABLED_THINKING_OPTION_ID) {
-      return { thinking: { type: "disabled" }, effort: undefined, ultracode: false };
+      return {
+        thinking: { type: "disabled" },
+        effort: undefined,
+        ultracode: false,
+      };
     }
     if (thinkingOptionId === CLAUDE_ULTRACODE_THINKING_OPTION_ID) {
-      return { thinking: { type: "adaptive" }, effort: "xhigh", ultracode: true };
+      return {
+        thinking: { type: "adaptive" },
+        effort: "xhigh",
+        ultracode: true,
+      };
     }
     if (thinkingOptionId && isClaudeThinkingEffort(thinkingOptionId)) {
-      return { thinking: { type: "adaptive" }, effort: thinkingOptionId, ultracode: false };
+      return {
+        thinking: { type: "adaptive" },
+        effort: thinkingOptionId,
+        ultracode: false,
+      };
     }
     return { thinking: undefined, effort: undefined, ultracode: false };
   }
@@ -3233,7 +3268,9 @@ class ClaudeAgentSession implements AgentSession {
       this.config.providerOptions,
       this.config.toolPolicy,
     );
-    const settingsOptions = this.buildSettingsOptions(providerOptions, { ultracode });
+    const settingsOptions = this.buildSettingsOptions(providerOptions, {
+      ultracode,
+    });
     const sdkEnv = this.buildSdkEnv();
     assertClaudeAutoModeEligible(this.currentMode, sdkEnv);
 
@@ -3375,7 +3412,10 @@ class ClaudeAgentSession implements AgentSession {
             });
           }
         } else {
-          content.push({ type: "text", text: renderPromptAttachmentAsText(chunk) });
+          content.push({
+            type: "text",
+            text: renderPromptAttachmentAsText(chunk),
+          });
         }
       }
     } else {
@@ -3659,7 +3699,11 @@ class ClaudeAgentSession implements AgentSession {
   private failRunningRuntimeTasks(): void {
     this.dispatchEvents(
       foldSubagentObservations(this.taskProtocolSource.failRunningTasks()).map(
-        (event): AgentStreamEvent => ({ type: "provider_subagent", provider: "claude", event }),
+        (event): AgentStreamEvent => ({
+          type: "provider_subagent",
+          provider: "claude",
+          event,
+        }),
       ),
     );
   }
@@ -4137,7 +4181,13 @@ class ClaudeAgentSession implements AgentSession {
         message,
         canonicalSubagentId ?? parentToolUseId,
       ),
-    ).map((event): AgentStreamEvent => ({ type: "provider_subagent", provider: "claude", event }));
+    ).map(
+      (event): AgentStreamEvent => ({
+        type: "provider_subagent",
+        provider: "claude",
+        event,
+      }),
+    );
     const routedId = canonicalSubagentId ?? parentToolUseId;
     return [...runtimeEvents, ...this.sidechainTracker.handleMessage(message, routedId)];
   }
@@ -4435,6 +4485,56 @@ class ClaudeAgentSession implements AgentSession {
     };
   }
 
+  /**
+   * Reconcile the permission mode reported by a system/init message against the
+   * mode Paseo actually launched the query with.
+   *
+   * Claude Code echoes a permissionMode on every init. On a fresh launch this
+   * matches what we passed. On a --resume (which happens after an interrupt,
+   * teardown, or a background-task stop that recreated the query) the echo can
+   * instead reflect the *persisted* session mode — typically "default" — even
+   * though we launched with the user's selection (e.g. "bypassPermissions").
+   *
+   * Blindly adopting that echo silently downgrades the user's mode. The next
+   * tool then goes through canUseTool and, with no interactive client to answer,
+   * resolves to a synthetic { behavior: "deny" }, which the SDK renders as
+   * "The user doesn't want to proceed with this tool use" — a false rejection
+   * the user never made. To preserve the invariant that only an explicit user
+   * action can produce a rejection, we never let init downgrade the launched
+   * mode: we keep it and re-assert it onto the live query so the SDK and Paseo
+   * agree again.
+   */
+  private adoptInitPermissionMode(reportedMode: PermissionMode): void {
+    const launchedMode = this.launchedMode;
+    const isDowngradeFromLaunch =
+      launchedMode !== null && launchedMode !== "plan" && reportedMode !== launchedMode;
+
+    if (isDowngradeFromLaunch) {
+      this.logger.warn(
+        { launchedMode, reportedMode },
+        "Claude init reported a permission mode that differs from the launched mode; " +
+          "keeping the launched mode and re-asserting it (stale --resume echo).",
+      );
+      this.currentMode = launchedMode;
+      this.planResumeMode = launchedMode;
+      const query = this.query;
+      if (query) {
+        void query.setPermissionMode(launchedMode).catch((error) => {
+          this.logger.warn(
+            { err: error, launchedMode },
+            "Failed to re-assert launched permission mode after stale init echo",
+          );
+        });
+      }
+      return;
+    }
+
+    this.currentMode = reportedMode;
+    if (this.currentMode !== "plan") {
+      this.planResumeMode = this.currentMode;
+    }
+  }
+
   private captureSessionIdFromMessage(message: SDKMessage): {
     threadStartedSessionId: string | null;
     notice: AgentTimelineItem | null;
@@ -4517,10 +4617,7 @@ class ClaudeAgentSession implements AgentSession {
       notice = this.createClaudeSessionChangedNotice(existingSessionId, newSessionId);
     }
     this.availableModes = DEFAULT_MODES;
-    this.currentMode = message.permissionMode;
-    if (this.currentMode !== "plan") {
-      this.planResumeMode = this.currentMode;
-    }
+    this.adoptInitPermissionMode(message.permissionMode);
     this.persistence = null;
     if (message.model) {
       const normalizedRuntimeModel = normalizeClaudeRuntimeModelId(message.model);
@@ -4721,7 +4818,11 @@ class ClaudeAgentSession implements AgentSession {
         for (const event of foldSubagentObservations(
           this.taskProtocolSource.observeHook(input as ClaudeHookObservationInput),
         )) {
-          this.notifySubscribers({ type: "provider_subagent", provider: "claude", event });
+          this.notifySubscribers({
+            type: "provider_subagent",
+            provider: "claude",
+            event,
+          });
         }
       } catch (error) {
         this.logger.debug({ err: error }, "Failed to read subagent effort from hook");
@@ -5680,7 +5781,9 @@ function readClaudeReplayParentFacts(parentEntries: ClaudeHistoryEntry[]): Claud
       const block = toObjectRecord(value);
       if (block?.type !== "tool_result" || typeof block.tool_use_id !== "string") continue;
       if (!toolCalls.has(block.tool_use_id)) continue;
-      outcomesByToolCallId.set(block.tool_use_id, { failed: block.is_error === true });
+      outcomesByToolCallId.set(block.tool_use_id, {
+        failed: block.is_error === true,
+      });
     }
   }
 
@@ -5715,7 +5818,9 @@ function readClaudeSidechainHistory(historyPath: string): ClaudeSidechainHistory
   };
   const workflowDirectory = path.join(sessionDirectory, "workflows");
   if (fs.existsSync(workflowDirectory)) {
-    for (const entry of fs.readdirSync(workflowDirectory, { withFileTypes: true })) {
+    for (const entry of fs.readdirSync(workflowDirectory, {
+      withFileTypes: true,
+    })) {
       if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
       try {
         history.workflowContents.push(
@@ -5825,7 +5930,10 @@ function readClaudeHistoricalSubagentToolResults(
       if (block?.type !== "tool_result" || typeof block.tool_use_id !== "string") continue;
       const match = /agentId:\s*([\w-]+)/.exec(JSON.stringify(block.content));
       if (!match?.[1]) continue;
-      results.set(match[1], { toolCallId: block.tool_use_id, failed: block.is_error === true });
+      results.set(match[1], {
+        toolCallId: block.tool_use_id,
+        failed: block.is_error === true,
+      });
     }
   }
   return results;

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -130,7 +130,13 @@ import type { RequestedSpeechProviders } from "./speech/speech-types.js";
 import { createSpeechService } from "./speech/speech-runtime.js";
 import { AgentManager } from "./agent/agent-manager.js";
 import { AgentStorage } from "./agent/agent-storage.js";
-import { attachAgentStoragePersistence } from "./persistence-hooks.js";
+import { readAgentResumeLedger, writeAgentResumeLedger } from "./agent/agent-resume-ledger.js";
+import {
+  attachAgentStoragePersistence,
+  buildConfigOverrides,
+  extractTimestamps,
+  toAgentPersistenceHandle,
+} from "./persistence-hooks.js";
 import { createAgentMcpServer } from "./agent/mcp-server.js";
 import {
   createPaseoToolCatalog,
@@ -566,6 +572,64 @@ function createInitialMutableDaemonConfig(config: PaseoDaemonConfig): MutableDae
   }
 
   return initialConfig;
+}
+
+async function rehydrateResumableAgents(
+  paseoHome: string,
+  agentManager: AgentManager,
+  agentStorage: AgentStorage,
+  logger: Logger,
+): Promise<void> {
+  const resumeAgentIds = await readAgentResumeLedger(paseoHome);
+  if (!resumeAgentIds || resumeAgentIds.length === 0) {
+    return;
+  }
+
+  logger.info(
+    { count: resumeAgentIds.length },
+    "Resuming active agents from previous daemon session",
+  );
+
+  const validProviders = new Set(agentManager.getRegisteredProviderIds());
+
+  await Promise.all(
+    resumeAgentIds.map(async (agentId) => {
+      try {
+        const record = await agentStorage.get(agentId);
+        if (!record) {
+          logger.warn({ agentId }, "Resume ledger referenced missing agent record; skipping");
+          return;
+        }
+        if (record.archivedAt) {
+          logger.debug({ agentId }, "Resume ledger agent is archived; skipping");
+          return;
+        }
+
+        const handle = toAgentPersistenceHandle(validProviders, record.persistence);
+        if (!handle) {
+          logger.warn(
+            { agentId },
+            "Resume ledger referenced agent without a resumable persistence handle; skipping",
+          );
+          return;
+        }
+
+        const overrides = buildConfigOverrides(record);
+        const timestamps = extractTimestamps(record);
+        await agentManager.resumeAgentFromPersistence(handle, overrides ?? undefined, agentId, {
+          createdAt: timestamps.createdAt,
+          updatedAt: timestamps.updatedAt,
+          lastUserMessageAt: timestamps.lastUserMessageAt,
+          labels: timestamps.labels,
+          workspaceId: timestamps.workspaceId,
+          owner: timestamps.owner,
+        });
+        logger.info({ agentId }, "Resumed agent after daemon restart");
+      } catch (error) {
+        logger.error({ err: error, agentId }, "Failed to resume agent after daemon restart");
+      }
+    }),
+  );
 }
 
 export async function createPaseoDaemon(
@@ -1657,6 +1721,7 @@ export async function createPaseoDaemon(
             );
             pluginRuntime.bindPaseoSessionHost(wsServer);
             await pluginRuntime.start();
+            await rehydrateResumableAgents(config.paseoHome, agentManager, agentStorage, logger);
             wsServer.beginAcceptingConnections();
             relayRuntime = createRelayRuntime({
               config: {
@@ -1718,6 +1783,8 @@ export async function createPaseoDaemon(
     // Freeze both ingress and registration before taking the agent closure snapshot.
     wsServer?.prepareForShutdown();
     agentManager.prepareForShutdown();
+    const liveAgentIds = agentManager.listAgents().map((agent) => agent.id);
+    await writeAgentResumeLedger(config.paseoHome, liveAgentIds);
     await closeAllAgents(logger, agentManager);
     await agentManager.flushForShutdown().catch(() => undefined);
     detachAgentStoragePersistence();

--- a/packages/server/src/server/daemon-e2e/daemon-restart-resume.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/daemon-restart-resume.e2e.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { createDaemonTestContext, type DaemonTestContext } from "../test-utils/index.js";
+import {
+  createDaemonTestContext,
+  createTestPaseoDaemon,
+  DaemonClient,
+  type DaemonTestContext,
+} from "../test-utils/index.js";
 import type { PersistenceHandle } from "@getpaseo/protocol/messages";
 
 function tmpCwd(): string {
@@ -63,4 +68,64 @@ describe("daemon restart resume", () => {
       rmSync(cwd, { recursive: true, force: true });
     }
   }, 30_000);
+
+  test("Codex agent automatically resumes after controlled daemon restart", async () => {
+    const paseoHomeRoot = mkdtempSync(path.join(tmpdir(), "daemon-restart-resume-home-"));
+    const cwd = tmpCwd();
+    const marker = `DAEMON_RESTART_MARKER_${Date.now()}`;
+    const daemon1 = await createTestPaseoDaemon({ paseoHomeRoot, cleanup: false });
+    const client1 = new DaemonClient({ url: `ws://127.0.0.1:${daemon1.port}/ws` });
+    await client1.connect();
+    await client1.fetchAgents({ subscribe: { subscriptionId: "test" } });
+
+    try {
+      const agent = await client1.createAgent({
+        provider: "codex",
+        cwd,
+        title: "Auto Resume Test Agent",
+        modeId: "full-access",
+      });
+
+      await client1.sendMessage(agent.id, `Remember this marker string for a test: "${marker}".`);
+
+      const afterRemember = await client1.waitForFinish(agent.id, 5_000);
+      expect(afterRemember.status).toBe("idle");
+      expect(afterRemember.final?.persistence).toBeTruthy();
+      expect(afterRemember.final!.persistence!.metadata).toMatchObject({ marker });
+
+      const firstAgentId = afterRemember.final!.id;
+      const handle = afterRemember.final!.persistence as PersistenceHandle;
+
+      await client1.close();
+      await daemon1.close();
+
+      const daemon2 = await createTestPaseoDaemon({ paseoHomeRoot, cleanup: true });
+      const client2 = new DaemonClient({ url: `ws://127.0.0.1:${daemon2.port}/ws` });
+      await client2.connect();
+      await client2.fetchAgents({ subscribe: { subscriptionId: "test" } });
+
+      const afterRestart = await client2.waitForFinish(firstAgentId, 5_000);
+      expect(afterRestart.status).toBe("idle");
+      expect(afterRestart.final?.persistence).toBeTruthy();
+      expect(afterRestart.final!.id).toBe(firstAgentId);
+      expect(afterRestart.final!.persistence!.sessionId).toBe(handle.sessionId);
+
+      await client2.sendMessage(
+        firstAgentId,
+        "What was the marker string I asked you to remember?",
+      );
+
+      const afterRecall = await client2.waitForFinish(firstAgentId, 5_000);
+      expect(afterRecall.status).toBe("idle");
+      expect(afterRecall.final?.persistence).toBeTruthy();
+      expect(afterRecall.final!.persistence!.metadata).toMatchObject({ marker });
+
+      await client2.deleteAgent(firstAgentId);
+      await client2.close();
+      await daemon2.close();
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(paseoHomeRoot, { recursive: true, force: true });
+    }
+  }, 60_000);
 });

--- a/packages/server/src/utils/tree-kill.test.ts
+++ b/packages/server/src/utils/tree-kill.test.ts
@@ -64,8 +64,13 @@ function killIfRunning(pid: number | null | undefined): void {
 
 function spawnOwnerWithDescendant(options: {
   childPidPath: string;
-  detachedDescendant: boolean;
+  detachedOwner?: boolean;
+  detachedDescendant?: boolean;
 }): ChildProcess {
+  const ownerOptions = {
+    stdio: "ignore" as const,
+    ...(options.detachedOwner ? { detached: true } : {}),
+  };
   const descendantOptions = options.detachedDescendant
     ? '{ detached: true, stdio: "ignore" }'
     : '{ stdio: "ignore" }';
@@ -91,7 +96,7 @@ function spawnOwnerWithDescendant(options: {
         setInterval(() => {}, 1000);
       `,
     ],
-    { stdio: "ignore" },
+    ownerOptions,
   );
 }
 
@@ -179,6 +184,62 @@ describe("terminateWithTreeKill", () => {
       await expectOwnerAndDescendantStopped(
         "owner or separate-process-group descendant survived terminateWithTreeKill",
       );
+    },
+  );
+
+  test.runIf(process.platform !== "win32")(
+    "kills descendants in the same process group when useProcessGroup is enabled",
+    async () => {
+      tempDir = await mkdtemp(join(tmpdir(), "paseo-server-tree-kill-"));
+      const childPidPath = join(tempDir, "descendant.pid");
+
+      ownerProcess = spawnOwnerWithDescendant({
+        childPidPath,
+        detachedOwner: true,
+        detachedDescendant: false,
+      });
+      expect(ownerProcess.pid).toBeTypeOf("number");
+      await waitForFixtureReady(childPidPath);
+
+      const result = await terminateWithTreeKill(ownerProcess, {
+        gracefulTimeoutMs: 100,
+        forceTimeoutMs: 2000,
+        useProcessGroup: true,
+      });
+
+      expect(result).toBe("killed");
+      await expectOwnerAndDescendantStopped(
+        "owner or same-process-group descendant survived terminateWithTreeKill",
+      );
+    },
+  );
+
+  test.runIf(process.platform !== "win32")(
+    "kills process group descendants even when the owner has already exited",
+    async () => {
+      tempDir = await mkdtemp(join(tmpdir(), "paseo-server-tree-kill-"));
+      const childPidPath = join(tempDir, "descendant.pid");
+
+      ownerProcess = spawnOwnerWithDescendant({
+        childPidPath,
+        detachedOwner: true,
+        detachedDescendant: false,
+      });
+      expect(ownerProcess.pid).toBeTypeOf("number");
+      await waitForFixtureReady(childPidPath);
+
+      // Simulate the owner already having exited; cleanup should still target the
+      // surviving process group so descendants do not leak.
+      ownerProcess.exitCode = 0;
+
+      const result = await terminateWithTreeKill(ownerProcess, {
+        gracefulTimeoutMs: 100,
+        forceTimeoutMs: 2000,
+        useProcessGroup: true,
+      });
+
+      expect(result).toBe("killed");
+      await expectOwnerAndDescendantStopped("descendant survived after owner already exited");
     },
   );
 });

--- a/packages/server/src/utils/tree-kill.ts
+++ b/packages/server/src/utils/tree-kill.ts
@@ -14,6 +14,7 @@ export interface TerminateWithTreeKillOptions {
   gracefulTimeoutMs: number;
   forceTimeoutMs?: number;
   onForceSignal?: () => void;
+  useProcessGroup?: boolean;
 }
 
 export type TerminateWithTreeKillResult =
@@ -33,6 +34,11 @@ export async function terminateWithTreeKill(
   child: TreeKillTarget,
   options: TerminateWithTreeKillOptions,
 ): Promise<TerminateWithTreeKillResult> {
+  const pid = child.pid;
+  if (options.useProcessGroup && typeof pid === "number" && pid > 0) {
+    return terminateProcessGroup(child, options, pid);
+  }
+
   if (isProcessExited(child)) {
     return "already-exited";
   }
@@ -51,6 +57,42 @@ export async function terminateWithTreeKill(
   return (await waitForExitOrTimeout(exitPromise, options.forceTimeoutMs))
     ? "killed"
     : "kill-timeout";
+}
+
+async function terminateProcessGroup(
+  child: TreeKillTarget,
+  options: TerminateWithTreeKillOptions,
+  pid: number,
+): Promise<TerminateWithTreeKillResult> {
+  if (isProcessExited(child) && !isProcessGroupAlive(pid)) {
+    return "already-exited";
+  }
+
+  await signalProcessGroup(pid, options.gracefulSignal ?? "SIGTERM");
+  if (await waitForProcessGroupExit(pid, options.gracefulTimeoutMs)) {
+    return "terminated";
+  }
+
+  options.onForceSignal?.();
+  await signalProcessGroup(pid, options.forceSignal ?? "SIGKILL");
+  if (options.forceTimeoutMs === undefined) {
+    return "killed";
+  }
+  return (await waitForProcessGroupExit(pid, options.forceTimeoutMs)) ? "killed" : "kill-timeout";
+}
+
+function signalProcessGroup(pid: number, signal: NodeJS.Signals): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      process.kill(-pid, signal);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+        // Ignore cleanup races and permission errors. The group may contain
+        // processes we cannot signal; that is not a reason to fail cleanup.
+      }
+    }
+    resolve();
+  });
 }
 
 export function signalProcessTree(child: TreeKillTarget, signal: NodeJS.Signals): Promise<void> {
@@ -100,6 +142,30 @@ function waitForProcessExit(child: TreeKillTarget): Promise<void> {
   return new Promise((resolve) => {
     child.once?.("exit", resolve);
   });
+}
+
+function isProcessGroupAlive(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EPERM") {
+      return true;
+    }
+    return false;
+  }
+}
+
+async function waitForProcessGroupExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessGroupAlive(pid)) {
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return true;
 }
 
 async function waitForExitOrTimeout(


### PR DESCRIPTION
## Summary
- Paseo `normalizeConfig` stripped `model: "default"` as a legacy “unspecified” sentinel, then filled `isDefault` / first catalog model (often `claude-opus-5`).
- Cursor Auto’s real provider-native id is `default`, so explicit Auto was rewritten to Opus and hit plan limits (`Upgrade your plan to continue`).
- Fix: keep `"default"` when the provider catalog lists that id; otherwise keep legacy strip→resolve behavior (Codex tests unchanged).

## Test plan
- [x] unit: preserve provider-native `default` (Cursor Auto)
- [x] unit: legacy Codex `model=default` still resolves to provider default
- [x] live: `paseo run --provider cursor --model default` → `config.model=default`, agent replies without plan upgrade
- [x] ACP E2E: `start_role` runtime=cursor model=auto → execution_model=default, `config.model=default`, `git status` runs