### PR TITLE
fix(server): keep the finish-notification watcher alive through a transient agent error

### DIFF
--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -51,6 +51,8 @@ interface FinishNotificationScenarioOptions {
   childParentAgentId?: string | null;
   requireParentOwnership?: boolean;
   parentPromptError?: Error;
+  /** Lifecycle the child already holds when the watch is set up. */
+  initialChildLifecycle?: "idle" | "running" | "error";
   logger?: Logger;
 }
 
@@ -61,6 +63,10 @@ interface FinishNotificationScenario {
   resolveChildPermissionFromState(requestId?: string): void;
   resolveChildPermissionWhileIdle(requestId?: string): void;
   finishChild(): void;
+  failChildRun(): void;
+  repeatChildError(): void;
+  idleChildWithoutRun(): void;
+  closeChild(): void;
   finishChildAndReadParentPrompt(): Promise<string>;
   closeChildAndReadParentPrompt(): Promise<string>;
   parentPrompts(): string[];
@@ -79,7 +85,7 @@ function createFinishNotificationScenario(
 
   const childAgent: ManagedAgent = Object.create(null);
   Reflect.set(childAgent, "id", "child-agent");
-  Reflect.set(childAgent, "lifecycle", "idle");
+  Reflect.set(childAgent, "lifecycle", options?.initialChildLifecycle ?? "idle");
   Reflect.set(childAgent, "config", { title: "Child Agent" });
   Reflect.set(childAgent, "pendingPermissions", new Map());
 
@@ -220,6 +226,40 @@ function createFinishNotificationScenario(
         agent: childAgent,
       });
     },
