### PR TITLE
docs(hub): explain execution recovery across restarts

### DIFF
--- a/public-docs/hub/daemons.md
+++ b/public-docs/hub/daemons.md
@@ -96,6 +96,8 @@ worktree:
 
 For agents it dispatched, Hub owns creation, reconnect recovery, output observation, and completion. Agents you start yourself are untouched.
 
+Restarting Hub lets active agents continue working. Hub reconnects to the same agents and resumes tracking their output and completion. [GitHub credentials retain their original lifetime](/docs/hub/github#restarts-and-credential-lifetime).
+
 If Hub loses the create response, or the daemon restarts mid-execution, Hub resends the same create intent with the same execution id. The daemon returns the existing agent rather than running the prompt again. An agent that closed or errored is recorded as interrupted; Hub never silently starts a second one.
 
 ## Status

--- a/public-docs/hub/github.md
+++ b/public-docs/hub/github.md
@@ -79,4 +79,8 @@ env:
   SOME_TOKEN: "${{ paseo.connections.some-connection.token }}"
 ```
 
-Hub persists resolved values as private execution data so it can recover after a restart. Authored configuration retains the expressions. See [Hub security](/docs/hub/security) for provider and host boundaries.
+Hub persists resolved values as private execution data so it can recover after a restart. Authored configuration retains the expressions.
+
+These values are stored in the Hub database without application-level encryption. Protect database access, storage, and backups as credentials. Hub deletes the execution authority record when the execution becomes terminal; token lease records remain until revocation succeeds or the token expires, so interrupted cleanup can resume. This cleanup is not a guarantee that every copy is erased: retained agent/session data and database backups may still contain resolved values. Token revocation ends access; it does not erase those copies. Backup retention and deletion remain the operator’s responsibility.
+
+See [Hub security](/docs/hub/security) for provider and host boundaries.

--- a/public-docs/hub/github.md
+++ b/public-docs/hub/github.md
@@ -37,7 +37,7 @@ steps:
           ${{ paseo.prompt }}
 ```
 
-The agent can use `git` and `gh` within the declared repositories and permissions. Hub mints the token when the step starts and revokes it when execution ends.
+The agent can use `git` and `gh` within the declared repositories and permissions. Hub mints the token when the step starts and revokes it when execution ends or its configured duration elapses.
 
 ## Fields
 
@@ -49,6 +49,12 @@ The agent can use `git` and `gh` within the declared repositories and permission
 | `duration`     | Positive token lifetime up to `1h`. Defaults to `1h`, GitHub's maximum.                                                                |
 
 Requested authority cannot exceed the GitHub App installation. Activation and dispatch fail clearly when the connection, repository, or permissions cannot be resolved.
+
+## Restarts and credential lifetime
+
+Restarting Hub preserves active executions and their existing credentials. Hub reconnects to the same agent and restores the original credential deadlines. A restart does not mint a replacement token or extend its lifetime.
+
+If Hub is unavailable when a shorter duration elapses, it revokes the overdue token when it returns. GitHub’s own expiry still limits the token lifetime to one hour. Revocation failures are retried after recovery.
 
 ## Agent environment
 
@@ -73,4 +79,4 @@ env:
   SOME_TOKEN: "${{ paseo.connections.some-connection.token }}"
 ```
 
-Hub resolves the value for the step and does not persist it. See [Hub security](/docs/hub/security) for provider and host boundaries.
+Hub persists resolved values as private execution data so it can recover after a restart. Authored configuration retains the expressions. See [Hub security](/docs/hub/security) for provider and host boundaries.


### PR DESCRIPTION
### Linked issue

Companion to https://github.com/getpaseo/hub/pull/133.

### Type of change

- [x] Docs

### Reasoning

Document how active agents recover after Hub restarts and where materialized credentials live. The previous statement that resolved connection values are never persisted is inaccurate for execution runtime state.

### Goals

Explain recovery of the same daemon agent, preservation of original credential deadlines, and private storage of execution credentials.

### Non-goals

Changing workflow syntax or daemon behavior.

### QA

Website typecheck, repository lint, and formatting checks for both changed documentation files passed. Markdown-only change; no runtime tests added.

### Checklist

- [x] Documentation reflects the companion implementation.
- [x] Website typecheck and lint pass.
- [x] Changed files pass formatting checks.

Publish alongside the companion Hub change; these recovery guarantees require that implementation.
