### PR TITLE
fix(server): expose Codex Fast for documented models

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.features.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.features.test.ts
@@ -97,6 +97,88 @@ async function createConnectedSession(
 }
 
 describe("Codex app-server provider features", () => {
+  test.each([
+    "gpt-6-astra",
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4",
+  ])("exposes and sends Fast for %s", async (model) => {
+    const { session, appServer } = await createConnectedSession({ model });
+    try {
+      expect(session.features).toContainEqual(
+        expect.objectContaining({
+          id: "fast_mode",
+          value: false,
+        }),
+      );
+      await session.setFeature?.("fast_mode", true);
+      await session.startTurn("hello");
+      await expect(appServer.waitForTurnStart()).resolves.toMatchObject({
+        model,
+        serviceTier: "fast",
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test.each([
+    "gpt-5.3-codex-spark",
+    "gpt-5.3-codex",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
+    "gpt-5.5-pro",
+    "gpt-5",
+    "gpt-4.1",
+    "o3",
+    "o4-mini",
+    "gpt-6-unknown",
+  ])("does not expose or restore Fast for %s", async (model) => {
+    const { session, appServer } = await createConnectedSession({
+      model,
+      featureValues: { fast_mode: true },
+    });
+    try {
+      expect(session.features.map((feature) => feature.id)).toEqual(["plan_mode"]);
+      await expect(session.setFeature?.("fast_mode", true)).rejects.toThrow(
+        `Codex fast mode is not available for model '${model}'`,
+      );
+      await session.startTurn("hello");
+      await expect(appServer.waitForTurnStart()).resolves.not.toMatchObject({
+        serviceTier: expect.anything(),
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("restores Fast on Astra and preserves it when switching supported models", async () => {
+    const { session, appServer } = await createConnectedSession({
+      model: "gpt-6-astra",
+      featureValues: { fast_mode: true },
+    });
+    try {
+      expect(session.features).toContainEqual(
+        expect.objectContaining({
+          id: "fast_mode",
+          value: true,
+        }),
+      );
+      await session.setModel("gpt-5.6-sol");
+      await session.setModel("gpt-6-astra");
+      await session.startTurn("hello");
+      await expect(appServer.waitForTurnStart()).resolves.toMatchObject({
+        model: "gpt-6-astra",
+        serviceTier: "fast",
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
   test("features returns fast and plan toggles when supported", async () => {
     const { session } = await createConnectedSession();
 
@@ -105,7 +187,7 @@ describe("Codex app-server provider features", () => {
         type: "toggle",
         id: "fast_mode",
         label: "Fast",
-        description: "Priority inference at 2x usage",
+        description: "Priority inference at increased usage",
         tooltip: "Toggle fast mode",
         icon: "zap",
         value: false,
@@ -129,7 +211,7 @@ describe("Codex app-server provider features", () => {
         type: "toggle",
         id: "fast_mode",
         label: "Fast",
-        description: "Priority inference at 2x usage",
+        description: "Priority inference at increased usage",
         tooltip: "Toggle fast mode",
         icon: "zap",
         value: true,
@@ -250,7 +332,7 @@ describe("Codex app-server provider features", () => {
         type: "toggle",
         id: "fast_mode",
         label: "Fast",
-        description: "Priority inference at 2x usage",
+        description: "Priority inference at increased usage",
         tooltip: "Toggle fast mode",
         icon: "zap",
         value: true,

--- a/packages/server/src/server/agent/providers/codex-feature-definitions.ts
+++ b/packages/server/src/server/agent/providers/codex-feature-definitions.ts
@@ -1,12 +1,22 @@
 import type { AgentFeature, AgentFeatureToggle } from "../agent-sdk-types.js";
 
-const CODEX_FAST_MODE_SUPPORTED_MODEL_PREFIXES = ["gpt-5", "gpt-4.1", "o3", "o4-mini"] as const;
+// Codex Fast is distinct from API Priority processing. Keep model support aligned with
+// https://developers.openai.com/codex/speed and https://developers.openai.com/codex/models.
+const CODEX_FAST_MODE_SUPPORTED_MODELS = new Set([
+  "gpt-6-astra",
+  "gpt-5.6",
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+  "gpt-5.4",
+]);
 
 export const CODEX_FAST_MODE_FEATURE: Omit<AgentFeatureToggle, "value"> = {
   type: "toggle",
   id: "fast_mode",
   label: "Fast",
-  description: "Priority inference at 2x usage",
+  description: "Priority inference at increased usage",
   tooltip: "Toggle fast mode",
   icon: "zap",
 };
@@ -30,9 +40,7 @@ export function codexModelSupportsFastMode(modelId: string | null | undefined): 
   if (!normalizedModelId) {
     return false;
   }
-  return CODEX_FAST_MODE_SUPPORTED_MODEL_PREFIXES.some(
-    (prefix) => normalizedModelId === prefix || normalizedModelId.startsWith(prefix),
-  );
+  return CODEX_FAST_MODE_SUPPORTED_MODELS.has(normalizedModelId);
 }
 
 export function buildCodexFeatures(input: {


### PR DESCRIPTION
### Linked issue

Closes #4451

### Type of change

- [x] Bug fix

### Reasoning

Selecting GPT-6 Astra hid the Fast toggle and rejected enabling it because Paseo's model-prefix allowlist stopped at GPT-5. The same list exposed Fast for older models and Spark without documented Codex Fast support.

Use explicit model IDs from the [official speed documentation](https://developers.openai.com/codex/speed) and [model guide](https://developers.openai.com/codex/models): GPT-6 Astra, GPT-5.6 and its Sol/Terra/Luna variants, GPT-5.5, and GPT-5.4. Replace the universal “2x usage” description with “increased usage”; documented credit rates vary by model.

### Goals

- Expose, enable, restore, and preserve Fast when switching between supported models, including Astra.
- Restrict Fast to documented models rather than inferring support from broad prefixes.
- Keep feature visibility and backend validation under the existing shared policy.

### Non-goals

- Dynamic capability discovery or account/region availability checks.
- Changes to Codex billing or the separate Fast-off lifecycle issue (#1629).

### Supersedes

- [PR #4552](https://github.com/getpaseo/paseo/pull/4552) — Takes over restoring Astra Fast availability, with explicit documented model support and provider-session regression coverage instead of another family prefix. Thanks to @noahg9 for the earlier fix.

### QA

Ran the provider session against its injectable fake app-server on Linux, through the public session interface.

Before the fix, the added Astra regression failed because `session.features` contained only `plan_mode`. After the fix, the same test exposes Fast and observes `model: "gpt-6-astra", serviceTier: "fast"` in the outgoing turn request.

```text
cd packages/server
npx vitest run src/server/agent/providers/codex-app-server-agent.features.test.ts --bail=1
Test Files  1 passed (1)
     Tests  31 passed (31)
```

Coverage includes each supported model, unsupported variants, restoring Astra Fast, supported-model switches, enabling/disabling Fast, and existing Plan interactions.

- `npm run typecheck`: passed across workspaces.
- `npm run lint`: 0 warnings, 0 errors.
- `npm run format`: passed.
- Live paid inference and mobile/web/desktop rendering were not exercised. The change is at the provider capability boundary; it changes the existing toggle's availability and description.

Risk surface: model support remains manually maintained. Models outside the explicit list lose the previously inferred Fast toggle; restored Fast is cleared for them. Provider/account availability remains enforced by Codex.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
