### PR TITLE
fix(app): keep terminal tab labels across terminals_changed pushes

### DIFF
--- a/packages/app/src/data/push-router.test.ts
+++ b/packages/app/src/data/push-router.test.ts
@@ -50,7 +50,11 @@ function createFakeClient(config: { rejectCheckoutDiffSubscribe?: boolean } = {}
   emit: <K extends RouterMessageType>(message: Extract<RouterMessage, { type: K }>) => void;
   subscribeCheckoutDiffCalls: Array<{
     cwd: string;
-    compare: { mode: "uncommitted" | "base"; baseRef?: string; ignoreWhitespace?: boolean };
+    compare: {
+      mode: "uncommitted" | "base";
+      baseRef?: string;
+      ignoreWhitespace?: boolean;
+    };
     subscriptionId: string;
   }>;
   unsubscribeCheckoutDiffCalls: string[];
@@ -66,7 +70,11 @@ function createFakeClient(config: { rejectCheckoutDiffSubscribe?: boolean } = {}
   };
   const subscribeCheckoutDiffCalls: Array<{
     cwd: string;
-    compare: { mode: "uncommitted" | "base"; baseRef?: string; ignoreWhitespace?: boolean };
+    compare: {
+      mode: "uncommitted" | "base";
+      baseRef?: string;
+      ignoreWhitespace?: boolean;
+    };
     subscriptionId: string;
   }> = [];
   const unsubscribeCheckoutDiffCalls: string[] = [];
@@ -151,8 +159,15 @@ describe("server data push router", () => {
     const fake = createFakeClient();
     const serverId = "server-1";
     const pairingOfferKey = daemonPairingOfferQueryKey(serverId);
-    queryClient.setQueryData(pairingOfferKey, { relayEnabled: true, url: "https://pairing" });
-    const unmount = mountServerDataPushRouter({ client: fake.client, queryClient, serverId });
+    queryClient.setQueryData(pairingOfferKey, {
+      relayEnabled: true,
+      url: "https://pairing",
+    });
+    const unmount = mountServerDataPushRouter({
+      client: fake.client,
+      queryClient,
+      serverId,
+    });
 
     fake.emit(providerUpdate("2026-01-01T00:00:00.000Z"));
     fake.emit({
@@ -204,7 +219,11 @@ describe("server data push router", () => {
       }),
     });
     const unsubscribeObserver = observer.subscribe(() => undefined);
-    const unmount = mountServerDataPushRouter({ client: fake.client, queryClient, serverId });
+    const unmount = mountServerDataPushRouter({
+      client: fake.client,
+      queryClient,
+      serverId,
+    });
 
     expect(fake.subscribeCheckoutDiffCalls).toEqual([
       {
@@ -236,7 +255,13 @@ describe("server data push router", () => {
 
     fake.emit({
       type: "checkout_diff_update",
-      payload: { subscriptionId, cwd, files: [], error: null, diffTooLarge: true },
+      payload: {
+        subscriptionId,
+        cwd,
+        files: [],
+        error: null,
+        diffTooLarge: true,
+      },
     });
 
     expect(queryClient.getQueryData(queryKey)).toEqual({
@@ -276,7 +301,11 @@ describe("server data push router", () => {
       }),
     });
     const unsubscribeObserver = observer.subscribe(() => undefined);
-    const unmount = mountServerDataPushRouter({ client: fake.client, queryClient, serverId });
+    const unmount = mountServerDataPushRouter({
+      client: fake.client,
+      queryClient,
+      serverId,
+    });
 
     expect(fake.subscribeCheckoutDiffCalls).toHaveLength(1);
 
@@ -312,7 +341,11 @@ describe("server data push router", () => {
       }),
     });
     const unsubscribeObserver = observer.subscribe(() => undefined);
-    const unmount = mountServerDataPushRouter({ client: fake.client, queryClient, serverId });
+    const unmount = mountServerDataPushRouter({
+      client: fake.client,
+      queryClient,
+      serverId,
+    });
 
     expect(fake.subscribeTerminalCalls).toEqual([{ cwd, workspaceId }]);
 
@@ -378,7 +411,11 @@ describe("server data push router", () => {
     });
     const unsubscribeCheckoutDiffObserver = checkoutDiffObserver.subscribe(() => undefined);
     const unsubscribeTerminalObserver = terminalObserver.subscribe(() => undefined);
-    const unmount = mountServerDataPushRouter({ client: fake.client, queryClient, serverId });
+    const unmount = mountServerDataPushRouter({
+      client: fake.client,
+      queryClient,
+      serverId,
+    });
     const plainCheckoutDiffObserver = new QueryObserver(queryClient, {
       queryKey: checkoutDiffKey,
       queryFn: skipToken,
@@ -462,7 +499,11 @@ describe("server data push router", () => {
       }),
     });
     const unsubscribePushObserver = pushObserver.subscribe(() => undefined);
-    const unmount = mountServerDataPushRouter({ client: fake.client, queryClient, serverId });
+    const unmount = mountServerDataPushRouter({
+      client: fake.client,
+      queryClient,
+      serverId,
+    });
     expect(fake.subscribeTerminalCalls).toEqual([{ cwd, workspaceId }]);
 
     const plainObserver = new QueryObserver(queryClient, {
@@ -483,7 +524,11 @@ describe("server data push router", () => {
             id: "terminal-a",
             name: "Main",
             workspaceId,
-            activity: { state: "idle", attentionReason: "needs_input", changedAt: 1 },
+            activity: {
+              state: "idle",
+              attentionReason: "needs_input",
+              changedAt: 1,
+            },
           },
         ],
       },
@@ -496,7 +541,11 @@ describe("server data push router", () => {
           id: "terminal-a",
           name: "Main",
           workspaceId,
-          activity: { state: "idle", attentionReason: "needs_input", changedAt: 1 },
+          activity: {
+            state: "idle",
+            attentionReason: "needs_input",
+            changedAt: 1,
+          },
         },
       ],
       requestId: expect.stringMatching(/^terminals-changed-/),
@@ -505,6 +554,63 @@ describe("server data push router", () => {
 
     unsubscribePlainObserver();
     unsubscribePushObserver();
+    unmount();
+  });
+
+  it("keeps workspace terminals whose push payload omits workspaceId", () => {
+    const queryClient = new QueryClient();
+    const fake = createFakeClient();
+    const serverId = "server-1";
+    const cwd = "/repo";
+    const workspaceId = "workspace-a";
+    const queryKey = buildTerminalsQueryKey(serverId, cwd, workspaceId);
+    const observer = new QueryObserver(queryClient, {
+      queryKey,
+      queryFn: skipToken,
+      enabled: true,
+      gcTime: Infinity,
+      staleTime: Infinity,
+      meta: workspaceTerminalsPushRoute({
+        enabled: true,
+        serverId,
+        cwd,
+        workspaceId,
+      }),
+    });
+    const unsubscribeObserver = observer.subscribe(() => undefined);
+    const unmount = mountServerDataPushRouter({
+      client: fake.client,
+      queryClient,
+      serverId,
+    });
+
+    queryClient.setQueryData(queryKey, {
+      cwd,
+      terminals: [{ id: "terminal-a", name: "Shell", title: "npm test", workspaceId }],
+      requestId: "seed",
+    });
+
+    // Title/activity pushes sometimes omit workspaceId. Strict equality against the
+    // route workspace must not wipe the terminal from the cache (tab label falls
+    // back to "Terminal" when the entry disappears).
+    fake.emit({
+      type: "terminals_changed",
+      payload: {
+        cwd,
+        terminals: [
+          { id: "terminal-a", name: "Shell", title: "npm test" },
+          { id: "terminal-b", name: "Other", workspaceId: "workspace-b" },
+        ],
+      },
+    });
+
+    expect(queryClient.getQueryData(queryKey)).toEqual({
+      cwd,
+      terminals: [{ id: "terminal-a", name: "Shell", title: "npm test" }],
+      requestId: "seed",
+    });
+
+    unsubscribeObserver();
     unmount();
   });
 
@@ -519,11 +625,24 @@ describe("server data push router", () => {
     const terminalKey = buildTerminalsQueryKey(serverId, "/repo", "workspace-a");
     const otherProviderKey = providersSnapshotQueryKey(otherServerId);
 
-    queryClient.setQueryData(providerKey, { entries: [], generatedAt: "now", requestId: "p" });
+    queryClient.setQueryData(providerKey, {
+      entries: [],
+      generatedAt: "now",
+      requestId: "p",
+    });
     queryClient.setQueryData(daemonConfigKey, daemonConfig);
     queryClient.setQueryData(pairingOfferKey, { relayEnabled: false, url: "" });
-    queryClient.setQueryData(diffKey, { cwd: "/repo", files: [], error: null, requestId: "d" });
-    queryClient.setQueryData(terminalKey, { cwd: "/repo", terminals: [], requestId: "t" });
+    queryClient.setQueryData(diffKey, {
+      cwd: "/repo",
+      files: [],
+      error: null,
+      requestId: "d",
+    });
+    queryClient.setQueryData(terminalKey, {
+      cwd: "/repo",
+      terminals: [],
+      requestId: "t",
+    });
     queryClient.setQueryData(otherProviderKey, {
       entries: [],
       generatedAt: "now",

--- a/packages/app/src/data/push-router.ts
+++ b/packages/app/src/data/push-router.ts
@@ -104,19 +104,25 @@ const RECONNECT_REPAIR_POLICIES: ReconnectRepairPolicy[] = [
   {
     domain: "providersSnapshot",
     invalidate: ({ queryClient, serverId }) => {
-      void queryClient.invalidateQueries({ queryKey: providersSnapshotQueryRoot(serverId) });
+      void queryClient.invalidateQueries({
+        queryKey: providersSnapshotQueryRoot(serverId),
+      });
     },
   },
   {
     domain: "daemonConfig",
     invalidate: ({ queryClient, serverId }) => {
-      void queryClient.invalidateQueries({ queryKey: daemonConfigQueryKey(serverId) });
+      void queryClient.invalidateQueries({
+        queryKey: daemonConfigQueryKey(serverId),
+      });
     },
   },
   {
     domain: "daemonPairingOffer",
     invalidate: ({ queryClient, serverId }) => {
-      void queryClient.invalidateQueries({ queryKey: daemonPairingOfferQueryKey(serverId) });
+      void queryClient.invalidateQueries({
+        queryKey: daemonPairingOfferQueryKey(serverId),
+      });
     },
   },
   {
@@ -194,7 +200,10 @@ export async function applyProvidersSnapshotUpdate(input: {
   client: Pick<ServerDataPushClient, "getProvidersSnapshot">;
   cache?: ProviderSnapshotCache;
 }): Promise<void> {
-  const snapshot = { ...input.message.payload, requestId: "providers_snapshot_update" };
+  const snapshot = {
+    ...input.message.payload,
+    requestId: "providers_snapshot_update",
+  };
   const cwd = normalizeProvidersSnapshotCwd(snapshot.cwd);
   const queryKey = providersSnapshotQueryKey(input.serverId, cwd);
   const previous = input.queryClient.getQueryData<{ snapshotHash?: string }>(queryKey);
@@ -300,7 +309,11 @@ export function mountServerDataPushRouter(input: PushRouterInput): () => void {
     });
   });
   const unsubscribeDaemonConfig = input.client.on("status", (message) => {
-    applyDaemonConfigStatus({ queryClient: input.queryClient, serverId: input.serverId, message });
+    applyDaemonConfigStatus({
+      queryClient: input.queryClient,
+      serverId: input.serverId,
+      message,
+    });
   });
   const unsubscribeCheckoutDiffUpdate = input.client.on("checkout_diff_update", (message) => {
     applyCheckoutDiffUpdate({
@@ -534,8 +547,8 @@ function applyTerminalsChanged(input: {
       continue;
     }
 
-    const matchingTerminals = input.message.payload.terminals.filter(
-      (terminal) => terminal.workspaceId === route.workspaceId,
+    const matchingTerminals = input.message.payload.terminals.filter((terminal) =>
+      terminalMatchesWorkspaceTerminalRoute(terminal, route.workspaceId),
     );
 
     input.queryClient.setQueryData<ListTerminalsPayload>(query.queryKey, (current) => ({
@@ -544,6 +557,24 @@ function applyTerminalsChanged(input: {
       requestId: current?.requestId ?? `terminals-changed-${Date.now()}`,
     }));
   }
+}
+
+/**
+ * Workspace-scoped terminal queries must keep terminals that omit `workspaceId`
+ * on a push. Title/activity updates sometimes leave it unset; strict equality
+ * wiped those entries and tab labels fell back to "Terminal".
+ *
+ * Sibling workspaces (a different non-empty id) stay filtered out. An unscoped
+ * route keeps every terminal for the cwd.
+ */
+function terminalMatchesWorkspaceTerminalRoute(
+  terminal: { workspaceId?: string },
+  routeWorkspaceId: string | undefined,
+): boolean {
+  if (!routeWorkspaceId) {
+    return true;
+  }
+  return terminal.workspaceId === undefined || terminal.workspaceId === routeWorkspaceId;
 }
 
 function getActiveServerDataRoute(

--- a/packages/app/src/panels/terminal-panel.tsx
+++ b/packages/app/src/panels/terminal-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { Terminal } from "lucide-react-native";
@@ -14,6 +14,7 @@ import { buildTerminalsQueryKey } from "@/screens/workspace/terminals/state";
 import { usePanelStore } from "@/stores/panel-store";
 import { useSessionStore } from "@/stores/session-store";
 import { useWorkspaceDirectory, useWorkspaceFields } from "@/stores/session-store-hooks";
+import { resolveTerminalTabLabel } from "@/utils/terminal-tab-label";
 
 type ListTerminalsPayload = ListTerminalsResponse["payload"];
 
@@ -24,14 +25,6 @@ const CENTERED_PADDED_STYLE = {
   padding: 16,
 } as const;
 
-function trimNonEmpty(value: string | null | undefined): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
 function useTerminalPanelDescriptor(
   target: { kind: "terminal"; terminalId: string },
   context: { serverId: string; workspaceId: string },
@@ -39,6 +32,7 @@ function useTerminalPanelDescriptor(
   const { t } = useTranslation();
   const client = useSessionStore((state) => state.sessions[context.serverId]?.client ?? null);
   const workspaceDirectory = useWorkspaceDirectory(context.serverId, context.workspaceId);
+  const rememberedLabelRef = useRef<string | null>(null);
   const terminalsQuery = useQuery(
     {
       queryKey: buildTerminalsQueryKey(
@@ -61,9 +55,14 @@ function useTerminalPanelDescriptor(
   );
   const terminal =
     terminalsQuery.data?.terminals.find((entry) => entry.id === target.terminalId) ?? null;
-  const label =
-    trimNonEmpty(terminal?.title ?? terminal?.name ?? null) ??
-    t("workspace.tabs.fallback.terminal");
+  const resolved = resolveTerminalTabLabel({
+    title: terminal?.title,
+    name: terminal?.name,
+    rememberedLabel: rememberedLabelRef.current,
+    fallback: t("workspace.tabs.fallback.terminal"),
+  });
+  rememberedLabelRef.current = resolved.rememberedLabel;
+  const label = resolved.label;
 
   return {
     label,
@@ -89,7 +88,11 @@ function TerminalPanel() {
     if (!workspaceDirectory) {
       return;
     }
-    openCompactFileExplorer({ serverId, cwd: workspaceDirectory, isGit: isGitCheckout });
+    openCompactFileExplorer({
+      serverId,
+      cwd: workspaceDirectory,
+      isGit: isGitCheckout,
+    });
   }, [isGitCheckout, openCompactFileExplorer, serverId, workspaceDirectory]);
   invariant(target.kind === "terminal", "TerminalPanel requires terminal target");
 

--- a/packages/app/src/utils/terminal-tab-label.test.ts
+++ b/packages/app/src/utils/terminal-tab-label.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveTerminalTabLabel } from "@/utils/terminal-tab-label";
+
+describe("resolveTerminalTabLabel", () => {
+  it("prefers a live title, then name", () => {
+    expect(
+      resolveTerminalTabLabel({
+        title: "npm test",
+        name: "Shell",
+        rememberedLabel: "old",
+        fallback: "Terminal",
+      }),
+    ).toEqual({ label: "npm test", rememberedLabel: "npm test" });
+
+    expect(
+      resolveTerminalTabLabel({
+        title: "  ",
+        name: "Shell",
+        rememberedLabel: null,
+        fallback: "Terminal",
+      }),
+    ).toEqual({ label: "Shell", rememberedLabel: "Shell" });
+  });
+
+  it("keeps the remembered label when the list entry is missing", () => {
+    expect(
+      resolveTerminalTabLabel({
+        title: null,
+        name: null,
+        rememberedLabel: "npm test",
+        fallback: "Terminal",
+      }),
+    ).toEqual({ label: "npm test", rememberedLabel: "npm test" });
+  });
+
+  it("falls back only when nothing live or remembered is available", () => {
+    expect(
+      resolveTerminalTabLabel({
+        title: undefined,
+        name: undefined,
+        rememberedLabel: "  ",
+        fallback: "Terminal",
+      }),
+    ).toEqual({ label: "Terminal", rememberedLabel: null });
+  });
+});

--- a/packages/app/src/utils/terminal-tab-label.ts
+++ b/packages/app/src/utils/terminal-tab-label.ts
@@ -1,0 +1,30 @@
+function trimNonEmpty(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Resolve the terminal tab label, remembering the last live title/name so a
+ * transient list-cache miss does not flash the generic "Terminal" fallback.
+ */
+export function resolveTerminalTabLabel(input: {
+  title?: string | null;
+  name?: string | null;
+  rememberedLabel?: string | null;
+  fallback: string;
+}): { label: string; rememberedLabel: string | null } {
+  const live = trimNonEmpty(input.title) ?? trimNonEmpty(input.name);
+  if (live) {
+    return { label: live, rememberedLabel: live };
+  }
+
+  const remembered = trimNonEmpty(input.rememberedLabel ?? null);
+  if (remembered) {
+    return { label: remembered, rememberedLabel: remembered };
+  }
+
+  return { label: input.fallback, rememberedLabel: null };
+}


### PR DESCRIPTION
## Summary
- `terminals_changed` used strict `workspaceId` equality, so pushes that omitted the field wiped terminals from the React Query cache and tab labels fell back to "Terminal".
- Keep terminals with a missing `workspaceId` for the subscribed workspace (still exclude sibling workspace ids).
- Remember the last live title/name on the terminal panel descriptor so a transient cache miss does not flash the fallback.

Fixes #4521

## Test plan
- [x] `npx vitest run packages/app/src/data/push-router.test.ts`
- [x] `npx vitest run packages/app/src/utils/terminal-tab-label.test.ts`
- [ ] Desktop: open terminals with custom/OSC titles, switch tabs/workspaces/agents, confirm labels stay instead of becoming "Terminal"
