### PR TITLE
fix(app): show loading state for restored terminal titles

### DIFF
--- a/packages/app/e2e/browser/terminal-tab-title-loading.spec.ts
+++ b/packages/app/e2e/browser/terminal-tab-title-loading.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from "../support/fixtures";
+import { clickNewTerminal, gotoWorkspace } from "../support/helpers/launcher";
+import { renameModalInput, renameModalSubmit } from "../support/helpers/rename";
+import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
+import { selectWorkspaceInSidebar } from "../support/helpers/sidebar";
+
+function terminalTab(page: Page, terminalId: string) {
+  // Terminal tab chips have no tab role; their persistent identity survives title loading.
+  return page.getByTestId(`workspace-tab-terminal_${terminalId}`).filter({ visible: true }).first();
+}
+
+async function createNamedTerminal(page: Page, workspace: SeededWorkspace, title: string) {
+  await gotoWorkspace(page, workspace.workspaceId);
+  await clickNewTerminal(page);
+  const list = () =>
+    workspace.client.listTerminals(workspace.repoPath, undefined, {
+      workspaceId: workspace.workspaceId,
+    });
+  await expect.poll(async () => (await list()).terminals.length).toBe(1);
+  const terminalId = (await list()).terminals[0]!.id;
+  await terminalTab(page, terminalId).click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Rename", exact: true }).click();
+  const modal = `workspace-tab-rename-modal-terminal-${terminalId}`;
+  await renameModalInput(page, modal).fill(title);
+  await renameModalSubmit(page, modal).click();
+  await expect(renameModalInput(page, modal)).toHaveCount(0);
+  await expect(terminalTab(page, terminalId)).toHaveText(title);
+  return terminalId;
+}
+
+async function recordRestoredTabText(page: Page, terminalId: string) {
+  // Install before the next document loads: a final-state assertion would miss the flash.
+  await page.addInitScript((id) => {
+    const samples: string[] = [];
+    Object.assign(window, { terminalTitleSamples: samples });
+    new MutationObserver(() => {
+      const tab = document.querySelector(`[data-testid="workspace-tab-terminal_${id}"]`);
+      if (!tab) return;
+      const text = (tab.textContent ?? "").trim();
+      if (samples.at(-1) !== text) samples.push(text);
+    }).observe(document, { subtree: true, childList: true, characterData: true });
+  }, terminalId);
+}
+
+async function expectRestoredTitle(page: Page, terminalId: string, title: string, stage: string) {
+  await expect(terminalTab(page, terminalId)).toHaveText(title, { timeout: 30_000 });
+  const samples = await page.evaluate(
+    () => (window as unknown as { terminalTitleSamples: string[] }).terminalTitleSamples,
+  );
+  await test.info().attach(`${stage}-tab-text`, {
+    body: JSON.stringify(samples),
+    contentType: "application/json",
+  });
+  expect(samples).toContain(title);
+  expect(samples).not.toContain("Terminal");
+}
+
+test("restored terminal titles do not flash a default name while loading", async ({ page }) => {
+  const workspace = await seedWorkspace({ repoPrefix: "terminal-title-loading-", git: false });
+  const other = await seedWorkspace({ repoPrefix: "terminal-title-other-", git: false });
+  try {
+    const title = "My named terminal";
+    const terminalId = await createNamedTerminal(page, workspace, title);
+    await recordRestoredTabText(page, terminalId);
+
+    await test.step("reload with a terminal tab restored", async () => {
+      await page.reload();
+      await expectRestoredTitle(page, terminalId, title, "reload");
+    });
+
+    await test.step("first workspace visit in a fresh page session", async () => {
+      await gotoWorkspace(page, other.workspaceId);
+      await selectWorkspaceInSidebar(page, workspace.workspaceId);
+      await expectRestoredTitle(page, terminalId, title, "first-visit");
+    });
+
+    await test.step("return to the workspace with its titles already loaded", async () => {
+      await selectWorkspaceInSidebar(page, other.workspaceId);
+      await selectWorkspaceInSidebar(page, workspace.workspaceId);
+      await expectRestoredTitle(page, terminalId, title, "return-visit");
+    });
+  } finally {
+    await workspace.cleanup();
+    await other.cleanup();
+  }
+});

--- a/packages/app/src/panels/terminal-panel.tsx
+++ b/packages/app/src/panels/terminal-panel.tsx
@@ -69,7 +69,7 @@ function useTerminalPanelDescriptor(
     label,
     subtitle: t("workspace.tabs.fallback.terminal"),
     tooltip: label,
-    titleState: "ready",
+    titleState: terminalsQuery.isPending ? "loading" : "ready",
     icon: Terminal,
     statusBucket: deriveTerminalActivityStatusBucket(terminal?.activity),
   };

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -1487,9 +1487,7 @@ function ResolvedDesktopTabChip({
   );
 
   const rawTooltipLabel =
-    presentation.titleState === "loading"
-      ? t("workspace.tabs.loadingAgentTitle")
-      : presentation.tooltip;
+    presentation.titleState === "loading" ? t("common.states.loading") : presentation.tooltip;
   const accessibilityLabel =
     item.tab.target.kind === "agent"
       ? normalizeAgentTooltipTitle(rawTooltipLabel)


### PR DESCRIPTION
### Linked issue

Refs #4521. This fixes the independently reproduced initial-loading flash. The reporter's title reverting after ordinary switching remains unconfirmed; this PR does not close that issue.

### Type of change

- [x] Bug fix

### Reasoning

Restored terminal tabs currently display "Terminal" before their first terminal list response arrives. They now use the existing loading placeholder until their titles are available. Shared loading tooltips use generic loading text so terminal tabs are not announced as loading an agent title.

### Goals

- Show loading while terminal metadata is unknown, then display the authoritative title.
- Cover reload, first workspace visit in a fresh app session, and returning to an already loaded workspace.

### Non-goals

- Change workspace ownership, terminal subscriptions, cached list contents, or preserve remembered labels.
- Claim to fix the unconfirmed same-session reversion or persistent fallback in #4521.

### QA

Linux Chromium, real isolated daemon and PTYs; one browser worker. Windows, macOS, Electron, iOS and Android runtime QA were not performed. Risk surface: pending terminal title presentation and shared loading tooltip text; terminal transport and ownership are unchanged.

Created a terminal through the app, renamed it, reloaded, then visited it from another workspace in a fresh page session. A MutationObserver installed before app startup captured the transient DOM text:

```text
Baseline c172076bffa84e4ccf3beffa0993bac6579801fd:
Expected: not "Terminal"
Received: ["Terminal", "My named terminal"]
1 failed

Changed code, same regression:
Reload:      ["", "My named terminal"]
First visit: ["", "My named terminal"]
Warm return: no generic-label flash
1 passed
```

The empty text is the existing skeleton. Repeated the real browser journey with two live terminals, one manually renamed and one titled by a running program using OSC 2: no generic label during reload or first visit, and no text mutation during three warm workspace round trips. Normal response timing was used for both reproduction and verification.

The actual changed app during loading, then after loading (real metadata responses held briefly **only to capture these screenshots**):

![Terminal title loading placeholder](https://raw.githubusercontent.com/getpaseo/paseo/b1c7d065cd810adf451a17e734eb943687cc51c9/loading-placeholder.png)
![Loaded terminal title](https://raw.githubusercontent.com/getpaseo/paseo/b1c7d065cd810adf451a17e734eb943687cc51c9/loaded-title.png)

[Captured before/after DOM sequences](https://github.com/getpaseo/paseo/blob/b1c7d065cd810adf451a17e734eb943687cc51c9/before-after.json).

```sh
npx playwright test --config packages/app/playwright.config.ts terminal-tab-title-loading.spec.ts --project browser --workers 1 --retries 0
# 1 passed
npx playwright test --config packages/app/playwright.config.ts workspace-terminal-tab-rename.spec.ts workspace-agent-title-handoff.spec.ts --project browser --workers 1 --retries 0
# 4 passed
npm run typecheck
# exit 0
npm run lint
# 0 warnings, 0 errors
npm run format
# exit 0
```

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
