### PR TITLE
fix(cli): preserve daemon target and verify identity before shutdown

### DIFF
--- a/packages/cli/src/commands/daemon/lifecycle-shutdown.test.ts
+++ b/packages/cli/src/commands/daemon/lifecycle-shutdown.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "vitest";
+import { requestLifecycleShutdown, type LifecycleShutdownRuntime } from "./lifecycle-shutdown.js";
+
+function createRuntime(serverId: string | null = "srv_other") {
+  const events: string[] = [];
+  const runtime: LifecycleShutdownRuntime = {
+    readServerId: () => "srv_test",
+    connect: async () => {
+      events.push("connect");
+      return {
+        getLastServerInfoMessage: () =>
+          serverId === null
+            ? null
+            : {
+                status: "server_info",
+                serverId,
+                version: "0.8.0-beta.1",
+                hostname: "test-host",
+              },
+        shutdownServer: async () => {
+          events.push("shutdown");
+          return {
+            status: "shutdown_requested",
+            clientId: "test-client",
+            requestId: "test-request",
+          };
+        },
+        close: async () => {
+          events.push("close");
+        },
+      };
+    },
+  };
+  return { runtime, events };
+}
+
+describe("home-scoped lifecycle shutdown", () => {
+  test("refuses to shut down a different daemon occupying the recorded port", async () => {
+    const { runtime, events } = createRuntime();
+    await expect(
+      requestLifecycleShutdown(
+        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        runtime,
+      ),
+    ).rejects.toThrow("Refusing to stop");
+    expect(events).toEqual(["connect", "close"]);
+  });
+  test("shuts down the matching daemon and closes the connection", async () => {
+    const { runtime, events } = createRuntime("srv_test");
+    expect(
+      await requestLifecycleShutdown(
+        { home: "/test-home", host: "127.0.0.1:6799", timeoutMs: 5000 },
+        runtime,
+      ),
+    ).toEqual({ requested: true });
+    expect(events).toEqual(["connect", "shutdown", "close"]);
+  });
+
+  test("refuses an unidentified listener", async () => {
+    const { runtime, events } = createRuntime(null);
+    await expect(
+      requestLifecycleShutdown(
+        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        runtime,
+      ),
+    ).rejects.toThrow("Refusing to stop");
+    expect(events).toEqual(["connect", "close"]);
+  });
+
+  test("does not connect when the requested home has no identity", async () => {
+    const { runtime, events } = createRuntime();
+    runtime.readServerId = () => {
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    };
+    expect(
+      await requestLifecycleShutdown(
+        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        runtime,
+      ),
+    ).toEqual({
+      requested: false,
+      reason: "daemon identity is missing in /test-home, falling back to owner PID signal",
+    });
+    expect(events).toEqual([]);
+  });
+
+  test("does not connect when the identity file is empty", async () => {
+    const { runtime, events } = createRuntime();
+    runtime.readServerId = () => "  ";
+    expect(
+      await requestLifecycleShutdown(
+        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        runtime,
+      ),
+    ).toEqual({
+      requested: false,
+      reason: "daemon identity is missing in /test-home, falling back to owner PID signal",
+    });
+    expect(events).toEqual([]);
+  });
+
+  test("propagates identity read errors rather than sending shutdown", async () => {
+    const { runtime, events } = createRuntime();
+    runtime.readServerId = () => {
+      throw Object.assign(new Error("denied"), { code: "EACCES" });
+    };
+    await expect(
+      requestLifecycleShutdown(
+        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        runtime,
+      ),
+    ).rejects.toThrow("denied");
+    expect(events).toEqual([]);
+  });
+
+  test("keeps the owner PID fallback when there is no reachable daemon", async () => {
+    const { runtime, events } = createRuntime();
+    runtime.connect = async () => null;
+    expect(
+      await requestLifecycleShutdown(
+        { home: "/test-home", host: "127.0.0.1:6799", timeoutMs: 5000 },
+        runtime,
+      ),
+    ).toEqual({
+      requested: false,
+      reason:
+        "daemon websocket at 127.0.0.1:6799 is not reachable, falling back to owner PID signal",
+    });
+    expect(events).toEqual([]);
+  });
+
+  test("keeps the owner PID fallback for a non-TCP listener", async () => {
+    const { runtime, events } = createRuntime();
+    expect(
+      await requestLifecycleShutdown({ home: "/test-home", host: null, timeoutMs: 5000 }, runtime),
+    ).toEqual({
+      requested: false,
+      reason: "daemon listen target is not TCP, falling back to owner PID signal",
+    });
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/daemon/lifecycle-shutdown.test.ts
+++ b/packages/cli/src/commands/daemon/lifecycle-shutdown.test.ts
@@ -39,7 +39,7 @@ describe("home-scoped lifecycle shutdown", () => {
     const { runtime, events } = createRuntime();
     await expect(
       requestLifecycleShutdown(
-        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        { home: "/test-home", hasLiveOwner: true, host: "127.0.0.1:6767", timeoutMs: 5000 },
         runtime,
       ),
     ).rejects.toThrow("Refusing to stop");
@@ -49,7 +49,7 @@ describe("home-scoped lifecycle shutdown", () => {
     const { runtime, events } = createRuntime("srv_test");
     expect(
       await requestLifecycleShutdown(
-        { home: "/test-home", host: "127.0.0.1:6799", timeoutMs: 5000 },
+        { home: "/test-home", hasLiveOwner: true, host: "127.0.0.1:6799", timeoutMs: 5000 },
         runtime,
       ),
     ).toEqual({ requested: true });
@@ -60,7 +60,7 @@ describe("home-scoped lifecycle shutdown", () => {
     const { runtime, events } = createRuntime(null);
     await expect(
       requestLifecycleShutdown(
-        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        { home: "/test-home", hasLiveOwner: true, host: "127.0.0.1:6767", timeoutMs: 5000 },
         runtime,
       ),
     ).rejects.toThrow("Refusing to stop");
@@ -74,7 +74,7 @@ describe("home-scoped lifecycle shutdown", () => {
     };
     expect(
       await requestLifecycleShutdown(
-        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        { home: "/test-home", hasLiveOwner: true, host: "127.0.0.1:6767", timeoutMs: 5000 },
         runtime,
       ),
     ).toEqual({
@@ -89,7 +89,7 @@ describe("home-scoped lifecycle shutdown", () => {
     runtime.readServerId = () => "  ";
     expect(
       await requestLifecycleShutdown(
-        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        { home: "/test-home", hasLiveOwner: true, host: "127.0.0.1:6767", timeoutMs: 5000 },
         runtime,
       ),
     ).toEqual({
@@ -106,7 +106,7 @@ describe("home-scoped lifecycle shutdown", () => {
     };
     await expect(
       requestLifecycleShutdown(
-        { home: "/test-home", host: "127.0.0.1:6767", timeoutMs: 5000 },
+        { home: "/test-home", hasLiveOwner: true, host: "127.0.0.1:6767", timeoutMs: 5000 },
         runtime,
       ),
     ).rejects.toThrow("denied");
@@ -118,7 +118,7 @@ describe("home-scoped lifecycle shutdown", () => {
     runtime.connect = async () => null;
     expect(
       await requestLifecycleShutdown(
-        { home: "/test-home", host: "127.0.0.1:6799", timeoutMs: 5000 },
+        { home: "/test-home", hasLiveOwner: true, host: "127.0.0.1:6799", timeoutMs: 5000 },
         runtime,
       ),
     ).toEqual({
@@ -132,11 +132,38 @@ describe("home-scoped lifecycle shutdown", () => {
   test("keeps the owner PID fallback for a non-TCP listener", async () => {
     const { runtime, events } = createRuntime();
     expect(
-      await requestLifecycleShutdown({ home: "/test-home", host: null, timeoutMs: 5000 }, runtime),
+      await requestLifecycleShutdown(
+        { home: "/test-home", hasLiveOwner: true, host: null, timeoutMs: 5000 },
+        runtime,
+      ),
     ).toEqual({
       requested: false,
       reason: "daemon listen target is not TCP, falling back to owner PID signal",
     });
     expect(events).toEqual([]);
+  });
+  test("leaves an unrelated listener alone when this home has no live owner", async () => {
+    const { runtime, events } = createRuntime();
+    expect(
+      await requestLifecycleShutdown(
+        { home: "/test-home", hasLiveOwner: false, host: "127.0.0.1:6767", timeoutMs: 5000 },
+        runtime,
+      ),
+    ).toEqual({
+      requested: false,
+      reason: "daemon at 127.0.0.1:6767 belongs to another home; no live owner in /test-home",
+    });
+    expect(events).toEqual(["connect", "close"]);
+  });
+
+  test("still stops the matching daemon when its PID file is missing", async () => {
+    const { runtime, events } = createRuntime("srv_test");
+    expect(
+      await requestLifecycleShutdown(
+        { home: "/test-home", hasLiveOwner: false, host: "127.0.0.1:6799", timeoutMs: 5000 },
+        runtime,
+      ),
+    ).toEqual({ requested: true });
+    expect(events).toEqual(["connect", "shutdown", "close"]);
   });
 });

--- a/packages/cli/src/commands/daemon/lifecycle-shutdown.ts
+++ b/packages/cli/src/commands/daemon/lifecycle-shutdown.ts
@@ -1,0 +1,84 @@
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+
+export interface LifecycleShutdownRuntime {
+  readServerId(home: string): string;
+  connect(options: {
+    host: string;
+    timeout: number;
+  }): Promise<Pick<DaemonClient, "getLastServerInfoMessage" | "shutdownServer" | "close"> | null>;
+}
+
+interface ShutdownTarget {
+  home: string;
+  host: string | null;
+  timeoutMs: number;
+}
+
+type LifecycleShutdownAttempt = { requested: true } | { requested: false; reason: string };
+
+export class DaemonIdentityMismatchError extends Error {
+  constructor(
+    readonly home: string,
+    readonly host: string,
+  ) {
+    super(`Refusing to stop daemon at ${host}: its identity does not match ${home}`);
+    this.name = "DaemonIdentityMismatchError";
+  }
+}
+
+export async function requestLifecycleShutdown(
+  target: ShutdownTarget,
+  runtime: LifecycleShutdownRuntime,
+): Promise<LifecycleShutdownAttempt> {
+  const { host, timeoutMs } = target;
+  if (!host) {
+    return {
+      requested: false,
+      reason: "daemon listen target is not TCP, falling back to owner PID signal",
+    };
+  }
+  // Do not create an identity while trying to stop an absent or incomplete home.
+  let expectedServerId: string;
+  try {
+    expectedServerId = runtime.readServerId(target.home).trim();
+  } catch (error) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+      throw error;
+    }
+    expectedServerId = "";
+  }
+  if (!expectedServerId) {
+    return {
+      requested: false,
+      reason: `daemon identity is missing in ${target.home}, falling back to owner PID signal`,
+    };
+  }
+  const deadline = Date.now() + timeoutMs;
+  const remainingTimeoutMs = () => Math.max(1, deadline - Date.now());
+  const client = await runtime.connect({ host, timeout: Math.min(remainingTimeoutMs(), 5000) });
+  if (!client) {
+    return {
+      requested: false,
+      reason: `daemon websocket at ${host} is not reachable, falling back to owner PID signal`,
+    };
+  }
+  try {
+    if (client.getLastServerInfoMessage()?.serverId !== expectedServerId) {
+      throw new DaemonIdentityMismatchError(target.home, host);
+    }
+    await client.shutdownServer({ timeout: Math.min(remainingTimeoutMs(), 5000) });
+    return { requested: true };
+  } catch (error) {
+    // A port collision is not permission to fall back to another destructive action.
+    if (error instanceof DaemonIdentityMismatchError) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      requested: false,
+      reason: `daemon lifecycle shutdown request failed (${message}), falling back to owner PID signal`,
+    };
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}

--- a/packages/cli/src/commands/daemon/lifecycle-shutdown.ts
+++ b/packages/cli/src/commands/daemon/lifecycle-shutdown.ts
@@ -10,6 +10,7 @@ export interface LifecycleShutdownRuntime {
 
 interface ShutdownTarget {
   home: string;
+  hasLiveOwner: boolean;
   host: string | null;
   timeoutMs: number;
 }
@@ -64,6 +65,12 @@ export async function requestLifecycleShutdown(
   }
   try {
     if (client.getLastServerInfoMessage()?.serverId !== expectedServerId) {
+      if (!target.hasLiveOwner) {
+        return {
+          requested: false,
+          reason: `daemon at ${host} belongs to another home; no live owner in ${target.home}`,
+        };
+      }
       throw new DaemonIdentityMismatchError(target.home, host);
     }
     await client.shutdownServer({ timeout: Math.min(remainingTimeoutMs(), 5000) });

--- a/packages/cli/src/commands/daemon/local-daemon.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.ts
@@ -678,6 +678,7 @@ export async function stopLocalDaemon(
   const shutdownAttempt = await requestLifecycleShutdown(
     {
       home: state.home,
+      hasLiveOwner: state.running,
       host: resolveTcpHostFromListen(state.listen),
       timeoutMs: remainingTimeoutMs(),
     },

--- a/packages/cli/src/commands/daemon/local-daemon.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { loadConfig, resolvePaseoHome, spawnProcess } from "@getpaseo/server";
 import treeKill from "tree-kill";
 import { tryConnectToDaemon } from "../../utils/client.js";
+import { requestLifecycleShutdown } from "./lifecycle-shutdown.js";
 
 export interface DaemonStartOptions {
   port?: string;
@@ -497,12 +498,6 @@ async function waitForStopAfterRequest(args: {
   return { stopped, forced: false };
 }
 
-type LifecycleShutdownAttempt = { requested: true } | { requested: false; reason: string };
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 export function resolveLocalPaseoHome(home?: string): string {
   return resolvePaseoHome(envWithHome(home));
 }
@@ -671,43 +666,6 @@ export function startLocalDaemonForeground(
   return result.status ?? 1;
 }
 
-async function requestLifecycleShutdown(
-  state: LocalDaemonState,
-  timeoutMs: number,
-): Promise<LifecycleShutdownAttempt> {
-  const host = resolveTcpHostFromListen(state.listen);
-  if (!host) {
-    return {
-      requested: false,
-      reason: "daemon listen target is not TCP, falling back to owner PID signal",
-    };
-  }
-
-  const deadline = Date.now() + timeoutMs;
-  const remainingTimeoutMs = () => Math.max(1, deadline - Date.now());
-  const client = await tryConnectToDaemon({ host, timeout: Math.min(remainingTimeoutMs(), 5000) });
-  if (!client) {
-    return {
-      requested: false,
-      reason: `daemon websocket at ${host} is not reachable, falling back to owner PID signal`,
-    };
-  }
-
-  try {
-    await client.shutdownServer({ timeout: Math.min(remainingTimeoutMs(), 5000) });
-    return { requested: true };
-  } catch (error) {
-    return {
-      requested: false,
-      reason: `daemon lifecycle shutdown request failed (${getErrorMessage(
-        error,
-      )}), falling back to owner PID signal`,
-    };
-  } finally {
-    await client.close().catch(() => undefined);
-  }
-}
-
 export async function stopLocalDaemon(
   options: StopLocalDaemonOptions = {},
 ): Promise<StopLocalDaemonResult> {
@@ -717,7 +675,17 @@ export async function stopLocalDaemon(
   const deadline = Date.now() + timeoutMs;
   const remainingTimeoutMs = () => Math.max(1, deadline - Date.now());
 
-  const shutdownAttempt = await requestLifecycleShutdown(state, remainingTimeoutMs());
+  const shutdownAttempt = await requestLifecycleShutdown(
+    {
+      home: state.home,
+      host: resolveTcpHostFromListen(state.listen),
+      timeoutMs: remainingTimeoutMs(),
+    },
+    {
+      readServerId: (home) => readFileSync(path.join(home, "server-id"), "utf8").trim(),
+      connect: tryConnectToDaemon,
+    },
+  );
   const lifecycleRequested = shutdownAttempt.requested;
 
   if (!state.pidInfo || (!state.running && !lifecycleRequested)) {

--- a/packages/cli/src/commands/daemon/restart.test.ts
+++ b/packages/cli/src/commands/daemon/restart.test.ts
@@ -52,9 +52,8 @@ describe("daemon restart target", () => {
   test.each(["127.0.0.1:6799", "[::1]:6799", "/test-home/daemon.sock"])(
     "preserves %s before stopping the old supervisor",
     async (previousListen) => {
-      const { runtime, starts, events } = createRuntime(previousListen);
+      const { runtime, starts } = createRuntime(previousListen);
       await runRestartCommand({ home: "/test-home" }, new Command(), runtime);
-      expect(events).toEqual(["resolve", "stop", "start"]);
       expect(starts.map(({ home, listen, port }) => ({ home, listen, port }))).toEqual([
         { home: "/test-home", listen: previousListen, port: undefined },
       ]);

--- a/packages/cli/src/commands/daemon/restart.test.ts
+++ b/packages/cli/src/commands/daemon/restart.test.ts
@@ -45,7 +45,7 @@ function createRuntime(listen = "127.0.0.1:6799") {
       return { pid: 456, logPath: "/test-home/daemon.log" };
     },
   };
-  return { runtime, starts, events };
+  return { runtime, starts, events, state };
 }
 
 describe("daemon restart target", () => {
@@ -94,5 +94,24 @@ describe("daemon restart target", () => {
     );
     expect(events).toEqual(["resolve", "stop"]);
     expect(starts).toEqual([]);
+  });
+  test("leaves listen selection to startup when the daemon is stopped", async () => {
+    const { runtime, starts, state } = createRuntime();
+    state.running = false;
+    state.pidInfo = null;
+    await runRestartCommand({ home: "/test-home" }, new Command(), runtime);
+    expect(starts.map(({ listen, port }) => ({ listen, port }))).toEqual([
+      { listen: undefined, port: undefined },
+    ]);
+  });
+
+  test("does not retain a stale supervisor's listen override", async () => {
+    const { runtime, starts, state } = createRuntime();
+    state.running = false;
+    state.stalePidFile = true;
+    await runRestartCommand({ home: "/test-home" }, new Command(), runtime);
+    expect(starts.map(({ listen, port }) => ({ listen, port }))).toEqual([
+      { listen: undefined, port: undefined },
+    ]);
   });
 });

--- a/packages/cli/src/commands/daemon/restart.test.ts
+++ b/packages/cli/src/commands/daemon/restart.test.ts
@@ -1,0 +1,99 @@
+import { Command } from "commander";
+import { describe, expect, test } from "vitest";
+import { runRestartCommand, type DaemonRestartRuntime } from "./restart.js";
+import type { DaemonStartOptions, LocalDaemonState } from "./local-daemon.js";
+
+function createRuntime(listen = "127.0.0.1:6799") {
+  const starts: DaemonStartOptions[] = [];
+  const events: string[] = [];
+  const state: LocalDaemonState = {
+    home: "/test-home",
+    listen,
+    relayEnabled: false,
+    relayEndpoint: "relay.paseo.sh:443",
+    relayUseTls: true,
+    relayPublicUseTls: true,
+    logPath: "/test-home/daemon.log",
+    pidPath: "/test-home/paseo.pid",
+    pidInfo: { pid: 123, listen },
+    running: true,
+    stalePidFile: false,
+  };
+  const runtime: DaemonRestartRuntime = {
+    resolveState: () => {
+      events.push("resolve");
+      return state;
+    },
+    stop: async () => {
+      events.push("stop");
+      // Stopping the supervisor removes the old listen metadata.
+      state.listen = "127.0.0.1:6767";
+      state.pidInfo = null;
+      return {
+        action: "stopped",
+        home: "/test-home",
+        pid: 123,
+        forced: false,
+        usedLifecycleRpc: true,
+        reason: "lifecycle_shutdown_rpc",
+        message: "stopped",
+      };
+    },
+    start: async (options) => {
+      events.push("start");
+      starts.push(options);
+      return { pid: 456, logPath: "/test-home/daemon.log" };
+    },
+  };
+  return { runtime, starts, events };
+}
+
+describe("daemon restart target", () => {
+  test.each(["127.0.0.1:6799", "[::1]:6799", "/test-home/daemon.sock"])(
+    "preserves %s before stopping the old supervisor",
+    async (previousListen) => {
+      const { runtime, starts, events } = createRuntime(previousListen);
+      await runRestartCommand({ home: "/test-home" }, new Command(), runtime);
+      expect(events).toEqual(["resolve", "stop", "start"]);
+      expect(starts.map(({ home, listen, port }) => ({ home, listen, port }))).toEqual([
+        { home: "/test-home", listen: previousListen, port: undefined },
+      ]);
+    },
+  );
+
+  test("honors an explicit port override", async () => {
+    const { runtime, starts } = createRuntime();
+    await runRestartCommand({ home: "/test-home", port: "6800" }, new Command(), runtime);
+    expect(starts.map(({ listen, port }) => ({ listen, port }))).toEqual([
+      { listen: undefined, port: "6800" },
+    ]);
+  });
+
+  test("honors an explicit listen override", async () => {
+    const { runtime, starts } = createRuntime();
+    await runRestartCommand(
+      { home: "/test-home", listen: "127.0.0.1:6800" },
+      new Command(),
+      runtime,
+    );
+    expect(starts.map(({ listen, port }) => ({ listen, port }))).toEqual([
+      { listen: "127.0.0.1:6800", port: undefined },
+    ]);
+  });
+
+  test("does not start or retry with force when stop rejects a different daemon", async () => {
+    const { runtime, starts, events } = createRuntime();
+    runtime.stop = async () => {
+      events.push("stop");
+      throw new Error("Refusing to stop a different daemon");
+    };
+    await expect(runRestartCommand({ home: "/test-home" }, new Command(), runtime)).rejects.toEqual(
+      {
+        code: "RESTART_FAILED",
+        message: "Failed to restart local daemon: Refusing to stop a different daemon",
+      },
+    );
+    expect(events).toEqual(["resolve", "stop"]);
+    expect(starts).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/daemon/restart.ts
+++ b/packages/cli/src/commands/daemon/restart.ts
@@ -102,8 +102,10 @@ export async function runRestartCommand(
     // Capture the effective target before stop removes the old supervisor's PID file.
     const state = runtime.resolveState({ home: startOptions.home });
     startOptions.home = state.home;
-    if (!startOptions.listen && !startOptions.port) {
-      startOptions.listen = state.listen;
+    const previousListen = state.running ? state.pidInfo?.listen : undefined;
+    const hasListenOverride = Boolean(startOptions.listen || startOptions.port);
+    if (!hasListenOverride && previousListen) {
+      startOptions.listen = previousListen;
     }
     let stopResult: Awaited<ReturnType<typeof stopLocalDaemon>>;
     try {

--- a/packages/cli/src/commands/daemon/restart.ts
+++ b/packages/cli/src/commands/daemon/restart.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import {
+  resolveLocalDaemonState,
   startLocalDaemonDetached,
   stopLocalDaemon,
   DEFAULT_STOP_TIMEOUT_MS,
@@ -31,6 +32,18 @@ const restartResultSchema: OutputSchema<RestartResult> = {
     { header: "PID", field: "pid" },
     { header: "MESSAGE", field: "message" },
   ],
+};
+
+export interface DaemonRestartRuntime {
+  resolveState: typeof resolveLocalDaemonState;
+  stop: typeof stopLocalDaemon;
+  start: typeof startLocalDaemonDetached;
+}
+
+const defaultRestartRuntime: DaemonRestartRuntime = {
+  resolveState: resolveLocalDaemonState,
+  stop: stopLocalDaemon,
+  start: startLocalDaemonDetached,
 };
 
 export type RestartCommandResult = SingleResult<RestartResult>;
@@ -79,15 +92,22 @@ function toStartOptions(options: CommandOptions): DaemonStartOptions {
 export async function runRestartCommand(
   options: CommandOptions,
   _command: Command,
+  runtime: DaemonRestartRuntime = defaultRestartRuntime,
 ): Promise<RestartCommandResult> {
   const timeoutMs = parseTimeoutMs(options.timeout);
   const force = options.force === true;
   const startOptions = toStartOptions(options);
 
   try {
+    // Capture the effective target before stop removes the old supervisor's PID file.
+    const state = runtime.resolveState({ home: startOptions.home });
+    startOptions.home = state.home;
+    if (!startOptions.listen && !startOptions.port) {
+      startOptions.listen = state.listen;
+    }
     let stopResult: Awaited<ReturnType<typeof stopLocalDaemon>>;
     try {
-      stopResult = await stopLocalDaemon({
+      stopResult = await runtime.stop({
         home: startOptions.home,
         timeoutMs,
         force,
@@ -96,7 +116,7 @@ export async function runRestartCommand(
       const isTimeout =
         err instanceof Error && err.message.includes("Timed out waiting for daemon PID");
       if (!force && isTimeout) {
-        stopResult = await stopLocalDaemon({
+        stopResult = await runtime.stop({
           home: startOptions.home,
           timeoutMs,
           force: true,
@@ -106,7 +126,7 @@ export async function runRestartCommand(
       }
     }
 
-    const startup = await startLocalDaemonDetached(startOptions);
+    const startup = await runtime.start(startOptions);
     const before = stopResult.pid === null ? "not running" : `PID ${stopResult.pid}`;
     const after = startup.pid === null ? "unknown PID" : `PID ${startup.pid}`;
 

--- a/public-docs/cli.md
+++ b/public-docs/cli.md
@@ -287,7 +287,7 @@ paseo daemon stop              # Stop the daemon
 
 Reload validates the whole file, applies runtime-safe changes, and reports `appliedPaths`, `restartRequiredPaths`, and `overrideControlledPaths`. Human output prints `paseo daemon restart` only when a changed setting needs it. Use `--json` or `--format yaml` for the structured result. Run `paseo --host <target> reload` to reload a remote daemon's own configuration file. An older host that does not support reload returns an update-host error.
 
-Use `PASEO_HOME` to run multiple isolated daemon instances.
+Use `PASEO_HOME` to run multiple isolated daemon instances. See [Configuration](/docs/configuration) for home-scoped shutdown checks and restart address overrides.
 
 ## Hub
 

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -20,7 +20,7 @@ By default, Paseo uses `~/.paseo` as its home directory. The configuration file 
 
 You can change the home directory by setting `PASEO_HOME` or passing `--home` to `paseo daemon start`. Use the same home for `paseo daemon stop` and `paseo daemon restart`. Shutdown verifies the listening daemon against that home’s saved identity and refuses a different daemon at the same address.
 
-`paseo daemon restart` retains the previous listen address. To change it, pass `--listen <address>` or `--port <port>` on the restart command, including when adopting a new listen address from `config.json`.
+See [Apply changes](#apply-changes) for restart and listen-address overrides.
 
 ## Precedence
 
@@ -65,13 +65,21 @@ The daemon validates the complete file before applying anything. It applies runt
 paseo daemon restart
 ```
 
+A running daemon's recorded listen address is retained across CLI restarts. To change it, including after editing `daemon.listen` in `config.json`, pass the new address explicitly:
+
+```bash
+paseo daemon restart --listen 127.0.0.1:6800
+```
+
+`--port <port>` also overrides the previous address. When there is no live supervisor with a recorded listen address, restart uses the normal environment and file configuration precedence.
+
 Runtime-safe settings include relay enablement, MCP settings, browser tools, hostnames, CORS origins, trusted proxies, Git process limits, agent and terminal profiles, provider definitions, metadata generation, the app base URL, provider catalog timeout, and the global plugin switch. Removing one of these settings applies its omitted-field behavior; removing a provider removes it from future launches.
 
 New homes keep relay disabled when you remove `daemon.relay.enabled`. A daemon whose config already omitted this field when it started keeps the legacy relay-enabled behavior for compatibility. Set `daemon.relay.enabled` explicitly when editing an older config.
 
 Listen addresses, authentication, relay endpoints and TLS, worktree allocation, service-proxy addresses, the bundled web UI, logging, speech, voice, credentials, and local model settings require a restart. Reload applies other valid edits in the same file before reporting those paths.
 
-Environment variables and daemon start flags remain authoritative. Reload reports a changed file setting under `overrideControlledPaths` when a launch override prevents it from taking effect. This includes startup settings such as listen addresses, passwords, relay endpoints and TLS, service-proxy and web UI settings, logging, speech, and voice configuration. List settings such as hostnames and CORS origins still append across sources, so values from `config.json` continue to apply. Remove the override and restart the daemon if you want the file value to become authoritative.
+Environment variables and daemon start flags remain authoritative. Reload reports a changed file setting under `overrideControlledPaths` when a launch override prevents it from taking effect. This includes startup settings such as listen addresses, passwords, relay endpoints and TLS, service-proxy and web UI settings, logging, speech, and voice configuration. List settings such as hostnames and CORS origins still append across sources, so values from `config.json` continue to apply. For the listen address, CLI restart retains the running supervisor’s address as a launch override; use `--listen` or `--port` to change it. To return to file-controlled listening, stop the daemon and start it with the listen override removed. For other settings, remove the override and restart the daemon if you want the file value to become authoritative.
 
 ## Agent providers
 

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -18,7 +18,9 @@ By default, Paseo uses `~/.paseo` as its home directory. The configuration file 
 ~/.paseo/config.json
 ```
 
-You can change the home directory by setting `PASEO_HOME` or passing `--home` to `paseo daemon start`.
+You can change the home directory by setting `PASEO_HOME` or passing `--home` to `paseo daemon start`. Use the same home for `paseo daemon stop` and `paseo daemon restart`. Shutdown verifies the listening daemon against that home’s saved identity and refuses a different daemon at the same address.
+
+`paseo daemon restart` retains the previous listen address. To change it, pass `--listen <address>` or `--port <port>` on the restart command, including when adopting a new listen address from `config.json`.
 
 ## Precedence
 


### PR DESCRIPTION
## Problem and change

Fixes #4520.

A daemon started with a separate home and custom port could restart on the parent daemon's port. A subsequent `daemon stop --home <test-home>` could then shut down the unrelated daemon listening there.

- Capture a live supervisor’s recorded listen target before stopping it and retain it on restart unless `--listen` or `--port` explicitly overrides it. Stopped/stale daemons retain normal environment and file precedence.
- Read the target home's existing server identity and compare it to the connected daemon's `server_info` before shutdown. A mismatch with a live owner raises an error without sending shutdown or falling back to signals; without a live owner, stopping an unrelated listener remains a no-op. A matching daemon without a PID file is still eligible for lifecycle shutdown. Missing identity avoids connecting and retains the existing owner-PID path.
- Document the restart address behavior, including explicit overrides when adopting a changed configuration address.

The shutdown logic uses typed injectable dependencies so the regression tests cannot contact an installed daemon. There are no protocol, installed-app, or live configuration changes. Supervisor bind-failure retry/readiness handling remains outside this focused patch (related #3333).

## Verification

Run in an isolated source checkout on macOS 26.5.2, Apple Silicon. The installed daemon was not restarted or reconfigured.

```text
npx vitest run packages/cli/src/commands/daemon/lifecycle-shutdown.test.ts packages/cli/src/commands/daemon/restart.test.ts --bail=1 --maxWorkers=1
Test Files  2 passed (2)
Tests       18 passed (18)
```

Regression proof before the fixes:

```text
Wrong-identity shutdown:
AssertionError: promise resolved "{ requested: true }" instead of rejecting

Restart without listen preservation:
- "listen": "127.0.0.1:6799"
+ "listen": undefined
```

```text
npm run typecheck --workspace=@getpaseo/cli
> tsgo --noEmit
(exit 0)

npm run lint -- <five changed CLI TypeScript files>
Found 0 warnings and 0 errors.

npm run format
Finished on 4386 files.

git diff --check
(exit 0)
```

Workspace dependency builds (protocol/client, highlight, plugin, relay, server) and the CLI build passed. Full `npm run typecheck` was also attempted, but the CLI-only dependency install leaves unrelated workspaces without dependencies including `expo-modules-core`, `expo-module-scripts`, and `@tanstack/react-query`, and produces app/desktop type errors. The CLI typecheck passes. Full repository coverage is left to CI rather than represented as locally green.

Platform coverage: isolated unit tests and CLI static checks on macOS. Windows/Linux and real-daemon end-to-end tests were not run locally. No full test suite or live lifecycle reproduction was run on the working machine.

## Independent review

An independent Claude Opus 5 session reviewed the diff in a separate worktree with read-only source access and no daemon commands. It confirmed the incident is addressed and identified two compatibility findings: no-op stop behavior for an unused home, and environment precedence when restarting a stopped daemon. Both were remediated with four additional regression tests; the same session reviewed commit `b7aa4e2` and confirmed both findings resolved, with no remaining blockers. Independent verification was a source review: the reviewer did not independently rerun the tests or real-daemon lifecycle flows.

Known limits identified by review: copied homes sharing the same `server-id` are not distinguished by this identity-only check; setting `PASEO_SERVER_ID` to differ from an existing saved identity causes conservative refusal rather than shutdown. These are not claimed fixed.

Upstream workflows currently report `action_required` with no jobs run; maintainer approval is needed for fork CI. Independent review is complete; broader integration and platform verification remains pending CI approval.

AI assistance: implementation and verification were performed with Codex; independent source review uses a separate model/session. The reporter's original incident evidence is in #4520.

<details>
<summary>Independent reviewer’s final source assessment (verbatim)</summary>

Reviewed `git diff f17db76 b7aa4e2` only. Read-only; no commands run beyond git/file reads.

## Both actionable findings are resolved

**Finding 1 — resolved.** `ShutdownTarget` gains a required `hasLiveOwner` (`lifecycle-shutdown.ts:13`), wired from `state.running` at the single call site (`local-daemon.ts:681`). The mismatch branch now returns `{requested: false, reason}` when there is no live owner (`lifecycle-shutdown.ts:67-73`) and still throws `DaemonIdentityMismatchError` when there is. I traced the downstream: with no live owner, `stopLocalDaemon`'s existing guard (`local-daemon.ts:692-700`) returns the benign `not_running` result, so `paseo daemon stop --home <scratch>` exits 0 again while an unrelated daemon holds the address — the behavior `packages/cli/tests/03-daemon.test.ts:197-206` asserts. The safety property is intact: no shutdown RPC is sent on a mismatch either way, and the throw path still has no PID-signal fallback. The new test "still stops the matching daemon when its PID file is missing" preserves the pid-file-less worker fixture (`03-daemon.test.ts` Test 8), which was the trap in this fix.

**Finding 2 — resolved.** `previousListen = state.running ? state.pidInfo?.listen : undefined` (`restart.ts:105`) pins only a live supervisor's recorded address. Stopped, stale-PID, and `listen: null`-before-worker-ready cases all fall through to normal env/file precedence, restoring `PASEO_LISTEN` and `config.json` adoption when nothing is running. Explicit `--listen`/`--port` still win. The two new restart tests discriminate correctly (the stale case keeps `pidInfo` set and only flips `running`/`stalePidFile`, so it fails without the fix).

**Finding 5 — resolved.** `cli.md:290` cross-links rather than duplicating.

**Docs.** The correction now lives in "Apply changes" with a concrete `--listen` example, and the `overrideControlledPaths` paragraph explains the retained launch override plus the stop-and-start escape hatch. `configuration.md:23` is a pointer to `#apply-changes`, which matches the heading anchor. This satisfies the "rewrite the part that is now wrong" rule I cited earlier.

Findings 3 and 4 as named residuals is the right call — neither is claimed fixed, and both are accurately characterized (a copied `server-id` defeats matching; a `PASEO_SERVER_ID` differing from the saved file causes a conservative refusal).

## Remaining blockers

None. One non-blocking nit: the new `reason` string ("daemon at `<host>` belongs to another home; no live owner in `<home>`") is discarded by `createNotRunningStopResult`, so the user sees only "Daemon is not running" with no hint that something else answers on that address. Diagnostic quality only — the safe outcome and exit code are correct. Worth surfacing in `--json` output eventually; not worth holding this PR.

## Verification limits

- I ran nothing. The 18 passing tests, both red-before proofs, typecheck, lint, formatter and diff check are your reported evidence, not re-observed; per repo rule I did not re-run green suites.
- My Finding-1 resolution claim is a code-path trace through `stopLocalDaemon`, not an observed run of `03-daemon.test.ts` Test 6. That test spawns real daemons and was out of bounds here.
- Scope was strictly `f17db76..b7aa4e2`. I did not re-verify the unchanged production code I cleared in the previous round, and did not read issue #4520 or PR #4541 (no network).
- Platform-specific paths (Windows pipes, IPv6, unix sockets) remain reasoned from source only; broad platform and integration coverage is still CI's job, as you scoped.

I have no acceptance authority. On the correctness question I was asked: the two blocking findings are closed, and I see no reason from this diff to keep it draft.

</details>
