### PR TITLE
Fix Codex continuation after workspace archive

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7765,6 +7765,53 @@ test("fires onAgentArchived for stored-only snapshot archives", async () => {
   expect(archivedIds).toEqual([storedOnly.id]);
 });
 
+test("native archive and restore release the loaded session writer", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-native-archive-writer-"));
+  class WriterClient extends NativeArchiveRecordingClient {
+    session: CloseRecordingTestAgentSession | undefined;
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      this.session = new CloseRecordingTestAgentSession(config);
+      return this.session;
+    }
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return this.createSession({ provider: "codex", cwd: workdir, ...config });
+    }
+    override async archiveNativeSession(handle: AgentPersistenceHandle): Promise<void> {
+      if (!this.session?.closed) throw new Error("native thread has an active writer");
+      await super.archiveNativeSession(handle);
+    }
+    override async unarchiveNativeSession(handle: AgentPersistenceHandle): Promise<void> {
+      if (!this.session?.closed) throw new Error("native thread has an active writer");
+      await super.unarchiveNativeSession(handle);
+    }
+  }
+  const client = new WriterClient();
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({ clients: { codex: client }, registry: storage, logger });
+  try {
+    const agent = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await manager.archiveAgent(agent.id);
+    expect(client.archivedHandles).toHaveLength(1);
+    // Opening archived history can retain a writer, including records archived by older daemons.
+    await ensureAgentLoaded(agent.id, { agentManager: manager, agentStorage: storage, logger });
+    expect(client.session?.closed).toBe(false);
+    await manager.unarchiveSnapshot(agent.id);
+    expect(client.unarchivedHandles).toHaveLength(1);
+    expect((await storage.get(agent.id))?.archivedAt).toBeNull();
+    expect(client.session?.closed).toBe(true);
+    await ensureAgentLoaded(agent.id, { agentManager: manager, agentStorage: storage, logger });
+    expect(client.session?.closed).toBe(false);
+  } finally {
+    for (const agent of manager.listAgents()) await manager.closeAgent(agent.id);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("unarchiveSnapshot skips native provider unarchive for active records", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-unarchive-active-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1703,6 +1703,7 @@ export class AgentManager {
     const { archivedAt } = await this.markRecordArchived(stored);
     agent.updatedAt = new Date(archivedAt);
     await this.closeAgentRuntime(agentId);
+    await this.syncNativeArchiveState(stored.provider, stored.persistence, "archive");
     this.discardRetainedAgentState(agentId);
 
     await this.cascadeArchiveChildren(agentId);
@@ -1761,8 +1762,6 @@ export class AgentManager {
       archivedAt,
       updatedAt: archivedAt,
     });
-
-    await this.syncNativeArchiveState(record.provider, record.persistence, "archive");
 
     if (this.agents.has(record.id)) {
       this.notifyAgentState(record.id);
@@ -2090,6 +2089,8 @@ export class AgentManager {
       return false;
     }
 
+    // Archived history may have loaded a runtime that still owns the native writer.
+    await this.closeAgent(agentId);
     await this.syncNativeArchiveState(record.provider, record.persistence, "restore");
 
     await registry.upsert({

--- a/packages/server/src/server/daemon-e2e/agent-archive.native.real.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/agent-archive.native.real.e2e.test.ts
@@ -8,99 +8,103 @@ import { CodexAppServerAgentClient } from "../agent/providers/codex-app-server-a
 import { DaemonClient } from "../test-utils/daemon-client.js";
 import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo-daemon.js";
 
+async function expectContextAfterWorkspaceRestore(legacyNativeArchive: boolean): Promise<void> {
+  const root = mkdtempSync(path.join(tmpdir(), "paseo-archive-codex-"));
+  const cwd = path.join(root, "repo");
+  mkdirSync(cwd);
+  execFileSync("git", ["init", "-b", "main", cwd]);
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=QA",
+      "-c",
+      "user.email=qa@example.invalid",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "QA",
+    ],
+    { cwd },
+  );
+  const logger = pino({ level: "warn" });
+  const provider = new CodexAppServerAgentClient(logger);
+  let daemon: TestPaseoDaemon | undefined;
+  let client: DaemonClient | undefined;
+  try {
+    daemon = await createTestPaseoDaemon({
+      agentClients: { codex: provider },
+      logger,
+      pluginsEnabled: false,
+    });
+    client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws`, appVersion: "0.8.0" });
+    await client.connect();
+    await client.fetchAgents({ subscribe: { subscriptionId: "archive-qa" } });
+    const agent = await client.createAgent({
+      config: {
+        provider: "codex",
+        cwd,
+        model: "gpt-5.6-sol",
+        modeId: "full-access",
+        thinkingOptionId: "low",
+      },
+      worktree: { mode: "branch-off", base: "main", newBranch: "archive-qa" },
+    });
+    const manager = daemon.daemon.agentManager;
+    const token = "ARCHIVE_CEDAR_7429";
+    const first = await manager.runAgent(
+      agent.id,
+      `Remember ${token}. Reply with only that token. Do not use tools.`,
+    );
+    expect(first.finalText).toContain(token);
+    const handle = manager.getAgent(agent.id)!.persistence!;
+    await client.archiveWorkspace(agent.workspaceId!);
+    expect(existsSync(agent.cwd)).toBe(false);
+    // Older daemons marked Paseo archived while native archive failed against its writer.
+    if (legacyNativeArchive) await provider.unarchiveNativeSession(handle);
+    await client.restoreWorkspace(agent.workspaceId!);
+    expect(existsSync(agent.cwd)).toBe(true);
+    await client.fetchAgentTimeline(agent.id, { direction: "tail", limit: 0 });
+    await client.sendAgentMessage(
+      agent.id,
+      "What token did I ask you to remember? Reply with RECALLED=<token>. Do not use tools.",
+      { activeTurnBehavior: "steer" },
+    );
+    const connectedClient = client;
+    await expect
+      .poll(
+        async () => {
+          const timeline = await connectedClient.fetchAgentTimeline(agent.id, {
+            direction: "tail",
+            limit: 0,
+            projection: "canonical",
+          });
+          return timeline.entries
+            .map(({ item }) => (item.type === "assistant_message" ? item.text : ""))
+            .join("");
+        },
+        { timeout: 30_000 },
+      )
+      .toContain(`RECALLED=${token}`);
+    expect(manager.getAgent(agent.id)?.persistence?.sessionId).toBe(handle.sessionId);
+    process.stdout.write(
+      `archived -> restored; same agent=${agent.id}; same session=${handle.sessionId}; two real replies recall ${token}; legacy=${legacyNativeArchive}\n`,
+    );
+    await client.archiveWorkspace(agent.workspaceId!);
+  } finally {
+    await client?.close();
+    await daemon?.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 // Opt in: real Codex requests using local authentication.
 test.runIf(process.env.PASEO_NATIVE_ARCHIVE_QA === "1").each([false, true])(
   "Codex recalls context after workspace restore (legacy native archive: %s)",
   async (legacyNativeArchive) => {
-    const root = mkdtempSync(path.join(tmpdir(), "paseo-archive-codex-"));
-    const cwd = path.join(root, "repo");
-    mkdirSync(cwd);
-    execFileSync("git", ["init", "-b", "main", cwd]);
-    execFileSync(
-      "git",
-      [
-        "-c",
-        "user.name=QA",
-        "-c",
-        "user.email=qa@example.invalid",
-        "-c",
-        "commit.gpgsign=false",
-        "commit",
-        "--allow-empty",
-        "-m",
-        "QA",
-      ],
-      { cwd },
-    );
-    const logger = pino({ level: "warn" });
-    const provider = new CodexAppServerAgentClient(logger);
-    let daemon: TestPaseoDaemon | undefined;
-    let client: DaemonClient | undefined;
-    try {
-      daemon = await createTestPaseoDaemon({
-        agentClients: { codex: provider },
-        logger,
-        pluginsEnabled: false,
-      });
-      client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws`, appVersion: "0.8.0" });
-      await client.connect();
-      await client.fetchAgents({ subscribe: { subscriptionId: "archive-qa" } });
-      const agent = await client.createAgent({
-        config: {
-          provider: "codex",
-          cwd,
-          model: "gpt-5.6-sol",
-          modeId: "full-access",
-          thinkingOptionId: "low",
-        },
-        worktree: { mode: "branch-off", base: "main", newBranch: "archive-qa" },
-      });
-      const manager = daemon.daemon.agentManager;
-      const token = "ARCHIVE_CEDAR_7429";
-      const first = await manager.runAgent(
-        agent.id,
-        `Remember ${token}. Reply with only that token. Do not use tools.`,
-      );
-      expect(first.finalText).toContain(token);
-      const handle = manager.getAgent(agent.id)!.persistence!;
-      await client.archiveWorkspace(agent.workspaceId!);
-      expect(existsSync(agent.cwd)).toBe(false);
-      // Older daemons marked Paseo archived while native archive failed against its writer.
-      if (legacyNativeArchive) await provider.unarchiveNativeSession(handle);
-      await client.restoreWorkspace(agent.workspaceId!);
-      expect(existsSync(agent.cwd)).toBe(true);
-      await client.fetchAgentTimeline(agent.id, { direction: "tail", limit: 0 });
-      await client.sendAgentMessage(
-        agent.id,
-        "What token did I ask you to remember? Reply with RECALLED=<token>. Do not use tools.",
-        { activeTurnBehavior: "steer" },
-      );
-      const connectedClient = client;
-      await expect
-        .poll(
-          async () => {
-            const timeline = await connectedClient.fetchAgentTimeline(agent.id, {
-              direction: "tail",
-              limit: 0,
-              projection: "canonical",
-            });
-            return timeline.entries
-              .map(({ item }) => (item.type === "assistant_message" ? item.text : ""))
-              .join("");
-          },
-          { timeout: 30_000 },
-        )
-        .toContain(`RECALLED=${token}`);
-      expect(manager.getAgent(agent.id)?.persistence?.sessionId).toBe(handle.sessionId);
-      process.stdout.write(
-        `archived -> restored; same agent=${agent.id}; same session=${handle.sessionId}; two real replies recall ${token}; legacy=${legacyNativeArchive}\n`,
-      );
-      await client.archiveWorkspace(agent.workspaceId!);
-    } finally {
-      await client?.close();
-      await daemon?.close();
-      rmSync(root, { recursive: true, force: true });
-    }
+    await expectContextAfterWorkspaceRestore(legacyNativeArchive);
   },
   90_000,
 );

--- a/packages/server/src/server/daemon-e2e/agent-archive.native.real.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/agent-archive.native.real.e2e.test.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { expect, test } from "vitest";
+import { CodexAppServerAgentClient } from "../agent/providers/codex-app-server-agent.js";
+import { DaemonClient } from "../test-utils/daemon-client.js";
+import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo-daemon.js";
+
+// Opt in: real Codex requests using local authentication.
+test.runIf(process.env.PASEO_NATIVE_ARCHIVE_QA === "1").each([false, true])(
+  "Codex recalls context after workspace restore (legacy native archive: %s)",
+  async (legacyNativeArchive) => {
+    const root = mkdtempSync(path.join(tmpdir(), "paseo-archive-codex-"));
+    const cwd = path.join(root, "repo");
+    mkdirSync(cwd);
+    execFileSync("git", ["init", "-b", "main", cwd]);
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=QA",
+        "-c",
+        "user.email=qa@example.invalid",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "QA",
+      ],
+      { cwd },
+    );
+    const logger = pino({ level: "warn" });
+    const provider = new CodexAppServerAgentClient(logger);
+    let daemon: TestPaseoDaemon | undefined;
+    let client: DaemonClient | undefined;
+    try {
+      daemon = await createTestPaseoDaemon({
+        agentClients: { codex: provider },
+        logger,
+        pluginsEnabled: false,
+      });
+      client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws`, appVersion: "0.8.0" });
+      await client.connect();
+      await client.fetchAgents({ subscribe: { subscriptionId: "archive-qa" } });
+      const agent = await client.createAgent({
+        config: {
+          provider: "codex",
+          cwd,
+          model: "gpt-5.6-sol",
+          modeId: "full-access",
+          thinkingOptionId: "low",
+        },
+        worktree: { mode: "branch-off", base: "main", newBranch: "archive-qa" },
+      });
+      const manager = daemon.daemon.agentManager;
+      const token = "ARCHIVE_CEDAR_7429";
+      const first = await manager.runAgent(
+        agent.id,
+        `Remember ${token}. Reply with only that token. Do not use tools.`,
+      );
+      expect(first.finalText).toContain(token);
+      const handle = manager.getAgent(agent.id)!.persistence!;
+      await client.archiveWorkspace(agent.workspaceId!);
+      expect(existsSync(agent.cwd)).toBe(false);
+      // Older daemons marked Paseo archived while native archive failed against its writer.
+      if (legacyNativeArchive) await provider.unarchiveNativeSession(handle);
+      await client.restoreWorkspace(agent.workspaceId!);
+      expect(existsSync(agent.cwd)).toBe(true);
+      await client.fetchAgentTimeline(agent.id, { direction: "tail", limit: 0 });
+      await client.sendAgentMessage(
+        agent.id,
+        "What token did I ask you to remember? Reply with RECALLED=<token>. Do not use tools.",
+        { activeTurnBehavior: "steer" },
+      );
+      const connectedClient = client;
+      await expect
+        .poll(
+          async () => {
+            const timeline = await connectedClient.fetchAgentTimeline(agent.id, {
+              direction: "tail",
+              limit: 0,
+              projection: "canonical",
+            });
+            return timeline.entries
+              .map(({ item }) => (item.type === "assistant_message" ? item.text : ""))
+              .join("");
+          },
+          { timeout: 30_000 },
+        )
+        .toContain(`RECALLED=${token}`);
+      expect(manager.getAgent(agent.id)?.persistence?.sessionId).toBe(handle.sessionId);
+      process.stdout.write(
+        `archived -> restored; same agent=${agent.id}; same session=${handle.sessionId}; two real replies recall ${token}; legacy=${legacyNativeArchive}\n`,
+      );
+      await client.archiveWorkspace(agent.workspaceId!);
+    } finally {
+      await client?.close();
+      await daemon?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  90_000,
+);


### PR DESCRIPTION
### Linked issue

Observed during hosted continuation QA in https://github.com/getpaseo/hub/issues/123. Related to #4353 and #4473; this focused archive fix does not replace the provider history refactor.

### Type of change

- [x] Bug fix

### Reasoning

After a GitHub follow-up restored an archived workspace, the same Codex agent failed with `thread … already has an active writer`. Paseo called native archive before closing its runtime, so Codex rejected archive. Loading that archived conversation then acquired a writer before native unarchive.

Close the runtime before native archive. Before native unarchive, release any runtime loaded for archived history. This also repairs continuation of existing records left native-active by older daemons; no stored data or protocol migration is required.

### Goals

- Continue the same agent and native conversation after workspace archive and restore.
- Support already archived records created by previous daemons.

### Non-goals

- Change provider history APIs, Hub trigger policy, RPCs, or restart recovery.

### QA

- Reproduced through real Codex and ordinary workspace recovery/send RPCs in an isolated daemon: unmodified source failed with the same active-writer error as hosted Hub.
- Fixed source: two real Codex cases pass, covering native-archived and legacy native-active records. Each creates an owned worktree, remembers a token, archives/removes the worktree, restores it, reads history, and sends a follow-up without the token. The same agent/session replies `RECALLED=ARCHIVE_CEDAR_7429`.
- `PASEO_NATIVE_ARCHIVE_QA=1 npx vitest run src/server/daemon-e2e/agent-archive.native.real.e2e.test.ts --bail=1`: 2 passed.
- `npx vitest run src/server/agent/agent-manager.test.ts --bail=1`: 180 passed, including native writer ownership regression.
- Server build, repository typecheck, lint, and format check pass.
- Hosted Hub QA against the built isolated daemon PASSED: [first reply](https://github.com/getpaseo/hub/issues/125#issuecomment-5589936187), then [memory recall after archive/restore](https://github.com/getpaseo/hub/issues/125#issuecomment-5589955241). Same agent `2ec6e916-2419-449b-b988-a7b1c0b92e68` and session `ce8d11ac-b9ea-5fcc-abe5-672dfc6e1276`; executions `046aee71-1034-5bd8-b6a0-19f3f50dbd47` → `d272d06e-9703-5de8-8f38-cabb2251f2c8`. Both replied, finished, and archived. The main development daemon was not restarted and still requires this update.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
