### PR TITLE
fix(server): show Codex Fast for the gpt-6 model family

### DIFF
--- a/packages/server/src/server/agent/providers/codex-feature-definitions.test.ts
+++ b/packages/server/src/server/agent/providers/codex-feature-definitions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+
+import { buildCodexFeatures, codexModelSupportsFastMode } from "./codex-feature-definitions.js";
+
+describe("codexModelSupportsFastMode", () => {
+  test("supports the gpt-6 family (e.g. gpt-6-astra)", () => {
+    expect(codexModelSupportsFastMode("gpt-6-astra")).toBe(true);
+  });
+
+  test("supports existing prefixes (e.g. gpt-5.6-sol)", () => {
+    expect(codexModelSupportsFastMode("gpt-5.6-sol")).toBe(true);
+  });
+
+  test("rejects unsupported models", () => {
+    expect(codexModelSupportsFastMode("unknown")).toBe(false);
+  });
+});
+
+describe("buildCodexFeatures", () => {
+  test("includes both fast_mode and plan_mode for a gpt-6 model", () => {
+    const features = buildCodexFeatures({
+      modelId: "gpt-6-astra",
+      fastModeEnabled: false,
+      planModeEnabled: true,
+    });
+
+    expect(features.map((feature) => ({ id: feature.id, value: feature.value }))).toEqual([
+      { id: "fast_mode", value: false },
+      { id: "plan_mode", value: true },
+    ]);
+  });
+
+  test("includes only plan_mode for an unsupported model", () => {
+    const features = buildCodexFeatures({
+      modelId: "unknown",
+      fastModeEnabled: true,
+      planModeEnabled: false,
+    });
+
+    expect(features.map((feature) => ({ id: feature.id, value: feature.value }))).toEqual([
+      { id: "plan_mode", value: false },
+    ]);
+  });
+});

--- a/packages/server/src/server/agent/providers/codex-feature-definitions.ts
+++ b/packages/server/src/server/agent/providers/codex-feature-definitions.ts
@@ -1,6 +1,12 @@
 import type { AgentFeature, AgentFeatureToggle } from "../agent-sdk-types.js";
 
-const CODEX_FAST_MODE_SUPPORTED_MODEL_PREFIXES = ["gpt-5", "gpt-4.1", "o3", "o4-mini"] as const;
+const CODEX_FAST_MODE_SUPPORTED_MODEL_PREFIXES = [
+  "gpt-6",
+  "gpt-5",
+  "gpt-4.1",
+  "o3",
+  "o4-mini",
+] as const;
 
 export const CODEX_FAST_MODE_FEATURE: Omit<AgentFeatureToggle, "value"> = {
   type: "toggle",


### PR DESCRIPTION
### Linked issue

Fixes #4451.

### Type of change

- [x] Bug fix

### Reasoning

Codex Fast visibility is gated by a static prefix allowlist in `codex-feature-definitions.ts` (`["gpt-5", "gpt-4.1", "o3", "o4-mini"]`), the single source of truth for both feature visibility and backend Fast validation. `gpt-6-astra` matched no prefix, so Fast disappeared for the whole `gpt-6` family even though the official Codex client supports it.

Add the broad `"gpt-6"` family prefix, consistent with `"gpt-5"` already covering `gpt-5.6-sol`. Stays a pure prefix allowlist — no per-call special-casing.

### QA

- Added `codex-feature-definitions.test.ts`: `gpt-6-astra` supports Fast, `buildCodexFeatures` returns `fast_mode` + `plan_mode`, and an unsupported model returns `plan_mode` only. `npx vitest run ... codex-feature-definitions.test.ts` — 5 passed.
- `npm run lint` / `npm run format` on the changed files — clean.
- `npm run typecheck --workspace=@getpaseo/server` — passes. The two residual failures on a full-repo run (`packages/app` route typegen, `packages/desktop` electron `ClipboardItem`) are pre-existing and unrelated to this change.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes (server package clean; unrelated pre-existing app/desktop failures noted in QA)
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense