### PR TITLE
fix(plugin-provider): discard rewound history

### DIFF
--- a/packages/server/src/server/agent/plugin-provider.test.ts
+++ b/packages/server/src/server/agent/plugin-provider.test.ts
@@ -25,6 +25,7 @@ const CAPABILITIES = [
 interface ProviderHarnessOptions {
   capabilities?: ProviderConnection["capabilities"];
   completeTurn?: boolean;
+  permissionResponseError?: Error;
   rewindable?: boolean;
 }
 
@@ -177,6 +178,7 @@ function createProviderHarness(options: ProviderHarnessOptions = {}) {
         return;
       }
       if (input.type === "session.permission") {
+        if (options.permissionResponseError) throw options.permissionResponseError;
         emit({
           type: "session.permission_resolved",
           sessionId: input.sessionId,
@@ -392,6 +394,14 @@ describe("PluginAgentClientRegistry", () => {
 
     await session.startTurn("old branch", { clientMessageId: "old-branch" });
     await session.revertConversation?.({ messageId: "rewind-target" });
+    expect(session.getPendingPermissions()).toEqual([]);
+    expect(harness.inputs).toContainEqual(
+      expect.objectContaining({
+        type: "session.permission",
+        permissionId: "permission-1",
+        response: { behavior: "deny", message: "Removed by rewind" },
+      }),
+    );
     await session.startTurn("replacement", { clientMessageId: "replacement" });
 
     const timeline = [];
@@ -402,6 +412,68 @@ describe("PluginAgentClientRegistry", () => {
       { type: "assistant_message", text: "Rep", messageId: "replacement-answer" },
       { type: "assistant_message", text: "lacement", messageId: "replacement-answer" },
     ]);
+
+    await registry.shutdown();
+  });
+
+  test("keeps local history consistent when permission cleanup fails", async () => {
+    const harness = createProviderHarness({
+      rewindable: true,
+      permissionResponseError: new Error("permission cleanup failed"),
+      capabilities: [...CAPABILITIES, "session.revert.conversation"],
+    });
+    const registry = new PluginAgentClientRegistry(createTestLogger());
+    registry.replace([harness.registration]);
+    const client = registry.clients()[harness.registration.id]!;
+    const session = await client.createSession({
+      provider: harness.registration.id,
+      cwd: "/workspace",
+    });
+
+    await session.startTurn("old branch", { clientMessageId: "old-branch" });
+    await expect(session.revertConversation?.({ messageId: "rewind-target" })).rejects.toThrow(
+      "permission cleanup failed",
+    );
+    expect(session.getPendingPermissions()).toEqual([]);
+
+    const timeline = [];
+    for await (const event of session.streamHistory()) {
+      if (event.type === "timeline") timeline.push(event.item);
+    }
+    expect(timeline).toEqual([]);
+    await expect(
+      session.startTurn("replacement", { clientMessageId: "replacement" }),
+    ).rejects.toThrow("permission cleanup failed");
+    expect(harness.inputs.filter((input) => input.type === "session.permission")).toHaveLength(2);
+
+    await registry.shutdown();
+  });
+
+  test.each(["both", "files"] as const)("applies history policy to %s rewinds", async (scope) => {
+    const harness = createProviderHarness({
+      rewindable: true,
+      capabilities: [...CAPABILITIES, `session.revert.${scope}`],
+    });
+    const registry = new PluginAgentClientRegistry(createTestLogger());
+    registry.replace([harness.registration]);
+    const client = registry.clients()[harness.registration.id]!;
+    const session = await client.createSession({
+      provider: harness.registration.id,
+      cwd: "/workspace",
+    });
+
+    await session.startTurn("old branch", { clientMessageId: "old-branch" });
+    if (scope === "both") {
+      await session.revertBoth?.({ messageId: "rewind-target" });
+    } else {
+      await session.revertFiles?.({ messageId: "rewind-target" });
+    }
+
+    const timeline = [];
+    for await (const event of session.streamHistory()) {
+      if (event.type === "timeline") timeline.push(event.item);
+    }
+    expect(timeline).toHaveLength(scope === "both" ? 0 : 3);
 
     await registry.shutdown();
   });

--- a/packages/server/src/server/agent/plugin-provider.test.ts
+++ b/packages/server/src/server/agent/plugin-provider.test.ts
@@ -1,5 +1,6 @@
 import type {
   ProviderConnection,
+  ProviderContent,
   ProviderEvent,
   ProviderInput,
   ProviderRegistration,
@@ -24,6 +25,7 @@ const CAPABILITIES = [
 interface ProviderHarnessOptions {
   capabilities?: ProviderConnection["capabilities"];
   completeTurn?: boolean;
+  rewindable?: boolean;
 }
 
 function createProviderHarness(options: ProviderHarnessOptions = {}) {
@@ -67,6 +69,19 @@ function createProviderHarness(options: ProviderHarnessOptions = {}) {
           persistence: { version: 1, data: { token: "root" } },
           cwd: input.config.cwd,
         });
+        if (options.rewindable) {
+          emit({
+            type: "timeline.item",
+            sessionId: input.sessionId,
+            item: {
+              type: "user_message",
+              id: "rewind-target",
+              messageId: "rewind-target",
+              text: "Discard this branch",
+              revertToken: "rewind-token",
+            },
+          });
+        }
         emit({
           type: "session.config",
           sessionId: input.sessionId,
@@ -124,15 +139,27 @@ function createProviderHarness(options: ProviderHarnessOptions = {}) {
           turnId: "turn-1",
           state: "started",
         });
+        const promptText =
+          input.prompt.input.type === "message"
+            ? input.prompt.input.content
+                .filter(
+                  (part): part is Extract<ProviderContent, { type: "text" }> =>
+                    part.type === "text",
+                )
+                .map((part) => part.text)
+                .join("\n")
+            : "";
+        const answerId = promptText === "replacement" ? "replacement-answer" : "answer";
+        const answerText = promptText === "replacement" ? "Replacement" : "Hello";
         emit({
           type: "timeline.item",
           sessionId: input.sessionId,
-          item: { type: "assistant_message", id: "answer", text: "Hel" },
+          item: { type: "assistant_message", id: answerId, text: answerText.slice(0, 3) },
         });
         emit({
           type: "timeline.item",
           sessionId: input.sessionId,
-          item: { type: "assistant_message", id: "answer", text: "Hello" },
+          item: { type: "assistant_message", id: answerId, text: answerText },
         });
         emit({
           type: "session.permission",
@@ -348,6 +375,35 @@ describe("PluginAgentClientRegistry", () => {
     } finally {
       await registry.shutdown();
     }
+  });
+
+  test("discards abandoned plugin history after conversation rewind", async () => {
+    const harness = createProviderHarness({
+      rewindable: true,
+      capabilities: [...CAPABILITIES, "session.revert.conversation"],
+    });
+    const registry = new PluginAgentClientRegistry(createTestLogger());
+    registry.replace([harness.registration]);
+    const client = registry.clients()[harness.registration.id]!;
+    const session = await client.createSession({
+      provider: harness.registration.id,
+      cwd: "/workspace",
+    });
+
+    await session.startTurn("old branch", { clientMessageId: "old-branch" });
+    await session.revertConversation?.({ messageId: "rewind-target" });
+    await session.startTurn("replacement", { clientMessageId: "replacement" });
+
+    const timeline = [];
+    for await (const event of session.streamHistory()) {
+      if (event.type === "timeline") timeline.push(event.item);
+    }
+    expect(timeline).toEqual([
+      { type: "assistant_message", text: "Rep", messageId: "replacement-answer" },
+      { type: "assistant_message", text: "lacement", messageId: "replacement-answer" },
+    ]);
+
+    await registry.shutdown();
   });
 
   test("adapts callback providers into the existing AgentClient and AgentSession path", async () => {

--- a/packages/server/src/server/agent/plugin-provider.ts
+++ b/packages/server/src/server/agent/plugin-provider.ts
@@ -837,9 +837,16 @@ function createPluginProviderDefinition(
   };
 }
 
-interface TimelineSnapshotVersion {
-  historyLengthAfter: number;
+interface TimelineSnapshotNode {
+  id: string;
   item: ProviderTimelineItem;
+  parent: TimelineSnapshotNode | null;
+}
+
+interface TimelineCheckpoint {
+  historyLengthBefore: number;
+  timelineHead: TimelineSnapshotNode | null;
+  childHeads: Map<string, TimelineSnapshotNode | null>;
 }
 
 interface PendingChild {
@@ -1045,13 +1052,11 @@ class PluginAgentSession implements AgentSession {
   >();
   private readonly revertTokens = new Map<string, ProviderTimelineItem["revertToken"]>();
   private readonly timelineSnapshots = new Map<string, ProviderTimelineItem>();
-  private readonly timelineSnapshotVersions = new Map<string, TimelineSnapshotVersion[]>();
+  private readonly timelineCheckpoints = new Map<string, TimelineCheckpoint[]>();
+  private timelineHead: TimelineSnapshotNode | null = null;
   private readonly childUnsubscribes = new Map<string, () => void>();
   private readonly childSnapshots = new Map<string, Map<string, ProviderTimelineItem>>();
-  private readonly childSnapshotVersions = new Map<
-    string,
-    Map<string, TimelineSnapshotVersion[]>
-  >();
+  private readonly childHeads = new Map<string, TimelineSnapshotNode | null>();
   private unsubscribe: (() => void) | null = null;
   private currentTurnId: string | null = null;
   private rewindLane: Promise<void> = Promise.resolve();
@@ -1279,7 +1284,7 @@ class PluginAgentSession implements AgentSession {
     });
     const snapshots = new Map<string, ProviderTimelineItem>();
     this.childSnapshots.set(childId, snapshots);
-    this.childSnapshotVersions.set(childId, new Map());
+    this.childHeads.set(childId, null);
     for (const event of child.history) this.acceptChildEvent(childId, event, snapshots);
     this.childUnsubscribes.set(
       childId,
@@ -1287,16 +1292,35 @@ class PluginAgentSession implements AgentSession {
     );
   }
 
+  private captureTimelineCheckpoint(
+    item: Extract<ProviderTimelineItem, { type: "user_message" }>,
+  ): void {
+    const checkpoint: TimelineCheckpoint = {
+      historyLengthBefore: this.history.length,
+      timelineHead: this.timelineHead,
+      childHeads: new Map(this.childHeads),
+    };
+    const key = item.messageId !== undefined ? `message:${item.messageId}` : `item:${item.id}`;
+    const checkpoints = this.timelineCheckpoints.get(key) ?? [];
+    checkpoints.push(checkpoint);
+    this.timelineCheckpoints.set(key, checkpoints);
+  }
+
   private accept(event: ProviderEvent, live: boolean): void {
+    if (event.type === "timeline.item" && event.item.type === "user_message") {
+      this.captureTimelineCheckpoint(event.item);
+    }
     const translated = this.translate(event);
     for (const next of translated) {
       this.history.push(next);
       if (live) this.emit(next);
     }
     if (event.type === "timeline.item") {
-      const versions = this.timelineSnapshotVersions.get(event.item.id) ?? [];
-      versions.push({ historyLengthAfter: this.history.length, item: event.item });
-      this.timelineSnapshotVersions.set(event.item.id, versions);
+      this.timelineHead = {
+        id: event.item.id,
+        item: event.item,
+        parent: this.timelineHead,
+      };
     }
   }
 
@@ -1488,12 +1512,11 @@ class PluginAgentSession implements AgentSession {
           event: { type: "timeline", id: childId, item, timestamp: event.timestamp },
         });
       }
-      const versionsByItem = this.childSnapshotVersions.get(childId);
-      if (versionsByItem) {
-        const versions = versionsByItem.get(event.item.id) ?? [];
-        versions.push({ historyLengthAfter: this.history.length, item: event.item });
-        versionsByItem.set(event.item.id, versions);
-      }
+      this.childHeads.set(childId, {
+        id: event.item.id,
+        item: event.item,
+        parent: this.childHeads.get(childId) ?? null,
+      });
       return;
     }
     if (event.type === "session.turn" && event.state !== "started") {
@@ -1553,9 +1576,11 @@ class PluginAgentSession implements AgentSession {
         .slice(targetIndex)
         .flatMap((event) => (event.type === "permission_requested" ? [event.request.id] : [])),
     );
+    const checkpoint =
+      this.findTimelineCheckpoint(`message:${messageId}`, targetIndex) ??
+      this.findTimelineCheckpoint(`item:${messageId}`, targetIndex);
     this.history.splice(targetIndex);
-    this.restoreTimelineSnapshots(targetIndex);
-    this.restoreChildSnapshots(targetIndex);
+    this.restoreSnapshots(checkpoint, targetIndex);
     this.detachDiscardedChildren();
 
     let permissionError: Error | null = null;
@@ -1569,40 +1594,43 @@ class PluginAgentSession implements AgentSession {
     if (permissionError) throw permissionError;
   }
 
-  private restoreTimelineSnapshots(targetIndex: number): void {
-    for (const [itemId, versions] of this.timelineSnapshotVersions) {
-      while (
-        versions.length > 0 &&
-        versions[versions.length - 1]!.historyLengthAfter > targetIndex
-      ) {
-        versions.pop();
-      }
-      const retained = versions[versions.length - 1];
-      if (retained) this.timelineSnapshots.set(itemId, retained.item);
-      else {
-        this.timelineSnapshotVersions.delete(itemId);
-        this.timelineSnapshots.delete(itemId);
-      }
+  private restoreSnapshots(checkpoint: TimelineCheckpoint | undefined, targetIndex: number): void {
+    this.timelineHead = checkpoint?.timelineHead ?? null;
+    this.restoreSnapshotMap(this.timelineSnapshots, this.timelineHead);
+
+    this.childHeads.clear();
+    const retainedChildHeads = checkpoint?.childHeads ?? new Map();
+    for (const [childId, head] of retainedChildHeads) {
+      const snapshots = this.childSnapshots.get(childId) ?? new Map();
+      this.restoreSnapshotMap(snapshots, head);
+      this.childSnapshots.set(childId, snapshots);
+      this.childHeads.set(childId, head);
+    }
+    for (const [key, checkpoints] of this.timelineCheckpoints) {
+      const retained = checkpoints.filter(
+        (candidate) => candidate.historyLengthBefore < targetIndex,
+      );
+      if (retained.length > 0) this.timelineCheckpoints.set(key, retained);
+      else this.timelineCheckpoints.delete(key);
     }
   }
 
-  private restoreChildSnapshots(targetIndex: number): void {
-    for (const [childId, versionsByItem] of this.childSnapshotVersions) {
-      const snapshots = this.childSnapshots.get(childId);
-      for (const [itemId, versions] of versionsByItem) {
-        while (
-          versions.length > 0 &&
-          versions[versions.length - 1]!.historyLengthAfter > targetIndex
-        ) {
-          versions.pop();
-        }
-        const retained = versions[versions.length - 1];
-        if (retained && snapshots) snapshots.set(itemId, retained.item);
-        else {
-          versionsByItem.delete(itemId);
-          snapshots?.delete(itemId);
-        }
-      }
+  private findTimelineCheckpoint(key: string, targetIndex: number): TimelineCheckpoint | undefined {
+    return this.timelineCheckpoints
+      .get(key)
+      ?.findLast((checkpoint) => checkpoint.historyLengthBefore === targetIndex);
+  }
+
+  private restoreSnapshotMap(
+    snapshots: Map<string, ProviderTimelineItem>,
+    head: TimelineSnapshotNode | null,
+  ): void {
+    snapshots.clear();
+    const seen = new Set<string>();
+    for (let node = head; node; node = node.parent) {
+      if (seen.has(node.id)) continue;
+      seen.add(node.id);
+      snapshots.set(node.id, node.item);
     }
   }
 
@@ -1615,7 +1643,7 @@ class PluginAgentSession implements AgentSession {
       unsubscribe();
       this.childUnsubscribes.delete(childId);
       this.childSnapshots.delete(childId);
-      this.childSnapshotVersions.delete(childId);
+      this.childHeads.delete(childId);
     }
   }
 

--- a/packages/server/src/server/agent/plugin-provider.ts
+++ b/packages/server/src/server/agent/plugin-provider.ts
@@ -1033,12 +1033,19 @@ class PluginAgentSession implements AgentSession {
   private readonly history: AgentStreamEvent[] = [];
   private readonly pendingPermissions = new Map<string, AgentPermissionRequest>();
   private readonly permissionResponses = new Map<string, AgentPermissionResponse>();
+  private readonly discardedPermissionResolutions = new Set<string>();
+  private readonly rewoundPermissionCleanups = new Map<
+    string,
+    { response: AgentPermissionResponse; accepted: boolean }
+  >();
   private readonly revertTokens = new Map<string, ProviderTimelineItem["revertToken"]>();
   private readonly timelineSnapshots = new Map<string, ProviderTimelineItem>();
   private readonly childUnsubscribes = new Map<string, () => void>();
   private readonly childSnapshots = new Map<string, Map<string, ProviderTimelineItem>>();
   private unsubscribe: (() => void) | null = null;
   private currentTurnId: string | null = null;
+  private rewindLane: Promise<void> = Promise.resolve();
+  private permissionCleanupLane: Promise<void> = Promise.resolve();
   private closed = false;
 
   constructor(
@@ -1083,6 +1090,8 @@ class PluginAgentSession implements AgentSession {
     prompt: AgentPromptInput,
     options: AgentRunOptions = {},
   ): Promise<{ turnId: string }> {
+    await this.rewindLane;
+    await this.flushRewoundPermissionCleanups();
     const clientMessageId = options.clientMessageId ?? randomUUID();
     const result = await this.bridge.prompt({
       clientMessageId,
@@ -1105,6 +1114,8 @@ class PluginAgentSession implements AgentSession {
     prompt: AgentPromptInput,
     options: SteerActiveTurnOptions,
   ): Promise<SteerResult> {
+    await this.rewindLane;
+    await this.flushRewoundPermissionCleanups();
     const result = await this.bridge.prompt({
       clientMessageId: options.clientMessageId ?? randomUUID(),
       delivery: "steer",
@@ -1290,8 +1301,10 @@ class PluginAgentSession implements AgentSession {
         return this.translateTimeline(event);
       case "session.permission":
         return [this.translatePermission(event)];
-      case "session.permission_resolved":
-        return [this.translatePermissionResolution(event)];
+      case "session.permission_resolved": {
+        const translated = this.translatePermissionResolution(event);
+        return translated ? [translated] : [];
+      }
       case "session.config":
         return this.translateConfig(event);
       case "session.notice":
@@ -1353,6 +1366,9 @@ class PluginAgentSession implements AgentSession {
     event: Extract<ProviderEvent, { type: "session.permission" }>,
   ): AgentStreamEvent {
     const request: AgentPermissionRequest = { ...event.request, provider: this.provider };
+    if (this.discardedPermissionResolutions.delete(request.id)) {
+      this.rewoundPermissionCleanups.delete(request.id);
+    }
     this.pendingPermissions.set(request.id, request);
     return {
       type: "permission_requested",
@@ -1364,7 +1380,11 @@ class PluginAgentSession implements AgentSession {
 
   private translatePermissionResolution(
     event: Extract<ProviderEvent, { type: "session.permission_resolved" }>,
-  ): AgentStreamEvent {
+  ): AgentStreamEvent | null {
+    if (this.discardedPermissionResolutions.delete(event.permissionId)) {
+      this.rewoundPermissionCleanups.delete(event.permissionId);
+      return null;
+    }
     this.pendingPermissions.delete(event.permissionId);
     const resolution = this.permissionResponses.get(event.permissionId) ?? {
       behavior: "deny" as const,
@@ -1476,6 +1496,15 @@ class PluginAgentSession implements AgentSession {
   }
 
   private async revert(messageId: string, scope: "conversation" | "files" | "both") {
+    const operation = this.rewindLane.then(() => this.revertOnce(messageId, scope));
+    this.rewindLane = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await operation;
+  }
+
+  private async revertOnce(messageId: string, scope: "conversation" | "files" | "both") {
     const token = this.revertTokens.get(messageId);
     if (token === undefined) throw new Error(`No provider revert token for message ${messageId}`);
     await this.bridge.revert({
@@ -1485,10 +1514,10 @@ class PluginAgentSession implements AgentSession {
       token,
       scope,
     });
-    if (scope !== "files") this.truncateHistoryAt(messageId);
+    if (scope !== "files") await this.truncateHistoryAt(messageId);
   }
 
-  private truncateHistoryAt(messageId: string): void {
+  private async truncateHistoryAt(messageId: string): Promise<void> {
     const targetIndex = this.history.findLastIndex(
       (event) =>
         event.type === "timeline" &&
@@ -1497,7 +1526,18 @@ class PluginAgentSession implements AgentSession {
     );
     if (targetIndex < 0) return;
 
+    const removedPermissionIds = new Set(
+      this.history
+        .slice(targetIndex)
+        .flatMap((event) => (event.type === "permission_requested" ? [event.request.id] : [])),
+    );
     this.history.splice(targetIndex);
+
+    let permissionError: Error | null = null;
+    for (const permissionId of removedPermissionIds) {
+      const error = await this.resolveRewoundPermission(permissionId);
+      if (error && !permissionError) permissionError = error;
+    }
 
     const retainedMessageIds = new Set(
       this.history.flatMap((event) =>
@@ -1523,6 +1563,70 @@ class PluginAgentSession implements AgentSession {
     for (const permissionId of this.permissionResponses.keys()) {
       if (!retainedPermissionIds.has(permissionId)) this.permissionResponses.delete(permissionId);
     }
+    if (permissionError) throw permissionError;
+  }
+
+  private async flushRewoundPermissionCleanups(): Promise<void> {
+    const operation = this.permissionCleanupLane.then(() =>
+      this.flushRewoundPermissionCleanupsNow(),
+    );
+    this.permissionCleanupLane = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await operation;
+  }
+
+  private async flushRewoundPermissionCleanupsNow(): Promise<void> {
+    let firstError: Error | null = null;
+    for (const [permissionId, cleanup] of this.rewoundPermissionCleanups) {
+      const error = await this.attemptRewoundPermissionCleanup(permissionId, cleanup);
+      if (error && !firstError) firstError = error;
+    }
+    if (firstError) throw firstError;
+  }
+
+  private async attemptRewoundPermissionCleanup(
+    permissionId: string,
+    cleanup: { response: AgentPermissionResponse; accepted: boolean },
+  ): Promise<Error | null> {
+    if (cleanup.accepted) return null;
+    try {
+      await this.bridge.respondToPermission(
+        permissionId,
+        toJsonValue(cleanup.response, "rewind permission resolution") as Extract<
+          ProviderInput,
+          { type: "session.permission" }
+        >["response"],
+      );
+      if (this.rewoundPermissionCleanups.get(permissionId) === cleanup) {
+        cleanup.accepted = true;
+      }
+      return null;
+    } catch (failure) {
+      return failure instanceof Error ? failure : new Error(String(failure));
+    }
+  }
+
+  private async resolveRewoundPermission(permissionId: string): Promise<Error | null> {
+    if (!this.pendingPermissions.has(permissionId)) return null;
+    const cleanup = {
+      response: { behavior: "deny" as const, message: "Removed by rewind" },
+      accepted: false,
+    };
+    this.rewoundPermissionCleanups.set(permissionId, cleanup);
+    this.discardedPermissionResolutions.add(permissionId);
+    const error = await this.attemptRewoundPermissionCleanup(permissionId, cleanup);
+    this.pendingPermissions.delete(permissionId);
+    this.permissionResponses.delete(permissionId);
+    this.emit({
+      type: "permission_resolved",
+      provider: this.provider,
+      requestId: permissionId,
+      resolution: cleanup.response,
+      turnId: this.currentTurnId ?? undefined,
+    });
+    return error;
   }
 
   private publish(event: AgentStreamEvent): void {

--- a/packages/server/src/server/agent/plugin-provider.ts
+++ b/packages/server/src/server/agent/plugin-provider.ts
@@ -1485,6 +1485,44 @@ class PluginAgentSession implements AgentSession {
       token,
       scope,
     });
+    if (scope !== "files") this.truncateHistoryAt(messageId);
+  }
+
+  private truncateHistoryAt(messageId: string): void {
+    const targetIndex = this.history.findLastIndex(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "user_message" &&
+        event.item.messageId === messageId,
+    );
+    if (targetIndex < 0) return;
+
+    this.history.splice(targetIndex);
+
+    const retainedMessageIds = new Set(
+      this.history.flatMap((event) =>
+        event.type === "timeline" &&
+        (event.item.type === "user_message" || event.item.type === "assistant_message") &&
+        event.item.messageId
+          ? [event.item.messageId]
+          : [],
+      ),
+    );
+    for (const messageKey of this.revertTokens.keys()) {
+      if (!retainedMessageIds.has(messageKey)) this.revertTokens.delete(messageKey);
+    }
+
+    const retainedPermissionIds = new Set(
+      this.history.flatMap((event) =>
+        event.type === "permission_requested" ? [event.request.id] : [],
+      ),
+    );
+    for (const permissionId of this.pendingPermissions.keys()) {
+      if (!retainedPermissionIds.has(permissionId)) this.pendingPermissions.delete(permissionId);
+    }
+    for (const permissionId of this.permissionResponses.keys()) {
+      if (!retainedPermissionIds.has(permissionId)) this.permissionResponses.delete(permissionId);
+    }
   }
 
   private publish(event: AgentStreamEvent): void {

--- a/packages/server/src/server/agent/plugin-provider.ts
+++ b/packages/server/src/server/agent/plugin-provider.ts
@@ -837,6 +837,11 @@ function createPluginProviderDefinition(
   };
 }
 
+interface TimelineSnapshotVersion {
+  historyLengthAfter: number;
+  item: ProviderTimelineItem;
+}
+
 interface PendingChild {
   session: ProviderRuntimeSession;
   opened: Extract<ProviderEvent, { type: "session.opened" }>;
@@ -1040,8 +1045,13 @@ class PluginAgentSession implements AgentSession {
   >();
   private readonly revertTokens = new Map<string, ProviderTimelineItem["revertToken"]>();
   private readonly timelineSnapshots = new Map<string, ProviderTimelineItem>();
+  private readonly timelineSnapshotVersions = new Map<string, TimelineSnapshotVersion[]>();
   private readonly childUnsubscribes = new Map<string, () => void>();
   private readonly childSnapshots = new Map<string, Map<string, ProviderTimelineItem>>();
+  private readonly childSnapshotVersions = new Map<
+    string,
+    Map<string, TimelineSnapshotVersion[]>
+  >();
   private unsubscribe: (() => void) | null = null;
   private currentTurnId: string | null = null;
   private rewindLane: Promise<void> = Promise.resolve();
@@ -1269,9 +1279,10 @@ class PluginAgentSession implements AgentSession {
     });
     const snapshots = new Map<string, ProviderTimelineItem>();
     this.childSnapshots.set(childId, snapshots);
+    this.childSnapshotVersions.set(childId, new Map());
     for (const event of child.history) this.acceptChildEvent(childId, event, snapshots);
     this.childUnsubscribes.set(
-      child.id,
+      childId,
       child.onEvent((event) => this.acceptChildEvent(childId, event, snapshots)),
     );
   }
@@ -1281,6 +1292,11 @@ class PluginAgentSession implements AgentSession {
     for (const next of translated) {
       this.history.push(next);
       if (live) this.emit(next);
+    }
+    if (event.type === "timeline.item") {
+      const versions = this.timelineSnapshotVersions.get(event.item.id) ?? [];
+      versions.push({ historyLengthAfter: this.history.length, item: event.item });
+      this.timelineSnapshotVersions.set(event.item.id, versions);
     }
   }
 
@@ -1472,6 +1488,12 @@ class PluginAgentSession implements AgentSession {
           event: { type: "timeline", id: childId, item, timestamp: event.timestamp },
         });
       }
+      const versionsByItem = this.childSnapshotVersions.get(childId);
+      if (versionsByItem) {
+        const versions = versionsByItem.get(event.item.id) ?? [];
+        versions.push({ historyLengthAfter: this.history.length, item: event.item });
+        versionsByItem.set(event.item.id, versions);
+      }
       return;
     }
     if (event.type === "session.turn" && event.state !== "started") {
@@ -1532,6 +1554,9 @@ class PluginAgentSession implements AgentSession {
         .flatMap((event) => (event.type === "permission_requested" ? [event.request.id] : [])),
     );
     this.history.splice(targetIndex);
+    this.restoreTimelineSnapshots(targetIndex);
+    this.restoreChildSnapshots(targetIndex);
+    this.detachDiscardedChildren();
 
     let permissionError: Error | null = null;
     for (const permissionId of removedPermissionIds) {
@@ -1539,6 +1564,62 @@ class PluginAgentSession implements AgentSession {
       if (error && !permissionError) permissionError = error;
     }
 
+    this.pruneRevertTokens();
+    this.prunePermissionState();
+    if (permissionError) throw permissionError;
+  }
+
+  private restoreTimelineSnapshots(targetIndex: number): void {
+    for (const [itemId, versions] of this.timelineSnapshotVersions) {
+      while (
+        versions.length > 0 &&
+        versions[versions.length - 1]!.historyLengthAfter > targetIndex
+      ) {
+        versions.pop();
+      }
+      const retained = versions[versions.length - 1];
+      if (retained) this.timelineSnapshots.set(itemId, retained.item);
+      else {
+        this.timelineSnapshotVersions.delete(itemId);
+        this.timelineSnapshots.delete(itemId);
+      }
+    }
+  }
+
+  private restoreChildSnapshots(targetIndex: number): void {
+    for (const [childId, versionsByItem] of this.childSnapshotVersions) {
+      const snapshots = this.childSnapshots.get(childId);
+      for (const [itemId, versions] of versionsByItem) {
+        while (
+          versions.length > 0 &&
+          versions[versions.length - 1]!.historyLengthAfter > targetIndex
+        ) {
+          versions.pop();
+        }
+        const retained = versions[versions.length - 1];
+        if (retained && snapshots) snapshots.set(itemId, retained.item);
+        else {
+          versionsByItem.delete(itemId);
+          snapshots?.delete(itemId);
+        }
+      }
+    }
+  }
+
+  private detachDiscardedChildren(): void {
+    const retainedChildIds = new Set(
+      this.history.flatMap((event) => (event.type === "provider_subagent" ? [event.event.id] : [])),
+    );
+    for (const [childId, unsubscribe] of this.childUnsubscribes) {
+      if (retainedChildIds.has(childId)) continue;
+      unsubscribe();
+      this.childUnsubscribes.delete(childId);
+      this.childSnapshots.delete(childId);
+      this.childSnapshotVersions.delete(childId);
+    }
+  }
+
+  private pruneRevertTokens(): void {
     const retainedMessageIds = new Set(
       this.history.flatMap((event) =>
         event.type === "timeline" &&
@@ -1551,7 +1632,9 @@ class PluginAgentSession implements AgentSession {
     for (const messageKey of this.revertTokens.keys()) {
       if (!retainedMessageIds.has(messageKey)) this.revertTokens.delete(messageKey);
     }
+  }
 
+  private prunePermissionState(): void {
     const retainedPermissionIds = new Set(
       this.history.flatMap((event) =>
         event.type === "permission_requested" ? [event.request.id] : [],
@@ -1563,7 +1646,6 @@ class PluginAgentSession implements AgentSession {
     for (const permissionId of this.permissionResponses.keys()) {
       if (!retainedPermissionIds.has(permissionId)) this.permissionResponses.delete(permissionId);
     }
-    if (permissionError) throw permissionError;
   }
 
   private async flushRewoundPermissionCleanups(): Promise<void> {


### PR DESCRIPTION
### Linked issue

Closes #4667

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Direct plugin providers kept their translated event history after a conversation rewind. The next forced hydration replayed rows from the abandoned branch, so replacement prompts could bring them back into the timeline. The adapter now truncates its retained history at the rewound user message before the replacement prompt runs.

### Goals

- Remove abandoned plugin timeline events after conversation and combined rewinds.
- Keep file-only rewinds from changing conversation history.
- Resolve removed permissions and retry failed cleanup without leaving the provider blocked.
- Restore retained timeline and child-session state after truncation.
- Keep the fix inside the existing plugin-provider adapter without changing the plugin contract.

### Non-goals

- Change native provider rewind behavior.
- Change file-only rewind semantics.
- Add a new plugin protocol or history replay API.

### QA

- Added regression coverage for conversation, combined, and file-only rewinds.
- Verified removed permissions are denied and no longer remain pending.
- Verified failed permission cleanup leaves local history consistent and retries before the next prompt.
- Ran `npx vitest run packages/server/src/server/agent/plugin-provider.test.ts --bail=1` — 9 tests passed.
- Ran the full workspace `npm run typecheck` — passed.
- Ran targeted lint and format checks — passed.
- Ran Cora against the updated diff — no issues found.

### Checklist

- [x] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (no SDK imports changed)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
