### PR TITLE
docs(hub): document configurable startup timeout

### DIFF
--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -188,20 +188,21 @@ An environment or dynamic named-agent expression must have a finite set of possi
 
 ### Steps
 
-| Field           | Required | Notes                                                                                    |
-| --------------- | -------- | ---------------------------------------------------------------------------------------- |
-| `id`            | yes      | Unique within the workflow.                                                              |
-| `environment`   | yes      | Literal environment name or finite expression resolving to one.                          |
-| `max_runtime`   | yes      | Step hard limit.                                                                         |
-| `idle_timeout`  | yes      | Idle limit no longer than `max_runtime`.                                                 |
-| `agent`         | yes      | Named agent, finite expression selecting a named agent, or complete static inline agent. |
-| `prompt`        | yes      | Ordered `text` and `include` blocks.                                                     |
-| `if`            | no       | Expression deciding whether the step runs.                                               |
-| `env`           | no       | Environment variables from connection values.                                            |
-| `output.schema` | no       | JSON Schema for structured step output.                                                  |
-| `allow_outputs` | no       | Provider output capabilities with optional `max` and `required`.                         |
-| `auto_archive`  | no       | Archive the agent after the step ends.                                                   |
-| `github`        | no       | Explicit GitHub authority for this step.                                                 |
+| Field             | Required | Notes                                                                                                         |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
+| `id`              | yes      | Unique within the workflow.                                                                                   |
+| `environment`     | yes      | Literal environment name or finite expression resolving to one.                                               |
+| `max_runtime`     | yes      | Step hard limit.                                                                                              |
+| `idle_timeout`    | yes      | Idle limit no longer than `max_runtime`.                                                                      |
+| `startup_timeout` | no       | How long Hub waits for startup; defaults to `2m`. Positive duration up to `24h`, capped by remaining runtime. |
+| `agent`           | yes      | Named agent, finite expression selecting a named agent, or complete static inline agent.                      |
+| `prompt`          | yes      | Ordered `text` and `include` blocks.                                                                          |
+| `if`              | no       | Expression deciding whether the step runs.                                                                    |
+| `env`             | no       | Environment variables from connection values.                                                                 |
+| `output.schema`   | no       | JSON Schema for structured step output.                                                                       |
+| `allow_outputs`   | no       | Provider output capabilities with optional `max` and `required`.                                              |
+| `auto_archive`    | no       | Archive the agent after the step ends.                                                                        |
+| `github`          | no       | Explicit GitHub authority for this step.                                                                      |
 
 An inline agent is static and complete:
 

--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -188,21 +188,21 @@ An environment or dynamic named-agent expression must have a finite set of possi
 
 ### Steps
 
-| Field             | Required | Notes                                                                                                         |
-| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| `id`              | yes      | Unique within the workflow.                                                                                   |
-| `environment`     | yes      | Literal environment name or finite expression resolving to one.                                               |
-| `max_runtime`     | yes      | Step hard limit.                                                                                              |
-| `idle_timeout`    | yes      | Idle limit no longer than `max_runtime`.                                                                      |
-| `startup_timeout` | no       | How long Hub waits for startup; defaults to `2m`. Positive duration up to `24h`, capped by remaining runtime. |
-| `agent`           | yes      | Named agent, finite expression selecting a named agent, or complete static inline agent.                      |
-| `prompt`          | yes      | Ordered `text` and `include` blocks.                                                                          |
-| `if`              | no       | Expression deciding whether the step runs.                                                                    |
-| `env`             | no       | Environment variables from connection values.                                                                 |
-| `output.schema`   | no       | JSON Schema for structured step output.                                                                       |
-| `allow_outputs`   | no       | Provider output capabilities with optional `max` and `required`.                                              |
-| `auto_archive`    | no       | Archive the agent after the step ends.                                                                        |
-| `github`          | no       | Explicit GitHub authority for this step.                                                                      |
+| Field             | Required | Notes                                                                                                                |
+| ----------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `id`              | yes      | Unique within the workflow.                                                                                          |
+| `environment`     | yes      | Literal environment name or finite expression resolving to one.                                                      |
+| `max_runtime`     | yes      | Step hard limit.                                                                                                     |
+| `idle_timeout`    | yes      | Idle limit no longer than `max_runtime`.                                                                             |
+| `startup_timeout` | no       | Step startup waiting budget. See [startup timeout](/docs/hub/configuration#startup-timeout) for defaults and limits. |
+| `agent`           | yes      | Named agent, finite expression selecting a named agent, or complete static inline agent.                             |
+| `prompt`          | yes      | Ordered `text` and `include` blocks.                                                                                 |
+| `if`              | no       | Expression deciding whether the step runs.                                                                           |
+| `env`             | no       | Environment variables from connection values.                                                                        |
+| `output.schema`   | no       | JSON Schema for structured step output.                                                                              |
+| `allow_outputs`   | no       | Provider output capabilities with optional `max` and `required`.                                                     |
+| `auto_archive`    | no       | Archive the agent after the step ends.                                                                               |
+| `github`          | no       | Explicit GitHub authority for this step.                                                                             |
 
 An inline agent is static and complete:
 

--- a/public-docs/hub/configuration/index.md
+++ b/public-docs/hub/configuration/index.md
@@ -64,6 +64,23 @@ A Discord starter uses `discord.mention`, your Discord user ID, and `discord.rep
 
 Setup asks before replacing the selected trigger file. It preserves other triggers and any existing legacy bundle. Read [Hub security](/docs/hub/security) before widening `from_users` or the agent's authority.
 
+## Startup timeout
+
+Hub waits up to **two minutes** for agent startup, including worktree creation, provider startup, and initial prompt acceptance. For a slower machine, set `run.startup_timeout` in the trigger YAML:
+
+```yaml
+name: inspect
+on:
+  manual.run: {}
+run:
+  target: { daemon: devbox, cwd: /workspace/project }
+  agent: { provider: codex, mode: full-access }
+  startup_timeout: 5m
+  prompt: Inspect this repository and summarize its current state.
+```
+
+Use a positive duration in `ms`, `s`, `m`, or `h`, up to `24h`. Omitting the field uses `2m`. The existing `max_runtime` and `idle_timeout` limits still apply during startup and can expire sooner. This setting changes Hub's waiting budget; provider-specific timeouts remain in effect.
+
 ## Deploy from the CLI
 
 Run from the repository root:


### PR DESCRIPTION
Document Hub's two-minute default startup wait and the optional `run.startup_timeout` setting, with a complete YAML example and the workflow-step reference field.

Documentation only; no daemon, CLI, or protocol changes. Implements the public documentation for [Hub #130](https://github.com/getpaseo/hub/pull/130).

Validation: the example compiles against the Hub change with a five-minute startup budget; repository typecheck, lint, and formatting passed. Website build passed.
