### PR TITLE
Explain full Hub prompts and credential recovery

### DIFF
--- a/public-docs/hub/workflows.md
+++ b/public-docs/hub/workflows.md
@@ -169,7 +169,7 @@ The workflow keeps one classifier branch and one worker branch. It does not dupl
 
 ## Prompt and context
 
-Prompt blocks remain ordered. Includes are literal file contents; Hub does not recursively scan partial text.
+Prompt blocks remain ordered. Includes are literal file contents; Hub does not recursively scan partial text. Hub sends the rendered prompt separately from the agent title, so the 200-character title limit does not limit your instructions or context.
 
 ```yaml
 prompt:
@@ -245,5 +245,7 @@ allow_outputs:
 ## Deadlines
 
 The workflow `max_runtime` limits the complete run. Every step has its own `max_runtime` and `idle_timeout`; remaining workflow time caps both. A timeout fails the run and stops later steps.
+
+Hub reconnects to the existing agent after a connection loss. If a run used temporary environment credentials and Hub no longer owns their live lease, recovery fails with `execution_credentials_unavailable`. This includes credentials revoked during Hub shutdown. Start a new run to obtain fresh credentials; an existing agent cannot receive a replacement process environment.
 
 The [configuration reference](/docs/hub/configuration/hub-yml) lists every field. Provider filters and invocation text are in [Triggers](/docs/hub/triggers).


### PR DESCRIPTION
### Linked issue

Companion documentation for https://github.com/getpaseo/hub/pull/128. Refs #4569.

### Type of change

- [x] Docs

### Reasoning

Hub now sends rendered workflow prompts separately from agent titles through ordinary daemon requests. Explain that the title limit does not cap instructions or context, and explain how operators recover when an existing agent's temporary credentials have been revoked.

### Goals

- Make the prompt/title distinction explicit for workflow authors.
- Explain `execution_credentials_unavailable` and when a new run is required.

### Non-goals

- Daemon code or protocol changes.
- Changes to title limits, workflow syntax, or credential permissions.

### QA

`npm run format:check:files -- public-docs/hub/workflows.md` passes. The documented behavior was exercised in the Hub companion: a 21 KB prompt arrived intact through an unchanged source-built daemon, and recovery with revoked credentials failed explicitly without creating a duplicate agent or reminting credentials. The Hub source integration suite passed all eight tests; its browser suite passed all 79 tests.

Risk surface: publish alongside the Hub update so operators see behavior supported by their deployed Hub version. This PR changes documentation only.

### Checklist

- [x] One focused change
- [x] Formatting passes
- [x] QA evidence
- [x] Behavioral coverage in the companion Hub PR
- [ ] `npm run typecheck` — not rerun for this documentation-only diff
- [ ] `npm run lint` — no code changed
