### PR TITLE
fix(claude): emit PowerShell-compatible hooks on Windows

### DIFF
--- a/docs/terminal-activity.md
+++ b/docs/terminal-activity.md
@@ -102,17 +102,25 @@ When enabled, Paseo installs provider hooks globally:
 - Codex hooks are written to `~/.codex/hooks.json` (or `CODEX_HOME/hooks.json` when that override is set). Codex supports a native `commandWindows`, so each Paseo hook includes both POSIX and Windows commands. Non-managed Codex hooks are trust-gated by Codex; users may see Codex's hook review prompt before the hook runs.
 - OpenCode gets a self-contained plugin at `$XDG_CONFIG_HOME/opencode/plugins/paseo-terminal-activity.js` (or `~/.config/opencode/plugins/paseo-terminal-activity.js` when XDG is unset; `OPENCODE_CONFIG_DIR` still wins when set).
 
-Installation is marker-based/idempotent for config hooks and exact-file/idempotent for the OpenCode plugin. Paseo preserves user hooks, removes only its own marker-matched command hooks, and leaves hooks installed across daemon shutdown. Outside a Paseo terminal they are inert because the command or plugin is gated on `PASEO_TERMINAL_ID`.
+Installation is marker-based/idempotent for config hooks and exact-file/idempotent for the OpenCode plugin. Encoded Windows commands are matched against the exact command Paseo generates because their marker is not visible. Paseo preserves user hooks, removes only its own command hooks, and leaves hooks installed across daemon shutdown. Outside a Paseo terminal they are inert because the command or plugin is gated on `PASEO_TERMINAL_ID`.
 
 Provider variation lives in `AGENT_HOOK_PROVIDERS`: provider id, installed events, config install metadata, and runtime event-to-activity resolution. The daemon calls `installRegisteredAgentHooks()` once; the CLI calls `resolveHookActivity(provider, event, input)`. Adding a provider should add one provider entry and register it in `AGENT_HOOK_PROVIDERS`, without editing the generic CLI command or daemon bootstrap.
 
-The installed hook command keeps the config portable and resolves the CLI at runtime:
+On macOS and Linux, the installed Claude hook resolves the CLI at runtime:
 
 ```sh
-[ -n "$PASEO_TERMINAL_ID" ] && "${PASEO_HOOK_CLI:-paseo}" hooks claude <event>
+if [ -n "$PASEO_TERMINAL_ID" ]; then "${PASEO_HOOK_CLI:-paseo}" hooks claude <event>; fi
 ```
 
-Codex also receives the Windows equivalent:
+On Windows, Claude's single command field invokes a UTF-16LE base64-encoded PowerShell script:
+
+```text
+powershell.exe -NoProfile -NonInteractive -EncodedCommand <base64>
+```
+
+The PowerShell script retains the terminal-id guard, CLI override, PATH fallback, and child exit code. It does not consume stdin before launching `paseo hooks`, so Claude's event JSON reaches the CLI unchanged.
+
+Codex also receives its Windows equivalent:
 
 ```bat
 if defined PASEO_TERMINAL_ID (if defined PASEO_HOOK_CLI ("%PASEO_HOOK_CLI%" hooks codex <event>) else (paseo hooks codex <event>))

--- a/packages/server/src/terminal/agent-hooks/agent-hook-installer.ts
+++ b/packages/server/src/terminal/agent-hooks/agent-hook-installer.ts
@@ -149,6 +149,26 @@ export function buildAgentHookWindowsCommand<TConfig>(
   return `if defined PASEO_TERMINAL_ID (if defined PASEO_HOOK_CLI ("%PASEO_HOOK_CLI%" ${hookArgs}) else (paseo ${hookArgs})) else (exit /b 0)`;
 }
 
+export function buildAgentHookWindowsPowerShellCommand<TConfig>(
+  provider: AgentHookProvider<TConfig>,
+  event: AgentHookEventDefinition,
+): string {
+  const hookArgs = `${powerShellString(provider.id)} ${powerShellString(event.event)}`;
+  const script = [
+    "if ([string]::IsNullOrEmpty($env:PASEO_TERMINAL_ID)) { exit 0 }",
+    "$cli = $env:PASEO_HOOK_CLI",
+    "if ([string]::IsNullOrEmpty($cli)) { $cli = 'paseo' }",
+    `& $cli 'hooks' ${hookArgs}`,
+    "$hookSucceeded = $?",
+    "$hookExitCode = $LASTEXITCODE",
+    "if ($hookSucceeded) { if ($null -ne $hookExitCode) { exit $hookExitCode }; exit 0 }",
+    "if ($null -ne $hookExitCode) { exit $hookExitCode }",
+    "exit 1",
+  ].join("\n");
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  return `powershell.exe -NoProfile -NonInteractive -EncodedCommand ${encoded}`;
+}
+
 function installAgentHookPluginFile(
   install: AgentHookPluginFileInstallStrategy,
   options: AgentHookInstallOptions,
@@ -244,4 +264,8 @@ function windowsToken(value: string): string {
     return value;
   }
   return `"${value.replaceAll('"', '\\"')}"`;
+}
+
+function powerShellString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
 }

--- a/packages/server/src/terminal/agent-hooks/claude/claude-settings.ts
+++ b/packages/server/src/terminal/agent-hooks/claude/claude-settings.ts
@@ -1,4 +1,8 @@
-import { type AgentHookConfigFormat, buildAgentHookShellCommand } from "../agent-hook-installer.js";
+import {
+  type AgentHookConfigFormat,
+  buildAgentHookShellCommand,
+  buildAgentHookWindowsPowerShellCommand,
+} from "../agent-hook-installer.js";
 
 interface ClaudeCommandHook {
   type?: unknown;
@@ -34,7 +38,12 @@ export const claudeSettingsFormat: AgentHookConfigFormat<ClaudeSettings> = {
     const install = provider.install;
     const hooks = normalizeHooks(config.hooks);
     for (const event of provider.events) {
-      const userEntries = removePaseoHooks(hooks[event.event], install.hookMarker);
+      const expectedCommand =
+        process.platform === "win32"
+          ? buildAgentHookWindowsPowerShellCommand(provider, event)
+          : undefined;
+      const userEntries = removePaseoHooks(hooks[event.event], install.hookMarker, expectedCommand);
+      const hookCommand = expectedCommand ?? buildAgentHookShellCommand(provider, event);
       hooks[event.event] = [
         ...userEntries,
         {
@@ -42,7 +51,7 @@ export const claudeSettingsFormat: AgentHookConfigFormat<ClaudeSettings> = {
           hooks: [
             {
               type: "command",
-              command: buildAgentHookShellCommand(provider, event),
+              command: hookCommand,
               timeout: 10,
             },
           ],
@@ -55,7 +64,11 @@ export const claudeSettingsFormat: AgentHookConfigFormat<ClaudeSettings> = {
     const install = provider.install;
     const hooks = normalizeHooks(config.hooks);
     for (const event of provider.events) {
-      const entries = removePaseoHooks(hooks[event.event], install.hookMarker);
+      const expectedCommand =
+        process.platform === "win32"
+          ? buildAgentHookWindowsPowerShellCommand(provider, event)
+          : undefined;
+      const entries = removePaseoHooks(hooks[event.event], install.hookMarker, expectedCommand);
       if (entries.length > 0) {
         hooks[event.event] = entries;
       } else {
@@ -69,9 +82,13 @@ export const claudeSettingsFormat: AgentHookConfigFormat<ClaudeSettings> = {
     const hooks = normalizeHooks(config.hooks);
     return provider.events.every((event) =>
       normalizeMatchers(hooks[event.event]).some((entry) =>
-        normalizeCommandHooks(entry.hooks).some((hook) =>
-          commandContainsMarker(hook, install.hookMarker),
-        ),
+        normalizeCommandHooks(entry.hooks).some((hook) => {
+          const expectedCommand =
+            process.platform === "win32"
+              ? buildAgentHookWindowsPowerShellCommand(provider, event)
+              : undefined;
+          return commandContainsMarker(hook, install.hookMarker, expectedCommand);
+        }),
       ),
     );
   },
@@ -95,11 +112,15 @@ function normalizeCommandHooks(value: unknown): ClaudeCommandHook[] {
   return value.filter(isRecord);
 }
 
-function removePaseoHooks(value: unknown, marker: string): ClaudeHookMatcher[] {
+function removePaseoHooks(
+  value: unknown,
+  marker: string,
+  expectedCommand: string | undefined,
+): ClaudeHookMatcher[] {
   const entries: ClaudeHookMatcher[] = [];
   for (const entry of normalizeMatchers(value)) {
     const hooks = normalizeCommandHooks(entry.hooks).filter(
-      (hook) => !commandContainsMarker(hook, marker),
+      (hook) => !commandContainsMarker(hook, marker, expectedCommand),
     );
     if (hooks.length > 0) {
       entries.push(Object.assign({}, entry, { hooks }));
@@ -108,8 +129,15 @@ function removePaseoHooks(value: unknown, marker: string): ClaudeHookMatcher[] {
   return entries;
 }
 
-function commandContainsMarker(hook: ClaudeCommandHook, marker: string): boolean {
-  return typeof hook.command === "string" && hook.command.includes(marker);
+function commandContainsMarker(
+  hook: ClaudeCommandHook,
+  marker: string,
+  expectedCommand: string | undefined,
+): boolean {
+  if (typeof hook.command !== "string") {
+    return false;
+  }
+  return hook.command.includes(marker) || hook.command === expectedCommand;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/server/src/terminal/agent-hooks/claude/claude-settings.ts
+++ b/packages/server/src/terminal/agent-hooks/claude/claude-settings.ts
@@ -1,5 +1,7 @@
 import {
   type AgentHookConfigFormat,
+  type AgentHookEventDefinition,
+  type AgentHookProvider,
   buildAgentHookShellCommand,
   buildAgentHookWindowsPowerShellCommand,
 } from "../agent-hook-installer.js";
@@ -38,12 +40,8 @@ export const claudeSettingsFormat: AgentHookConfigFormat<ClaudeSettings> = {
     const install = provider.install;
     const hooks = normalizeHooks(config.hooks);
     for (const event of provider.events) {
-      const expectedCommand =
-        process.platform === "win32"
-          ? buildAgentHookWindowsPowerShellCommand(provider, event)
-          : undefined;
+      const expectedCommand = buildClaudeHookCommand(provider, event);
       const userEntries = removePaseoHooks(hooks[event.event], install.hookMarker, expectedCommand);
-      const hookCommand = expectedCommand ?? buildAgentHookShellCommand(provider, event);
       hooks[event.event] = [
         ...userEntries,
         {
@@ -51,7 +49,7 @@ export const claudeSettingsFormat: AgentHookConfigFormat<ClaudeSettings> = {
           hooks: [
             {
               type: "command",
-              command: hookCommand,
+              command: expectedCommand,
               timeout: 10,
             },
           ],
@@ -64,10 +62,7 @@ export const claudeSettingsFormat: AgentHookConfigFormat<ClaudeSettings> = {
     const install = provider.install;
     const hooks = normalizeHooks(config.hooks);
     for (const event of provider.events) {
-      const expectedCommand =
-        process.platform === "win32"
-          ? buildAgentHookWindowsPowerShellCommand(provider, event)
-          : undefined;
+      const expectedCommand = buildClaudeHookCommand(provider, event);
       const entries = removePaseoHooks(hooks[event.event], install.hookMarker, expectedCommand);
       if (entries.length > 0) {
         hooks[event.event] = entries;
@@ -80,19 +75,25 @@ export const claudeSettingsFormat: AgentHookConfigFormat<ClaudeSettings> = {
   isInstalled(config, provider) {
     const install = provider.install;
     const hooks = normalizeHooks(config.hooks);
-    return provider.events.every((event) =>
-      normalizeMatchers(hooks[event.event]).some((entry) =>
-        normalizeCommandHooks(entry.hooks).some((hook) => {
-          const expectedCommand =
-            process.platform === "win32"
-              ? buildAgentHookWindowsPowerShellCommand(provider, event)
-              : undefined;
-          return commandContainsMarker(hook, install.hookMarker, expectedCommand);
-        }),
-      ),
-    );
+    return provider.events.every((event) => {
+      const expectedCommand = buildClaudeHookCommand(provider, event);
+      return normalizeMatchers(hooks[event.event]).some((entry) =>
+        normalizeCommandHooks(entry.hooks).some((hook) =>
+          commandContainsMarker(hook, install.hookMarker, expectedCommand),
+        ),
+      );
+    });
   },
 };
+
+function buildClaudeHookCommand(
+  provider: AgentHookProvider<ClaudeSettings>,
+  event: AgentHookEventDefinition,
+): string {
+  return process.platform === "win32"
+    ? buildAgentHookWindowsPowerShellCommand(provider, event)
+    : buildAgentHookShellCommand(provider, event);
+}
 
 function normalizeHooks(value: unknown): Record<string, unknown> {
   return isRecord(value) ? { ...value } : {};
@@ -115,7 +116,7 @@ function normalizeCommandHooks(value: unknown): ClaudeCommandHook[] {
 function removePaseoHooks(
   value: unknown,
   marker: string,
-  expectedCommand: string | undefined,
+  expectedCommand: string,
 ): ClaudeHookMatcher[] {
   const entries: ClaudeHookMatcher[] = [];
   for (const entry of normalizeMatchers(value)) {
@@ -132,7 +133,7 @@ function removePaseoHooks(
 function commandContainsMarker(
   hook: ClaudeCommandHook,
   marker: string,
-  expectedCommand: string | undefined,
+  expectedCommand: string,
 ): boolean {
   if (typeof hook.command !== "string") {
     return false;

--- a/packages/server/src/terminal/agent-hooks/claude/claude.test.ts
+++ b/packages/server/src/terminal/agent-hooks/claude/claude.test.ts
@@ -88,6 +88,24 @@ function installedClaudeHookCommand(event: string): string {
   return commands[0]!;
 }
 
+function claudeEvent(eventName: string) {
+  const definition = AGENT_HOOK_PROVIDERS.claude.events.find(
+    ({ event: candidate }) => candidate === eventName,
+  );
+  if (!definition) {
+    throw new Error(`Claude provider is missing the ${eventName} event`);
+  }
+  return definition;
+}
+
+function hookMatchers(settings: TestClaudeSettings, event: string): unknown[] {
+  const matchers = settings.hooks?.[event];
+  if (!Array.isArray(matchers)) {
+    throw new Error(`Claude settings are missing hooks for ${event}`);
+  }
+  return matchers;
+}
+
 describe("Claude terminal agent hooks", () => {
   it("installs registered provider hooks idempotently", () => {
     const configDir = createTempDir("paseo-claude-config-");
@@ -98,19 +116,43 @@ describe("Claude terminal agent hooks", () => {
 
     const settings = readSettings(configDir);
     for (const event of provider.events) {
-      const expectedCommand = isPlatform("win32")
-        ? buildAgentHookWindowsPowerShellCommand(provider, event)
-        : buildAgentHookShellCommand(provider, event);
-      expect(hookCommands(settings, event.event)).toEqual([expectedCommand]);
+      expect(hookCommands(settings, event.event)).toHaveLength(1);
     }
     expect(firstInstall.every((result) => result.changed)).toBe(true);
     expect(secondInstall.every((result) => !result.changed)).toBe(true);
     expect(registeredAgentHooksAreInstalled({ configDir })).toBe(true);
   });
 
+  it.skipIf(isPlatform("win32"))("installs POSIX hook commands on macOS and Linux", () => {
+    const configDir = createTempDir("paseo-claude-posix-command-");
+    const provider = AGENT_HOOK_PROVIDERS.claude;
+
+    installRegisteredAgentHooks({ configDir });
+
+    const settings = readSettings(configDir);
+    for (const event of provider.events) {
+      expect(hookCommands(settings, event.event)).toEqual([
+        buildAgentHookShellCommand(provider, event),
+      ]);
+    }
+  });
+
+  it.skipIf(!isPlatform("win32"))("installs PowerShell hook commands on Windows", () => {
+    const configDir = createTempDir("paseo-claude-windows-command-");
+    const provider = AGENT_HOOK_PROVIDERS.claude;
+
+    installRegisteredAgentHooks({ configDir });
+
+    const settings = readSettings(configDir);
+    for (const event of provider.events) {
+      expect(hookCommands(settings, event.event)).toEqual([
+        buildAgentHookWindowsPowerShellCommand(provider, event),
+      ]);
+    }
+  });
+
   it("preserves unrelated user hooks", () => {
     const configDir = createTempDir("paseo-claude-config-preserve-");
-    const provider = AGENT_HOOK_PROVIDERS.claude;
     writeFileSync(
       join(configDir, "settings.json"),
       `${JSON.stringify(
@@ -134,25 +176,21 @@ describe("Claude terminal agent hooks", () => {
 
     const settings = readSettings(configDir);
     expect(settings.theme).toBe("dark");
-    const stopEvent = provider.events.find((event) => event.event === "Stop");
-    if (!stopEvent) throw new Error("Claude provider is missing the Stop event");
-    const expectedCommand = isPlatform("win32")
-      ? buildAgentHookWindowsPowerShellCommand(provider, stopEvent)
-      : buildAgentHookShellCommand(provider, stopEvent);
-    expect(hookCommands(settings, "Stop")).toEqual(["say done", expectedCommand]);
+    const commands = hookCommands(settings, "Stop");
+    expect(commands).toHaveLength(2);
+    expect(commands[0]).toBe("say done");
   });
 
   it("uninstalls current and legacy Paseo hooks while preserving user hooks", () => {
     const configDir = createTempDir("paseo-claude-config-uninstall-");
     installRegisteredAgentHooks({ configDir });
     const provider = AGENT_HOOK_PROVIDERS.claude;
-    const stopEvent = provider.events.find((event) => event.event === "Stop");
-    if (!stopEvent) throw new Error("Claude provider is missing the Stop event");
+    const stopEvent = claudeEvent("Stop");
     const settings = readSettings(configDir);
     settings.hooks = {
       ...settings.hooks,
       Stop: [
-        ...(Array.isArray(settings.hooks?.Stop) ? settings.hooks.Stop : []),
+        ...hookMatchers(settings, "Stop"),
         {
           matcher: "",
           hooks: [{ type: "command", command: buildAgentHookShellCommand(provider, stopEvent) }],
@@ -319,8 +357,7 @@ describe("Claude terminal agent hooks", () => {
       writeFileSync(paseoCmd, '@echo off\r\necho %* > "%PASEO_HOOK_TEST_MARKER%"\r\nexit /b 0\r\n');
       const command = installedClaudeHookCommand("UserPromptSubmit");
 
-      const existingPath = process.env.PATH ?? "";
-      const path = existingPath.length > 0 ? [binDir, existingPath].join(delimiter) : binDir;
+      const path = [binDir, process.env.PATH ?? process.env.Path].filter(Boolean).join(delimiter);
 
       const result = runWindowsHook(command, {
         PASEO_TERMINAL_ID: "test-terminal",

--- a/packages/server/src/terminal/agent-hooks/claude/claude.test.ts
+++ b/packages/server/src/terminal/agent-hooks/claude/claude.test.ts
@@ -1,11 +1,14 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { isPlatform } from "../../../test-utils/platform.js";
 import { buildTerminalEnvironment } from "../../terminal.js";
-import { buildAgentHookShellCommand } from "../agent-hook-installer.js";
+import {
+  buildAgentHookShellCommand,
+  buildAgentHookWindowsPowerShellCommand,
+} from "../agent-hook-installer.js";
 import {
   AGENT_HOOK_PROVIDERS,
   installRegisteredAgentHooks,
@@ -64,30 +67,50 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function runWindowsHook(command: string, env: NodeJS.ProcessEnv, input?: string) {
+  const parts = command.split(" ");
+  return spawnSync(parts[0]!, parts.slice(1), {
+    env,
+    encoding: "utf8",
+    input,
+    timeout: 10_000,
+    windowsHide: true,
+  });
+}
+
+function installedClaudeHookCommand(event: string): string {
+  const configDir = createTempDir("paseo-claude-installed-hook-");
+  installRegisteredAgentHooks({ configDir });
+  const commands = hookCommands(readSettings(configDir), event);
+  if (commands.length !== 1) {
+    throw new Error(`Expected one installed Claude hook for ${event}, got ${commands.length}`);
+  }
+  return commands[0]!;
+}
+
 describe("Claude terminal agent hooks", () => {
   it("installs registered provider hooks idempotently", () => {
     const configDir = createTempDir("paseo-claude-config-");
     const provider = AGENT_HOOK_PROVIDERS.claude;
-    const install = provider.install;
 
-    installRegisteredAgentHooks({ configDir });
-    installRegisteredAgentHooks({ configDir });
+    const firstInstall = installRegisteredAgentHooks({ configDir });
+    const secondInstall = installRegisteredAgentHooks({ configDir });
 
     const settings = readSettings(configDir);
     for (const event of provider.events) {
-      const paseoCommands = hookCommands(settings, event.event).filter((command) =>
-        command.includes(install.hookMarker),
-      );
-      expect(paseoCommands).toHaveLength(1);
-      expect(paseoCommands[0]).toBe(
-        `if [ -n "$PASEO_TERMINAL_ID" ]; then "\${PASEO_HOOK_CLI:-paseo}" hooks ${provider.id} ${event.event}; fi`,
-      );
+      const expectedCommand = isPlatform("win32")
+        ? buildAgentHookWindowsPowerShellCommand(provider, event)
+        : buildAgentHookShellCommand(provider, event);
+      expect(hookCommands(settings, event.event)).toEqual([expectedCommand]);
     }
+    expect(firstInstall.every((result) => result.changed)).toBe(true);
+    expect(secondInstall.every((result) => !result.changed)).toBe(true);
     expect(registeredAgentHooksAreInstalled({ configDir })).toBe(true);
   });
 
   it("preserves unrelated user hooks", () => {
     const configDir = createTempDir("paseo-claude-config-preserve-");
+    const provider = AGENT_HOOK_PROVIDERS.claude;
     writeFileSync(
       join(configDir, "settings.json"),
       `${JSON.stringify(
@@ -111,20 +134,29 @@ describe("Claude terminal agent hooks", () => {
 
     const settings = readSettings(configDir);
     expect(settings.theme).toBe("dark");
-    expect(hookCommands(settings, "Stop")).toContain("say done");
-    expect(
-      hookCommands(settings, "Stop").some((command) => command.includes("hooks claude Stop")),
-    ).toBe(true);
+    const stopEvent = provider.events.find((event) => event.event === "Stop");
+    if (!stopEvent) throw new Error("Claude provider is missing the Stop event");
+    const expectedCommand = isPlatform("win32")
+      ? buildAgentHookWindowsPowerShellCommand(provider, stopEvent)
+      : buildAgentHookShellCommand(provider, stopEvent);
+    expect(hookCommands(settings, "Stop")).toEqual(["say done", expectedCommand]);
   });
 
-  it("uninstalls only marker-matched hooks", () => {
+  it("uninstalls current and legacy Paseo hooks while preserving user hooks", () => {
     const configDir = createTempDir("paseo-claude-config-uninstall-");
     installRegisteredAgentHooks({ configDir });
+    const provider = AGENT_HOOK_PROVIDERS.claude;
+    const stopEvent = provider.events.find((event) => event.event === "Stop");
+    if (!stopEvent) throw new Error("Claude provider is missing the Stop event");
     const settings = readSettings(configDir);
     settings.hooks = {
       ...settings.hooks,
       Stop: [
         ...(Array.isArray(settings.hooks?.Stop) ? settings.hooks.Stop : []),
+        {
+          matcher: "",
+          hooks: [{ type: "command", command: buildAgentHookShellCommand(provider, stopEvent) }],
+        },
         {
           matcher: "",
           hooks: [{ type: "command", command: "say still-here", timeout: 5 }],
@@ -149,6 +181,27 @@ describe("Claude terminal agent hooks", () => {
     );
   });
 
+  it("builds a UTF-16LE encoded Windows PowerShell command", () => {
+    const provider = AGENT_HOOK_PROVIDERS.claude;
+    const command = buildAgentHookWindowsPowerShellCommand(provider, provider.events[0]);
+    const prefix = "powershell.exe -NoProfile -NonInteractive -EncodedCommand ";
+
+    expect(command.startsWith(prefix)).toBe(true);
+    expect(Buffer.from(command.slice(prefix.length), "base64").toString("utf16le")).toBe(
+      [
+        "if ([string]::IsNullOrEmpty($env:PASEO_TERMINAL_ID)) { exit 0 }",
+        "$cli = $env:PASEO_HOOK_CLI",
+        "if ([string]::IsNullOrEmpty($cli)) { $cli = 'paseo' }",
+        "& $cli 'hooks' 'claude' 'UserPromptSubmit'",
+        "$hookSucceeded = $?",
+        "$hookExitCode = $LASTEXITCODE",
+        "if ($hookSucceeded) { if ($null -ne $hookExitCode) { exit $hookExitCode }; exit 0 }",
+        "if ($null -ne $hookExitCode) { exit $hookExitCode }",
+        "exit 1",
+      ].join("\n"),
+    );
+  });
+
   it.skipIf(isPlatform("win32")).each(AGENT_HOOK_PROVIDERS.claude.events)(
     "$event hook command exits 0 when PASEO_TERMINAL_ID is unset",
     (event) => {
@@ -163,6 +216,160 @@ describe("Claude terminal agent hooks", () => {
       expect(result.status).toBe(0);
     },
   );
+
+  describe.skipIf(!isPlatform("win32"))("Windows PowerShell hook commands", () => {
+    it.each(AGENT_HOOK_PROVIDERS.claude.events)(
+      "exits 0 when PASEO_TERMINAL_ID is unset for $event",
+      (event) => {
+        const command = installedClaudeHookCommand(event.event);
+
+        const result = runWindowsHook(command, { PATH: process.env.PATH ?? "" });
+
+        expect(result.status).toBe(0);
+      },
+    );
+
+    it("does not invoke PASEO_HOOK_CLI when PASEO_TERMINAL_ID is unset", () => {
+      const binDir = createTempDir("paseo-claude-win-guard-");
+      const hookCli = join(binDir, "paseo-fail.cmd");
+      const marker = join(binDir, "marker.txt");
+      writeFileSync(hookCli, '@echo off\r\necho %* > "%PASEO_HOOK_TEST_MARKER%"\r\nexit /b 1\r\n');
+      const command = installedClaudeHookCommand("UserPromptSubmit");
+
+      const result = runWindowsHook(command, {
+        PASEO_HOOK_CLI: hookCli,
+        PASEO_HOOK_TEST_MARKER: marker,
+        PATH: process.env.PATH ?? process.env.Path ?? "",
+      });
+
+      expect(result.status).toBe(0);
+      expect(existsSync(marker)).toBe(false);
+    });
+
+    it("runs the configured PASEO_HOOK_CLI when it contains spaces", () => {
+      const binDir = createTempDir("paseo-claude-win-cli-");
+      const spacedDir = join(binDir, "path with spaces");
+      mkdirSync(spacedDir);
+      const hookCli = join(spacedDir, "paseo with spaces.cmd");
+      const marker = join(binDir, "marker.txt");
+      writeFileSync(hookCli, '@echo off\r\necho %* > "%PASEO_HOOK_TEST_MARKER%"\r\nexit /b 0\r\n');
+      const command = installedClaudeHookCommand("UserPromptSubmit");
+
+      const result = runWindowsHook(command, {
+        PASEO_TERMINAL_ID: "test-terminal",
+        PASEO_HOOK_CLI: hookCli,
+        PASEO_HOOK_TEST_MARKER: marker,
+        PATHEXT: process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+        PATH: process.env.PATH ?? process.env.Path ?? "",
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(marker, "utf8").trim()).toBe("hooks claude UserPromptSubmit");
+    });
+
+    it("propagates a configured command shim's nonzero exit code", () => {
+      const binDir = createTempDir("paseo-claude-win-exit-");
+      const hookCli = join(binDir, "paseo-exit.cmd");
+      const marker = join(binDir, "marker.txt");
+      writeFileSync(hookCli, '@echo off\r\necho %* > "%PASEO_HOOK_TEST_MARKER%"\r\nexit /b 7\r\n');
+      const command = installedClaudeHookCommand("Stop");
+
+      const result = runWindowsHook(command, {
+        PASEO_TERMINAL_ID: "test-terminal",
+        PASEO_HOOK_CLI: hookCli,
+        PASEO_HOOK_TEST_MARKER: marker,
+        PATHEXT: process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+        PATH: process.env.PATH ?? process.env.Path ?? "",
+      });
+
+      expect(result.status).toBe(7);
+      expect(readFileSync(marker, "utf8").trim()).toBe("hooks claude Stop");
+    });
+
+    it("propagates a native executable's nonzero exit code", () => {
+      const hookCli = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "find.exe");
+      expect(existsSync(hookCli)).toBe(true);
+      const command = installedClaudeHookCommand("Stop");
+
+      const result = runWindowsHook(command, {
+        ...process.env,
+        PASEO_TERMINAL_ID: "test-terminal",
+        PASEO_HOOK_CLI: hookCli,
+      });
+
+      expect(result.status).toBe(2);
+    });
+
+    it("exits 1 when the configured hook CLI cannot be resolved", () => {
+      const command = installedClaudeHookCommand("StopFailure");
+
+      const result = runWindowsHook(command, {
+        PASEO_TERMINAL_ID: "test-terminal",
+        PASEO_HOOK_CLI: "paseo-hook-cli-that-does-not-exist",
+        PATH: process.env.PATH ?? process.env.Path ?? "",
+      });
+
+      expect(result.status).toBe(1);
+    });
+
+    it("falls back to paseo on PATH when PASEO_HOOK_CLI is unset", () => {
+      const binDir = createTempDir("paseo-claude-win-path-");
+      const paseoCmd = join(binDir, "paseo.cmd");
+      const marker = join(binDir, "marker.txt");
+      writeFileSync(paseoCmd, '@echo off\r\necho %* > "%PASEO_HOOK_TEST_MARKER%"\r\nexit /b 0\r\n');
+      const command = installedClaudeHookCommand("UserPromptSubmit");
+
+      const existingPath = process.env.PATH ?? "";
+      const path = existingPath.length > 0 ? [binDir, existingPath].join(delimiter) : binDir;
+
+      const result = runWindowsHook(command, {
+        PASEO_TERMINAL_ID: "test-terminal",
+        PASEO_HOOK_TEST_MARKER: marker,
+        PATHEXT: process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+        PATH: path,
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(marker, "utf8").trim()).toBe("hooks claude UserPromptSubmit");
+    });
+
+    it("forwards stdin JSON to the configured CLI for Notification", () => {
+      const binDir = createTempDir("paseo-claude-win-stdin-");
+      const hookCli = join(binDir, "paseo-stdin.cmd");
+      const captureScript = join(binDir, "capture.cjs");
+      const argsPath = join(binDir, "args.txt");
+      const stdinPath = join(binDir, "stdin.txt");
+      const payload = `${JSON.stringify({ message: "ação", notification_type: "idle_prompt" })}\n`;
+      writeFileSync(
+        captureScript,
+        'const { readFileSync, writeFileSync } = require("node:fs"); writeFileSync(process.env.PASEO_HOOK_STDIN, readFileSync(0)); writeFileSync(process.env.PASEO_HOOK_ARGS, process.argv.slice(2).join(" "));',
+      );
+      writeFileSync(
+        hookCli,
+        '@echo off\r\n"%PASEO_HOOK_TEST_NODE%" "%PASEO_HOOK_CAPTURE_SCRIPT%" %*\r\nexit /b %ERRORLEVEL%\r\n',
+      );
+      const command = installedClaudeHookCommand("Notification");
+
+      const result = runWindowsHook(
+        command,
+        {
+          PASEO_TERMINAL_ID: "test-terminal",
+          PASEO_HOOK_CLI: hookCli,
+          PASEO_HOOK_ARGS: argsPath,
+          PASEO_HOOK_CAPTURE_SCRIPT: captureScript,
+          PASEO_HOOK_STDIN: stdinPath,
+          PASEO_HOOK_TEST_NODE: process.execPath,
+          PATHEXT: process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+          PATH: process.env.PATH ?? process.env.Path ?? "",
+        },
+        payload,
+      );
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(argsPath, "utf8")).toBe("hooks claude Notification");
+      expect(readFileSync(stdinPath)).toEqual(Buffer.from(payload));
+    });
+  });
 
   it("keeps provider names out of the generic server bootstrap", () => {
     const source = readFileSync(


### PR DESCRIPTION
### Linked issue

Fixes #4554

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Claude stores one shell-form `command` per hook. Paseo wrote the POSIX command on every platform, so native Windows Claude installations that select PowerShell fail while parsing `[ -n ... ]` before the terminal guard can run.

Windows now gets `powershell.exe -NoProfile -NonInteractive -EncodedCommand <base64>` with a UTF-16LE payload. Encoding avoids nested quoting and shell-tokenization problems. The wrapper preserves the terminal guard, CLI override, PATH fallback, child exit status, and inherited stdin. macOS and Linux keep the existing POSIX command.

The encoded command is opaque, so install detection and uninstall compare it with the exact command Paseo generates while retaining marker matching for legacy POSIX hooks.

### Goals

- Make all generated Claude hooks executable through Windows PowerShell.
- Preserve `PASEO_TERMINAL_ID`, `PASEO_HOOK_CLI`, PATH fallback, exit-code, and stdin behavior.
- Keep install and uninstall idempotent without removing unrelated user hooks.
- Keep existing macOS/Linux behavior unchanged.

### Non-goals

- Changing Codex hook behavior or taking ownership of #3877.
- Adding generalized hook versioning.
- Changing Claude event handling or activity mapping.

#3877 remains open and changes the analogous Codex Windows helper. This PR leaves Codex untouched and remains independently reviewable. If #3877 lands first, this branch can be rebased to reuse its encoded PowerShell helper.

### QA

Windows 11 with Windows PowerShell 5.1:

- Reproduced the old command under PowerShell: exit `1` with `ParserError`.
- Executed the command read back from an isolated generated Claude settings file.
- Verified all five no-terminal guards exit `0`, and the guarded CLI is not invoked.
- Verified a space-containing `.cmd` path, `paseo.cmd` PATH fallback, `.cmd` exit `7`, native executable exit `2`, unresolved-command exit `1`, exact arguments, and byte-preserving Notification stdin forwarding.
- Verified repeat install, legacy-hook cleanup, exact encoded-hook detection, safe uninstall, and unrelated-hook preservation.

```text
cd packages/server
npx vitest run src/terminal/agent-hooks/claude/claude.test.ts src/terminal/agent-hooks/codex/codex.test.ts src/terminal/agent-hooks/terminal-agent-hook-setting.test.ts --bail=1
# 3 files passed; 31 tests passed; 5 POSIX-only tests skipped on Windows

npm run typecheck --workspace=@getpaseo/server
# passed

npm run build:server
npm run typecheck
# passed

npm run lint -- docs/terminal-activity.md packages/server/src/terminal/agent-hooks/agent-hook-installer.ts packages/server/src/terminal/agent-hooks/claude/claude-settings.ts packages/server/src/terminal/agent-hooks/claude/claude.test.ts
# 0 warnings, 0 errors

npm run format:check:files -- docs/terminal-activity.md packages/server/src/terminal/agent-hooks/agent-hook-installer.ts packages/server/src/terminal/agent-hooks/claude/claude-settings.ts packages/server/src/terminal/agent-hooks/claude/claude.test.ts
# passed
```

Claude Code CLI was not installed in this environment, so an actual Claude session was not run. macOS/Linux runtime QA was not run locally; the POSIX generator is unchanged and its exact command remains covered.

### Checklist

- [x] Plugin changes follow the SDK import boundaries (not applicable; no plugin changes)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes for the changed source files
- [x] Changed files pass the repository formatter and formatting check
- [x] QA evidence
- [x] Tests added or updated where it made sense
