### PR TITLE
docs(cli): clarify terminal cwd workspace behavior

### DIFF
--- a/packages/cli/src/cli-surface.test.ts
+++ b/packages/cli/src/cli-surface.test.ts
@@ -73,6 +73,14 @@ describe("canonical CLI surface", () => {
     expect(open?.helpInformation()).toContain("--server <server-id>");
   });
 
+  it("discloses implicit workspace opening for terminal cwd creation", () => {
+    const terminal = createCli().commands.find((command) => command.name() === "terminal");
+    const create = terminal?.commands.find((command) => command.name() === "create");
+    const help = (create?.helpInformation() ?? "").replace(/\s+/gu, " ");
+
+    expect(help).toContain("opens or reuses a workspace unless --workspace is set");
+  });
+
   it("offers the complete local plugin lifecycle", () => {
     const plugin = createCli().commands.find((command) => command.name() === "plugin");
 

--- a/packages/cli/src/commands/terminal/index.ts
+++ b/packages/cli/src/commands/terminal/index.ts
@@ -30,7 +30,10 @@ export function createTerminalCommand(): Command {
       .command("create")
       .description("Create a terminal")
       .option("--workspace <id>", "Workspace ID")
-      .option("--cwd <path>", "Working directory")
+      .option(
+        "--cwd <path>",
+        "Working directory (opens or reuses a workspace unless --workspace is set)",
+      )
       .option("--name <name>", "Terminal name"),
   ).action(withOutput(runCreateCommand));
 


### PR DESCRIPTION
`paseo terminal create --cwd` opens or reuses a workspace when `--workspace` is omitted, but the command help currently labels it only as "Working directory." That makes the workspace side effect easy to miss.

Clarify the option help and add a CLI-surface regression so the behavior remains visible.