### PR TITLE
Fix macOS Command-arrow terminal navigation with Electron regression coverage

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -160,7 +160,7 @@ Assert editing through the command the real shell executes and its output file.
 Use the accessible terminal input and tab controls to check focus and selection;
 do not inspect xterm buffers or install browser probes for assertions.
 
-For a review video, add `-- --record`. Recording uses 22px terminal text, a steady
+For a review video, add `-- --record`. Recording uses 22px terminal text, a
 block cursor, visible key labels, and three-second pauses at each checkpoint. The
 demonstration shows both line boundaries before editing, then tab switching, pane
 focus, and moving a tab between panes. Its isolated app settings leave your normal

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -144,6 +144,18 @@ Run it locally with the same command owned by the Ubuntu `desktop-tests` require
 npm run test:e2e:browser-tabs --workspace=@getpaseo/desktop
 ```
 
+### macOS terminal keyboard regression
+
+Run `npm run test:e2e:terminal-command-arrows --workspace=@getpaseo/desktop` on a Mac
+after building the server stack and `@getpaseo/expo-two-way-audio`. This launches an
+isolated daemon and the checkout's real Electron app. A browser with a macOS user
+agent cannot verify native Command-arrow behavior.
+
+Set `PASEO_TERMINAL_ARROW_ARTIFACT_DIR` to keep the screenshots, Playwright trace,
+process logs, and results together. The result records the commit and macOS/Electron
+versions. Keep an unpatched run's failure with the patched run's evidence so you can
+tell whether the check catches the original bug.
+
 ## Test organization
 
 - Collocate tests with implementation: `thing.ts` + `thing.test.ts`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -152,9 +152,21 @@ isolated daemon and the checkout's real Electron app. A browser with a macOS use
 agent cannot verify native Command-arrow behavior.
 
 Set `PASEO_TERMINAL_ARROW_ARTIFACT_DIR` to keep the screenshots, Playwright trace,
-process logs, and results together. The result records the commit and macOS/Electron
-versions. Keep an unpatched run's failure with the patched run's evidence so you can
-tell whether the check catches the original bug.
+process logs, and results together. The result records the commit, host, and
+macOS/Electron versions. Keep an unpatched run's failure with the patched run's
+evidence so you can tell whether the check catches the original bug.
+
+For a review video, add `-- --record`. Recording uses 22px terminal text, a steady
+block cursor, visible key labels, and three-second pauses at each checkpoint. The
+demonstration shows both line boundaries before editing, then tab switching, pane
+focus, and moving a tab between panes. Its isolated app settings leave your normal
+desktop settings alone.
+
+The `recording/` directory contains full-resolution Electron frames, their capture
+timestamps, and an FFmpeg concat manifest. Run the FFmpeg arguments listed in
+`recording/recording.json` from that directory to encode the video, including on a
+different host. Keep the original timing; a trace's reduced screenshots make the
+terminal cursor too small to review.
 
 ## Test organization
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -156,6 +156,10 @@ process logs, and results together. The result records the commit, host, and
 macOS/Electron versions. Keep an unpatched run's failure with the patched run's
 evidence so you can tell whether the check catches the original bug.
 
+Assert editing through the command the real shell executes and its output file.
+Use the accessible terminal input and tab controls to check focus and selection;
+do not inspect xterm buffers or install browser probes for assertions.
+
 For a review video, add `-- --record`. Recording uses 22px terminal text, a steady
 block cursor, visible key labels, and three-second pauses at each checkpoint. The
 demonstration shows both line boundaries before editing, then tab switching, pane

--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
@@ -17,10 +17,8 @@ import {
   type PendingTerminalModifiers,
   isAppleHandheldPlatform,
   isTerminalModifierDomKey,
-  mergeTerminalModifiers,
   normalizeDomTerminalKey,
-  normalizeTerminalTransportKey,
-  shouldInterceptDomTerminalKey,
+  resolveDomTerminalKeyInput,
 } from "@/utils/terminal-keys";
 import { renderTerminalSnapshotToAnsi } from "./terminal-snapshot";
 import {
@@ -447,32 +445,23 @@ export class TerminalEmulatorRuntime {
         return true;
       }
 
-      if (
-        !shouldInterceptDomTerminalKey({
-          key: normalizedKey,
-          ctrlKey: event.ctrlKey,
-          shiftKey: event.shiftKey,
-          altKey: event.altKey,
-          metaKey: event.metaKey,
-          pendingModifiers: this.pendingModifiers,
-          enhancedInputActive: this.inputModeTracker.supportsModifiedEnter(),
-          isAppleHandheld,
-        })
-      ) {
-        return true;
-      }
-
-      const modifiers = mergeTerminalModifiers({
-        pendingModifiers: this.pendingModifiers,
+      const terminalKeyInput = resolveDomTerminalKeyInput({
+        key: normalizedKey,
         ctrlKey: event.ctrlKey,
         shiftKey: event.shiftKey,
         altKey: event.altKey,
         metaKey: event.metaKey,
+        pendingModifiers: this.pendingModifiers,
+        enhancedInputActive: this.inputModeTracker.supportsModifiedEnter(),
+        isAppleHandheld,
+        isMacDesktop: isMac && !isAppleHandheld,
       });
-      this.callbacks.onTerminalKey?.({
-        key: normalizeTerminalTransportKey(normalizedKey),
-        ...modifiers,
-      });
+
+      if (!terminalKeyInput) {
+        return true;
+      }
+
+      this.callbacks.onTerminalKey?.(terminalKeyInput);
 
       if (this.pendingModifiers.ctrl || this.pendingModifiers.shift || this.pendingModifiers.alt) {
         this.callbacks.onPendingModifiersConsumed?.();

--- a/packages/app/src/utils/terminal-keys.test.ts
+++ b/packages/app/src/utils/terminal-keys.test.ts
@@ -89,6 +89,26 @@ describe("terminal key helpers", () => {
     expect(resolveDomTerminalKeyInput({ ...baseInput, key: "ArrowUp" })).toBeNull();
   });
 
+  it("preserves pending terminal modifiers instead of applying macOS line-boundary mapping", () => {
+    expect(
+      resolveDomTerminalKeyInput({
+        key: "ArrowLeft",
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        metaKey: true,
+        pendingModifiers: { ctrl: false, shift: true, alt: false },
+        isMacDesktop: true,
+      }),
+    ).toEqual({
+      key: "ArrowLeft",
+      ctrl: false,
+      shift: true,
+      alt: false,
+      meta: true,
+    });
+  });
+
   it("merges pending modifiers with native key modifiers", () => {
     expect(
       mergeTerminalModifiers({

--- a/packages/app/src/utils/terminal-keys.test.ts
+++ b/packages/app/src/utils/terminal-keys.test.ts
@@ -7,6 +7,7 @@ import {
   mergeTerminalModifiers,
   normalizeDomTerminalKey,
   normalizeTerminalTransportKey,
+  resolveDomTerminalKeyInput,
   resolvePendingModifierDataInput,
   shouldInterceptDomTerminalKey,
 } from "./terminal-keys";
@@ -41,6 +42,51 @@ describe("terminal key helpers", () => {
   it("lowercases printable transport keys", () => {
     expect(normalizeTerminalTransportKey("C")).toBe("c");
     expect(normalizeTerminalTransportKey("Escape")).toBe("Escape");
+  });
+
+  it("maps bare macOS Cmd+Left/Right to terminal line-boundary controls", () => {
+    const baseInput = {
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      metaKey: true,
+      pendingModifiers: { ctrl: false, shift: false, alt: false },
+      isMacDesktop: true,
+    };
+
+    expect(resolveDomTerminalKeyInput({ ...baseInput, key: "ArrowLeft" })).toEqual({
+      key: "a",
+      ctrl: true,
+      shift: false,
+      alt: false,
+      meta: false,
+    });
+    expect(resolveDomTerminalKeyInput({ ...baseInput, key: "ArrowRight" })).toEqual({
+      key: "e",
+      ctrl: true,
+      shift: false,
+      alt: false,
+      meta: false,
+    });
+  });
+
+  it("leaves non-macOS and modified Command arrows available to their existing shortcuts", () => {
+    const baseInput = {
+      key: "ArrowLeft",
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      metaKey: true,
+      pendingModifiers: { ctrl: false, shift: false, alt: false },
+      isMacDesktop: true,
+    };
+
+    expect(resolveDomTerminalKeyInput({ ...baseInput, isMacDesktop: false })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, shiftKey: true })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, altKey: true })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, ctrlKey: true })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, metaKey: false })).toBeNull();
+    expect(resolveDomTerminalKeyInput({ ...baseInput, key: "ArrowUp" })).toBeNull();
   });
 
   it("merges pending modifiers with native key modifiers", () => {

--- a/packages/app/src/utils/terminal-keys.ts
+++ b/packages/app/src/utils/terminal-keys.ts
@@ -122,14 +122,16 @@ export function resolveDomTerminalKeyInput(args: {
   alt: boolean;
   meta: boolean;
 } | null {
-  const macLineBoundaryKey = resolveMacLineBoundaryTerminalKey({
-    key: args.key,
-    ctrlKey: args.ctrlKey,
-    shiftKey: args.shiftKey,
-    altKey: args.altKey,
-    metaKey: args.metaKey,
-    isMacDesktop: Boolean(args.isMacDesktop),
-  });
+  const macLineBoundaryKey = hasPendingTerminalModifiers(args.pendingModifiers)
+    ? null
+    : resolveMacLineBoundaryTerminalKey({
+        key: args.key,
+        ctrlKey: args.ctrlKey,
+        shiftKey: args.shiftKey,
+        altKey: args.altKey,
+        metaKey: args.metaKey,
+        isMacDesktop: Boolean(args.isMacDesktop),
+      });
   if (macLineBoundaryKey) {
     return macLineBoundaryKey;
   }

--- a/packages/app/src/utils/terminal-keys.ts
+++ b/packages/app/src/utils/terminal-keys.ts
@@ -78,6 +78,72 @@ export function normalizeTerminalTransportKey(key: string): string {
   return key;
 }
 
+function resolveMacLineBoundaryTerminalKey(args: {
+  key: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  isMacDesktop: boolean;
+}): {
+  key: "a" | "e";
+  ctrl: true;
+  shift: false;
+  alt: false;
+  meta: false;
+} | null {
+  if (!args.isMacDesktop || !args.metaKey || args.ctrlKey || args.shiftKey || args.altKey) {
+    return null;
+  }
+
+  if (args.key === "ArrowLeft") {
+    return { key: "a", ctrl: true, shift: false, alt: false, meta: false };
+  }
+  if (args.key === "ArrowRight") {
+    return { key: "e", ctrl: true, shift: false, alt: false, meta: false };
+  }
+  return null;
+}
+
+export function resolveDomTerminalKeyInput(args: {
+  key: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  pendingModifiers: PendingTerminalModifiers;
+  enhancedInputActive?: boolean;
+  isAppleHandheld?: boolean;
+  isMacDesktop?: boolean;
+}): {
+  key: string;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+} | null {
+  const macLineBoundaryKey = resolveMacLineBoundaryTerminalKey({
+    key: args.key,
+    ctrlKey: args.ctrlKey,
+    shiftKey: args.shiftKey,
+    altKey: args.altKey,
+    metaKey: args.metaKey,
+    isMacDesktop: Boolean(args.isMacDesktop),
+  });
+  if (macLineBoundaryKey) {
+    return macLineBoundaryKey;
+  }
+
+  if (!shouldInterceptDomTerminalKey(args)) {
+    return null;
+  }
+
+  return {
+    key: normalizeTerminalTransportKey(args.key),
+    ...mergeTerminalModifiers(args),
+  };
+}
+
 export function hasPendingTerminalModifiers(modifiers: PendingTerminalModifiers): boolean {
   return modifiers.ctrl || modifiers.shift || modifiers.alt;
 }

--- a/packages/desktop/e2e/support/electron-session.mjs
+++ b/packages/desktop/e2e/support/electron-session.mjs
@@ -255,3 +255,48 @@ export async function startElectronSession({ artifactDir }) {
     throw error;
   }
 }
+
+export async function runElectronScenario({ artifactDir, report, recordVideo }, scenario) {
+  let session;
+  let tracing;
+  const cleanups = [];
+
+  async function recordFailure(failure) {
+    const details = failure?.stack ?? String(failure);
+    const alreadyFailed = report.result === "failed";
+    if (alreadyFailed) {
+      report.secondaryErrors ??= [];
+      report.secondaryErrors.push(details);
+    } else {
+      report.error = details;
+    }
+    report.result = "failed";
+    process.exitCode = 1;
+    console.error(failure);
+    if (!alreadyFailed) {
+      await session?.page
+        .screenshot({ path: path.join(artifactDir, "failure.png") })
+        .catch(() => undefined);
+    }
+  }
+
+  try {
+    session = await startElectronSession({ artifactDir });
+    const contextTracing = session.browser.contexts()[0].tracing;
+    await contextTracing.start({ screenshots: !recordVideo, snapshots: true, sources: true });
+    tracing = contextTracing;
+    await scenario({ ...session, addCleanup: (cleanup) => cleanups.push(cleanup) });
+    report.result = "passed";
+  } catch (error) {
+    await recordFailure(error);
+  } finally {
+    for (const cleanup of cleanups.toReversed()) {
+      await Promise.resolve().then(cleanup).catch(recordFailure);
+    }
+    await tracing?.stop({ path: path.join(artifactDir, "trace.zip") }).catch(recordFailure);
+    await session?.close().catch(recordFailure);
+    writeJson(path.join(artifactDir, "result.json"), report);
+    console.log(`Evidence: ${artifactDir}`);
+  }
+  return report;
+}

--- a/packages/desktop/e2e/support/electron-session.mjs
+++ b/packages/desktop/e2e/support/electron-session.mjs
@@ -1,0 +1,257 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const rootDir = fileURLToPath(new URL("../../../../", import.meta.url));
+const desktopDir = path.join(rootDir, "packages", "desktop");
+const readyTimeoutMs = 180_000;
+
+async function reservePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close((error) => {
+        if (error) return reject(error);
+        if (!address || typeof address === "string") {
+          return reject(new Error("Failed to reserve an Electron test port"));
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function seedPaseoHome({ paseoHome, listen, workspaceId, cwd }) {
+  const timestamp = "2026-01-01T00:00:00.000Z";
+  const projectId = `project-${workspaceId}`;
+  fs.mkdirSync(cwd, { recursive: true });
+  writeJson(path.join(paseoHome, "config.json"), {
+    version: 1,
+    daemon: {
+      listen,
+      relay: { enabled: false },
+      mcp: { enabled: true, injectIntoAgents: false },
+      cors: { allowedOrigins: ["*"] },
+    },
+  });
+  writeJson(path.join(paseoHome, "projects", "projects.json"), [
+    {
+      projectId,
+      rootPath: cwd,
+      kind: "non_git",
+      displayName: "Electron keyboard project",
+      customName: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      archivedAt: null,
+    },
+  ]);
+  writeJson(path.join(paseoHome, "projects", "workspaces.json"), [
+    {
+      workspaceId,
+      projectId,
+      cwd,
+      kind: "directory",
+      displayName: "Electron keyboard workspace",
+      title: "Electron keyboard workspace",
+      branch: null,
+      baseBranch: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      archivedAt: null,
+      pinnedAt: null,
+    },
+  ]);
+}
+
+function spawnLogged({ name, command, args, env, artifactDir }) {
+  const logPath = path.join(artifactDir, `${name}.log`);
+  const descriptor = fs.openSync(logPath, "a");
+  let child;
+  try {
+    child = spawn(command, args, {
+      cwd: rootDir,
+      env,
+      detached: process.platform !== "win32",
+      stdio: ["ignore", descriptor, descriptor],
+    });
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  const processInfo = { child, logPath, error: null };
+  child.once("error", (error) => {
+    processInfo.error = error;
+  });
+  return processInfo;
+}
+
+async function waitForPort(port, processInfo) {
+  const deadline = Date.now() + readyTimeoutMs;
+  while (Date.now() < deadline) {
+    if (processInfo.error) throw processInfo.error;
+    const exited = processInfo.child.exitCode !== null || processInfo.child.signalCode !== null;
+    if (exited) {
+      throw new Error(`Process exited before opening port ${port}; see ${processInfo.logPath}`);
+    }
+    const connected = await new Promise((resolve) => {
+      const socket = net.createConnection({ host: "127.0.0.1", port });
+      socket.setTimeout(500);
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once("timeout", () => {
+        socket.destroy();
+        resolve(false);
+      });
+      socket.once("error", () => resolve(false));
+    });
+    if (connected) return;
+    await delay(200);
+  }
+  throw new Error(`Timed out waiting for port ${port}; see ${processInfo.logPath}`);
+}
+
+async function stopProcess(child) {
+  if (!child.pid || child.exitCode !== null || child.signalCode !== null) return;
+  const target = process.platform === "win32" ? child.pid : -child.pid;
+  try {
+    process.kill(target, "SIGTERM");
+  } catch (error) {
+    if (error.code === "ESRCH") return;
+    throw error;
+  }
+  const deadline = Date.now() + 5_000;
+  while (child.exitCode === null && child.signalCode === null && Date.now() < deadline) {
+    await delay(100);
+  }
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  try {
+    process.kill(target, "SIGKILL");
+  } catch (error) {
+    if (error.code !== "ESRCH") throw error;
+  }
+}
+
+async function waitForAppPage(browser, expoPort) {
+  const deadline = Date.now() + readyTimeoutMs;
+  while (Date.now() < deadline) {
+    const pages = browser.contexts().flatMap((context) => context.pages());
+    const page = pages.find((candidate) => candidate.url().includes(`localhost:${expoPort}`));
+    if (page) return page;
+    await delay(250);
+  }
+  throw new Error("Timed out waiting for the real Electron app renderer");
+}
+
+export async function startElectronSession({ artifactDir }) {
+  fs.mkdirSync(artifactDir, { recursive: true });
+  const runtimeDir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-electron-e2e-"));
+  const paseoHome = path.join(runtimeDir, "paseo-home");
+  const cwd = path.join(runtimeDir, "workspace");
+  const workspaceId = "electron-keyboard-workspace";
+  const children = [];
+  let browser = null;
+  let closed = false;
+
+  async function close() {
+    if (closed) return;
+    closed = true;
+    await browser?.close().catch(() => undefined);
+    const stopped = await Promise.allSettled(children.toReversed().map(stopProcess));
+    fs.rmSync(runtimeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    for (const result of stopped) {
+      if (result.status === "rejected") throw result.reason;
+    }
+  }
+
+  try {
+    const [daemonPort, expoPort, cdpPort] = await Promise.all([
+      reservePort(),
+      reservePort(),
+      reservePort(),
+    ]);
+    const listen = `127.0.0.1:${daemonPort}`;
+    seedPaseoHome({ paseoHome, listen, workspaceId, cwd });
+    const commonEnv = {
+      ...process.env,
+      PASEO_HOME: paseoHome,
+      PASEO_LISTEN: listen,
+      PASEO_DAEMON_ENDPOINT: `localhost:${daemonPort}`,
+      PASEO_CORS_ORIGINS: "*",
+      PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: "0",
+      PASEO_DICTATION_ENABLED: "0",
+      PASEO_VOICE_MODE_ENABLED: "0",
+      FORCE_COLOR: "0",
+      NO_COLOR: "1",
+    };
+    const daemon = spawnLogged({
+      name: "daemon",
+      command: process.execPath,
+      args: ["--import", "tsx", path.join(rootDir, "packages/server/scripts/dev-runner.ts")],
+      env: { ...commonEnv, PASEO_NODE_ENV: "development" },
+      artifactDir,
+    });
+    children.push(daemon.child);
+    await waitForPort(daemonPort, daemon);
+
+    const desktopArgs = [process.execPath, path.join(desktopDir, "scripts/dev-runner.mjs")];
+    const isLinux = process.platform === "linux";
+    const command = isLinux ? "xvfb-run" : desktopArgs.shift();
+    const args = isLinux
+      ? ["-a", "--server-args=-screen 0 1280x800x24", ...desktopArgs, "--no-sandbox"]
+      : desktopArgs;
+    const desktop = spawnLogged({
+      name: "desktop",
+      command,
+      args,
+      env: {
+        ...commonEnv,
+        EXPO_PORT: String(expoPort),
+        EXPO_DEV_URL: `http://localhost:${expoPort}`,
+        PASEO_ELECTRON_REMOTE_DEBUGGING_PORT: String(cdpPort),
+        PASEO_ELECTRON_USER_DATA_DIR: path.join(runtimeDir, "electron-user-data"),
+        PASEO_ELECTRON_FLAGS: `--remote-debugging-address=127.0.0.1 --remote-debugging-port=${cdpPort}`,
+      },
+      artifactDir,
+    });
+    children.push(desktop.child);
+    await waitForPort(cdpPort, desktop);
+
+    browser = await chromium.connectOverCDP(`http://127.0.0.1:${cdpPort}`);
+    const page = await waitForAppPage(browser, expoPort);
+    page.setDefaultTimeout(30_000);
+    const statusHandle = await page.waitForFunction(
+      async () => {
+        if (typeof window.paseoDesktop?.invoke !== "function") return null;
+        const status = await window.paseoDesktop.invoke("desktop_daemon_status");
+        return typeof status?.serverId === "string" ? status : null;
+      },
+      undefined,
+      { timeout: readyTimeoutMs },
+    );
+    const status = await statusHandle.jsonValue();
+    await statusHandle.dispose();
+    const serverId = status.serverId;
+    await page
+      .getByTestId(`sidebar-workspace-row-${serverId}:${workspaceId}`)
+      .waitFor({ state: "visible", timeout: readyTimeoutMs });
+    return { page, browser, paseoHome, daemonPort, serverId, workspaceId, cwd, close };
+  } catch (error) {
+    await close();
+    throw error;
+  }
+}

--- a/packages/desktop/e2e/support/terminal-keyboard-recording.mjs
+++ b/packages/desktop/e2e/support/terminal-keyboard-recording.mjs
@@ -1,0 +1,255 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const overlayId = "paseo-terminal-keyboard-recording";
+
+function jpegSize(bytes) {
+  for (let offset = 2; offset < bytes.length; ) {
+    const marker = bytes.readUInt16BE(offset);
+    const length = bytes.readUInt16BE(offset + 2);
+    if (marker === 0xffc0 || marker === 0xffc1 || marker === 0xffc2) {
+      return { width: bytes.readUInt16BE(offset + 7), height: bytes.readUInt16BE(offset + 5) };
+    }
+    if (marker === 0xffda || marker === 0xffd9) break;
+    offset += length + 2;
+  }
+  throw new Error("Recording frame has no supported JPEG dimensions");
+}
+
+export async function startTerminalKeyboardRecording({ page, artifactDir }) {
+  const recordingDir = path.join(artifactDir, "recording");
+  const framesDir = path.join(recordingDir, "frames");
+  await fs.mkdir(framesDir, { recursive: true });
+  const cdp = await page.context().newCDPSession(page);
+  const frames = [];
+  const keys = [];
+  const pendingAcks = new Set();
+  let writeQueue = Promise.resolve();
+  let captureError = null;
+  let closePromise = null;
+
+  function rememberError(error) {
+    captureError ??= error;
+  }
+
+  function queueFrame(bytes, timestampSeconds, details) {
+    writeQueue = writeQueue
+      .then(async () => {
+        const file = `frames/frame-${String(frames.length).padStart(6, "0")}.jpeg`;
+        const dimensions = jpegSize(bytes);
+        await fs.writeFile(path.join(recordingDir, file), bytes);
+        return frames.push({ file, timestampSeconds, ...dimensions, ...details });
+      })
+      .catch(rememberError);
+  }
+
+  function onFrame({ data, metadata, sessionId }) {
+    queueFrame(Buffer.from(data, "base64"), metadata.timestamp, {
+      source: "Page.screencastFrame",
+      metadata,
+    });
+    // Acknowledge independently of disk writes so recording does not block the next frame.
+    const ack = cdp.send("Page.screencastFrameAck", { sessionId }).catch(rememberError);
+    pendingAcks.add(ack);
+    void ack.then(() => pendingAcks.delete(ack));
+  }
+
+  async function removeOverlay() {
+    await page.evaluate((id) => document.getElementById(id)?.remove(), overlayId);
+  }
+
+  async function showKey(label) {
+    await page.evaluate(
+      ({ id, label: text }) => {
+        const overlay = document.getElementById(id);
+        if (!overlay) throw new Error("Keyboard recording label is missing");
+        overlay.lastElementChild.textContent = text;
+      },
+      { id: overlayId, label },
+    );
+    keys.push({ label, timestampSeconds: Date.now() / 1000 });
+  }
+
+  async function finish() {
+    try {
+      await cdp.send("Page.stopScreencast");
+      cdp.off("Page.screencastFrame", onFrame);
+      await Promise.all(pendingAcks);
+      await writeQueue;
+      if (captureError) throw captureError;
+      if (frames.length === 0) throw new Error("Recording did not receive any screencast frames");
+
+      // Screencasts emit on paint. Capture the actual final view to retain an idle ending.
+      const first = frames[0];
+      const { visualViewport } = await cdp.send("Page.getLayoutMetrics");
+      const screenshotOptions = { format: "jpeg", quality: 95, captureBeyondViewport: false };
+      const nativeScreenshot = await cdp.send("Page.captureScreenshot", screenshotOptions);
+      const nativeBytes = Buffer.from(nativeScreenshot.data, "base64");
+      const nativeSize = jpegSize(nativeBytes);
+      const nativeFile = "final-viewport-native.jpeg";
+      await fs.writeFile(path.join(recordingDir, nativeFile), nativeBytes);
+      // Retina surfaces can exceed the screencast limit. Ask Chromium to capture at the
+      // same scale, and keep the native snapshot and scale in the evidence for comparison.
+      const scale = first.width / nativeSize.width;
+      const clip = {
+        x: visualViewport.pageX,
+        y: visualViewport.pageY,
+        width: visualViewport.clientWidth,
+        height: visualViewport.clientHeight,
+        scale,
+      };
+      const requestedAtSeconds = Date.now() / 1000;
+      const screenshot = await cdp.send("Page.captureScreenshot", { ...screenshotOptions, clip });
+      const completedAtSeconds = Date.now() / 1000;
+      queueFrame(Buffer.from(screenshot.data, "base64"), completedAtSeconds, {
+        source: "Page.captureScreenshot",
+        requestedAtSeconds,
+        completedAtSeconds,
+        clip,
+        viewport: visualViewport,
+        nativeSnapshot: { file: nativeFile, ...nativeSize },
+      });
+      await writeQueue;
+      if (captureError) throw captureError;
+
+      const concat = ["ffconcat version 1.0"];
+      for (let index = 0; index < frames.length; index++) {
+        const frame = frames[index];
+        if (frame.width !== first.width || frame.height !== first.height) {
+          throw new Error("Recording dimensions changed; use a fixed Electron window size");
+        }
+        if (!Number.isFinite(frame.timestampSeconds)) {
+          throw new Error("Recording frame is missing its capture timestamp");
+        }
+        concat.push(`file '${frame.file}'`, "option framerate 1000000");
+        const next = frames[index + 1];
+        if (next) {
+          const duration = next.timestampSeconds - frame.timestampSeconds;
+          if (duration <= 0) throw new Error("Recording frame timestamps must increase");
+          concat.push(`duration ${duration.toFixed(6)}`);
+        }
+      }
+      const concatPath = path.join(recordingDir, "frames.ffconcat");
+      const ffmpegArgs = [
+        "-safe",
+        "0",
+        "-f",
+        "concat",
+        "-i",
+        "frames.ffconcat",
+        "-fps_mode",
+        "vfr",
+        "-c:v",
+        "libx264",
+        "-crf",
+        "18",
+        "-pix_fmt",
+        "yuv420p",
+        "-vf",
+        "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+        "-enc_time_base:v",
+        "1:1000000",
+        "-video_track_timescale",
+        "1000000",
+        "-x264-params",
+        "fps=60/1",
+        "-movflags",
+        "+faststart",
+        "interaction.mp4",
+      ];
+      await fs.writeFile(concatPath, `${concat.join("\n")}\n`);
+      await fs.writeFile(
+        path.join(recordingDir, "recording.json"),
+        `${JSON.stringify(
+          {
+            source: "Electron renderer captured with a dedicated CDP screencast session",
+            width: first.width,
+            height: first.height,
+            startedAtSeconds: first.timestampSeconds,
+            endedAtSeconds: frames.at(-1).timestampSeconds,
+            frameCount: frames.length,
+            frames,
+            keys,
+            encoding: { cwd: ".", command: "ffmpeg", args: ffmpegArgs },
+            notes: [
+              "Frames contain the real renderer and a noninteractive keyboard label.",
+              "CDP timestamps are preserved; gaps retain the preceding captured frame.",
+              "The final screenshot uses its completion time; its capture bounds are recorded.",
+              "Chromium captures the final screenshot at the screencast resolution; its scale and an unscaled comparison screenshot are retained.",
+              "No cursor or success indicators are drawn by the recorder.",
+            ],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      console.log(`Recording frames: ${recordingDir}`);
+      console.log(
+        `Run from the recording directory with ffmpeg arguments (JSON array): ${JSON.stringify(ffmpegArgs)}`,
+      );
+    } catch (error) {
+      cdp.off("Page.screencastFrame", onFrame);
+      await writeQueue;
+      await fs.writeFile(
+        path.join(recordingDir, "recording.json"),
+        `${JSON.stringify({ result: "failed", error: String(error), frames, keys }, null, 2)}\n`,
+      );
+      throw error;
+    } finally {
+      cdp.off("Page.screencastFrame", onFrame);
+      await Promise.allSettled([writeQueue, ...pendingAcks, cdp.detach(), removeOverlay()]);
+    }
+  }
+
+  try {
+    await page.evaluate((id) => {
+      const overlay = document.createElement("div");
+      overlay.id = id;
+      overlay.setAttribute("aria-hidden", "true");
+      Object.assign(overlay.style, {
+        position: "fixed",
+        right: "24px",
+        bottom: "24px",
+        zIndex: "2147483647",
+        pointerEvents: "none",
+        userSelect: "none",
+        background: "#111827",
+        color: "#ffffff",
+        border: "1px solid #64748b",
+        borderRadius: "12px",
+        padding: "14px 20px",
+        boxShadow: "0 4px 20px #0004",
+        minWidth: "220px",
+        fontFamily: "system-ui, sans-serif",
+      });
+      const title = document.createElement("div");
+      title.textContent = "Keyboard demonstration";
+      Object.assign(title.style, { fontSize: "13px", color: "#cbd5e1", marginBottom: "6px" });
+      const key = document.createElement("div");
+      key.textContent = "Ready";
+      Object.assign(key.style, { fontSize: "24px", fontWeight: "600", whiteSpace: "pre-wrap" });
+      overlay.append(title, key);
+      document.body.append(overlay);
+    }, overlayId);
+    cdp.on("Page.screencastFrame", onFrame);
+    await cdp.send("Page.startScreencast", {
+      format: "jpeg",
+      quality: 95,
+      maxWidth: 1920,
+      maxHeight: 1200,
+      everyNthFrame: 1,
+    });
+  } catch (error) {
+    cdp.off("Page.screencastFrame", onFrame);
+    await Promise.allSettled([writeQueue, ...pendingAcks, cdp.detach(), removeOverlay()]);
+    throw error;
+  }
+
+  return {
+    showKey,
+    close() {
+      closePromise ??= finish();
+      return closePromise;
+    },
+  };
+}

--- a/packages/desktop/e2e/support/terminal-keyboard-recording.mjs
+++ b/packages/desktop/e2e/support/terminal-keyboard-recording.mjs
@@ -81,7 +81,9 @@ export async function startTerminalKeyboardRecording({ page, artifactDir }) {
 
       // Screencasts emit on paint. Capture the actual final view to retain an idle ending.
       const first = frames[0];
-      const { visualViewport } = await cdp.send("Page.getLayoutMetrics");
+      // Screenshot clips use CSS pixels; legacy visualViewport uses device pixels
+      // on Retina displays and would double the final frame's dimensions.
+      const { cssVisualViewport: visualViewport } = await cdp.send("Page.getLayoutMetrics");
       const screenshotOptions = { format: "jpeg", quality: 95, captureBeyondViewport: false };
       const nativeScreenshot = await cdp.send("Page.captureScreenshot", screenshotOptions);
       const nativeBytes = Buffer.from(nativeScreenshot.data, "base64");

--- a/packages/desktop/e2e/support/terminal-keyboard-recording.mjs
+++ b/packages/desktop/e2e/support/terminal-keyboard-recording.mjs
@@ -98,6 +98,8 @@ export async function startTerminalKeyboardRecording({ page, artifactDir }) {
         height: visualViewport.clientHeight,
         scale,
       };
+      // ScreencastFrameMetadata.timestamp is Network.TimeSinceEpoch, also in seconds.
+      // https://chromedevtools.github.io/devtools-protocol/tot/Page/#type-ScreencastFrameMetadata
       const requestedAtSeconds = Date.now() / 1000;
       const screenshot = await cdp.send("Page.captureScreenshot", { ...screenshotOptions, clip });
       const completedAtSeconds = Date.now() / 1000;
@@ -144,6 +146,9 @@ export async function startTerminalKeyboardRecording({ page, artifactDir }) {
         "vfr",
         "-c:v",
         "libx264",
+        // B-frame reordering can put the final VFR frame beyond the MP4 duration.
+        "-bf",
+        "0",
         "-crf",
         "18",
         "-pix_fmt",

--- a/packages/desktop/e2e/support/terminal-keyboard-recording.mjs
+++ b/packages/desktop/e2e/support/terminal-keyboard-recording.mjs
@@ -112,6 +112,9 @@ export async function startTerminalKeyboardRecording({ page, artifactDir }) {
       await writeQueue;
       if (captureError) throw captureError;
 
+      // CDP delivery can lag newer frames; play each frame at its capture timestamp.
+      // Numbered filenames retain the original delivery order for inspection.
+      frames.sort((a, b) => a.timestampSeconds - b.timestampSeconds);
       const concat = ["ffconcat version 1.0"];
       for (let index = 0; index < frames.length; index++) {
         const frame = frames[index];
@@ -174,6 +177,7 @@ export async function startTerminalKeyboardRecording({ page, artifactDir }) {
             notes: [
               "Frames contain the real renderer and a noninteractive keyboard label.",
               "CDP timestamps are preserved; gaps retain the preceding captured frame.",
+              "Frames are ordered by capture timestamp; numbered files preserve delivery order.",
               "The final screenshot uses its completion time; its capture bounds are recorded.",
               "Chromium captures the final screenshot at the screencast resolution; its scale and an unscaled comparison screenshot are retained.",
               "No cursor or success indicators are drawn by the recorder.",

--- a/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
+++ b/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
@@ -153,7 +153,7 @@ async function checkCommandEditing(page, addCleanup) {
   await page.keyboard.type("PS1='QA> ' exec /bin/bash --noprofile --norc");
   await page.keyboard.press("Enter");
   await waitForValue(async () => (await readTerminal(page))?.line, "QA> ", "Bash prompt");
-  await page.keyboard.type("set -o emacs; clear; printf '\\033[2 qSETUP_%s\\n' complete");
+  await page.keyboard.type("set -o emacs; clear; printf '\\033[2 q\\033[?12lSETUP_%s\\n' complete");
   await page.keyboard.press("Enter");
   await waitForValue(
     async () => (await readTerminal(page))?.lines.includes("SETUP_complete"),
@@ -164,6 +164,7 @@ async function checkCommandEditing(page, addCleanup) {
 
   if (recordVideo) {
     assert.equal(await page.evaluate(() => window.__paseoTerminal.options.fontSize), 22);
+    assert.equal(await page.evaluate(() => window.__paseoTerminal.options.cursorBlink), false);
     recording = await startTerminalKeyboardRecording({ page, artifactDir });
     addCleanup(() => recording.close());
   }
@@ -227,7 +228,7 @@ async function prepareShortcutTerminal(page, pane, label) {
   await pane.getByTestId("terminal-attach-loading").waitFor({ state: "hidden" });
   await surface.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
   await surface.click();
-  await page.keyboard.type(`printf '\\033[2 q\\033[2J\\033[H%s\\n' '${label}'`);
+  await page.keyboard.type(`printf '\\033[2 q\\033[?12l\\033[2J\\033[H%s\\n' '${label}'`);
   await page.keyboard.press("Enter");
   await waitForValue(
     async () => (await readTerminal(page))?.lines.includes(label),

--- a/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
+++ b/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { startElectronSession } from "./support/electron-session.mjs";
+
+const artifactDir = path.resolve(
+  process.env.PASEO_TERMINAL_ARROW_ARTIFACT_DIR ??
+    fs.mkdtempSync(path.join(os.tmpdir(), "paseo-terminal-arrows-")),
+);
+fs.mkdirSync(artifactDir, { recursive: true });
+assert.equal(process.platform, "darwin", "This check requires real macOS Electron");
+
+const report = {
+  commit: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+  runtimeBlob: execFileSync(
+    "git",
+    [
+      "hash-object",
+      fileURLToPath(
+        new URL("../../app/src/terminal/runtime/terminal-emulator-runtime.ts", import.meta.url),
+      ),
+    ],
+    { encoding: "utf8" },
+  ).trim(),
+  macOS: execFileSync("sw_vers", [], { encoding: "utf8" }).trim(),
+  arch: process.arch,
+  kernel: os.release(),
+  input: "Playwright keyboard events sent through CDP to the real Electron renderer",
+  steps: [],
+};
+
+async function checkpoint(page, name, details) {
+  await page.screenshot({ path: path.join(artifactDir, `${name}.png`) });
+  report.steps.push({ name, ...details });
+  console.log(`PASS ${name}: ${JSON.stringify(details)}`);
+}
+
+async function waitForValue(read, expected, message) {
+  const deadline = Date.now() + 10_000;
+  let actual;
+  do {
+    actual = await read();
+    if (actual === expected) return;
+    await delay(50);
+  } while (Date.now() < deadline);
+  assert.equal(actual, expected, message);
+}
+
+async function runAction(page, title) {
+  await page.getByTestId("sidebar-search").click();
+  const panel = page.getByTestId("command-center-panel");
+  await panel.getByTestId("command-center-input").fill(title);
+  await panel.getByRole("button", { name: new RegExp(`^${title}(?:\\s|$)`) }).click();
+  await panel.waitFor({ state: "hidden" });
+}
+
+async function readTerminal(page) {
+  return page.evaluate(() => {
+    const terminal = window.__paseoTerminal;
+    if (!terminal) return null;
+    const buffer = terminal.buffer.active;
+    return {
+      cursorX: buffer.cursorX,
+      line: buffer.getLine(buffer.baseY + buffer.cursorY)?.translateToString(true),
+      lines: Array.from({ length: buffer.length }, (_, index) =>
+        buffer.getLine(index)?.translateToString(true),
+      ),
+    };
+  });
+}
+
+async function checkLineBoundary(page, key, cursorX, name) {
+  // Using page.keyboard preserves any focus loss. locator.press would refocus first.
+  await page.keyboard.press(key);
+  await waitForValue(
+    async () => (await readTerminal(page))?.cursorX,
+    cursorX,
+    `LINE_BOUNDARY_CURSOR: ${key} did not move the shell cursor`,
+  );
+  const focus = await page.evaluate(() => {
+    const probe = window.__commandArrowProbe;
+    return {
+      sameTextarea: document.activeElement === probe.textarea,
+      blurCount: probe.blurCount,
+      documentFocused: document.hasFocus(),
+      sameUrl: location.href === probe.url,
+      samePane: probe.textarea.closest('[data-testid^="workspace-pane-"]') === probe.pane,
+      sameTabs:
+        JSON.stringify(
+          [...document.querySelectorAll('[data-testid^="workspace-tab-"]')].map((tab) => [
+            tab.getAttribute("data-testid"),
+            tab.getAttribute("aria-selected"),
+          ]),
+        ) === probe.tabs,
+    };
+  });
+  assert.deepEqual(focus, {
+    sameTextarea: true,
+    blurCount: 0,
+    documentFocused: true,
+    sameUrl: true,
+    samePane: true,
+    sameTabs: true,
+  });
+  await checkpoint(page, name, { key, cursorX, focus });
+}
+
+async function checkCommandEditing(page) {
+  await runAction(page, "New terminal");
+  const surface = page.getByTestId("terminal-surface").filter({ visible: true });
+  await surface.waitFor({ state: "visible", timeout: 30_000 });
+  await page.getByTestId("terminal-attach-loading").waitFor({ state: "hidden" });
+  await surface.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+  await surface.click();
+  await page.keyboard.type("PS1='QA> ' exec /bin/bash --noprofile --norc");
+  await page.keyboard.press("Enter");
+  await waitForValue(async () => (await readTerminal(page))?.line, "QA> ", "Bash prompt");
+  await page.keyboard.type("set -o emacs; clear; printf 'SETUP_%s\\n' complete");
+  await page.keyboard.press("Enter");
+  await waitForValue(
+    async () => (await readTerminal(page))?.lines.includes("SETUP_complete"),
+    true,
+    "Completed Bash setup",
+  );
+  await waitForValue(async () => (await readTerminal(page))?.line, "QA> ", "Clean Bash prompt");
+
+  await page.keyboard.type("echo one two");
+  await waitForValue(
+    async () => (await readTerminal(page))?.line,
+    "QA> echo one two",
+    "Typed command",
+  );
+  await page.evaluate(() => {
+    const textarea = document.activeElement;
+    if (!textarea?.classList.contains("xterm-helper-textarea")) {
+      throw new Error("The actual xterm textarea must receive input");
+    }
+    const probe = {
+      textarea,
+      pane: textarea.closest('[data-testid^="workspace-pane-"]'),
+      url: location.href,
+      blurCount: 0,
+      tabs: JSON.stringify(
+        [...document.querySelectorAll('[data-testid^="workspace-tab-"]')].map((tab) => [
+          tab.getAttribute("data-testid"),
+          tab.getAttribute("aria-selected"),
+        ]),
+      ),
+    };
+    textarea.addEventListener("blur", () => probe.blurCount++);
+    window.__commandArrowProbe = probe;
+  });
+  await checkpoint(page, "01-command-before-arrows", await readTerminal(page));
+  await checkLineBoundary(page, "Meta+ArrowLeft", 4, "02-command-left");
+  const prefix = "PASEO_PREFIX=ok; ";
+  await page.keyboard.type(prefix);
+  await waitForValue(async () => (await readTerminal(page))?.cursorX, 4 + prefix.length, "Prefix");
+  await checkLineBoundary(page, "Meta+ArrowRight", 4 + prefix.length + 12, "03-command-right");
+  await page.keyboard.type(' "$PASEO_PREFIX"');
+  await page.keyboard.press("Enter");
+  await waitForValue(
+    async () => (await readTerminal(page))?.lines.includes("one two ok"),
+    true,
+    "The shell must execute the command with both inserted edits",
+  );
+  await checkpoint(page, "04-command-executed", await readTerminal(page));
+}
+
+async function focusedPaneId(page) {
+  return page.evaluate(() =>
+    document.activeElement
+      ?.closest('[data-testid^="workspace-pane-"]')
+      ?.getAttribute("data-testid"),
+  );
+}
+
+async function checkWorkspaceShortcuts(page) {
+  const leftPaneId = await focusedPaneId(page);
+  assert.equal(typeof leftPaneId, "string");
+  await runAction(page, "Split pane right");
+  const newPane = page
+    .locator('[data-testid^="workspace-pane-"]')
+    .filter({ has: page.getByTestId("workspace-new-tab-panel") })
+    .filter({ visible: true });
+  const rightPaneId = await newPane.getAttribute("data-testid");
+  assert.notEqual(rightPaneId, leftPaneId);
+  const rightPane = page.getByTestId(rightPaneId);
+  await runAction(page, "New terminal");
+  const tabs = rightPane.locator('[data-testid^="workspace-tab-terminal_"]');
+  await waitForValue(() => tabs.count(), 1, "First right terminal tab");
+  // Moving a pane's only tab collapses it. Keep a second tab for the return trip.
+  await runAction(page, "New terminal");
+  await waitForValue(() => tabs.count(), 2, "Second right terminal tab");
+  await rightPane.getByTestId("terminal-surface").filter({ visible: true }).click();
+  await waitForValue(() => focusedPaneId(page), rightPaneId, "Right terminal focus");
+
+  await page.keyboard.press("Meta+Shift+ArrowLeft");
+  await waitForValue(() => focusedPaneId(page), leftPaneId, "Cmd+Shift+Left focuses left pane");
+  await checkpoint(page, "05-focus-left", { focusedPaneId: leftPaneId });
+  await page.keyboard.press("Meta+Shift+ArrowRight");
+  await waitForValue(() => focusedPaneId(page), rightPaneId, "Cmd+Shift+Right focuses right pane");
+  await checkpoint(page, "06-focus-right", { focusedPaneId: rightPaneId });
+
+  const tab = rightPane.locator('[data-testid^="workspace-tab-terminal_"][aria-selected="true"]');
+  const tabId = await tab.getAttribute("data-testid");
+  assert.equal(typeof tabId, "string");
+  const tabPaneId = () =>
+    page
+      .getByTestId(tabId)
+      .evaluate((element) =>
+        element.closest('[data-testid^="workspace-pane-"]')?.getAttribute("data-testid"),
+      );
+  await page.keyboard.press("Meta+Alt+Shift+ArrowLeft");
+  await waitForValue(tabPaneId, leftPaneId, "Cmd+Alt+Shift+Left moves terminal tab left");
+  await checkpoint(page, "07-move-tab-left", { tabId, paneId: leftPaneId });
+  await page.keyboard.press("Meta+Alt+Shift+ArrowRight");
+  await waitForValue(tabPaneId, rightPaneId, "Cmd+Alt+Shift+Right moves terminal tab right");
+  await checkpoint(page, "08-move-tab-right", { tabId, paneId: rightPaneId });
+}
+
+let session;
+try {
+  session = await startElectronSession({ artifactDir });
+  const { page, browser, serverId, workspaceId } = session;
+  await browser.contexts()[0].tracing.start({ screenshots: true, snapshots: true, sources: true });
+  report.runtime = await page.evaluate(() => ({
+    platform: window.paseoDesktop.platform,
+    navigatorPlatform: navigator.platform,
+    userAgent: navigator.userAgent,
+    maxTouchPoints: navigator.maxTouchPoints,
+  }));
+  assert.equal(report.runtime.platform, "darwin");
+  assert.match(report.runtime.userAgent, /Electron\//);
+  const workspaceUrl = new URL(`/h/${serverId}/workspace/${workspaceId}`, page.url());
+  await page.goto(workspaceUrl.href);
+  await page.getByTestId("workspace-new-tab-button").first().waitFor({ timeout: 60_000 });
+  await checkCommandEditing(page);
+  await checkWorkspaceShortcuts(page);
+  report.result = "passed";
+} catch (error) {
+  report.result = "failed";
+  report.error = error.stack;
+  await session?.page.screenshot({ path: path.join(artifactDir, "failure.png") }).catch(() => {});
+  process.exitCode = 1;
+  console.error(error);
+} finally {
+  fs.writeFileSync(path.join(artifactDir, "result.json"), `${JSON.stringify(report, null, 2)}\n`);
+  try {
+    await session?.browser
+      .contexts()[0]
+      .tracing.stop({ path: path.join(artifactDir, "trace.zip") });
+  } finally {
+    await session?.close();
+  }
+  console.log(`Evidence: ${artifactDir}`);
+}

--- a/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
+++ b/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
@@ -106,12 +106,12 @@ function terminalInput(surface) {
   return surface.getByRole("textbox", { name: "Terminal input", exact: true });
 }
 
-async function selectedTabs(page) {
-  return page
-    .locator('[data-testid^="workspace-tab-"]')
-    .evaluateAll((tabs) =>
-      tabs.map((tab) => [tab.getAttribute("data-testid"), tab.getAttribute("aria-selected")]),
-    );
+function terminalTabs(pane) {
+  return pane.getByRole("button", { name: /^Terminal \d+$/ });
+}
+
+function terminalTab(pane, name) {
+  return pane.getByRole("button", { name, exact: true });
 }
 
 async function checkLineBoundary(page, surface, originalUi, key, name) {
@@ -123,11 +123,12 @@ async function checkLineBoundary(page, surface, originalUi, key, name) {
   ).toBeFocused();
   assert.equal(page.url(), originalUi.url, "Command arrows must keep the workspace open");
   assert.equal(await focusedPaneId(page), originalUi.paneId);
-  assert.deepEqual(await selectedTabs(page), originalUi.tabs);
+  await expect(terminalTabs(page)).toHaveCount(1);
+  await expect(terminalTab(page, "Terminal 1")).toHaveAttribute("aria-selected", "true");
   await checkpoint(page, name, { key, terminalFocused: true });
 }
 
-async function prepareTerminal(page, pane, cwd, label) {
+async function prepareTerminal(page, pane, cwd, label, tabName) {
   const surface = pane.getByTestId("terminal-surface").filter({ visible: true });
   await surface.waitFor({ state: "visible", timeout: 30_000 });
   await pane.getByTestId("terminal-attach-loading").waitFor({ state: "hidden" });
@@ -137,10 +138,11 @@ async function prepareTerminal(page, pane, cwd, label) {
   const setupFile = `${fixtureName}.bashrc`;
   // DECSCUSR configures the cursor through ordinary terminal output. Bash keeps
   // user prompt plugins from replacing it before the recording checkpoint.
+  // OSC 0 gives each tab a stable accessible name before asserting selection.
   const cursorSequence = recordVideo ? "\\033[1 q" : "";
   fs.writeFileSync(
     path.join(cwd, setupFile),
-    `PS1='QA> '\nset -o emacs\nprintf '\\033[2J\\033[H${cursorSequence}%s\\n' '${label}'\nprintf 'ready\\n' > '${readyFile}'\n`,
+    `PS1='QA> '\nset -o emacs\nprintf '\\033[2J\\033[H${cursorSequence}\\033]0;%s\\007%s\\n' '${tabName}' '${label}'\nprintf 'ready\\n' > '${readyFile}'\n`,
   );
   // Bash owns setup so no keyboard input races its startup.
   await surface.click();
@@ -154,12 +156,13 @@ async function prepareTerminal(page, pane, cwd, label) {
     `${label} shell setup completed`,
   );
   await expect(terminalInput(surface)).toBeFocused();
+  await expect(terminalTab(pane, tabName)).toHaveAttribute("aria-selected", "true");
   return surface;
 }
 
 async function checkCommandEditing({ page, cwd, addCleanup }) {
   await runAction(page, "New terminal");
-  const surface = await prepareTerminal(page, page, cwd, "SETUP_complete");
+  const surface = await prepareTerminal(page, page, cwd, "SETUP_complete", "Terminal 1");
   const resultFile = path.join(cwd, "command-result.txt");
   addCleanup(() => {
     const output = readShellFile(resultFile);
@@ -173,7 +176,6 @@ async function checkCommandEditing({ page, cwd, addCleanup }) {
   const originalUi = {
     url: page.url(),
     paneId: await focusedPaneId(page),
-    tabs: await selectedTabs(page),
   };
   await checkpoint(page, "01-command-before-arrows", { typed: "echo one two" });
   await checkLineBoundary(page, surface, originalUi, "Meta+ArrowLeft", "02-command-left");
@@ -212,29 +214,18 @@ async function focusedPaneId(page) {
 }
 
 async function checkTabSwitching(page, pane) {
-  const selectedTab = pane.locator(
-    '[data-testid^="workspace-tab-terminal_"][aria-selected="true"]',
-  );
-  const startingTabId = await selectedTab.getAttribute("data-testid");
-  const otherTabId = await pane
-    .locator('[data-testid^="workspace-tab-terminal_"]:not([aria-selected="true"])')
-    .getAttribute("data-testid");
-  assert.equal(typeof startingTabId, "string");
-  assert.equal(typeof otherTabId, "string");
+  const startingTab = terminalTab(pane, "Terminal 3");
+  const otherTab = terminalTab(pane, "Terminal 2");
+  await expect(startingTab).toHaveAttribute("aria-selected", "true");
+  await expect(otherTab).toHaveAttribute("aria-selected", "false");
   await pressKey(page, "Alt+Shift+[");
-  await waitForValue(
-    () => selectedTab.getAttribute("data-testid"),
-    otherTabId,
-    "Option+Shift+[ selects the previous terminal tab",
-  );
-  await checkpoint(page, "04c-switch-tab-previous", { selectedTabId: otherTabId });
+  await expect(otherTab).toHaveAttribute("aria-selected", "true");
+  await expect(startingTab).toHaveAttribute("aria-selected", "false");
+  await checkpoint(page, "04c-switch-tab-previous", { selectedTab: "Terminal 2" });
   await pressKey(page, "Alt+Shift+]");
-  await waitForValue(
-    () => selectedTab.getAttribute("data-testid"),
-    startingTabId,
-    "Option+Shift+] returns to the original terminal tab",
-  );
-  await checkpoint(page, "04d-switch-tab-next", { selectedTabId: startingTabId });
+  await expect(startingTab).toHaveAttribute("aria-selected", "true");
+  await expect(otherTab).toHaveAttribute("aria-selected", "false");
+  await checkpoint(page, "04d-switch-tab-next", { selectedTab: "Terminal 3" });
 }
 
 async function checkWorkspaceShortcuts({ page, cwd }) {
@@ -247,15 +238,15 @@ async function checkWorkspaceShortcuts({ page, cwd }) {
     .filter({ visible: true });
   const rightPaneId = await newPane.getAttribute("data-testid");
   assert.notEqual(rightPaneId, leftPaneId);
+  const leftPane = page.getByTestId(leftPaneId);
   const rightPane = page.getByTestId(rightPaneId);
   await runAction(page, "New terminal");
-  const tabs = rightPane.locator('[data-testid^="workspace-tab-terminal_"]');
-  await waitForValue(() => tabs.count(), 1, "First right terminal tab");
-  await prepareTerminal(page, rightPane, cwd, "TERMINAL TWO");
+  await prepareTerminal(page, rightPane, cwd, "TERMINAL TWO", "Terminal 2");
+  await expect(terminalTabs(rightPane)).toHaveCount(1);
   // Moving a pane's only tab collapses it. Keep a second tab for the return trip.
   await runAction(page, "New terminal");
-  await waitForValue(() => tabs.count(), 2, "Second right terminal tab");
-  await prepareTerminal(page, rightPane, cwd, "TERMINAL THREE");
+  await prepareTerminal(page, rightPane, cwd, "TERMINAL THREE", "Terminal 3");
+  await expect(terminalTabs(rightPane)).toHaveCount(2);
   await waitForValue(() => focusedPaneId(page), rightPaneId, "Right terminal focus");
   await recording?.showKey("Two panes ready; Terminal 3 is active");
   await checkpoint(page, "04b-shortcuts-ready", { focusedPaneId: rightPaneId });
@@ -268,21 +259,16 @@ async function checkWorkspaceShortcuts({ page, cwd }) {
   await waitForValue(() => focusedPaneId(page), rightPaneId, "Cmd+Shift+Right focuses right pane");
   await checkpoint(page, "06-focus-right", { focusedPaneId: rightPaneId });
 
-  const tab = rightPane.locator('[data-testid^="workspace-tab-terminal_"][aria-selected="true"]');
-  const tabId = await tab.getAttribute("data-testid");
-  assert.equal(typeof tabId, "string");
-  const tabPaneId = () =>
-    page
-      .getByTestId(tabId)
-      .evaluate((element) =>
-        element.closest('[data-testid^="workspace-pane-"]')?.getAttribute("data-testid"),
-      );
+  const tabName = "Terminal 3";
+  await expect(terminalTab(rightPane, tabName)).toHaveAttribute("aria-selected", "true");
   await pressKey(page, "Meta+Alt+Shift+ArrowLeft");
-  await waitForValue(tabPaneId, leftPaneId, "Cmd+Alt+Shift+Left moves terminal tab left");
-  await checkpoint(page, "07-move-tab-left", { tabId, paneId: leftPaneId });
+  await expect(terminalTab(leftPane, tabName)).toBeVisible();
+  await expect(terminalTab(rightPane, tabName)).toHaveCount(0);
+  await checkpoint(page, "07-move-tab-left", { tabName, paneId: leftPaneId });
   await pressKey(page, "Meta+Alt+Shift+ArrowRight");
-  await waitForValue(tabPaneId, rightPaneId, "Cmd+Alt+Shift+Right moves terminal tab right");
-  await checkpoint(page, "08-move-tab-right", { tabId, paneId: rightPaneId });
+  await expect(terminalTab(rightPane, tabName)).toBeVisible();
+  await expect(terminalTab(leftPane, tabName)).toHaveCount(0);
+  await checkpoint(page, "08-move-tab-right", { tabName, paneId: rightPaneId });
 }
 
 async function prepareScenario(session) {

--- a/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
+++ b/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
@@ -72,6 +72,22 @@ async function setRecordingFontSize(page) {
   await page.getByTestId("settings-back-to-workspace").click();
 }
 
+async function setRecordingCursor(page) {
+  if (!recordVideo) return;
+  // Configure xterm's real cursor for capture; key handling and focus remain untouched.
+  const appearance = await page.evaluate(() => {
+    const terminal = window.__paseoTerminal;
+    terminal.options.cursorBlink = false;
+    terminal.options.cursorStyle = "block";
+    return {
+      fontSize: terminal.options.fontSize,
+      cursorBlink: terminal.options.cursorBlink,
+      cursorStyle: terminal.options.cursorStyle,
+    };
+  });
+  assert.deepEqual(appearance, { fontSize: 22, cursorBlink: false, cursorStyle: "block" });
+}
+
 async function waitForValue(read, expected, message) {
   const deadline = Date.now() + 10_000;
   let actual;
@@ -153,7 +169,7 @@ async function checkCommandEditing(page, addCleanup) {
   await page.keyboard.type("PS1='QA> ' exec /bin/bash --noprofile --norc");
   await page.keyboard.press("Enter");
   await waitForValue(async () => (await readTerminal(page))?.line, "QA> ", "Bash prompt");
-  await page.keyboard.type("set -o emacs; clear; printf '\\033[2 q\\033[?12lSETUP_%s\\n' complete");
+  await page.keyboard.type("set -o emacs; clear; printf 'SETUP_%s\\n' complete");
   await page.keyboard.press("Enter");
   await waitForValue(
     async () => (await readTerminal(page))?.lines.includes("SETUP_complete"),
@@ -162,9 +178,8 @@ async function checkCommandEditing(page, addCleanup) {
   );
   await waitForValue(async () => (await readTerminal(page))?.line, "QA> ", "Clean Bash prompt");
 
+  await setRecordingCursor(page);
   if (recordVideo) {
-    assert.equal(await page.evaluate(() => window.__paseoTerminal.options.fontSize), 22);
-    assert.equal(await page.evaluate(() => window.__paseoTerminal.options.cursorBlink), false);
     recording = await startTerminalKeyboardRecording({ page, artifactDir });
     addCleanup(() => recording.close());
   }
@@ -228,13 +243,14 @@ async function prepareShortcutTerminal(page, pane, label) {
   await pane.getByTestId("terminal-attach-loading").waitFor({ state: "hidden" });
   await surface.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
   await surface.click();
-  await page.keyboard.type(`printf '\\033[2 q\\033[?12l\\033[2J\\033[H%s\\n' '${label}'`);
+  await page.keyboard.type(`printf '\\033[2J\\033[H%s\\n' '${label}'`);
   await page.keyboard.press("Enter");
   await waitForValue(
     async () => (await readTerminal(page))?.lines.includes(label),
     true,
     `${label} is ready`,
   );
+  await setRecordingCursor(page);
 }
 
 async function checkTabSwitching(page, pane) {

--- a/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
+++ b/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
@@ -5,7 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
-import { startElectronSession } from "./support/electron-session.mjs";
+import { runElectronScenario } from "./support/electron-session.mjs";
+import { startTerminalKeyboardRecording } from "./support/terminal-keyboard-recording.mjs";
+
+const recordVideo = process.argv.includes("--record");
+let recording;
 
 const artifactDir = path.resolve(
   process.env.PASEO_TERMINAL_ARROW_ARTIFACT_DIR ??
@@ -28,15 +32,44 @@ const report = {
   ).trim(),
   macOS: execFileSync("sw_vers", [], { encoding: "utf8" }).trim(),
   arch: process.arch,
+  hostname: os.hostname(),
   kernel: os.release(),
+  recording: recordVideo,
   input: "Playwright keyboard events sent through CDP to the real Electron renderer",
   steps: [],
 };
 
 async function checkpoint(page, name, details) {
+  if (recording) await delay(3_000);
   await page.screenshot({ path: path.join(artifactDir, `${name}.png`) });
-  report.steps.push({ name, ...details });
+  report.steps.push({ name, recordedAt: new Date().toISOString(), ...details });
   console.log(`PASS ${name}: ${JSON.stringify(details)}`);
+}
+
+async function pressKey(page, key) {
+  const labels = { Meta: "Cmd", Alt: "Option", ArrowLeft: "←", ArrowRight: "→" };
+  await recording?.showKey(
+    key
+      .split("+")
+      .map((part) => labels[part] ?? part)
+      .join(" + "),
+  );
+  await page.keyboard.press(key);
+}
+
+async function typeRecordedText(page, text) {
+  await recording?.showKey(`Type: ${text}`);
+  await page.keyboard.type(text, { delay: recordVideo ? 100 : 0 });
+}
+
+async function setRecordingFontSize(page) {
+  await page.getByTestId("sidebar-settings").click();
+  await page.getByRole("button", { name: "Appearance", exact: true }).click();
+  const input = page.getByRole("textbox", { name: "Code font size", exact: true });
+  await input.fill("22");
+  await input.press("Tab");
+  assert.equal(await input.inputValue(), "22");
+  await page.getByTestId("settings-back-to-workspace").click();
 }
 
 async function waitForValue(read, expected, message) {
@@ -51,6 +84,7 @@ async function waitForValue(read, expected, message) {
 }
 
 async function runAction(page, title) {
+  await recording?.showKey(`Command Center: ${title}`);
   await page.getByTestId("sidebar-search").click();
   const panel = page.getByTestId("command-center-panel");
   await panel.getByTestId("command-center-input").fill(title);
@@ -75,7 +109,7 @@ async function readTerminal(page) {
 
 async function checkLineBoundary(page, key, cursorX, name) {
   // Using page.keyboard preserves any focus loss. locator.press would refocus first.
-  await page.keyboard.press(key);
+  await pressKey(page, key);
   await waitForValue(
     async () => (await readTerminal(page))?.cursorX,
     cursorX,
@@ -109,7 +143,7 @@ async function checkLineBoundary(page, key, cursorX, name) {
   await checkpoint(page, name, { key, cursorX, focus });
 }
 
-async function checkCommandEditing(page) {
+async function checkCommandEditing(page, addCleanup) {
   await runAction(page, "New terminal");
   const surface = page.getByTestId("terminal-surface").filter({ visible: true });
   await surface.waitFor({ state: "visible", timeout: 30_000 });
@@ -119,7 +153,7 @@ async function checkCommandEditing(page) {
   await page.keyboard.type("PS1='QA> ' exec /bin/bash --noprofile --norc");
   await page.keyboard.press("Enter");
   await waitForValue(async () => (await readTerminal(page))?.line, "QA> ", "Bash prompt");
-  await page.keyboard.type("set -o emacs; clear; printf 'SETUP_%s\\n' complete");
+  await page.keyboard.type("set -o emacs; clear; printf '\\033[2 qSETUP_%s\\n' complete");
   await page.keyboard.press("Enter");
   await waitForValue(
     async () => (await readTerminal(page))?.lines.includes("SETUP_complete"),
@@ -128,7 +162,12 @@ async function checkCommandEditing(page) {
   );
   await waitForValue(async () => (await readTerminal(page))?.line, "QA> ", "Clean Bash prompt");
 
-  await page.keyboard.type("echo one two");
+  if (recordVideo) {
+    assert.equal(await page.evaluate(() => window.__paseoTerminal.options.fontSize), 22);
+    recording = await startTerminalKeyboardRecording({ page, artifactDir });
+    addCleanup(() => recording.close());
+  }
+  await typeRecordedText(page, "echo one two");
   await waitForValue(
     async () => (await readTerminal(page))?.line,
     "QA> echo one two",
@@ -156,12 +195,16 @@ async function checkCommandEditing(page) {
   });
   await checkpoint(page, "01-command-before-arrows", await readTerminal(page));
   await checkLineBoundary(page, "Meta+ArrowLeft", 4, "02-command-left");
+  await checkLineBoundary(page, "Meta+ArrowRight", 16, "02b-command-right-unchanged");
+  await checkLineBoundary(page, "Meta+ArrowLeft", 4, "02c-command-left-again");
   const prefix = "PASEO_PREFIX=ok; ";
-  await page.keyboard.type(prefix);
+  await typeRecordedText(page, prefix);
   await waitForValue(async () => (await readTerminal(page))?.cursorX, 4 + prefix.length, "Prefix");
+  await checkpoint(page, "02d-prefix-inserted", await readTerminal(page));
   await checkLineBoundary(page, "Meta+ArrowRight", 4 + prefix.length + 12, "03-command-right");
-  await page.keyboard.type(' "$PASEO_PREFIX"');
-  await page.keyboard.press("Enter");
+  await typeRecordedText(page, ' "$PASEO_PREFIX"');
+  await checkpoint(page, "03b-suffix-inserted", await readTerminal(page));
+  await pressKey(page, "Enter");
   await waitForValue(
     async () => (await readTerminal(page))?.lines.includes("one two ok"),
     true,
@@ -178,6 +221,47 @@ async function focusedPaneId(page) {
   );
 }
 
+async function prepareShortcutTerminal(page, pane, label) {
+  const surface = pane.getByTestId("terminal-surface").filter({ visible: true });
+  await surface.waitFor({ state: "visible" });
+  await pane.getByTestId("terminal-attach-loading").waitFor({ state: "hidden" });
+  await surface.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+  await surface.click();
+  await page.keyboard.type(`printf '\\033[2 q\\033[2J\\033[H%s\\n' '${label}'`);
+  await page.keyboard.press("Enter");
+  await waitForValue(
+    async () => (await readTerminal(page))?.lines.includes(label),
+    true,
+    `${label} is ready`,
+  );
+}
+
+async function checkTabSwitching(page, pane) {
+  const selectedTab = pane.locator(
+    '[data-testid^="workspace-tab-terminal_"][aria-selected="true"]',
+  );
+  const startingTabId = await selectedTab.getAttribute("data-testid");
+  const otherTabId = await pane
+    .locator('[data-testid^="workspace-tab-terminal_"]:not([aria-selected="true"])')
+    .getAttribute("data-testid");
+  assert.equal(typeof startingTabId, "string");
+  assert.equal(typeof otherTabId, "string");
+  await pressKey(page, "Alt+Shift+[");
+  await waitForValue(
+    () => selectedTab.getAttribute("data-testid"),
+    otherTabId,
+    "Option+Shift+[ selects the previous terminal tab",
+  );
+  await checkpoint(page, "04c-switch-tab-previous", { selectedTabId: otherTabId });
+  await pressKey(page, "Alt+Shift+]");
+  await waitForValue(
+    () => selectedTab.getAttribute("data-testid"),
+    startingTabId,
+    "Option+Shift+] returns to the original terminal tab",
+  );
+  await checkpoint(page, "04d-switch-tab-next", { selectedTabId: startingTabId });
+}
+
 async function checkWorkspaceShortcuts(page) {
   const leftPaneId = await focusedPaneId(page);
   assert.equal(typeof leftPaneId, "string");
@@ -192,16 +276,20 @@ async function checkWorkspaceShortcuts(page) {
   await runAction(page, "New terminal");
   const tabs = rightPane.locator('[data-testid^="workspace-tab-terminal_"]');
   await waitForValue(() => tabs.count(), 1, "First right terminal tab");
+  await prepareShortcutTerminal(page, rightPane, "TERMINAL TWO");
   // Moving a pane's only tab collapses it. Keep a second tab for the return trip.
   await runAction(page, "New terminal");
   await waitForValue(() => tabs.count(), 2, "Second right terminal tab");
-  await rightPane.getByTestId("terminal-surface").filter({ visible: true }).click();
+  await prepareShortcutTerminal(page, rightPane, "TERMINAL THREE");
   await waitForValue(() => focusedPaneId(page), rightPaneId, "Right terminal focus");
+  await recording?.showKey("Two panes ready; Terminal 3 is active");
+  await checkpoint(page, "04b-shortcuts-ready", { focusedPaneId: rightPaneId });
+  await checkTabSwitching(page, rightPane);
 
-  await page.keyboard.press("Meta+Shift+ArrowLeft");
+  await pressKey(page, "Meta+Shift+ArrowLeft");
   await waitForValue(() => focusedPaneId(page), leftPaneId, "Cmd+Shift+Left focuses left pane");
   await checkpoint(page, "05-focus-left", { focusedPaneId: leftPaneId });
-  await page.keyboard.press("Meta+Shift+ArrowRight");
+  await pressKey(page, "Meta+Shift+ArrowRight");
   await waitForValue(() => focusedPaneId(page), rightPaneId, "Cmd+Shift+Right focuses right pane");
   await checkpoint(page, "06-focus-right", { focusedPaneId: rightPaneId });
 
@@ -214,19 +302,16 @@ async function checkWorkspaceShortcuts(page) {
       .evaluate((element) =>
         element.closest('[data-testid^="workspace-pane-"]')?.getAttribute("data-testid"),
       );
-  await page.keyboard.press("Meta+Alt+Shift+ArrowLeft");
+  await pressKey(page, "Meta+Alt+Shift+ArrowLeft");
   await waitForValue(tabPaneId, leftPaneId, "Cmd+Alt+Shift+Left moves terminal tab left");
   await checkpoint(page, "07-move-tab-left", { tabId, paneId: leftPaneId });
-  await page.keyboard.press("Meta+Alt+Shift+ArrowRight");
+  await pressKey(page, "Meta+Alt+Shift+ArrowRight");
   await waitForValue(tabPaneId, rightPaneId, "Cmd+Alt+Shift+Right moves terminal tab right");
   await checkpoint(page, "08-move-tab-right", { tabId, paneId: rightPaneId });
 }
 
-let session;
-try {
-  session = await startElectronSession({ artifactDir });
-  const { page, browser, serverId, workspaceId } = session;
-  await browser.contexts()[0].tracing.start({ screenshots: true, snapshots: true, sources: true });
+async function prepareScenario(session) {
+  const { page, serverId, workspaceId } = session;
   report.runtime = await page.evaluate(() => ({
     platform: window.paseoDesktop.platform,
     navigatorPlatform: navigator.platform,
@@ -235,26 +320,14 @@ try {
   }));
   assert.equal(report.runtime.platform, "darwin");
   assert.match(report.runtime.userAgent, /Electron\//);
+  if (recordVideo) await setRecordingFontSize(page);
   const workspaceUrl = new URL(`/h/${serverId}/workspace/${workspaceId}`, page.url());
   await page.goto(workspaceUrl.href);
   await page.getByTestId("workspace-new-tab-button").first().waitFor({ timeout: 60_000 });
-  await checkCommandEditing(page);
-  await checkWorkspaceShortcuts(page);
-  report.result = "passed";
-} catch (error) {
-  report.result = "failed";
-  report.error = error.stack;
-  await session?.page.screenshot({ path: path.join(artifactDir, "failure.png") }).catch(() => {});
-  process.exitCode = 1;
-  console.error(error);
-} finally {
-  fs.writeFileSync(path.join(artifactDir, "result.json"), `${JSON.stringify(report, null, 2)}\n`);
-  try {
-    await session?.browser
-      .contexts()[0]
-      .tracing.stop({ path: path.join(artifactDir, "trace.zip") });
-  } finally {
-    await session?.close();
-  }
-  console.log(`Evidence: ${artifactDir}`);
 }
+
+await runElectronScenario({ artifactDir, report, recordVideo }, async (session) => {
+  await prepareScenario(session);
+  await checkCommandEditing(session.page, session.addCleanup);
+  await checkWorkspaceShortcuts(session.page);
+});

--- a/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
+++ b/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+import { expect } from "playwright/test";
 import { runElectronScenario } from "./support/electron-session.mjs";
 import { startTerminalKeyboardRecording } from "./support/terminal-keyboard-recording.mjs";
 
@@ -72,22 +73,6 @@ async function setRecordingFontSize(page) {
   await page.getByTestId("settings-back-to-workspace").click();
 }
 
-async function setRecordingCursor(page) {
-  if (!recordVideo) return;
-  // Configure xterm's real cursor for capture; key handling and focus remain untouched.
-  const appearance = await page.evaluate(() => {
-    const terminal = window.__paseoTerminal;
-    terminal.options.cursorBlink = false;
-    terminal.options.cursorStyle = "block";
-    return {
-      fontSize: terminal.options.fontSize,
-      cursorBlink: terminal.options.cursorBlink,
-      cursorStyle: terminal.options.cursorStyle,
-    };
-  });
-  assert.deepEqual(appearance, { fontSize: 22, cursorBlink: false, cursorStyle: "block" });
-}
-
 async function waitForValue(read, expected, message) {
   const deadline = Date.now() + 10_000;
   let actual;
@@ -108,125 +93,112 @@ async function runAction(page, title) {
   await panel.waitFor({ state: "hidden" });
 }
 
-async function readTerminal(page) {
-  return page.evaluate(() => {
-    const terminal = window.__paseoTerminal;
-    if (!terminal) return null;
-    const buffer = terminal.buffer.active;
-    return {
-      cursorX: buffer.cursorX,
-      line: buffer.getLine(buffer.baseY + buffer.cursorY)?.translateToString(true),
-      lines: Array.from({ length: buffer.length }, (_, index) =>
-        buffer.getLine(index)?.translateToString(true),
-      ),
-    };
-  });
+function readShellFile(file) {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
 }
 
-async function checkLineBoundary(page, key, cursorX, name) {
+function terminalInput(surface) {
+  return surface.getByRole("textbox", { name: "Terminal input", exact: true });
+}
+
+async function selectedTabs(page) {
+  return page
+    .locator('[data-testid^="workspace-tab-"]')
+    .evaluateAll((tabs) =>
+      tabs.map((tab) => [tab.getAttribute("data-testid"), tab.getAttribute("aria-selected")]),
+    );
+}
+
+async function checkLineBoundary(page, surface, originalUi, key, name) {
   // Using page.keyboard preserves any focus loss. locator.press would refocus first.
   await pressKey(page, key);
-  await waitForValue(
-    async () => (await readTerminal(page))?.cursorX,
-    cursorX,
-    `LINE_BOUNDARY_CURSOR: ${key} did not move the shell cursor`,
-  );
-  const focus = await page.evaluate(() => {
-    const probe = window.__commandArrowProbe;
-    return {
-      sameTextarea: document.activeElement === probe.textarea,
-      blurCount: probe.blurCount,
-      documentFocused: document.hasFocus(),
-      sameUrl: location.href === probe.url,
-      samePane: probe.textarea.closest('[data-testid^="workspace-pane-"]') === probe.pane,
-      sameTabs:
-        JSON.stringify(
-          [...document.querySelectorAll('[data-testid^="workspace-tab-"]')].map((tab) => [
-            tab.getAttribute("data-testid"),
-            tab.getAttribute("aria-selected"),
-          ]),
-        ) === probe.tabs,
-    };
-  });
-  assert.deepEqual(focus, {
-    sameTextarea: true,
-    blurCount: 0,
-    documentFocused: true,
-    sameUrl: true,
-    samePane: true,
-    sameTabs: true,
-  });
-  await checkpoint(page, name, { key, cursorX, focus });
+  await expect(
+    terminalInput(surface),
+    `LINE_BOUNDARY_FOCUS: ${key} must keep terminal input focused`,
+  ).toBeFocused();
+  assert.equal(page.url(), originalUi.url, "Command arrows must keep the workspace open");
+  assert.equal(await focusedPaneId(page), originalUi.paneId);
+  assert.deepEqual(await selectedTabs(page), originalUi.tabs);
+  await checkpoint(page, name, { key, terminalFocused: true });
 }
 
-async function checkCommandEditing(page, addCleanup) {
-  await runAction(page, "New terminal");
-  const surface = page.getByTestId("terminal-surface").filter({ visible: true });
+async function prepareTerminal(page, pane, cwd, label) {
+  const surface = pane.getByTestId("terminal-surface").filter({ visible: true });
   await surface.waitFor({ state: "visible", timeout: 30_000 });
-  await page.getByTestId("terminal-attach-loading").waitFor({ state: "hidden" });
-  await surface.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+  await pane.getByTestId("terminal-attach-loading").waitFor({ state: "hidden" });
+  await terminalInput(surface).waitFor({ state: "attached" });
+  const fixtureName = label.toLowerCase().replaceAll(" ", "-");
+  const readyFile = `${fixtureName}-ready.txt`;
+  const setupFile = `${fixtureName}.bashrc`;
+  // DECSCUSR configures the cursor through ordinary terminal output. Bash keeps
+  // user prompt plugins from replacing it before the recording checkpoint.
+  const cursorSequence = recordVideo ? "\\033[2 q" : "";
+  fs.writeFileSync(
+    path.join(cwd, setupFile),
+    `PS1='QA> '\nset -o emacs\nprintf '\\033[2J\\033[H${cursorSequence}%s\\n' '${label}'\nprintf 'ready\\n' > '${readyFile}'\n`,
+  );
+  // Bash owns setup so no keyboard input races its startup.
   await surface.click();
-  await page.keyboard.type("PS1='QA> ' exec /bin/bash --noprofile --norc");
-  await page.keyboard.press("Enter");
-  await waitForValue(async () => (await readTerminal(page))?.line, "QA> ", "Bash prompt");
-  await page.keyboard.type("set -o emacs; clear; printf 'SETUP_%s\\n' complete");
+  await page.keyboard.type(`exec /bin/bash --noprofile --rcfile './${setupFile}' -i`);
   await page.keyboard.press("Enter");
   await waitForValue(
-    async () => (await readTerminal(page))?.lines.includes("SETUP_complete"),
-    true,
-    "Completed Bash setup",
+    () => readShellFile(path.join(cwd, readyFile)),
+    "ready\n",
+    `${label} shell setup completed`,
   );
-  await waitForValue(async () => (await readTerminal(page))?.line, "QA> ", "Clean Bash prompt");
+  await expect(terminalInput(surface)).toBeFocused();
+  return surface;
+}
 
-  await setRecordingCursor(page);
+async function checkCommandEditing({ page, cwd, addCleanup }) {
+  await runAction(page, "New terminal");
+  const surface = await prepareTerminal(page, page, cwd, "SETUP_complete");
+  const resultFile = path.join(cwd, "command-result.txt");
+  addCleanup(() => {
+    const output = readShellFile(resultFile);
+    if (output !== null) fs.writeFileSync(path.join(artifactDir, "command-result.txt"), output);
+  });
   if (recordVideo) {
     recording = await startTerminalKeyboardRecording({ page, artifactDir });
     addCleanup(() => recording.close());
   }
   await typeRecordedText(page, "echo one two");
-  await waitForValue(
-    async () => (await readTerminal(page))?.line,
-    "QA> echo one two",
-    "Typed command",
+  const originalUi = {
+    url: page.url(),
+    paneId: await focusedPaneId(page),
+    tabs: await selectedTabs(page),
+  };
+  await checkpoint(page, "01-command-before-arrows", { typed: "echo one two" });
+  await checkLineBoundary(page, surface, originalUi, "Meta+ArrowLeft", "02-command-left");
+  await checkLineBoundary(
+    page,
+    surface,
+    originalUi,
+    "Meta+ArrowRight",
+    "02b-command-right-unchanged",
   );
-  await page.evaluate(() => {
-    const textarea = document.activeElement;
-    if (!textarea?.classList.contains("xterm-helper-textarea")) {
-      throw new Error("The actual xterm textarea must receive input");
-    }
-    const probe = {
-      textarea,
-      pane: textarea.closest('[data-testid^="workspace-pane-"]'),
-      url: location.href,
-      blurCount: 0,
-      tabs: JSON.stringify(
-        [...document.querySelectorAll('[data-testid^="workspace-tab-"]')].map((tab) => [
-          tab.getAttribute("data-testid"),
-          tab.getAttribute("aria-selected"),
-        ]),
-      ),
-    };
-    textarea.addEventListener("blur", () => probe.blurCount++);
-    window.__commandArrowProbe = probe;
-  });
-  await checkpoint(page, "01-command-before-arrows", await readTerminal(page));
-  await checkLineBoundary(page, "Meta+ArrowLeft", 4, "02-command-left");
-  await checkLineBoundary(page, "Meta+ArrowRight", 16, "02b-command-right-unchanged");
-  await checkLineBoundary(page, "Meta+ArrowLeft", 4, "02c-command-left-again");
+  await checkLineBoundary(page, surface, originalUi, "Meta+ArrowLeft", "02c-command-left-again");
   const prefix = "PASEO_PREFIX=ok; ";
   await typeRecordedText(page, prefix);
-  await waitForValue(async () => (await readTerminal(page))?.cursorX, 4 + prefix.length, "Prefix");
-  await checkpoint(page, "02d-prefix-inserted", await readTerminal(page));
-  await checkLineBoundary(page, "Meta+ArrowRight", 4 + prefix.length + 12, "03-command-right");
-  await typeRecordedText(page, ' "$PASEO_PREFIX"');
-  await checkpoint(page, "03b-suffix-inserted", await readTerminal(page));
+  await checkpoint(page, "02d-prefix-inserted", { typed: prefix });
+  await checkLineBoundary(page, surface, originalUi, "Meta+ArrowRight", "03-command-right");
+  const suffix = ' "$PASEO_PREFIX" | tee command-result.txt';
+  await typeRecordedText(page, suffix);
+  await checkpoint(page, "03b-suffix-inserted", { typed: suffix });
   await pressKey(page, "Enter");
+  // Executing the edited line must produce the complete result through the real
+  // shell. Missing either boundary changes the command or its output.
   await waitForValue(
-    async () => (await readTerminal(page))?.lines.includes("one two ok"),
-    true,
-    "The shell must execute the command with both inserted edits",
+    () => readShellFile(resultFile),
+    "one two ok\n",
+    "LINE_BOUNDARY_EDIT: the shell must execute the command with both inserted edits",
   );
-  await checkpoint(page, "04-command-executed", await readTerminal(page));
+  await checkpoint(page, "04-command-executed", { output: readShellFile(resultFile) });
 }
 
 async function focusedPaneId(page) {
@@ -235,22 +207,6 @@ async function focusedPaneId(page) {
       ?.closest('[data-testid^="workspace-pane-"]')
       ?.getAttribute("data-testid"),
   );
-}
-
-async function prepareShortcutTerminal(page, pane, label) {
-  const surface = pane.getByTestId("terminal-surface").filter({ visible: true });
-  await surface.waitFor({ state: "visible" });
-  await pane.getByTestId("terminal-attach-loading").waitFor({ state: "hidden" });
-  await surface.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
-  await surface.click();
-  await page.keyboard.type(`printf '\\033[2J\\033[H%s\\n' '${label}'`);
-  await page.keyboard.press("Enter");
-  await waitForValue(
-    async () => (await readTerminal(page))?.lines.includes(label),
-    true,
-    `${label} is ready`,
-  );
-  await setRecordingCursor(page);
 }
 
 async function checkTabSwitching(page, pane) {
@@ -279,7 +235,7 @@ async function checkTabSwitching(page, pane) {
   await checkpoint(page, "04d-switch-tab-next", { selectedTabId: startingTabId });
 }
 
-async function checkWorkspaceShortcuts(page) {
+async function checkWorkspaceShortcuts({ page, cwd }) {
   const leftPaneId = await focusedPaneId(page);
   assert.equal(typeof leftPaneId, "string");
   await runAction(page, "Split pane right");
@@ -293,11 +249,11 @@ async function checkWorkspaceShortcuts(page) {
   await runAction(page, "New terminal");
   const tabs = rightPane.locator('[data-testid^="workspace-tab-terminal_"]');
   await waitForValue(() => tabs.count(), 1, "First right terminal tab");
-  await prepareShortcutTerminal(page, rightPane, "TERMINAL TWO");
+  await prepareTerminal(page, rightPane, cwd, "TERMINAL TWO");
   // Moving a pane's only tab collapses it. Keep a second tab for the return trip.
   await runAction(page, "New terminal");
   await waitForValue(() => tabs.count(), 2, "Second right terminal tab");
-  await prepareShortcutTerminal(page, rightPane, "TERMINAL THREE");
+  await prepareTerminal(page, rightPane, cwd, "TERMINAL THREE");
   await waitForValue(() => focusedPaneId(page), rightPaneId, "Right terminal focus");
   await recording?.showKey("Two panes ready; Terminal 3 is active");
   await checkpoint(page, "04b-shortcuts-ready", { focusedPaneId: rightPaneId });
@@ -345,6 +301,6 @@ async function prepareScenario(session) {
 
 await runElectronScenario({ artifactDir, report, recordVideo }, async (session) => {
   await prepareScenario(session);
-  await checkCommandEditing(session.page, session.addCleanup);
-  await checkWorkspaceShortcuts(session.page);
+  await checkCommandEditing(session);
+  await checkWorkspaceShortcuts(session);
 });

--- a/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
+++ b/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
@@ -137,14 +137,16 @@ async function prepareTerminal(page, pane, cwd, label) {
   const setupFile = `${fixtureName}.bashrc`;
   // DECSCUSR configures the cursor through ordinary terminal output. Bash keeps
   // user prompt plugins from replacing it before the recording checkpoint.
-  const cursorSequence = recordVideo ? "\\033[2 q" : "";
+  const cursorSequence = recordVideo ? "\\033[1 q" : "";
   fs.writeFileSync(
     path.join(cwd, setupFile),
     `PS1='QA> '\nset -o emacs\nprintf '\\033[2J\\033[H${cursorSequence}%s\\n' '${label}'\nprintf 'ready\\n' > '${readyFile}'\n`,
   );
   // Bash owns setup so no keyboard input races its startup.
   await surface.click();
-  await page.keyboard.type(`exec /bin/bash --noprofile --rcfile './${setupFile}' -i`);
+  await page.keyboard.type(
+    `BASH_SILENCE_DEPRECATION_WARNING=1 exec /bin/bash --noprofile --rcfile './${setupFile}' -i`,
+  );
   await page.keyboard.press("Enter");
   await waitForValue(
     () => readShellFile(path.join(cwd, readyFile)),

--- a/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
+++ b/packages/desktop/e2e/terminal-command-arrows.e2e.mjs
@@ -142,18 +142,19 @@ async function prepareTerminal(page, pane, cwd, label, tabName) {
   const cursorSequence = recordVideo ? "\\033[1 q" : "";
   fs.writeFileSync(
     path.join(cwd, setupFile),
-    `PS1='QA> '\nset -o emacs\nprintf '\\033[2J\\033[H${cursorSequence}\\033]0;%s\\007%s\\n' '${tabName}' '${label}'\nprintf 'ready\\n' > '${readyFile}'\n`,
+    `PS1='QA> '\nset -o emacs\nprintf '\\033[2J\\033[H${cursorSequence}\\033]0;%s\\007%s\\n' '${tabName}' '${label}'\nprintf 'ready:%s\\n' "$BASH_SILENCE_DEPRECATION_WARNING" > '${readyFile}'\n`,
   );
   // Bash owns setup so no keyboard input races its startup.
   await surface.click();
+  await expect(terminalInput(surface)).toBeFocused();
   await page.keyboard.type(
     `BASH_SILENCE_DEPRECATION_WARNING=1 exec /bin/bash --noprofile --rcfile './${setupFile}' -i`,
   );
   await page.keyboard.press("Enter");
   await waitForValue(
     () => readShellFile(path.join(cwd, readyFile)),
-    "ready\n",
-    `${label} shell setup completed`,
+    "ready:1\n",
+    `${label} shell setup received the complete environment assignment`,
   );
   await expect(terminalInput(surface)).toBeFocused();
   await expect(terminalTab(pane, tabName)).toHaveAttribute("aria-selected", "true");
@@ -245,6 +246,8 @@ async function checkWorkspaceShortcuts({ page, cwd }) {
   await expect(terminalTabs(rightPane)).toHaveCount(1);
   // Moving a pane's only tab collapses it. Keep a second tab for the return trip.
   await runAction(page, "New terminal");
+  // The command menu can close before the new tab replaces the old visible surface.
+  await expect(terminalTab(rightPane, "Terminal 2")).toHaveAttribute("aria-selected", "false");
   await prepareTerminal(page, rightPane, cwd, "TERMINAL THREE", "Terminal 3");
   await expect(terminalTabs(rightPane)).toHaveCount(2);
   await waitForValue(() => focusedPaneId(page), rightPaneId, "Right terminal focus");

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -22,6 +22,7 @@
     "dev:win": "powershell ./scripts/dev.ps1",
     "test:e2e:renderer": "cross-env E2E_DESKTOP_RUNTIME=1 playwright test --config=playwright.config.ts --project=desktop",
     "test:e2e:browser-tabs": "npm run build:main && node ./e2e/browser-tabs.e2e.mjs",
+    "test:e2e:terminal-command-arrows": "npm run build:main && node ./e2e/terminal-command-arrows.e2e.mjs",
     "verify:electron-cdp": "node ./scripts/verify-electron-cdp.mjs",
     "test": "vitest run --exclude \"e2e/**\"",
     "typecheck": "tsgo --noEmit -p tsconfig.json"


### PR DESCRIPTION
### Linked issue

Closes #4219. Replaces #4220.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

In a focused terminal on macOS, bare `Cmd+Left` and `Cmd+Right` fall through xterm's custom key handler. Chromium can consume them as navigation, taking keyboard focus away from the terminal instead of moving the shell cursor.

This change resolves bare Command+Left/Right before the event falls through. It forwards `Ctrl+A`/`Ctrl+E` for beginning/end of line and prevents the original DOM event. Existing terminal key resolution is consolidated in one tested helper to keep the runtime callback within the repository's complexity limit.

### Goals

- Keep terminal focus while moving to the beginning/end of the command line.
- Preserve existing tab switching, pane focus, and tab movement shortcuts.
- Restrict the behavior to macOS desktop, excluding iPadOS's Mac-like user agent.

### Non-goals

- Change shell-configurable Option+Left/Right word motion or Cmd+Up/Down.
- Change terminal behavior on Windows, Linux, iOS, or Android.

### QA

Verified exact PR commit **`f0b3a6efdf3b9b138b1c44e4128a273c94fcabab`** on **lappy (`Justins-MacBook-Pro.local`), macOS 26.6.2 (25G83), arm64, Retina, Electron 44.2.0, Paseo 0.8.0-beta.1**. The task was launched remotely through Paseo and ran in an isolated daemon/profile with a real Bash PTY. The existing main daemon stayed running.

[Lappy video — 56 seconds](https://raw.githubusercontent.com/EasyAsABC123/paseo/d4976675c1148fe8f8543bb64a0bd6c2782a5d0f/.qa/terminal-command-arrows-readable/lappy/interaction.mp4) · [Original runtime — 39 seconds](https://raw.githubusercontent.com/EasyAsABC123/paseo/d4976675c1148fe8f8543bb64a0bd6c2782a5d0f/.qa/terminal-command-arrows-readable/lappy-unpatched/interaction.mp4) · [Screenshots and evidence](https://github.com/EasyAsABC123/paseo/blob/d4976675c1148fe8f8543bb64a0bd6c2782a5d0f/.qa/terminal-command-arrows-readable/README.md) · [Passing macOS CI](https://github.com/EasyAsABC123/paseo/actions/runs/34323545745)

The 1800×1200 recording uses 22px text, a real blinking block cursor, visible key labels, and three-second checkpoint holds. All **424 frames** retain their original microsecond concat timing; full decoding passes. The decoded video was independently inspected through cursor movement and shortcut actions. [Visual review](https://github.com/EasyAsABC123/paseo/blob/d4976675c1148fe8f8543bb64a0bd6c2782a5d0f/.qa/terminal-command-arrows-readable/lappy/visual-review.json) · [Timing verification](https://github.com/EasyAsABC123/paseo/blob/d4976675c1148fe8f8543bb64a0bd6c2782a5d0f/.qa/terminal-command-arrows-readable/lappy/timing-verification.json).

| Video time | Action and observed result |
| --- | --- |
| 00:04 | Cmd+Left moves onto the first `e` in `echo`, immediately after the prompt. |
| 00:07 / 00:10 | Cmd+Right reaches the end; Cmd+Left returns to the beginning. |
| 00:13–00:31 | Insert a prefix at the beginning, use Cmd+Right, append a suffix, and execute: the shell prints `one two ok`. |
| 00:38 / 00:41 | Option+Shift+[/] switches between Terminal 2 and Terminal 3. |
| 00:44 / 00:47 | Cmd+Shift+Left/Right switches the focused pane. |
| 00:50 / 00:53 | Cmd+Option+Shift+Left/Right moves Terminal 3 to the left pane and back. |

All **15 checkpoints pass**. Line-boundary assertions check the accessible terminal input's focus and preserve the workspace URL, pane, and selected tab. Bash executes the edited command through `tee`; the [actual file](https://github.com/EasyAsABC123/paseo/blob/d4976675c1148fe8f8543bb64a0bd6c2782a5d0f/.qa/terminal-command-arrows-readable/lappy/command-result.txt) contains exactly `one two ok` followed by a newline. Tab assertions use the controls' actual button roles, accessible names, and selected state. Setup waits for the new terminal before typing and verifies the complete Bash environment assignment; Terminal 2/3 prompts are clean in the video.

Restoring only the original runtime completes setup but fails `LINE_BOUNDARY_EDIT` with an empty output file. Both recordings finalize and decode successfully. The [fresh macOS CI run](https://github.com/EasyAsABC123/paseo/actions/runs/34323545745) passes the same patched/negative-control sequence on source `943714e691d2f40000b847664a0cd1d38d4a68bd`, matching the recorded `f0b3a6ef` checkout. The current rebased head `98c424db` preserves all eight PR files, dependency manifests, and lockfiles unchanged. Its unrelated upstream changes still need normal CI validation; the current upstream workflows are awaiting maintainer approval.

The harness owns setup, failure reporting, recording finalization, tracing, and cleanup. Reproduce on a Mac after building the server stack and `@getpaseo/expo-two-way-audio`:

```bash
PASEO_TERMINAL_ARROW_ARTIFACT_DIR=/tmp/paseo-terminal-arrows \
npm run test:e2e:terminal-command-arrows --workspace=@getpaseo/desktop -- --record
```

Validation: full [typecheck](https://github.com/EasyAsABC123/paseo/blob/d4976675c1148fe8f8543bb64a0bd6c2782a5d0f/.qa/terminal-command-arrows-readable/lappy/typecheck.log), [lint](https://github.com/EasyAsABC123/paseo/blob/d4976675c1148fe8f8543bb64a0bd6c2782a5d0f/.qa/terminal-command-arrows-readable/lappy/lint.log), and [format](https://github.com/EasyAsABC123/paseo/blob/d4976675c1148fe8f8543bb64a0bd6c2782a5d0f/.qa/terminal-command-arrows-readable/lappy/format.log) pass. Terminal-key unit coverage has 27 passing cases. Upstream CI, Docker, and Nix workflows require approval from a maintainer with write access.

Untested: physical-keyboard input (these events use Playwright/CDP), the packaged release build, standalone browser web, iOS, Android, Windows, and Linux desktop keyboard behavior.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
