### PR TITLE
fix(server): forward steerActiveTurn through wrapSessionProvider

### DIFF
--- a/packages/server/src/server/agent/provider-registry-wrap.test.ts
+++ b/packages/server/src/server/agent/provider-registry-wrap.test.ts
@@ -18,6 +18,7 @@ type OptionalAgentSessionMethodName = {
 }[keyof AgentSession];
 
 const OPTIONAL_AGENT_SESSION_METHOD_NAMES = [
+  "steerActiveTurn",
   "listCommands",
   "setModel",
   "setThinkingOption",
@@ -69,6 +70,11 @@ class FakeSession implements AgentSession {
   async startTurn() {
     this.recordedCalls.push("startTurn");
     return { turnId: "turn-1" };
+  }
+
+  async steerActiveTurn() {
+    this.recordedCalls.push("steerActiveTurn");
+    return { status: "accepted" } as const;
   }
 
   subscribe(_callback: (event: AgentStreamEvent) => void) {

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -451,6 +451,7 @@ export function wrapSessionProvider(provider: AgentProvider, inner: AgentSession
     },
     run: (prompt, options) => inner.run(prompt, options),
     startTurn: (prompt, options) => inner.startTurn(prompt, options),
+    steerActiveTurn: inner.steerActiveTurn?.bind(inner),
     subscribe: (callback) => inner.subscribe((event) => callback(mapStreamEvent(provider, event))),
     async *streamHistory() {
       for await (const event of inner.streamHistory()) {


### PR DESCRIPTION
`wrapSessionProvider` rebuilds the session object by naming each method it forwards. `steerActiveTurn` is not among them, so a wrapped session reports no steering support — `steerOrReplaceActiveTurn` takes its `unavailable` branch and **replaces the running turn** instead of steering into it.

The inner providers already implement steering; wrapping hides it.

## What it looks like in practice

A long-running coordinator agent dispatches worker agents and keeps working while they run. When a worker finishes, its completion is delivered to the coordinator as a prompt. If the coordinator is mid-turn, that prompt replaces the turn — and the tool call in flight comes back to the model as:

```
The user doesn't want to proceed with this tool use. The tool use was rejected.
```

Nobody rejected anything. The model reads it as an instruction to stop, abandons what it was doing, and often reports to the operator that they cancelled an action they never touched. On a fleet where completions arrive continuously, a coordinator loses in-flight work repeatedly through the day.

It reproduces on some agents and not others on the same daemon with the same model, which is what makes it confusing in the field. The difference is whether the session was wrapped:

```jsonc
// ~/.paseo/config.json — a custom provider entry is enough
{
  "agents": {
    "providers": {
      "claude-teamalpha": {
        "extends": "claude",
        "label": "Claude (Team Alpha)",
        "env": { "CLAUDE_CONFIG_DIR": "/home/example/.claude-teamalpha" }
      }
    }
  }
}
```

An agent created under `claude-teamalpha` never steers. An agent created under the built-in `claude` provider, with no `profileModels` or `additionalModels`, steers correctly. Same daemon, same model, same prompt.

Per `createResolvedProviderClient`, wrapping applies to **every custom provider unconditionally** — its provider id differs from the base client's — and to the built-in `claude` provider once it carries `profileModels` or `additionalModels`. So the `extends`-only case above has no model overrides at all and is still wrapped.

## The fix

One forward, alongside the other optional methods:

```ts
steerActiveTurn: inner.steerActiveTurn?.bind(inner),
```

## On the existing guard

`provider-registry-wrap.test.ts` derives `OptionalAgentSessionMethodName` from `AgentSession` and asserts the coverage list is exhaustive, which is exactly the guard for this class of omission. `steerActiveTurn?` is declared on `AgentSession` in the same method-shorthand style as the eight names already listed, so I would have expected that assertion to flag it.

I have not run the repo's typecheck, so I am not claiming CI is broken — but whatever the reason, the guard did not prevent this, and that seems worth a look independently of this change. This PR adds the name to the coverage list and gives `FakeSession` a `steerActiveTurn`, so the assertion now covers the new forward either way.

## Related

- #4112 — the same fallback, reported from the `additionalModels` trigger; this is the plain `extends` trigger
- #3999 — measured impact of turn replacement
- #2495 — the mirror case: when the parent *is* busy, the child completion is dropped rather than delivered
