### PR TITLE
Document scoped credentials during Hub continuation

### DIFF
--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -271,7 +271,11 @@ Keys use the existing expression syntax and must resolve to a non-empty string o
 
 An existing session keeps its daemon, agent configuration, target, environment, and tool contracts. Changing those settings for the same key fails with an explanation; choose a different key or **New agent**. Prompts and output destinations belong to each arrival and may change. A worktree branch is chosen when the session is first created and reused on later arrivals.
 
-Triggers that mint temporary environment credentials, including a `run.github` grant or a connection token in `run.env`, must choose **New agent** when the event has a conversation or uses a custom key. These credentials expire with the execution, and an existing agent's environment cannot be refreshed. Hub-managed reply tools remain available with continuation.
+An arrival while the agent is working steers that agent. It does not extend the active work's original hard runtime deadline. Each arrival keeps its own output destination and completion contract.
+
+Triggers with a `run.github` grant or a connection token in `run.env` can continue an active agent. They keep the existing credentials and their original expiry; steering does not refresh the agent's environment or renew a token. Finishing one request leaves leased credentials available to other active requests sharing that agent. Hub revokes them when all those requests finish, while any configured credential expiry still applies during the work.
+
+After all requests in a session with temporary credentials finish, the next arrival for the same conversation or key starts a fresh agent with newly materialized credentials. Sessions without temporary environment credentials can reuse or restore their agent after completion.
 
 ### Upgrading
 

--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -271,7 +271,7 @@ Keys use the existing expression syntax and must resolve to a non-empty string o
 
 An existing session keeps its daemon, agent configuration, target, environment, and tool contracts. Changing those settings for the same key fails with an explanation; choose a different key or **New agent**. Prompts and output destinations belong to each arrival and may change. A worktree branch is chosen when the session is first created and reused on later arrivals.
 
-A follow-up steers the active agent without extending its runtime deadline or credential expiry. With a `run.github` grant or connection token in `run.env`, follow-ups share the active agent’s credentials. Once all requests finish, the next arrival starts a new agent with fresh credentials. Agents without temporary credentials can be reused after completion.
+A follow-up steers the active agent without extending its runtime deadline or credential expiry. With a `run.github` grant or connection token in `run.env`, follow-ups share the active agent’s credentials. Once all requests finish, Hub revokes leased tokens; the next arrival starts a new agent with fresh credentials. Agents without temporary credentials can be reused after completion.
 
 ### Upgrading
 

--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -271,11 +271,7 @@ Keys use the existing expression syntax and must resolve to a non-empty string o
 
 An existing session keeps its daemon, agent configuration, target, environment, and tool contracts. Changing those settings for the same key fails with an explanation; choose a different key or **New agent**. Prompts and output destinations belong to each arrival and may change. A worktree branch is chosen when the session is first created and reused on later arrivals.
 
-An arrival while the agent is working steers that agent. It does not extend the active work's original hard runtime deadline. Each arrival keeps its own output destination and completion contract.
-
-Triggers with a `run.github` grant or a connection token in `run.env` can continue an active agent. They keep the existing credentials and their original expiry; steering does not refresh the agent's environment or renew a token. Finishing one request leaves leased credentials available to other active requests sharing that agent. Hub revokes them when all those requests finish, while any configured credential expiry still applies during the work.
-
-After all requests in a session with temporary credentials finish, the next arrival for the same conversation or key starts a fresh agent with newly materialized credentials. Sessions without temporary environment credentials can reuse or restore their agent after completion.
+A follow-up steers the active agent without extending its runtime deadline or credential expiry. With a `run.github` grant or connection token in `run.env`, follow-ups share the active agent’s credentials. Once all requests finish, the next arrival starts a new agent with fresh credentials. Agents without temporary credentials can be reused after completion.
 
 ### Upgrading
 

--- a/public-docs/hub/github.md
+++ b/public-docs/hub/github.md
@@ -37,7 +37,7 @@ steps:
           ${{ paseo.prompt }}
 ```
 
-The agent can use `git` and `gh` within the declared repositories and permissions. Hub mints the token when the step starts and revokes it when execution ends.
+The agent can use `git` and `gh` within the declared repositories and permissions. Hub mints the token when the agent starts. With [agent continuation](/docs/hub/configuration/hub-yml#agent-continuation), overlapping requests share that token until all requests using the agent finish or the token's configured lifetime expires. Steering does not renew the token. After all requests finish, the next credentialed task starts a fresh agent with a new scoped token.
 
 ## Fields
 
@@ -73,4 +73,4 @@ env:
   SOME_TOKEN: "${{ paseo.connections.some-connection.token }}"
 ```
 
-Hub resolves the value for the step and does not persist it. See [Hub security](/docs/hub/security) for provider and host boundaries.
+Hub resolves the value when it prepares the agent's environment. See [Hub security](/docs/hub/security) for provider and host boundaries.

