### PR TITLE
fix(plugin-provider): recover stale sessions after reload

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -19,6 +19,7 @@ import { toAgentPayload } from "./agent-projections.js";
 import { projectTimelineRows } from "./timeline-projection.js";
 import { getOpenAgentTabLabel, PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 import { formatSystemNotificationPrompt, startAgentRun } from "./agent-prompt.js";
+import { StaleProviderSessionError } from "./stale-provider-session-error.js";
 import { ensureAgentLoaded, ensureUnarchivedAgentLoaded } from "./agent-loading.js";
 import type { StoredAgentRecord } from "./agent-storage.js";
 import type {
@@ -3675,6 +3676,140 @@ test("updateProviderRegistry removes providers omitted from the next registry", 
     }),
   ).rejects.toThrow("Unknown provider 'zai-claude'");
   expect(removedClient.createSessionCalls).toBe(0);
+});
+
+test("retires loaded agents when their plugin provider is replaced", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-plugin-provider-reload-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const provider = "plugin-provider";
+
+  class OriginalPluginClient extends TestAgentClient {
+    session: CloseRecordingTestAgentSession | null = null;
+
+    constructor() {
+      super(provider);
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      const session = new CloseRecordingTestAgentSession(config);
+      session.describePersistence = () => ({
+        provider,
+        sessionId: "plugin-session",
+      });
+      this.session = session;
+      return session;
+    }
+  }
+
+  const original = new OriginalPluginClient();
+  const replacement = new TestAgentClient(provider);
+  const manager = new AgentManager({
+    clients: { [provider]: original },
+    providerDefinitions: { [provider]: { enabled: true } },
+    registry: storage,
+    logger,
+  });
+  let createdId: string | null = null;
+
+  try {
+    const created = await manager.createAgent({ provider, cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    createdId = created.id;
+
+    manager.updateProviderRegistry({
+      providerDefinitions: { [provider]: { enabled: true } },
+      clients: { [provider]: replacement },
+      retiredProviders: [provider],
+    });
+
+    await manager.waitForAgentClose(created.id);
+    expect(original.session?.closed).toBe(true);
+    expect(manager.getAgent(created.id)).toBeNull();
+
+    const resumed = await ensureAgentLoaded(created.id, {
+      agentManager: manager,
+      agentStorage: storage,
+      logger,
+    });
+    expect(resumed.id).toBe(created.id);
+    expect(replacement.resumeOverrides).toEqual([
+      expect.objectContaining({ cwd: workdir, provider }),
+    ]);
+  } finally {
+    if (createdId) await manager.closeAgent(createdId).catch(() => undefined);
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("a prompt after provider replacement reopens the stale session", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-stale-prompt-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const provider = "plugin-provider";
+
+  class StalePluginSession extends CloseRecordingTestAgentSession {
+    override async startTurn(): Promise<{ turnId: string }> {
+      throw new StaleProviderSessionError("stale-bridge");
+    }
+  }
+
+  class StalePluginClient extends TestAgentClient {
+    constructor() {
+      super(provider);
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      const session = new StalePluginSession(config);
+      session.describePersistence = () => ({
+        provider,
+        sessionId: "plugin-session",
+      });
+      return session;
+    }
+  }
+
+  const staleClient = new StalePluginClient();
+  const replacement = new TestAgentClient(provider);
+  const manager = new AgentManager({
+    clients: { [provider]: staleClient },
+    providerDefinitions: { [provider]: { enabled: true } },
+    registry: storage,
+    logger,
+  });
+  let createdId: string | null = null;
+
+  try {
+    const created = await manager.createAgent({ provider, cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    createdId = created.id;
+
+    manager.updateProviderRegistry({
+      providerDefinitions: { [provider]: { enabled: true } },
+      clients: { [provider]: replacement },
+      retiredProviders: [provider],
+    });
+    await manager.waitForAgentClose(created.id);
+
+    const resumed = await ensureAgentLoaded(created.id, {
+      agentManager: manager,
+      agentStorage: storage,
+      logger,
+    });
+    expect(resumed.id).toBe(created.id);
+
+    const dispatch = await startAgentRun(manager, created.id, "continue after reload", logger);
+    expect(dispatch.disposition).toBe("turn_started");
+    await manager.waitForAgentEvent(created.id, { waitForActive: false });
+    expect(manager.getAgent(created.id)?.lifecycle).not.toBe("error");
+  } finally {
+    if (createdId) await manager.closeAgent(createdId).catch(() => undefined);
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("createAgent passes explicit model strings through to the provider", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -69,6 +69,12 @@ function deferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
+async function drainAsyncGenerator<T>(generator: AsyncGenerator<T>): Promise<void> {
+  for await (const _ of generator) {
+    // Drain provider events while AgentManager subscribers observe them.
+  }
+}
+
 function waitForAgentLifecycle(
   manager: AgentManager,
   agentId: string,
@@ -518,6 +524,32 @@ class TestAgentSession implements AgentSession {
   }
 
   async close(): Promise<void> {}
+}
+
+class ResumeTrackingTestAgentClient extends TestAgentClient {
+  private readonly retryStarted = deferred<void>();
+
+  override async resumeSession(
+    _handle: AgentPersistenceHandle,
+    config?: Partial<AgentSessionConfig>,
+  ): Promise<AgentSession> {
+    this.resumeOverrides.push(config);
+    const signalRetryStarted = () => this.retryStarted.resolve();
+    return new (class extends TestAgentSession {
+      override async startTurn(): Promise<{ turnId: string }> {
+        signalRetryStarted();
+        return await super.startTurn();
+      }
+    })({
+      provider: this.provider,
+      cwd: config?.cwd ?? process.cwd(),
+      daemonAppendSystemPrompt: config?.daemonAppendSystemPrompt,
+    });
+  }
+
+  waitForRetryStart(): Promise<void> {
+    return this.retryStarted.promise;
+  }
 }
 
 class McpCapableTestAgentSession extends TestAgentSession {
@@ -3768,7 +3800,7 @@ test("a prompt after provider replacement reopens the stale session", async () =
   }
 
   const staleClient = new StalePluginClient();
-  const replacement = new TestAgentClient(provider);
+  const replacement = new ResumeTrackingTestAgentClient(provider);
   const manager = new AgentManager({
     clients: { [provider]: staleClient },
     providerDefinitions: { [provider]: { enabled: true } },
@@ -3787,8 +3819,84 @@ test("a prompt after provider replacement reopens the stale session", async () =
 
     const dispatch = await startAgentRun(manager, created.id, "continue after reload", logger);
     expect(dispatch.disposition).toBe("turn_started");
-    await expect.poll(() => replacement.resumeOverrides).toHaveLength(1);
-    await expect.poll(() => manager.getAgent(created.id)?.lifecycle).toBe("idle");
+    await replacement.waitForRetryStart();
+    const result = await manager.waitForAgentEvent(created.id);
+    expect(result.status).toBe("idle");
+    expect(replacement.resumeOverrides).toHaveLength(1);
+  } finally {
+    await manager.closeAgent(created.id).catch(() => undefined);
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("a replacement prompt recovers when the retired session fails to start", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-stale-replacement-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const provider = "plugin-provider";
+
+  class StaleReplacementSession extends TestAgentSession {
+    private starts = 0;
+
+    override async startTurn(): Promise<{ turnId: string }> {
+      this.starts += 1;
+      if (this.starts > 1) throw new StaleProviderSessionError("stale-bridge");
+      return { turnId: "initial-turn" };
+    }
+
+    override async interrupt(): Promise<void> {
+      if (this.starts > 1) throw new StaleProviderSessionError("stale-bridge");
+      this.pushEvent({
+        type: "turn_canceled",
+        provider: this.provider,
+        turnId: "initial-turn",
+      });
+    }
+  }
+
+  class StaleReplacementClient extends TestAgentClient {
+    constructor() {
+      super(provider);
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      const session = new StaleReplacementSession(config);
+      session.describePersistence = () => ({ provider, sessionId: "plugin-session" });
+      return session;
+    }
+  }
+
+  const replacement = new ResumeTrackingTestAgentClient(provider);
+  const manager = new AgentManager({
+    clients: { [provider]: new StaleReplacementClient() },
+    providerDefinitions: { [provider]: { enabled: true } },
+    registry: storage,
+    logger,
+    rescueTimeouts: { interruptSessionMs: 20 },
+  });
+  const created = await manager.createAgent({ provider, cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+
+  try {
+    const initial = manager.streamAgent(created.id, "initial");
+    void drainAsyncGenerator(initial);
+    await manager.waitForAgentRunStart(created.id);
+
+    manager.updateProviderRegistry({
+      providerDefinitions: { [provider]: { enabled: true } },
+      clients: { [provider]: replacement },
+    });
+
+    const dispatch = await startAgentRun(manager, created.id, "replacement", logger, {
+      replaceRunning: true,
+    });
+    expect(dispatch.disposition).toBe("turn_started");
+    await replacement.waitForRetryStart();
+    const result = await manager.waitForAgentEvent(created.id);
+    expect(result.status).toBe("idle");
+    expect(replacement.resumeOverrides).toHaveLength(1);
   } finally {
     await manager.closeAgent(created.id).catch(() => undefined);
     await manager.flush().catch(() => undefined);

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -3709,14 +3709,11 @@ test("retires loaded agents when their plugin provider is replaced", async () =>
     registry: storage,
     logger,
   });
-  let createdId: string | null = null;
+  const created = await manager.createAgent({ provider, cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
 
   try {
-    const created = await manager.createAgent({ provider, cwd: workdir }, undefined, {
-      workspaceId: undefined,
-    });
-    createdId = created.id;
-
     manager.updateProviderRegistry({
       providerDefinitions: { [provider]: { enabled: true } },
       clients: { [provider]: replacement },
@@ -3737,7 +3734,7 @@ test("retires loaded agents when their plugin provider is replaced", async () =>
       expect.objectContaining({ cwd: workdir, provider }),
     ]);
   } finally {
-    if (createdId) await manager.closeAgent(createdId).catch(() => undefined);
+    await manager.closeAgent(created.id).catch(() => undefined);
     await manager.flush().catch(() => undefined);
     await storage.flush().catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });
@@ -3778,34 +3775,22 @@ test("a prompt after provider replacement reopens the stale session", async () =
     registry: storage,
     logger,
   });
-  let createdId: string | null = null;
+  const created = await manager.createAgent({ provider, cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
 
   try {
-    const created = await manager.createAgent({ provider, cwd: workdir }, undefined, {
-      workspaceId: undefined,
-    });
-    createdId = created.id;
-
     manager.updateProviderRegistry({
       providerDefinitions: { [provider]: { enabled: true } },
       clients: { [provider]: replacement },
-      retiredProviders: [provider],
     });
-    await manager.waitForAgentClose(created.id);
-
-    const resumed = await ensureAgentLoaded(created.id, {
-      agentManager: manager,
-      agentStorage: storage,
-      logger,
-    });
-    expect(resumed.id).toBe(created.id);
 
     const dispatch = await startAgentRun(manager, created.id, "continue after reload", logger);
     expect(dispatch.disposition).toBe("turn_started");
-    await manager.waitForAgentEvent(created.id, { waitForActive: false });
-    expect(manager.getAgent(created.id)?.lifecycle).not.toBe("error");
+    await expect.poll(() => replacement.resumeOverrides).toHaveLength(1);
+    await expect.poll(() => manager.getAgent(created.id)?.lifecycle).toBe("idle");
   } finally {
-    if (createdId) await manager.closeAgent(createdId).catch(() => undefined);
+    await manager.closeAgent(created.id).catch(() => undefined);
     await manager.flush().catch(() => undefined);
     await storage.flush().catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -77,6 +77,7 @@ import {
 } from "./agent-run-state.js";
 import { invokeRewindCapability, type RewindMode } from "./rewind/rewind.js";
 import { isSystemInjectedEnvelope } from "./agent-prompt.js";
+import { isStaleProviderSessionError } from "./stale-provider-session-error.js";
 import { stripInternalPaseoMcpServer, withRuntimePaseoMcpServer } from "./runtime-mcp-config.js";
 import { resolveCreateAgentTitles } from "./create-agent-title.js";
 import type { PaseoToolCatalogFactory } from "./tools/types.js";
@@ -775,6 +776,7 @@ export class AgentManager {
   updateProviderRegistry(input: {
     providerDefinitions: ProviderEnabledMap;
     clients: ProviderClientMap;
+    retiredProviders?: readonly AgentProvider[];
   }): void {
     this.providerEnabled.clear();
     this.providerDefinitions.clear();
@@ -789,6 +791,18 @@ export class AgentManager {
     for (const [provider, client] of Object.entries(input.clients)) {
       if (client) {
         this.clients.set(provider, client);
+      }
+    }
+
+    for (const provider of input.retiredProviders ?? []) {
+      for (const agent of this.agents.values()) {
+        if (agent.provider !== provider) continue;
+        void this.closeAgent(agent.id).catch((error) => {
+          this.logger.warn(
+            { err: error, agentId: agent.id, provider },
+            "Failed to close agent after provider retirement",
+          );
+        });
       }
     }
   }
@@ -2358,6 +2372,11 @@ export class AgentManager {
       return result.turnId;
     } catch (error) {
       if (pendingRun.settled) {
+        throw error;
+      }
+      if (isStaleProviderSessionError(error)) {
+        pendingRun.start = { status: "failed", error: (error as Error).message };
+        this.runs.settleForegroundRun(agentId, pendingRun.token);
         throw error;
       }
       agent.pendingReplacement = false;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2375,7 +2375,9 @@ export class AgentManager {
         throw error;
       }
       if (isStaleProviderSessionError(error)) {
-        pendingRun.start = { status: "failed", error: (error as Error).message };
+        pendingRun.start = { status: "failed", error: error.message };
+        agent.pendingReplacement = false;
+        if (!agent.activeForegroundTurnId) agent.lifecycle = "idle";
         this.runs.settleForegroundRun(agentId, pendingRun.token);
         throw error;
       }

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -81,6 +81,14 @@ async function startOrReplaceRun(
   return { iterator, replaced };
 }
 
+async function drainAgentRunIterator(
+  iterator: AsyncGenerator<import("./agent-sdk-types.js").AgentStreamEvent>,
+): Promise<void> {
+  for await (const _ of iterator) {
+    // Events are broadcast via AgentManager subscribers.
+  }
+}
+
 export async function startAgentRun(
   agentManager: AgentRunController,
   agentId: string,
@@ -145,8 +153,17 @@ async function startAgentRunInner(
   );
   void (async () => {
     try {
-      for await (const _ of iterator) {
-        // Events are broadcast via AgentManager subscribers.
+      try {
+        await drainAgentRunIterator(iterator);
+      } catch (error) {
+        if (!isStaleProviderSessionError(error)) throw error;
+        logger.info(
+          { agentId, err: error },
+          "Provider session went stale; reopening from persistence",
+        );
+        await agentManager.reloadAgentSession(agentId);
+        const retry = await startOrReplaceRun(agentManager, agentId, prompt, options);
+        await drainAgentRunIterator(retry.iterator);
       }
       logger.trace(
         {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -8,6 +8,7 @@ import type {
 import type { AgentManager, ManagedAgent } from "./agent-manager.js";
 import type { AgentStorage } from "./agent-storage.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
+import { isStaleProviderSessionError } from "./stale-provider-session-error.js";
 import { getParentAgentIdFromLabels } from "@getpaseo/protocol/agent-labels";
 import type { ActiveTurnBehavior } from "@getpaseo/protocol/messages";
 
@@ -21,7 +22,9 @@ export type AgentRunController = Pick<
   | "replaceAgentRun"
   | "steerOrReplaceActiveTurn"
   | "streamAgent"
->;
+> & {
+  reloadAgentSession(agentId: string): Promise<unknown>;
+};
 
 export interface StartAgentRunOptions {
   replaceRunning?: boolean;
@@ -104,6 +107,26 @@ export async function startAgentRun(
   if (agentManager.tryRunOutOfBand(agentId, prompt, options?.runOptions)) {
     return { disposition: "out_of_band" };
   }
+  try {
+    return await startAgentRunInner(agentManager, agentId, prompt, logger, options);
+  } catch (error) {
+    if (!isStaleProviderSessionError(error)) throw error;
+    logger.info({ agentId, err: error }, "Provider session went stale; reopening from persistence");
+    // The live session belongs to a retired plugin runtime. Reload swaps in a
+    // fresh session on the current runtime while preserving history and labels.
+    await agentManager.reloadAgentSession(agentId);
+    return await startAgentRunInner(agentManager, agentId, prompt, logger, options);
+  }
+}
+
+async function startAgentRunInner(
+  agentManager: AgentRunController,
+  agentId: string,
+  prompt: AgentPromptInput,
+  logger: Logger,
+  options?: StartAgentRunOptions,
+): Promise<{ disposition: PromptDispatchDisposition }> {
+  const snapshot = agentManager.getAgent(agentId);
   const steered = await steerOrReplaceActiveRun(agentManager, agentId, prompt, options);
   if (steered?.disposition === "steered") {
     return steered;

--- a/packages/server/src/server/agent/plugin-provider.test.ts
+++ b/packages/server/src/server/agent/plugin-provider.test.ts
@@ -29,6 +29,10 @@ interface ProviderHarnessOptions {
 function createProviderHarness(options: ProviderHarnessOptions = {}) {
   let listener: ((event: ProviderEvent) => void) | null = null;
   let closeCount = 0;
+  let resolveClosed!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
   const inputs: ProviderInput[] = [];
   const emit = (event: ProviderEvent) => listener?.(event);
   const capabilities = options.capabilities ?? CAPABILITIES;
@@ -184,6 +188,7 @@ function createProviderHarness(options: ProviderHarnessOptions = {}) {
     },
     async close() {
       closeCount += 1;
+      resolveClosed();
     },
   };
 
@@ -195,7 +200,12 @@ function createProviderHarness(options: ProviderHarnessOptions = {}) {
     },
   };
 
-  return { registration, inputs, closeCount: () => closeCount };
+  return {
+    registration,
+    inputs,
+    closeCount: () => closeCount,
+    waitForClose: () => closed,
+  };
 }
 
 function eventsOfType(events: AgentStreamEvent[], type: AgentStreamEvent["type"]) {
@@ -278,7 +288,8 @@ describe("PluginAgentClientRegistry", () => {
       expect(persistence).not.toBeNull();
 
       registry.replace([next.registration]);
-      await expect.poll(old.closeCount).toBe(1);
+      await old.waitForClose();
+      expect(old.closeCount()).toBe(1);
 
       await expect(stale.close()).resolves.toBeUndefined();
 
@@ -321,7 +332,8 @@ describe("PluginAgentClientRegistry", () => {
       });
 
       registry.replace([]);
-      await expect.poll(old.closeCount).toBe(1);
+      await old.waitForClose();
+      expect(old.closeCount()).toBe(1);
 
       const failure = await stale
         .startTurn("after reload", { clientMessageId: "after-reload" })

--- a/packages/server/src/server/agent/plugin-provider.test.ts
+++ b/packages/server/src/server/agent/plugin-provider.test.ts
@@ -8,6 +8,10 @@ import { describe, expect, test } from "vitest";
 import { createTestLogger } from "../../test-utils/test-logger.js";
 import type { AgentStreamEvent } from "./agent-sdk-types.js";
 import { PluginAgentClientRegistry } from "./plugin-provider.js";
+import {
+  isStaleProviderSessionError,
+  StaleProviderSessionError,
+} from "./stale-provider-session-error.js";
 
 const CAPABILITIES = [
   "prompt.message",
@@ -300,6 +304,35 @@ describe("PluginAgentClientRegistry", () => {
       );
 
       await resumed.close();
+    } finally {
+      await registry.shutdown();
+    }
+  });
+
+  test("prompting a stale session raises StaleProviderSessionError", async () => {
+    const old = createProviderHarness();
+    const registry = new PluginAgentClientRegistry(createTestLogger());
+
+    try {
+      registry.replace([old.registration]);
+      const stale = await registry.clients()[old.registration.id]!.createSession({
+        provider: old.registration.id,
+        cwd: "/workspace",
+      });
+
+      registry.replace([]);
+      await expect.poll(old.closeCount).toBe(1);
+
+      const failure = await stale
+        .startTurn("after reload", { clientMessageId: "after-reload" })
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+      expect(failure).toBeInstanceOf(StaleProviderSessionError);
+      expect(isStaleProviderSessionError(failure)).toBe(true);
+      expect(isStaleProviderSessionError(new Error("Provider connection is closed"))).toBe(true);
+      expect(isStaleProviderSessionError(new Error("boom"))).toBe(false);
     } finally {
       await registry.shutdown();
     }

--- a/packages/server/src/server/agent/plugin-provider.test.ts
+++ b/packages/server/src/server/agent/plugin-provider.test.ts
@@ -275,7 +275,7 @@ describe("PluginAgentClientRegistry", () => {
         cwd: "/workspace",
       });
       const persistence = stale.describePersistence();
-      if (!persistence) throw new Error("Expected plugin session persistence");
+      expect(persistence).not.toBeNull();
 
       registry.replace([next.registration]);
       await expect.poll(old.closeCount).toBe(1);
@@ -283,8 +283,8 @@ describe("PluginAgentClientRegistry", () => {
       await expect(stale.close()).resolves.toBeUndefined();
 
       const replacement = registry.clients()[next.registration.id];
-      if (!replacement) throw new Error("Expected replacement plugin client");
-      const resumed = await replacement.resumeSession(persistence, {
+      expect(replacement).toBeDefined();
+      const resumed = await replacement!.resumeSession(persistence!, {
         cwd: "/workspace",
       });
 
@@ -331,7 +331,7 @@ describe("PluginAgentClientRegistry", () => {
         );
       expect(failure).toBeInstanceOf(StaleProviderSessionError);
       expect(isStaleProviderSessionError(failure)).toBe(true);
-      expect(isStaleProviderSessionError(new Error("Provider connection is closed"))).toBe(true);
+      expect(isStaleProviderSessionError(new Error("Provider connection is closed"))).toBe(false);
       expect(isStaleProviderSessionError(new Error("boom"))).toBe(false);
     } finally {
       await registry.shutdown();

--- a/packages/server/src/server/agent/plugin-provider.test.ts
+++ b/packages/server/src/server/agent/plugin-provider.test.ts
@@ -258,6 +258,53 @@ describe("PluginAgentClientRegistry", () => {
     expect(eventsOfType(events, "turn_failed")).toHaveLength(1);
   });
 
+  test("closes a stale session after its plugin provider is replaced", async () => {
+    const old = createProviderHarness();
+    const next = createProviderHarness();
+    const registry = new PluginAgentClientRegistry(createTestLogger());
+
+    try {
+      registry.replace([old.registration]);
+
+      const stale = await registry.clients()[old.registration.id]!.createSession({
+        provider: old.registration.id,
+        cwd: "/workspace",
+      });
+      const persistence = stale.describePersistence();
+      if (!persistence) throw new Error("Expected plugin session persistence");
+
+      registry.replace([next.registration]);
+      await expect.poll(old.closeCount).toBe(1);
+
+      await expect(stale.close()).resolves.toBeUndefined();
+
+      const replacement = registry.clients()[next.registration.id];
+      if (!replacement) throw new Error("Expected replacement plugin client");
+      const resumed = await replacement.resumeSession(persistence, {
+        cwd: "/workspace",
+      });
+
+      await expect(
+        resumed.startTurn("after reload", { clientMessageId: "after-reload" }),
+      ).resolves.toEqual({ turnId: "turn-1" });
+
+      expect(next.inputs).toContainEqual(
+        expect.objectContaining({
+          type: "session.open",
+          history: "replay",
+          persistence: {
+            version: 1,
+            data: { token: "root" },
+          },
+        }),
+      );
+
+      await resumed.close();
+    } finally {
+      await registry.shutdown();
+    }
+  });
+
   test("adapts callback providers into the existing AgentClient and AgentSession path", async () => {
     const harness = createProviderHarness();
     const registry = new PluginAgentClientRegistry(createTestLogger());

--- a/packages/server/src/server/agent/plugin-provider.ts
+++ b/packages/server/src/server/agent/plugin-provider.ts
@@ -58,6 +58,10 @@ import {
 } from "./create-agent-mode.js";
 import type { ProviderDefinition } from "./provider-registry.js";
 import { runProviderTurn } from "./providers/provider-runner.js";
+import {
+  isStaleProviderSessionError,
+  StaleProviderSessionError,
+} from "./stale-provider-session-error.js";
 
 interface Deferred<Value> {
   promise: Promise<Value>;
@@ -563,6 +567,7 @@ class ProviderRuntimeSession {
       sessionId: this.providerSessionId,
       prompt,
     });
+    if (this.terminal) throw new StaleProviderSessionError(this.id);
     const pending = deferred<Extract<ProviderEvent, { type: "session.prompt_result" }>>();
     this.prompts.set(prompt.clientMessageId, pending);
     try {
@@ -572,6 +577,9 @@ class ProviderRuntimeSession {
         prompt,
       });
       return (await pending.promise).result;
+    } catch (error) {
+      if (isStaleProviderSessionError(error)) throw new StaleProviderSessionError(this.id);
+      throw error;
     } finally {
       this.prompts.delete(prompt.clientMessageId);
     }

--- a/packages/server/src/server/agent/plugin-provider.ts
+++ b/packages/server/src/server/agent/plugin-provider.ts
@@ -130,6 +130,10 @@ class ProviderRuntime {
     return this.connection?.capabilities ?? [];
   }
 
+  get isClosed(): boolean {
+    return this.closed;
+  }
+
   async isAvailable(): Promise<boolean> {
     await this.getConnection();
     return true;
@@ -623,6 +627,8 @@ class ProviderRuntimeSession {
         requestId: randomUUID(),
         sessionId: this.providerSessionId,
       });
+    } catch (error) {
+      if (!this.runtime.isClosed) throw error;
     } finally {
       this.runtime.removeSession(this.id, this.providerSessionId);
     }

--- a/packages/server/src/server/agent/plugin-provider.ts
+++ b/packages/server/src/server/agent/plugin-provider.ts
@@ -58,10 +58,7 @@ import {
 } from "./create-agent-mode.js";
 import type { ProviderDefinition } from "./provider-registry.js";
 import { runProviderTurn } from "./providers/provider-runner.js";
-import {
-  isStaleProviderSessionError,
-  StaleProviderSessionError,
-} from "./stale-provider-session-error.js";
+import { StaleProviderSessionError } from "./stale-provider-session-error.js";
 
 interface Deferred<Value> {
   promise: Promise<Value>;
@@ -578,7 +575,7 @@ class ProviderRuntimeSession {
       });
       return (await pending.promise).result;
     } catch (error) {
-      if (isStaleProviderSessionError(error)) throw new StaleProviderSessionError(this.id);
+      if (this.terminal || this.runtime.isClosed) throw new StaleProviderSessionError(this.id);
       throw error;
     } finally {
       this.prompts.delete(prompt.clientMessageId);

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -2281,6 +2281,7 @@ describe("ProviderSnapshotManager cwd routing", () => {
       const withoutPlugin = manager.replacePluginProviders([]);
       expect(manager.hasProvider(registration.id)).toBe(false);
       expect(withoutPlugin.clients[registration.id]).toBeUndefined();
+      expect(withoutPlugin.retiredProviders).toEqual([registration.id]);
     } finally {
       await manager.shutdown();
       manager.destroy();

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -191,6 +191,7 @@ export interface AgentManagerProviderState {
     >
   >;
   clients: Partial<Record<AgentProvider, AgentClient>>;
+  retiredProviders?: readonly AgentProvider[];
 }
 
 interface ProviderLoadOptions {
@@ -402,6 +403,9 @@ export class ProviderSnapshotManager {
     this.createAgentManagerState(this.generation.definitions, clients);
     this.pluginProviders.replace(registrations);
     const plugins = this.pluginProviders.definitions();
+    const retiredProviders = Object.keys(previousPlugins).filter(
+      (provider) => previousPlugins[provider] !== plugins[provider],
+    );
     const definitions = { ...this.generation.definitions };
     const changed = new Set<AgentProvider>();
     for (const provider of new Set([...Object.keys(previousPlugins), ...Object.keys(plugins)])) {
@@ -415,7 +419,7 @@ export class ProviderSnapshotManager {
     const generation = this.createGeneration(definitions, this.providerOverrides);
     const state = this.createAgentManagerState(definitions, clients);
     this.installGeneration(generation, clients, changed);
-    return state;
+    return { ...state, retiredProviders };
   }
 
   private ensureClient(

--- a/packages/server/src/server/agent/stale-provider-session-error.ts
+++ b/packages/server/src/server/agent/stale-provider-session-error.ts
@@ -7,12 +7,5 @@ export class StaleProviderSessionError extends Error {
 }
 
 export function isStaleProviderSessionError(error: unknown): boolean {
-  if (error instanceof StaleProviderSessionError) return true;
-  if (!(error instanceof Error)) return false;
-  return (
-    error.message === "Provider connection is closed" ||
-    error.message === "Provider connection closed" ||
-    error.message === "Provider runtime is closed" ||
-    error.message === "Provider closed"
-  );
+  return error instanceof StaleProviderSessionError;
 }

--- a/packages/server/src/server/agent/stale-provider-session-error.ts
+++ b/packages/server/src/server/agent/stale-provider-session-error.ts
@@ -1,0 +1,18 @@
+/** Thrown when a prompt reaches a plugin session whose connection died with its plugin. */
+export class StaleProviderSessionError extends Error {
+  constructor(sessionId: string) {
+    super(`Provider session ${sessionId} is stale after its plugin reloaded`);
+    this.name = "StaleProviderSessionError";
+  }
+}
+
+export function isStaleProviderSessionError(error: unknown): boolean {
+  if (error instanceof StaleProviderSessionError) return true;
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message === "Provider connection is closed" ||
+    error.message === "Provider connection closed" ||
+    error.message === "Provider runtime is closed" ||
+    error.message === "Provider closed"
+  );
+}

--- a/packages/server/src/server/agent/stale-provider-session-error.ts
+++ b/packages/server/src/server/agent/stale-provider-session-error.ts
@@ -6,6 +6,6 @@ export class StaleProviderSessionError extends Error {
   }
 }
 
-export function isStaleProviderSessionError(error: unknown): boolean {
+export function isStaleProviderSessionError(error: unknown): error is StaleProviderSessionError {
   return error instanceof StaleProviderSessionError;
 }

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -202,6 +202,7 @@ function buildRunOutput(params: {
 type ScheduleAgentManager = Pick<
   AgentRunController,
   | "getAgent"
+  | "reloadAgentSession"
   | "tryRunOutOfBand"
   | "hasInFlightRun"
   | "replaceAgentRun"


### PR DESCRIPTION
### Linked issue

Closes #4626

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Reloading a plugin retires its provider runtime while a loaded agent can still hold the old session. Two paths failed:

1. **Reload agent** — closing the stale session raised `Provider runtime is closed` before Paseo could resume the persistence handle. Fixed by treating close as complete once the owning runtime has retired.
2. **Continue (next prompt)** — the live session still points at the dead plugin connection, so `startTurn` fails with `Provider connection is closed`. The committed close-fix never runs on this path. Fixed by detecting the stale session on prompt, reloading from the persistence handle onto the current runtime, and retrying once.

A close failure while the runtime is still live still blocks replacement, and a stale prompt that cannot reload surfaces the reload error rather than the stale-connection error.

### Goals

- Allow Reload agent to discard a stale plugin-provider session after plugin reload.
- Auto-recover on the next prompt: reopen the persisted agent through the replacement plugin provider runtime and retry once, preserving history and labels.
- Resume the persisted agent through the replacement plugin provider runtime in both paths.
- Preserve live provider session-close failures so reload does not replace a session with ambiguous cleanup.

### Non-goals

- Change AgentManager generic session-close behavior or the plugin provider protocol beyond the stale-session signal.

### QA

- Verified against dogfood: create pi-plugin agent → reload plugin → send prompt without explicit Reload recovers via the persistence handle and runs.
- New regression test: prompting a stale plugin session raises `StaleProviderSessionError` (`plugin-provider.test.ts`).
- New regression test: a prompt after provider replacement reopens the stale session and completes (`agent-manager.test.ts`: retires loaded agents + prompt-after-replacement).
- Existing regression test (replace registration, close old session, resume through replacement client, start prompt) still passes.
- `npx vitest run packages/server/src/server/agent/plugin-provider.test.ts packages/server/src/server/agent/agent-prompt.test.ts` — 19 passed.
- `npm run typecheck`, `npm run lint`, `npm run format` clean; pre-commit hook (lint, format check, typecheck) passed.

### Checklist

- [x] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (if applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense