### PR TITLE
fix(app): render terminal-profile icons instead of the generic Bot

### DIFF
--- a/packages/app/src/components/provider-icons.test.ts
+++ b/packages/app/src/components/provider-icons.test.ts
@@ -1,5 +1,6 @@
 import { Bot } from "lucide-react-native";
 import { SvgXml } from "react-native-svg";
+import { TERMINAL_PROFILE_ICON_NAMES } from "@getpaseo/protocol/provider-icon-names";
 import { describe, expect, it } from "vitest";
 import { replaceProviderSnapshotIcons } from "./provider-icon-name";
 import { getProviderIcon, type ProviderIconComponent } from "./provider-icons";
@@ -29,5 +30,27 @@ describe("getProviderIcon", () => {
     replaceProviderSnapshotIcons("server-1", [{ provider: "plain-provider" }]);
 
     expect(getProviderIcon("plain-provider", "server-1")).toBe(Bot);
+  });
+
+  it("renders the shipped SVG for the agy terminal-profile icon instead of the Bot", () => {
+    const icon = getProviderIcon("agy");
+    expect(icon).not.toBe(Bot);
+    expect(icon.displayName).toBe("SvgProviderIcon(agy)");
+  });
+
+  it("resolves every registered terminal-profile icon to its shipped SVG, not the Bot", () => {
+    for (const name of TERMINAL_PROFILE_ICON_NAMES) {
+      const icon = getProviderIcon(name);
+      expect(icon, `terminal-profile icon "${name}" fell back to Bot`).not.toBe(Bot);
+      expect(icon.displayName).toBe(`SvgProviderIcon(${name})`);
+    }
+  });
+
+  it("still resolves ACP catalog icons to their SVG (the seeded map is shared)", () => {
+    expect(getProviderIcon("cursor")).not.toBe(Bot);
+  });
+
+  it("falls back to the Bot for an unknown icon id", () => {
+    expect(getProviderIcon("definitely-not-a-real-icon")).toBe(Bot);
   });
 });

--- a/packages/app/src/components/provider-icons.ts
+++ b/packages/app/src/components/provider-icons.ts
@@ -1,6 +1,7 @@
 import { Bot, PackagePlus } from "lucide-react-native";
 import { createElement, type ComponentType } from "react";
 import { SvgXml } from "react-native-svg";
+import { TERMINAL_PROFILE_ICON_NAMES } from "@getpaseo/protocol/provider-icon-names";
 import { ClaudeIcon } from "@/components/icons/claude-icon";
 import { CodexIcon } from "@/components/icons/codex-icon";
 import { CopilotIcon } from "@/components/icons/copilot-icon";
@@ -8,6 +9,7 @@ import { MiniMaxIcon } from "@/components/icons/minimax-icon";
 import { OpenCodeIcon } from "@/components/icons/opencode-icon";
 import { OmpIcon } from "@/components/icons/omp-icon";
 import { PiIcon } from "@/components/icons/pi-icon";
+import { ACP_PROVIDER_ICON_SVGS } from "@/assets/acp-provider-icons";
 import { ACP_PROVIDER_CATALOG } from "@/data/acp-provider-catalog";
 import { resolveProviderIconName } from "@/components/provider-icon-name";
 
@@ -29,9 +31,16 @@ const BUILTIN_PROVIDER_ICONS: Record<string, ProviderIconComponent> = {
   pi: PiIcon as unknown as ProviderIconComponent,
 };
 
-const CATALOG_ICON_SVGS = new Map(
+const CATALOG_ICON_SVGS = new Map<string, string>(
   ACP_PROVIDER_CATALOG.flatMap((entry) => (entry.iconSvg ? [[entry.id, entry.iconSvg]] : [])),
 );
+
+for (const name of TERMINAL_PROFILE_ICON_NAMES) {
+  const iconSvg = (ACP_PROVIDER_ICON_SVGS as Record<string, string | undefined>)[name];
+  if (iconSvg) {
+    CATALOG_ICON_SVGS.set(name, iconSvg);
+  }
+}
 
 const catalogIconComponents = new Map<string, ProviderIconComponent>();
 const snapshotIconComponents = new Map<string, { svg: string; component: ProviderIconComponent }>();


### PR DESCRIPTION
### Linked issue

Closes #4303

### Type of change

- [x] Bug fix

### Reasoning

A terminal profile with `"icon": "agy"` drew the generic Bot even though the Antigravity SVG ships in `ACP_PROVIDER_ICON_SVGS`. `resolveProviderIconName("agy")` returns `{ kind: "catalog" }`, but the app's `CATALOG_ICON_SVGS` map was built only from `ACP_PROVIDER_CATALOG`, which has no `agy` entry, so the lookup missed and fell back to Bot. Seed the map with the terminal-profile icons from `ACP_PROVIDER_ICON_SVGS` so those ids resolve.

### Goals

- Render every registered terminal-profile icon (`TERMINAL_PROFILE_ICON_NAMES`) from its shipped SVG instead of Bot.
- Keep one resolution path for builtin / ACP / terminal-profile icons; unknown ids still fall back to Bot.

### Non-goals

- No change to `resolveProviderIconName` classification or the protocol icon-name lists.
- No `ACP_PROVIDER_CATALOG` entry for `agy` — it is a terminal profile, not an ACP provider.
- No new icon assets; the SVG already ships.

### QA

- `npx vitest run packages/app/src/components/provider-icons.test.ts` — 4 passed: `getProviderIcon("agy")` resolves to a `CatalogProviderIcon(agy)` SVG component, every terminal-profile name resolves non-Bot, an ACP id still resolves, and an unknown id returns Bot.
- Traced the render path: all terminal-profile icon surfaces (new-tab launcher, workspace header/new-tab menus, new-workspace launch control, settings list) draw through `getProviderIcon`, so the fix covers each.
- `npm run typecheck`, `npm run lint`, and `npm run format` all pass.
- No screenshot captured — verified via the unit test and render-path trace.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense