### PR TITLE
feat(providers): add Antigravity ACP provider

### DIFF
--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -33,6 +33,15 @@ const CATALOG_DATA = [
     command: ["amp-acp"],
   },
   {
+    id: "antigravity",
+    title: "Antigravity CLI",
+    description: "Google Antigravity via the community paseo-agy-acp bridge",
+    version: "2.3.1",
+    iconId: "agy",
+    installLink: "https://github.com/tiezbro/paseo-agy-acp",
+    command: ["npx", "-y", "paseo-agy-acp@2.3.1"],
+  },
+  {
     id: "auggie",
     title: "Auggie CLI",
     description:

--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -35,7 +35,8 @@ const CATALOG_DATA = [
   {
     id: "antigravity",
     title: "Antigravity CLI",
-    description: "Google Antigravity via the community paseo-agy-acp bridge",
+    description:
+      "Google Antigravity via the community paseo-agy-acp bridge. Requires the official Antigravity ACP kernel to be installed separately.",
     version: "2.3.1",
     iconId: "agy",
     installLink: "https://github.com/tiezbro/paseo-agy-acp",

--- a/packages/app/src/hooks/use-acp-provider-catalog.test.ts
+++ b/packages/app/src/hooks/use-acp-provider-catalog.test.ts
@@ -59,6 +59,15 @@ describe("ACP provider catalog", () => {
     expect(findProvider("minimax-code").iconSvg).toContain("<svg");
   });
 
+  it("offers Antigravity through its pinned ACP bridge", () => {
+    expect(findProvider("antigravity")).toMatchObject({
+      title: "Antigravity CLI",
+      version: "2.3.1",
+      command: ["npx", "-y", "paseo-agy-acp@2.3.1"],
+    });
+    expect(findProvider("antigravity").iconSvg).toContain("<svg");
+  });
+
   it("maps a catalog entry to the daemon provider config patch", () => {
     expect(buildAcpProviderConfigPatch(findProvider("amp-acp"))).toEqual({
       providers: {

--- a/packages/protocol/src/provider-icon-names.ts
+++ b/packages/protocol/src/provider-icon-names.ts
@@ -12,6 +12,7 @@ export const BUILTIN_PROVIDER_ICON_NAMES = [
 export const ACP_PROVIDER_ICON_NAMES = [
   "agoragentic-acp",
   "amp-acp",
+  "antigravity",
   "auggie",
   "autohand",
   "cline",

--- a/public-docs/supported-providers.md
+++ b/public-docs/supported-providers.md
@@ -25,6 +25,7 @@ Pick any of these from the in-app provider catalog. Each entry is a one-click in
 
 - [Agoragentic](https://agoragentic.com), agent marketplace with 174+ AI capabilities.
 - [Amp](https://github.com/tao12345666333/amp-acp), frontier coding agent.
+- [Antigravity CLI](https://github.com/tiezbro/paseo-agy-acp), Google Antigravity through a community ACP bridge; the official Antigravity ACP kernel must be installed separately.
 - [Auggie CLI](https://www.augmentcode.com/), Augment Code's agent backed by their context engine.
 - [Autohand Code](https://www.autohand.ai/cli/), Autohand AI's coding agent.
 - [Cline](https://cline.bot/cli), autonomous coding agent.


### PR DESCRIPTION
## Summary

- keep Gemini CLI available for enterprise/API-key users
- add Antigravity CLI to the ACP catalog through the pinned paseo-agy-acp bridge
- reuse the existing Antigravity icon and document the separate official ACP-kernel prerequisite

## Validation

- npm run test --workspace=@getpaseo/app -- src/hooks/use-acp-provider-catalog.test.ts
- npm run typecheck --workspace=@getpaseo/protocol
- npm exec -- oxfmt --check packages/app/src/data/acp-provider-catalog.ts packages/app/src/hooks/use-acp-provider-catalog.test.ts packages/protocol/src/provider-icon-names.ts public-docs/supported-providers.md
- timeout 20s npx -y paseo-agy-acp@2.3.1 --version

The repository-wide ACP version-drift check still reports 13 pre-existing stale pins, including Gemini; the new Antigravity package is not reported as drifted.