### PR TITLE
feat(desktop): add --daemon-only to run the app as a headless daemon service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ At the start of non-trivial work, list `docs/` and skim anything relevant to the
 | [docs/browser-capture-harness.md](docs/browser-capture-harness.md)   | Real-Electron browser screenshot harness and compositor-surface gotcha                                                         |
 | [docs/android.md](docs/android.md)                                   | App variants, local/cloud builds, EAS workflows, version codes, F-Droid source builds and store metadata                       |
 | [docs/docker.md](docs/docker.md)                                     | Running the daemon and bundled web UI in Docker, volumes, agent images, security                                               |
+| [docs/daemon-service.md](docs/daemon-service.md)                     | Running the daemon as an OS service with `--daemon-only`, unit configuration, and env precedence                               |
 | [docs/release.md](docs/release.md)                                   | Release playbook, draft releases, completion checklist                                                                         |
 | [docs/terminal-activity.md](docs/terminal-activity.md)               | Terminal activity indicators — source-agnostic tracker, agent hook reporting, adding a new hook provider                       |
 | [SECURITY.md](SECURITY.md)                                           | Relay threat model, E2E encryption, DNS rebinding, agent auth                                                                  |

--- a/docs/daemon-service.md
+++ b/docs/daemon-service.md
@@ -1,0 +1,71 @@
+# Running the daemon as a service
+
+The desktop app starts its daemon when you open a window, and that daemon
+outlives the app once started. Nothing starts it before then, so on a freshly
+booted machine phone clients, browser clients, schedules, and the CLI have
+nothing to talk to until someone logs in and opens the GUI.
+
+`--daemon-only` runs the packaged app as a headless daemon host instead:
+
+```
+Paseo --daemon-only
+```
+
+No window is created and no display is needed. The app already re-execs its own
+Electron binary with `ELECTRON_RUN_AS_NODE=1` to run the bundled daemon every
+time it starts one; the flag runs that same daemon in the foreground and stays
+alive alongside it, so a service manager can supervise it.
+
+Because the daemon ships inside the app, the client and the daemon are one
+artifact. There is no separate daemon install to keep in step, and an app update
+replaces both halves at once.
+
+## systemd
+
+```ini
+[Unit]
+Description=Paseo daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/Applications/Paseo-x86_64.AppImage --daemon-only
+EnvironmentFile=%h/.config/paseo/daemon.env
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=default.target
+```
+
+Run it as a user unit (`systemctl --user`). The daemon needs the user's home,
+SSH agent, and agent CLIs, so a system unit is the wrong scope.
+
+`systemctl stop` exits 0, and a daemon that dies on its own exits non-zero so
+`Restart=` brings it back.
+
+## Configuration
+
+Configure it through the environment, the same variables the daemon reads
+anywhere else — `PASEO_HOME`, `PASEO_LISTEN`, `PASEO_PASSWORD`.
+
+**A unit's environment outranks the login shell.** The app inherits the login
+shell's environment on startup so agents get the `PATH` a terminal would give
+them, which matters more here than usual because a service at boot has no shell
+to inherit from. Every `PASEO_*` variable the service manager passed in survives
+that inheritance. Without it, a shell rc that exports `PASEO_HOME` for
+interactive CLI use would move the daemon to a different home and take every
+agent and project with it.
+
+## What it is not
+
+A `--daemon-only` process is not a desktop-managed daemon. It is not recorded as
+`desktopManaged` in the PID lock, so a desktop app that later attaches to it
+treats it as an external daemon: it will not stop it on quit and will not stop
+it to install an app update. Set `manageBuiltInDaemon: false` in the desktop
+app's settings so it attaches to this daemon rather than starting a second one.
+
+The Chromium browser process still initializes — it is the service's main
+process — and its zygote and network helpers stay resident with it. That costs a
+few hundred MB of RSS beyond the daemon itself.

--- a/packages/desktop/src/daemon/daemon-manager.ts
+++ b/packages/desktop/src/daemon/daemon-manager.ts
@@ -348,6 +348,43 @@ async function pollForRunningDaemon(): Promise<DesktopDaemonStatus> {
   return poll(0);
 }
 
