### PR TITLE
fix(omp): stream content blocks by content index so reasoning stays contiguous

### DIFF
--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -245,6 +245,108 @@ describe("OMP agent client and session", () => {
     expect(omp.completedTurnCount()).toBe(1);
   });
 
+  test("streams OMP content blocks by content index when an earlier thinking delta arrives late", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    await omp.runPromptWithEvents("hello OMP", (runtime) => {
+      const message = {
+        role: "assistant" as const,
+        responseId: "response-1",
+        content: [
+          { type: "thinking" as const, thinking: "" },
+          { type: "text" as const, text: "" },
+        ],
+      };
+      runtime.emit({ type: "message_start", message });
+      runtime.emit({
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "thinking_start", contentIndex: 0 },
+      });
+      runtime.emit({
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "thinking_delta", contentIndex: 0, delta: "verify" },
+      });
+      runtime.emit({
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "text_start", contentIndex: 1 },
+      });
+      runtime.emit({
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "text_delta", contentIndex: 1, delta: "Answer" },
+      });
+      runtime.emit({
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "thinking_delta", contentIndex: 0, delta: "." },
+      });
+      runtime.emit({
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "thinking_end", contentIndex: 0 },
+      });
+      runtime.emit({
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "text_delta", contentIndex: 1, delta: " complete." },
+      });
+      runtime.emit({
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "text_end", contentIndex: 1 },
+      });
+    });
+
+    expect(omp.timeline()).toEqual([
+      { type: "user_message", text: "hello OMP", messageId: "user-1" },
+      { type: "reasoning", text: "verify" },
+      { type: "reasoning", text: "." },
+      { type: "assistant_message", text: "Answer", messageId: "response-1" },
+      { type: "assistant_message", text: " complete.", messageId: "response-1" },
+    ]);
+  });
+
+  test("flushes indexed OMP blocks under the previous message id when its end event is missing", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    await omp.runPromptWithEvents("hello OMP", (runtime) => {
+      const first = {
+        role: "assistant" as const,
+        responseId: "response-1",
+        content: [
+          { type: "thinking" as const, thinking: "" },
+          { type: "text" as const, text: "" },
+        ],
+      };
+      runtime.emit({ type: "message_start", message: first });
+      runtime.emit({
+        type: "message_update",
+        message: first,
+        assistantMessageEvent: { type: "thinking_delta", contentIndex: 0, delta: "think" },
+      });
+      runtime.emit({
+        type: "message_update",
+        message: first,
+        assistantMessageEvent: { type: "text_delta", contentIndex: 1, delta: "answer" },
+      });
+      runtime.emit({
+        type: "message_start",
+        message: { role: "assistant" as const, responseId: "response-2", content: [] },
+      });
+    });
+
+    expect(omp.timeline()).toEqual([
+      { type: "user_message", text: "hello OMP", messageId: "user-1" },
+      { type: "reasoning", text: "think" },
+      { type: "assistant_message", text: "answer", messageId: "response-1" },
+    ]);
+  });
+
   test("starts and stops context usage polling with the active turn", async () => {
     const scheduler = new ManualUsagePollScheduler();
     const omp = new OmpHarness({ usagePollScheduler: scheduler });

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -72,6 +72,7 @@ import { getUserMessageText } from "./message-history.js";
 import { mapOmpSystemNoticeToNotification } from "./system-notice.js";
 import { materializeProviderImage } from "../provider-image-output.js";
 import { OmpCliRuntime } from "./cli-runtime.js";
+import { OmpMessageContentStream, type OmpMessageContentChunk } from "./message-content-stream.js";
 import { listOmpImportableSessions, readOmpImportSessionConfig } from "./session-descriptor.js";
 import type { OmpRuntime, OmpRuntimeSession, OmpStartSessionInput } from "./runtime.js";
 import type {
@@ -852,6 +853,7 @@ export class OmpAgentSession implements AgentSession {
   private activeTurnId: string | null = null;
   private activeClientMessageId: string | null = null;
   private activeAssistantMessageId: string | null = null;
+  private readonly activeAssistantContent = new OmpMessageContentStream();
   private activeTurnTerminalAssistantMessage: OmpAgentMessage | null = null;
   private activeTurnStarted = false;
   private activeTurnHasUserMessage = false;
@@ -961,6 +963,7 @@ export class OmpAgentSession implements AgentSession {
     this.activeTurnId = turnId;
     this.activeClientMessageId = options?.clientMessageId ?? null;
     this.activeAssistantMessageId = null;
+    this.activeAssistantContent.reset();
     this.activeTurnTerminalAssistantMessage = null;
     this.activeTurnStarted = false;
     this.activeTurnHasUserMessage = false;
@@ -1822,7 +1825,7 @@ export class OmpAgentSession implements AgentSession {
         });
         return;
       case "message_start":
-        this.handleMessageStart(event);
+        this.handleMessageStart(event, turnId);
         return;
       case "message_end":
         if (event.message.role === "user") {
@@ -1966,29 +1969,41 @@ export class OmpAgentSession implements AgentSession {
     if (event.message.role !== "assistant") {
       return;
     }
-    if (event.assistantMessageEvent.type === "text_delta") {
-      // Omp-compatible runtimes may emit updates without a preceding message_start.
-      this.activeAssistantMessageId ??= event.message.responseId || randomUUID();
-      this.emit({
-        type: "timeline",
-        provider: this.provider,
-        turnId,
-        item: {
-          type: "assistant_message",
-          text: event.assistantMessageEvent.delta ?? "",
-          messageId: this.activeAssistantMessageId,
-        },
-      });
-      return;
-    }
-    if (event.assistantMessageEvent.type === "thinking_delta") {
+    this.emitMessageContentChunks(
+      this.activeAssistantContent.update(event.assistantMessageEvent, event.message),
+      turnId,
+      event.message.responseId,
+    );
+  }
+
+  private emitMessageContentChunks(
+    chunks: OmpMessageContentChunk[],
+    turnId: string | undefined,
+    responseId?: string,
+  ): void {
+    for (const chunk of chunks) {
+      if (chunk.type === "text") {
+        // Omp-compatible runtimes may emit updates without a preceding message_start.
+        this.activeAssistantMessageId ??= responseId || randomUUID();
+        this.emit({
+          type: "timeline",
+          provider: this.provider,
+          turnId,
+          item: {
+            type: "assistant_message",
+            text: chunk.text,
+            messageId: this.activeAssistantMessageId,
+          },
+        });
+        continue;
+      }
       this.emit({
         type: "timeline",
         provider: this.provider,
         turnId,
         item: {
           type: "reasoning",
-          text: event.assistantMessageEvent.delta ?? "",
+          text: chunk.text,
         },
       });
     }
@@ -1996,9 +2011,12 @@ export class OmpAgentSession implements AgentSession {
 
   private handleMessageStart(
     event: Extract<OmpAgentSessionEvent, { type: "message_start" }>,
+    turnId: string | undefined,
   ): void {
     if (event.message.role === "assistant") {
+      this.emitMessageContentChunks(this.activeAssistantContent.finish(), turnId);
       this.activeAssistantMessageId = event.message.responseId || null;
+      this.activeAssistantContent.start(event.message.content);
     }
   }
 
@@ -2007,6 +2025,7 @@ export class OmpAgentSession implements AgentSession {
     turnId: string | undefined,
   ): void {
     if (event.message.role === "assistant") {
+      this.emitMessageContentChunks(this.activeAssistantContent.finish(), turnId);
       this.activeAssistantMessageId = null;
       if (turnId) {
         this.activeTurnTerminalAssistantMessage = event.message;
@@ -2126,6 +2145,7 @@ export class OmpAgentSession implements AgentSession {
   }
 
   private completeTurn(turnId: string | undefined, messages: OmpAgentMessage[]): void {
+    this.emitMessageContentChunks(this.activeAssistantContent.finish(), turnId);
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;

--- a/packages/server/src/server/agent/providers/omp/message-content-stream.ts
+++ b/packages/server/src/server/agent/providers/omp/message-content-stream.ts
@@ -1,0 +1,129 @@
+import type {
+  OmpAssistantContent,
+  OmpAssistantMessageEvent,
+  OmpAgentMessage,
+} from "./rpc-types.js";
+
+export interface OmpMessageContentChunk {
+  type: "text" | "thinking";
+  text: string;
+}
+
+interface PendingContentBlock {
+  chunks: OmpMessageContentChunk[];
+  complete: boolean;
+}
+
+// OMP may revisit an earlier contentIndex while a later block is already streaming. Paseo's
+// timeline is append-only, so later blocks wait here until every earlier block has ended.
+export class OmpMessageContentStream {
+  private readonly blocks = new Map<number, PendingContentBlock>();
+  private readonly completedIndexes = new Set<number>();
+
+  start(content: OmpAssistantContent[]): void {
+    this.reset();
+    this.seedBlocks(content);
+  }
+
+  update(
+    event: OmpAssistantMessageEvent,
+    message?: Extract<OmpAgentMessage, { role: "assistant" }>,
+  ): OmpMessageContentChunk[] {
+    this.seedBlocks(message?.content ?? []);
+    const contentIndex = readContentIndex(event);
+
+    if (event.type === "text_delta" || event.type === "thinking_delta") {
+      const chunk = {
+        type: event.type === "text_delta" ? ("text" as const) : ("thinking" as const),
+        text: event.delta ?? "",
+      };
+      if (contentIndex === null) {
+        return [chunk];
+      }
+      this.ensureBlock(contentIndex).chunks.push(chunk);
+      return this.flushReadyBlocks();
+    }
+
+    if (contentIndex === null) {
+      return [];
+    }
+    if (isContentStart(event)) {
+      this.ensureBlock(contentIndex);
+      return this.flushReadyBlocks();
+    }
+    if (isContentEnd(event)) {
+      this.ensureBlock(contentIndex).complete = true;
+      return this.flushReadyBlocks();
+    }
+    return [];
+  }
+
+  finish(): OmpMessageContentChunk[] {
+    for (const block of this.blocks.values()) {
+      block.complete = true;
+    }
+    const chunks = this.flushReadyBlocks();
+    this.reset();
+    return chunks;
+  }
+
+  reset(): void {
+    this.blocks.clear();
+    this.completedIndexes.clear();
+  }
+
+  private seedBlocks(content: OmpAssistantContent[]): void {
+    for (let index = 0; index < content.length; index += 1) {
+      this.ensureBlock(index);
+    }
+  }
+
+  private ensureBlock(contentIndex: number): PendingContentBlock {
+    const existing = this.blocks.get(contentIndex);
+    if (existing) {
+      return existing;
+    }
+    const block = { chunks: [], complete: false };
+    if (!this.completedIndexes.has(contentIndex)) {
+      this.blocks.set(contentIndex, block);
+    }
+    return block;
+  }
+
+  private flushReadyBlocks(): OmpMessageContentChunk[] {
+    const chunks: OmpMessageContentChunk[] = [];
+    while (this.blocks.size > 0) {
+      const contentIndex = Math.min(...this.blocks.keys());
+      const block = this.blocks.get(contentIndex);
+      if (!block) break;
+      chunks.push(...block.chunks.splice(0));
+      if (!block.complete) break;
+      this.blocks.delete(contentIndex);
+      this.completedIndexes.add(contentIndex);
+    }
+    return chunks;
+  }
+}
+
+// A missing or negative index means the runtime did not identify the block; callers then
+// stream the chunk directly instead of holding it behind earlier blocks.
+function readContentIndex(event: OmpAssistantMessageEvent): number | null {
+  const { contentIndex } = event;
+  return contentIndex !== undefined && Number.isInteger(contentIndex) && contentIndex >= 0
+    ? contentIndex
+    : null;
+}
+
+function isContentStart(event: OmpAssistantMessageEvent): boolean {
+  return (
+    event.type === "text_start" ||
+    event.type === "thinking_start" ||
+    event.type === "toolcall_start"
+  );
+}
+
+function isContentEnd(event: OmpAssistantMessageEvent): boolean {
+  return (
+    event.type === "text_end" || event.type === "thinking_end" || event.type === "toolcall_end"
+  );
+}

--- a/packages/server/src/server/agent/providers/omp/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/omp/rpc-types.ts
@@ -263,14 +263,35 @@ export const OmpSubagentProgressPayloadSchema = z
   .passthrough();
 
 export const OmpAssistantMessageEventSchema = z.discriminatedUnion("type", [
-  z.object({ type: z.literal("text_delta"), delta: z.string().optional() }).passthrough(),
-  z.object({ type: z.literal("thinking_delta"), delta: z.string().optional() }).passthrough(),
-  z.object({ type: z.literal("start") }).passthrough(),
-  z.object({ type: z.literal("text_start") }).passthrough(),
-  z.object({ type: z.literal("text_end") }).passthrough(),
-  z.object({ type: z.literal("thinking_start") }).passthrough(),
-  z.object({ type: z.literal("thinking_end") }).passthrough(),
-  z.object({ type: z.literal("done") }).passthrough(),
+  z
+    .object({
+      type: z.literal("text_delta"),
+      contentIndex: z.number().optional(),
+      delta: z.string().optional(),
+    })
+    .passthrough(),
+  z
+    .object({
+      type: z.literal("thinking_delta"),
+      contentIndex: z.number().optional(),
+      delta: z.string().optional(),
+    })
+    .passthrough(),
+  z.object({ type: z.literal("start"), contentIndex: z.number().optional() }).passthrough(),
+  z.object({ type: z.literal("text_start"), contentIndex: z.number().optional() }).passthrough(),
+  z.object({ type: z.literal("text_end"), contentIndex: z.number().optional() }).passthrough(),
+  z
+    .object({ type: z.literal("thinking_start"), contentIndex: z.number().optional() })
+    .passthrough(),
+  z.object({ type: z.literal("thinking_end"), contentIndex: z.number().optional() }).passthrough(),
+  z
+    .object({ type: z.literal("toolcall_start"), contentIndex: z.number().optional() })
+    .passthrough(),
+  z
+    .object({ type: z.literal("toolcall_delta"), contentIndex: z.number().optional() })
+    .passthrough(),
+  z.object({ type: z.literal("toolcall_end"), contentIndex: z.number().optional() }).passthrough(),
+  z.object({ type: z.literal("done"), contentIndex: z.number().optional() }).passthrough(),
 ]);
 
 export const OmpAgentSessionEventSchema = z.discriminatedUnion("type", [

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -20,8 +20,7 @@ import {
 } from "../agent.js";
 import type { OmpUsagePollScheduler } from "../usage-poller.js";
 import type { OmpAgentMessage, OmpRpcSlashCommand } from "../rpc-types.js";
-import { FakeOmp } from "./fake-omp.js";
-
+import { FakeOmp, type FakeOmpSession } from "./fake-omp.js";
 const CWD = "/tmp/paseo-omp-agent-test";
 
 interface OmpHistoryMessage {
@@ -166,6 +165,22 @@ export class OmpHarness {
     runtime.queueStateReports(
       providerStatesAfterEnd.map((state) => ({ ...runtime.state, ...state })),
     );
+    runtime.finishTurn();
+    return await run;
+  }
+
+  async runPromptWithEvents(
+    input: string,
+    stream: (runtime: FakeOmpSession) => void,
+  ): Promise<unknown> {
+    const session = this.requireSession();
+    const promptStarted = this.omp.latestSession().nextPrompt();
+    const run = session.run(input);
+    await promptStarted;
+    const runtime = this.omp.latestSession();
+    runtime.beginTurn();
+    runtime.acceptPrompt(input, "user-1");
+    stream(runtime);
     runtime.finishTurn();
     return await run;
   }


### PR DESCRIPTION
### Linked issue

Closes #4509

### Type of change

- [x] Bug fix

### Reasoning

OMP identifies every streamed assistant content block with `contentIndex`, but the OMP adapter relayed thinking and text deltas in arrival order. With GLM models on OpenRouter, reasoning deltas for an earlier block arrive after later blocks have started, so one thinking block rendered as many one-to-few-word Thought rows in the live timeline while the replay path showed the same conversation as one contiguous block.

This applies to the OMP provider the same contentIndex-based grouping PR #3984 added for the Pi provider: later indexed blocks are held behind unfinished earlier blocks and released when their block-end signal arrives. Blocks without a usable index keep the existing direct streaming behavior.

### Goals

- Preserve OMP content-block order during live streaming so one thinking block renders as one contiguous reasoning run.
- Keep thinking deltas as `reasoning` and text deltas as `assistant_message` timeline items, with the correct message id retained when an assistant message-end event is missing.
- Accept `toolcall_start`/`toolcall_delta`/`toolcall_end` assistant message events in the OMP RPC union so tool blocks participate in the ordering instead of dropping the whole event frame at the schema boundary.
- Keep the fix entirely inside the OMP provider.

### Non-goals

- No change to the shared timeline projection or the app's stream coalescing.
- No change to the Pi provider (covered by #3984).
- No change to persisted OMP history mapping; the replay path was already correct.
- Runtimes that omit `contentIndex` retain today's arrival-order streaming.

### QA

Added two provider-level regressions in `omp/agent.test.ts`:

- `thinking(0) -> text(1) -> thinking(0)`: before the fix the late `thinking_delta` produced `[reasoning][assistant][reasoning][assistant]` fragments; after the fix the reasoning chunks stream contiguously before both text chunks. This test fails on `main` and passes with the change (verified by stashing the adapter change).
- Missing block-end events: held text flushes under the previous response id when a new `message_start` arrives, the exact ownership bug flagged in review on #2804.

- `npx vitest run src/server/agent/providers/omp/ src/server/agent/providers/pi/` — 26 files, 255 passed.
- `npm run typecheck` (root, all workspaces) — passed.
- `npx oxlint` on the OMP provider directory — 0 warnings, 0 errors.
- `npx oxfmt --check` on all changed files — passed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
