### PR TITLE
docs(hub): explain pending dashboard navigation

### DIFF
--- a/public-docs/hub/faq.md
+++ b/public-docs/hub/faq.md
@@ -38,6 +38,10 @@ Each trigger and its ordered steps live in one direct `.paseo/workflows/*.yml` f
 
 Yes, with a manual source. A project using a GitHub source is read-only in the dashboard, since the repository is the source of truth. Switching to manual copies the active revision into the editor and stops syncing.
 
+## Why does the previous page stay visible after I click a dashboard link?
+
+Hub keeps the current page and its navigation labels together while the next page loads. If loading takes longer than a second, the labels switch to your destination and a loading placeholder replaces the previous page. The sidebar stays available, so you can choose another page or use Back while you wait.
+
 ## Who can trigger an agent?
 
 Only the users listed in a trigger's `from_users`. It is required and cannot be empty.


### PR DESCRIPTION
Explain the dashboard's loading behavior in the Hub FAQ: page labels stay with the visible content during short loads, then advance with a loading placeholder while the sidebar remains available.

Goal: help users recognize pending navigation and know they can choose another destination or use Back. This documents https://github.com/getpaseo/hub/pull/132; it does not change application behavior.

Validation: repository formatter passed for the changed Markdown file. Risk is limited to the accuracy of the documented loading behavior, covered by the Hub browser regression suite.
