### PR TITLE
fix(app): preserve plugin provider icons in model buttons

### DIFF
--- a/packages/app/e2e/browser/plugin-provider-icons.spec.ts
+++ b/packages/app/e2e/browser/plugin-provider-icons.spec.ts
@@ -1,131 +1,16 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import type { Locator, TestInfo } from "@playwright/test";
-import { expect, test, type Page } from "../support/fixtures";
-import { gotoAppShell, openSettings } from "../support/helpers/app";
-import { openModelPicker } from "../support/helpers/agent-profiles";
-import { openAgentRoute } from "../support/helpers/mock-agent";
 import {
-  connectNewWorkspaceDaemonClient,
-  openGlobalNewWorkspaceComposer,
-} from "../support/helpers/new-workspace";
-import { copyPluginExample } from "../support/helpers/plugin-fixture";
-import { seedWorkspace } from "../support/helpers/seed-client";
-import { getServerId } from "../support/helpers/server-id";
-import { openSettingsHostSection } from "../support/helpers/settings";
-
-const MODEL_LABEL = "Select model (Example 1)";
-const WIDE = { width: 1400, height: 950 };
-const COMPACT = { width: 390, height: 844 };
-
-async function readIconPaths(page: Page, pluginDirectory: string): Promise<string[]> {
-  const svg = await readFile(path.join(pluginDirectory, "icon.svg"), "utf8");
-  return page.evaluate(
-    (source) =>
-      Array.from(
-        new DOMParser().parseFromString(source, "image/svg+xml").querySelectorAll("path"),
-        (element) => element.getAttribute("d") ?? "",
-      ),
-    svg,
-  );
-}
-
-function readIconDrawings(icons: SVGElement[]): string[][] {
-  return icons.map((icon) =>
-    Array.from(icon.querySelectorAll("path"), (element) => element.getAttribute("d") ?? ""),
-  );
-}
-
-async function expectProviderIcon(surface: Locator, paths: string[]): Promise<void> {
-  await expect(surface).toBeVisible();
-  // Provider icons are decorative SVGs without accessible names. Compare the
-  // plugin asset's drawing, allowing surface-specific size and theme colours.
-  await expect
-    .poll(() => surface.locator("svg").evaluateAll(readIconDrawings))
-    .toContainEqual(paths);
-}
-
-async function selectPluginModel(page: Page): Promise<void> {
-  await openModelPicker(page);
-  await page.getByRole("button", { name: "Back", exact: true }).click();
-  await page.getByText("Direct provider example", { exact: true }).click();
-  await page.getByText("Example 1", { exact: true }).click();
-  await expect(page.getByRole("button", { name: MODEL_LABEL, exact: true })).toBeVisible();
-}
-
-async function capture(page: Page, testInfo: TestInfo, name: string): Promise<void> {
-  const screenshot = testInfo.outputPath(`${name}.png`);
-  await page.screenshot({ path: screenshot });
-  await testInfo.attach(name, { path: screenshot, contentType: "image/png" });
-}
+  test,
+  verifyProviderSettings,
+  verifyNewWorkspaceModelIcon,
+  verifyCompactModelIcon,
+  verifyExistingAgentModelIcon,
+} from "../support/helpers/plugin-provider-icons";
 
 test("plugin provider icons follow the model through settings and wide and compact composers", async ({
-  page,
-}, testInfo) => {
-  const plugin = await copyPluginExample("provider-direct");
-  const client = await connectNewWorkspaceDaemonClient();
-  const workspace = await seedWorkspace({ repoPrefix: "plugin-provider-icons-" });
-  try {
-    await client.patchDaemonConfig({ pluginsEnabled: true });
-    await client.installDirectoryPlugin(plugin.directory);
-    await page.setViewportSize(WIDE);
-    await gotoAppShell(page);
-    const iconPaths = await readIconPaths(page, plugin.directory);
-
-    await test.step("provider settings render the registered icon", async () => {
-      await openSettings(page);
-      await openSettingsHostSection(page, getServerId(), "providers");
-      await expectProviderIcon(
-        page.getByRole("button", { name: "Direct provider example provider details", exact: true }),
-        iconPaths,
-      );
-      await capture(page, testInfo, "provider-settings");
-      await page.getByTestId("settings-back-to-workspace").click();
-    });
-
-    await test.step("new workspace keeps the picker icon on its selected model button", async () => {
-      await openGlobalNewWorkspaceComposer(page);
-      await selectPluginModel(page);
-      await openModelPicker(page);
-      await expectProviderIcon(page.getByTestId("model-row-direct-example-example-1"), iconPaths);
-      await capture(page, testInfo, "new-workspace-picker");
-      await page.keyboard.press("Escape");
-      await expectProviderIcon(
-        page.getByRole("button", { name: MODEL_LABEL, exact: true }),
-        iconPaths,
-      );
-      await capture(page, testInfo, "new-workspace-selected-model");
-    });
-
-    await test.step("compact composer preserves the same provider icon", async () => {
-      await page.setViewportSize(COMPACT);
-      await expectProviderIcon(
-        page.getByRole("button", { name: MODEL_LABEL, exact: true }),
-        iconPaths,
-      );
-      await capture(page, testInfo, "compact-selected-model");
-    });
-
-    await test.step("existing agent composer uses the same icon", async () => {
-      const agent = await workspace.client.createAgent({
-        provider: "direct-example",
-        model: "example-1",
-        cwd: workspace.repoPath,
-        workspaceId: workspace.workspaceId,
-        title: "Plugin icon agent",
-      });
-      await page.setViewportSize(WIDE);
-      await openAgentRoute(page, { workspaceId: workspace.workspaceId, agentId: agent.id });
-      await expectProviderIcon(
-        page.getByRole("button", { name: MODEL_LABEL, exact: true }),
-        iconPaths,
-      );
-      await capture(page, testInfo, "agent-selected-model");
-    });
-  } finally {
-    await workspace.cleanup();
-    await client.removePlugin("provider-direct-example");
-    await client.close();
-    await plugin.cleanup();
-  }
+  providerIcons,
+}) => {
+  await verifyProviderSettings(providerIcons);
+  await verifyNewWorkspaceModelIcon(providerIcons);
+  await verifyCompactModelIcon(providerIcons);
+  await verifyExistingAgentModelIcon(providerIcons);
 });

--- a/packages/app/e2e/browser/plugin-provider-icons.spec.ts
+++ b/packages/app/e2e/browser/plugin-provider-icons.spec.ts
@@ -1,0 +1,131 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { Locator, TestInfo } from "@playwright/test";
+import { expect, test, type Page } from "../support/fixtures";
+import { gotoAppShell, openSettings } from "../support/helpers/app";
+import { openModelPicker } from "../support/helpers/agent-profiles";
+import { openAgentRoute } from "../support/helpers/mock-agent";
+import {
+  connectNewWorkspaceDaemonClient,
+  openGlobalNewWorkspaceComposer,
+} from "../support/helpers/new-workspace";
+import { copyPluginExample } from "../support/helpers/plugin-fixture";
+import { seedWorkspace } from "../support/helpers/seed-client";
+import { getServerId } from "../support/helpers/server-id";
+import { openSettingsHostSection } from "../support/helpers/settings";
+
+const MODEL_LABEL = "Select model (Example 1)";
+const WIDE = { width: 1400, height: 950 };
+const COMPACT = { width: 390, height: 844 };
+
+async function readIconPaths(page: Page, pluginDirectory: string): Promise<string[]> {
+  const svg = await readFile(path.join(pluginDirectory, "icon.svg"), "utf8");
+  return page.evaluate(
+    (source) =>
+      Array.from(
+        new DOMParser().parseFromString(source, "image/svg+xml").querySelectorAll("path"),
+        (element) => element.getAttribute("d") ?? "",
+      ),
+    svg,
+  );
+}
+
+function readIconDrawings(icons: SVGElement[]): string[][] {
+  return icons.map((icon) =>
+    Array.from(icon.querySelectorAll("path"), (element) => element.getAttribute("d") ?? ""),
+  );
+}
+
+async function expectProviderIcon(surface: Locator, paths: string[]): Promise<void> {
+  await expect(surface).toBeVisible();
+  // Provider icons are decorative SVGs without accessible names. Compare the
+  // plugin asset's drawing, allowing surface-specific size and theme colours.
+  await expect
+    .poll(() => surface.locator("svg").evaluateAll(readIconDrawings))
+    .toContainEqual(paths);
+}
+
+async function selectPluginModel(page: Page): Promise<void> {
+  await openModelPicker(page);
+  await page.getByRole("button", { name: "Back", exact: true }).click();
+  await page.getByText("Direct provider example", { exact: true }).click();
+  await page.getByText("Example 1", { exact: true }).click();
+  await expect(page.getByRole("button", { name: MODEL_LABEL, exact: true })).toBeVisible();
+}
+
+async function capture(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  const screenshot = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ path: screenshot });
+  await testInfo.attach(name, { path: screenshot, contentType: "image/png" });
+}
+
+test("plugin provider icons follow the model through settings and wide and compact composers", async ({
+  page,
+}, testInfo) => {
+  const plugin = await copyPluginExample("provider-direct");
+  const client = await connectNewWorkspaceDaemonClient();
+  const workspace = await seedWorkspace({ repoPrefix: "plugin-provider-icons-" });
+  try {
+    await client.patchDaemonConfig({ pluginsEnabled: true });
+    await client.installDirectoryPlugin(plugin.directory);
+    await page.setViewportSize(WIDE);
+    await gotoAppShell(page);
+    const iconPaths = await readIconPaths(page, plugin.directory);
+
+    await test.step("provider settings render the registered icon", async () => {
+      await openSettings(page);
+      await openSettingsHostSection(page, getServerId(), "providers");
+      await expectProviderIcon(
+        page.getByRole("button", { name: "Direct provider example provider details", exact: true }),
+        iconPaths,
+      );
+      await capture(page, testInfo, "provider-settings");
+      await page.getByTestId("settings-back-to-workspace").click();
+    });
+
+    await test.step("new workspace keeps the picker icon on its selected model button", async () => {
+      await openGlobalNewWorkspaceComposer(page);
+      await selectPluginModel(page);
+      await openModelPicker(page);
+      await expectProviderIcon(page.getByTestId("model-row-direct-example-example-1"), iconPaths);
+      await capture(page, testInfo, "new-workspace-picker");
+      await page.keyboard.press("Escape");
+      await expectProviderIcon(
+        page.getByRole("button", { name: MODEL_LABEL, exact: true }),
+        iconPaths,
+      );
+      await capture(page, testInfo, "new-workspace-selected-model");
+    });
+
+    await test.step("compact composer preserves the same provider icon", async () => {
+      await page.setViewportSize(COMPACT);
+      await expectProviderIcon(
+        page.getByRole("button", { name: MODEL_LABEL, exact: true }),
+        iconPaths,
+      );
+      await capture(page, testInfo, "compact-selected-model");
+    });
+
+    await test.step("existing agent composer uses the same icon", async () => {
+      const agent = await workspace.client.createAgent({
+        provider: "direct-example",
+        model: "example-1",
+        cwd: workspace.repoPath,
+        workspaceId: workspace.workspaceId,
+        title: "Plugin icon agent",
+      });
+      await page.setViewportSize(WIDE);
+      await openAgentRoute(page, { workspaceId: workspace.workspaceId, agentId: agent.id });
+      await expectProviderIcon(
+        page.getByRole("button", { name: MODEL_LABEL, exact: true }),
+        iconPaths,
+      );
+      await capture(page, testInfo, "agent-selected-model");
+    });
+  } finally {
+    await workspace.cleanup();
+    await client.removePlugin("provider-direct-example");
+    await client.close();
+    await plugin.cleanup();
+  }
+});

--- a/packages/app/e2e/support/helpers/plugin-provider-icons.ts
+++ b/packages/app/e2e/support/helpers/plugin-provider-icons.ts
@@ -1,0 +1,175 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { Locator, TestInfo } from "@playwright/test";
+import { expect, test as base, type Page } from "../fixtures";
+import { gotoAppShell, openSettings } from "./app";
+import { openModelPicker } from "./agent-profiles";
+import { openAgentRoute } from "./mock-agent";
+import { connectNewWorkspaceDaemonClient, openGlobalNewWorkspaceComposer } from "./new-workspace";
+import { copyPluginExample } from "./plugin-fixture";
+import { seedWorkspace, type SeededWorkspace } from "./seed-client";
+import { getServerId } from "./server-id";
+import { openSettingsHostSection } from "./settings";
+
+const MODEL_LABEL = "Select model (Example 1)";
+const WIDE = { width: 1400, height: 950 };
+const COMPACT = { width: 390, height: 844 };
+
+async function readIconPaths(page: Page, pluginDirectory: string): Promise<string[]> {
+  const svg = await readFile(path.join(pluginDirectory, "icon.svg"), "utf8");
+  return page.evaluate(
+    (source) =>
+      Array.from(
+        new DOMParser().parseFromString(source, "image/svg+xml").querySelectorAll("path"),
+        (element) => element.getAttribute("d") ?? "",
+      ),
+    svg,
+  );
+}
+
+function readIconDrawings(icons: SVGElement[]): string[][] {
+  return icons.map((icon) =>
+    Array.from(icon.querySelectorAll("path"), (element) => element.getAttribute("d") ?? ""),
+  );
+}
+
+async function expectProviderIcon(surface: Locator, paths: string[]): Promise<void> {
+  await expect(surface).toBeVisible();
+  // Provider icons are decorative SVGs without accessible names. Compare the
+  // plugin asset's drawing, allowing surface-specific size and theme colours.
+  await expect
+    .poll(() => surface.locator("svg").evaluateAll(readIconDrawings))
+    .toContainEqual(paths);
+}
+
+async function selectPluginModel(page: Page): Promise<void> {
+  await openModelPicker(page);
+  await page.getByRole("button", { name: "Back", exact: true }).click();
+  await page.getByText("Direct provider example", { exact: true }).click();
+  await page.getByText("Example 1", { exact: true }).click();
+  await expect(page.getByRole("button", { name: MODEL_LABEL, exact: true })).toBeVisible();
+}
+
+async function capture(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  const screenshot = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ path: screenshot });
+  await testInfo.attach(name, { path: screenshot, contentType: "image/png" });
+}
+
+interface ProviderIconJourney {
+  page: Page;
+  testInfo: TestInfo;
+  iconPaths: string[];
+  workspace: SeededWorkspace;
+}
+
+export const test = base.extend<{ providerIcons: ProviderIconJourney }>({
+  providerIcons: async ({ page }, provide, testInfo) => {
+    const client = await connectNewWorkspaceDaemonClient();
+    try {
+      const previous = await client.getDaemonConfig();
+      const plugin = await copyPluginExample("provider-direct");
+      try {
+        try {
+          await client.patchDaemonConfig({ pluginsEnabled: true });
+          await client.installDirectoryPlugin(plugin.directory);
+          const workspace = await seedWorkspace({ repoPrefix: "plugin-provider-icons-" });
+          try {
+            await page.setViewportSize(WIDE);
+            await gotoAppShell(page);
+            const iconPaths = await readIconPaths(page, plugin.directory);
+            await provide({ page, testInfo, iconPaths, workspace });
+          } finally {
+            await workspace.cleanup();
+          }
+        } finally {
+          try {
+            await client.removePlugin("provider-direct-example");
+          } finally {
+            await client.patchDaemonConfig({ pluginsEnabled: previous.config.pluginsEnabled });
+          }
+        }
+      } finally {
+        await plugin.cleanup();
+      }
+    } finally {
+      await client.close();
+    }
+  },
+});
+
+export async function verifyProviderSettings({
+  page,
+  iconPaths,
+  testInfo,
+}: ProviderIconJourney): Promise<void> {
+  await test.step("provider settings render the registered icon", async () => {
+    await openSettings(page);
+    await openSettingsHostSection(page, getServerId(), "providers");
+    await expectProviderIcon(
+      page.getByRole("button", { name: "Direct provider example provider details", exact: true }),
+      iconPaths,
+    );
+    await capture(page, testInfo, "provider-settings");
+    await page.getByTestId("settings-back-to-workspace").click();
+  });
+}
+
+export async function verifyNewWorkspaceModelIcon({
+  page,
+  iconPaths,
+  testInfo,
+}: ProviderIconJourney): Promise<void> {
+  await test.step("new workspace keeps the picker icon on its selected model button", async () => {
+    await openGlobalNewWorkspaceComposer(page);
+    await selectPluginModel(page);
+    await openModelPicker(page);
+    await expectProviderIcon(page.getByTestId("model-row-direct-example-example-1"), iconPaths);
+    await capture(page, testInfo, "new-workspace-picker");
+    await page.keyboard.press("Escape");
+    await expectProviderIcon(
+      page.getByRole("button", { name: MODEL_LABEL, exact: true }),
+      iconPaths,
+    );
+    await capture(page, testInfo, "new-workspace-selected-model");
+  });
+}
+
+export async function verifyCompactModelIcon({
+  page,
+  iconPaths,
+  testInfo,
+}: ProviderIconJourney): Promise<void> {
+  await test.step("compact composer preserves the same provider icon", async () => {
+    await page.setViewportSize(COMPACT);
+    await expectProviderIcon(
+      page.getByRole("button", { name: MODEL_LABEL, exact: true }),
+      iconPaths,
+    );
+    await capture(page, testInfo, "compact-selected-model");
+  });
+}
+
+export async function verifyExistingAgentModelIcon({
+  page,
+  iconPaths,
+  testInfo,
+  workspace,
+}: ProviderIconJourney): Promise<void> {
+  await test.step("existing agent composer uses the same icon", async () => {
+    const agent = await workspace.client.createAgent({
+      provider: "direct-example",
+      model: "example-1",
+      cwd: workspace.repoPath,
+      workspaceId: workspace.workspaceId,
+      title: "Plugin icon agent",
+    });
+    await page.setViewportSize(WIDE);
+    await openAgentRoute(page, { workspaceId: workspace.workspaceId, agentId: agent.id });
+    await expectProviderIcon(
+      page.getByRole("button", { name: MODEL_LABEL, exact: true }),
+      iconPaths,
+    );
+    await capture(page, testInfo, "agent-selected-model");
+  });
+}

