### PR TITLE
fix(server): derive Hub agent title from prompt

### DIFF
--- a/packages/server/src/server/hub/daemon-executions.test.ts
+++ b/packages/server/src/server/hub/daemon-executions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, test } from "vitest";
+import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "@getpaseo/protocol/agent-title-limits";
 import { HubRelationshipHarness } from "./test-utils/relationship-harness.js";
 
 let relationship: HubRelationshipHarness | null = null;
@@ -25,6 +26,23 @@ test("sequential replay after reconstruction keeps one durable owned agent", asy
   expect(reconstructed.replay.agent.id).toBe(created.first.agentId);
   expect(reconstructed.replay.agent.status).toBe("closed");
   expect(reconstructed.durableAgentCount).toBe(1);
+});
+
+test("Hub creates an agent from a prompt beyond the explicit title limit", async () => {
+  const hub = await launchRelationship();
+  const prompt = "a".repeat(MAX_EXPLICIT_AGENT_TITLE_CHARS + 1);
+  hub.beginOwnedCreate("long-prompt-create", "long-prompt-execution", { prompt });
+
+  const response = await hub.ownedCreateResult("long-prompt-create");
+  const title = hub.latestProviderCreateConfig()?.title;
+
+  expect(response).toMatchObject({
+    type: "hub.execution.agent.create.response",
+    payload: { success: true, executionId: "long-prompt-execution" },
+  });
+  expect(title).toBe(prompt.slice(0, 60));
+  expect(title?.length).toBeLessThanOrEqual(MAX_EXPLICIT_AGENT_TITLE_CHARS);
+  expect(hub.providerPromptTexts()).toEqual([prompt]);
 });
 
 test("Hub MCP configuration reaches the provider alongside Paseo MCP without entering snapshots", async () => {

--- a/packages/server/src/server/hub/daemon-executions.ts
+++ b/packages/server/src/server/hub/daemon-executions.ts
@@ -12,6 +12,7 @@ import type { AgentStorage, StoredAgentRecord } from "../agent/agent-storage.js"
 import type { BoundCreateAgentCommand } from "../agent/create-agent/create.js";
 import type { CreatePaseoWorktreeWorkflowResult } from "../worktree-session.js";
 import { buildStoredAgentPayload } from "../agent/agent-projections.js";
+import { resolveCreateAgentTitles } from "../agent/create-agent-title.js";
 import { serializeAgentSnapshot, serializeAgentStreamEvent } from "../messages.js";
 import { daemonExecutionKey, type DaemonAgentOwner } from "../agent/agent-owner.js";
 
@@ -179,6 +180,7 @@ export class DaemonExecutions implements HubExecutionAgents {
     this.requireAuthority(authorityGeneration);
     requireHubMcpNamespace(input.mcpServers);
     requireToolPolicyServers(input.toolPolicy, input.mcpServers);
+    const { provisionalTitle } = resolveCreateAgentTitles({ initialPrompt: input.prompt });
 
     let createdWorktree: CreatePaseoWorktreeWorkflowResult | null = null;
     let createdAgentId: string | null = null;
@@ -187,7 +189,7 @@ export class DaemonExecutions implements HubExecutionAgents {
       result = await this.createAgentCommand({
         kind: "mcp",
         provider: input.model ? `${input.provider}/${input.model}` : input.provider,
-        title: input.prompt,
+        title: provisionalTitle ?? "Hub execution",
         initialPrompt: input.prompt,
         promptFailure: "throw",
         cwd: input.cwd,


### PR DESCRIPTION
First time contributor, so forgive me if I missed something here. 😄 

## Summary
- derive a bounded Hub execution title from the rendered prompt
- retain the full rendered prompt as the provider initial prompt
- cover Hub creation with a prompt longer than the 200-character explicit-title limit

Fixes #4569.

## Failure fixed
Hub sent the complete rendered trigger prompt as `title` and `initialPrompt`. Trigger instructions plus an incoming Discord message routinely exceed `MAX_EXPLICIT_AGENT_TITLE_CHARS` (200), so agent creation was rejected with `Too big: expected string to have <=200 characters`.

## QA evidence

```text
$ npm run typecheck --workspace=@getpaseo/server
> @getpaseo/server typecheck
> tsgo -p tsconfig.server.typecheck.json --noEmit
# exit 0

$ npm exec --workspace=@getpaseo/server -- vitest run src/server/hub/daemon-executions.test.ts --bail=1 -t "Hub creates an agent from a prompt beyond the explicit title limit"
Test Files  1 passed (1)
Tests       1 passed | 12 skipped (13)

$ npm run lint -- packages/server/src/server/hub/daemon-executions.ts packages/server/src/server/hub/daemon-executions.test.ts
Found 0 warnings and 0 errors.

$ npm run format:check -- packages/server/src/server/hub/daemon-executions.ts packages/server/src/server/hub/daemon-executions.test.ts
All matched files use the correct format.
```

`npm run build:server` also completed successfully.

The full `npm run typecheck` does not pass on this base because of existing, unrelated CLI errors in `packages/cli/src/commands/{agent/ls,mode,permit/*,plugin/index,provider/ls}.ts`; server typecheck passes.

## Platforms
- Tested: Linux daemon, using the real in-process Hub relationship harness.
- Not tested: browser, Electron, iOS, Android, and a live Discord/Hub deployment. This is daemon-only behavior with no UI changes.

## Limitations
Hub has no trigger-schema agent-title override; it now uses the existing concise first-line title derivation. The entire rendered prompt is still delivered unchanged to the agent.