+/**
+ * Starts the bundled daemon in the foreground, attached to this process's stdio,
+ * for `--daemon-only` service launches. Unlike the desktop-managed daemon this
+ * one is not marked `PASEO_DESKTOP_MANAGED`: it outlives any app window, and a
+ * desktop instance that later attaches to it must not stop it on quit or update.
+ * The web UI is left at the daemon's own default so browser and phone clients
+ * can reach a machine that has no desktop session.
+ */
+export function spawnBundledDaemonForeground(): ChildProcess {
+  const daemonRunner = resolveDaemonRunnerEntrypoint();
+  const invocation = createNodeEntrypointInvocation({
+    entrypoint: daemonRunner,
+    argvMode: "node-script",
+    args: [],
+    baseEnv: process.env,
+  });
+
+  logDesktopDaemonLifecycle("starting foreground daemon", {
+    appIsPackaged: app.isPackaged,
+    daemonRunnerEntry: daemonRunner.entryPath,
+    command: invocation.command,
+    args: invocation.args,
+    electronRunAsNode: invocation.env.ELECTRON_RUN_AS_NODE ?? null,
+    paseoHome: process.env.PASEO_HOME ?? null,
+    listen: process.env.PASEO_LISTEN ?? null,
+  });
+
+  return spawnProcess(invocation.command, invocation.args, {
+    envMode: "internal",
+    env: invocation.env,
+    envOverlay: {
+      PASEO_CLI: getBundledCliShimPath(),
+    },
+    stdio: "inherit",
+  });
+}
+
 async function startDaemon(): Promise<DesktopDaemonStatus> {
   assertBuiltInDaemonManagementEnabled(await getDesktopSettingsStore().get());
 

--- a/packages/desktop/src/daemon/daemon-only.test.ts
+++ b/packages/desktop/src/daemon/daemon-only.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  inheritLoginShellEnvForService,
+  isDaemonOnlyLaunch,
+  resolveDaemonOnlyExitCode,
+  runDaemonOnly,
+  type DaemonOnlyChildProcess,
+} from "./daemon-only";
+
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+
+class FakeDaemonProcess implements DaemonOnlyChildProcess {
+  readonly signalsReceived: NodeJS.Signals[] = [];
+  private exitListener: ExitListener | null = null;
+  private errorListener: ((error: Error) => void) | null = null;
+
+  once(event: "exit", listener: ExitListener): this;
+  once(event: "error", listener: (error: Error) => void): this;
+  once(event: "exit" | "error", listener: ExitListener | ((error: Error) => void)): this {
+    if (event === "exit") {
+      this.exitListener = listener as ExitListener;
+    } else {
+      this.errorListener = listener as (error: Error) => void;
+    }
+    return this;
+  }
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.signalsReceived.push(signal);
+    return true;
+  }
+
+  emitExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.exitListener?.(code, signal);
+  }
+
+  emitError(error: Error): void {
+    this.errorListener?.(error);
+  }
+}
+
+class StopTrigger {
+  private requestStop: (() => void) | null = null;
+
+  register = (requestStop: () => void): void => {
+    this.requestStop = requestStop;
+  };
+
+  fire(): void {
+    if (!this.requestStop) {
+      throw new Error("No stop handler was registered");
+    }
+    this.requestStop();
+  }
+}
+
+describe("daemon-only launch detection", () => {
+  it("detects the flag in a packaged launch", () => {
+    expect(
+      isDaemonOnlyLaunch({
+        argv: ["/opt/Paseo/paseo", "--no-sandbox", "--daemon-only"],
+        isDefaultApp: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("detects the flag in a dev launch that passes the app directory", () => {
+    expect(
+      isDaemonOnlyLaunch({
+        argv: ["/usr/bin/electron", "/repo/packages/desktop", "--daemon-only"],
+        isDefaultApp: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat the executable path as a flag", () => {
+    expect(isDaemonOnlyLaunch({ argv: ["/opt/--daemon-only/paseo"], isDefaultApp: false })).toBe(
+      false,
+    );
+  });
+
+  it("is false for a plain GUI launch", () => {
+    expect(isDaemonOnlyLaunch({ argv: ["/opt/Paseo/paseo"], isDefaultApp: false })).toBe(false);
+  });
+
+  it("is false for a passthrough CLI launch", () => {
+    expect(
+      isDaemonOnlyLaunch({ argv: ["/opt/Paseo/paseo", "daemon", "status"], isDefaultApp: false }),
+    ).toBe(false);
+  });
+});
+
+describe("daemon-only exit code", () => {
+  it("uses the daemon's own exit code", () => {
+    expect(resolveDaemonOnlyExitCode({ code: 3, signal: null, requestedStopSignal: null })).toBe(3);
+  });
+
+  it("reports success when the daemon died from the signal we forwarded", () => {
+    expect(
+      resolveDaemonOnlyExitCode({ code: null, signal: "SIGTERM", requestedStopSignal: "SIGTERM" }),
+    ).toBe(0);
+  });
+
+  it("reports failure when the daemon died from a signal we did not send", () => {
+    expect(
+      resolveDaemonOnlyExitCode({ code: null, signal: "SIGKILL", requestedStopSignal: "SIGTERM" }),
+    ).toBe(1);
+  });
+
+  it("reports failure when the daemon died from a signal and no stop was requested", () => {
+    expect(
+      resolveDaemonOnlyExitCode({ code: null, signal: "SIGSEGV", requestedStopSignal: null }),
+    ).toBe(1);
+  });
+});
+
+describe("runDaemonOnly", () => {
+  it("stops the daemon when Electron asks to quit and exits 0 once it is down", async () => {
+    const child = new FakeDaemonProcess();
+    const stopTrigger = new StopTrigger();
+
+    const exitCode = runDaemonOnly({
+      spawnDaemon: () => child,
+      onStopRequested: stopTrigger.register,
+      onSpawnError: vi.fn(),
+    });
+
+    stopTrigger.fire();
+    expect(child.signalsReceived).toEqual(["SIGTERM"]);
+
+    child.emitExit(null, "SIGTERM");
+    await expect(exitCode).resolves.toBe(0);
+  });
+
+  it("escalates to SIGKILL when a second stop arrives", async () => {
+    const child = new FakeDaemonProcess();
+    const stopTrigger = new StopTrigger();
+
+    const exitCode = runDaemonOnly({
+      spawnDaemon: () => child,
+      onStopRequested: stopTrigger.register,
+      onSpawnError: vi.fn(),
+    });
+
+    stopTrigger.fire();
+    stopTrigger.fire();
+    stopTrigger.fire();
+    expect(child.signalsReceived).toEqual(["SIGTERM", "SIGKILL"]);
+
+    child.emitExit(null, "SIGKILL");
+    await expect(exitCode).resolves.toBe(0);
+  });
+
+  it("propagates a daemon crash exit code so a service supervisor can restart it", async () => {
+    const child = new FakeDaemonProcess();
+
+    const exitCode = runDaemonOnly({
+      spawnDaemon: () => child,
+      onStopRequested: new StopTrigger().register,
+      onSpawnError: vi.fn(),
+    });
+
+    child.emitExit(1, null);
+    await expect(exitCode).resolves.toBe(1);
+  });
+
+  it("reports a crash signal as a failure when no stop was requested", async () => {
+    const child = new FakeDaemonProcess();
+
+    const exitCode = runDaemonOnly({
+      spawnDaemon: () => child,
+      onStopRequested: new StopTrigger().register,
+      onSpawnError: vi.fn(),
+    });
+
+    child.emitExit(null, "SIGSEGV");
+    await expect(exitCode).resolves.toBe(1);
+  });
+
+  it("reports a spawn failure and exits non-zero", async () => {
+    const child = new FakeDaemonProcess();
+    const onSpawnError = vi.fn();
+    const error = new Error("ENOENT");
+
+    const exitCode = runDaemonOnly({
+      spawnDaemon: () => child,
+      onStopRequested: new StopTrigger().register,
+      onSpawnError,
+    });
+
+    child.emitError(error);
+    await expect(exitCode).resolves.toBe(1);
+    expect(onSpawnError).toHaveBeenCalledWith(error);
+  });
+});
+
+describe("service environment precedence", () => {
+  it("keeps the unit's Paseo configuration when the login shell exports its own", () => {
+    const env: NodeJS.ProcessEnv = {
+      PASEO_HOME: "/srv/paseo-home",
+      PASEO_LISTEN: "127.0.0.1:6767",
+      PATH: "/usr/bin",
+    };
+
+    inheritLoginShellEnvForService({
+      env,
+      inheritLoginShellEnv: () => {
+        Object.assign(env, {
+          PASEO_HOME: "/home/dev/.paseo",
+          PASEO_LISTEN: "127.0.0.1:9999",
+          PATH: "/home/dev/.local/bin:/usr/bin",
+        });
+      },
+    });
+
+    expect(env.PASEO_HOME).toBe("/srv/paseo-home");
+    expect(env.PASEO_LISTEN).toBe("127.0.0.1:6767");
+  });
+
+  it("still takes the login shell PATH the agents need", () => {
+    const env: NodeJS.ProcessEnv = { PASEO_HOME: "/srv/paseo-home", PATH: "/usr/bin" };
+
+    inheritLoginShellEnvForService({
+      env,
+      inheritLoginShellEnv: () => {
+        env.PATH = "/home/dev/.local/bin:/usr/bin";
+        env.NVM_DIR = "/home/dev/.nvm";
+      },
+    });
+
+    expect(env.PATH).toBe("/home/dev/.local/bin:/usr/bin");
+    expect(env.NVM_DIR).toBe("/home/dev/.nvm");
+  });
+
+  it("takes a Paseo variable from the login shell when the unit did not set it", () => {
+    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+
+    inheritLoginShellEnvForService({
+      env,
+      inheritLoginShellEnv: () => {
+        env.PASEO_HOME = "/home/dev/.paseo";
+      },
+    });
+
+    expect(env.PASEO_HOME).toBe("/home/dev/.paseo");
+  });
+});

--- a/packages/desktop/src/daemon/daemon-only.ts
+++ b/packages/desktop/src/daemon/daemon-only.ts
@@ -1,0 +1,116 @@
+export const DAEMON_ONLY_FLAG = "--daemon-only";
+
+const GRACEFUL_STOP_SIGNAL: NodeJS.Signals = "SIGTERM";
+const FORCED_STOP_SIGNAL: NodeJS.Signals = "SIGKILL";
+const SERVICE_ENV_PREFIX = "PASEO_";
+
+export interface DaemonOnlyChildProcess {
+  once(
+    event: "exit",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
+  once(event: "error", listener: (error: Error) => void): unknown;
+  kill(signal: NodeJS.Signals): unknown;
+}
+
+export interface RunDaemonOnlyDeps {
+  spawnDaemon: () => DaemonOnlyChildProcess;
+  /**
+   * Registers the shutdown trigger. Electron is the only thing that hears a
+   * stop request here: Chromium's browser process handles SIGTERM/SIGINT itself
+   * and exits without ever running Node's `process.on("SIGTERM")` listeners, so
+   * `app.on("before-quit")` is the signal, and this hook owns deferring the
+   * quit until the daemon is actually down.
+   */
+  onStopRequested: (requestStop: () => void) => void;
+  onSpawnError: (error: Error) => void;
+}
+
+/**
+ * Inherits the login shell's environment (agents need the PATH a shell would
+ * give them, and a service started at boot has no shell to inherit from) while
+ * keeping the configuration the service manager passed in.
+ *
+ * The login shell wins every other key by design, but `Environment=` and
+ * `EnvironmentFile=` in a unit are deliberate configuration. A shell rc that
+ * exports PASEO_HOME for interactive CLI use would otherwise silently move the
+ * daemon to a different home, taking every agent and project with it.
+ */
+export function inheritLoginShellEnvForService(input: {
+  env: NodeJS.ProcessEnv;
+  inheritLoginShellEnv: () => void;
+}): void {
+  const serviceConfig: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(input.env)) {
+    if (key.startsWith(SERVICE_ENV_PREFIX) && value !== undefined) {
+      serviceConfig[key] = value;
+    }
+  }
+
+  input.inheritLoginShellEnv();
+
+  Object.assign(input.env, serviceConfig);
+}
+
+export function isDaemonOnlyLaunch(input: { argv: string[]; isDefaultApp: boolean }): boolean {
+  return input.argv.slice(input.isDefaultApp ? 2 : 1).includes(DAEMON_ONLY_FLAG);
+}
+
+export function isDaemonOnlyLaunchFromArgv(argv: string[]): boolean {
+  return isDaemonOnlyLaunch({ argv, isDefaultApp: process.defaultApp });
+}
+
+/**
+ * A daemon killed by the signal we sent it stopped because we asked it to, so
+ * the service exits 0. A daemon that dies from anything else crashed, and a
+ * service supervisor should see that as a failure worth restarting.
+ */
+export function resolveDaemonOnlyExitCode(input: {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  requestedStopSignal: NodeJS.Signals | null;
+}): number {
+  if (typeof input.code === "number") {
+    return input.code;
+  }
+  return input.signal !== null && input.signal === input.requestedStopSignal ? 0 : 1;
+}
+
+/**
+ * Runs the bundled daemon in the foreground and stays alive for as long as it
+ * does, so the packaged app can be a service unit's main process.
+ */
+export async function runDaemonOnly(deps: RunDaemonOnlyDeps): Promise<number> {
+  const child = deps.spawnDaemon();
+  const stop: { requestedSignal: NodeJS.Signals | null } = { requestedSignal: null };
+
+  // A repeated stop escalates, so a second Ctrl-C is not a no-op when a daemon
+  // refuses to shut down. Past the second request there is nothing left to try.
+  deps.onStopRequested(() => {
+    if (stop.requestedSignal === null) {
+      stop.requestedSignal = GRACEFUL_STOP_SIGNAL;
+      child.kill(GRACEFUL_STOP_SIGNAL);
+      return;
+    }
+    if (stop.requestedSignal === GRACEFUL_STOP_SIGNAL) {
+      stop.requestedSignal = FORCED_STOP_SIGNAL;
+      child.kill(FORCED_STOP_SIGNAL);
+    }
+  });
+
+  return await new Promise<number>((resolve) => {
+    child.once("error", (error) => {
+      deps.onSpawnError(error);
+      resolve(1);
+    });
+    child.once("exit", (code, signal) => {
+      resolve(
+        resolveDaemonOnlyExitCode({
+          code,
+          signal,
+          requestedStopSignal: stop.requestedSignal,
+        }),
+      );
+    });
+  });
+}

--- a/packages/desktop/src/desktop-startup.test.ts
+++ b/packages/desktop/src/desktop-startup.test.ts
@@ -6,6 +6,7 @@ describe("desktop startup", () => {
     const calls: string[] = [];
     await runDesktopStartup({
       hasPendingGuiLaunchRequest: false,
+      runDaemonOnlyIfRequested: vi.fn(async () => false),
       runCliPassthroughIfRequested: vi.fn(async () => {
         calls.push("cli");
         return true;
@@ -23,6 +24,7 @@ describe("desktop startup", () => {
     const calls: string[] = [];
     await runDesktopStartup({
       hasPendingGuiLaunchRequest: false,
+      runDaemonOnlyIfRequested: vi.fn(async () => false),
       runCliPassthroughIfRequested: vi.fn(async () => {
         calls.push("cli");
         return false;
@@ -42,6 +44,7 @@ describe("desktop startup", () => {
 
     await runDesktopStartup({
       hasPendingGuiLaunchRequest: true,
+      runDaemonOnlyIfRequested: vi.fn(async () => false),
       runCliPassthroughIfRequested,
       inheritLoginShellEnv: vi.fn(() => calls.push("env")),
       bootstrapGui: vi.fn(async () => {
@@ -51,5 +54,44 @@ describe("desktop startup", () => {
 
     expect(runCliPassthroughIfRequested).not.toHaveBeenCalled();
     expect(calls).toEqual(["env", "gui"]);
+  });
+  it("runs the headless daemon service instead of the CLI or a window", async () => {
+    const calls: string[] = [];
+    const runCliPassthroughIfRequested = vi.fn(async () => true);
+
+    await runDesktopStartup({
+      hasPendingGuiLaunchRequest: false,
+      runDaemonOnlyIfRequested: vi.fn(async () => {
+        calls.push("daemon-only");
+        return true;
+      }),
+      runCliPassthroughIfRequested,
+      inheritLoginShellEnv: vi.fn(() => calls.push("env")),
+      bootstrapGui: vi.fn(async () => {
+        calls.push("gui");
+      }),
+    });
+
+    expect(runCliPassthroughIfRequested).not.toHaveBeenCalled();
+    expect(calls).toEqual(["daemon-only"]);
+  });
+
+  it("runs the headless daemon service even when argv also names a project to open", async () => {
+    const calls: string[] = [];
+
+    await runDesktopStartup({
+      hasPendingGuiLaunchRequest: true,
+      runDaemonOnlyIfRequested: vi.fn(async () => {
+        calls.push("daemon-only");
+        return true;
+      }),
+      runCliPassthroughIfRequested: vi.fn(async () => false),
+      inheritLoginShellEnv: vi.fn(() => calls.push("env")),
+      bootstrapGui: vi.fn(async () => {
+        calls.push("gui");
+      }),
+    });
+
+    expect(calls).toEqual(["daemon-only"]);
   });
 });

--- a/packages/desktop/src/desktop-startup.ts
+++ b/packages/desktop/src/desktop-startup.ts
@@ -1,11 +1,19 @@
 export interface DesktopStartupDependencies {
   hasPendingGuiLaunchRequest: boolean;
+  runDaemonOnlyIfRequested: () => Promise<boolean>;
   runCliPassthroughIfRequested: () => Promise<boolean>;
   inheritLoginShellEnv: () => void;
   bootstrapGui: () => Promise<void>;
 }
 
 export async function runDesktopStartup(deps: DesktopStartupDependencies): Promise<void> {
+  // Checked before the passthrough CLI, and regardless of any GUI launch
+  // request: `--daemon-only` runs the app as a headless service, so it must
+  // never fall through to a window or to the bundled CLI's argument parser.
+  if (await deps.runDaemonOnlyIfRequested()) {
+    return;
+  }
+
   if (!deps.hasPendingGuiLaunchRequest && (await deps.runCliPassthroughIfRequested())) {
     return;
   }

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -28,6 +28,11 @@ import {
 } from "electron";
 import { registerDaemonManager } from "./daemon/daemon-manager.js";
 import { parsePassthroughCliArgsFromArgv, runPassthroughCli } from "./daemon/cli/passthrough.js";
+import {
+  inheritLoginShellEnvForService,
+  isDaemonOnlyLaunchFromArgv,
+  runDaemonOnly,
+} from "./daemon/daemon-only.js";
 import { closeAllTransportSessions } from "./daemon/local-transport.js";
 import {
   applyDesktopWindowChromeMode,
@@ -89,6 +94,7 @@ import { getDesktopSettingsStore } from "./settings/desktop-settings-electron.js
 import { clampWindowStateToWorkAreas, createWindowStateStore } from "./settings/window-state.js";
 import {
   isDesktopManagedDaemonRunningSync,
+  spawnBundledDaemonForeground,
   stopDesktopDaemonViaCli,
 } from "./daemon/daemon-manager.js";
 import {
@@ -118,6 +124,10 @@ const DESKTOP_WINDOW_CHROME_MODE = resolveDesktopWindowChromeMode({
   isPackaged: app.isPackaged,
 });
 const UPDATE_QUIT_DEADLINE_MS = 5_000;
+// `--daemon-only` runs the packaged app as a headless daemon service. It owns
+// its own quit path, so the GUI quit lifecycle, the auto-updater and window
+// management below stay unregistered for it.
+const IS_DAEMON_ONLY_LAUNCH = isDaemonOnlyLaunchFromArgv(process.argv);
 const pendingBrowserWindowOpenRequests = new PendingBrowserWindowOpenRequests();
 const agentNavigationInbox = new AgentNavigationInbox();
 
@@ -897,6 +907,36 @@ function setupSingleInstanceLock(): boolean {
   return true;
 }
 
+async function runDaemonOnlyIfRequested(): Promise<boolean> {
+  if (!IS_DAEMON_ONLY_LAUNCH) {
+    return false;
+  }
+
+  inheritLoginShellEnvForService({ env: process.env, inheritLoginShellEnv });
+
+  const exitCode = await runDaemonOnly({
+    spawnDaemon: spawnBundledDaemonForeground,
+    onStopRequested: (requestStop) => {
+      app.on("before-quit", () => {
+        // Signal the daemon, then let the quit proceed. Calling
+        // event.preventDefault() here aborts the browser process with SIGTRAP:
+        // Chromium tears down its helper processes as soon as it handles the
+        // signal, and holding the quit open leaves it running without them.
+        // Nothing is lost by exiting first — the daemon shuts down on the
+        // SIGTERM it just received, and a service manager waits for every
+        // process in the unit's cgroup rather than only this one.
+        requestStop();
+      });
+    },
+    onSpawnError: (error) => {
+      log.error("[desktop daemon] --daemon-only failed to start the bundled daemon", error);
+    },
+  });
+
+  app.exit(exitCode);
+  return true;
+}
+
 async function runCliPassthroughIfRequested(): Promise<boolean> {
   const cliArgs = parsePassthroughCliArgsFromArgv(process.argv);
   if (!cliArgs) {
@@ -1008,6 +1048,7 @@ async function bootstrap(): Promise<void> {
 
 void runDesktopStartup({
   hasPendingGuiLaunchRequest: Boolean(pendingOpenProjectPath || pendingAgentNavigation),
+  runDaemonOnlyIfRequested,
   runCliPassthroughIfRequested,
   inheritLoginShellEnv,
   bootstrapGui: bootstrap,
@@ -1050,16 +1091,18 @@ const quitLifecycle = createQuitLifecycle({
   },
 });
 
-// electron-updater forwards this event through Electron's built-in autoUpdater.
-electronAutoUpdater.on("before-quit-for-update", () => {
-  log.info("[auto-updater] before-quit-for-update", { currentVersion: app.getVersion() });
-  quitLifecycle.handleBeforeQuitForUpdate();
-});
-app.on("before-quit", quitLifecycle.handleBeforeQuit);
-registerExternalQuitSignals({ signals: process, quit: () => app.quit() });
+if (!IS_DAEMON_ONLY_LAUNCH) {
+  // electron-updater forwards this event through Electron's built-in autoUpdater.
+  electronAutoUpdater.on("before-quit-for-update", () => {
+    log.info("[auto-updater] before-quit-for-update", { currentVersion: app.getVersion() });
+    quitLifecycle.handleBeforeQuitForUpdate();
+  });
+  app.on("before-quit", quitLifecycle.handleBeforeQuit);
+  registerExternalQuitSignals({ signals: process, quit: () => app.quit() });
 
-app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
-    app.quit();
-  }
-});
+  app.on("window-all-closed", () => {
+    if (process.platform !== "darwin") {
+      app.quit();
+    }
+  });
+}


### PR DESCRIPTION
## Problem

The desktop app starts its daemon when you open a window, and that daemon outlives the app once started — but nothing starts it before then. On a freshly booted machine, phone clients, browser clients, schedules, and the CLI have nothing to talk to until someone logs in and opens the GUI.

## What this adds

`Paseo --daemon-only` runs the packaged app as a headless daemon host: no window, no display needed.

It reuses the path the app already walks. `resolveDaemonRunnerEntrypoint()` + `createNodeEntrypointInvocation()` already re-exec the app's own Electron binary with `ELECTRON_RUN_AS_NODE=1` against the bundled `@getpaseo/server` supervisor every time the app starts its own daemon. The flag runs that same daemon in the foreground and keeps the app alive alongside it, so a service manager can supervise it.

Because the daemon ships inside the app, client and daemon are one artifact: no separate daemon install to keep in step, and an app update replaces both halves at once.

```ini
[Service]
Type=simple
ExecStart=%h/Applications/Paseo-x86_64.AppImage --daemon-only
EnvironmentFile=%h/.config/paseo/daemon.env
Restart=always
```

## Three things this had to get right

Each of these was found by running it as a real systemd user unit. None of them show up when you reason about the code, and the first two do not reproduce with a plain `kill -TERM` on the main pid.

1. **Node signal handlers never run.** Chromium's browser process handles `SIGTERM`/`SIGINT` itself and exits without dispatching to `process.on("SIGTERM")`. Verified by instrumenting the handler: `SIGTERM listeners=1` at registration, and the handler never fired while the process still exited 0. The stop therefore hangs off `app.on("before-quit")`, which does fire.

2. **`event.preventDefault()` on that event aborts the browser process.** Holding the quit open to wait for the daemon produced `Main process exited, code=dumped, status=5/TRAP` and left the unit `failed` after a normal `systemctl stop` — Chromium tears down its helper processes as soon as it handles the signal, so vetoing the quit leaves it running without them. The daemon is signalled and the quit is allowed to proceed. Nothing is lost: the daemon shuts down on the `SIGTERM` it just received, and a service manager waits for every process in the unit's cgroup rather than only the main one.

3. **A unit's environment must outrank the login shell.** The app inherits the login shell environment on startup so agents get the `PATH` a terminal would give them — which matters more for a service at boot than anywhere else, since there is no shell to inherit from. But `inheritLoginShellEnv()` applies that with `Object.assign(process.env, shellEnv)`, so a shell rc exporting `PASEO_HOME` for interactive CLI use would silently move the daemon to a different home and take every agent and project with it. `inheritLoginShellEnvForService()` re-applies the `PASEO_*` variables the service manager passed in.

## Interaction with a desktop app

The daemon is deliberately **not** marked `PASEO_DESKTOP_MANAGED`, so it is not recorded as `desktopManaged` in the PID lock. A desktop app that later attaches treats it as an external daemon and will not stop it on quit or to install an app update. The GUI quit lifecycle, auto-updater, and window management stay unregistered for this launch mode.

The web UI is left at the daemon's own default rather than forced off the way the desktop-managed daemon forces it, so browser and phone clients can reach a machine with no desktop session.

## QA

### Automated

22 new unit tests in `packages/desktop/src/daemon/daemon-only.test.ts` and `packages/desktop/src/desktop-startup.test.ts`, covering flag parsing (packaged and `defaultApp` argv shapes), exit-code resolution, stop forwarding and escalation, spawn failure, startup routing precedence, and environment precedence. No mocks — the child process, signal source, and environment are injected.

```
$ npx vitest run packages/desktop/src/daemon/daemon-only.test.ts \
    packages/desktop/src/desktop-startup.test.ts \
    packages/desktop/src/daemon/daemon-manager.test.ts \
    packages/desktop/src/daemon/node-entrypoint-launcher.test.ts --bail=1

 Test Files  4 passed (4)
      Tests  38 passed (38)

$ npm run typecheck   # clean
$ npm run lint -- packages/desktop/src
Found 0 warnings and 0 errors.
Finished in 190ms on 137 files with 177 rules using 16 threads.
```

### Manual — packaged app, real systemd user unit

Built with `electron-builder --linux --dir` so the asar and `app.asar.unpacked/dist/daemon/node-entrypoint-runner.js` paths are the ones under test. Run as a `systemctl --user` unit with `UnsetEnvironment=DISPLAY WAYLAND_DISPLAY`, a spare port, and a temporary `PASEO_HOME`.

| Check | Result |
| --- | --- |
| Starts with no `DISPLAY` and no `WAYLAND_DISPLAY` | `Active: active (running)`, `Main PID: … (Paseo)` |
| Honours `PASEO_HOME` | daemon state written to the unit's home, `paseo.pid` present |
| Honours `PASEO_LISTEN` | `LISTEN 127.0.0.1:6795 users:(("Paseo Daemon",…))` |
| Not marked desktop-managed | `desktopManaged` absent from the PID lock |
| `systemctl --user stop` | `ActiveState=inactive Result=success ExecMainCode=0 ExecMainStatus=0`; port and PID lock released |
| Graceful daemon shutdown | `supervisor_received_SIGTERM. Stopping worker...` → `Server closed` → `Worker exited (code 0). Supervisor shutting down.` |
| `systemctl --user restart` | back to `active`/`running` and listening |
| Daemon crash (`SIGKILL` the supervisor) | main process exits 1, `Restart=` starts a fresh invocation, daemon listening again |
| No orphans | unit cgroup empty after stop |

Environment precedence was proved end to end, not just in a unit test: the service was started with `PASEO_HOME` set by the unit and `SHELL` pointed at a stub login shell that exports `PASEO_HOME=/tmp/WRONG-HOME-FROM-SHELL`. The stub ran and its environment was applied (`afterPath: '/usr/bin:/bin'`, `pathChanged: true`), and the daemon still used the unit's home; `/tmp/WRONG-HOME-FROM-SHELL` was never created.

### Platform matrix

| Platform | Tested | Notes |
| --- | --- | --- |
| Linux (packaged, systemd user unit) | Yes | Arch, Electron 44. Full lifecycle above. |
| Linux (unpackaged dev Electron) | Yes | Same start/stop behaviour via the non-packaged runner path. |
| macOS | No | The flag is platform-neutral and the code path is shared, but launchd is untested. I do not have a Mac to verify on. |
| Windows | No | Untested. |
| iOS / Android / browser web | N/A | No app or protocol changes. |

Nothing outside `packages/desktop` changes, and every new branch is behind the flag: without `--daemon-only`, `runDesktopStartup` is byte-for-byte the previous path plus one predicate that returns `false`.

### Known cost

The Chromium browser process still initializes — it is the service's main process — and its zygote and network helpers stay resident. On this machine that measured ~430 MB RSS for the browser process plus ~200 MB across the helpers, beyond the daemon itself. A launcher-level wrapper that `exec`s the Node runner directly would avoid it, but only for the AppImage; this approach is the one that works for every packaging target and platform. Happy to follow up with a Linux-only optimisation if you'd rather have it.