+    failChildRun() {
+      childAgent.lifecycle = "running";
+      subscriber?.({
+        type: "agent_state",
+        agent: childAgent,
+      });
+
+      childAgent.lifecycle = "error";
+      subscriber?.({
+        type: "agent_state",
+        agent: childAgent,
+      });
+    },
+    repeatChildError() {
+      childAgent.lifecycle = "error";
+      subscriber?.({
+        type: "agent_state",
+        agent: childAgent,
+      });
+    },
+    idleChildWithoutRun() {
+      childAgent.lifecycle = "idle";
+      subscriber?.({
+        type: "agent_state",
+        agent: childAgent,
+      });
+    },
+    closeChild() {
+      childAgent.lifecycle = "closed";
+      subscriber?.({
+        type: "agent_state",
+        agent: childAgent,
+      });
+    },
     async finishChildAndReadParentPrompt() {
       const parentPrompt = new Promise<string>((resolve) => {
         resolveParentPrompt = resolve;
@@ -306,6 +346,107 @@ test("closing a watched child notifies the caller", async () => {
   expect(parentPrompt).toEqual(
     formatSystemNotificationPrompt("Agent child-agent (Child Agent) was closed."),
   );
+});
+
+test("a failed run keeps the watch armed for the next run's finish", async () => {
+  const scenario = createFinishNotificationScenario();
+
+  scenario.startWatchingChild();
+  scenario.failChildRun();
+
+  await vi.waitFor(() => {
+    expect(scenario.parentPrompts()).toHaveLength(1);
+  });
+  expect(scenario.parentPrompts()[0]).toContain("errored.");
+
+  scenario.finishChild();
+
+  await vi.waitFor(() => {
+    expect(scenario.parentPrompts()).toHaveLength(2);
+  });
+  expect(scenario.parentPrompts()[1]).toContain("finished.");
+});
+
+test("an error not followed by a fresh run never reports a finish", async () => {
+  const scenario = createFinishNotificationScenario();
+
+  scenario.startWatchingChild();
+  scenario.failChildRun();
+
+  await vi.waitFor(() => {
+    expect(scenario.parentPrompts()).toHaveLength(1);
+  });
+
+  // A stale "idle" republished after the failed run is not that run finishing.
+  scenario.idleChildWithoutRun();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  expect(scenario.parentPrompts()).toHaveLength(1);
+  expect(scenario.parentPrompts()[0]).not.toContain("finished.");
+});
+
+test("a child republishing an error does not notify per event", async () => {
+  const scenario = createFinishNotificationScenario();
+
+  scenario.startWatchingChild();
+  scenario.failChildRun();
+  scenario.repeatChildError();
+  scenario.repeatChildError();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  expect(scenario.parentPrompts()).toHaveLength(1);
+});
+
+test("each failed run reports once", async () => {
+  const scenario = createFinishNotificationScenario();
+
+  scenario.startWatchingChild();
+  scenario.failChildRun();
+  scenario.failChildRun();
+
+  await vi.waitFor(() => {
+    expect(scenario.parentPrompts()).toHaveLength(2);
+  });
+  expect(scenario.parentPrompts().filter((prompt) => prompt.includes("errored."))).toHaveLength(2);
+});
+
+test("closing an errored child still ends the notification", async () => {
+  const scenario = createFinishNotificationScenario();
+
+  scenario.startWatchingChild();
+  scenario.failChildRun();
+  await vi.waitFor(() => {
+    expect(scenario.parentPrompts()).toHaveLength(1);
+  });
+
+  scenario.closeChild();
+  await vi.waitFor(() => {
+    expect(scenario.parentPrompts()).toHaveLength(2);
+  });
+  expect(scenario.parentPrompts()[1]).toContain("was closed.");
+
+  scenario.finishChild();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  expect(scenario.parentPrompts()).toHaveLength(2);
+});
+
+test("a watch opened on an errored child reports once and stays armed", async () => {
+  const scenario = createFinishNotificationScenario({ initialChildLifecycle: "error" });
+
+  scenario.startWatchingChild();
+
+  await vi.waitFor(() => {
+    expect(scenario.parentPrompts()).toHaveLength(1);
+  });
+  expect(scenario.parentPrompts()[0]).toContain("errored.");
+
+  scenario.finishChild();
+
+  await vi.waitFor(() => {
+    expect(scenario.parentPrompts()).toHaveLength(2);
+  });
+  expect(scenario.parentPrompts()[1]).toContain("finished.");
 });
 
 test("finish notifications survive permission responses", async () => {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -392,6 +392,12 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
     logger,
   } = params;
   let hasSeenRunning = false;
+  // An "error" lifecycle is not an end state: providers surface a failed turn
+  // as "error" and the agent stays usable, so the caller's next prompt can
+  // still finish. The report is spent per run and refreshed by the next
+  // observed run, so a child that flaps in error costs one notification per
+  // run rather than one per state event.
+  let errorReportable = true;
   let stopped = false;
   const notifiedPermissionRequestIds = new Set<string>();
   let unsubscribe: (() => void) | null = null;
@@ -450,6 +456,16 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
       });
   }
 
+  // Report an error without ending the watch. Clearing the run gate is the
+  // point: a failed run must never be reported later as that run finishing, so
+  // only a genuinely fresh run can produce the next "finished".
+  function notifyErroredKeepingWatch(): void {
+    hasSeenRunning = false;
+    if (!errorReportable) return;
+    errorReportable = false;
+    notifySafely("errored", { terminal: false });
+  }
+
   unsubscribe = agentManager.subscribe(
     (event) => {
       if (stopped) {
@@ -465,11 +481,13 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
         if (event.agent.lifecycle === "running") {
           if (event.agent.pendingPermissions.size === 0) {
             hasSeenRunning = true;
+            // A fresh run refreshes the error report allowance.
+            errorReportable = true;
           }
           return;
         }
         if (event.agent.lifecycle === "error") {
-          notifySafely("errored");
+          notifyErroredKeepingWatch();
           return;
         }
         if (event.agent.lifecycle === "idle" && hasSeenRunning) {
@@ -507,6 +525,9 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
         const childAgent = agentManager.getAgent(childAgentId);
         if (childAgent?.pendingPermissions.size === 0) {
           hasSeenRunning = childAgent.lifecycle === "running";
+          // Resuming after a permission pause is a fresh run for the
+          // allowance too.
+          if (hasSeenRunning) errorReportable = true;
         }
       }
     },
@@ -526,6 +547,8 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
   if (childSnapshot.lifecycle === "running") {
     hasSeenRunning = true;
   } else if (childSnapshot.lifecycle === "error") {
-    notifySafely("errored");
+    // A watch that opens on an already-errored child reports once and stays
+    // armed, same as the event path.
+    notifyErroredKeepingWatch();
   }
 }


### PR DESCRIPTION
Fixes the failure reported in #4231.

When a caller creates or prompts an agent with `notifyOnFinish: true`, the child-state subscription in `setupFinishNotification` maps `lifecycle === "error"` to `notifySafely("errored")`. `notifySafely` treats any call without `terminal: false` as terminal and calls `stop()`, which unsubscribes the watcher. A transient error therefore ends the watch permanently. When the same run then recovers — a provider 503, a resumed turn, an interrupted start that self-heals seconds later — the work completes and the caller is never told. The same path runs on the initial snapshot, so a watcher installed while the child is already in `error` from an earlier turn can spend its notification before the caller's own turn has begun.

#4231 reports this on the `opencode` provider and names the cause: the notification latch is consumed by the `errored` lifecycle event, so a later successful finish has no registered callback.

**What this changes.** An `error` is reported without ending the watch. Because a failed run must never be reported as that run *finishing*, the error report clears the run gate: only a genuinely fresh run can produce the next `finished`. The error report is spent per run and refreshed when a new run is observed, so a child that sits in error or flaps costs the caller one notification per run rather than one per event. Both error paths — the event handler and the initial snapshot — go through it.

**What this does not change.** The first `finished` still disarms the watcher. Every existing caller still receives exactly one `finished`, ever, and no default moves. This is deliberately not the re-arming behaviour proposed in #3455 and closed as a feature; nothing here asks for that discussion. Permanent disarm on `was closed` and on caller archival is untouched.

The tool schemas already promise notification when the created agent "finishes, errors, or needs permission" — a conjunction of three classes, not a single notification. This restores that for the case where the error is not the final outcome.

Tests cover: a transient error keeps the watch armed for the next run's finish; an error not followed by a fresh run never delivers a `finished`; a flapping child does not deliver a notification per event; a close after an error still disarms permanently; an initial-snapshot error behaves as the event-handler error does; and the first-finish disarm is unchanged.

`npx vitest run packages/server/src/server/agent/agent-prompt.test.ts` passes 20/20 on this branch. I have not run the full suite or CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