--- a/public-docs/hub/github.md
+++ b/public-docs/hub/github.md
@@ -37,7 +37,7 @@ steps:
           ${{ paseo.prompt }}
 ```
 
-The agent can use `git` and `gh` within the declared repositories and permissions. Hub mints the token when the agent starts. With [agent continuation](/docs/hub/configuration/hub-yml#agent-continuation), overlapping requests share that token until all requests using the agent finish or the token's configured lifetime expires. Steering does not renew the token. After all requests finish, the next credentialed task starts a fresh agent with a new scoped token.
+The agent can use `git` and `gh` within the declared repositories and permissions. See [agent continuation](/docs/hub/configuration/hub-yml#agent-continuation) for the token lifecycle when requests continue an agent.
 
 ## Fields
 

--- a/public-docs/hub/triggers/index.md
+++ b/public-docs/hub/triggers/index.md
@@ -67,7 +67,7 @@ run:
   prompt: Handle this request and call finish_execution when complete.
 ```
 
-The [continuation reference](/docs/hub/configuration/hub-yml#agent-continuation) describes keys, compatibility, runtime deadlines, and how temporary credentials affect agent reuse. The run detail shows whether each arrival created, continued, or restored an agent.
+The [continuation reference](/docs/hub/configuration/hub-yml#agent-continuation) covers keys and agent reuse. The run detail shows whether each arrival created, continued, or restored an agent.
 
 Hub includes an `executionId` in each prompt. When using a continuing agent, pass that ID to `reply` and `finish_execution`. These tools act on that arrival's destination and contract; an old or unrelated execution ID is rejected.
 

--- a/public-docs/hub/triggers/index.md
+++ b/public-docs/hub/triggers/index.md
@@ -44,7 +44,9 @@ If the daemon is offline or needs a newer Paseo version, the agent selectors sho
 
 Dashboard triggers default to **Same conversation**. Messages in the same Slack or Discord thread, events on the same GitHub issue or pull request, and events on the same Linear issue continue the existing agent in that project. An event without a conversation starts a new agent.
 
-If the agent is busy, the new prompt steers its current work. If its workspace is archived, Hub asks Paseo to restore it before sending the prompt. Each arrival still has its own deadline, output limits, and completion status.
+If the agent is busy, the new prompt steers its current work without extending the original hard runtime deadline. Each arrival keeps its own output limits and completion status. If a reusable workspace is archived, Hub asks Paseo to restore it before sending the prompt.
+
+When requests share temporary environment credentials, those credentials keep their original expiry and remain available until all requests finish. The next arrival after completion starts a fresh agent with newly materialized credentials. See the [continuation reference](/docs/hub/configuration/hub-yml#agent-continuation) for the full lifecycle.
 
 Choose **Custom key** to group arrivals by an input, or **New agent** to keep them separate. A self-contained trigger document can express the same choice:
 

--- a/public-docs/hub/triggers/index.md
+++ b/public-docs/hub/triggers/index.md
@@ -44,9 +44,7 @@ If the daemon is offline or needs a newer Paseo version, the agent selectors sho
 
 Dashboard triggers default to **Same conversation**. Messages in the same Slack or Discord thread, events on the same GitHub issue or pull request, and events on the same Linear issue continue the existing agent in that project. An event without a conversation starts a new agent.
 
-If the agent is busy, the new prompt steers its current work without extending the original hard runtime deadline. Each arrival keeps its own output limits and completion status. If a reusable workspace is archived, Hub asks Paseo to restore it before sending the prompt.
-
-When requests share temporary environment credentials, those credentials keep their original expiry and remain available until all requests finish. The next arrival after completion starts a fresh agent with newly materialized credentials. See the [continuation reference](/docs/hub/configuration/hub-yml#agent-continuation) for the full lifecycle.
+If the agent is busy, the new prompt steers its current work. Each arrival keeps its own output limits and completion status. If a reusable workspace is archived, Hub asks Paseo to restore it before sending the prompt.
 
 Choose **Custom key** to group arrivals by an input, or **New agent** to keep them separate. A self-contained trigger document can express the same choice:
 
@@ -69,7 +67,7 @@ run:
   prompt: Handle this request and call finish_execution when complete.
 ```
 
-The [continuation reference](/docs/hub/configuration/hub-yml#agent-continuation) describes keys and compatibility. The run detail shows whether each arrival created, continued, or restored an agent.
+The [continuation reference](/docs/hub/configuration/hub-yml#agent-continuation) describes keys, compatibility, runtime deadlines, and how temporary credentials affect agent reuse. The run detail shows whether each arrival created, continued, or restored an agent.
 
 Hub includes an `executionId` in each prompt. When using a continuing agent, pass that ID to `reply` and `finish_execution`. These tools act on that arrival's destination and contract; an old or unrelated execution ID is rejected.
 


### PR DESCRIPTION
Explain when a follow-up reuses an agent and when a later request starts a fresh agent. Replace the outdated credential restriction in the continuation reference with one paragraph; other pages link there. Also remove the inaccurate claim that resolved environment values are never persisted.

### Linked issue

Companion to getpaseo/hub#131.

### Type of change

- [x] Docs

### Reasoning

Users need to know that follow-ups retain the original runtime and credential expiry, and that completed credentialed work starts fresh on the next request.

### Goals

Keep continuation behavior in its existing reference, with no duplicated lifecycle explanation.

### Non-goals

Runtime changes or internal cleanup documentation.

### QA

Website typecheck, repository lint, formatting, and diff checks passed after trimming. Runtime behavior is covered by the companion Hub tests.

### Checklist

- [x] Focused documentation change
- [x] Typecheck, lint, and formatting verified

Publish with the companion Hub change.
