### PR TITLE
Add paseo-plugin-zcode to community list; document npm agent resolution for provider plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -331,6 +331,30 @@ For an ACP command, register `runAcpProvider({ id, label, command })` from
 whole provider event stream. The direct and ACP examples live in `plugin-examples/provider-direct`
 and `plugin-examples/provider-acp-transformer`.
 
+
+Agents distributed through npm should be resolved at runtime instead of relying on `PATH`. Plugin
+server code runs without `__dirname` or a usable `import.meta`, and the injected `require` exposes
+no `resolve`. Built-ins still load through it: grab `node:module`, anchor `createRequire` at
+`process.argv[1]` — the plugin worker script inside the Paseo server package, whose `node_modules`
+ancestor chain covers the npm global install directory — and launch the resolved entry with
+`process.execPath`:
+
+```ts
+const { createRequire } = require("node:module");
+const nodeRequire = createRequire(process.argv[1]);
+const cli = nodeRequire.resolve("zcode-acp-server/dist/cli.js");
+
+runAcpProvider({
+  id: "zcode",
+  label: "ZCode",
+  command: [process.execPath, cli],
+});
+```
+
+The community plugin [`paseo-plugin-zcode`](https://github.com/lianxin255/paseo-plugin-zcode) ships
+this pattern end to end, including a sanitized provider icon and the wider handshake timeout an
+npm-launched bridge needs on its first run.
+
 Provider-emitted plugin timeline items use the same renderer registration as transformed and
 daemon-appended plugin items. The direct example includes both sides. The renderer-only
 `plugin-examples/inline-thinking` example shows that timeline presentation remains independent of a

--- a/public-docs/community.md
+++ b/public-docs/community.md
@@ -19,6 +19,7 @@ These projects are related to Paseo and built by the community.
 | [Paseo Icon](https://github.com/gpambrozio/paseo-menubar)                                    | Shows workspace status across Paseo hosts in the macOS menu bar and opens a workspace with one click.                                |
 | [Paseo Cross-Daemon Comms](https://github.com/xpufx/paseo-cross-daemon-comms)                | Lets agents communicate with agents on another Paseo daemon through an MCP server.                                                   |
 | [Paseo Antigravity ACP](https://github.com/tiezbro/paseo-agy-acp)                            | Connects Google Antigravity CLI to Paseo through ACP, with Paseo-specific context, permissions, and concurrency handling.            |
+| [paseo-plugin-zcode](https://github.com/lianxin255/paseo-plugin-zcode)                        | Registers ZCode (Z.ai's GLM coding agent) as a Paseo provider by wrapping the npm zcode-acp-server ACP bridge.                        |
 | [Desvio](https://github.com/cleiter/desvio)                                                  | Rebuilds a personal fork from a set of branches, using an agent to resolve new conflicts and Git rerere to replay known resolutions. |
 
 ## Hosting and infrastructure


### PR DESCRIPTION
Two small docs additions, both coming out of shipping a real provider plugin:

**`public-docs/community.md`** — list [`paseo-plugin-zcode`](https://github.com/lianxin255/paseo-plugin-zcode) under Tools and integrations. It registers ZCode (Z.ai's GLM coding agent) as a Paseo provider by wrapping the npm `zcode-acp-server` ACP bridge — same slot as the Antigravity ACP entry. This is the plugin-shaped follow-up to #3374, per the direction set when that PR was closed.

**`docs/plugins.md`** — in "Contribute a provider", document how an npm-distributed agent gets resolved at runtime. The loader evaluates plugin bundles without `__dirname` or a usable `import.meta`, and the injected `require` has no `.resolve`; the reference says backend code can use installed dependencies but not how. The recipe (grab `node:module` via the injected require, anchor `createRequire` at `process.argv[1]`, launch with `process.execPath`) took actual reverse-engineering of the plugin process to find, and any provider plugin wrapping an npm-installed agent will need it.

The plugin itself is MIT, tested end to end against a real agent (`paseo run --provider zcode`), and installed here from its own Git source via `paseo plugin add`.