### PR TITLE
fix: use tea's configured web URL for Gitea source links

### DIFF
--- a/packages/app/src/git/forge-url.test.ts
+++ b/packages/app/src/git/forge-url.test.ts
@@ -27,6 +27,27 @@ describe("buildForgeChecksUrl", () => {
 });
 
 describe("buildForgeBranchTreeUrl", () => {
+  it("preserves a canonical web scheme, port and reverse-proxy prefix", () => {
+    expect(
+      buildForgeBranchTreeUrl("gitea", {
+        remoteUrl: "ssh://git@git.example:7998/owner/repo.git",
+        repositoryWebUrl: "http://projects.example:3000/gitea/owner/repo/",
+        branch: "main",
+      }),
+    ).toBe("http://projects.example:3000/gitea/owner/repo/src/branch/main");
+  });
+
+  it.each([
+    "not a URL",
+    "javascript:alert(1)",
+    "file:///tmp/repo",
+    "https://user:secret@example.com/owner/repo",
+  ])("rejects an unsafe canonical URL: %s", (repositoryWebUrl) => {
+    const input = { remoteUrl: "git@git.example:owner/repo.git", repositoryWebUrl, branch: "main" };
+    expect(buildForgeBranchTreeUrl("gitea", input)).toBeNull();
+    expect(buildForgeBlobUrl("gitea", { ...input, path: "README.md" })).toBeNull();
+  });
+
   it("builds a branch-specific GitHub tree URL", () => {
     expect(
       buildForgeBranchTreeUrl("github", {

--- a/packages/app/src/git/forge-url.ts
+++ b/packages/app/src/git/forge-url.ts
@@ -1,7 +1,7 @@
 /**
  * Forge-neutral web URL builders for "Open on <forge>" actions (a file blob or a
- * branch tree). The host comes from the workspace remote — not a hardcoded
- * cloud host — so self-hosted and Enterprise instances link correctly. Each
+ * branch tree). Prefer the daemon's canonical repository web URL; an SSH
+ * hostname need not serve the web UI. Otherwise derive it from the remote. Each
  * forge contributes a small URL grammar (the path infixes and line-anchor
  * format); an unknown forge has no grammar and yields null, so the action is
  * simply absent rather than wrong.
@@ -14,15 +14,14 @@ import { getForgeDefinition } from "@getpaseo/protocol/forge-manifest";
 import { normalizeHost, parseGitRemoteLocation } from "@getpaseo/protocol/git-remote";
 import { getClientForgeLogicModule } from "@/git/forges";
 
-export interface ForgeBlobUrlInput {
-  remoteUrl: string | null | undefined;
-  branch: string | null | undefined;
+export interface ForgeBlobUrlInput extends ForgeBranchTreeUrlInput {
   path: string | null | undefined;
   lineStart?: number;
   lineEnd?: number;
 }
 
 export interface ForgeBranchTreeUrlInput {
+  repositoryWebUrl?: string | null;
   remoteUrl: string | null | undefined;
   branch: string | null | undefined;
 }
@@ -90,6 +89,27 @@ function resolveForgeWebLocation(
   return { host: webHost, port, repo: location.path };
 }
 
+function resolveRepositoryWebUrl(forge: string, input: ForgeBranchTreeUrlInput): string | null {
+  if (input.repositoryWebUrl != null) {
+    try {
+      const url = new URL(input.repositoryWebUrl);
+      if (url.protocol !== "https:" && url.protocol !== "http:") {
+        return null;
+      }
+      if (url.username || url.password || !isValidRepoPath(url.pathname)) {
+        return null;
+      }
+      url.search = "";
+      url.hash = "";
+      return url.toString().replace(/\/$/, "");
+    } catch {
+      return null;
+    }
+  }
+  const location = resolveForgeWebLocation(forge, input.remoteUrl);
+  return location ? `https://${forgeAuthority(location)}/${location.repo}` : null;
+}
+
 function encodeBranch(branch: string): string {
   return branch.split("/").map(encodeURIComponent).join("/");
 }
@@ -126,24 +146,24 @@ export function buildForgeBranchTreeUrl(
   input: ForgeBranchTreeUrlInput,
 ): string | null {
   const grammar = getClientForgeLogicModule(forge)?.urlGrammar;
-  const location = resolveForgeWebLocation(forge, input.remoteUrl);
+  const repositoryUrl = resolveRepositoryWebUrl(forge, input);
   const branch = input.branch?.trim();
-  if (!grammar || !location || !branch || branch === "HEAD") {
+  if (!grammar || !repositoryUrl || !branch || branch === "HEAD") {
     return null;
   }
-  return `https://${forgeAuthority(location)}/${location.repo}${grammar.treeInfix}${encodeBranch(branch)}`;
+  return `${repositoryUrl}${grammar.treeInfix}${encodeBranch(branch)}`;
 }
 
 export function buildForgeBlobUrl(forge: string, input: ForgeBlobUrlInput): string | null {
   const grammar = getClientForgeLogicModule(forge)?.urlGrammar;
-  const location = resolveForgeWebLocation(forge, input.remoteUrl);
+  const repositoryUrl = resolveRepositoryWebUrl(forge, input);
   const branch = input.branch?.trim();
   const filePath = normalizeBlobPath(input.path);
-  if (!grammar || !location || !branch || branch === "HEAD" || !filePath) {
+  if (!grammar || !repositoryUrl || !branch || branch === "HEAD" || !filePath) {
     return null;
   }
   const encodedPath = filePath.split("/").map(encodeURIComponent).join("/");
-  let url = `https://${forgeAuthority(location)}/${location.repo}${grammar.blobInfix}${encodeBranch(branch)}/${encodedPath}`;
+  let url = `${repositoryUrl}${grammar.blobInfix}${encodeBranch(branch)}/${encodedPath}`;
   if (input.lineStart && input.lineStart > 0) {
     url += grammar.lineAnchor(input.lineStart, input.lineEnd);
   }

--- a/packages/app/src/git/use-pr-status-query.ts
+++ b/packages/app/src/git/use-pr-status-query.ts
@@ -47,6 +47,7 @@ export function useCheckoutPrStatusQuery({
 
   return {
     status: query.data?.status ?? null,
+    repositoryWebUrl: query.data?.repositoryWebUrl ?? null,
     githubFeaturesEnabled: query.data?.githubFeaturesEnabled ?? true,
     authState: query.data?.authState,
     forge: normalizeForge(query.data?.forge),

--- a/packages/app/src/workspace/open-in-editor/button.tsx
+++ b/packages/app/src/workspace/open-in-editor/button.tsx
@@ -113,7 +113,7 @@ export function WorkspaceOpenInEditorButton({
     serverId,
     cwd: shouldQueryCheckout ? cwd : "",
   });
-  const { resolvedForge } = useCheckoutPrStatusQuery({
+  const { resolvedForge, repositoryWebUrl } = useCheckoutPrStatusQuery({
     serverId,
     cwd: shouldQueryCheckout ? cwd : "",
   });
@@ -129,6 +129,7 @@ export function WorkspaceOpenInEditorButton({
         isLocalExecution: isLocalDaemon,
         checkoutStatus,
         forge: resolvedForge,
+        repositoryWebUrl,
       }).map((target) => {
         if (target.source === "forge") {
           const presentation = getForgePresentation(target.forge);
@@ -154,6 +155,7 @@ export function WorkspaceOpenInEditorButton({
       cwd,
       desktopOpenTargets,
       resolvedForge,
+      repositoryWebUrl,
       isDesktopOpenAvailable,
       isLocalDaemon,
       resolvedFile,

--- a/packages/app/src/workspace/open-in-editor/planner.test.ts
+++ b/packages/app/src/workspace/open-in-editor/planner.test.ts
@@ -184,6 +184,36 @@ describe("planWorkspaceOpenTargets", () => {
     ]);
   });
 
+  it.each(["gitea", "forgejo", "codeberg"])(
+    "uses the canonical repository URL for %s branch and file links",
+    (forge) => {
+      const input = {
+        workspaceDirectory: "/repo",
+        desktopTargets: [],
+        canUseDesktopBridge: false,
+        isLocalExecution: false,
+        checkoutStatus: {
+          isGit: true,
+          remoteUrl: "ssh://git@git.example.com:7998/Acme/main.git",
+          currentBranch: "feature/web links",
+        },
+        forge,
+        repositoryWebUrl: "https://projects.example.com/Acme/main",
+      };
+      expect(
+        planWorkspaceOpenTargets(input).map((target) => target.source === "forge" && target.url),
+      ).toEqual(["https://projects.example.com/Acme/main/src/branch/feature/web%20links"]);
+      expect(
+        planWorkspaceOpenTargets({
+          ...input,
+          activeFile: { path: "src/my file.ts", lineStart: 3, lineEnd: 5 },
+        }).map((target) => target.source === "forge" && target.url),
+      ).toEqual([
+        "https://projects.example.com/Acme/main/src/branch/feature/web%20links/src/my%20file.ts#L3-L5",
+      ]);
+    },
+  );
+
   it("infers the forge from the remote URL when the forge input is null", () => {
     const targets = planWorkspaceOpenTargets({
       workspaceDirectory: "/repo",

--- a/packages/app/src/workspace/open-in-editor/planner.ts
+++ b/packages/app/src/workspace/open-in-editor/planner.ts
@@ -41,6 +41,7 @@ export interface PlanWorkspaceOpenTargetsInput {
   isLocalExecution: boolean;
   checkoutStatus?: CheckoutStatusForOpenTarget | null;
   forge?: Forge | null;
+  repositoryWebUrl?: string | null;
 }
 
 function resolveActiveFileForOpenTargets(
@@ -118,6 +119,7 @@ function buildForgeWebUrl(
   forge: Forge,
   input: {
     remoteUrl: string | null | undefined;
+    repositoryWebUrl?: string | null;
     branch: string | null | undefined;
     path: string | null;
     lineStart?: number;
@@ -129,6 +131,7 @@ function buildForgeWebUrl(
     return (
       presentation.buildBlobUrl?.({
         remoteUrl: input.remoteUrl,
+        repositoryWebUrl: input.repositoryWebUrl,
         branch: input.branch,
         path: input.path,
         lineStart: input.lineStart,
@@ -139,6 +142,7 @@ function buildForgeWebUrl(
   return (
     presentation.buildBranchTreeUrl?.({
       remoteUrl: input.remoteUrl,
+      repositoryWebUrl: input.repositoryWebUrl,
       branch: input.branch,
     }) ?? null
   );
@@ -149,6 +153,7 @@ function planForgeOpenTarget(input: {
   resolvedFile: ResolvedWorkspaceFilePaths | null;
   checkoutStatus?: CheckoutStatusForOpenTarget | null;
   forge?: Forge | null;
+  repositoryWebUrl?: string | null;
 }): PlannedForgeOpenTarget | null {
   if (!input.checkoutStatus?.isGit) {
     return null;
@@ -159,6 +164,7 @@ function planForgeOpenTarget(input: {
   }
   const url = buildForgeWebUrl(forge, {
     remoteUrl: input.checkoutStatus.remoteUrl,
+    repositoryWebUrl: input.repositoryWebUrl,
     branch: input.checkoutStatus.currentBranch,
     path: input.resolvedFile?.relativePath ?? null,
     lineStart: input.activeFile?.lineStart,

--- a/packages/protocol/src/messages.pull-request-timeline.test.ts
+++ b/packages/protocol/src/messages.pull-request-timeline.test.ts
@@ -344,6 +344,21 @@ describe("pull request timeline message schemas", () => {
 });
 
 describe("checkout PR status compatibility", () => {
+  test("accepts an old daemon response without a canonical repository URL", () => {
+    const response = {
+      type: "checkout_pr_status_response",
+      payload: {
+        cwd: "/repo",
+        status: null,
+        githubFeaturesEnabled: true,
+        forge: "gitea",
+        error: null,
+        requestId: "old-daemon",
+      },
+    };
+    expect(CheckoutPrStatusResponseSchema.parse(response)).toEqual(response);
+  });
+
   test("an old client schema parses a new daemon checkout PR status response", () => {
     const oldClientCheckoutPrStatusResponseSchema = z.object({
       type: z.literal("checkout_pr_status_response"),
@@ -380,6 +395,7 @@ describe("checkout PR status compatibility", () => {
       type: "checkout_pr_status_response",
       payload: {
         cwd: "/tmp/repo",
+        repositoryWebUrl: "https://github.com/getpaseo/paseo",
         status: {
           number: 42,
           url: "https://github.com/getpaseo/paseo/pull/42",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -5121,6 +5121,8 @@ export const ForgeAuthStateSchema = z.unknown().optional();
 
 const CheckoutPrStatusPayloadSchema = z.object({
   cwd: z.string(),
+  // Repository-level metadata: present even when the branch has no PR.
+  repositoryWebUrl: z.string().optional(),
   status: CheckoutPrStatusSchema.nullable(),
   githubFeaturesEnabled: z.boolean(),
   // COMPAT(forgeAuthState): added in v0.2.0-beta.1. Remove the legacy

--- a/packages/server/src/server/checkout/status-projection.test.ts
+++ b/packages/server/src/server/checkout/status-projection.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 
-import { CheckoutPrStatusSchema } from "@getpaseo/protocol/messages";
+import {
+  CheckoutPrStatusSchema,
+  CheckoutPrStatusResponseSchema,
+} from "@getpaseo/protocol/messages";
 import type { WorkspaceGitRuntimeSnapshot } from "../workspace-git-service.js";
 import {
   buildCheckoutPrStatusPayloadFromSnapshot,
@@ -8,6 +11,55 @@ import {
 } from "./status-projection.js";
 
 describe("checkout status projection", () => {
+  test("sends the canonical repository web URL through the wire schema without a PR", () => {
+    const snapshot: WorkspaceGitRuntimeSnapshot = {
+      cwd: "/repo",
+      git: {
+        isGit: true,
+        repoRoot: "/repo",
+        mainRepoRoot: null,
+        currentBranch: "main",
+        remoteUrl: "ssh://git@git.example.com:7998/Acme/main.git",
+        isPaseoOwnedWorktree: false,
+        isDirty: false,
+        baseRef: "main",
+        aheadBehind: null,
+        upstreamRef: null,
+        aheadOfOrigin: null,
+        behindOfOrigin: null,
+        hasRemote: true,
+        diffStat: null,
+      },
+      forge: {
+        forge: "gitea",
+        featuresEnabled: true,
+        authState: "authenticated",
+        repositoryWebUrl: "https://projects.example.com/Acme/main",
+        pullRequest: null,
+        error: null,
+      },
+    };
+    const payload = buildCheckoutPrStatusPayloadFromSnapshot({
+      cwd: "/repo",
+      requestId: "web-url",
+      snapshot,
+    });
+    const response = CheckoutPrStatusResponseSchema.parse({
+      type: "checkout_pr_status_response",
+      payload,
+    });
+    expect(response.payload).toEqual({
+      cwd: "/repo",
+      requestId: "web-url",
+      forge: "gitea",
+      githubFeaturesEnabled: true,
+      authState: "authenticated",
+      repositoryWebUrl: "https://projects.example.com/Acme/main",
+      status: null,
+      error: null,
+    });
+  });
+
   test("includes repository identity fields on the PR status wire payload", () => {
     const payload = normalizeCheckoutPrStatusPayload(
       {

--- a/packages/server/src/server/checkout/status-projection.ts
+++ b/packages/server/src/server/checkout/status-projection.ts
@@ -111,6 +111,9 @@ export function buildCheckoutPrStatusPayloadFromSnapshot({
     status: normalizeCheckoutPrStatusPayload(snapshot.forge.pullRequest, forge),
     githubFeaturesEnabled: snapshot.forge.featuresEnabled,
     authState: snapshot.forge.authState,
+    ...(snapshot.forge.repositoryWebUrl
+      ? { repositoryWebUrl: snapshot.forge.repositoryWebUrl }
+      : {}),
     ...(forge ? { forge } : {}),
     error: snapshot.forge.error
       ? {

--- a/packages/server/src/server/workspace-git-service.test.ts
+++ b/packages/server/src/server/workspace-git-service.test.ts
@@ -255,6 +255,7 @@ interface CreateServiceTestOptions {
   getCheckoutWorktreeState?: ReturnType<typeof vi.fn>;
   getPullRequestStatus?: ReturnType<typeof vi.fn>;
   github?: ForgeService;
+  forgeOverrides?: Record<string, ForgeService>;
   resolveAbsoluteGitDir?: ReturnType<typeof vi.fn>;
   hasOriginRemote?: ReturnType<typeof vi.fn>;
   runGitFetch?: ReturnType<typeof vi.fn>;
@@ -369,6 +370,49 @@ describe("WorkspaceGitServiceImpl", () => {
 
     workspaceSubscription.unsubscribe();
     service.dispose();
+  });
+
+  test("keeps the repository web URL without a PR and across PR poll updates", async () => {
+    const repositoryWebUrl = "https://projects.example/acme/repo";
+    const adapter = createGitHubServiceStub();
+    adapter.getRepositoryWebUrl = async () => repositoryWebUrl;
+    let poll:
+      | Parameters<NonNullable<ForgeService["retainCurrentPullRequestStatusPoll"]>>[0]
+      | undefined;
+    adapter.retainCurrentPullRequestStatusPoll = (options) => {
+      poll = options;
+      return { unsubscribe() {} };
+    };
+    const service = createService({
+      forgeOverrides: { github: adapter },
+      getPullRequestStatus: vi.fn(async () => createPullRequestStatusResult({ status: null })),
+    });
+    const subscription = service.registerWorkspace({ cwd: REPO_CWD }, () => {});
+    try {
+      const snapshot = await service.getSnapshot(REPO_CWD);
+      expect(snapshot.forge).toMatchObject({ repositoryWebUrl, pullRequest: null });
+      expect(snapshot.git.remoteUrl).toBe("https://github.com/acme/repo.git");
+      expect(poll).not.toBeUndefined();
+      poll?.onStatus?.(null);
+      expect(service.peekSnapshot(REPO_CWD)?.forge.repositoryWebUrl).toBe(repositoryWebUrl);
+    } finally {
+      subscription.unsubscribe();
+      service.dispose();
+    }
+  });
+
+  test("a failed web URL lookup does not discard PR status", async () => {
+    const adapter = createGitHubServiceStub();
+    adapter.getRepositoryWebUrl = async () => {
+      throw new Error("tea unavailable");
+    };
+    const service = createService({ forgeOverrides: { github: adapter } });
+    try {
+      const snapshot = await service.getSnapshot(REPO_CWD);
+      expect(snapshot.forge).toEqual(createSnapshot(REPO_CWD).forge);
+    } finally {
+      service.dispose();
+    }
   });
 
   test("getSnapshot populates github pull request state in the runtime snapshot", async () => {

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -151,6 +151,7 @@ export interface WorkspaceGitRuntimeSnapshot {
      * correctly. The wire projection prefers this over the bare name heuristic.
      */
     forge?: string;
+    repositoryWebUrl?: string;
     pullRequest: {
       number?: number;
       repoOwner?: string;
@@ -3039,6 +3040,20 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
     // Carry the resolved forge (probe-aware) so the wire projection labels
     // self-managed GitLab hosts correctly instead of falling back to "github".
     target.latestForge = { ...forgeSnapshot, forge: resolution.forge };
+    if (remoteUrl && forgeService.getRepositoryWebUrl) {
+      try {
+        const repositoryWebUrl = await forgeService.getRepositoryWebUrl({
+          cwd: target.cwd,
+          remoteUrl,
+        });
+        if (repositoryWebUrl) {
+          target.latestForge.repositoryWebUrl = repositoryWebUrl;
+        }
+      } catch (error) {
+        // Link metadata must not turn a successful PR lookup into an error.
+        this.logger.warn({ err: error, cwd: target.cwd }, "Failed to resolve repository web URL");
+      }
+    }
     target.latestForgeLoadedAtMs = this.deps.now().getTime();
   }
 
@@ -3086,7 +3101,11 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
       return;
     }
 
-    target.latestForge = github;
+    const repositoryWebUrl = target.latestForge?.repositoryWebUrl;
+    target.latestForge = {
+      ...github,
+      ...(repositoryWebUrl ? { repositoryWebUrl } : {}),
+    };
     target.latestForgeLoadedAtMs = this.deps.now().getTime();
     this.rememberSnapshot(target, this.combineSnapshot(target), {
       notify: options?.notify,

--- a/packages/server/src/services/forge-service.ts
+++ b/packages/server/src/services/forge-service.ts
@@ -434,6 +434,8 @@ export interface CreatePullRequestOptions {
 }
 
 export interface ForgeService {
+  /** Canonical browser URL for the remote repository, independent of any PR. */
+  getRepositoryWebUrl?(options: { cwd: string; remoteUrl: string }): Promise<string | null>;
   listPullRequests(options: ListPullRequestsOptions): Promise<PullRequestSummary[]>;
   listIssues(options: ListIssuesOptions): Promise<IssueSummary[]>;
   getPullRequest(options: GetPullRequestOptions): Promise<PullRequestSummary>;

--- a/packages/server/src/services/gitea-service.test.ts
+++ b/packages/server/src/services/gitea-service.test.ts
@@ -32,6 +32,81 @@ function makeService(responder: Responder, overrides: Partial<CreateGiteaService
   return { service, calls };
 }
 
+describe("repository web URL", () => {
+  it.each([
+    ["http://projects.example:3000/gitea/", "http://projects.example:3000/gitea/Acme/main"],
+    [
+      "https://projects.example/forge?unused=1#fragment",
+      "https://projects.example/forge/Acme/main",
+    ],
+    ["https://user:secret@projects.example", "https://projects.example/Acme/main"],
+    ["not a URL", null],
+    ["javascript:alert(1)", null],
+    ["file:///tmp/forge", null],
+  ])("resolves a login URL of %s safely", async (url, expected) => {
+    const { service } = makeService(() =>
+      ok(JSON.stringify([{ name: "acme", url, ssh_host: "git.example.com" }])),
+    );
+    expect(
+      await service.getRepositoryWebUrl?.({
+        cwd: "/repo",
+        remoteUrl: "git@git.example.com:Acme/main.git",
+      }),
+    ).toBe(expected);
+  });
+
+  it("does not duplicate the deployment prefix already present in an HTTPS remote", async () => {
+    const { service } = makeService(() =>
+      ok(
+        JSON.stringify([
+          { name: "acme", url: "https://projects.example/gitea/", ssh_host: "git.example" },
+        ]),
+      ),
+    );
+    expect(
+      await service.getRepositoryWebUrl?.({
+        cwd: "/repo",
+        remoteUrl: "https://projects.example/gitea/Acme/main.git",
+      }),
+    ).toBe("https://projects.example/gitea/Acme/main");
+  });
+
+  it("does not use an unrelated login for an unmatched remote", async () => {
+    const { service } = makeService(() =>
+      ok(
+        JSON.stringify([
+          { name: "other", url: "https://projects.example", ssh_host: "other.example" },
+        ]),
+      ),
+    );
+    expect(
+      await service.getRepositoryWebUrl?.({
+        cwd: "/repo",
+        remoteUrl: "git@git.example.com:Acme/main.git",
+      }),
+    ).toBeNull();
+  });
+
+  it("uses the matching tea login URL, not the SSH hostname or default login", async () => {
+    const { service, calls } = makeService(() =>
+      ok(
+        JSON.stringify([
+          { name: "other", url: "https://other.example", ssh_host: "other.example" },
+          { name: "acme", url: "https://projects.example.com", ssh_host: "git.example.com" },
+        ]),
+      ),
+    );
+
+    expect(
+      await service.getRepositoryWebUrl?.({
+        cwd: "/repo",
+        remoteUrl: "ssh://git@git.example.com:7998/Acme/main.git",
+      }),
+    ).toBe("https://projects.example.com/Acme/main");
+    expect(calls).toEqual([["login", "list", "-o", "json"]]);
+  });
+});
+
 function argValue(args: string[], flag: string): string | undefined {
   const index = args.indexOf(flag);
   return index === -1 ? undefined : args[index + 1];

--- a/packages/server/src/services/gitea-service.ts
+++ b/packages/server/src/services/gitea-service.ts
@@ -1195,7 +1195,10 @@ export async function probeGiteaHost(host: string): Promise<boolean> {
   }
 }
 
-function findTeaLoginNameForHost(stdout: string, host: string): string | null {
+function findTeaLoginForHost(
+  stdout: string,
+  host: string,
+): z.infer<typeof GiteaLoginSchema> | null {
   let data: unknown;
   try {
     data = JSON.parse(stdout);
@@ -1218,11 +1221,11 @@ function findTeaLoginNameForHost(stdout: string, host: string): string | null {
     }
     return candidates.some((candidate) => candidate?.toLowerCase() === target);
   });
-  return match?.name ?? null;
+  return match ?? null;
 }
 
 function hostHasLogin(stdout: string, host: string): boolean {
-  return findTeaLoginNameForHost(stdout, host) !== null;
+  return findTeaLoginForHost(stdout, host) !== null;
 }
 
 export type GiteaFamilySoftware = "gitea" | "forgejo";
@@ -1274,7 +1277,7 @@ async function probeForgejoNamespaceByTea(
   let loginName: string | null;
   try {
     const { stdout } = await runTea(["login", "list", "-o", "json"]);
-    loginName = findTeaLoginNameForHost(stdout, host);
+    loginName = findTeaLoginForHost(stdout, host)?.name ?? null;
   } catch {
     return null;
   }
@@ -1954,6 +1957,37 @@ export function createGiteaService(options: CreateGiteaServiceOptions = {}): For
   }
 
   return {
+    async getRepositoryWebUrl(input) {
+      const location = parseGitRemoteLocation(input.remoteUrl);
+      if (!location) {
+        return null;
+      }
+      const stdout = await run(["login", "list", "-o", "json"], { cwd: input.cwd });
+      const login = findTeaLoginForHost(stdout, location.host);
+      if (!login?.url) {
+        return null;
+      }
+      let url: URL;
+      try {
+        url = new URL(login.url);
+      } catch {
+        return null;
+      }
+      if (url.protocol !== "https:" && url.protocol !== "http:") {
+        return null;
+      }
+      // HTTP remotes already include the deployment prefix; SSH remotes don't.
+      const prefix = url.pathname.replace(/^\/+|\/+$/g, "");
+      const isHttpRemote = location.transport === "http" || location.transport === "https";
+      const includesPrefix = isHttpRemote && prefix && location.path.startsWith(`${prefix}/`);
+      const repoPath = includesPrefix ? location.path.slice(prefix.length + 1) : location.path;
+      url.pathname = `${url.pathname.replace(/\/$/, "")}/${repoPath}`;
+      url.username = "";
+      url.password = "";
+      url.search = "";
+      url.hash = "";
+      return url.toString().replace(/\/$/, "");
+    },
     async isAuthenticated(input: { cwd: string } & ForgeReadOptions): Promise<boolean> {
       const teaPath = await resolveTea();
       if (!teaPath) {


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

You MUST read CONTRIBUTING.md before sending a PR.
-->

### Linked issue

Closes #4641

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A repository can use `ssh://git@git.example.com:7998/Acme/main.git` while its web UI and API are at `https://projects.example.com`. The matching tea login already records both addresses, but Paseo's toolbar constructs browser links from the SSH remote's hostname. Clicking the Gitea button therefore opens the wrong host. All hostnames and repository names in this description are dummy values substituted for a private instance.

Resolve a canonical repository web URL through the forge adapter and carry it independently of PR status to the toolbar's existing source-link builders. This fixes both branch and selected-file links without changing the user's remote or requiring a PR to exist.


### Goals

- Reuse Gitea's existing tea-login matching (SSH host, login name, or URL hostname); do not use an unrelated/default login.
- Provide an optional `getRepositoryWebUrl` adapter method. The Gitea-family adapter resolves the URL from local `tea login list -o json`, without another API request or reading tokens.
- Add optional `repositoryWebUrl` metadata to checkout PR-status responses, including when `status` is null, and retain it across PR poll updates.
- Prefer the canonical URL for both source-link builders; preserve web scheme, port, deployment prefix, branch/file encoding, and line anchors.
- Avoid duplicating deployment prefixes already present in HTTP(S) remotes.
- Reject non-HTTP(S) browser URLs and do not expose embedded URL credentials.
- Keep existing PR status usable if web-URL metadata lookup fails.

### Non-goals

- Changing Git remotes, SSH configuration, tea credentials, or authentication routing.
- Adding web-host configuration UI or a hostname override list.
- Adding GitHub/GitLab canonical-URL discovery; their existing remote-derived behavior is unchanged, and the adapter seam is forge-neutral.
- Changing PR/check URLs or pasted-link recognition.
- Starting/restarting the user's production daemon.

### QA

This patch was prepared with a coding agent. Automated checks and a read-only smoke test were run on Fedora Linux 44.

#### Reproduced before the fix

The open-target planner regression failed with:

```diff
- "https://projects.example.com/Acme/main/src/branch/feature/web%20links"
+ "https://git.example.com/Acme/main/src/branch/feature/web%20links"
```

Additional tests initially failed because the adapter/snapshot did not expose the web URL, and because a deployment prefix was duplicated for an HTTPS remote. Failure output is included in the accompanying evidence files, with private identifiers replaced by dummy values.

#### Automated checks

```bash
npm ci
npm run format
npm run build:server
npm run typecheck
npm run lint
npx vitest run \
  packages/server/src/services/gitea-service.test.ts \
  packages/server/src/server/workspace-git-service.test.ts \
  packages/server/src/server/checkout/status-projection.test.ts \
  packages/app/src/git/forge-url.test.ts \
  packages/app/src/workspace/open-in-editor/planner.test.ts \
  packages/protocol/src/messages.pull-request-timeline.test.ts \
  --bail=1
git diff --check
```

Results:

```text
Build and all workspace typechecks: passed
Lint: Found 0 warnings and 0 errors.
Test Files  6 passed (6)
     Tests  188 passed (188)
git diff --check: no output
```

Tests cover split SSH/web hosts, login selection, HTTP ports and deployment prefixes, malformed/unsafe URLs, Gitea/Forgejo/Codeberg branch and file links, no-PR metadata, poll retention, failed metadata lookup, and wire compatibility. Only the six affected test files were run, not the full suite.

#### Read-only smoke test with the real tea login

The built Gitea adapter was invoked with a private instance's actual remote and local tea configuration. Its result was passed to the real app open-target planner (no mocked tea runner). The output below is redacted: hostnames and repository names are dummy values, not hosts contacted during the test.

```json
{
  "remoteUrl": "ssh://git@git.example.com:7998/Acme/main.git",
  "repositoryWebUrl": "https://projects.example.com/Acme/main",
  "treeUrl": "https://projects.example.com/Acme/main/src/branch/main",
  "blobUrl": "https://projects.example.com/Acme/main/src/branch/main/Makefile#L25-L30",
  "metadataLookupMs": 48,
  "remoteUnchanged": true
}
```

This verifies real local CLI discovery and link construction, not a browser click or an end-to-end daemon/WebSocket session. A parameterized smoke script and redacted output are included in the accompanying evidence. The new metadata lookup adds one local tea command on a Gitea full forge-snapshot refresh; PR-only polling retains the resolved URL and does not add a lookup. The 48 ms observation is a single smoke measurement, not a performance benchmark.

#### Version compatibility

`repositoryWebUrl` is an optional string on the existing response envelope. Old clients ignore the added field; new clients accept old responses without it. There is no new RPC or required capability. When no canonical URL is available (including adapters that do not implement discovery), the existing remote-based URL behavior remains. Schema tests cover both version directions. Both app and daemon need this patch to fix split-host links.


### Checklist

- [ ] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (not applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense
