### PR TITLE
fix(pi): show only the thinking levels each pi model supports

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -2324,6 +2324,97 @@ describe("PiRpcAgentClient", () => {
     expect(pi.recordedLaunches[0]).toMatchObject({ cwd: "/workspace/with-extension" });
   });
 
+  test("filters pi thinking levels to those the model supports", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const catalogPromise = client.fetchCatalog({
+      scope: "workspace",
+      cwd: "/workspace/with-extension",
+      force: false,
+    });
+    pi.latestSession().models = [
+      {
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        reasoning: true,
+        thinkingLevelMap: { max: "max" },
+      },
+    ];
+
+    const catalog = await catalogPromise;
+
+    expect(catalog.models[0]?.thinkingOptions?.map((option) => option.id)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "max",
+    ]);
+    expect(catalog.models[0]?.defaultThinkingOptionId).toBe("medium");
+  });
+
+  test("clamps the default pi thinking level to the model's supported levels", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const catalogPromise = client.fetchCatalog({
+      scope: "workspace",
+      cwd: "/workspace/with-extension",
+      force: false,
+    });
+    pi.latestSession().models = [
+      {
+        provider: "moonshotai",
+        id: "kimi-k3",
+        name: "Kimi K3",
+        reasoning: true,
+        thinkingLevelMap: {
+          off: null,
+          minimal: null,
+          low: "low",
+          medium: null,
+          high: "high",
+          xhigh: null,
+          max: "max",
+        },
+      },
+    ];
+
+    const catalog = await catalogPromise;
+
+    expect(catalog.models[0]?.thinkingOptions?.map((option) => option.id)).toEqual([
+      "low",
+      "high",
+      "max",
+    ]);
+    expect(catalog.models[0]?.thinkingOptions?.find((option) => option.isDefault)?.id).toBe("high");
+    expect(catalog.models[0]?.defaultThinkingOptionId).toBe("high");
+  });
+
+  test("hides pi thinking options for non-reasoning models", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const catalogPromise = client.fetchCatalog({
+      scope: "workspace",
+      cwd: "/workspace/with-extension",
+      force: false,
+    });
+    pi.latestSession().models = [
+      {
+        provider: "openrouter",
+        id: "google/gemini-2.5-flash-lite",
+        name: "google/gemini-2.5-flash-lite",
+        reasoning: false,
+      },
+    ];
+
+    const catalog = await catalogPromise;
+
+    expect(catalog.models[0]?.thinkingOptions).toBeUndefined();
+    expect(catalog.models[0]?.defaultThinkingOptionId).toBeUndefined();
+  });
+
   test("lists no draft features without starting a Pi session", async () => {
     const pi = new FakePi();
     const client = createClient(pi);

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -24,6 +24,7 @@ import {
   type AgentRunOptions,
   type AgentRunResult,
   type AgentRuntimeInfo,
+  type AgentSelectOption,
   type AgentSession,
   type AgentSessionConfig,
   type AgentSlashCommand,
@@ -181,6 +182,17 @@ const PI_THINKING_OPTIONS: ReadonlyArray<{
   { id: "xhigh", label: "XHigh", description: "Very deep reasoning" },
   { id: "max", label: "Max", description: "Extreme reasoning" },
 ] as const;
+
+// Ordered from least to most reasoning, matching pi's own level ordering.
+const PI_EXTENDED_THINKING_LEVELS: readonly PiThinkingLevel[] = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
 
 export interface PiRpcAgentClientOptions {
   logger: Logger;
@@ -373,19 +385,76 @@ function parseAutoCompactMode(value: string | undefined): AutoCompactMode {
   return "unknown";
 }
 
-function mapThinkingOption(option: (typeof PI_THINKING_OPTIONS)[number]) {
-  const mappedOption = {
+function mapThinkingOption(
+  option: (typeof PI_THINKING_OPTIONS)[number],
+  isDefault?: boolean,
+): AgentSelectOption {
+  const mapped: AgentSelectOption = {
     id: option.id,
     label: option.label,
     description: option.description,
   };
-  if (option.isDefault) {
-    return {
-      ...mappedOption,
-      isDefault: true,
-    };
+  if (isDefault ?? option.isDefault) {
+    mapped.isDefault = true;
   }
-  return mappedOption;
+  return mapped;
+}
+
+// Mirrors pi's getSupportedThinkingLevels: a null mapping marks a level unsupported, and
+// xhigh/max stay unsupported unless the model maps them explicitly.
+function piSupportedThinkingLevels(model: PiModel): PiThinkingLevel[] {
+  return PI_EXTENDED_THINKING_LEVELS.filter((level) => {
+    const mapped = model.thinkingLevelMap?.[level];
+    if (mapped === null) {
+      return false;
+    }
+    if (level === "xhigh" || level === "max") {
+      return mapped !== undefined;
+    }
+    return true;
+  });
+}
+
+// Mirrors pi's clampThinkingLevel: fall forward to the next supported level, then backward.
+function clampPiThinkingLevel(
+  level: PiThinkingLevel,
+  supported: readonly PiThinkingLevel[],
+): PiThinkingLevel {
+  if (supported.includes(level)) {
+    return level;
+  }
+  const requestedIndex = PI_EXTENDED_THINKING_LEVELS.indexOf(level);
+  for (let i = requestedIndex; i < PI_EXTENDED_THINKING_LEVELS.length; i += 1) {
+    const candidate = PI_EXTENDED_THINKING_LEVELS[i];
+    if (candidate !== undefined && supported.includes(candidate)) {
+      return candidate;
+    }
+  }
+  for (let i = requestedIndex - 1; i >= 0; i -= 1) {
+    const candidate = PI_EXTENDED_THINKING_LEVELS[i];
+    if (candidate !== undefined && supported.includes(candidate)) {
+      return candidate;
+    }
+  }
+  return supported[0] ?? "off";
+}
+
+function resolvePiThinkingConfig(model: PiModel): {
+  thinkingOptions: AgentSelectOption[] | undefined;
+  defaultThinkingOptionId: string | undefined;
+} {
+  if (!model.reasoning) {
+    return { thinkingOptions: undefined, defaultThinkingOptionId: undefined };
+  }
+  const supported = piSupportedThinkingLevels(model);
+  const supportedSet = new Set(supported);
+  const defaultThinkingOptionId = clampPiThinkingLevel(DEFAULT_PI_THINKING_LEVEL, supported);
+  return {
+    thinkingOptions: PI_THINKING_OPTIONS.filter((option) => supportedSet.has(option.id)).map(
+      (option) => mapThinkingOption(option, option.id === defaultThinkingOptionId),
+    ),
+    defaultThinkingOptionId,
+  };
 }
 
 function piModelSupportsImageInput(model: PiModel | null | undefined): boolean {
@@ -1196,6 +1265,7 @@ function buildExtensionUiResponse(
 }
 
 function mapPiModel(model: PiModel, provider: AgentProvider): AgentModelDefinition {
+  const { thinkingOptions, defaultThinkingOptionId } = resolvePiThinkingConfig(model);
   return {
     provider,
     id: `${model.provider}/${model.id}`,
@@ -1205,8 +1275,8 @@ function mapPiModel(model: PiModel, provider: AgentProvider): AgentModelDefiniti
       provider: model.provider,
       modelId: model.id,
     },
-    thinkingOptions: model.reasoning ? PI_THINKING_OPTIONS.map(mapThinkingOption) : undefined,
-    defaultThinkingOptionId: model.reasoning ? DEFAULT_PI_THINKING_LEVEL : undefined,
+    thinkingOptions,
+    defaultThinkingOptionId,
   };
 }
 

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -74,6 +74,8 @@ export interface PiModel {
   id: string;
   name?: string;
   reasoning?: boolean;
+  /** Maps pi thinking levels to provider-specific values; null marks a level as unsupported. */
+  thinkingLevelMap?: Partial<Record<PiThinkingLevel, string | null>>;
   contextWindow?: number;
   maxTokens?: number;
   api?: string;


### PR DESCRIPTION
### Linked issue

Closes #4382

### Type of change

- [x] Bug fix

### Reasoning

Paseo gave every reasoning pi model the full `off → max` thinking-level list and dropped the per-model `thinkingLevelMap` from the `get_available_models` RPC response. Models that mark a level unsupported with `null`, or that never map `xhigh`/`max`, still showed those levels in the picker, and pi only clamped them internally.

This change reads `thinkingLevelMap` and mirrors pi's own `getSupportedThinkingLevels` / `clampThinkingLevel` logic, so the selector offers exactly what the model accepts and the default (`medium`) is clamped to a supported level.

### Goals

- Show only the thinking levels a pi model supports.
- Match pi semantics: `null` means unsupported, and `xhigh`/`max` are unsupported unless explicitly mapped.
- Clamp the `medium` default to the nearest supported level instead of always selecting `medium`.

### Non-goals

- Non-reasoning models keep hiding the selector.
- No direct reads of pi config files; the catalog stays RPC-sourced.

### QA

Automated regression tests in `packages/server/src/server/agent/providers/pi/agent.test.ts`:

```
npx vitest run packages/server/src/server/agent/providers/pi --bail=1
# 6 files, 132 tests passed
```

- `thinkingLevelMap: { max: "max" }` → `off, minimal, low, medium, high, max` (no `xhigh`), default `medium`.
- `thinkingLevelMap` with `medium: null` (Kimi K3 shape) → `low, high, max`, default clamped to `high`.
- non-reasoning model → no options and no default.

Manual: built the daemon and web UI (`npm run build:daemon-web-ui`) and opened the built daemon web UI against a custom provider whose models cover the different maps. The selector showed only the supported levels, and the default matched the clamped value (models with `medium: null` defaulted to `high`).

<img width="1308" height="735" alt="image" src="https://github.com/user-attachments/assets/85ba1666-c5ae-4181-8871-67787b4f160a" />



### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
