### PR TITLE
fix: close failed relay sockets and bound timeline frames

### DIFF
--- a/docs/timeline-sync.md
+++ b/docs/timeline-sync.md
@@ -34,6 +34,11 @@ Heartbeat is used for notification routing. It must not be used as a correctness
 
 Large unbounded timeline responses can exceed relay frame limits, so catch-up uses bounded pages. Bounded does not mean partial.
 
+The daemon also bounds the complete response by its encrypted wire size. Oversized responses
+are reselected with smaller page limits using the same projection and cursor rules. A single
+projected item or response metadata that cannot fit returns an explicit RPC error; history is
+never truncated to make the frame fit.
+
 Page limits are projected-item targets. A tool call lifecycle is one projected item even if it spans many source sequence numbers, and assistant/reasoning chunks are merged before counting. The response carries `seqStart`, `seqEnd`, `sourceSeqRanges`, and `collapsed` so clients can advance sequence cursors without rendering delta rows.
 
 When live delivery detects a sequence gap, the app fetches `direction: "after"`. If the daemon

--- a/packages/server/src/server/relay-transport.test.ts
+++ b/packages/server/src/server/relay-transport.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type pino from "pino";
 import { createClientChannel, type Transport } from "@getpaseo/relay/e2ee";
 import { exportPublicKey, generateKeyPair } from "@getpaseo/relay";
-import { startRelayTransport } from "./relay-transport";
+import { startRelayTransport, type RelaySocketLike } from "./relay-transport";
 
 function createMockLogger() {
   const messages: { level: "debug" | "info" | "warn" | "error"; args: unknown[] }[] = [];
@@ -80,8 +80,8 @@ class FakeRelayWebSocket {
     callback();
   }
 
-  completeNextSend() {
-    this.pendingSendCallbacks.shift()?.();
+  completeNextSend(error?: Error) {
+    this.pendingSendCallbacks.shift()?.(error);
   }
 
   ping() {
@@ -348,5 +348,70 @@ describe("relay-transport control lifecycle", () => {
 
     expect(relay.sockets[0]?.url).toMatch(/^wss:\/\/\[::1\]\/ws\?/);
     expect(relay.sockets[1]?.url).toMatch(/^wss:\/\/\[::1\]\/ws\?/);
+  });
+
+  test("pending encrypted send failures log once and allow a replacement data connection", async () => {
+    const logger = createMockLogger();
+    const daemonKeyPair = generateKeyPair();
+    let resolveAttached: (socket: RelaySocketLike) => void = () => {};
+    const attached = new Promise<RelaySocketLike>((resolve) => (resolveAttached = resolve));
+    controllers.push(
+      startRelayTransport({
+        logger: logger as unknown as pino.Logger,
+        attachSocket: async (socket) => resolveAttached(socket),
+        relayEndpoint: "relay.paseo.sh:443",
+        relayUseTls: true,
+        serverId: "srv_test",
+        daemonKeyPair,
+        createWebSocket: relay.createWebSocket,
+      }),
+    );
+    const control = relay.sockets[0];
+    control.open();
+    control.message(JSON.stringify({ type: "connected", connectionId: "clt_test" }));
+    const dataSocket = relay.sockets[1];
+    dataSocket.open();
+    const clientTransport: Transport = {
+      send: (data) => dataSocket.message(data, data instanceof ArrayBuffer),
+      close: () => undefined,
+      onmessage: null,
+      onclose: null,
+      onerror: null,
+    };
+    dataSocket.onSend = (data) =>
+      clientTransport.onmessage?.({
+        data: data instanceof Uint8Array ? data.slice().buffer : data,
+        isBinary: data instanceof ArrayBuffer || data instanceof Uint8Array,
+      });
+    await createClientChannel(clientTransport, exportPublicKey(daemonKeyPair.publicKey));
+    const socket = await attached;
+    socket.on("error", () => {});
+    dataSocket.deferSendCompletion = true;
+    const sending = Promise.allSettled([
+      socket.send("first"),
+      socket.send("second"),
+      socket.send("third"),
+    ]);
+    const failure = new Error("write EPIPE");
+
+    dataSocket.completeNextSend(failure);
+    dataSocket.completeNextSend(failure);
+    dataSocket.completeNextSend(failure);
+
+    expect(await sending).toEqual(
+      Array.from({ length: 3 }, () => ({
+        status: "rejected",
+        reason: failure,
+      })),
+    );
+    expect(dataSocket.terminateCalls).toBe(1);
+    expect(socket.readyState).toBe(3);
+    expect(
+      logger.messages.filter((entry) => entry.args.includes("relay_socket_send_failed")),
+    ).toHaveLength(1);
+    await expect(socket.send("later")).rejects.toThrow("not open");
+    expect(control.readyState).toBe(FakeRelayWebSocket.OPEN);
+    control.message(JSON.stringify({ type: "connected", connectionId: "clt_test" }));
+    expect(relay.sockets).toHaveLength(3);
   });
 });

--- a/packages/server/src/server/relay-transport.ts
+++ b/packages/server/src/server/relay-transport.ts
@@ -445,6 +445,11 @@ async function attachEncryptedSocket(
       emitter,
       getTransportBufferedAmount: () => socket.bufferedAmount,
       terminateTransport: () => socket.terminate(),
+      onOversizedMessage: (details) =>
+        logger.warn(
+          { ...details, transport: "relay", connectionId: metadata?.relayConnectionId },
+          "relay_message_too_large",
+        ),
     });
     await attachSocket(encryptedSocket, metadata);
     attached = true;
@@ -466,21 +471,32 @@ function createRelayTransportAdapter(
   socket: RelayWebSocketLike,
   logger: pino.Logger,
 ): RelayTransport {
+  let sendFailure: Error | null = null;
+  const failSend = (error: Error) => {
+    if (sendFailure) return;
+    sendFailure = error;
+    logger.warn({ err: error }, "relay_socket_send_failed");
+    if (socket.readyState !== WebSocket.CLOSED) socket.terminate();
+  };
   const relayTransport: RelayTransport = {
     send: (data) =>
       new Promise<void>((resolve, reject) => {
+        if (sendFailure || socket.readyState !== WebSocket.OPEN) {
+          reject(sendFailure ?? new Error("Relay transport is not open"));
+          return;
+        }
         try {
           socket.send(data, (error) => {
             if (!error) {
               resolve();
               return;
             }
-            logger.warn({ err: error }, "relay_socket_send_failed");
+            failSend(error);
             reject(error);
           });
         } catch (error) {
           const err = error instanceof Error ? error : new Error(String(error));
-          logger.warn({ err }, "relay_socket_send_failed");
+          failSend(err);
           reject(err);
         }
       }),

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1,4 +1,5 @@
 import type { SessionEventSubscription } from "@getpaseo/protocol/messages";
+import { boundTimelineResponse } from "./timeline-response.js";
 import type { AgentRequests } from "./agent/requests/index.js";
 import equal from "fast-deep-equal";
 import { v4 as uuidv4 } from "uuid";
@@ -7236,33 +7237,35 @@ export class Session {
       });
       const agentPayload = await this.buildAgentPayload(snapshot);
 
-      const fetchedControlTimeline = this.agentManager.fetchTimeline(msg.agentId, {
-        direction,
-        cursor,
-        limit: pageLimit,
-      });
-      const selectedTimeline = this.selectTimelineProjection({
-        agentId: msg.agentId,
-        projection,
-        controlTimeline: fetchedControlTimeline,
-        direction,
-        ...(cursor ? { cursor } : {}),
-        pageLimit,
-      });
-      const startCursor =
-        selectedTimeline.startSeq !== null
-          ? { epoch: selectedTimeline.timeline.epoch, seq: selectedTimeline.startSeq }
-          : null;
-      const endCursor =
-        selectedTimeline.endSeq !== null
-          ? { epoch: selectedTimeline.timeline.epoch, seq: selectedTimeline.endSeq }
-          : null;
-      const entries = selectedTimeline.entries.filter((entry) =>
-        this.supportsTimelineItem(entry.item, source),
-      );
+      const selectPage = (
+        limit: number,
+      ): Extract<SessionOutboundMessage, { type: "fetch_agent_timeline_response" }> => {
+        const fetchedControlTimeline = this.agentManager.fetchTimeline(msg.agentId, {
+          direction,
+          cursor,
+          limit,
+        });
+        const selectedTimeline = this.selectTimelineProjection({
+          agentId: msg.agentId,
+          projection,
+          controlTimeline: fetchedControlTimeline,
+          direction,
+          ...(cursor ? { cursor } : {}),
+          pageLimit: limit,
+        });
+        const startCursor =
+          selectedTimeline.startSeq !== null
+            ? { epoch: selectedTimeline.timeline.epoch, seq: selectedTimeline.startSeq }
+            : null;
+        const endCursor =
+          selectedTimeline.endSeq !== null
+            ? { epoch: selectedTimeline.timeline.epoch, seq: selectedTimeline.endSeq }
+            : null;
+        const entries = selectedTimeline.entries.filter((entry) =>
+          this.supportsTimelineItem(entry.item, source),
+        );
 
-      this.emitForSource(
-        {
+        return {
           type: "fetch_agent_timeline_response",
           payload: {
             requestId: msg.requestId,
@@ -7302,9 +7305,9 @@ export class Session {
             }),
             error: null,
           },
-        },
-        source,
-      );
+        };
+      };
+      this.emitForSource(boundTimelineResponse(selectPage(pageLimit), selectPage), source);
     } catch (error) {
       this.sessionLogger.error(
         { err: error, agentId: msg.agentId },

--- a/packages/server/src/server/timeline-response.test.ts
+++ b/packages/server/src/server/timeline-response.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "vitest";
+import { base64EncryptedWireByteLength } from "@getpaseo/relay";
+import {
+  wrapSessionMessage,
+  type FetchAgentTimelineResponseMessage,
+} from "@getpaseo/protocol/messages";
+import { boundTimelineResponse } from "./timeline-response.js";
+import { MAX_RELAY_PAYLOAD_BYTES } from "./websocket/relay-payload.js";
+
+function response(
+  direction: "tail" | "before" | "after",
+  text: string,
+): FetchAgentTimelineResponseMessage {
+  return {
+    type: "fetch_agent_timeline_response",
+    payload: {
+      requestId: "request",
+      agentId: "agent",
+      agent: null,
+      direction,
+      projection: "projected",
+      epoch: "epoch",
+      reset: false,
+      staleCursor: false,
+      gap: false,
+      window: { minSeq: 1, maxSeq: 3, nextSeq: 4 },
+      startCursor: { epoch: "epoch", seq: 1 },
+      endCursor: { epoch: "epoch", seq: 3 },
+      hasOlder: false,
+      hasNewer: false,
+      error: null,
+      entries: [1, 2, 3].map((seq) => ({
+        provider: "codex",
+        item: { type: "assistant_message", text },
+        timestamp: "2026-01-01T00:00:00.000Z",
+        seqStart: seq,
+        seqEnd: seq,
+        sourceSeqRanges: [{ startSeq: seq, endSeq: seq }],
+        collapsed: [],
+      })),
+    },
+  };
+}
+
+function selectPage(
+  message: FetchAgentTimelineResponseMessage,
+  limit: number,
+): FetchAgentTimelineResponseMessage {
+  const payload = message.payload;
+  const entries =
+    payload.direction === "after" ? payload.entries.slice(0, limit) : payload.entries.slice(-limit);
+  return {
+    ...message,
+    payload: {
+      ...payload,
+      entries,
+      startCursor: { epoch: payload.epoch, seq: entries[0].seqStart },
+      endCursor: { epoch: payload.epoch, seq: entries[entries.length - 1].seqEnd },
+      hasOlder: payload.direction !== "after" && entries.length < payload.entries.length,
+      hasNewer: payload.direction === "after" && entries.length < payload.entries.length,
+    },
+  };
+}
+
+test("ordinary timeline pages preserve their cursors and flags", () => {
+  const message = response("tail", "small");
+  expect(boundTimelineResponse(message, (limit) => selectPage(message, limit))).toEqual(message);
+});
+
+test.each(["tail", "before", "after"] as const)(
+  "%s pages stay within the encrypted relay limit",
+  (direction) => {
+    const message = response(direction, "x".repeat(9 * 1024 * 1024));
+    const bounded = boundTimelineResponse(message, (limit) => selectPage(message, limit));
+    const expectedSeqs = direction === "after" ? [1, 2] : [2, 3];
+
+    expect(bounded.payload.entries.map((entry) => entry.seqEnd)).toEqual(expectedSeqs);
+    expect(bounded.payload.startCursor).toEqual({ epoch: "epoch", seq: expectedSeqs[0] });
+    expect(bounded.payload.endCursor).toEqual({ epoch: "epoch", seq: expectedSeqs[1] });
+    expect(bounded.payload.hasOlder).toBe(direction !== "after");
+    expect(bounded.payload.hasNewer).toBe(direction === "after");
+    expect(bounded.payload.window).toEqual(message.payload.window);
+    expect(
+      base64EncryptedWireByteLength(Buffer.byteLength(JSON.stringify(wrapSessionMessage(bounded)))),
+    ).toBeLessThanOrEqual(MAX_RELAY_PAYLOAD_BYTES);
+    expect(message.payload.entries).toHaveLength(3);
+  },
+);
+
+test("Unicode and JSON escaping count as wire bytes rather than characters", () => {
+  const message = response("after", "\u0000日".repeat(1024 * 1024));
+  const bounded = boundTimelineResponse(message, (limit) => selectPage(message, limit));
+  expect(bounded.payload.entries).toHaveLength(2);
+  expect(
+    base64EncryptedWireByteLength(Buffer.byteLength(JSON.stringify(wrapSessionMessage(bounded)))),
+  ).toBeLessThanOrEqual(MAX_RELAY_PAYLOAD_BYTES);
+});
+
+test("one oversized item fails explicitly without advancing a cursor or truncating content", () => {
+  const message = response("after", "x".repeat(24 * 1024 * 1024));
+  expect(() => boundTimelineResponse(message, (limit) => selectPage(message, limit))).toThrow(
+    "relay payload limit",
+  );
+  expect(message.payload.endCursor).toEqual({ epoch: "epoch", seq: 3 });
+  expect(message.payload.entries[0].item).toEqual({
+    type: "assistant_message",
+    text: "x".repeat(24 * 1024 * 1024),
+  });
+});

--- a/packages/server/src/server/timeline-response.ts
+++ b/packages/server/src/server/timeline-response.ts
@@ -1,0 +1,24 @@
+import { base64EncryptedWireByteLength } from "@getpaseo/relay";
+import {
+  wrapSessionMessage,
+  type FetchAgentTimelineResponseMessage,
+} from "@getpaseo/protocol/messages";
+import { MAX_RELAY_PAYLOAD_BYTES } from "./websocket/relay-payload.js";
+
+export function boundTimelineResponse(
+  message: FetchAgentTimelineResponseMessage,
+  selectPage: (limit: number) => FetchAgentTimelineResponseMessage,
+): FetchAgentTimelineResponseMessage {
+  let limit = message.payload.entries.length;
+  while (
+    base64EncryptedWireByteLength(Buffer.byteLength(JSON.stringify(wrapSessionMessage(message)))) >
+    MAX_RELAY_PAYLOAD_BYTES
+  ) {
+    if (limit <= 1) {
+      throw new Error("A timeline item or its metadata exceeds the relay payload limit");
+    }
+    limit = Math.ceil(limit / 2);
+    message = selectPage(limit);
+  }
+  return message;
+}

--- a/packages/server/src/server/websocket-server.relay-reconnect.test.ts
+++ b/packages/server/src/server/websocket-server.relay-reconnect.test.ts
@@ -480,6 +480,31 @@ describe("relay external socket reconnect behavior", () => {
     vi.useRealTimers();
   });
 
+  test("oversized relay diagnostics identify the response without logging its content", async () => {
+    const logger = createLogger();
+    const server = createServer({ logger });
+    const socket = new MockSocket();
+    await attachRelayAndHello({ server, socket, clientId: "cid-size-diagnostic" });
+    logger.warn.mockClear();
+    const privateText = "private-tool-result".repeat(2 * 1024 * 1024);
+    sessionMock.instances[0].publish({
+      type: "fetch_agent_timeline_response",
+      payload: { privateText },
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transport: "relay",
+        messageType: "session",
+        sessionMessageType: "fetch_agent_timeline_response",
+        plaintextBytes: expect.any(Number),
+        wireBytes: expect.any(Number),
+      }),
+      "ws_relay_message_too_large",
+    );
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain("private-tool-result");
+    await server.close();
+  });
+
   test("keeps the same session when relay reconnects within grace window", async () => {
     const server = createServer();
     const clientId = "cid-relay-reconnect";

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -102,6 +102,8 @@ import type { DaemonRuntimeConfig } from "./session/daemon/daemon-session.js";
 import { DirectorySyncService } from "./directory-sync/index.js";
 import { OWNER_PERMISSIONS, type DaemonPermission } from "./authorization/index.js";
 import type { WorkspaceLabelService } from "./workspace-labels/index.js";
+import { base64EncryptedWireByteLength } from "@getpaseo/relay";
+import { MAX_RELAY_PAYLOAD_BYTES } from "./websocket/relay-payload.js";
 import {
   APPLICATION_SOCKET_LEASE_CHECK_INTERVAL_MS,
   ApplicationSocketLease,
@@ -1129,6 +1131,24 @@ export class VoiceAssistantWebSocketServer {
 
     const payloadBytes = outboundFrameByteLength(payload);
     for (const ws of writableSockets) {
+      const identity = this.socketIdentities.get(ws);
+      const wireBytes = base64EncryptedWireByteLength(payloadBytes);
+      if (identity?.transport === "relay" && wireBytes > MAX_RELAY_PAYLOAD_BYTES) {
+        this.logger.warn(
+          {
+            connectionId: identity.connectionId,
+            relayConnectionId: identity.relayConnectionId,
+            transport: identity.transport,
+            messageType: message.type,
+            sessionMessageType: message.type === "session" ? message.message.type : undefined,
+            plaintextBytes: payloadBytes,
+            wireBytes,
+            maxWireBytes: MAX_RELAY_PAYLOAD_BYTES,
+            queuedBytes: ws.bufferedAmount ?? 0,
+          },
+          "ws_relay_message_too_large",
+        );
+      }
       this.sendFrameToClient(ws, payload, payloadBytes, () => {
         this.runtimeMetrics.recordOutboundMessage(message, ws.bufferedAmount);
       });

--- a/packages/server/src/server/websocket/encrypted-relay-socket.integration.test.ts
+++ b/packages/server/src/server/websocket/encrypted-relay-socket.integration.test.ts
@@ -1,0 +1,126 @@
+import { EventEmitter, once } from "node:events";
+import { WebSocket, WebSocketServer } from "ws";
+import { expect, test } from "vitest";
+import {
+  EncryptedChannel,
+  decrypt,
+  deriveSharedKey,
+  generateKeyPair,
+  maxBase64EncryptedPlaintextByteLength,
+} from "@getpaseo/relay";
+import type { Transport } from "@getpaseo/relay/e2ee";
+import { createEncryptedRelaySocket } from "./encrypted-relay-socket.js";
+import { MAX_RELAY_PAYLOAD_BYTES } from "./relay-payload.js";
+
+test.each(["binary", "text", "unicode"] as const)(
+  "%s relay frames respect the wire ceiling and a new connection recovers",
+  async (kind) => {
+    const server = new WebSocketServer({
+      host: "127.0.0.1",
+      port: 0,
+      maxPayload: MAX_RELAY_PAYLOAD_BYTES,
+    });
+    await once(server, "listening");
+    const address = server.address();
+    if (typeof address === "string" || address === null)
+      throw new Error("Missing listener address");
+    const clients: WebSocket[] = [];
+    const connect = async () => {
+      const connected = once(server, "connection");
+      const client = new WebSocket(`ws://127.0.0.1:${address.port}`);
+      clients.push(client);
+      await once(client, "open");
+      const [peer] = (await connected) as [WebSocket];
+      const emitter = new EventEmitter();
+      const transport: Transport = {
+        send: (data) =>
+          new Promise<void>((resolve, reject) => {
+            client.send(data, (error) => {
+              if (error) reject(error);
+              else resolve();
+            });
+          }),
+        close: (code, reason) => client.close(code, reason),
+        onmessage: null,
+        onclose: null,
+        onerror: null,
+      };
+      client.on("close", (code, reason) => transport.onclose?.(code, reason.toString()));
+      client.on("error", (error) => transport.onerror?.(error));
+      const daemonKeys = generateKeyPair();
+      const clientKeys = generateKeyPair();
+      const sharedKey = deriveSharedKey(daemonKeys.secretKey, clientKeys.publicKey);
+      const channel = new EncryptedChannel(
+        transport,
+        sharedKey,
+        {
+          onclose: (code, reason) => emitter.emit("close", code, reason),
+        },
+        { binaryCiphertext: true },
+      );
+      const socket = createEncryptedRelaySocket({
+        channel,
+        emitter,
+        getTransportBufferedAmount: () => client.bufferedAmount,
+        terminateTransport: () => client.terminate(),
+      });
+      return { client, peer, socket, sharedKey };
+    };
+    try {
+      const { client, peer, socket } = await connect();
+      const healthy = await connect();
+      const textLimit = maxBase64EncryptedPlaintextByteLength(MAX_RELAY_PAYLOAD_BYTES);
+      let payload: string | Uint8Array;
+      if (kind === "binary") {
+        payload = new Uint8Array(MAX_RELAY_PAYLOAD_BYTES - 40);
+      } else if (kind === "unicode") {
+        payload = "日".repeat(Math.floor(textLimit / 3)) + "x".repeat(textLimit % 3);
+      } else {
+        payload = "x".repeat(textLimit);
+      }
+      const received = once(peer, "message");
+      await socket.send(payload);
+      const [frame, binary] = (await received) as [Buffer, boolean];
+      expect(frame.byteLength).toBe(
+        kind === "binary" ? MAX_RELAY_PAYLOAD_BYTES : Math.floor(MAX_RELAY_PAYLOAD_BYTES / 4) * 4,
+      );
+      expect(binary).toBe(kind === "binary");
+      const closed = once(client, "close");
+      const tooLarge =
+        typeof payload === "string" ? payload + "x" : new Uint8Array(payload.byteLength + 1);
+      await expect(socket.send(tooLarge)).rejects.toThrow("relay payload limit");
+      await closed;
+      expect(socket.readyState).toBe(3);
+
+      const unaffected = once(healthy.peer, "message");
+      await healthy.socket.send("still-healthy");
+      const [healthyFrame] = (await unaffected) as [Buffer];
+      const healthyCiphertext = Uint8Array.from(
+        Buffer.from(healthyFrame.toString(), "base64"),
+      ).buffer;
+      expect(new TextDecoder().decode(decrypt(healthy.sharedKey, healthyCiphertext))).toBe(
+        "still-healthy",
+      );
+      expect(healthy.socket.readyState).toBe(1);
+
+      const replacement = await connect();
+      const recovered = once(replacement.peer, "message");
+      await replacement.socket.send("recovered");
+      const [recoveredFrame] = (await recovered) as [Buffer];
+      const ciphertext = Uint8Array.from(Buffer.from(recoveredFrame.toString(), "base64")).buffer;
+      expect(new TextDecoder().decode(decrypt(replacement.sharedKey, ciphertext))).toBe(
+        "recovered",
+      );
+      expect(replacement.socket.readyState).toBe(1);
+    } finally {
+      for (const client of clients) client.terminate();
+      for (const peer of server.clients) peer.terminate();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    }
+  },
+);

--- a/packages/server/src/server/websocket/encrypted-relay-socket.test.ts
+++ b/packages/server/src/server/websocket/encrypted-relay-socket.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { MAX_PHYSICAL_SOCKET_BUFFERED_BYTES } from "./physical-socket.js";
+import { MAX_RELAY_PAYLOAD_BYTES } from "./relay-payload.js";
 import {
   createEncryptedRelaySocket,
   type EncryptedRelayChannel,
@@ -37,7 +38,7 @@ class BlockingChannel implements EncryptedRelayChannel {
   }
 }
 
-test("negotiated binary ciphertext accepts the exact hard bound and rejects one byte over", async () => {
+test("accepts the exact relay payload limit and rejects a full transport queue", async () => {
   const channel = new BlockingChannel();
   let terminations = 0;
   let transportBufferedAmount = 0;
@@ -50,7 +51,7 @@ test("negotiated binary ciphertext accepts the exact hard bound and rejects one 
     },
   });
 
-  socket.send(new Uint8Array(MAX_PHYSICAL_SOCKET_BUFFERED_BYTES - 40));
+  socket.send(new Uint8Array(MAX_RELAY_PAYLOAD_BYTES - 40));
   expect(channel.sent).toHaveLength(1);
   transportBufferedAmount = MAX_PHYSICAL_SOCKET_BUFFERED_BYTES;
   expect(socket.bufferedAmount).toBe(MAX_PHYSICAL_SOCKET_BUFFERED_BYTES);
@@ -143,4 +144,59 @@ test("encrypted sockets do not double-count bytes already buffered by the transp
   transportBufferedAmount = payload.byteLength + 40;
 
   expect(socket.bufferedAmount).toBe(payload.byteLength + 40);
+});
+
+test.each([1, 3])(
+  "%i failed sends close the socket once and prevent further sends",
+  async (count) => {
+    const failures: Array<(error: Error) => void> = [];
+    const channel = new BlockingChannel();
+    const send = vi
+      .spyOn(channel, "send")
+      .mockImplementation(() => new Promise<void>((_resolve, reject) => failures.push(reject)));
+    const emitter = new EventEmitter();
+    const terminateTransport = vi.fn();
+    const socket = createEncryptedRelaySocket({
+      channel,
+      emitter,
+      getTransportBufferedAmount: () => 0,
+      terminateTransport,
+    });
+    const onError = vi.fn(() => {
+      expect(socket.readyState).toBe(3);
+      expect(terminateTransport).toHaveBeenCalledTimes(1);
+    });
+    emitter.on("error", onError);
+    const sending = Array.from({ length: count }, () => socket.send("message"));
+    const settled = Promise.allSettled(sending);
+    const failure = new Error("write EPIPE");
+
+    for (const reject of failures) reject(failure);
+
+    expect(await settled).toEqual(
+      Array.from({ length: count }, () => ({ status: "rejected", reason: failure })),
+    );
+    expect(socket.readyState).toBe(3);
+    expect(terminateTransport).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    await expect(socket.send("later message")).rejects.toThrow("not open");
+    expect(send).toHaveBeenCalledTimes(count);
+  },
+);
+
+test("rejects a relay message over the payload ceiling even when the queue is empty", async () => {
+  const channel = new BlockingChannel();
+  const terminateTransport = vi.fn();
+  const socket = createEncryptedRelaySocket({
+    channel,
+    emitter: new EventEmitter(),
+    getTransportBufferedAmount: () => 0,
+    terminateTransport,
+  });
+  const payload = new Uint8Array(32 * 1024 * 1024 - 14 - 40 + 1);
+
+  await expect(socket.send(payload)).rejects.toThrow("relay payload limit");
+  expect(channel.sent).toEqual([]);
+  expect(terminateTransport).toHaveBeenCalledTimes(1);
+  expect(socket.readyState).toBe(3);
 });

--- a/packages/server/src/server/websocket/encrypted-relay-socket.ts
+++ b/packages/server/src/server/websocket/encrypted-relay-socket.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { MAX_PHYSICAL_SOCKET_BUFFERED_BYTES } from "./physical-socket.js";
+import { MAX_RELAY_PAYLOAD_BYTES } from "./relay-payload.js";
 
 export interface EncryptedRelayChannel {
   setState: (state: "open") => void;
@@ -23,6 +24,12 @@ export function createEncryptedRelaySocket(params: {
   emitter: EventEmitter;
   getTransportBufferedAmount: () => number | undefined;
   terminateTransport: () => void;
+  onOversizedMessage?: (details: {
+    plaintextBytes: number;
+    wireBytes: number;
+    queuedBytes: number;
+    maxWireBytes: number;
+  }) => void;
 }): EncryptedRelaySocket {
   const { channel, emitter, getTransportBufferedAmount, terminateTransport } = params;
   let readyState = 1;
@@ -59,6 +66,17 @@ export function createEncryptedRelaySocket(params: {
       const outbound = normalizeRelaySendPayload(data);
       const outboundBytes = channel.outboundWireByteLength(outbound);
       const queuedBytes = getTransportBufferedAmount() ?? 0;
+      if (outboundBytes > MAX_RELAY_PAYLOAD_BYTES) {
+        terminate();
+        params.onOversizedMessage?.({
+          plaintextBytes:
+            typeof outbound === "string" ? Buffer.byteLength(outbound) : outbound.byteLength,
+          wireBytes: outboundBytes,
+          queuedBytes,
+          maxWireBytes: MAX_RELAY_PAYLOAD_BYTES,
+        });
+        return Promise.reject(new Error("Encrypted message exceeded the relay payload limit"));
+      }
       if (queuedBytes + outboundBytes > MAX_PHYSICAL_SOCKET_BUFFERED_BYTES) {
         terminate();
         return Promise.reject(
@@ -66,7 +84,10 @@ export function createEncryptedRelaySocket(params: {
         );
       }
       return channel.send(outbound).catch((error) => {
-        emitter.emit("error", error);
+        if (readyState === 1) {
+          terminate();
+          emitter.emit("error", error);
+        }
         throw error;
       });
     },

--- a/packages/server/src/server/websocket/relay-payload.ts
+++ b/packages/server/src/server/websocket/relay-payload.ts
@@ -1,0 +1,2 @@
+// https://github.com/getpaseo/paseo-relay/blob/3fc41c96c8c63f3a7109e832899cc57d473c4531/lib/paseo_relay/protocol.ex
+export const MAX_RELAY_PAYLOAD_BYTES = 32 * 1024 * 1024 - 14;

--- a/packages/server/src/server/wire-compat.test.ts
+++ b/packages/server/src/server/wire-compat.test.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 import { describe, expect, test } from "vitest";
 
 import { CLIENT_CAPS } from "@getpaseo/protocol/client-capabilities";
+import { base64EncryptedWireByteLength } from "@getpaseo/relay";
+import { MAX_RELAY_PAYLOAD_BYTES } from "./websocket/relay-payload.js";
 import {
   AgentTimelineItemPayloadSchema,
   FetchAgentTimelineResponseMessageSchema,
@@ -312,6 +314,122 @@ async function emitTimelineResponse(options?: {
 }
 
 describe("wire compatibility", () => {
+  test("byte-bounded projected pages do not skip rows inside a tool lifecycle", async () => {
+    const text = "x".repeat(9 * 1024 * 1024);
+    const timestamp = "2026-05-02T00:00:00.000Z";
+    const tool = {
+      type: "tool_call" as const,
+      callId: "tool-1",
+      name: "shell",
+      error: null,
+      detail: { type: "unknown" as const, input: {}, output: { text } },
+    };
+    const rows: AgentTimelineRow[] = [
+      { seq: 1, timestamp, item: { type: "user_message", text } },
+      { seq: 2, timestamp, item: { ...tool, status: "running" } },
+      { seq: 3, timestamp, item: { type: "user_message", text } },
+      { seq: 4, timestamp, item: { ...tool, status: "completed" } },
+    ];
+    const first = await emitTimelineResponse({ rows, request: { direction: "after", limit: 0 } });
+    expect(first.payload.error).toBeNull();
+    expect(first.payload.endCursor).toEqual({ epoch: "epoch-1", seq: 2 });
+    expect(first.payload.entries.map((entry) => entry.seqEnd)).toEqual([1, 4]);
+    expect(first.payload.hasNewer).toBe(true);
+    const second = await emitTimelineResponse({
+      rows,
+      request: {
+        direction: "after",
+        cursor: { epoch: "epoch-1", seq: 2 },
+        limit: 0,
+      },
+    });
+    expect(second.payload.error).toBeNull();
+    expect(second.payload.entries.map((entry) => entry.seqStart)).toContain(3);
+    expect(second.payload.endCursor).toEqual({ epoch: "epoch-1", seq: 4 });
+    expect(second.payload.hasNewer).toBe(false);
+  });
+
+  test("byte-bounded tail and backward pages retain every canonical row", async () => {
+    const text = "x".repeat(9 * 1024 * 1024);
+    const rows: AgentTimelineRow[] = [1, 2, 3].map((seq) => ({
+      seq,
+      timestamp: "2026-05-02T00:00:00.000Z",
+      item: { type: "user_message", text },
+    }));
+    const tail = await emitTimelineResponse({
+      rows,
+      request: { direction: "tail", projection: "canonical", limit: 0 },
+    });
+    expect(tail.payload.error).toBeNull();
+    expect(tail.payload.entries.map((entry) => entry.seqEnd)).toEqual([2, 3]);
+    expect(tail.payload.hasOlder).toBe(true);
+    expect(tail.payload.startCursor).toEqual({ epoch: "epoch-1", seq: 2 });
+    const older = await emitTimelineResponse({
+      rows,
+      request: {
+        direction: "before",
+        projection: "canonical",
+        cursor: { epoch: "epoch-1", seq: 2 },
+        limit: 0,
+      },
+    });
+    expect(older.payload.entries.map((entry) => entry.seqEnd)).toEqual([1]);
+    expect(older.payload.hasOlder).toBe(false);
+  });
+
+  test("large canonical history stays complete across byte-bounded forward pages", async () => {
+    const text = "x".repeat(9 * 1024 * 1024);
+    const rows: AgentTimelineRow[] = [1, 2, 3].map((seq) => ({
+      seq,
+      timestamp: "2026-05-02T00:00:00.000Z",
+      item: { type: "user_message", text },
+    }));
+    const first = await emitTimelineResponse({
+      rows,
+      request: { direction: "after", projection: "canonical", limit: 0 },
+    });
+    expect(first.payload.error).toBeNull();
+    expect(first.payload.entries.map((entry) => entry.seqEnd)).toEqual([1, 2]);
+    expect(first.payload.hasNewer).toBe(true);
+    expect(first.payload.endCursor).toEqual({ epoch: "epoch-1", seq: 2 });
+    const second = await emitTimelineResponse({
+      rows,
+      request: {
+        direction: "after",
+        projection: "canonical",
+        cursor: first.payload.endCursor!,
+        limit: 0,
+      },
+    });
+    expect(second.payload.error).toBeNull();
+    expect(second.payload.entries.map((entry) => entry.seqEnd)).toEqual([3]);
+    expect(second.payload.hasNewer).toBe(false);
+    for (const message of [first, second]) {
+      expect(FetchAgentTimelineResponseMessageSchema.safeParse(message).success).toBe(true);
+      const wireBytes = base64EncryptedWireByteLength(
+        Buffer.byteLength(JSON.stringify({ type: "session", message })),
+      );
+      expect(wireBytes).toBeLessThanOrEqual(MAX_RELAY_PAYLOAD_BYTES);
+    }
+  });
+
+  test("one oversized timeline item returns a bounded RPC error", async () => {
+    const message = await emitTimelineResponse({
+      rows: [
+        {
+          seq: 1,
+          timestamp: "2026-05-02T00:00:00.000Z",
+          item: { type: "user_message", text: "x".repeat(24 * 1024 * 1024) },
+        },
+      ],
+    });
+    expect(message.payload.error).toContain("relay payload limit");
+    expect(message.payload.entries).toEqual([]);
+    expect(message.payload.agent).toBeNull();
+    expect(message.payload.endCursor).toBeNull();
+    expect(Buffer.byteLength(JSON.stringify(message))).toBeLessThan(1024);
+  });
+
   test("sends project updates only to clients that declare support", async () => {
     const project = createPersistedProjectRecord({
       projectId: "project-1",


### PR DESCRIPTION
Failed relay sends could leave the encrypted socket reporting itself open, allowing subsequent sends to repeat the same failure. A separate queue watermark also allowed an individual encrypted message to exceed the relay's payload ceiling.

This change terminates a failed connection once, rejects later sends, and checks the complete encrypted wire size before sending. Oversized-message diagnostics record message types, connection identifiers, and byte counts without payload contents.

Timeline replies reselect smaller pages through the existing projection and cursor logic until the complete wrapped response fits. A single oversized item returns an explicit bounded error without truncating history.

Validation completed locally:

- 87 focused tests covering failed and pending sends, encrypted text/binary/Unicode boundaries, independent healthy connections, reconnect recovery, logging privacy, canonical pagination, and projected tool lifecycle cursors.
- Full repository formatting, lint, and all-package typechecks.
- Complete server and CLI build.
- Registry signatures verified for 2,669 installed packages; lockfile lint passed.
- Public package dry runs for protocol, client, and server, with emitted JavaScript verified.
- Generic Codex review plus product, architecture, security, comment, and focused QA review: no actionable findings.

The full server suite is delegated to PR CI with explicit approval, so this PR is a draft. Its local rerun could not acquire the mandatory shared-machine test lock before starting. The initial broader run stopped at a Hub enrollment timeout after 2,454 tests passed; that test passed in isolation after correcting local dependencies, and its harness has relay disabled. The 87 focused tests passed again with the locked dependencies. Upstream's [latest completed Linux and Windows server checks](https://github.com/getpaseo/paseo/actions/runs/34465412984) both passed. The delegated CI command is `npm run test --workspace=@getpaseo/server`, covering unit and integration suites.

In addition to the committed localhost WebSocket regression, an isolated 512 MiB container running relay commit `3fc41c96c8c63f3a7109e832899cc57d473c4531` passed the binary/text/Unicode boundary, healthy-peer isolation, and decrypted replacement-connection checks. A direct over-limit frame was rejected, with the sender observing a reset (1006), not a 1009 close frame. A separate v0.5.2 backport passed the same compatibility proof and 84 focused tests.

Deployment and production recovery verification remain separate; the original production message that exceeded the ceiling has not been conclusively identified.
