### PR TITLE
fix(app): keep the settings sidebar mounted across sections

### DIFF
--- a/docs/expo-router.md
+++ b/docs/expo-router.md
@@ -93,6 +93,16 @@ store-ready protected group so a cold host deep link can survive daemon startup.
 Do not collapse this topology with a catch-all, `getId`, or
 `dangerouslySingular` workaround.
 
+Because they are separate routes, selecting a section replaces the stack entry
+and unmounts the whole settings screen. Anything that must keep state across
+sections therefore cannot live inside a settings screen. The desktop sidebar is
+the case that matters: it renders from `SettingsChrome`, which wraps the root
+stack in `_layout.tsx`, so navigation only swaps the detail pane and the sidebar
+keeps its scroll offset, hover and host picker. `SettingsChrome` reads the
+selected section with `parseSettingsViewFromPathname()` rather than route
+params, so that parser has to mirror `src/app/settings`. Put new persistent
+settings chrome there too, not in `settings-screen.tsx`.
+
 ## Agent Targets
 
 Notifications and agent URLs enter the router with different authoritative
@@ -183,6 +193,8 @@ Before landing route changes:
 - [ ] Did a route return to a workspace? Use `navigateToWorkspace()` and pass a
       `target` when the action names a specific tab.
 - [ ] Did you add a route? Register it in the layout that directly owns it.
+- [ ] Did you add or move a settings route? Update
+      `parseSettingsViewFromPathname()` so the sidebar still resolves it.
 - [ ] Did `useLocalSearchParams()` lose a required param? Fix the route tree.
 - [ ] Did native show a blank screen without a crash? Suspect route ownership
       before stores, themes, or rendering.

--- a/packages/app/e2e/browser/settings-navigation.spec.ts
+++ b/packages/app/e2e/browser/settings-navigation.spec.ts
@@ -40,6 +40,8 @@ import {
   expectSettingsHostPickerLabel,
   openSettingsHostSection,
   removeCurrentHostFromSettings,
+  scrollSettingsSidebarToEnd,
+  expectSettingsSidebarScrollOffset,
 } from "../support/helpers/settings";
 import { getServerId } from "../support/helpers/server-id";
 import { expectAppRoute } from "../support/helpers/route-assertions";
@@ -72,6 +74,25 @@ test.describe("Settings sidebar navigation", () => {
     await openSettingsSection(page, "appearance");
     await expectSettingsHeader(page, "Appearance");
     await expectAppearanceContent(page);
+  });
+
+  test("the sidebar keeps its scroll position when a section is selected", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 480 });
+    await gotoAppShell(page);
+    await openSettings(page);
+
+    const offset = await scrollSettingsSidebarToEnd(page);
+
+    // Only click rows already in view at this offset. Playwright scrolls a
+    // target into view before clicking, so reaching for a row above the fold
+    // would move the sidebar on its own and fail for the wrong reason.
+    await openSettingsHostSection(page, getServerId(), "usage");
+    await expectSettingsHeader(page, "Usage");
+    await expectSettingsSidebarScrollOffset(page, offset);
+
+    await openSettingsHostSection(page, getServerId(), "plugins");
+    await expectSettingsHeader(page, "Plugins");
+    await expectSettingsSidebarScrollOffset(page, offset);
   });
 
   test("/h/[serverId]/settings redirects to the host connections section", async ({ page }) => {

--- a/packages/app/e2e/support/helpers/settings.ts
+++ b/packages/app/e2e/support/helpers/settings.ts
@@ -181,6 +181,26 @@ export async function expectSettingsSidebarVisible(page: Page): Promise<void> {
   await expect(page.getByTestId("settings-sidebar")).toBeVisible();
 }
 
+export async function scrollSettingsSidebarToEnd(page: Page): Promise<number> {
+  const offset = await page.getByTestId("settings-sidebar-scroll-body").evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    return element.scrollTop;
+  });
+  expect(offset).toBeGreaterThan(0);
+  return offset;
+}
+
+export async function expectSettingsSidebarScrollOffset(
+  page: Page,
+  expected: number,
+): Promise<void> {
+  await expect
+    .poll(() =>
+      page.getByTestId("settings-sidebar-scroll-body").evaluate((element) => element.scrollTop),
+    )
+    .toBe(expected);
+}
+
 export async function expectSettingsSidebarHidden(page: Page): Promise<void> {
   await expect(page.locator('[data-testid="settings-sidebar"]:visible')).toHaveCount(0);
 }

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -43,6 +43,7 @@ import { WorkspacePinShortcutHandler } from "@/components/workspace-pin-shortcut
 import { WorkspaceRenameHost } from "@/components/workspace-rename-host";
 import { CompactExplorerSidebarHost } from "@/components/compact-explorer-sidebar-host";
 import { ProviderSettingsHost } from "@/components/provider-settings-host";
+import { SettingsChrome } from "@/screens/settings/settings-chrome";
 import { RootErrorBoundary } from "@/components/root-error-boundary";
 import { WorkspaceSetupDialog } from "@/components/workspace-setup-dialog";
 import { WorkspaceShortcutTargetsSubscriber } from "@/components/workspace-shortcut-targets-subscriber";
