### PR TITLE
fix(server): leave plan mode when Copilot Allow All is selected - #3856

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1454,7 +1454,12 @@ describe("ACPAgentSession Zed parity", () => {
       configId: "allow_all",
       value: "on",
     });
-    expect(setSessionMode).not.toHaveBeenCalled();
+    // Allow All is agent mode with permissions pre-granted, so it has to leave
+    // whatever mode the session is in, not just flip the flag.
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
     await expect(session.getCurrentMode()).resolves.toBe(COPILOT_ALLOW_ALL_MODE_ID);
     expect(events.some((event) => event.type === "permission_requested")).toBe(false);
   });
@@ -1485,7 +1490,50 @@ describe("ACPAgentSession Zed parity", () => {
       configId: "allow_all",
       value: "on",
     });
-    expect(setSessionMode).not.toHaveBeenCalled();
+    // Allow All is agent mode with permissions pre-granted, so it has to leave
+    // whatever mode the session is in, not just flip the flag.
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
+    await expect(session.getCurrentMode()).resolves.toBe(COPILOT_ALLOW_ALL_MODE_ID);
+  });
+
+  test("selecting Copilot Allow All from plan mode leaves plan mode and enables allow_all", async () => {
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [
+        copilotModeConfigOption("https://agentclientprotocol.com/protocol/session-modes#agent"),
+        copilotAllowAllConfigOption("on"),
+      ],
+    }));
+    const setSessionMode = vi.fn(async () => undefined);
+    const session = createCopilotSessionWithConfig();
+    prepareConfiguredOverrideSession(session, {
+      currentMode: "https://agentclientprotocol.com/protocol/session-modes#plan",
+      availableModes: COPILOT_MODES,
+      configOptions: [
+        copilotModeConfigOption("https://agentclientprotocol.com/protocol/session-modes#plan"),
+        copilotAllowAllConfigOption("off"),
+      ],
+      connection: { setSessionConfigOption, setSessionMode },
+    });
+
+    await session.setMode(COPILOT_ALLOW_ALL_MODE_ID);
+
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
+    expect(setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      configId: "allow_all",
+      value: "on",
+    });
+    // Copilot reverts allow_all to off when a session leaves #autopilot, so the
+    // mode write has to land before the flag or a later mode write clobbers it.
+    expect(setSessionMode.mock.invocationCallOrder[0]!).toBeLessThan(
+      setSessionConfigOption.mock.invocationCallOrder[0]!,
+    );
     await expect(session.getCurrentMode()).resolves.toBe(COPILOT_ALLOW_ALL_MODE_ID);
   });
 

--- a/packages/server/src/server/agent/providers/copilot-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/copilot-acp-agent.ts
@@ -37,7 +37,7 @@ const COPILOT_CAPABILITIES: AgentCapabilityFlags = {
 
 const COPILOT_AGENT_MODE_ID = "https://agentclientprotocol.com/protocol/session-modes#agent";
 const COPILOT_PLAN_MODE_ID = "https://agentclientprotocol.com/protocol/session-modes#plan";
-const COPILOT_AUTOPILOT_MODE_ID =
+export const COPILOT_AUTOPILOT_MODE_ID =
   "https://agentclientprotocol.com/protocol/session-modes#autopilot";
 export const COPILOT_ALLOW_ALL_MODE_ID = "allow-all";
 const COPILOT_ALLOW_ALL_CONFIG_ID = "allow_all";
@@ -209,6 +209,10 @@ export async function writeCopilotProviderMode(
   if (!requestsAllowAll) {
     return { handled: false };
   }
+  await context.connection.setSessionMode({
+    sessionId: context.sessionId,
+    modeId: COPILOT_AGENT_MODE_ID,
+  });
   const response = await context.connection.setSessionConfigOption({
     sessionId: context.sessionId,
     configId: COPILOT_ALLOW_ALL_CONFIG_ID,

--- a/packages/server/src/server/agent/providers/copilot-allow-all-mode.real.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/copilot-allow-all-mode.real.e2e.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import { asInternals } from "../../test-utils/class-mocks.js";
+import {
+  canRunRealProvider,
+  createRealProviderClient,
+  getRealProviderConfig,
+} from "../../daemon-e2e/real-provider-test-config.js";
+import { COPILOT_ALLOW_ALL_MODE_ID } from "./copilot-acp-agent.js";
+
+const AGENT_MODE_ID = "https://agentclientprotocol.com/protocol/session-modes#agent";
+const PLAN_MODE_ID = "https://agentclientprotocol.com/protocol/session-modes#plan";
+
+interface CopilotSessionInternals {
+  sessionId: string;
+  connection: {
+    setSessionConfigOption(input: {
+      sessionId: string;
+      configId: string;
+      value: string;
+    }): Promise<{ configOptions: SessionConfigOption[] }>;
+  };
+}
+
+interface LiveCopilotState {
+  mode: string | undefined;
+  allowAll: string | undefined;
+}
+
+function tmpCwd(): string {
+  return mkdtempSync(path.join(tmpdir(), "copilot-allow-all-real-"));
+}
+
+function currentValueOf(options: SessionConfigOption[], id: string): string | undefined {
+  const option = options.find((candidate) => candidate.id === id);
+  return option?.type === "select" ? option.currentValue : undefined;
+}
+
+// Paseo applies its mode writes to the session optimistically, and its Copilot
+// transformer reports Allow All whenever allow_all is on, whatever mode the
+// session is really in. Both hide the state this test exists to catch, so read
+// what Copilot itself reports: a no-op config write whose response carries the
+// agent's current, untransformed configuration.
+async function readLiveCopilotState(session: unknown): Promise<LiveCopilotState> {
+  const internals = asInternals<CopilotSessionInternals>(session);
+  const response = await internals.connection.setSessionConfigOption({
+    sessionId: internals.sessionId,
+    configId: "reasoning_effort",
+    value: "medium",
+  });
+  return {
+    mode: currentValueOf(response.configOptions, "mode"),
+    allowAll: currentValueOf(response.configOptions, "allow_all"),
+  };
+}
+
+describe("Copilot ACP provider (real) Allow All mode", () => {
+  let canRun = false;
+
+  beforeAll(async () => {
+    canRun = await canRunRealProvider("copilot");
+  });
+
+  beforeEach((context) => {
+    if (!canRun) {
+      context.skip();
+    }
+  });
+
+  // The headline bug: allow_all and mode are independent Copilot config options,
+  // so granting permissions never moved the session out of plan mode. Copilot
+  // kept framing its instructions as a plan and refused to edit anything.
+  test("selecting Allow All from plan mode leaves plan mode", async () => {
+    const cwd = tmpCwd();
+    const client = createRealProviderClient("copilot", createTestLogger());
+
+    try {
+      const session = await client.createSession({ ...getRealProviderConfig("copilot"), cwd });
+
+      try {
+        await session.setMode(PLAN_MODE_ID);
+        await expect(session.getCurrentMode()).resolves.toBe(PLAN_MODE_ID);
+
+        await session.setMode(COPILOT_ALLOW_ALL_MODE_ID);
+
+        const live = await readLiveCopilotState(session);
+        expect(live).toEqual({ mode: AGENT_MODE_ID, allowAll: "on" });
+      } finally {
+        await session.close();
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 240_000);
+});

--- a/packages/server/src/server/daemon-e2e/real-provider-test-config.ts
+++ b/packages/server/src/server/daemon-e2e/real-provider-test-config.ts
@@ -8,13 +8,17 @@ import type { AgentClient, AgentProvider, AgentSessionConfig } from "../agent/ag
 import type { ProviderRuntimeSettings } from "../agent/provider-launch-config.js";
 import { ClaudeAgentClient } from "../agent/providers/claude/agent.js";
 import { CodexAppServerAgentClient } from "../agent/providers/codex-app-server-agent.js";
+import { CopilotACPAgentClient } from "../agent/providers/copilot-acp-agent.js";
 import { OpenCodeAgentClient } from "../agent/providers/opencode-agent.js";
 import { OmpAgentClient } from "../agent/providers/omp/agent.js";
 import { PiRpcAgentClient } from "../agent/providers/pi/agent.js";
 import { isCommandAvailable } from "../../executable-resolution/executable-resolution.js";
 
+// The full real-provider matrix; ui-action-stress runs one leg per entry.
 export const realProviders = ["claude", "codex", "opencode", "pi", "omp"] as const;
-export type RealProvider = (typeof realProviders)[number];
+// Copilot authenticates through the GitHub CLI rather than OpenRouter and has no
+// stress leg, but the helpers below support it for its own focused real tests.
+export type RealProvider = (typeof realProviders)[number] | "copilot";
 export type RealProviderConfig = Pick<
   AgentSessionConfig,
   "provider" | "model" | "modeId" | "thinkingOptionId"
@@ -68,10 +72,16 @@ export function getRealProviderConfig(provider: RealProvider): RealProviderConfi
         thinkingOptionId: "medium",
         modeId: "full",
       };
+    case "copilot":
+      // Copilot picks its own default model; the mode tests never run a turn.
+      return { provider };
   }
 }
 
 export function getRealProviderRuntimeSettings(provider: RealProvider): ProviderRuntimeSettings {
+  if (provider === "copilot") {
+    return {};
+  }
   if (provider === "omp" || provider === "pi") {
     if (hasCodexAuthTokens()) {
       return {
@@ -151,6 +161,8 @@ export function createRealProviderClient(provider: RealProvider, logger: Logger)
       return new PiRpcAgentClient({ logger, runtimeSettings });
     case "omp":
       return new OmpAgentClient({ logger, runtimeSettings });
+    case "copilot":
+      return new CopilotACPAgentClient({ logger, runtimeSettings });
   }
 }
 
@@ -170,7 +182,12 @@ export function canRunRealProvider(provider: RealProvider): Promise<boolean> {
   }
 
   const availability = (async () => {
-    if (provider !== "omp" && provider !== "pi" && !getOpenRouterApiKeyOrNull()) {
+    if (
+      provider !== "omp" &&
+      provider !== "pi" &&
+      provider !== "copilot" &&
+      !getOpenRouterApiKeyOrNull()
+    ) {
       return false;
     }
     return await isCommandAvailable(getProviderBinary(provider));


### PR DESCRIPTION
### Linked issue

Closes https://github.com/getpaseo/paseo/issues/3855

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

This continues #3856, which you closed with: _"this needs a before/after Paseo-to-Copilot run showing that Plan → Allow All permits the requested edit, with a regression test through the ACP session. Please reopen with that evidence."_

GitHub won't let me reopen it — the branch was force-pushed while the PR was closed — so this is the same work in a new PR, with that evidence.

### Goals

- Selecting Allow All from plan mode leaves plan mode, so the approved plan actually runs.
- Nothing changes for any other mode selection.

### Non-goals

- Exposing Copilot's native autopilot mode. It was bundled into the version you closed; it's a separate PR now.
- Removing the `COMPAT(copilotAutopilotMode)` shim. Its own comment says after 2026-11-12, and that date hasn't passed, so it's restored here.
- The ordering — mode before flag — only matters when starting from `#autopilot`, which isn't reachable through Paseo while that shim exists. Its regression test travels with the autopilot PR, where the state can be entered normally.

### QA

Two takes of the same scenario in a throwaway git repo, same prompt both times: plan two trivial file changes, approve with Allow All. **Both videos show "Allow all" in the mode selector**, the difference is in the tool trail and the task counter, so that's where to look.

Without the fix :`Edit apply_patch` followed by `Record plan mode blocker`, `0/2 tasks`, no files touched:

https://github.com/user-attachments/assets/62f17778-c907-47e0-a64d-33f223567dbc

With the fix: `Completed` for both steps, `2/2 tasks`, and the Changes panel showing `notes.txt +1 −0`

https://github.com/user-attachments/assets/32ae0ebc-f0bd-4f85-81f4-2bcb2c3f8f47


**Regression test through the ACP session**, against the real Copilot CLI, not skipped:

```
✓ selecting Allow All from plan mode leaves plan mode   4915ms
  Tests  1 passed (1)
```

And it fails without the fix. Reverting just the four added lines:

```
× selecting Allow All from plan mode leaves plan mode
  → mode: #plan
```

### Checklist

- [ ] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (if applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
