### PR TITLE
fix(server): accept MCP clients that negotiate a newer protocol version at /mcp/agents

### DIFF
--- a/packages/server/src/server/agent/agent-mcp.e2e.test.ts
+++ b/packages/server/src/server/agent/agent-mcp.e2e.test.ts
@@ -1,4 +1,5 @@
 import net from "node:net";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { existsSync } from "node:fs";
@@ -84,6 +85,22 @@ async function createMcpClient(url: string, authToken?: string): Promise<McpClie
     new URL(url),
     authToken ? { requestInit: { headers: { Authorization: `Bearer ${authToken}` } } } : undefined,
   );
+  const rawClient = await experimental_createMCPClient({ transport });
+  const boundCallTool: McpClient["callTool"] = Reflect.get(rawClient, "callTool").bind(rawClient);
+  return { callTool: boundCallTool, close: () => rawClient.close() };
+}
+
+/**
+ * Like createMcpClient, but pins an explicit `mcp-protocol-version` request
+ * header on every request from construction. The SDK client spreads extra
+ * headers after its negotiated `_protocolVersion` (client/streamableHttp.js
+ * `_commonHeaders`), so an injected value wins — this is how a seat CLI that
+ * speaks a protocol newer than the daemon's bundled SDK presents itself.
+ */
+async function createMcpClientWithProtocol(url: string, protocolVersion: string): Promise<McpClient> {
+  const transport = new StreamableHTTPClientTransport(new URL(url), {
+    requestInit: { headers: { "mcp-protocol-version": protocolVersion } },
+  });
   const rawClient = await experimental_createMCPClient({ transport });
   const boundCallTool: McpClient["callTool"] = Reflect.get(rawClient, "callTool").bind(rawClient);
   return { callTool: boundCallTool, close: () => rawClient.close() };
@@ -826,4 +843,267 @@ describe("agent MCP end-to-end (offline)", () => {
       await rm(repoRoot, { recursive: true, force: true });
     }
   }, 60_000);
