### PR TITLE
Fix auto-naming for pre-opened workspaces

### DIFF
--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -99,6 +99,7 @@ export class AgentStorage {
   private pathById: Map<string, string> = new Map();
   private pathsById: Map<string, Set<string>> = new Map();
   private pendingWrites: Map<string, Promise<void>> = new Map();
+  private workspaceCreateTails: Map<string, Promise<void>> = new Map();
   private deleting: Set<string> = new Set();
   private daemonAgentIdsByExecution: Map<string, string> = new Map();
   private daemonExecutionKeysByAgentId: Map<string, string> = new Map();
@@ -153,6 +154,28 @@ export class AgentStorage {
   async upsert(record: StoredAgentRecord): Promise<void> {
     await this.load();
     await this.queueRecordWrite(record);
+  }
+
+  // Session instances share one AgentStorage. Queue direct creates for the same workspace so a
+  // first-agent decision observes the preceding create after it has been persisted.
+  async runWithWorkspaceCreateLock<T>(workspaceId: string, run: () => Promise<T>): Promise<T> {
+    const predecessor = this.workspaceCreateTails.get(workspaceId) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = predecessor.then(() => gate);
+    this.workspaceCreateTails.set(workspaceId, tail);
+
+    await predecessor;
+    try {
+      return await run();
+    } finally {
+      release();
+      if (this.workspaceCreateTails.get(workspaceId) === tail) {
+        this.workspaceCreateTails.delete(workspaceId);
+      }
+    }
   }
 
   private queueRecordWrite(record: StoredAgentRecord): Promise<void> {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -388,7 +388,7 @@ type CreateAgentRequestMessage = Extract<SessionInboundMessage, { type: "create_
 interface ResolvedSessionCreateAgentIntent {
   config: AgentSessionConfig;
   intent: CreateAgentIntent;
-  createdDirectoryWorkspace: boolean;
+  shouldAutoNameDirectoryWorkspace: boolean;
 }
 
 type FetchWorkspacesRequestMessage = Extract<
@@ -3717,7 +3717,7 @@ export class Session {
       );
       createdAgentId = snapshot.id;
       await this.agentUpdates.forwardLiveAgent(snapshot);
-      if (resolvedIntent.createdDirectoryWorkspace && trimmedPrompt) {
+      if (resolvedIntent.shouldAutoNameDirectoryWorkspace && trimmedPrompt) {
         this.workspaceAutoName.scheduleForDirectory(
           {
             workspaceId: resolvedIntent.intent.workspaceId,
@@ -3760,6 +3760,10 @@ export class Session {
     }
 
     let config = request.config;
+    const requestedWorkspace =
+      !createdWorktree && request.workspaceId
+        ? await this.workspaceRegistry.get(request.workspaceId)
+        : null;
 
     const intent = await resolveCreateAgentIntent({
       explicitWorkspaceId: createdWorktree?.workspace.workspaceId ?? request.workspaceId,
@@ -3771,7 +3775,10 @@ export class Session {
         if (createdWorktree?.workspace.workspaceId === workspaceId) {
           return { workspaceId, cwd: createdWorktree.workspace.cwd };
         }
-        const workspace = await this.workspaceRegistry.get(workspaceId);
+        const workspace =
+          requestedWorkspace?.workspaceId === workspaceId
+            ? requestedWorkspace
+            : await this.workspaceRegistry.get(workspaceId);
         if (!workspace || workspace.archivedAt) {
           throw new Error(`Workspace ${workspaceId} not found`);
         }
@@ -3788,10 +3795,24 @@ export class Session {
     });
     config = { ...config, cwd: intent.cwd };
 
+    const createdDirectoryWorkspace = !createdWorktree && !request.workspaceId && !callerAgent;
+    let shouldAutoNameDirectoryWorkspace = createdDirectoryWorkspace;
+    if (
+      !createdWorktree &&
+      request.workspaceId &&
+      !callerAgent &&
+      requestedWorkspace &&
+      requestedWorkspace.kind !== "worktree" &&
+      requestedWorkspace.title === null
+    ) {
+      const existingAgents = await this.agentStorage.listByWorkspace(intent.workspaceId);
+      shouldAutoNameDirectoryWorkspace = existingAgents.every((agent) => agent.internal === true);
+    }
+
     return {
       config,
       intent,
-      createdDirectoryWorkspace: !createdWorktree && !request.workspaceId && !callerAgent,
+      shouldAutoNameDirectoryWorkspace,
     };
   }
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3629,6 +3629,22 @@ export class Session {
     msg: CreateAgentRequestMessage,
     agentId?: string,
   ): Promise<AgentSnapshotPayload> {
+    const coordinatedWorkspaceId =
+      msg.workspaceId && !msg.callerAgentId && !msg.worktreeName && !msg.git && !msg.worktree
+        ? msg.workspaceId
+        : null;
+    if (coordinatedWorkspaceId) {
+      return this.agentStorage.runWithWorkspaceCreateLock(coordinatedWorkspaceId, () =>
+        this.createSessionAgentUncoordinated(msg, agentId),
+      );
+    }
+    return this.createSessionAgentUncoordinated(msg, agentId);
+  }
+
+  private async createSessionAgentUncoordinated(
+    msg: CreateAgentRequestMessage,
+    agentId?: string,
+  ): Promise<AgentSnapshotPayload> {
     const {
       config,
       worktreeName,

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -1234,7 +1234,20 @@ test("create_agent_request launches from an exact subdirectory in a created work
   }
 });
 
-test("create_agent_request does not title an existing workspace from the agent prompt", async () => {
+test.each([
+  {
+    name: "titles an existing workspace from its first agent prompt",
+    existingAgent: false,
+    expectedGenerateCalls: 1,
+    expectedTitle: "Generated login fix title",
+  },
+  {
+    name: "does not title an existing workspace that already has an agent",
+    existingAgent: true,
+    expectedGenerateCalls: 0,
+    expectedTitle: null,
+  },
+])("create_agent_request $name", async (testCase) => {
   vi.useFakeTimers();
   const workdir = mkdtempSync(path.join(tmpdir(), "paseo-create-agent-existing-title-"));
   try {
@@ -1287,8 +1300,23 @@ test("create_agent_request does not title an existing workspace from the agent p
         updatedAt: "2026-05-07T00:00:00.000Z",
       }),
     );
+    if (testCase.existingAgent) {
+      await agentStorage.upsert({
+        id: "agent-existing",
+        provider: "codex",
+        cwd,
+        workspaceId: "ws-existing",
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+        labels: {},
+        lastStatus: "closed",
+      });
+    }
 
     let generateCalls = 0;
+    const autoNameCompleted = deferred<void>();
+    const providerSnapshotManager = createProviderSnapshotManagerStub().manager;
+    const workspaceGitService = createNoopWorkspaceGitService();
     const session = asTestSession(
       new Session({
         agentRequests: createAgentRequestsStub(),
@@ -1321,7 +1349,24 @@ test("create_agent_request does not title an existing workspace from the agent p
           }),
           dispose: () => {},
         }),
-        workspaceGitService: createNoopWorkspaceGitService(),
+        workspaceGitService,
+        workspaceAutoName: new WorkspaceAutoName({
+          agentManager,
+          workspaceRegistry,
+          workspaceGitService,
+          providerSnapshotManager,
+          readDaemonConfig: () => ({ metadataGeneration: { providers: [] } }),
+          gitMutation: { notifyGitMutation: async () => {} },
+          emitWorkspaceUpdateForCwd: async () => {},
+          emitWorkspaceUpdateForWorkspaceId: async () => {
+            autoNameCompleted.resolve(undefined);
+          },
+          logger: asSessionLogger(logger),
+          generateWorkspaceName: async () => {
+            generateCalls += 1;
+            return { title: "Generated login fix title", branch: null };
+          },
+        }),
         daemonConfigStore: asDaemonConfigStore({
           get: () => ({ mcp: { injectIntoAgents: false }, providers: {} }),
           onChange: () => () => {},
@@ -1329,11 +1374,7 @@ test("create_agent_request does not title an existing workspace from the agent p
         mcpBaseUrl: null,
         stt: null,
         tts: null,
-        generateWorkspaceName: async () => {
-          generateCalls += 1;
-          return { title: "Generated title that must not be written", branch: null };
-        },
-        providerSnapshotManager: createProviderSnapshotManagerStub().manager,
+        providerSnapshotManager,
         terminalManager: null,
       }),
     );
@@ -1347,13 +1388,15 @@ test("create_agent_request does not title an existing workspace from the agent p
       attachments: [],
     });
     await vi.runAllTimersAsync();
+    if (testCase.expectedGenerateCalls > 0) {
+      await autoNameCompleted.promise;
+    }
 
     const [createdAgent] = agentManager.listAgents();
     expect(createdAgent?.workspaceId).toBe("ws-existing");
-    expect(generateCalls).toBe(0);
+    expect(generateCalls).toBe(testCase.expectedGenerateCalls);
     await expect(workspaceRegistry.get("ws-existing")).resolves.toMatchObject({
-      title: null,
-      updatedAt: "2026-05-07T00:00:00.000Z",
+      title: testCase.expectedTitle,
     });
   } finally {
     vi.useRealTimers();

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -462,10 +462,12 @@ const CREATE_AGENT_TEST_CAPABILITIES = {
 
 class CreateAgentTestSession implements AgentSession {
   readonly provider = "codex";
-  readonly id = "create-agent-test-session";
   readonly capabilities = CREATE_AGENT_TEST_CAPABILITIES;
 
-  constructor(private readonly config: AgentSessionConfig) {}
+  constructor(
+    private readonly config: AgentSessionConfig,
+    readonly id = "create-agent-test-session",
+  ) {}
 
   async run(): Promise<AgentRunResult> {
     return { sessionId: this.id, finalText: "", timeline: [] };
@@ -518,13 +520,14 @@ class CreateAgentTestSession implements AgentSession {
 class CreateAgentTestClient implements AgentClient {
   readonly provider = "codex";
   readonly capabilities = CREATE_AGENT_TEST_CAPABILITIES;
+  private nextSessionId = 1;
 
   async createSession(
     config: AgentSessionConfig,
     _launchContext?: AgentLaunchContext,
     _options?: AgentCreateSessionOptions,
   ): Promise<AgentSession> {
-    return new CreateAgentTestSession(config);
+    return new CreateAgentTestSession(config, `create-agent-test-session-${this.nextSessionId++}`);
   }
 
   async resumeSession(
@@ -1234,20 +1237,13 @@ test("create_agent_request launches from an exact subdirectory in a created work
   }
 });
 
-test.each([
-  {
-    name: "titles an existing workspace from its first agent prompt",
-    existingAgent: false,
-    expectedGenerateCalls: 1,
-    expectedTitle: "Generated login fix title",
-  },
-  {
-    name: "does not title an existing workspace that already has an agent",
-    existingAgent: true,
-    expectedGenerateCalls: 0,
-    expectedTitle: null,
-  },
-])("create_agent_request $name", async (testCase) => {
+async function runExistingWorkspaceAutoNameScenario(input: {
+  existingAgent: boolean;
+  requestCount?: number;
+  expectedGenerateCalls: number;
+  expectedGeneratedPrompts: string[];
+  expectedTitle: string | null;
+}): Promise<void> {
   vi.useFakeTimers();
   const workdir = mkdtempSync(path.join(tmpdir(), "paseo-create-agent-existing-title-"));
   try {
@@ -1263,11 +1259,12 @@ test.each([
       error: vi.fn(),
     };
     const agentStorage = new AgentStorage(path.join(workdir, "agents"), asSessionLogger(logger));
+    let nextAgentId = 552;
     const agentManager = new AgentManager({
       clients: { codex: new CreateAgentTestClient() },
       registry: agentStorage,
       logger: asSessionLogger(logger),
-      idFactory: () => "00000000-0000-4000-8000-000000000552",
+      idFactory: () => `00000000-0000-4000-8000-${String(nextAgentId++).padStart(12, "0")}`,
     });
     const projectRegistry = new FileBackedProjectRegistry(
       path.join(workdir, "projects.json"),
@@ -1300,7 +1297,7 @@ test.each([
         updatedAt: "2026-05-07T00:00:00.000Z",
       }),
     );
-    if (testCase.existingAgent) {
+    if (input.existingAgent) {
       await agentStorage.upsert({
         id: "agent-existing",
         provider: "codex",
@@ -1314,6 +1311,8 @@ test.each([
     }
 
     let generateCalls = 0;
+    const generatedPrompts: string[] = [];
+    const emitted: SessionOutboundMessage[] = [];
     const autoNameCompleted = deferred<void>();
     const providerSnapshotManager = createProviderSnapshotManagerStub().manager;
     const workspaceGitService = createNoopWorkspaceGitService();
@@ -1323,7 +1322,7 @@ test.each([
         clientId: "test-client",
         permissions: OWNER_PERMISSIONS,
         appVersion: null,
-        onMessage: vi.fn(),
+        onMessage: (message) => emitted.push(message),
         logger: asSessionLogger(logger),
         downloadTokenStore: asDownloadTokenStore(),
         pushNotifications: asPushNotifications(),
@@ -1362,8 +1361,9 @@ test.each([
             autoNameCompleted.resolve(undefined);
           },
           logger: asSessionLogger(logger),
-          generateWorkspaceName: async () => {
+          generateWorkspaceName: async ({ firstAgentContext }) => {
             generateCalls += 1;
+            generatedPrompts.push(firstAgentContext.prompt ?? "");
             return { title: "Generated login fix title", branch: null };
           },
         }),
@@ -1379,29 +1379,70 @@ test.each([
       }),
     );
 
-    await session.handleMessage({
-      type: "create_agent_request",
-      requestId: "req-create-existing-title",
-      workspaceId: "ws-existing",
-      config: { provider: "codex", cwd },
-      initialPrompt: "Fix login bug\nwith better validation",
-      attachments: [],
-    });
+    const prompts = ["Fix login bug\nwith better validation", "Refactor billing retry behavior"];
+    await Promise.all(
+      prompts.slice(0, input.requestCount ?? 1).map((initialPrompt, index) =>
+        session.handleMessage({
+          type: "create_agent_request",
+          requestId: `req-create-existing-title-${index}`,
+          workspaceId: "ws-existing",
+          config: { provider: "codex", cwd },
+          initialPrompt,
+          attachments: [],
+        }),
+      ),
+    );
     await vi.runAllTimersAsync();
-    if (testCase.expectedGenerateCalls > 0) {
+    if (input.expectedGenerateCalls > 0) {
       await autoNameCompleted.promise;
     }
 
-    const [createdAgent] = agentManager.listAgents();
-    expect(createdAgent?.workspaceId).toBe("ws-existing");
-    expect(generateCalls).toBe(testCase.expectedGenerateCalls);
+    expect(
+      emitted.filter(
+        (message) => message.type === "status" && message.payload.status === "agent_create_failed",
+      ),
+    ).toEqual([]);
+    expect(agentManager.listAgents()).toHaveLength(input.requestCount ?? 1);
+    expect(agentManager.listAgents().every((agent) => agent.workspaceId === "ws-existing")).toBe(
+      true,
+    );
+    expect(generateCalls).toBe(input.expectedGenerateCalls);
+    expect(generatedPrompts).toEqual(input.expectedGeneratedPrompts);
     await expect(workspaceRegistry.get("ws-existing")).resolves.toMatchObject({
-      title: testCase.expectedTitle,
+      title: input.expectedTitle,
     });
   } finally {
     vi.useRealTimers();
     rmSync(workdir, { recursive: true, force: true });
   }
+}
+
+test("create_agent_request titles an existing workspace from its first agent prompt", async () => {
+  await runExistingWorkspaceAutoNameScenario({
+    existingAgent: false,
+    expectedGenerateCalls: 1,
+    expectedGeneratedPrompts: ["Fix login bug\nwith better validation"],
+    expectedTitle: "Generated login fix title",
+  });
+});
+
+test("create_agent_request preserves an existing workspace that already has an agent", async () => {
+  await runExistingWorkspaceAutoNameScenario({
+    existingAgent: true,
+    expectedGenerateCalls: 0,
+    expectedGeneratedPrompts: [],
+    expectedTitle: null,
+  });
+});
+
+test("concurrent first agents schedule one existing workspace title from the first request", async () => {
+  await runExistingWorkspaceAutoNameScenario({
+    existingAgent: false,
+    requestCount: 2,
+    expectedGenerateCalls: 1,
+    expectedGeneratedPrompts: ["Fix login bug\nwith better validation"],
+    expectedTitle: "Generated login fix title",
+  });
 });
 
 test("unsupported persisted agents are excluded from active lists but preserved in history payloads", async () => {


### PR DESCRIPTION
## Summary

- auto-name an explicitly selected, untitled directory workspace from its first user agent prompt
- preserve workspaces that already contain a user agent
- serialize direct agent creation per workspace through shared agent storage so concurrent first requests cannot race the naming decision
- keep conditional setup out of test bodies and cover first, previously used, and concurrent scenarios separately

## Validation

- `npm run typecheck -w packages/server`
- `npm run lint`
- `npx vitest run src/server/session.workspaces.test.ts --bail=1` (110 passed, 4 skipped)