@@ -943,7 +944,9 @@ function AppShell() {
         <AgentNavigationListener />
         <AppWithSidebar>
           <WorkspaceRouteNavigationBridge />
-          <RootStack />
+          <SettingsChrome>
+            <RootStack />
+          </SettingsChrome>
         </AppWithSidebar>
       </HorizontalScrollProvider>
     </MobilePanelsProvider>

--- a/packages/app/src/navigation/settings-navigation.test.ts
+++ b/packages/app/src/navigation/settings-navigation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { parseSettingsViewFromPathname } from "./settings-navigation";
+
+describe("parseSettingsViewFromPathname", () => {
+  it("returns null off the settings tree", () => {
+    expect(parseSettingsViewFromPathname("/")).toBeNull();
+    expect(parseSettingsViewFromPathname("/open-project")).toBeNull();
+    expect(parseSettingsViewFromPathname("/h/srv_1/workspace/ws_1")).toBeNull();
+    expect(parseSettingsViewFromPathname("/settingsish")).toBeNull();
+  });
+
+  it("reads the settings root", () => {
+    expect(parseSettingsViewFromPathname("/settings")).toEqual({ kind: "root" });
+    expect(parseSettingsViewFromPathname("/settings/")).toEqual({ kind: "root" });
+  });
+
+  it("reads an app section", () => {
+    expect(parseSettingsViewFromPathname("/settings/appearance")).toEqual({
+      kind: "section",
+      section: "appearance",
+    });
+  });
+
+  it("falls back to general for an unknown app section", () => {
+    expect(parseSettingsViewFromPathname("/settings/nope")).toEqual({
+      kind: "section",
+      section: "general",
+    });
+  });
+
+  it("reads a host section", () => {
+    expect(parseSettingsViewFromPathname("/settings/hosts/srv_1/usage")).toEqual({
+      kind: "host",
+      serverId: "srv_1",
+      section: "usage",
+    });
+  });
+
+  it("normalizes legacy host section slugs", () => {
+    expect(parseSettingsViewFromPathname("/settings/hosts/srv_1/daemon")).toEqual({
+      kind: "host",
+      serverId: "srv_1",
+      section: "host",
+    });
+  });
+
+  it("treats the host index like its connections redirect target", () => {
+    expect(parseSettingsViewFromPathname("/settings/hosts/srv_1")).toEqual({
+      kind: "host",
+      serverId: "srv_1",
+      section: "connections",
+    });
+  });
+
+  it("reads the projects index as the projects host section", () => {
+    expect(parseSettingsViewFromPathname("/settings/hosts/srv_1/projects")).toEqual({
+      kind: "host",
+      serverId: "srv_1",
+      section: "projects",
+    });
+  });
+
+  it("reads a project detail route", () => {
+    expect(parseSettingsViewFromPathname("/settings/hosts/srv_1/projects/proj_1")).toEqual({
+      kind: "project",
+      serverId: "srv_1",
+      projectId: "proj_1",
+    });
+  });
+
+  it("reads a plugin screen route rather than the plugins host section", () => {
+    expect(
+      parseSettingsViewFromPathname("/settings/hosts/srv_1/plugins/my-plugin/my-screen"),
+    ).toEqual({
+      kind: "plugin",
+      serverId: "srv_1",
+      pluginId: "my-plugin",
+      screenId: "my-screen",
+    });
+  });
+
+  it("decodes percent-encoded segments", () => {
+    expect(parseSettingsViewFromPathname("/settings/hosts/srv%20one/usage")).toEqual({
+      kind: "host",
+      serverId: "srv one",
+      section: "usage",
+    });
+  });
+
+  it("ignores search and hash", () => {
+    expect(parseSettingsViewFromPathname("/settings/general?addHost=1")).toEqual({
+      kind: "section",
+      section: "general",
+    });
+  });
+
+  it("falls back to the settings root when a host segment is empty", () => {
+    expect(parseSettingsViewFromPathname("/settings/hosts")).toEqual({ kind: "root" });
+    expect(parseSettingsViewFromPathname("/settings/hosts//usage")).toEqual({ kind: "root" });
+  });
+});

--- a/packages/app/src/navigation/settings-navigation.ts
+++ b/packages/app/src/navigation/settings-navigation.ts
@@ -6,6 +6,10 @@ import {
   buildProjectsSettingsRoute,
   buildSettingsHostSectionRoute,
   buildSettingsRoute,
+  decodeSegment,
+  isSettingsSectionSlug,
+  normalizeHostSectionSlug,
+  stripSearchAndHash,
   type HostSectionSlug,
   type SettingsSectionSlug,
 } from "@/utils/host-routes";
@@ -16,6 +20,54 @@ export type SettingsView =
   | { kind: "section"; section: SettingsSectionSlug }
   | { kind: "host"; serverId: string; section: HostSectionSlug }
   | { kind: "project"; serverId: string; projectId: string };
+
+/** Mirrors the route tree in `src/app/settings`; keep the two in sync. */
+export function parseSettingsViewFromPathname(pathname: string): SettingsView | null {
+  const pathOnly = stripSearchAndHash(pathname);
+  if (pathOnly !== "/settings" && !pathOnly.startsWith("/settings/")) {
+    return null;
+  }
+
+  const segments = pathOnly
+    .slice("/settings".length)
+    .replace(/^\//, "")
+    .split("/")
+    .map(decodeSegment);
+  while (segments.length > 0 && segments[segments.length - 1] === "") {
+    segments.pop();
+  }
+
+  const [first, ...rest] = segments;
+  if (first === undefined) {
+    return { kind: "root" };
+  }
+
+  if (first !== "hosts") {
+    return { kind: "section", section: isSettingsSectionSlug(first) ? first : "general" };
+  }
+
+  const [serverId, hostSection, detailId, screenId] = rest;
+  if (!serverId) {
+    return { kind: "root" };
+  }
+
+  if (hostSection === undefined) {
+    return { kind: "host", serverId, section: "connections" };
+  }
+
+  if (hostSection === "projects" && detailId) {
+    return { kind: "project", serverId, projectId: detailId };
+  }
+  if (hostSection === "plugins" && detailId && screenId) {
+    return { kind: "plugin", serverId, pluginId: detailId, screenId };
+  }
+
+  return {
+    kind: "host",
+    serverId,
+    section: normalizeHostSectionSlug(hostSection) ?? "connections",
+  };
+}
 
 export function openHostOverview(serverId: string): void {
   router.push(buildSettingsHostSectionRoute(serverId, "host"));

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -16,37 +16,8 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { Buffer } from "buffer";
-import {
-  ArrowLeft,
-  Settings,
-  Palette,
-  Server,
-  Network,
-  Bot,
-  Boxes,
-  Gauge,
-  Keyboard,
-  Stethoscope,
-  Info,
-  Bell,
-  Shield,
-  Puzzle,
-  Plus,
-  FolderGit2,
-  SquareTerminal,
-  Code2,
-  Smartphone,
-  Sparkles,
-  Blocks,
-  PanelsTopLeft,
-  ChevronRight,
-} from "lucide-react-native";
+import { FolderGit2, Blocks, ChevronRight } from "lucide-react-native";
 import { DropdownTrigger } from "@/components/ui/dropdown-trigger";
-import { ComboboxTrigger } from "@/components/ui/combobox-trigger";
-import { SidebarHeaderRow } from "@/components/sidebar/sidebar-header-row";
-import { SidebarSeparator } from "@/components/sidebar/sidebar-separator";
-import { HostPicker as SharedHostPicker } from "@/components/hosts/host-picker";
-import { HostStatusDot } from "@/components/host-status-dot";
 import { ScreenTitle } from "@/components/headers/screen-title";
 import { HeaderIconBadge } from "@/components/headers/header-icon-badge";
 import { SettingsSection } from "@/components/settings/headings/settings-section";
@@ -63,20 +34,10 @@ import {
 } from "@/hooks/use-settings";
 import { useHostRuntimeIsConnected, useHosts } from "@/runtime/host-runtime";
 import { useSessionStore } from "@/stores/session-store";
-import {
-  orderHostsLocalFirst,
-  resolveActiveHostServerId,
-  type HostProfile,
-} from "@/types/host-connection";
-import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
-import { WindowChromeRegion, WindowChromeSafeArea } from "@/utils/desktop-window";
+import { resolveActiveHostServerId, type HostProfile } from "@/types/host-connection";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { BackHeader } from "@/components/headers/back-header";
 import { ScreenHeader } from "@/components/headers/screen-header";
-import { AddHostMethodModal } from "@/components/add-host-method-modal";
-import { AddHostModal } from "@/components/add-host-modal";
-import { AddRemoteSshHostModal } from "@/components/add-remote-ssh-host-modal";
-import { PairLinkModal } from "@/components/pair-link-modal";
 import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-section";
 import { EditorSection } from "@/screens/settings/editor-section";
 import { Button } from "@/components/ui/button";
@@ -121,12 +82,8 @@ import { HostPluginsPage } from "@/screens/settings/plugins-page";
 import { MetadataGenerationPage } from "@/screens/settings/metadata-generation-page";
 import ProjectsScreen from "@/screens/projects-screen";
 import ProjectSettingsScreen from "@/screens/project-settings-screen";
-import { SETTINGS_DESKTOP_SIDEBAR_WIDTH, useIsCompactFormFactor } from "@/constants/layout";
+import { useIsCompactFormFactor } from "@/constants/layout";
 import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
-import {
-  type EnableBuiltInDaemonOption,
-  useEnableBuiltInDaemonOption,
-} from "@/desktop/hooks/use-enable-built-in-daemon-option";
 import {
   buildSettingsHostSectionRoute,
   buildSettingsSectionRoute,
@@ -135,72 +92,18 @@ import {
 } from "@/utils/host-routes";
 import { useLastWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
 import { returnFromSettings, type SettingsView } from "@/navigation/settings-navigation";
+import { useSettingsAddHostFlowStore } from "@/stores/settings-add-host-flow-store";
+import {
+  HOST_SECTION_ITEMS,
+  SIDEBAR_SECTION_ITEMS,
+  SettingsSidebar,
+  useSortedHosts,
+} from "@/screens/settings/settings-sidebar";
 import { isNative, isWeb } from "@/constants/platform";
 
 // ---------------------------------------------------------------------------
 // View model
 // ---------------------------------------------------------------------------
-
-interface SidebarSectionItem {
-  id: SettingsSectionSlug;
-  labelKey: string;
-  icon: ComponentType<{ size: number; color: string }>;
-  desktopOnly?: boolean;
-  webOnly?: boolean;
-}
-
-const SIDEBAR_SECTION_ITEMS: SidebarSectionItem[] = [
-  { id: "general", labelKey: "settings.sections.general", icon: Settings },
-  { id: "appearance", labelKey: "settings.sections.appearance", icon: Palette },
-  {
-    id: "layout",
-    labelKey: "settings.sections.layout",
-    icon: PanelsTopLeft,
-    desktopOnly: true,
-  },
-  { id: "editor", labelKey: "settings.sections.editor", icon: Code2, webOnly: true },
-  { id: "shortcuts", labelKey: "settings.sections.shortcuts", icon: Keyboard, desktopOnly: true },
-  {
-    id: "integrations",
-    labelKey: "settings.sections.integrations",
-    icon: Puzzle,
-    desktopOnly: true,
-  },
-  {
-    id: "notifications",
-    labelKey: "settings.sections.notifications",
-    icon: Bell,
-    desktopOnly: true,
-  },
-  {
-    id: "permissions",
-    labelKey: "settings.sections.permissions",
-    icon: Shield,
-    desktopOnly: true,
-  },
-  { id: "diagnostics", labelKey: "settings.sections.diagnostics", icon: Stethoscope },
-  { id: "about", labelKey: "settings.sections.about", icon: Info },
-];
-
-interface HostSectionItem {
-  id: HostSectionSlug;
-  labelKey: string;
-  icon: ComponentType<{ size: number; color: string }>;
-}
-
-const HOST_SECTION_ITEMS: HostSectionItem[] = [
-  { id: "host", labelKey: "settings.hostSections.host", icon: Server },
-  { id: "projects", labelKey: "settings.hostSections.projects", icon: FolderGit2 },
-  { id: "connections", labelKey: "settings.hostSections.connections", icon: Network },
-  { id: "pair-device", labelKey: "openProject.tiles.pairDevice.title", icon: Smartphone },
-  { id: "agents", labelKey: "settings.hostSections.agents", icon: Bot },
-  { id: "metadata", labelKey: "settings.hostSections.metadata", icon: Sparkles },
-  { id: "workspaces", labelKey: "settings.hostSections.workspaces", icon: FolderGit2 },
-  { id: "providers", labelKey: "settings.hostSections.providers", icon: Boxes },
-  { id: "usage", labelKey: "settings.hostSections.usage", icon: Gauge },
-  { id: "terminals", labelKey: "settings.hostSections.terminals", icon: SquareTerminal },
-  { id: "plugins", labelKey: "settings.hostSections.plugins", icon: Blocks },
-];
 
 function renderHostSettingsContent(
   view: Extract<SettingsView, { kind: "host" }>,
@@ -238,18 +141,6 @@ function renderHostSettingsContent(
 
 function themeTriggerStyle({ pressed }: PressableStateCallbackType) {
   return [styles.themeTrigger, pressed && { opacity: 0.85 }];
-}
-
-function sidebarItemStyle({ hovered }: PressableStateCallbackType & { hovered?: boolean }) {
-  return [sidebarStyles.item, Boolean(hovered) && sidebarStyles.itemHovered];
-}
-
-function selectedSidebarItemStyle({ hovered }: PressableStateCallbackType & { hovered?: boolean }) {
-  return [
-    sidebarStyles.item,
-    Boolean(hovered) && sidebarStyles.itemHovered,
-    sidebarStyles.itemSelected,
-  ];
 }
 
 function getSendBehaviorOptions(t: TFunction) {
@@ -876,336 +767,6 @@ function DesktopAppUpdateRow() {
 }
 
 // ---------------------------------------------------------------------------
-// Sidebar
-// ---------------------------------------------------------------------------
-
-/**
- * Local daemon first, then remaining hosts in their existing order.
- */
-function useSortedHosts(hosts: HostProfile[], localServerId: string | null): HostProfile[] {
-  return useMemo(() => orderHostsLocalFirst(hosts, localServerId), [hosts, localServerId]);
-}
-
-interface SidebarSectionButtonProps {
-  itemId: SettingsSectionSlug;
-  label: string;
-  icon: ComponentType<{ size: number; color: string }>;
-  isSelected: boolean;
-  onSelect: (section: SettingsSectionSlug) => void;
-}
-
-function SidebarSectionButton({
-  itemId,
-  label,
-  icon: IconComponent,
-  isSelected,
-  onSelect,
-}: SidebarSectionButtonProps) {
-  const { theme } = useUnistyles();
-  const handlePress = useCallback(() => {
-    onSelect(itemId);
-  }, [onSelect, itemId]);
-  const accessibilityState = useMemo(() => ({ selected: isSelected }), [isSelected]);
-  const labelStyle = useMemo(
-    () => [sidebarStyles.label, isSelected && { color: theme.colors.foreground }],
-    [isSelected, theme.colors.foreground],
-  );
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityState={accessibilityState}
-      onPress={handlePress}
-      style={isSelected ? selectedSidebarItemStyle : sidebarItemStyle}
-    >
-      <IconComponent
-        size={theme.iconSize.md}
-        color={isSelected ? theme.colors.foreground : theme.colors.foregroundMuted}
-      />
-      <Text style={labelStyle} numberOfLines={1}>
-        {label}
-      </Text>
-    </Pressable>
-  );
-}
-
-interface SidebarHostSectionButtonProps {
-  itemId: HostSectionSlug;
-  label: string;
-  icon: ComponentType<{ size: number; color: string }>;
-  isSelected: boolean;
-  onSelect: (section: HostSectionSlug) => void;
-}
-
-function SidebarHostSectionButton({
-  itemId,
-  label,
-  icon: IconComponent,
-  isSelected,
-  onSelect,
-}: SidebarHostSectionButtonProps) {
-  const { theme } = useUnistyles();
-  const handlePress = useCallback(() => {
-    onSelect(itemId);
-  }, [onSelect, itemId]);
-  const accessibilityState = useMemo(() => ({ selected: isSelected }), [isSelected]);
-  const labelStyle = useMemo(
-    () => [sidebarStyles.label, isSelected && { color: theme.colors.foreground }],
-    [isSelected, theme.colors.foreground],
-  );
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityState={accessibilityState}
-      onPress={handlePress}
-      testID={`settings-host-section-${itemId}`}
-      style={isSelected ? selectedSidebarItemStyle : sidebarItemStyle}
-    >
-      <IconComponent
-        size={theme.iconSize.md}
-        color={isSelected ? theme.colors.foreground : theme.colors.foregroundMuted}
-      />
-      <Text style={labelStyle} numberOfLines={1}>
-        {label}
-      </Text>
-    </Pressable>
-  );
-}
-
-interface HostPickerProps {
-  activeServerId: string | null;
-  sortedHosts: HostProfile[];
-  onSelectHost: (serverId: string) => void;
-  onAddHost: () => void;
-  enableBuiltInDaemonOption: EnableBuiltInDaemonOption;
-}
-
-/**
- * Scopes the host sections to a host. Reuses the canonical sidebar host
- * switcher pattern (left-sidebar.tsx): a quiet row-styled trigger opening a
- * <Combobox>. The local host is listed first, each row shows the connection it
- * is using right now; an "Add host" row is always reachable from the list —
- * even with a single host.
- */
-function HostPicker({
-  activeServerId,
-  sortedHosts,
-  onSelectHost,
-  onAddHost,
-  enableBuiltInDaemonOption,
-}: HostPickerProps) {
-  const { t } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
-  const triggerRef = useRef<View | null>(null);
-  const activeHost =
-    sortedHosts.find((host) => host.serverId === activeServerId) ?? sortedHosts[0] ?? null;
-
-  const handleOpen = useCallback(() => setIsOpen(true), []);
-  const hostOptionTestID = useCallback(
-    (serverId: string) => `settings-host-picker-item-${serverId}`,
-    [],
-  );
-  const triggerStyle = useCallback(
-    ({ hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => [
-      sidebarStyles.pickerTrigger,
-      hovered && sidebarStyles.pickerTriggerHovered,
-    ],
-    [],
-  );
-
-  return (
-    <SharedHostPicker
-      hosts={sortedHosts}
-      value={activeServerId ?? ""}
-      onSelect={onSelectHost}
-      open={isOpen}
-      onOpenChange={setIsOpen}
-      anchorRef={triggerRef}
-      includeAddHost
-      onAddHost={onAddHost}
-      includeEnableBuiltInDaemon={enableBuiltInDaemonOption.visible}
-      onEnableBuiltInDaemon={enableBuiltInDaemonOption.onPress}
-      showActiveConnection
-      searchable={false}
-      title={t("settings.hostPicker.switchHost")}
-      desktopMinWidth={240}
-      addHostTestID="settings-add-host"
-      hostOptionTestID={hostOptionTestID}
-    >
-      <ComboboxTrigger
-        ref={triggerRef}
-        block
-        style={triggerStyle}
-        onPress={handleOpen}
-        accessibilityRole="button"
-        accessibilityLabel={t("settings.hostPicker.switchHost")}
-        testID="settings-host-picker"
-      >
-        {activeHost ? (
-          <View style={sidebarStyles.pickerTriggerDot}>
-            <HostStatusDot serverId={activeHost.serverId} />
-          </View>
-        ) : null}
-        <Text style={sidebarStyles.pickerTriggerLabel} numberOfLines={1}>
-          {activeHost?.label ?? t("settings.groups.host")}
-        </Text>
-      </ComboboxTrigger>
-    </SharedHostPicker>
-  );
-}
-
-interface SettingsSidebarProps {
-  view: SettingsView;
-  onSelectSection: (section: SettingsSectionSlug) => void;
-  onSelectHostSection: (section: HostSectionSlug) => void;
-  onSelectHost: (serverId: string) => void;
-  onAddHost: () => void;
-  onBackToWorkspace: () => void;
-  activeHostServerId: string | null;
-  layout: "desktop" | "mobile";
-}
-
-function SettingsSidebar({
-  view,
-  onSelectSection,
-  onSelectHostSection,
-  onSelectHost,
-  onAddHost,
-  onBackToWorkspace,
-  activeHostServerId,
-  layout,
-}: SettingsSidebarProps) {
-  const { theme } = useUnistyles();
-  const { t } = useTranslation();
-  const hosts = useHosts();
-  const localServerId = useLocalDaemonServerId();
-  const sortedHosts = useSortedHosts(hosts, localServerId);
-  const hasHosts = sortedHosts.length > 0;
-  const enableBuiltInDaemonOption = useEnableBuiltInDaemonOption();
-  const isDesktopApp = isElectronRuntime();
-  const items = SIDEBAR_SECTION_ITEMS.filter(
-    (item) => (!item.desktopOnly || isDesktopApp) && (!item.webOnly || isWeb),
-  );
-  const insets = useSafeAreaInsets();
-  const isDesktop = layout === "desktop";
-  const outerContainerStyle = useMemo(
-    () => [isDesktop ? sidebarStyles.desktopContainer : sidebarStyles.mobileContainer],
-    [isDesktop],
-  );
-  const innerContainerStyle = useMemo(
-    () => [{ flex: 1 }, isDesktop ? { paddingTop: insets.top } : null],
-    [insets.top, isDesktop],
-  );
-  const selectedSectionId = view.kind === "section" ? view.section : null;
-  let selectedHostSection: HostSectionSlug | null = null;
-  if (view.kind === "host") selectedHostSection = view.section;
-  if (view.kind === "project") selectedHostSection = "projects";
-  if (view.kind === "plugin") selectedHostSection = "plugins";
-
-  const sidebarBody = (
-    <>
-      <View style={sidebarStyles.list}>
-        <Text style={sidebarStyles.groupLabel}>{t("settings.groups.app")}</Text>
-        {items.map((item) => (
-          <SidebarSectionButton
-            key={item.id}
-            itemId={item.id}
-            label={t(item.labelKey)}
-            icon={item.icon}
-            isSelected={selectedSectionId === item.id}
-            onSelect={onSelectSection}
-          />
-        ))}
-      </View>
-      <SidebarSeparator />
-      {hasHosts ? (
-        <View style={sidebarStyles.list}>
-          <Text style={sidebarStyles.groupLabel}>{t("settings.groups.host")}</Text>
-          <HostPicker
-            activeServerId={activeHostServerId}
-            sortedHosts={sortedHosts}
-            onSelectHost={onSelectHost}
-            onAddHost={onAddHost}
-            enableBuiltInDaemonOption={enableBuiltInDaemonOption}
-          />
-          {HOST_SECTION_ITEMS.map((item) => (
-            <SidebarHostSectionButton
-              key={item.id}
-              itemId={item.id}
-              label={t(item.labelKey)}
-              icon={item.icon}
-              isSelected={selectedHostSection === item.id}
-              onSelect={onSelectHostSection}
-            />
-          ))}
-        </View>
-      ) : (
-        <View style={sidebarStyles.list}>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t("settings.addHost")}
-            onPress={onAddHost}
-            testID="settings-add-host"
-            style={sidebarItemStyle}
-          >
-            <Plus size={theme.iconSize.md} color={theme.colors.foregroundMuted} />
-            <Text style={sidebarStyles.label} numberOfLines={1}>
-              {t("settings.addHost")}
-            </Text>
-          </Pressable>
-          {enableBuiltInDaemonOption.visible ? (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t("settings.enableBuiltInDaemon")}
-              onPress={enableBuiltInDaemonOption.onPress}
-              testID="settings-enable-built-in-daemon"
-              style={sidebarItemStyle}
-            >
-              <Server size={theme.iconSize.md} color={theme.colors.foregroundMuted} />
-              <Text style={sidebarStyles.label} numberOfLines={1}>
-                {t("settings.enableBuiltInDaemon")}
-              </Text>
-            </Pressable>
-          ) : null}
-        </View>
-      )}
-    </>
-  );
-
-  return (
-    <View
-      accessibilityLabel={t("settings.title")}
-      role="navigation"
-      style={outerContainerStyle}
-      testID="settings-sidebar"
-    >
-      {isDesktop ? (
-        <View style={innerContainerStyle}>
-          <View style={sidebarStyles.sidebarDragArea}>
-            <TitlebarDragRegion />
-            <WindowChromeSafeArea placement="below" />
-            <SidebarHeaderRow
-              icon={ArrowLeft}
-              label={t("settings.backToWorkspace")}
-              onPress={onBackToWorkspace}
-              testID="settings-back-to-workspace"
-            />
-          </View>
-          <ScrollView
-            style={sidebarStyles.scrollBody}
-            showsVerticalScrollIndicator={false}
-            testID="settings-sidebar-scroll-body"
-          >
-            {sidebarBody}
-          </ScrollView>
-        </View>
-      ) : (
-        sidebarBody
-      )}
-    </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Main screen
 // ---------------------------------------------------------------------------
 
@@ -1220,10 +781,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const { t } = useTranslation();
   const voiceAudioEngine = useVoiceAudioEngineOptional();
   const { settings, isLoading: settingsLoading, updateSettings } = useAppSettings();
-  const [isAddHostMethodVisible, setIsAddHostMethodVisible] = useState(false);
-  const [isDirectHostVisible, setIsDirectHostVisible] = useState(false);
-  const [isRemoteSshVisible, setIsRemoteSshVisible] = useState(false);
-  const [isPasteLinkVisible, setIsPasteLinkVisible] = useState(false);
   const [isPlaybackTestRunning, setIsPlaybackTestRunning] = useState(false);
   const [playbackTestResult, setPlaybackTestResult] = useState<string | null>(null);
   const lastOpenedAddHostIntentRef = useRef<string | null>(null);
@@ -1329,23 +886,7 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     }
   }, [isPlaybackTestRunning, t, voiceAudioEngine]);
 
-  const closeAddConnectionFlow = useCallback(() => {
-    setIsAddHostMethodVisible(false);
-    setIsDirectHostVisible(false);
-    setIsRemoteSshVisible(false);
-    setIsPasteLinkVisible(false);
-  }, []);
-
-  const goBackToAddConnectionMethods = useCallback(() => {
-    setIsDirectHostVisible(false);
-    setIsRemoteSshVisible(false);
-    setIsPasteLinkVisible(false);
-    setIsAddHostMethodVisible(true);
-  }, []);
-
-  const handleAddHost = useCallback(() => {
-    setIsAddHostMethodVisible(true);
-  }, []);
+  const handleAddHost = useSettingsAddHostFlowStore((state) => state.open);
 
   useEffect(() => {
     if (!openAddHostIntent || lastOpenedAddHostIntentRef.current === openAddHostIntent) {
@@ -1354,33 +895,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     lastOpenedAddHostIntentRef.current = openAddHostIntent;
     handleAddHost();
   }, [handleAddHost, openAddHostIntent]);
-
-  const handleSelectDirectConnection = useCallback(() => {
-    setIsAddHostMethodVisible(false);
-    setIsDirectHostVisible(true);
-  }, []);
-
-  const handleSelectRemoteSsh = useCallback(() => {
-    setIsAddHostMethodVisible(false);
-    setIsRemoteSshVisible(true);
-  }, []);
-
-  const handleSelectPasteLink = useCallback(() => {
-    setIsAddHostMethodVisible(false);
-    setIsPasteLinkVisible(true);
-  }, []);
-
-  const handleHostAdded = useCallback(
-    ({ serverId }: { serverId: string }) => {
-      const target = buildSettingsHostSectionRoute(serverId, "connections");
-      if (isCompactLayout) {
-        router.push(target);
-      } else {
-        router.replace(target);
-      }
-    },
-    [isCompactLayout, router],
-  );
 
   const handleSelectSection = useCallback(
     (section: SettingsSectionSlug) => {
@@ -1436,14 +950,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     },
     [activeHostServerId, handleAddHost, isCompactLayout, router],
   );
-
-  const handleScanQr = useCallback(() => {
-    closeAddConnectionFlow();
-    router.push({
-      pathname: "/pair-scan",
-      params: { source: "settings" },
-    });
-  }, [closeAddConnectionFlow, router]);
 
   const handleHostRemoved = useCallback(() => {
     const fallback = buildSettingsSectionRoute("general");
@@ -1590,37 +1096,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     </>
   ) : null;
 
-  const addHostModals = (
-    <>
-      <AddHostMethodModal
-        visible={isAddHostMethodVisible}
-        onClose={closeAddConnectionFlow}
-        onDirectConnection={handleSelectDirectConnection}
-        onRemoteSsh={handleSelectRemoteSsh}
-        onPasteLink={handleSelectPasteLink}
-        onScanQr={handleScanQr}
-      />
-      <AddHostModal
-        visible={isDirectHostVisible}
-        onClose={closeAddConnectionFlow}
-        onCancel={goBackToAddConnectionMethods}
-        onSaved={handleHostAdded}
-      />
-      <AddRemoteSshHostModal
-        visible={isRemoteSshVisible}
-        onClose={closeAddConnectionFlow}
-        onCancel={goBackToAddConnectionMethods}
-        onSaved={handleHostAdded}
-      />
-      <PairLinkModal
-        visible={isPasteLinkVisible}
-        onClose={closeAddConnectionFlow}
-        onCancel={goBackToAddConnectionMethods}
-        onSaved={handleHostAdded}
-      />
-    </>
-  );
-
   // Mobile root: full-screen sidebar-as-list.
   if (isCompactLayout && view.kind === "root") {
     return (
@@ -1638,7 +1113,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
             layout="mobile"
           />
         </ScrollView>
-        {addHostModals}
       </View>
     );
   }
@@ -1654,44 +1128,21 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
         <ScrollView style={styles.scrollView} contentContainerStyle={insetBottomStyle}>
           <View style={styles.content}>{content}</View>
         </ScrollView>
-        {addHostModals}
       </View>
     );
   }
 
-  // Desktop split view — mirrors AppContainer: sidebar owns the titlebar drag
-  // region + traffic-light padding; detail pane renders whatever header the
-  // selected section provides.
   return (
-    <View style={styles.container}>
-      <View style={desktopStyles.row}>
-        <WindowChromeRegion corners="top-left">
-          <SettingsSidebar
-            view={view}
-            onSelectSection={handleSelectSection}
-            onSelectHostSection={handleSelectHostSection}
-            onSelectHost={handleSelectHost}
-            onAddHost={handleAddHost}
-            onBackToWorkspace={handleBackToWorkspace}
-            activeHostServerId={activeHostServerId}
-            layout="desktop"
-          />
-        </WindowChromeRegion>
-        <WindowChromeRegion corners="top-right">
-          <View style={desktopStyles.contentPane} testID="settings-detail-pane">
-            <ScreenHeader
-              borderless={!detailHeader}
-              left={desktopDetailHeaderLeft}
-              leftStyle={desktopStyles.detailLeft}
-            />
-            <ScrollView style={styles.scrollView} contentContainerStyle={insetBottomStyle}>
-              <View style={styles.content}>{content}</View>
-            </ScrollView>
-          </View>
-        </WindowChromeRegion>
-      </View>
-      {addHostModals}
-    </View>
+    <>
+      <ScreenHeader
+        borderless={!detailHeader}
+        left={desktopDetailHeaderLeft}
+        leftStyle={desktopStyles.detailLeft}
+      />
+      <ScrollView style={styles.scrollView} contentContainerStyle={insetBottomStyle}>
+        <View style={styles.content}>{content}</View>
+      </ScrollView>
+    </>
   );
 }
 
@@ -1793,83 +1244,5 @@ const desktopStyles = StyleSheet.create((theme) => ({
   },
   detailLeft: {
     gap: theme.spacing[2],
-  },
-}));
-
-const sidebarStyles = StyleSheet.create((theme) => ({
-  desktopContainer: {
-    width: SETTINGS_DESKTOP_SIDEBAR_WIDTH,
-    borderRightWidth: 1,
-    borderRightColor: theme.colors.border,
-    backgroundColor: theme.colors.surfaceSidebar,
-  },
-  scrollBody: {
-    flex: 1,
-  },
-  sidebarDragArea: {
-    position: "relative",
-  },
-  mobileContainer: {
-    paddingVertical: theme.spacing[2],
-    paddingHorizontal: theme.spacing[2],
-  },
-  list: {
-    paddingVertical: theme.spacing[2],
-    paddingHorizontal: theme.spacing[2],
-    gap: theme.spacing[1],
-  },
-  groupLabel: {
-    fontSize: theme.fontSize.base,
-    fontWeight: theme.fontWeight.medium,
-    color: theme.colors.foregroundMuted,
-    paddingHorizontal: theme.spacing[2],
-    paddingVertical: theme.spacing[1],
-  },
-  item: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[2],
-    minHeight: 36,
-    paddingVertical: theme.spacing[2],
-    paddingHorizontal: theme.spacing[2],
-    borderRadius: theme.borderRadius.lg,
-  },
-  itemHovered: {
-    backgroundColor: theme.colors.surfaceSidebarHover,
-  },
-  itemSelected: {
-    backgroundColor: theme.colors.surfaceSidebarHover,
-  },
-  label: {
-    fontSize: theme.fontSize.base,
-    color: theme.colors.foregroundMuted,
-    fontWeight: theme.fontWeight.normal,
-    flex: 1,
-  },
-  pickerTrigger: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[2],
-    minHeight: 36,
-    paddingVertical: theme.spacing[2],
-    paddingHorizontal: theme.spacing[2],
-    borderRadius: theme.borderRadius.lg,
-  },
-  pickerTriggerHovered: {
-    backgroundColor: theme.colors.surfaceSidebarHover,
-  },
-  pickerTriggerLabel: {
-    flex: 1,
-    minWidth: 0,
-    fontSize: theme.fontSize.base,
-    color: theme.colors.foreground,
-    fontWeight: theme.fontWeight.normal,
-  },
-  // Match the setting items' icon footprint so the host label aligns with them.
-  pickerTriggerDot: {
-    width: theme.iconSize.md,
-    height: theme.iconSize.md,
-    alignItems: "center",
-    justifyContent: "center",
   },
 }));

--- a/packages/app/src/screens/settings/settings-add-host-flow.tsx
+++ b/packages/app/src/screens/settings/settings-add-host-flow.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from "react";
+import { useRouter } from "expo-router";
+import { AddHostMethodModal } from "@/components/add-host-method-modal";
+import { AddHostModal } from "@/components/add-host-modal";
+import { AddRemoteSshHostModal } from "@/components/add-remote-ssh-host-modal";
+import { PairLinkModal } from "@/components/pair-link-modal";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import { useSettingsAddHostFlowStore } from "@/stores/settings-add-host-flow-store";
+import { buildSettingsHostSectionRoute } from "@/utils/host-routes";
+
+export function SettingsAddHostFlow() {
+  const router = useRouter();
+  const isCompactLayout = useIsCompactFormFactor();
+  const step = useSettingsAddHostFlowStore((state) => state.step);
+  const goTo = useSettingsAddHostFlowStore((state) => state.goTo);
+  const close = useSettingsAddHostFlowStore((state) => state.close);
+
+  const goBackToMethods = useCallback(() => goTo("method"), [goTo]);
+  const selectDirectConnection = useCallback(() => goTo("direct"), [goTo]);
+  const selectRemoteSsh = useCallback(() => goTo("remote-ssh"), [goTo]);
+  const selectPasteLink = useCallback(() => goTo("paste-link"), [goTo]);
+
+  const handleScanQr = useCallback(() => {
+    close();
+    router.push({ pathname: "/pair-scan", params: { source: "settings" } });
+  }, [close, router]);
+
+  const handleHostAdded = useCallback(
+    ({ serverId }: { serverId: string }) => {
+      const target = buildSettingsHostSectionRoute(serverId, "connections");
+      if (isCompactLayout) {
+        router.push(target);
+      } else {
+        router.replace(target);
+      }
+    },
+    [isCompactLayout, router],
+  );
+
+  return (
+    <>
+      <AddHostMethodModal
+        visible={step === "method"}
+        onClose={close}
+        onDirectConnection={selectDirectConnection}
+        onRemoteSsh={selectRemoteSsh}
+        onPasteLink={selectPasteLink}
+        onScanQr={handleScanQr}
+      />
+      <AddHostModal
+        visible={step === "direct"}
+        onClose={close}
+        onCancel={goBackToMethods}
+        onSaved={handleHostAdded}
+      />
+      <AddRemoteSshHostModal
+        visible={step === "remote-ssh"}
+        onClose={close}
+        onCancel={goBackToMethods}
+        onSaved={handleHostAdded}
+      />
+      <PairLinkModal
+        visible={step === "paste-link"}
+        onClose={close}
+        onCancel={goBackToMethods}
+        onSaved={handleHostAdded}
+      />
+    </>
+  );
+}

--- a/packages/app/src/screens/settings/settings-chrome.tsx
+++ b/packages/app/src/screens/settings/settings-chrome.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { View } from "react-native";
+import { usePathname, useRouter } from "expo-router";
+import { StyleSheet } from "react-native-unistyles";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
+import { useHosts } from "@/runtime/host-runtime";
+import { SettingsAddHostFlow } from "@/screens/settings/settings-add-host-flow";
+import { SettingsSidebar, useSortedHosts } from "@/screens/settings/settings-sidebar";
+import { useLastWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
+import { useSettingsAddHostFlowStore } from "@/stores/settings-add-host-flow-store";
+import { resolveActiveHostServerId } from "@/types/host-connection";
+import { WindowChromeRegion } from "@/utils/desktop-window";
+import {
+  buildSettingsHostSectionRoute,
+  buildSettingsSectionRoute,
+  type HostSectionSlug,
+  type SettingsSectionSlug,
+} from "@/utils/host-routes";
+import {
+  parseSettingsViewFromPathname,
+  returnFromSettings,
+  type SettingsView,
+} from "@/navigation/settings-navigation";
+
+interface SettingsChromeProps {
+  children: ReactNode;
+}
+
+export function SettingsChrome({ children }: SettingsChromeProps) {
+  const pathname = usePathname();
+  const isCompactLayout = useIsCompactFormFactor();
+  const view = useMemo(() => parseSettingsViewFromPathname(pathname), [pathname]);
+
+  if (!view || isCompactLayout) {
+    return (
+      <>
+        {children}
+        {view ? <SettingsAddHostFlow /> : null}
+      </>
+    );
+  }
+
+  return <DesktopSettingsChrome view={view}>{children}</DesktopSettingsChrome>;
+}
+
+function DesktopSettingsChrome({ view, children }: SettingsChromeProps & { view: SettingsView }) {
+  const router = useRouter();
+  const hosts = useHosts();
+  const localServerId = useLocalDaemonServerId();
+  const sortedHosts = useSortedHosts(hosts, localServerId);
+  const lastWorkspaceSelection = useLastWorkspaceSelection();
+  const openAddHost = useSettingsAddHostFlowStore((state) => state.open);
+
+  const routedHostServerId =
+    view.kind === "host" || view.kind === "project" || view.kind === "plugin"
+      ? view.serverId
+      : null;
+  const [pickedHostServerId, setPickedHostServerId] = useState<string | null>(null);
+
+  const activeHostServerId = useMemo(() => {
+    if (routedHostServerId) return routedHostServerId;
+    return resolveActiveHostServerId({
+      selectedServerId: pickedHostServerId ?? lastWorkspaceSelection?.serverId ?? null,
+      localServerId,
+      hosts,
+      orderedHosts: sortedHosts,
+    });
+  }, [
+    routedHostServerId,
+    pickedHostServerId,
+    lastWorkspaceSelection?.serverId,
+    localServerId,
+    hosts,
+    sortedHosts,
+  ]);
+
+  const handleSelectSection = useCallback(
+    (section: SettingsSectionSlug) => {
+      router.replace(buildSettingsSectionRoute(section));
+    },
+    [router],
+  );
+
+  const handleSelectHostSection = useCallback(
+    (section: HostSectionSlug) => {
+      if (!activeHostServerId) {
+        openAddHost();
+        return;
+      }
+      router.replace(buildSettingsHostSectionRoute(activeHostServerId, section));
+    },
+    [activeHostServerId, openAddHost, router],
+  );
+
+  const handleSelectHost = useCallback(
+    (serverId: string) => {
+      setPickedHostServerId(serverId);
+      if (view.kind === "project") {
+        router.replace(buildSettingsHostSectionRoute(serverId, "projects"));
+        return;
+      }
+      if (view.kind !== "host") {
+        return;
+      }
+      router.replace(buildSettingsHostSectionRoute(serverId, view.section));
+    },
+    [router, view],
+  );
+
+  const handleBackToWorkspace = useCallback(() => {
+    returnFromSettings({ kind: "root" });
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <WindowChromeRegion corners="top-left">
+          <SettingsSidebar
+            view={view}
+            onSelectSection={handleSelectSection}
+            onSelectHostSection={handleSelectHostSection}
+            onSelectHost={handleSelectHost}
+            onAddHost={openAddHost}
+            onBackToWorkspace={handleBackToWorkspace}
+            activeHostServerId={activeHostServerId}
+            layout="desktop"
+          />
+        </WindowChromeRegion>
+        <WindowChromeRegion corners="top-right">
+          <View style={styles.contentPane} testID="settings-detail-pane">
+            {children}
+          </View>
+        </WindowChromeRegion>
+      </View>
+      <SettingsAddHostFlow />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.surface0,
+  },
+  row: {
+    flex: 1,
+    flexDirection: "row",
+  },
+  contentPane: {
+    flex: 1,
+  },
+}));

--- a/packages/app/src/screens/settings/settings-sidebar.tsx
+++ b/packages/app/src/screens/settings/settings-sidebar.tsx
@@ -1,0 +1,510 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { ComponentType } from "react";
+import { Pressable, ScrollView, Text, View, type PressableStateCallbackType } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { useTranslation } from "react-i18next";
+import {
+  ArrowLeft,
+  Settings,
+  Palette,
+  Server,
+  Network,
+  Bot,
+  Boxes,
+  Gauge,
+  Keyboard,
+  Stethoscope,
+  Info,
+  Bell,
+  Shield,
+  Puzzle,
+  Plus,
+  FolderGit2,
+  SquareTerminal,
+  Code2,
+  Smartphone,
+  Sparkles,
+  Blocks,
+  PanelsTopLeft,
+} from "lucide-react-native";
+import { ComboboxTrigger } from "@/components/ui/combobox-trigger";
+import { SidebarHeaderRow } from "@/components/sidebar/sidebar-header-row";
+import { SidebarSeparator } from "@/components/sidebar/sidebar-separator";
+import { HostPicker as SharedHostPicker } from "@/components/hosts/host-picker";
+import { HostStatusDot } from "@/components/host-status-dot";
+import { useHosts } from "@/runtime/host-runtime";
+import { orderHostsLocalFirst, type HostProfile } from "@/types/host-connection";
+import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
+import { WindowChromeSafeArea } from "@/utils/desktop-window";
+import { isElectronRuntime } from "@/desktop/host";
+import { SETTINGS_DESKTOP_SIDEBAR_WIDTH } from "@/constants/layout";
+import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
+import {
+  type EnableBuiltInDaemonOption,
+  useEnableBuiltInDaemonOption,
+} from "@/desktop/hooks/use-enable-built-in-daemon-option";
+import type { HostSectionSlug, SettingsSectionSlug } from "@/utils/host-routes";
+import type { SettingsView } from "@/navigation/settings-navigation";
+import { isWeb } from "@/constants/platform";
+import { ICON_SIZE, type Theme } from "@/styles/theme";
+
+const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
+const foregroundMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+const ThemedPlus = withUnistyles(Plus);
+const ThemedServer = withUnistyles(Server);
+
+type SidebarIcon = ComponentType<{ size: number; color: string }>;
+
+function createThemedSidebarIcon(Icon: SidebarIcon) {
+  return withUnistyles(Icon);
+}
+
+const themedSidebarIcons = new Map<SidebarIcon, ReturnType<typeof createThemedSidebarIcon>>();
+
+function getThemedSidebarIcon(Icon: SidebarIcon) {
+  const cached = themedSidebarIcons.get(Icon);
+  if (cached) return cached;
+  const themed = createThemedSidebarIcon(Icon);
+  themedSidebarIcons.set(Icon, themed);
+  return themed;
+}
+
+interface SidebarSectionItem {
+  id: SettingsSectionSlug;
+  labelKey: string;
+  icon: SidebarIcon;
+  desktopOnly?: boolean;
+  webOnly?: boolean;
+}
+
+export const SIDEBAR_SECTION_ITEMS: SidebarSectionItem[] = [
+  { id: "general", labelKey: "settings.sections.general", icon: Settings },
+  { id: "appearance", labelKey: "settings.sections.appearance", icon: Palette },
+  {
+    id: "layout",
+    labelKey: "settings.sections.layout",
+    icon: PanelsTopLeft,
+    desktopOnly: true,
+  },
+  { id: "editor", labelKey: "settings.sections.editor", icon: Code2, webOnly: true },
+  { id: "shortcuts", labelKey: "settings.sections.shortcuts", icon: Keyboard, desktopOnly: true },
+  {
+    id: "integrations",
+    labelKey: "settings.sections.integrations",
+    icon: Puzzle,
+    desktopOnly: true,
+  },
+  {
+    id: "notifications",
+    labelKey: "settings.sections.notifications",
+    icon: Bell,
+    desktopOnly: true,
+  },
+  {
+    id: "permissions",
+    labelKey: "settings.sections.permissions",
+    icon: Shield,
+    desktopOnly: true,
+  },
+  { id: "diagnostics", labelKey: "settings.sections.diagnostics", icon: Stethoscope },
+  { id: "about", labelKey: "settings.sections.about", icon: Info },
+];
+
+interface HostSectionItem {
+  id: HostSectionSlug;
+  labelKey: string;
+  icon: SidebarIcon;
+}
+
+export const HOST_SECTION_ITEMS: HostSectionItem[] = [
+  { id: "host", labelKey: "settings.hostSections.host", icon: Server },
+  { id: "projects", labelKey: "settings.hostSections.projects", icon: FolderGit2 },
+  { id: "connections", labelKey: "settings.hostSections.connections", icon: Network },
+  { id: "pair-device", labelKey: "openProject.tiles.pairDevice.title", icon: Smartphone },
+  { id: "agents", labelKey: "settings.hostSections.agents", icon: Bot },
+  { id: "metadata", labelKey: "settings.hostSections.metadata", icon: Sparkles },
+  { id: "workspaces", labelKey: "settings.hostSections.workspaces", icon: FolderGit2 },
+  { id: "providers", labelKey: "settings.hostSections.providers", icon: Boxes },
+  { id: "usage", labelKey: "settings.hostSections.usage", icon: Gauge },
+  { id: "terminals", labelKey: "settings.hostSections.terminals", icon: SquareTerminal },
+  { id: "plugins", labelKey: "settings.hostSections.plugins", icon: Blocks },
+];
+
+function sidebarItemStyle({ hovered }: PressableStateCallbackType & { hovered?: boolean }) {
+  return [sidebarStyles.item, Boolean(hovered) && sidebarStyles.itemHovered];
+}
+
+function selectedSidebarItemStyle({ hovered }: PressableStateCallbackType & { hovered?: boolean }) {
+  return [
+    sidebarStyles.item,
+    Boolean(hovered) && sidebarStyles.itemHovered,
+    sidebarStyles.itemSelected,
+  ];
+}
+
+/**
+ * Local daemon first, then remaining hosts in their existing order.
+ */
+export function useSortedHosts(hosts: HostProfile[], localServerId: string | null): HostProfile[] {
+  return useMemo(() => orderHostsLocalFirst(hosts, localServerId), [hosts, localServerId]);
+}
+
+interface SidebarNavButtonProps<Id extends string> {
+  itemId: Id;
+  label: string;
+  icon: SidebarIcon;
+  isSelected: boolean;
+  onSelect: (id: Id) => void;
+  testID?: string;
+}
+
+function SidebarNavButton<Id extends string>({
+  itemId,
+  label,
+  icon: IconComponent,
+  isSelected,
+  onSelect,
+  testID,
+}: SidebarNavButtonProps<Id>) {
+  const ThemedIcon = getThemedSidebarIcon(IconComponent);
+  const handlePress = useCallback(() => {
+    onSelect(itemId);
+  }, [onSelect, itemId]);
+  const accessibilityState = useMemo(() => ({ selected: isSelected }), [isSelected]);
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={accessibilityState}
+      onPress={handlePress}
+      testID={testID}
+      style={isSelected ? selectedSidebarItemStyle : sidebarItemStyle}
+    >
+      <ThemedIcon
+        size={ICON_SIZE.md}
+        uniProps={isSelected ? foregroundColorMapping : foregroundMutedColorMapping}
+      />
+      <Text
+        style={[sidebarStyles.label, isSelected && sidebarStyles.labelSelected]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+interface HostPickerProps {
+  activeServerId: string | null;
+  sortedHosts: HostProfile[];
+  onSelectHost: (serverId: string) => void;
+  onAddHost: () => void;
+  enableBuiltInDaemonOption: EnableBuiltInDaemonOption;
+}
+
+/**
+ * Scopes the host sections to a host. Reuses the canonical sidebar host
+ * switcher pattern (left-sidebar.tsx): a quiet row-styled trigger opening a
+ * <Combobox>. The local host is listed first, each row shows the connection it
+ * is using right now; an "Add host" row is always reachable from the list —
+ * even with a single host.
+ */
+function HostPicker({
+  activeServerId,
+  sortedHosts,
+  onSelectHost,
+  onAddHost,
+  enableBuiltInDaemonOption,
+}: HostPickerProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<View | null>(null);
+  const activeHost =
+    sortedHosts.find((host) => host.serverId === activeServerId) ?? sortedHosts[0] ?? null;
+
+  const handleOpen = useCallback(() => setIsOpen(true), []);
+  const hostOptionTestID = useCallback(
+    (serverId: string) => `settings-host-picker-item-${serverId}`,
+    [],
+  );
+  const triggerStyle = useCallback(
+    ({ hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => [
+      sidebarStyles.pickerTrigger,
+      hovered && sidebarStyles.pickerTriggerHovered,
+    ],
+    [],
+  );
+
+  return (
+    <SharedHostPicker
+      hosts={sortedHosts}
+      value={activeServerId ?? ""}
+      onSelect={onSelectHost}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      anchorRef={triggerRef}
+      includeAddHost
+      onAddHost={onAddHost}
+      includeEnableBuiltInDaemon={enableBuiltInDaemonOption.visible}
+      onEnableBuiltInDaemon={enableBuiltInDaemonOption.onPress}
+      showActiveConnection
+      searchable={false}
+      title={t("settings.hostPicker.switchHost")}
+      desktopMinWidth={240}
+      addHostTestID="settings-add-host"
+      hostOptionTestID={hostOptionTestID}
+    >
+      <ComboboxTrigger
+        ref={triggerRef}
+        block
+        style={triggerStyle}
+        onPress={handleOpen}
+        accessibilityRole="button"
+        accessibilityLabel={t("settings.hostPicker.switchHost")}
+        testID="settings-host-picker"
+      >
+        {activeHost ? (
+          <View style={sidebarStyles.pickerTriggerDot}>
+            <HostStatusDot serverId={activeHost.serverId} />
+          </View>
+        ) : null}
+        <Text style={sidebarStyles.pickerTriggerLabel} numberOfLines={1}>
+          {activeHost?.label ?? t("settings.groups.host")}
+        </Text>
+      </ComboboxTrigger>
+    </SharedHostPicker>
+  );
+}
+
+interface SettingsSidebarProps {
+  view: SettingsView;
+  onSelectSection: (section: SettingsSectionSlug) => void;
+  onSelectHostSection: (section: HostSectionSlug) => void;
+  onSelectHost: (serverId: string) => void;
+  onAddHost: () => void;
+  onBackToWorkspace: () => void;
+  activeHostServerId: string | null;
+  layout: "desktop" | "mobile";
+}
+
+export function SettingsSidebar({
+  view,
+  onSelectSection,
+  onSelectHostSection,
+  onSelectHost,
+  onAddHost,
+  onBackToWorkspace,
+  activeHostServerId,
+  layout,
+}: SettingsSidebarProps) {
+  const { t } = useTranslation();
+  const hosts = useHosts();
+  const localServerId = useLocalDaemonServerId();
+  const sortedHosts = useSortedHosts(hosts, localServerId);
+  const hasHosts = sortedHosts.length > 0;
+  const enableBuiltInDaemonOption = useEnableBuiltInDaemonOption();
+  const isDesktopApp = isElectronRuntime();
+  const items = SIDEBAR_SECTION_ITEMS.filter(
+    (item) => (!item.desktopOnly || isDesktopApp) && (!item.webOnly || isWeb),
+  );
+  const insets = useSafeAreaInsets();
+  const isDesktop = layout === "desktop";
+  const outerContainerStyle = useMemo(
+    () => [isDesktop ? sidebarStyles.desktopContainer : sidebarStyles.mobileContainer],
+    [isDesktop],
+  );
+  const innerContainerStyle = useMemo(
+    () => [{ flex: 1 }, isDesktop ? { paddingTop: insets.top } : null],
+    [insets.top, isDesktop],
+  );
+  const selectedSectionId = view.kind === "section" ? view.section : null;
+  let selectedHostSection: HostSectionSlug | null = null;
+  if (view.kind === "host") selectedHostSection = view.section;
+  if (view.kind === "project") selectedHostSection = "projects";
+  if (view.kind === "plugin") selectedHostSection = "plugins";
+
+  const sidebarBody = (
+    <>
+      <View style={sidebarStyles.list}>
+        <Text style={sidebarStyles.groupLabel}>{t("settings.groups.app")}</Text>
+        {items.map((item) => (
+          <SidebarNavButton
+            key={item.id}
+            itemId={item.id}
+            label={t(item.labelKey)}
+            icon={item.icon}
+            isSelected={selectedSectionId === item.id}
+            onSelect={onSelectSection}
+          />
+        ))}
+      </View>
+      <SidebarSeparator />
+      {hasHosts ? (
+        <View style={sidebarStyles.list}>
+          <Text style={sidebarStyles.groupLabel}>{t("settings.groups.host")}</Text>
+          <HostPicker
+            activeServerId={activeHostServerId}
+            sortedHosts={sortedHosts}
+            onSelectHost={onSelectHost}
+            onAddHost={onAddHost}
+            enableBuiltInDaemonOption={enableBuiltInDaemonOption}
+          />
+          {HOST_SECTION_ITEMS.map((item) => (
+            <SidebarNavButton
+              key={item.id}
+              itemId={item.id}
+              label={t(item.labelKey)}
+              icon={item.icon}
+              isSelected={selectedHostSection === item.id}
+              onSelect={onSelectHostSection}
+              testID={`settings-host-section-${item.id}`}
+            />
+          ))}
+        </View>
+      ) : (
+        <View style={sidebarStyles.list}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t("settings.addHost")}
+            onPress={onAddHost}
+            testID="settings-add-host"
+            style={sidebarItemStyle}
+          >
+            <ThemedPlus size={ICON_SIZE.md} uniProps={foregroundMutedColorMapping} />
+            <Text style={sidebarStyles.label} numberOfLines={1}>
+              {t("settings.addHost")}
+            </Text>
+          </Pressable>
+          {enableBuiltInDaemonOption.visible ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("settings.enableBuiltInDaemon")}
+              onPress={enableBuiltInDaemonOption.onPress}
+              testID="settings-enable-built-in-daemon"
+              style={sidebarItemStyle}
+            >
+              <ThemedServer size={ICON_SIZE.md} uniProps={foregroundMutedColorMapping} />
+              <Text style={sidebarStyles.label} numberOfLines={1}>
+                {t("settings.enableBuiltInDaemon")}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      )}
+    </>
+  );
+
+  return (
+    <View
+      accessibilityLabel={t("settings.title")}
+      role="navigation"
+      style={outerContainerStyle}
+      testID="settings-sidebar"
+    >
+      {isDesktop ? (
+        <View style={innerContainerStyle}>
+          <View style={sidebarStyles.sidebarDragArea}>
+            <TitlebarDragRegion />
+            <WindowChromeSafeArea placement="below" />
+            <SidebarHeaderRow
+              icon={ArrowLeft}
+              label={t("settings.backToWorkspace")}
+              onPress={onBackToWorkspace}
+              testID="settings-back-to-workspace"
+            />
+          </View>
+          <ScrollView
+            style={sidebarStyles.scrollBody}
+            showsVerticalScrollIndicator={false}
+            testID="settings-sidebar-scroll-body"
+          >
+            {sidebarBody}
+          </ScrollView>
+        </View>
+      ) : (
+        sidebarBody
+      )}
+    </View>
+  );
+}
+
+const sidebarStyles = StyleSheet.create((theme) => ({
+  desktopContainer: {
+    width: SETTINGS_DESKTOP_SIDEBAR_WIDTH,
+    borderRightWidth: 1,
+    borderRightColor: theme.colors.border,
+    backgroundColor: theme.colors.surfaceSidebar,
+  },
+  scrollBody: {
+    flex: 1,
+  },
+  sidebarDragArea: {
+    position: "relative",
+  },
+  mobileContainer: {
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
+  },
+  list: {
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
+    gap: theme.spacing[1],
+  },
+  groupLabel: {
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.foregroundMuted,
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: theme.spacing[1],
+  },
+  item: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    minHeight: 36,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.lg,
+  },
+  itemHovered: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  itemSelected: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  label: {
+    fontSize: theme.fontSize.base,
+    color: theme.colors.foregroundMuted,
+    fontWeight: theme.fontWeight.normal,
+    flex: 1,
+  },
+  labelSelected: {
+    color: theme.colors.foreground,
+  },
+  pickerTrigger: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    minHeight: 36,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.lg,
+  },
+  pickerTriggerHovered: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  pickerTriggerLabel: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.base,
+    color: theme.colors.foreground,
+    fontWeight: theme.fontWeight.normal,
+  },
+  // Match the setting items' icon footprint so the host label aligns with them.
+  pickerTriggerDot: {
+    width: theme.iconSize.md,
+    height: theme.iconSize.md,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+}));

--- a/packages/app/src/stores/settings-add-host-flow-store.ts
+++ b/packages/app/src/stores/settings-add-host-flow-store.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+export type SettingsAddHostStep = "method" | "direct" | "remote-ssh" | "paste-link";
+
+interface SettingsAddHostFlowState {
+  step: SettingsAddHostStep | null;
+  open: () => void;
+  goTo: (step: SettingsAddHostStep) => void;
+  close: () => void;
+}
+
+export const useSettingsAddHostFlowStore = create<SettingsAddHostFlowState>((set) => ({
+  step: null,
+  open: () => set({ step: "method" }),
+  goTo: (step) => set({ step }),
+  close: () => set({ step: null }),
+}));
+
+export function openSettingsAddHostFlow(): void {
+  useSettingsAddHostFlowStore.getState().open();
+}

--- a/packages/app/src/utils/host-routes.ts
+++ b/packages/app/src/utils/host-routes.ts
@@ -4,7 +4,7 @@ import { buildAgentDeepLinkRoute } from "@getpaseo/protocol/agent-deep-link";
 type NullableString = string | null | undefined;
 const BASE64_WORKSPACE_ID_PREFIX = "b64_";
 
-function stripSearchAndHash(pathname: string): string {
+export function stripSearchAndHash(pathname: string): string {
   const hashIndex = pathname.indexOf("#");
   const queryIndex = pathname.indexOf("?");
   const end = [hashIndex, queryIndex]
@@ -41,7 +41,7 @@ function encodeSegment(value: string): string {
   return encodeURIComponent(value);
 }
 
-function decodeSegment(value: string): string {
+export function decodeSegment(value: string): string {
   try {
     return decodeURIComponent(value);
   } catch {


### PR DESCRIPTION
### Linked issue

Closes #1532

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Open Settings, scroll the left sidebar down, click a section: the sidebar jumps back to the top and you lose your place. On a sidebar with ~20 rows this happens on every single selection, so moving between Providers, Usage and Terminals means re-scrolling each time.

The cause is not scroll restoration. Every settings section is its own route (`settings/[section]`, `settings/hosts/[serverId]/[hostSection]`, …), and the sidebar — including its `ScrollView` — was rendered *inside* `SettingsScreen`, which each of those routes mounts. Selecting a section calls `router.replace(...)`, which swaps the stack entry, so the whole screen was destroyed and a brand new sidebar mounted at offset 0. I verified the DOM node identity changes, not just the offset.

So this PR stops the sidebar from being torn down at all, rather than saving and re-applying an offset. `SettingsChrome` renders it above the router stack, and navigation only swaps the detail pane. Scroll offset, hover state and the host picker all survive because nothing about the sidebar is re-created.

This is deliberately a different approach from #3430 and #3506, which both kept the remount and restored the saved offset afterwards.

### Goals

- Selecting any settings section leaves the desktop sidebar scroll offset untouched.
- Cover both route transitions the issue calls out separately: app-section → host-section (different route files) and host-section → host-section (same route file, different params).
- No change to the settings route topology — `docs/expo-router.md` requires those routes to stay distinct siblings, and `router.dismissTo()` depends on it.
- A regression test that fails on the broken code for the reported reason.

### Non-goals

- **Compact/mobile is unchanged.** It pushes a full-screen page per section, where returning to the top of the list is ordinary navigation, not the reported bug. `SettingsChrome` is a pass-through there.
- **No scroll-offset persistence.** No saved offset, no restore-on-mount, no scroll animation. If the sidebar ever remounts again, this fix does not paper over it — the regression test fails instead.
- **No new scroll-into-view behaviour.** Clicking a row above the fold still scrolls it into view; that is the platform's behaviour and it is correct.

Trade-offs taken:

- The sidebar can no longer read the selected section from route params, because it lives outside the stack. It derives it from the pathname via `parseSettingsViewFromPathname()`, which has to mirror `src/app/settings`. That is a real coupling — it is unit-tested (13 cases) and called out in `docs/expo-router.md` plus its checklist.
- The add-host modals moved into the chrome behind a small store, because the sidebar trigger and the modals no longer share a component. This follows the existing `AddProjectFlowHost` pattern.
- The extracted sidebar had to move off `useUnistyles()` to `withUnistyles`/`uniProps`; the ban's grandfathering does not follow code into a new file, and lint enforces it.

One intentional behaviour change: the host picker selection now also survives section changes. Previously it was reset from the last workspace on every settings navigation, which was a symptom of the same remount.

### QA

**Platforms**

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | No     | Compact path only, unchanged by this PR (`SettingsChrome` is a pass-through when compact). Not run on a simulator. |
| Android         | No     | Same as iOS. |
| Web             | Yes    | Playwright, and manual Chromium at 1280x600 and 420x800. |
| Desktop macOS   | Yes    | Electron dev build (Electron 44.2.0), macOS 26.6.2 arm64. Before/after below. |
| Desktop Windows | No     | No machine. Change is platform-neutral React, no `Platform.OS` or Electron branches added. |
| Desktop Linux   | No     | Same as Windows. |

#### Before / after on real Electron (the issue's completion criteria)

Same Electron build, same window (1200x800, dpr 1), same steps. `before` is this branch's parent commit with `git checkout HEAD~1 -- packages/app/src`; `after` is the branch. Driven over CDP so the offsets are measured, not eyeballed, entering Settings from the app sidebar exactly as the report describes.

`sidebarSameDomNode` tags the scroll container's DOM node before navigating and checks whether the same node is still there afterwards — it distinguishes "remounted and reset" from "kept".

Step 2 is **Plugins** (app section → host section, separate route files) and step 3 is **Terminals** (host section → host section, same route file, different param) — the two transitions the issue asks to be exercised separately.

**Before (broken):**

```json
{
  "steps": [
    { "step": "1. scrolled settings sidebar to the end", "scrollTop": 244, "scrollHeight": 963, "clientHeight": 719 },
    { "step": "2. clicked Plugins",   "scrollTop": 0, "sidebarSameDomNode": false, "url": "/settings/hosts/<serverId>/plugins",   "header": "Plugins" },
    { "step": "3. clicked Terminals", "scrollTop": 0, "sidebarSameDomNode": false, "url": "/settings/hosts/<serverId>/terminals", "header": "Terminals" }
  ],
  "hostLabel": "paseo-dev-host",
  "viewport": { "w": 1200, "h": 800, "dpr": 1 }
}
```

**After (fixed):**

```json
{
  "steps": [
    { "step": "1. scrolled settings sidebar to the end", "scrollTop": 244, "scrollHeight": 963, "clientHeight": 719 },
    { "step": "2. clicked Plugins",   "scrollTop": 244, "sidebarSameDomNode": true, "url": "/settings/hosts/<serverId>/plugins",   "header": "Plugins" },
    { "step": "3. clicked Terminals", "scrollTop": 244, "sidebarSameDomNode": true, "url": "/settings/hosts/<serverId>/terminals", "header": "Terminals" }
  ],
  "hostLabel": "paseo-dev-host",
  "viewport": { "w": 1200, "h": 800, "dpr": 1 }
}
```

Offset 244 → 0 before, 244 → 244 after, on both transitions.

State after clicking **Plugins** from the scrolled position:

| Before | After |
| --- | --- |
| <img width="600" alt="Before: sidebar reset to top, Plugins off-screen" src="https://raw.githubusercontent.com/AlmogEinstein/paseo/qa-evidence-1532/qa-electron-before-2-after-plugins.png"> | <img width="600" alt="After: sidebar keeps its offset, Plugins visible and selected" src="https://raw.githubusercontent.com/AlmogEinstein/paseo/qa-evidence-1532/qa-electron-after-2-after-plugins.png"> |

Before, the sidebar is back at the top: the list ends at Agents, so the Plugins row the user just clicked is off-screen below the fold even though the detail pane reads Plugins. After, the sidebar has not moved and Plugins is visible and highlighted where the user left it.

The host in these captures is a local dev daemon renamed to `paseo-dev-host` through the app's own rename flow, so the screenshots carry no machine name.

Full evidence including the third step and the raw JSON: <https://github.com/AlmogEinstein/paseo/tree/qa-evidence-1532>

#### Regression test

Added to the existing spec. It only clicks rows already visible at the scrolled offset — Playwright scrolls a target into view before clicking, so reaching for a row above the fold would move the sidebar itself and prove nothing. `scrollSettingsSidebarToEnd` asserts a non-zero offset so the test cannot silently pass on a sidebar that does not overflow.

Passing on this branch:

```
$ npx playwright test --project=browser e2e/browser/settings-navigation.spec.ts
  ✓   1 … clicking a sidebar section updates the URL and renders the section (2.3s)
  ✓   2 … the sidebar keeps its scroll position when a section is selected (2.1s)
  ✓   3 … /h/[serverId]/settings redirects to the host connections section (3.0s)
  ✓   4 … the + Add host button opens the add-host method modal (2.1s)
  ✓   5 … direct connection advanced URI round-trips SSL and password into the form (2.2s)
  ✓   6 … sidebar shows a Back to workspace row that leaves /settings (2.0s)
  ✓   7 … pressing Escape closes settings (2.0s)
  ✓   8 … Escape lets settings dropdowns and modals close before leaving settings (2.6s)
  ✓   9 … /settings renders only the sidebar list (no section content) (2.3s)
  ✓  10 … tapping a section pushes /settings/[section] and shows a back button (2.3s)
  ✓  11 … back from a section detail returns to the /settings list (2.3s)
  ✓  12 … tapping a host section row pushes /settings/hosts/[serverId]/connections (2.3s)
  ✓  13 … back from a host detail returns to the /settings list (2.3s)
  ✓  14 … host picker settings opens Overview and backs through the settings list (5.0s)
  ✓  15 … switching the host picker on the settings list scopes host rows without navigating (4.3s)
  ✓  16 … removing the last active host returns to welcome after settings closes (4.8s)
  16 passed (50.2s)
```

Failing for the reported reason on the broken behaviour. I re-introduced the remount with a one-line `key={JSON.stringify(view)}` on the sidebar and re-ran only the new test:

```
  ✘  1 … the sidebar keeps its scroll position when a section is selected (12.4s)
    Expected: 319
    Received: 0
  1 failed
```

That is the reported symptom — the offset collapsing to 0 — not an incidental assertion.

#### Regressions around the change

The sidebar, the add-host flow and the host picker all moved, so I exercised the surfaces next to them.

```
$ npx playwright test --project=browser e2e/browser/settings-navigation.spec.ts \
    e2e/browser/projects-settings.spec.ts
  33 passed (1.0m)

$ npx playwright test --project=browser e2e/browser/appearance-theme-picker.spec.ts \
    e2e/browser/plugin-theme.spec.ts
  5 passed (19.1s)
```

That covers compact project navigation, the projects index and project detail routes, the theme picker, `switching the host picker on the settings list scopes host rows without navigating`, and `project detail does not render a second host selector` — the last two being useful checks that the hoisted chrome neither duplicates the host picker nor breaks its scoping.

Manually in Chromium, on this branch:

- Desktop width (1280x600): app sections (General → Appearance → Diagnostics → About → General) all keep the sidebar node and update the header; host sections, projects index, and a project deep link (`/settings/hosts/<id>/projects/<id>`) all render with the sidebar intact.
- Host picker popover opens anchored in the sidebar; Add host → Direct connection → Cancel returns to the method sheet; the modal overlays the whole window.
- `?addHost=1` deep link opens the sheet in compact.
- Compact (420x800): settings root list and detail pages render as before, each with their own back header and no chrome.
- Leaving Settings via "Back to workspace" removes the chrome and restores the normal app sidebar.

Not verified: iOS/Android on device, and Windows/Linux desktop.

#### Commands

```
$ npm run typecheck   # all workspaces
$ npm run lint        # Found 0 warnings and 0 errors.
$ npm run format
$ npx vitest run --root packages/app src/navigation/settings-navigation.test.ts \
    src/components/appearance-style-boundary.test.ts
  Test Files  2 passed (2)
       Tests  16 passed (16)
```

All three also ran clean via the pre-commit hook.

### Checklist

- [x] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (if applicable) — n/a, no plugin changes
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

---

Rebased onto `main` at `7bcf16786`. All numbers above are from runs after that rebase, except the deliberately-broken run, which is unaffected by it.

Claude Code was used for the investigation, the implementation, and the QA runs above. The numbers and screenshots are raw output from those runs against the real Electron app and a real daemon, not a summary.
