### PR TITLE
fix(app): stop sidebar row height shift on hover

### DIFF
--- a/packages/app/e2e/browser/sidebar-shortcut-reveal.spec.ts
+++ b/packages/app/e2e/browser/sidebar-shortcut-reveal.spec.ts
@@ -1,0 +1,64 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
+import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
+
+async function firstProjectRowTop(page: Page): Promise<number | null> {
+  return page
+    .locator('[data-testid^="sidebar-project-row-"]')
+    .first()
+    .evaluate((el) => el.getBoundingClientRect().top)
+    .catch(() => null);
+}
+
+test.describe("Sidebar header row shortcut reveal", () => {
+  let workspace: SeededWorkspace;
+
+  test.beforeEach(async () => {
+    workspace = await seedWorkspace({ repoPrefix: "sidebar-shortcut-reveal-" });
+  });
+
+  test.afterEach(async () => {
+    await workspace?.cleanup();
+  });
+
+  test("revealing the shortcut badge on hover keeps the row and the list below it in place", async ({
+    page,
+  }) => {
+    await gotoAppShell(page);
+    await waitForSidebarHydration(page);
+
+    const row = page.getByTestId("sidebar-global-new-workspace");
+    const shortcut = row.getByTestId("sidebar-header-row-shortcut");
+    await expect(row).toBeVisible();
+    await expect(shortcut).toBeHidden();
+
+    const rowBox = async () => {
+      const box = await row.boundingBox();
+      if (!box) throw new Error("sidebar header row has no bounding box");
+      return box;
+    };
+
+    const beforeRow = await rowBox();
+    const projectRowTop = await firstProjectRowTop(page);
+
+    await row.hover();
+    await expect(shortcut).toBeVisible();
+    const hoveredRow = await rowBox();
+    expect(Math.round(hoveredRow.height)).toBe(Math.round(beforeRow.height));
+    expect(Math.round(hoveredRow.y)).toBe(Math.round(beforeRow.y));
+
+    const hoveredProjectRowTop = await firstProjectRowTop(page);
+    if (projectRowTop !== null && hoveredProjectRowTop !== null) {
+      expect(Math.round(hoveredProjectRowTop)).toBe(Math.round(projectRowTop));
+    }
+
+    // Removing the badge must not move anything either.
+    await page.mouse.move(0, 0);
+    await expect(shortcut).toBeHidden();
+    const restedRow = await rowBox();
+    expect(Math.round(restedRow.height)).toBe(Math.round(beforeRow.height));
+    expect(Math.round(restedRow.y)).toBe(Math.round(beforeRow.y));
+  });
+});

--- a/packages/app/e2e/browser/sidebar-shortcut-reveal.spec.ts
+++ b/packages/app/e2e/browser/sidebar-shortcut-reveal.spec.ts
@@ -1,16 +1,7 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "../support/fixtures";
 import { gotoAppShell } from "../support/helpers/app";
 import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
 import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
-
-async function firstProjectRowTop(page: Page): Promise<number | null> {
-  return page
-    .locator('[data-testid^="sidebar-project-row-"]')
-    .first()
-    .evaluate((el) => el.getBoundingClientRect().top)
-    .catch(() => null);
-}
 
 test.describe("Sidebar header row shortcut reveal", () => {
   let workspace: SeededWorkspace;
@@ -31,34 +22,38 @@ test.describe("Sidebar header row shortcut reveal", () => {
 
     const row = page.getByTestId("sidebar-global-new-workspace");
     const shortcut = row.getByTestId("sidebar-header-row-shortcut");
+    const firstProjectRow = page.locator('[data-testid^="sidebar-project-row-"]').first();
     await expect(row).toBeVisible();
+    await expect(firstProjectRow).toBeVisible();
     await expect(shortcut).toBeHidden();
 
-    const rowBox = async () => {
+    const rowGeometry = async () => {
       const box = await row.boundingBox();
       if (!box) throw new Error("sidebar header row has no bounding box");
-      return box;
+      return { height: box.height, top: box.y };
+    };
+    const projectRowTop = async () => {
+      const box = await firstProjectRow.boundingBox();
+      if (!box) throw new Error("first project row has no bounding box");
+      return box.y;
     };
 
-    const beforeRow = await rowBox();
-    const projectRowTop = await firstProjectRowTop(page);
+    const beforeRow = await rowGeometry();
+    const beforeProjectRowTop = await projectRowTop();
 
     await row.hover();
     await expect(shortcut).toBeVisible();
-    const hoveredRow = await rowBox();
+    const hoveredRow = await rowGeometry();
+    const hoveredProjectRowTop = await projectRowTop();
     expect(Math.round(hoveredRow.height)).toBe(Math.round(beforeRow.height));
-    expect(Math.round(hoveredRow.y)).toBe(Math.round(beforeRow.y));
-
-    const hoveredProjectRowTop = await firstProjectRowTop(page);
-    if (projectRowTop !== null && hoveredProjectRowTop !== null) {
-      expect(Math.round(hoveredProjectRowTop)).toBe(Math.round(projectRowTop));
-    }
+    expect(Math.round(hoveredRow.top)).toBe(Math.round(beforeRow.top));
+    expect(Math.round(hoveredProjectRowTop)).toBe(Math.round(beforeProjectRowTop));
 
     // Removing the badge must not move anything either.
     await page.mouse.move(0, 0);
     await expect(shortcut).toBeHidden();
-    const restedRow = await rowBox();
+    const restedRow = await rowGeometry();
     expect(Math.round(restedRow.height)).toBe(Math.round(beforeRow.height));
-    expect(Math.round(restedRow.y)).toBe(Math.round(beforeRow.y));
+    expect(Math.round(restedRow.top)).toBe(Math.round(beforeRow.top));
   });
 });

--- a/packages/app/src/components/sidebar/sidebar-header-row.tsx
+++ b/packages/app/src/components/sidebar/sidebar-header-row.tsx
@@ -105,7 +105,11 @@ function SidebarHeaderRowLabel({
     () => [styles.label, isHighlighted && styles.labelHighlighted],
     [isHighlighted],
   );
-  return <Text style={labelStyle}>{label}</Text>;
+  return (
+    <Text style={labelStyle} numberOfLines={1}>
+      {label}
+    </Text>
+  );
 }
 
 const styles = StyleSheet.create((theme) => ({
@@ -158,5 +162,10 @@ const styles = StyleSheet.create((theme) => ({
   },
   shortcut: {
     marginLeft: "auto",
+    // The badge carries vertical padding, so it is taller than the label's line
+    // box and mounting it on hover grows the row, shifting the whole sidebar
+    // below. Cancel that height so the reveal is pure paint; the pill keeps its
+    // visual size.
+    marginVertical: -theme.spacing[0.5],
   },
 }));

--- a/packages/app/src/components/sidebar/sidebar-header-row.tsx
+++ b/packages/app/src/components/sidebar/sidebar-header-row.tsx
@@ -69,7 +69,11 @@ export function SidebarHeaderRow({
           />
           <SidebarHeaderRowLabel label={label} isHighlighted={isHighlighted} />
           {shortcutKeys && Boolean(state.hovered) ? (
-            <Shortcut chord={shortcutKeys} style={styles.shortcut} />
+            <Shortcut
+              chord={shortcutKeys}
+              style={styles.shortcut}
+              testID="sidebar-header-row-shortcut"
+            />
           ) : null}
         </>
       );

--- a/packages/app/src/components/ui/shortcut.tsx
+++ b/packages/app/src/components/ui/shortcut.tsx
@@ -11,11 +11,13 @@ export function Shortcut({
   chord,
   style,
   textStyle,
+  testID,
 }: {
   keys?: ShortcutKey[];
   chord?: ShortcutKey[][];
   style?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
+  testID?: string;
 }): ReactElement | null {
   const shortcutsAvailable = useKeyboardShortcutsAvailable();
   const displayChord = normalizeDisplayChord(chord, keys);
@@ -38,7 +40,7 @@ export function Shortcut({
 
   if (displayChord.length === 1) {
     return (
-      <View style={badgeStyle}>
+      <View style={badgeStyle} testID={testID}>
         <View style={styles.badgeBackground} />
         <Text style={textCombinedStyle}>{formatShortcut(singleCombo, shortcutOs)}</Text>
       </View>
@@ -46,7 +48,7 @@ export function Shortcut({
   }
 
   return (
-    <View style={sequenceStyle}>
+    <View style={sequenceStyle} testID={testID}>
       {displayChord.map(function (combo) {
         return (
           <View key={combo.join("+")} style={styles.badge}>


### PR DESCRIPTION
### Linked issue

None — found and verified during manual UI testing.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Hovering a sidebar header row that has a keyboard-shortcut hint mounts the `Shortcut` badge only on hover. The pill is taller than the label's line box (it carries vertical padding), and once it takes horizontal room the label can reflow as well. Mounting the badge therefore grew the row height and shifted the whole sidebar content below it down by a few pixels.

The fix keeps the reveal as pure paint: `SidebarHeaderRowLabel` is clamped to a single line, and the badge cancels its vertical-padding height contribution with an equal negative `marginVertical`. With and without the badge the row now occupies the exact same height.

### Goals

- Sidebar rows keep their exact height on hover — nothing below shifts when the shortcut hint mounts.
- The hint still appears and keeps its visual size on hover.

### Non-goals

- No change to shortcut styling, hover triggers, or which rows show hints.

### QA

- Reproduced before the fix: hovering a header row with a shortcut hint pushed the rows below it down a few pixels.
- Manually reviewed by the author in the running app: after the fix, hovering mounts the hint with the row height unchanged and nothing below shifts — the bug is confirmed fixed.
- Added an e2e regression test (`packages/app/e2e/browser/sidebar-shortcut-reveal.spec.ts`): hovers the row, asserts the shortcut badge mounts and the row height/position (plus the project list below) stay identical. Verified fail-first — with the layout changes reverted the test fails (row grows 32→33px on hover).
- `npm run typecheck`, `npm run lint` (on the changed files), and `npm run format:check` all pass; the e2e spec passes locally.

### Checklist

- [ ] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (if applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
