### PR TITLE
feat(plugin): expose host Markdown component

### DIFF
--- a/packages/app/e2e/browser/plugin-host-ui.spec.ts
+++ b/packages/app/e2e/browser/plugin-host-ui.spec.ts
@@ -12,11 +12,14 @@ import {
 
 const PLUGIN_ID = "plugin-host-ui-e2e";
 
-const PLUGIN_SOURCE = `import { usePaseo } from "@getpaseo/plugin/client";
-import { Icon, Modal, useToast } from "@getpaseo/plugin/client/react-native";
+function createPluginSource(linkUrl: string): string {
+  return `import { usePaseo } from "@getpaseo/plugin/client";
+import { Icon, Markdown, Modal, useToast } from "@getpaseo/plugin/client/react-native";
 import { useQueryClient } from "@tanstack/react-query";
 import React, { useState } from "react";
 import { Pressable, Text, View } from "react-native";
+
+const LINK_URL = ${JSON.stringify(linkUrl)};
 
 function ModalBody({ onSaved }) {
   usePaseo();
@@ -36,9 +39,20 @@ function ModalBody({ onSaved }) {
   </View>;
 }
 
-function Surface() {
+function Surface({ theme, layout }) {
   const [open, setOpen] = useState(false);
+  const [handledLinks, setHandledLinks] = useState([]);
   return <View>
+    <Markdown
+      text={"**Plugin Markdown** and [handled link](" + LINK_URL + ")."}
+      compact={layout.compact}
+      onLinkPress={(url) => { setHandledLinks((links) => [...links, url]); return false; }}
+    />
+    <Text testID="handled-markdown-links" style={{ color: theme.colors.foreground }}>
+      {handledLinks.join(", ")}
+    </Text>
+    <Markdown text={"[default link](" + LINK_URL + ")"} />
+    <Markdown text={"[allowed link](" + LINK_URL + ")"} onLinkPress={() => true} />
     <Pressable accessibilityRole="button" onPress={() => setOpen(true)}>
       <View style={{ flexDirection: "row" }}>
         <Icon name="Pencil" size={18} />
@@ -68,6 +82,7 @@ export default function contribute(plugin) {
   });
   return () => {};
 }`;
+}
 
 async function openHostUiPlugin(page: Page): Promise<void> {
   await gotoAppShell(page);
@@ -115,7 +130,33 @@ async function savePluginIssue(page: Page): Promise<void> {
   await expect(page.getByText("Plugin modal contexts ready", { exact: true })).not.toBeVisible();
 }
 
-test("plugin modal adapts its presentation and preserves host contexts", async ({ page }) => {
+async function expectPluginMarkdown(page: Page, linkUrl: string): Promise<void> {
+  await expect(page.getByText("Plugin Markdown", { exact: true })).toHaveCSS("font-weight", "500");
+  const url = page.url();
+  const handledLinks = page.getByTestId("handled-markdown-links");
+  const previous = await handledLinks.innerText();
+  await page.getByRole("link", { name: "handled link", exact: true }).click();
+  await expect(handledLinks).toHaveText(previous ? `${previous}, ${linkUrl}` : linkUrl);
+  expect(page.context().pages()).toEqual([page]);
+
+  for (const name of ["default link", "allowed link"]) {
+    const popupPromise = page.context().waitForEvent("page");
+    await page.getByRole("link", { name, exact: true }).click();
+    const popup = await popupPromise;
+    try {
+      await expect(popup).toHaveURL(linkUrl);
+    } finally {
+      await popup.close();
+    }
+  }
+  await expect(page).toHaveURL(url);
+}
+
+test("plugin host UI renders Markdown and preserves modal contexts across layouts", async ({
+  page,
+  baseURL,
+}) => {
+  const linkUrl = new URL("/favicon.ico", baseURL).href;
   const directory = await mkdtemp(path.join(tmpdir(), "paseo-plugin-host-ui-e2e-"));
   const client = await connectNewWorkspaceDaemonClient({ ownProjects: false });
   const previousConfig = await client.getDaemonConfig();
@@ -123,7 +164,7 @@ test("plugin modal adapts its presentation and preserves host contexts", async (
     path.join(directory, "paseo-plugin.json"),
     JSON.stringify({ id: PLUGIN_ID, requirements: pluginRequirements }),
   );
-  await writeFile(path.join(directory, "index.client.tsx"), PLUGIN_SOURCE);
+  await writeFile(path.join(directory, "index.client.tsx"), createPluginSource(linkUrl));
 
   try {
     await client.patchDaemonConfig({ pluginsEnabled: true });
@@ -132,6 +173,7 @@ test("plugin modal adapts its presentation and preserves host contexts", async (
     await openHostUiPlugin(page);
 
     await test.step("non-compact layouts use a centered dialog", async () => {
+      await expectPluginMarkdown(page, linkUrl);
       await openPluginModal(page);
       await expectCenteredPluginDialog(page);
       await closeCenteredPluginDialog(page);
@@ -140,10 +182,13 @@ test("plugin modal adapts its presentation and preserves host contexts", async (
     await test.step("compact layouts preserve host contexts inside a sheet", async () => {
       await useCompactLayout(page);
       await reopenHostUiPluginFromCompactSidebar(page);
+      await expectPluginMarkdown(page, linkUrl);
       await openPluginModal(page);
       await expectCompactPluginSheet(page);
       await savePluginIssue(page);
     });
+
+    await gotoAppShell(page);
   } finally {
     await client.removePlugin(PLUGIN_ID).catch(() => undefined);
     await client

--- a/packages/app/src/plugins/react-native/runtime.ts
+++ b/packages/app/src/plugins/react-native/runtime.ts
@@ -5,8 +5,10 @@ import { TextInput } from "./text-input";
 import { copyText } from "./clipboard";
 import { useToast } from "./toast";
 import { useRevealedText } from "@/hooks/use-revealed-text";
+import { MarkdownRenderer } from "@/components/markdown/renderer";
 
 export const pluginReactNativeRuntime = {
+  Markdown: MarkdownRenderer,
   Icon,
   Modal,
   ScrollView,
@@ -15,4 +17,4 @@ export const pluginReactNativeRuntime = {
   copyText,
   useRevealedText,
   useToast,
-};
+} satisfies typeof import("@getpaseo/plugin/client/react-native");

--- a/packages/plugin/src/client/react-native.ts
+++ b/packages/plugin/src/client/react-native.ts
@@ -53,6 +53,14 @@ export interface ToastApi {
   error(message: string): void;
 }
 
+export interface MarkdownProps {
+  text: string;
+  compact?: boolean;
+  /** Return false to handle the link yourself; true lets Paseo open it. */
+  onLinkPress?: (url: string) => boolean;
+}
+
+export declare const Markdown: ComponentType<MarkdownProps>;
 export declare const Icon: ComponentType<PluginIconProps>;
 export declare const Modal: ModalComponent;
 export declare function useToast(): ToastApi;

--- a/packages/server/src/server/plugins/compiler.test.ts
+++ b/packages/server/src/server/plugins/compiler.test.ts
@@ -100,9 +100,9 @@ export const serverLabel = "Server contribution";`,
     ),
     writeFile(
       path.join(directory, "client", "surface.tsx"),
-      `import { Text } from "react-native";
+      `import { Markdown } from "@getpaseo/plugin/client/react-native";
 import { clientLabel } from "../shared/labels";
-export function Surface() { return <Text>{clientLabel}</Text>; }`,
+export function Surface() { return <Markdown text={clientLabel} />; }`,
     ),
     writeFile(
       path.join(directory, "server", "handler.ts"),
@@ -144,6 +144,7 @@ describe("plugin runtime entries", () => {
     "react-native",
     "@getpaseo/plugin/client",
     "@getpaseo/plugin/client/ui",
+    "@getpaseo/plugin/client/react-native",
   ])("rejects %s from server code", async (specifier) => {
     const entries = await createSplitPlugin();
     await writeFile(
@@ -171,6 +172,7 @@ describe("plugin runtime entries", () => {
     "node:fs",
     "fs",
     "@getpaseo/plugin/client",
+    "@getpaseo/plugin/client/react-native",
     "@getpaseo/plugin/server",
     "../client/surface",
     "../server/handler",

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -669,6 +669,22 @@ export function IssueActions({ theme }: PluginSurfaceProps) {
 }
 ```
 
+### Markdown
+
+Use `Markdown` in surfaces and timeline renderers for Paseo's themed Markdown and platform text selection.
+
+```tsx
+import { Markdown } from "@getpaseo/plugin/client/react-native";
+
+<Markdown text="**Result**: [details](https://example.com)" compact />;
+```
+
+`text` is required; `compact` defaults to `false`. Return `false` from `onLinkPress(url)` to suppress
+opening. Omit it or return `true` for Paseo's normal HTTP(S) link handling.
+
+Parser customization, workspace-file links, and assistant actions are not exposed.
+For streaming, pass the result of `useRevealedText(text, phase)` as `text`.
+
 ### Modal
 
 `Modal` uses a bottom sheet on compact layouts and a centered dialog otherwise. The plugin owns


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

You MUST read CONTRIBUTING.md before sending a PR.
-->

### Linked issue

Related discussion: https://github.com/getpaseo/paseo/discussions/2778

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Timeline plugins cannot currently reuse Paseo's Markdown presentation. They must render plain text or maintain a separate renderer, losing consistent styling, selection, and link behavior.

This exposes the existing Markdown renderer through the client-only plugin UI module.

### Goals

- Export `Markdown` from `@getpaseo/plugin/client/react-native`.
- Support `text`, compact presentation, and link interception.
- Reuse the host renderer without a wrapper or new dependency.
- Preserve SDK runtime boundaries.

### Non-goals

- LaTeX or math rendering.
- Custom parsers or token rules.
- Assistant actions or workspace-file link handling.
- Built-in streaming pacing; plugins can use `useRevealedText`.

### QA

Automated checks:

```text
npm run build:server
Passed

cd packages/server && npx vitest run src/server/plugins/compiler.test.ts --bail=1
Test Files  1 passed (1)
Tests       72 passed (72)

E2E_RECORD_VIDEO=1 npm run test:e2e --workspace=@getpaseo/app -- e2e/browser/plugin-host-ui.spec.ts
1 passed (43.6s)

npm run typecheck
Passed

npm run lint
Found 0 warnings and 0 errors.

npm run format
Passed
```
[paseo-plugin-markdown-web-qa.webm](https://github.com/user-attachments/assets/2a560457-0cdb-425b-9938-55fc18e1cd70)