--- a/packages/app/src/components/combined-model-selector.tsx
+++ b/packages/app/src/components/combined-model-selector.tsx
@@ -255,6 +255,7 @@ export function CombinedModelSelector({
             <View style={toolbar?.glyphSize === 20 ? styles.toolbarGlyph20 : styles.toolbarGlyph16}>
               <ModelProviderGlyph
                 provider={selectedProvider}
+                serverId={serverId}
                 size={toolbar?.glyphSize ?? ICON_SIZE.md}
               />
             </View>

--- a/packages/app/src/components/model-browser.tsx
+++ b/packages/app/src/components/model-browser.tsx
@@ -219,7 +219,7 @@ export function ModelProviderGlyph({
   tone = "muted",
 }: {
   provider: string;
-  serverId?: string | null;
+  serverId: string | null;
   size: number;
   tone?: ProviderGlyphTone;
 }) {


### PR DESCRIPTION
### Linked issue

Closes #4513

### Type of change

- [x] Bug fix

### Reasoning

Selecting a plugin provider's model showed its SVG in the picker but a robot on the composer button, even with one host. The button now forwards the selected host to the existing icon resolver. The glyph's host prop is required but nullable so TypeScript catches another omitted prop.

### Goals

- Keep the selected model's plugin icon consistent with its picker.
- Preserve host-scoped icon identity and existing built-in/fallback behavior.
- Cover provider settings, new-workspace wide/compact controls, and existing-agent controls with a real daemon/plugin/browser regression.

### Non-goals

- Change plugin registration, icon assets, terminal-profile logos, or quota-service logos.

### QA

- Audited every provider-icon resolver/glyph caller. Settings, import-session rows/filters, schedules, agent lists/tabs, subagent tabs/track, Command Center, and compact controls already pass their owning host. Only the shared wide selected-model glyph omitted it. Terminal-profile and usage callers select static catalog logos rather than registered plugin identities.
- Reproduced against `origin/main` at `c172076bffa84e4ccf3beffa0993bac6579801fd` using the bundled direct-provider example installed through the real plugin API, an isolated daemon, and Chromium on Linux.
- Failing-first browser test: provider settings and picker checks passed; the selected button contained robot paths instead of the registered SVG paths. With this change, the same journey passes through the wide button, compact button, and existing-agent button.

```text
node node_modules/@playwright/test/cli.js test -c packages/app/playwright.config.ts \
  --project=browser --workers=1 --retries=0 plugin-provider-icons.spec.ts

Before: 1 failed — selected model button rendered robot paths
After:  1 passed (14.0s)

npm run typecheck — passed, all workspaces
npm run lint      — 0 warnings, 0 errors
npm run format    — passed
```

The regression attaches screenshots for provider settings, picker, wide selected button, compact selected button, and existing-agent selected button to the Playwright results.

Runtime coverage: Linux browser, wide and compact viewports. Native iOS/Android and actual Electron on Linux/macOS/Windows were not run locally. Production behavior changes only the wide selector's icon identity; compact is a regression control.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
- Plugin SDK boundaries: not changed
