### PR TITLE
fix(app): fix titlebar drag region under RNW z-index model

### DIFF
--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -51,6 +51,10 @@
       }
     </style>
     <style>
+      [data-titlebar-drag-region] {
+        -webkit-app-region: drag;
+      }
+
       button,
       a,
       input,

--- a/packages/app/src/components/compact-explorer-sidebar.tsx
+++ b/packages/app/src/components/compact-explorer-sidebar.tsx
@@ -27,7 +27,10 @@ import { FileExplorerPane } from "./file-explorer-pane";
 import { useKeyboardShiftStyle } from "@/hooks/use-keyboard-shift-style";
 import { shouldUseCompactExplorerKeyboardPadding } from "@/hooks/keyboard-shift-policy";
 import { WindowChromeSafeArea } from "@/utils/desktop-window";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import {
+  TitlebarDragRegion,
+  titlebarDragRegionDataSet,
+} from "@/components/desktop/titlebar-drag-region";
 import { RetainedPanel, RetainedPanelActivity } from "@/components/retained-panel";
 import { useMountedTabSet } from "@/screens/workspace/use-mounted-tab-set";
 import { usePullRequestPanelAvailability } from "@/panels/pull-request-availability";
@@ -283,7 +286,13 @@ function ExplorerTabButton({
   const tabStyle = useMemo(() => [styles.tab, active && styles.tabActive], [active]);
   const tabTextStyle = useMemo(() => [styles.tabText, active && styles.tabTextActive], [active]);
   return (
-    <Pressable testID={testID} style={tabStyle} onPress={handlePress}>
+    <Pressable
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={tabStyle}
+      onPress={handlePress}
+    >
       {children}
       {label !== undefined ? <Text style={tabTextStyle}>{label}</Text> : null}
     </Pressable>
@@ -346,6 +355,7 @@ function ExplorerSidebarContent({
         horizontalPadding={theme.spacing[2]}
         style={styles.header}
         testID="explorer-header"
+        dataSet={titlebarDragRegionDataSet}
       >
         <TitlebarDragRegion />
         <View style={styles.tabsContainer}>

--- a/packages/app/src/components/desktop/titlebar-drag-region.tsx
+++ b/packages/app/src/components/desktop/titlebar-drag-region.tsx
@@ -2,61 +2,41 @@ import { getIsElectronRuntime } from "@/constants/layout";
 import { isNative } from "@/constants/platform";
 
 /**
- * VS Code-style titlebar drag region for Electron.
+ * Electron titlebar drag region plumbing.
  *
- * Copied from VS Code at commit daa0a70:
- *   - titlebarPart.ts:463-464  → prepend(container, $('div.titlebar-drag-region'))
- *   - titlebarpart.css:57-64   → position: absolute, full size, -webkit-app-region: drag
- *   - titlebarpart.css:249-260 → top-edge resizer, no-drag, 4px
+ * The drag surface is the container itself: `-webkit-app-region: drag` on the
+ * marked container propagates to all non-`no-drag` descendants, and app-region
+ * hit-testing follows the DOM ancestor chain. The attribute is applied via
+ * `dataSet` because RNW's style compiler drops unknown CSS properties like
+ * `-webkit-app-region` when compiling atomic classes.
  *
- * VS Code's drag region is a static DOM element — no z-index, no pointer-events,
- * no state, no event listeners. Interactive elements get no-drag from their own
- * CSS (global backstop in index.html). The drag region never re-renders.
- *
- * The resizer is Windows/Linux only (titlebarpart.css:249 scopes to .windows/.linux).
- * On macOS, Electron handles edge resize natively.
+ * An earlier VS Code-style absolute overlay (first-child sibling) does not
+ * work under RNW 0.21: every View defaults to `position: relative; z-index: 0`
+ * and paints above the overlay, and app-region never applies to siblings.
  */
 
-export const titlebarDragSurfaceStyle: React.CSSProperties = {
-  cursor: "default",
-  // @ts-expect-error — WebkitAppRegion is not in CSSProperties
-  WebkitAppRegion: "drag",
-};
-
-const DRAG_OVERLAY_STYLE: React.CSSProperties = {
-  ...titlebarDragSurfaceStyle,
-  top: 0,
-  left: 0,
-  display: "block",
-  position: "absolute",
-  width: "100%",
-  height: "100%",
-};
+export const titlebarDragRegionDataSet = { titlebarDragRegion: "true" };
 
 const TOP_RESIZER_STYLE: React.CSSProperties = {
   position: "absolute",
   top: 0,
+  left: 0,
   width: "100%",
   height: 4,
+  zIndex: 1000,
   // @ts-expect-error — WebkitAppRegion is not in CSSProperties
   WebkitAppRegion: "no-drag",
 };
 
 /**
- * Static drag overlay and top-edge resizer. Returns null on non-Electron.
- * Place as FIRST child of any positioned container that should be draggable.
+ * Top-edge resizer keeping the window resizable under the drag region
+ * (VS Code titlebarpart.css:249-256). Returns null on non-Electron.
+ * Pair with `titlebarDragRegionDataSet` on the positioned container.
  */
 export function TitlebarDragRegion() {
   if (isNative || !getIsElectronRuntime()) {
     return null;
   }
 
-  return (
-    <>
-      {/* Drag overlay — VS Code .titlebar-drag-region (titlebarpart.css:57-64) */}
-      <div style={DRAG_OVERLAY_STYLE} />
-      {/* Top-edge resizer — VS Code .resizer (titlebarpart.css:249-256) */}
-      <div style={TOP_RESIZER_STYLE} />
-    </>
-  );
+  return <div style={TOP_RESIZER_STYLE} />;
 }

--- a/packages/app/src/components/headers/screen-header.tsx
+++ b/packages/app/src/components/headers/screen-header.tsx
@@ -10,7 +10,10 @@ import {
   useIsCompactFormFactor,
 } from "@/constants/layout";
 import { WindowChromeSafeArea } from "@/utils/desktop-window";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import {
+  TitlebarDragRegion,
+  titlebarDragRegionDataSet,
+} from "@/components/desktop/titlebar-drag-region";
 
 interface ScreenHeaderProps {
   left?: ReactNode;
@@ -56,6 +59,7 @@ export function ScreenHeader({
           horizontalPadding={baseHorizontalPadding}
           onLayout={onRowLayout}
           style={rowStyle}
+          dataSet={titlebarDragRegionDataSet}
         >
           <TitlebarDragRegion />
           <View style={leftCombinedStyle}>{left}</View>

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -15,7 +15,10 @@ import Animated, { runOnJS, useAnimatedStyle, useSharedValue } from "react-nativ
 import { scheduleOnRN } from "react-native-worklets";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import {
+  TitlebarDragRegion,
+  titlebarDragRegionDataSet,
+} from "@/components/desktop/titlebar-drag-region";
 import { resolveDesktopSidebarWidth } from "@/components/desktop-sidebar-layout";
 import {
   SIDEBAR_RESIZE_ACTIVATION_OFFSET,
@@ -730,7 +733,7 @@ function DesktopSidebar({
       style={desktopSidebarStyle}
     >
       <View style={desktopSidebarBorderStyle}>
-        <View style={styles.sidebarDragArea}>
+        <View style={styles.sidebarDragArea} dataSet={titlebarDragRegionDataSet}>
           {ownsTopLeft || DEV_BUILD_LABEL ? (
             <View style={styles.desktopChromeRow}>
               <TitlebarDragRegion />

--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -53,7 +53,10 @@ import {
   useWindowChromeCorners,
   type WindowChromeCorners,
 } from "@/utils/desktop-window";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import {
+  TitlebarDragRegion,
+  titlebarDragRegionDataSet,
+} from "@/components/desktop/titlebar-drag-region";
 import {
   computeTabDropPreview,
   type TabDropPreview,
@@ -1258,7 +1261,11 @@ function SplitPaneView({
         style={styles.pane}
         testID={`workspace-pane-${pane.id}`}
       >
-        <WindowChromeSafeArea placement="inline" style={styles.paneTabs}>
+        <WindowChromeSafeArea
+          placement="inline"
+          style={styles.paneTabs}
+          dataSet={titlebarDragRegionDataSet}
+        >
           <TitlebarDragRegion />
           <WorkspaceDesktopTabsRow
             paneId={pane.id}

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -24,7 +24,10 @@ import type { ComboboxOption as ComboboxOptionType, ComboboxProps } from "@/comp
 import { ComboboxTrigger } from "@/components/ui/combobox-trigger";
 import { Shortcut } from "@/components/ui/shortcut";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import {
+  TitlebarDragRegion,
+  titlebarDragRegionDataSet,
+} from "@/components/desktop/titlebar-drag-region";
 import { SidebarMenuToggle } from "@/components/headers/menu-header";
 import { ScreenHeader } from "@/components/headers/screen-header";
 import { HEADER_INNER_HEIGHT, MAX_CONTENT_WIDTH, useIsCompactFormFactor } from "@/constants/layout";
@@ -2260,7 +2263,7 @@ export function NewWorkspaceScreen({
   return (
     <FileDropZone style={styles.container}>
       <ScreenHeader left={screenHeaderLeft} borderless />
-      <View style={contentStyle}>
+      <View style={contentStyle} dataSet={titlebarDragRegionDataSet}>
         <TitlebarDragRegion />
         <KeyboardTranslateView style={animatedStaticStyles.centered}>
           <View style={styles.composerTitleContainer}>

--- a/packages/app/src/screens/open-project-screen.tsx
+++ b/packages/app/src/screens/open-project-screen.tsx
@@ -17,7 +17,10 @@ import {
   HEADER_INNER_HEIGHT_MOBILE,
   HEADER_TOP_PADDING_MOBILE,
 } from "@/constants/layout";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import {
+  TitlebarDragRegion,
+  titlebarDragRegionDataSet,
+} from "@/components/desktop/titlebar-drag-region";
 import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
 import { PairDeviceModal } from "@/desktop/components/pair-device-modal";
 import { buildSettingsHostSectionRoute } from "@/utils/host-routes";
@@ -59,7 +62,7 @@ export function OpenProjectScreen() {
   return (
     <View style={styles.container}>
       <MenuHeader borderless />
-      <View style={styles.content}>
+      <View dataSet={titlebarDragRegionDataSet} style={styles.content}>
         <TitlebarDragRegion />
         <View style={styles.logo}>
           <PaseoLogo size={52} />
@@ -141,6 +144,7 @@ function HomeTile({ icon: Icon, title, description, onPress, testID, accent }: H
 
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={onPress}
       onHoverIn={handleHoverIn}
       onHoverOut={handleHoverOut}

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -67,7 +67,10 @@ import {
   resolveActiveHostServerId,
   type HostProfile,
 } from "@/types/host-connection";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import {
+  TitlebarDragRegion,
+  titlebarDragRegionDataSet,
+} from "@/components/desktop/titlebar-drag-region";
 import { WindowChromeRegion, WindowChromeSafeArea } from "@/utils/desktop-window";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { BackHeader } from "@/components/headers/back-header";
@@ -1146,7 +1149,7 @@ function SettingsSidebar({
     >
       {isDesktop ? (
         <View style={innerContainerStyle}>
-          <View style={sidebarStyles.sidebarDragArea}>
+          <View style={sidebarStyles.sidebarDragArea} dataSet={titlebarDragRegionDataSet}>
             <TitlebarDragRegion />
             <WindowChromeSafeArea placement="below" />
             <SidebarHeaderRow

--- a/packages/app/src/screens/startup-splash-screen.tsx
+++ b/packages/app/src/screens/startup-splash-screen.tsx
@@ -18,7 +18,10 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { PaseoLogo } from "@/components/icons/paseo-logo";
 import { Button } from "@/components/ui/button";
 import { getDesktopDaemonLogs, type DesktopDaemonLogs } from "@/desktop/daemon/desktop-daemon";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import {
+  TitlebarDragRegion,
+  titlebarDragRegionDataSet,
+} from "@/components/desktop/titlebar-drag-region";
 import { isNative, isWeb } from "@/constants/platform";
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
 
@@ -383,7 +386,7 @@ export function StartupSplashScreen({ bootstrapState }: StartupSplashScreenProps
 
   if (!isError) {
     return (
-      <View testID="startup-splash" style={styles.container}>
+      <View testID="startup-splash" style={styles.container} dataSet={titlebarDragRegionDataSet}>
         <TitlebarDragRegion />
         <LogoShimmer />
       </View>
@@ -391,7 +394,7 @@ export function StartupSplashScreen({ bootstrapState }: StartupSplashScreenProps
   }
 
   return (
-    <View style={styles.errorScreen}>
+    <View style={styles.errorScreen} dataSet={titlebarDragRegionDataSet}>
       <TitlebarDragRegion />
       <ScrollView
         style={styles.errorScrollView}

--- a/packages/app/src/screens/workspace/explorer-sidebar-tab-rail.tsx
+++ b/packages/app/src/screens/workspace/explorer-sidebar-tab-rail.tsx
@@ -17,7 +17,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { titlebarDragSurfaceStyle } from "@/components/desktop/titlebar-drag-region";
+import { titlebarDragRegionDataSet } from "@/components/desktop/titlebar-drag-region";
 import { WORKSPACE_SECONDARY_HEADER_HEIGHT } from "@/constants/layout";
 import { iconButtonChromeGlyphSize } from "@/components/ui/icon-button-chrome";
 import { HEADER_CONTROL_HEIGHT } from "@/components/ui/control-geometry";
@@ -337,7 +337,8 @@ export function ExplorerSidebarTabRail({
     <ContextMenu>
       <ContextMenuTrigger
         contextOnly
-        style={[styles.track, titlebarDragSurfaceStyle as never]}
+        style={styles.track}
+        dataSet={titlebarDragRegionDataSet}
         testID="explorer-sidebar-tab-rail"
       >
         <View style={styles.scrollContainer}>

--- a/packages/app/src/screens/workspace/explorer-sidebar.tsx
+++ b/packages/app/src/screens/workspace/explorer-sidebar.tsx
@@ -2,7 +2,10 @@ import { useCallback, useMemo, type ReactNode } from "react";
 import { View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { RetainedPanel } from "@/components/retained-panel";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import {
+  TitlebarDragRegion,
+  titlebarDragRegionDataSet,
+} from "@/components/desktop/titlebar-drag-region";
 import type { TabDropPreview } from "@/components/split-container-tab-drop-preview";
 import { ExplorerSidebarTabRail } from "@/screens/workspace/explorer-sidebar-tab-rail";
 import { WorkspacePanelHost } from "@/screens/workspace/workspace-panel-host";
@@ -84,7 +87,11 @@ export function ExplorerSidebarDock({
     <RetainedPanel active>
       <WindowChromeRegion corners="top-right">
         <View style={styles.dock} testID="workspace-explorer-sidebar">
-          <WindowChromeSafeArea placement="inline" style={styles.tabRail}>
+          <WindowChromeSafeArea
+            placement="inline"
+            style={styles.tabRail}
+            dataSet={titlebarDragRegionDataSet}
+          >
             <TitlebarDragRegion />
             <ExplorerSidebarTabRail
               paneId={pane.id}

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -889,6 +889,7 @@ function TabChip({
             <Pressable
               {...(closeButtonDragBlockers as object | undefined)}
               testID={closeButtonTestId}
+              accessibilityRole="button"
               disabled={isClosingTab}
               onPressIn={handleCloseButtonPressIn}
               onHoverIn={handleCloseButtonHoverIn}


### PR DESCRIPTION
Closes #3399.

## Problem

The VS Code-style sibling overlay in `TitlebarDragRegion` did not work under RNW 0.21:

- Every RNW `View` defaults to `position: relative; z-index: 0`, so flex containers like the workspace title row's content box paint above the absolutely positioned overlay.
- `-webkit-app-region` hit-testing follows the DOM ancestor chain only — it never applies to siblings. Clicks on the title row landed in the content subtree, so the window could not be dragged (only the outer padding gaps still worked).

## Fix

- Mark drag containers with `data-titlebar-drag-region` (applied via `dataSet`, since RNW's atomic style compiler drops unknown CSS properties) and assign `-webkit-app-region: drag` in `index.html`. The drag surface is now the container itself, and the existing global `no-drag` catchlist keeps buttons/inputs clickable.
- `TitlebarDragRegion` now only renders the top-edge 4px `no-drag` resizer (VS Code `titlebarpart.css` pattern), with an elevated `z-index` so it sits above content.
- Removed the overlay export `titlebarDragSurfaceStyle` (tab rail now uses the dataset marker).
- Added missing `accessibilityRole="button"` on interactive elements inside drag containers (`HomeTile`, workspace tab close button, explorer sidebar tab buttons) so the global `no-drag` CSS catches them.

## Testing

- `oxlint` and `oxfmt --check` green on all touched files; full workspace typecheck green.
- `-webkit-app-region` behavior needs manual verification on Windows: drag from workspace title row / tab rail / sidebar blank areas, confirm buttons and inputs still receive clicks, and the top edge still resizes the window.