+
+  test("a client speaking protocol 2026-07-28 completes post-initialize requests after the version clip", async () => {
+    // initialize is exempt from the header gate (the SDK wraps the check in
+    // `if (!isInitializationRequest)`), so the initialize leg is green by
+    // design. But the AI SDK client sends `notifications/initialized` during
+    // construction — the first post-initialize request — so on the unpatched
+    // daemon construction itself is rejected with the protocol 400 (red;
+    // cleanup below still runs), and after the version clip it completes
+    // (green).
+    const paseoHome = await mkdtemp(path.join(os.tmpdir(), "paseo-home-"));
+    const staticDir = await mkdtemp(path.join(os.tmpdir(), "paseo-static-"));
+    const agentCwd = await mkdtemp(path.join(os.tmpdir(), "paseo-agent-cwd-"));
+    const port = await getAvailablePort();
+
+    const daemonConfig: PaseoDaemonConfig = {
+      listen: `127.0.0.1:${port}`,
+      paseoHome,
+      corsAllowedOrigins: [],
+      hostnames: true,
+      mcpEnabled: true,
+      staticDir,
+      mcpDebug: false,
+      agentClients: createTestAgentClients(),
+      agentStoragePath: path.join(paseoHome, "agents"),
+    };
+    const daemon = await createPaseoDaemon(daemonConfig, pino({ level: "silent" }));
+    await daemon.start();
+
+    let client: McpClient | null = null;
+    let agentId: string | null = null;
+    try {
+      client = await createMcpClientWithProtocol(
+        `http://127.0.0.1:${port}/mcp/agents`,
+        "2026-07-28",
+      );
+      const result = await client.callTool({
+        name: "create_agent",
+        args: {
+          cwd: agentCwd,
+          title: "Newer protocol MCP",
+          provider: "claude/claude-test-model",
+          mode: "bypassPermissions",
+          initialPrompt: "reply with done and stop",
+          background: true,
+        },
+      });
+      const payload = getStructuredContent(result);
+      agentId = typeof payload?.agentId === "string" ? payload.agentId : null;
+      expect(agentId).toBeTruthy();
+    } finally {
+      if (agentId) {
+        await client?.callTool({ name: "kill_agent", args: { agentId } });
+      }
+      await client?.close();
+      await daemon.stop();
+      await rm(paseoHome, { recursive: true, force: true });
+      await rm(staticDir, { recursive: true, force: true });
+      await rm(agentCwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("a DRAFT-2026-v1 protocol header is normalised the same way", async () => {
+    const paseoHome = await mkdtemp(path.join(os.tmpdir(), "paseo-home-"));
+    const staticDir = await mkdtemp(path.join(os.tmpdir(), "paseo-static-"));
+    const agentCwd = await mkdtemp(path.join(os.tmpdir(), "paseo-agent-cwd-"));
+    const port = await getAvailablePort();
+
+    const daemonConfig: PaseoDaemonConfig = {
+      listen: `127.0.0.1:${port}`,
+      paseoHome,
+      corsAllowedOrigins: [],
+      hostnames: true,
+      mcpEnabled: true,
+      staticDir,
+      mcpDebug: false,
+      agentClients: createTestAgentClients(),
+      agentStoragePath: path.join(paseoHome, "agents"),
+    };
+    const daemon = await createPaseoDaemon(daemonConfig, pino({ level: "silent" }));
+    await daemon.start();
+
+    let client: McpClient | null = null;
+    let agentId: string | null = null;
+    try {
+      client = await createMcpClientWithProtocol(
+        `http://127.0.0.1:${port}/mcp/agents`,
+        "DRAFT-2026-v1",
+      );
+      const result = await client.callTool({
+        name: "create_agent",
+        args: {
+          cwd: agentCwd,
+          title: "Draft protocol MCP",
+          provider: "claude/claude-test-model",
+          mode: "bypassPermissions",
+          initialPrompt: "reply with done and stop",
+          background: true,
+        },
+      });
+      const payload = getStructuredContent(result);
+      agentId = typeof payload?.agentId === "string" ? payload.agentId : null;
+      expect(agentId).toBeTruthy();
+    } finally {
+      if (agentId) {
+        await client?.callTool({ name: "kill_agent", args: { agentId } });
+      }
+      await client?.close();
+      await daemon.stop();
+      await rm(paseoHome, { recursive: true, force: true });
+      await rm(staticDir, { recursive: true, force: true });
+      await rm(agentCwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("a supported 2025-11-25 protocol header passes untouched", async () => {
+    const paseoHome = await mkdtemp(path.join(os.tmpdir(), "paseo-home-"));
+    const staticDir = await mkdtemp(path.join(os.tmpdir(), "paseo-static-"));
+    const agentCwd = await mkdtemp(path.join(os.tmpdir(), "paseo-agent-cwd-"));
+    const port = await getAvailablePort();
+
+    const daemonConfig: PaseoDaemonConfig = {
+      listen: `127.0.0.1:${port}`,
+      paseoHome,
+      corsAllowedOrigins: [],
+      hostnames: true,
+      mcpEnabled: true,
+      staticDir,
+      mcpDebug: false,
+      agentClients: createTestAgentClients(),
+      agentStoragePath: path.join(paseoHome, "agents"),
+    };
+    const daemon = await createPaseoDaemon(daemonConfig, pino({ level: "silent" }));
+    await daemon.start();
+
+    let client: McpClient | null = null;
+    let agentId: string | null = null;
+    try {
+      client = await createMcpClientWithProtocol(
+        `http://127.0.0.1:${port}/mcp/agents`,
+        "2025-11-25",
+      );
+      const result = await client.callTool({
+        name: "create_agent",
+        args: {
+          cwd: agentCwd,
+          title: "Supported protocol MCP",
+          provider: "claude/claude-test-model",
+          mode: "bypassPermissions",
+          initialPrompt: "reply with done and stop",
+          background: true,
+        },
+      });
+      const payload = getStructuredContent(result);
+      agentId = typeof payload?.agentId === "string" ? payload.agentId : null;
+      expect(agentId).toBeTruthy();
+    } finally {
+      if (agentId) {
+        await client?.callTool({ name: "kill_agent", args: { agentId } });
+      }
+      await client?.close();
+      await daemon.stop();
+      await rm(paseoHome, { recursive: true, force: true });
+      await rm(staticDir, { recursive: true, force: true });
+      await rm(agentCwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("duplicate mcp-protocol-version raw headers collapse to one effective value", async () => {
+    // A client can emit the protocol header twice as separate raw lines (same
+    // name, any casing). @hono/node-server joins same-name raw pairs into one
+    // comma-separated value, which the SDK's server rejects — so the clip must
+    // leave exactly one effective raw pair. Node's http client emits an array
+    // header value as repeated raw lines, exercising that path through the real
+    // HTTP boundary.
+    const paseoHome = await mkdtemp(path.join(os.tmpdir(), "paseo-home-"));
+    const staticDir = await mkdtemp(path.join(os.tmpdir(), "paseo-static-"));
+    const agentCwd = await mkdtemp(path.join(os.tmpdir(), "paseo-agent-cwd-"));
+    const port = await getAvailablePort();
+    const daemonConfig: PaseoDaemonConfig = {
+      listen: `127.0.0.1:${port}`,
+      paseoHome,
+      corsAllowedOrigins: [],
+      hostnames: true,
+      mcpEnabled: true,
+      staticDir,
+      mcpDebug: false,
+      agentClients: createTestAgentClients(),
+      agentStoragePath: path.join(paseoHome, "agents"),
+    };
+    const daemon = await createPaseoDaemon(daemonConfig, pino({ level: "silent" }));
+    await daemon.start();
+
+    const post = (
+      headers: Record<string, string | string[]>,
+      body: string,
+    ): Promise<{ status: number; text: string }> =>
+      new Promise((resolve, reject) => {
+        const req = http.request(
+          new URL(`http://127.0.0.1:${port}/mcp/agents`),
+          { method: "POST", headers },
+          async (res) => {
+            try {
+              let data = "";
+              for await (const chunk of res) data += chunk;
+              resolve({ status: res.statusCode ?? 0, text: data });
+            } catch (error) {
+              reject(error);
+            }
+          },
+        );
+        req.on("error", reject);
+        req.end(body);
+      });
+
+    try {
+      const initializeLeg = await post(
+        {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-protocol-version": ["2026-07-28", "2026-07-28"],
+        },
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2026-07-28",
+            capabilities: {},
+            clientInfo: { name: "dup-probe", version: "1" },
+          },
+        }),
+      );
+      expect(initializeLeg.status).toBe(200);
+
+      const listLeg = await post(
+        {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-protocol-version": ["2026-07-28", "2026-07-28"],
+        },
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+      );
+      expect(listLeg.status).toBe(200);
+      // The stateless server streams tools/list as SSE; the payload's `data:`
+      // line is the JSON-RPC result — it must not be the protocol-version 400.
+      const dataLine = listLeg.text
+        .split("\n")
+        .find((line) => line.startsWith("data:"));
+      const parsed = dataLine
+        ? (JSON.parse(dataLine.slice("data:".length).trim()) as {
+            error?: { message?: string };
+            result?: unknown;
+          })
+        : null;
+      expect(parsed).toBeTruthy();
+      expect(parsed?.error?.message).toBeUndefined();
+    } finally {
+      await daemon.stop();
+      await rm(paseoHome, { recursive: true, force: true });
+      await rm(staticDir, { recursive: true, force: true });
+      await rm(agentCwd, { recursive: true, force: true });
+    }
+  }, 30_000);
 });

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -7,9 +7,47 @@ import { randomUUID } from "node:crypto";
 import { hostname as getHostname } from "node:os";
 import path from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "pino";
 import { z } from "zod";
 import { createBranchChangeRouteHandler } from "./script-route-branch-handler.js";
+
+// A seat CLI can bundle an MCP client that negotiates a protocol version newer
+// than the bundled @modelcontextprotocol/sdk server supports (e.g. 2026-07-28
+// or DRAFT-2026-v1). The streamable-HTTP transport hard-gates every
+// non-initialize request on the `mcp-protocol-version` header (see
+// `if (!isInitializationRequest)` in the SDK's webStandardStreamableHttp.js)
+// and rejects unknown versions before the JSON-RPC body is handled, so the
+// agent's first post-initialize request fails the mount. Normalize the header
+// to the server's newest supported version. Initialize is exempt from the gate
+// and its body-param negotiation already falls back gracefully, so the
+// response stays honest. Node preserves wire case in `req.rawHeaders` (it
+// lowercases only `req.headers`), @hono/node-server builds the Web Request
+// from `incoming.rawHeaders`, and it joins same-name raw pairs into one
+// comma-separated value the SDK rejects — so both representations are
+// rewritten and duplicates collapse to one effective value.
+function clipMcpProtocolVersionHeader(req: express.Request): void {
+  const current = req.header("mcp-protocol-version");
+  if (!current || SUPPORTED_PROTOCOL_VERSIONS.includes(current)) {
+    return;
+  }
+  const clipped = SUPPORTED_PROTOCOL_VERSIONS[0];
+  req.headers["mcp-protocol-version"] = clipped;
+  let replaced = false;
+  for (let i = 0; i < req.rawHeaders.length - 1; ) {
+    if (req.rawHeaders[i].toLowerCase() === "mcp-protocol-version") {
+      if (replaced) {
+        req.rawHeaders.splice(i, 2);
+      } else {
+        req.rawHeaders[i + 1] = clipped;
+        replaced = true;
+        i += 2;
+      }
+    } else {
+      i += 2;
+    }
+  }
+}
 
 export type ListenTarget =
   | { type: "tcp"; host: string; port: number }
@@ -1518,6 +1556,7 @@ export async function createPaseoDaemon(
           });
           return;
         }
+        clipMcpProtocolVersionHeader(req);
         const callerAgentIdRaw = req.query.callerAgentId;
         let callerAgentId: string | undefined;
         if (typeof callerAgentIdRaw === "string") {


### PR DESCRIPTION
## Problem

Agents that drive the daemon's `/mcp/agents` endpoint can bundle an MCP client
that negotiates a protocol version newer than the bundled
`@modelcontextprotocol/sdk` server supports (e.g. `2026-07-28`, `DRAFT-2026-v1`;
the bundled SDK is 1.29.0 and its `SUPPORTED_PROTOCOL_VERSIONS` tops out at
`2025-11-25`). The streamable-HTTP transport hard-gates **every non-initialize
request** on the `mcp-protocol-version` request header (the check sits inside
`if (!isInitializationRequest)` in the SDK's `webStandardStreamableHttp.js`)
and rejects unknown versions with HTTP 400 **before the JSON-RPC body is
handled**. The result: the mount completes `initialize` (exempt, body-param
negotiated softly) and then fails on its first post-initialize request
(`notifications/initialized`, `tools/list`, `tools/call`) with
`Bad Request: Unsupported protocol version`.

## Fix

Normalize the header to `SUPPORTED_PROTOCOL_VERSIONS[0]` when it is present
but unsupported, in `runAgentMcpRequest` (`bootstrap.ts`):

- rewrite both `req.headers["mcp-protocol-version"]` and every
  `req.rawHeaders` pair whose name matches case-insensitively — Node preserves
  wire case in `rawHeaders` (it lowercases only `req.headers`), and
  `@hono/node-server` builds the Web Request from `incoming.rawHeaders`, so
  mutating only `req.headers` is a silent no-op;
- collapse duplicate raw pairs to **one effective value** — Hono joins
  same-name raw pairs into a comma-separated value (`2025-11-25, 2025-11-25`)
  that the SDK's validator also rejects.

`initialize` is exempt from the gate and its `params.protocolVersion` already
falls back to the server's latest supported version in the response, so the
negotiation stays honest. Supported and absent headers are untouched.

## Tests

Four e2e cases in `agent-mcp.e2e.test.ts` (real daemon, in-process):

- a client speaking `2026-07-28` completes post-initialize requests;
- a `DRAFT-2026-v1` header is normalised the same way;
- a supported `2025-11-25` header passes untouched;
- duplicated raw header lines collapse to one effective value through the real
  HTTP boundary (Hono).

## Notes

- The SDK upgrade path is the long-term fix: when the bundled
  `@modelcontextprotocol/sdk` learns the newer protocol version, the accepted
  set grows and this normalisation becomes a no-op (the clip only fires for
  versions outside the supported list).
- Verified in the fork with `format/lint/typecheck/build` and the e2e suite
  (11/11); the identical code (minus fork patch markers/comments) is in this
  PR.