### PR TITLE
fix(app): inherit built-in resume commands for custom providers extending Claude/Codex

### DIFF
--- a/packages/app/src/data/provider-snapshot-cache-version.test.ts
+++ b/packages/app/src/data/provider-snapshot-cache-version.test.ts
@@ -30,7 +30,7 @@ function createStorage() {
 }
 
 describe("provider snapshot cache version contract", () => {
-  it("round-trips a v3 body carrying derivedFromProviderId and launchSource", async () => {
+  it("round-trips a v3 body carrying derivedFromProviderId and canUseDefaultResumeCommand", async () => {
     const storage = createStorage();
     const cache: ProviderSnapshotCache = createProviderSnapshotCache(storage);
 
@@ -45,7 +45,7 @@ describe("provider snapshot cache version contract", () => {
           status: "ready",
           enabled: true,
           derivedFromProviderId: "codex",
-          launchSource: "default",
+          canUseDefaultResumeCommand: true,
         },
       ]),
     });
@@ -55,7 +55,7 @@ describe("provider snapshot cache version contract", () => {
     expect(v3!.entries[0]).toMatchObject({
       provider: "my-codex",
       derivedFromProviderId: "codex",
-      launchSource: "default",
+      canUseDefaultResumeCommand: true,
     });
   });
 

--- a/packages/app/src/data/provider-snapshot-cache-version.test.ts
+++ b/packages/app/src/data/provider-snapshot-cache-version.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { compactProviderSnapshot } from "@getpaseo/protocol/provider-snapshot-codec";
+import { createProviderSnapshotCache, type ProviderSnapshotCache } from "./provider-snapshot-cache";
+
+function createStorage() {
+  const values = new Map<string, string>();
+  return {
+    values,
+    async getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    async setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+    async removeItem(key: string) {
+      values.delete(key);
+    },
+    async getAllKeys() {
+      return [...values.keys()];
+    },
+    async multiGet(keys: readonly string[]) {
+      return keys.map((key) => [key, values.get(key) ?? null] as const);
+    },
+    async multiRemove(keys: readonly string[]) {
+      for (const key of keys) {
+        values.delete(key);
+      }
+    },
+  };
+}
+
+describe("provider snapshot cache version contract", () => {
+  it("round-trips a v3 body carrying derivedFromProviderId and launchSource", async () => {
+    const storage = createStorage();
+    const cache: ProviderSnapshotCache = createProviderSnapshotCache(storage);
+
+    await cache.write({
+      serverId: "server-1",
+      cwd: "/ancestry",
+      hash: "v3-hash",
+      generatedAt: "2026-09-01T00:00:00.000Z",
+      compactSnapshot: compactProviderSnapshot([
+        {
+          provider: "my-codex",
+          status: "ready",
+          enabled: true,
+          derivedFromProviderId: "codex",
+          launchSource: "default",
+        },
+      ]),
+    });
+
+    const v3 = await cache.read("server-1", "/ancestry");
+    expect(v3).not.toBeNull();
+    expect(v3!.entries[0]).toMatchObject({
+      provider: "my-codex",
+      derivedFromProviderId: "codex",
+      launchSource: "default",
+    });
+  });
+
+  it("rejects a pre-v3 cache body and does not reuse it as v3", async () => {
+    const storage = createStorage();
+    storage.values.set(
+      '@paseo/provider-snapshot/v2:["server-1","hash","v2"]',
+      JSON.stringify({
+        version: 2,
+        hash: "v2",
+        generatedAt: "2026-09-01T00:00:00.000Z",
+        compactSnapshot: { entries: [], thinkingSets: [] },
+      }),
+    );
+
+    const cache: ProviderSnapshotCache = createProviderSnapshotCache(storage);
+    await expect(cache.readHash("server-1", "v2")).resolves.toBeNull();
+  });
+});

--- a/packages/app/src/data/provider-snapshot-cache.test.ts
+++ b/packages/app/src/data/provider-snapshot-cache.test.ts
@@ -4,8 +4,8 @@ import type { ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
 import { compactProviderSnapshot } from "@getpaseo/protocol/provider-snapshot-codec";
 import { createProviderSnapshotCache, type ProviderSnapshotCache } from "./provider-snapshot-cache";
 
-const SNAPSHOT_KEY_PREFIX = "@paseo/provider-snapshot/v2:";
-const SNAPSHOT_INDEX_KEY = "@paseo/provider-snapshot-index/v2";
+const SNAPSHOT_KEY_PREFIX = "@paseo/provider-snapshot/v3:";
+const SNAPSHOT_INDEX_KEY = "@paseo/provider-snapshot-index/v3";
 function createStorage(maxSnapshotBytes = Number.POSITIVE_INFINITY) {
   const values = new Map<string, string>();
   const stats = { getAllKeysCalls: 0 };

--- a/packages/app/src/data/provider-snapshot-cache.ts
+++ b/packages/app/src/data/provider-snapshot-cache.ts
@@ -11,7 +11,7 @@ import type { GetProvidersSnapshotResponseMessage } from "@getpaseo/protocol/mes
 type SnapshotPayload = GetProvidersSnapshotResponseMessage["payload"];
 
 // COMPAT(providerSnapshotAncestry): bump v2 to v3 to force fresh snapshots after adding
-// derivedFromProviderId/launchSource. Remove legacy v2 cleanup after 2027-03-15.
+// derivedFromProviderId/canUseDefaultResumeCommand. Remove legacy v2 cleanup after 2027-03-15.
 const CACHE_VERSION = 3;
 const CACHE_KEY_PREFIX = "@paseo/provider-snapshot/v3";
 const CACHE_INDEX_KEY = "@paseo/provider-snapshot-index/v3";

--- a/packages/app/src/data/provider-snapshot-cache.ts
+++ b/packages/app/src/data/provider-snapshot-cache.ts
@@ -10,9 +10,11 @@ import { z } from "zod";
 import type { GetProvidersSnapshotResponseMessage } from "@getpaseo/protocol/messages";
 type SnapshotPayload = GetProvidersSnapshotResponseMessage["payload"];
 
-const CACHE_VERSION = 2;
-const CACHE_KEY_PREFIX = "@paseo/provider-snapshot/v2";
-const CACHE_INDEX_KEY = "@paseo/provider-snapshot-index/v2";
+// COMPAT(providerSnapshotAncestry): bump v2 to v3 to force fresh snapshots after adding
+// derivedFromProviderId/launchSource. Remove legacy v2 cleanup after 2027-03-15.
+const CACHE_VERSION = 3;
+const CACHE_KEY_PREFIX = "@paseo/provider-snapshot/v3";
+const CACHE_INDEX_KEY = "@paseo/provider-snapshot-index/v3";
 const DEFAULT_MAX_CACHE_BYTES = 4 * 1024 * 1024;
 
 interface ProviderSnapshotStorage {
@@ -130,7 +132,9 @@ export function createProviderSnapshotCache(
     const legacyKeys = allKeys.filter(
       (key) =>
         key.startsWith("@paseo/provider-snapshot/v1:") ||
+        key.startsWith("@paseo/provider-snapshot/v2:") ||
         key === "@paseo/provider-snapshot-index/v1" ||
+        key === "@paseo/provider-snapshot-index/v2" ||
         key === CACHE_INDEX_KEY,
     );
     if (legacyKeys.length) await storage.multiRemove(legacyKeys);

--- a/packages/app/src/data/providers-snapshot.ts
+++ b/packages/app/src/data/providers-snapshot.ts
@@ -119,12 +119,16 @@ export async function fetchProvidersSnapshot(input: {
   return snapshot;
 }
 
-export async function ensureProvidersSnapshotEntries(input: {
+export interface EnsureProvidersSnapshotEntriesInput {
   queryClient: QueryClient;
   client: DaemonClient;
   serverId: string;
   cwd?: string | null;
-}): Promise<ProviderSnapshotEntry[] | undefined> {
+}
+
+export async function ensureProvidersSnapshotEntries(
+  input: EnsureProvidersSnapshotEntriesInput,
+): Promise<ProviderSnapshotEntry[] | undefined> {
   try {
     const snapshot = await input.queryClient.ensureQueryData({
       queryKey: providersSnapshotQueryKey(input.serverId, input.cwd),

--- a/packages/app/src/data/providers-snapshot.ts
+++ b/packages/app/src/data/providers-snapshot.ts
@@ -121,22 +121,16 @@ export async function fetchProvidersSnapshot(input: {
 
 export async function ensureProvidersSnapshotEntries(input: {
   queryClient: QueryClient;
-  client: DaemonClient | null;
+  client: DaemonClient;
   serverId: string;
   cwd?: string | null;
 }): Promise<ProviderSnapshotEntry[] | undefined> {
-  if (!input.client) {
-    return input.queryClient.getQueryData<Snapshot>(
-      providersSnapshotQueryKey(input.serverId, input.cwd),
-    )?.entries;
-  }
-  const client = input.client;
   try {
     const snapshot = await input.queryClient.ensureQueryData({
       queryKey: providersSnapshotQueryKey(input.serverId, input.cwd),
       queryFn: ({ signal }) =>
         fetchProvidersSnapshot({
-          client,
+          client: input.client,
           serverId: input.serverId,
           cwd: input.cwd ?? null,
           queryClient: input.queryClient,

--- a/packages/app/src/data/providers-snapshot.ts
+++ b/packages/app/src/data/providers-snapshot.ts
@@ -146,8 +146,11 @@ export async function ensureProvidersSnapshotEntries(input: {
       structuralSharing: false,
     });
     return snapshot.entries;
-  } catch {
-    return undefined;
+  } catch (error) {
+    if (error instanceof CancelledError) {
+      return undefined;
+    }
+    throw error;
   }
 }
 

--- a/packages/app/src/data/providers-snapshot.ts
+++ b/packages/app/src/data/providers-snapshot.ts
@@ -9,7 +9,7 @@ import {
 import { queryClient as singletonQueryClient } from "./query-client";
 import { replaceProviderSnapshotIcons } from "@/components/provider-icon-name";
 import { agentCommandsQueryRoot } from "@/hooks/agent-commands-query";
-import type { AgentProvider } from "@getpaseo/protocol/agent-types";
+import type { AgentProvider, ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
 import { normalizeWorkspacePath } from "@/utils/workspace-identity";
 
 export const PROVIDERS_SNAPSHOT_QUERY_ROOT = "providersSnapshot";
@@ -117,6 +117,38 @@ export async function fetchProvidersSnapshot(input: {
   if (input.signal?.aborted) throw new CancelledError();
   replaceProviderSnapshotIcons(input.serverId, snapshot.entries);
   return snapshot;
+}
+
+export async function ensureProvidersSnapshotEntries(input: {
+  queryClient: QueryClient;
+  client: DaemonClient | null;
+  serverId: string;
+  cwd?: string | null;
+}): Promise<ProviderSnapshotEntry[] | undefined> {
+  if (!input.client) {
+    return input.queryClient.getQueryData<Snapshot>(
+      providersSnapshotQueryKey(input.serverId, input.cwd),
+    )?.entries;
+  }
+  const client = input.client;
+  try {
+    const snapshot = await input.queryClient.ensureQueryData({
+      queryKey: providersSnapshotQueryKey(input.serverId, input.cwd),
+      queryFn: ({ signal }) =>
+        fetchProvidersSnapshot({
+          client,
+          serverId: input.serverId,
+          cwd: input.cwd ?? null,
+          queryClient: input.queryClient,
+          signal,
+        }),
+      staleTime: Infinity,
+      structuralSharing: false,
+    });
+    return snapshot.entries;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function refreshAndApplyProvidersSnapshot(input: {

--- a/packages/app/src/hooks/use-providers-snapshot.test.ts
+++ b/packages/app/src/hooks/use-providers-snapshot.test.ts
@@ -173,7 +173,7 @@ describe("fetchProvidersSnapshot", () => {
     const compactSnapshot = compactProviderSnapshot(entries);
     const cache = createCache(
       {
-        version: 2,
+        version: 3,
         hash: "snapshot-hash",
         generatedAt: "2026-01-01T00:00:00.000Z",
         compactSnapshot,

--- a/packages/app/src/hooks/use-providers-snapshot.ts
+++ b/packages/app/src/hooks/use-providers-snapshot.ts
@@ -14,6 +14,7 @@ import {
   providersSnapshotQueryRoot,
   fetchProvidersSnapshot,
   refreshAndApplyProvidersSnapshot,
+  ensureProvidersSnapshotEntries,
 } from "@/data/providers-snapshot";
 
 export {
@@ -21,6 +22,7 @@ export {
   providersSnapshotQueryRoot,
   fetchProvidersSnapshot,
   refreshAndApplyProvidersSnapshot,
+  ensureProvidersSnapshotEntries,
 };
 
 export type ProvidersSnapshotClient = Pick<

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -2761,7 +2761,8 @@ function WorkspaceScreenContent({
         if (error instanceof ProviderResumeCommandUnavailableError) {
           toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
         } else {
-          throw error;
+          console.error("[WorkspaceScreen] Failed to resolve resume command", { error });
+          toast.error(t("workspace.tabs.toasts.copyFailed"));
         }
       }
     },

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -96,7 +96,10 @@ import {
   useHostRuntimeSnapshot,
   useHosts,
 } from "@/runtime/host-runtime";
-import { prefetchProvidersSnapshot } from "@/hooks/use-providers-snapshot";
+import {
+  ensureProvidersSnapshotEntries,
+  prefetchProvidersSnapshot,
+} from "@/hooks/use-providers-snapshot";
 import {
   shouldSeedWorkspaceSetupTab,
   shouldShowWorkspaceSetup,
@@ -2725,11 +2728,18 @@ function WorkspaceScreenContent({
         return;
       }
 
+      const providerSnapshot = await ensureProvidersSnapshotEntries({
+        queryClient,
+        client,
+        serverId: normalizedServerId,
+        cwd: workspaceDirectory ?? null,
+      });
       const command =
         buildProviderCommand({
           provider: agent.provider,
           id: "resume",
           sessionId: providerSessionId,
+          providerSnapshot,
         }) ?? null;
       if (!command) {
         toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
@@ -2742,7 +2752,7 @@ function WorkspaceScreenContent({
         toast.error(t("workspace.tabs.toasts.copyFailed"));
       }
     },
-    [normalizedServerId, toast, t],
+    [client, normalizedServerId, workspaceDirectory, queryClient, toast, t],
   );
 
   const handleReloadAgent = useCallback(

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -114,7 +114,7 @@ import { useStableEvent } from "@/hooks/use-stable-event";
 import { removeResidentBrowserWebview } from "@/desktop/browser/resident-webviews";
 import { createWorkspaceBrowser, useBrowserStore } from "@/desktop/browser/store";
 import { getDesktopHost } from "@/desktop/host";
-import { buildProviderCommand } from "@/utils/provider-command-templates";
+import { resolveProviderResumeCommand } from "@/utils/provider-command-templates";
 import { generateDraftId } from "@/stores/draft-keys";
 import { resolveWorkspaceRouteId } from "@/utils/workspace-identity";
 import { useOpenAgentTabLabels } from "@/subagents/use-open-agent-tab-labels";
@@ -2728,28 +2728,31 @@ function WorkspaceScreenContent({
         return;
       }
 
-      const providerSnapshot = await ensureProvidersSnapshotEntries({
-        queryClient,
-        client,
-        serverId: normalizedServerId,
-        cwd: workspaceDirectory ?? null,
-      });
-      const command =
-        buildProviderCommand({
-          provider: agent.provider,
-          id: "resume",
-          sessionId: providerSessionId,
-          providerSnapshot,
-        }) ?? null;
-      if (!command) {
-        toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
-        return;
-      }
+      const supportsProviderAncestry =
+        useSessionStore.getState().sessions[normalizedServerId]?.serverInfo?.features
+          ?.providerAncestry === true;
+
       try {
-        await Clipboard.setStringAsync(command);
-        toast.copied(t("workspace.tabs.toasts.resumeCommandCopiedLabel"));
+        const command = await resolveProviderResumeCommand({
+          provider: agent.provider,
+          sessionId: providerSessionId,
+          supportsProviderAncestry,
+          getProviderSnapshot: () =>
+            ensureProvidersSnapshotEntries({
+              queryClient,
+              client,
+              serverId: normalizedServerId,
+              cwd: workspaceDirectory ?? null,
+            }),
+        });
+        try {
+          await Clipboard.setStringAsync(command);
+          toast.copied(t("workspace.tabs.toasts.resumeCommandCopiedLabel"));
+        } catch {
+          toast.error(t("workspace.tabs.toasts.copyFailed"));
+        }
       } catch {
-        toast.error(t("workspace.tabs.toasts.copyFailed"));
+        toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
       }
     },
     [client, normalizedServerId, workspaceDirectory, queryClient, toast, t],

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -116,7 +116,7 @@ import { createWorkspaceBrowser, useBrowserStore } from "@/desktop/browser/store
 import { getDesktopHost } from "@/desktop/host";
 import {
   ProviderResumeCommandUnavailableError,
-  resolveProviderResumeCommand,
+  resolveProviderResumeCommandOutcome,
 } from "@/utils/provider-command-templates";
 import { generateDraftId } from "@/stores/draft-keys";
 import { resolveWorkspaceRouteId } from "@/utils/workspace-identity";
@@ -2734,36 +2734,38 @@ function WorkspaceScreenContent({
         useSessionStore.getState().sessions[normalizedServerId]?.serverInfo?.features
           ?.providerAncestry === true;
 
-      try {
-        const command = await resolveProviderResumeCommand({
-          provider: agent.provider,
-          sessionId: providerSessionId,
-          supportsProviderAncestry,
-          getProviderSnapshot: async () => {
-            if (!client) {
-              throw new ProviderResumeCommandUnavailableError();
-            }
-            return ensureProvidersSnapshotEntries({
-              queryClient,
-              client,
-              serverId: normalizedServerId,
-              cwd: workspaceDirectory,
-            });
-          },
+      const outcome = await resolveProviderResumeCommandOutcome({
+        provider: agent.provider,
+        sessionId: providerSessionId,
+        supportsProviderAncestry,
+        getProviderSnapshot: async () => {
+          if (!client) {
+            throw new ProviderResumeCommandUnavailableError();
+          }
+          return ensureProvidersSnapshotEntries({
+            queryClient,
+            client,
+            serverId: normalizedServerId,
+            cwd: workspaceDirectory,
+          });
+        },
+      });
+      if (outcome.status === "unavailable") {
+        toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
+        return;
+      }
+      if (outcome.status === "failed") {
+        console.error("[WorkspaceScreen] Failed to resolve resume command", {
+          error: outcome.error,
         });
-        try {
-          await Clipboard.setStringAsync(command);
-          toast.copied(t("workspace.tabs.toasts.resumeCommandCopiedLabel"));
-        } catch {
-          toast.error(t("workspace.tabs.toasts.copyFailed"));
-        }
-      } catch (error) {
-        if (error instanceof ProviderResumeCommandUnavailableError) {
-          toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
-        } else {
-          console.error("[WorkspaceScreen] Failed to resolve resume command", { error });
-          toast.error(t("workspace.tabs.toasts.copyFailed"));
-        }
+        toast.error(t("workspace.tabs.toasts.copyFailed"));
+        return;
+      }
+      try {
+        await Clipboard.setStringAsync(outcome.command);
+        toast.copied(t("workspace.tabs.toasts.resumeCommandCopiedLabel"));
+      } catch {
+        toast.error(t("workspace.tabs.toasts.copyFailed"));
       }
     },
     [client, normalizedServerId, workspaceDirectory, queryClient, toast, t],

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -2719,6 +2719,8 @@ function WorkspaceScreenContent({
     [toast, t],
   );
 
+  const resumeCopyPendingRef = useRef(new Set<string>());
+
   const handleCopyResumeCommand = useCallback(
     async (agentId: string) => {
       const agent =
@@ -2729,43 +2731,50 @@ function WorkspaceScreenContent({
         toast.error(t("workspace.tabs.toasts.resumeIdUnavailable"));
         return;
       }
-
-      const supportsProviderAncestry =
-        useSessionStore.getState().sessions[normalizedServerId]?.serverInfo?.features
-          ?.providerAncestry === true;
-
-      const outcome = await resolveProviderResumeCommandOutcome({
-        provider: agent.provider,
-        sessionId: providerSessionId,
-        supportsProviderAncestry,
-        getProviderSnapshot: async () => {
-          if (!client) {
-            throw new ProviderResumeCommandUnavailableError();
-          }
-          return ensureProvidersSnapshotEntries({
-            queryClient,
-            client,
-            serverId: normalizedServerId,
-            cwd: workspaceDirectory,
-          });
-        },
-      });
-      if (outcome.status === "unavailable") {
-        toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
+      if (resumeCopyPendingRef.current.has(agentId)) {
         return;
       }
-      if (outcome.status === "failed") {
-        console.error("[WorkspaceScreen] Failed to resolve resume command", {
-          error: outcome.error,
-        });
-        toast.error(t("workspace.tabs.toasts.copyFailed"));
-        return;
-      }
+      resumeCopyPendingRef.current.add(agentId);
       try {
-        await Clipboard.setStringAsync(outcome.command);
-        toast.copied(t("workspace.tabs.toasts.resumeCommandCopiedLabel"));
-      } catch {
-        toast.error(t("workspace.tabs.toasts.copyFailed"));
+        const supportsProviderAncestry =
+          useSessionStore.getState().sessions[normalizedServerId]?.serverInfo?.features
+            ?.providerAncestry === true;
+
+        const outcome = await resolveProviderResumeCommandOutcome({
+          provider: agent.provider,
+          sessionId: providerSessionId,
+          supportsProviderAncestry,
+          getProviderSnapshot: async () => {
+            if (!client) {
+              throw new ProviderResumeCommandUnavailableError();
+            }
+            return ensureProvidersSnapshotEntries({
+              queryClient,
+              client,
+              serverId: normalizedServerId,
+              cwd: workspaceDirectory,
+            });
+          },
+        });
+        if (outcome.status === "unavailable") {
+          toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
+          return;
+        }
+        if (outcome.status === "failed") {
+          console.error("[WorkspaceScreen] Failed to resolve resume command", {
+            error: outcome.error,
+          });
+          toast.error(t("workspace.tabs.toasts.copyFailed"));
+          return;
+        }
+        try {
+          await Clipboard.setStringAsync(outcome.command);
+          toast.copied(t("workspace.tabs.toasts.resumeCommandCopiedLabel"));
+        } catch {
+          toast.error(t("workspace.tabs.toasts.copyFailed"));
+        }
+      } finally {
+        resumeCopyPendingRef.current.delete(agentId);
       }
     },
     [client, normalizedServerId, workspaceDirectory, queryClient, toast, t],

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -1,6 +1,5 @@
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import type { JsonValue } from "@getpaseo/protocol/agent-types";
-import type { GetProvidersSnapshotResponseMessage } from "@getpaseo/protocol/messages";
 import { getOpenAgentTabLabel } from "@getpaseo/protocol/agent-labels";
 import {
   memo,
@@ -100,7 +99,6 @@ import {
 import {
   ensureProvidersSnapshotEntries,
   prefetchProvidersSnapshot,
-  providersSnapshotQueryKey,
 } from "@/hooks/use-providers-snapshot";
 import {
   shouldSeedWorkspaceSetupTab,
@@ -116,7 +114,10 @@ import { useStableEvent } from "@/hooks/use-stable-event";
 import { removeResidentBrowserWebview } from "@/desktop/browser/resident-webviews";
 import { createWorkspaceBrowser, useBrowserStore } from "@/desktop/browser/store";
 import { getDesktopHost } from "@/desktop/host";
-import { resolveProviderResumeCommand } from "@/utils/provider-command-templates";
+import {
+  ProviderResumeCommandUnavailableError,
+  resolveProviderResumeCommand,
+} from "@/utils/provider-command-templates";
 import { generateDraftId } from "@/stores/draft-keys";
 import { resolveWorkspaceRouteId } from "@/utils/workspace-identity";
 import { useOpenAgentTabLabels } from "@/subagents/use-open-agent-tab-labels";
@@ -1582,6 +1583,7 @@ function WorkspaceScreenContent({
   useWorkspaceTerminalSessionRetention({
     scopeKey: workspaceTerminalScopeKey,
   });
+  const queryClient = useQueryClient();
 
   const client = useHostRuntimeClient(normalizedServerId);
   const isConnected = useHostRuntimeIsConnected(normalizedServerId);
@@ -1705,7 +1707,6 @@ function WorkspaceScreenContent({
     },
     toast,
   });
-  const queryClient = useQueryClient();
   const {
     createMutation: createTerminalMutation,
     createTerminal,
@@ -2720,7 +2721,6 @@ function WorkspaceScreenContent({
 
   const handleCopyResumeCommand = useCallback(
     async (agentId: string) => {
-      if (!agentId) return;
       const agent =
         useSessionStore.getState().sessions[normalizedServerId]?.agents?.get(agentId) ?? null;
       const providerSessionId =
@@ -2734,23 +2734,22 @@ function WorkspaceScreenContent({
         useSessionStore.getState().sessions[normalizedServerId]?.serverInfo?.features
           ?.providerAncestry === true;
 
-      const cachedProviderSnapshot = queryClient.getQueryData<
-        GetProvidersSnapshotResponseMessage["payload"]
-      >(providersSnapshotQueryKey(normalizedServerId, workspaceDirectory ?? null))?.entries;
-
       try {
         const command = await resolveProviderResumeCommand({
           provider: agent.provider,
           sessionId: providerSessionId,
           supportsProviderAncestry,
-          cachedProviderSnapshot,
-          getProviderSnapshot: () =>
-            ensureProvidersSnapshotEntries({
+          getProviderSnapshot: async () => {
+            if (!client) {
+              throw new ProviderResumeCommandUnavailableError();
+            }
+            return ensureProvidersSnapshotEntries({
               queryClient,
               client,
               serverId: normalizedServerId,
-              cwd: workspaceDirectory ?? null,
-            }),
+              cwd: workspaceDirectory,
+            });
+          },
         });
         try {
           await Clipboard.setStringAsync(command);
@@ -2758,8 +2757,12 @@ function WorkspaceScreenContent({
         } catch {
           toast.error(t("workspace.tabs.toasts.copyFailed"));
         }
-      } catch {
-        toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
+      } catch (error) {
+        if (error instanceof ProviderResumeCommandUnavailableError) {
+          toast.error(t("workspace.tabs.toasts.resumeCommandUnavailable"));
+        } else {
+          throw error;
+        }
       }
     },
     [client, normalizedServerId, workspaceDirectory, queryClient, toast, t],

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -1,5 +1,6 @@
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import type { JsonValue } from "@getpaseo/protocol/agent-types";
+import type { GetProvidersSnapshotResponseMessage } from "@getpaseo/protocol/messages";
 import { getOpenAgentTabLabel } from "@getpaseo/protocol/agent-labels";
 import {
   memo,
@@ -99,6 +100,7 @@ import {
 import {
   ensureProvidersSnapshotEntries,
   prefetchProvidersSnapshot,
+  providersSnapshotQueryKey,
 } from "@/hooks/use-providers-snapshot";
 import {
   shouldSeedWorkspaceSetupTab,
@@ -2732,11 +2734,16 @@ function WorkspaceScreenContent({
         useSessionStore.getState().sessions[normalizedServerId]?.serverInfo?.features
           ?.providerAncestry === true;
 
+      const cachedProviderSnapshot = queryClient.getQueryData<
+        GetProvidersSnapshotResponseMessage["payload"]
+      >(providersSnapshotQueryKey(normalizedServerId, workspaceDirectory ?? null))?.entries;
+
       try {
         const command = await resolveProviderResumeCommand({
           provider: agent.provider,
           sessionId: providerSessionId,
           supportsProviderAncestry,
+          cachedProviderSnapshot,
           getProviderSnapshot: () =>
             ensureProvidersSnapshotEntries({
               queryClient,

--- a/packages/app/src/utils/provider-command-templates.test.ts
+++ b/packages/app/src/utils/provider-command-templates.test.ts
@@ -1,13 +1,17 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
 
-import { buildProviderCommand } from "@/utils/provider-command-templates";
+import {
+  buildProviderCommand,
+  resolveProviderResumeCommand,
+} from "@/utils/provider-command-templates";
 
 function snapshotEntry(
   provider: string,
   derivedFromProviderId?: string | null,
-): Pick<ProviderSnapshotEntry, "provider" | "derivedFromProviderId"> {
-  return { provider, derivedFromProviderId };
+  launchSource: ProviderSnapshotEntry["launchSource"] = "default",
+): Pick<ProviderSnapshotEntry, "provider" | "derivedFromProviderId" | "launchSource"> {
+  return { provider, derivedFromProviderId, launchSource };
 }
 
 describe("buildProviderCommand", () => {
@@ -77,7 +81,7 @@ describe("buildProviderCommand", () => {
         provider: "my-claude",
         id: "resume",
         sessionId: "example-session",
-        providerSnapshot: [snapshotEntry("my-claude", "claude")],
+        providerSnapshot: [snapshotEntry("my-claude", "claude", "default")],
       }),
     ).toBe("claude --resume example-session");
   });
@@ -88,7 +92,7 @@ describe("buildProviderCommand", () => {
         provider: "my-codex",
         id: "resume",
         sessionId: "example-session",
-        providerSnapshot: [snapshotEntry("my-codex", "codex")],
+        providerSnapshot: [snapshotEntry("my-codex", "codex", "default")],
       }),
     ).toBe("codex resume example-session");
   });
@@ -109,8 +113,111 @@ describe("buildProviderCommand", () => {
         provider: "my-agent",
         id: "resume",
         sessionId: "example-session",
-        providerSnapshot: [snapshotEntry("my-agent", null)],
+        providerSnapshot: [snapshotEntry("my-agent", null, "default")],
       }),
     ).toBeNull();
+  });
+
+  test("refuses the built-in template when the snapshot says the command is overridden", () => {
+    expect(
+      buildProviderCommand({
+        provider: "claude",
+        id: "resume",
+        sessionId: "example-session",
+        providerSnapshot: [snapshotEntry("claude", null, "override")],
+      }),
+    ).toBeNull();
+  });
+
+  test("refuses the inherited template for a custom provider that overrides its command", () => {
+    expect(
+      buildProviderCommand({
+        provider: "my-codex",
+        id: "resume",
+        sessionId: "example-session",
+        providerSnapshot: [snapshotEntry("my-codex", "codex", "override")],
+      }),
+    ).toBeNull();
+  });
+
+  test("refuses the inherited template for a custom provider that appends to its command", () => {
+    expect(
+      buildProviderCommand({
+        provider: "my-codex",
+        id: "resume",
+        sessionId: "example-session",
+        providerSnapshot: [snapshotEntry("my-codex", "codex", "append")],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveProviderResumeCommand", () => {
+  test("resolves built-in Codex immediately without a snapshot", async () => {
+    const getProviderSnapshot = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: false,
+        getProviderSnapshot,
+      }),
+    ).resolves.toBe("codex resume example-session");
+    expect(getProviderSnapshot).not.toHaveBeenCalled();
+  });
+
+  test("resolves built-in Claude immediately without a snapshot", async () => {
+    const getProviderSnapshot = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "claude",
+        sessionId: "example-session",
+        supportsProviderAncestry: false,
+        getProviderSnapshot,
+      }),
+    ).resolves.toBe("claude --resume example-session");
+    expect(getProviderSnapshot).not.toHaveBeenCalled();
+  });
+
+  test("rejects an inherited custom provider when the daemon does not advertise providerAncestry", async () => {
+    const getProviderSnapshot = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "my-codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: false,
+        getProviderSnapshot,
+      }),
+    ).rejects.toThrow("Resume command not available");
+    expect(getProviderSnapshot).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the ancestor template for a custom provider when providerAncestry is advertised", async () => {
+    const getProviderSnapshot = vi
+      .fn()
+      .mockResolvedValue([snapshotEntry("my-codex", "codex", "default")]);
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "my-codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        getProviderSnapshot,
+      }),
+    ).resolves.toBe("codex resume example-session");
+    expect(getProviderSnapshot).toHaveBeenCalledOnce();
+  });
+
+  test("rejects a custom provider with an overridden command even when ancestry is advertised", async () => {
+    const getProviderSnapshot = vi
+      .fn()
+      .mockResolvedValue([snapshotEntry("my-codex", "codex", "override")]);
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "my-codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        getProviderSnapshot,
+      }),
+    ).rejects.toThrow("Resume command not available");
   });
 });

--- a/packages/app/src/utils/provider-command-templates.test.ts
+++ b/packages/app/src/utils/provider-command-templates.test.ts
@@ -5,6 +5,7 @@ import {
   buildProviderCommand,
   ProviderResumeCommandUnavailableError,
   resolveProviderResumeCommand,
+  resolveProviderResumeCommandOutcome,
 } from "@/utils/provider-command-templates";
 
 function snapshotEntry(
@@ -171,7 +172,7 @@ describe("buildProviderCommand", () => {
 });
 
 describe("resolveProviderResumeCommand", () => {
-  test("resolves built-in Codex immediately without a snapshot", async () => {
+  test("rejects built-in Codex when providerAncestry is not advertised", async () => {
     await expect(
       resolveProviderResumeCommand({
         provider: "codex",
@@ -179,10 +180,10 @@ describe("resolveProviderResumeCommand", () => {
         supportsProviderAncestry: false,
         getProviderSnapshot: neverCalledSnapshot,
       }),
-    ).resolves.toBe("codex resume example-session");
+    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
   });
 
-  test("resolves built-in Claude immediately without a snapshot", async () => {
+  test("rejects built-in Claude when providerAncestry is not advertised", async () => {
     await expect(
       resolveProviderResumeCommand({
         provider: "claude",
@@ -190,18 +191,40 @@ describe("resolveProviderResumeCommand", () => {
         supportsProviderAncestry: false,
         getProviderSnapshot: neverCalledSnapshot,
       }),
-    ).resolves.toBe("claude --resume example-session");
+    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
   });
 
-  test("resolves built-in Codex with providerAncestry without a snapshot", async () => {
+  test("resolves built-in Codex from the authoritative snapshot when providerAncestry is advertised", async () => {
     await expect(
       resolveProviderResumeCommand({
         provider: "codex",
         sessionId: "example-session",
         supportsProviderAncestry: true,
-        getProviderSnapshot: neverCalledSnapshot,
+        getProviderSnapshot: () => Promise.resolve([snapshotEntry("codex", null, true)]),
       }),
     ).resolves.toBe("codex resume example-session");
+  });
+
+  test("rejects a customized built-in provider when providerAncestry is advertised", async () => {
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        getProviderSnapshot: () => Promise.resolve([snapshotEntry("codex", null, false)]),
+      }),
+    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
+  });
+
+  test("rejects a built-in provider when the authoritative snapshot is unavailable", async () => {
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        getProviderSnapshot: () => Promise.resolve(undefined),
+      }),
+    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
   });
 
   test("rejects a custom provider when providerAncestry is not advertised", async () => {
@@ -282,5 +305,31 @@ describe("resolveProviderResumeCommand", () => {
         getProviderSnapshot: () => Promise.reject(new Error("network failure")),
       }),
     ).rejects.toThrow("network failure");
+  });
+});
+
+describe("resolveProviderResumeCommandOutcome", () => {
+  test("classifies unsupported providers as unavailable", async () => {
+    await expect(
+      resolveProviderResumeCommandOutcome({
+        provider: "my-codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: false,
+        getProviderSnapshot: neverCalledSnapshot,
+      }),
+    ).resolves.toEqual({ status: "unavailable" });
+  });
+
+  test("returns unexpected snapshot failures without rejecting or classifying them as unavailable", async () => {
+    const snapshotError = new Error("network failure");
+
+    await expect(
+      resolveProviderResumeCommandOutcome({
+        provider: "my-codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        getProviderSnapshot: () => Promise.reject(snapshotError),
+      }),
+    ).resolves.toEqual({ status: "failed", error: snapshotError });
   });
 });

--- a/packages/app/src/utils/provider-command-templates.test.ts
+++ b/packages/app/src/utils/provider-command-templates.test.ts
@@ -179,6 +179,20 @@ describe("resolveProviderResumeCommand", () => {
     expect(getProviderSnapshot).not.toHaveBeenCalled();
   });
 
+  test("rejects a built-in Codex whose cached snapshot launch source is overridden", async () => {
+    const getProviderSnapshot = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        cachedProviderSnapshot: [snapshotEntry("codex", null, "override")],
+        getProviderSnapshot,
+      }),
+    ).rejects.toThrow("Resume command not available");
+    expect(getProviderSnapshot).not.toHaveBeenCalled();
+  });
+
   test("rejects an inherited custom provider when the daemon does not advertise providerAncestry", async () => {
     const getProviderSnapshot = vi.fn().mockResolvedValue(undefined);
     await expect(

--- a/packages/app/src/utils/provider-command-templates.test.ts
+++ b/packages/app/src/utils/provider-command-templates.test.ts
@@ -10,9 +10,12 @@ import {
 function snapshotEntry(
   provider: string,
   derivedFromProviderId?: string | null,
-  launchSource: ProviderSnapshotEntry["launchSource"] = "default",
-): Pick<ProviderSnapshotEntry, "provider" | "derivedFromProviderId" | "launchSource"> {
-  return { provider, derivedFromProviderId, launchSource };
+  canUseDefaultResumeCommand: ProviderSnapshotEntry["canUseDefaultResumeCommand"] = true,
+): Pick<
+  ProviderSnapshotEntry,
+  "provider" | "derivedFromProviderId" | "canUseDefaultResumeCommand"
+> {
+  return { provider, derivedFromProviderId, canUseDefaultResumeCommand };
 }
 
 const neverCalledSnapshot = () =>
@@ -85,7 +88,7 @@ describe("buildProviderCommand", () => {
         provider: "my-claude",
         id: "resume",
         sessionId: "example-session",
-        providerSnapshot: [snapshotEntry("my-claude", "claude", "default")],
+        providerSnapshot: [snapshotEntry("my-claude", "claude", true)],
       }),
     ).toBe("claude --resume example-session");
   });
@@ -96,7 +99,7 @@ describe("buildProviderCommand", () => {
         provider: "my-codex",
         id: "resume",
         sessionId: "example-session",
-        providerSnapshot: [snapshotEntry("my-codex", "codex", "default")],
+        providerSnapshot: [snapshotEntry("my-codex", "codex", true)],
       }),
     ).toBe("codex resume example-session");
   });
@@ -117,7 +120,7 @@ describe("buildProviderCommand", () => {
         provider: "my-agent",
         id: "resume",
         sessionId: "example-session",
-        providerSnapshot: [snapshotEntry("my-agent", null, "default")],
+        providerSnapshot: [snapshotEntry("my-agent", null, true)],
       }),
     ).toBeNull();
   });
@@ -128,7 +131,7 @@ describe("buildProviderCommand", () => {
         provider: "claude",
         id: "resume",
         sessionId: "example-session",
-        providerSnapshot: [snapshotEntry("claude", null, "override")],
+        providerSnapshot: [snapshotEntry("claude", null, false)],
       }),
     ).toBeNull();
   });
@@ -139,7 +142,7 @@ describe("buildProviderCommand", () => {
         provider: "my-codex",
         id: "resume",
         sessionId: "example-session",
-        providerSnapshot: [snapshotEntry("my-codex", "codex", "override")],
+        providerSnapshot: [snapshotEntry("my-codex", "codex", false)],
       }),
     ).toBeNull();
   });
@@ -150,7 +153,18 @@ describe("buildProviderCommand", () => {
         provider: "my-codex",
         id: "resume",
         sessionId: "example-session",
-        providerSnapshot: [snapshotEntry("my-codex", "codex", "append")],
+        providerSnapshot: [snapshotEntry("my-codex", "codex", false)],
+      }),
+    ).toBeNull();
+  });
+
+  test("refuses the inherited template for a custom provider with a false safety flag", () => {
+    expect(
+      buildProviderCommand({
+        provider: "my-codex",
+        id: "resume",
+        sessionId: "example-session",
+        providerSnapshot: [snapshotEntry("my-codex", "codex", false)],
       }),
     ).toBeNull();
   });
@@ -207,7 +221,7 @@ describe("resolveProviderResumeCommand", () => {
         provider: "my-codex",
         sessionId: "example-session",
         supportsProviderAncestry: true,
-        getProviderSnapshot: () => Promise.resolve([snapshotEntry("my-codex", "codex", "default")]),
+        getProviderSnapshot: () => Promise.resolve([snapshotEntry("my-codex", "codex", true)]),
       }),
     ).resolves.toBe("codex resume example-session");
   });
@@ -218,8 +232,7 @@ describe("resolveProviderResumeCommand", () => {
         provider: "my-codex",
         sessionId: "example-session",
         supportsProviderAncestry: true,
-        getProviderSnapshot: () =>
-          Promise.resolve([snapshotEntry("my-codex", "codex", "override")]),
+        getProviderSnapshot: () => Promise.resolve([snapshotEntry("my-codex", "codex", false)]),
       }),
     ).rejects.toThrow(ProviderResumeCommandUnavailableError);
   });
@@ -230,19 +243,21 @@ describe("resolveProviderResumeCommand", () => {
         provider: "my-codex",
         sessionId: "example-session",
         supportsProviderAncestry: true,
-        getProviderSnapshot: () => Promise.resolve([snapshotEntry("my-codex", "codex", "append")]),
+        getProviderSnapshot: () => Promise.resolve([snapshotEntry("my-codex", "codex", false)]),
       }),
     ).rejects.toThrow(ProviderResumeCommandUnavailableError);
   });
 
-  test("rejects a custom provider with an absent launchSource", async () => {
+  test("rejects a custom provider with an absent canUseDefaultResumeCommand", async () => {
     await expect(
       resolveProviderResumeCommand({
         provider: "my-codex",
         sessionId: "example-session",
         supportsProviderAncestry: true,
         getProviderSnapshot: () =>
-          Promise.resolve([{ ...snapshotEntry("my-codex", "codex"), launchSource: undefined }]),
+          Promise.resolve([
+            { ...snapshotEntry("my-codex", "codex"), canUseDefaultResumeCommand: undefined },
+          ]),
       }),
     ).rejects.toThrow(ProviderResumeCommandUnavailableError);
   });

--- a/packages/app/src/utils/provider-command-templates.test.ts
+++ b/packages/app/src/utils/provider-command-templates.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "vitest";
+import type { ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
 
 import { buildProviderCommand } from "@/utils/provider-command-templates";
+
+function snapshotEntry(
+  provider: string,
+  derivedFromProviderId?: string | null,
+): Pick<ProviderSnapshotEntry, "provider" | "derivedFromProviderId"> {
+  return { provider, derivedFromProviderId };
+}
 
 describe("buildProviderCommand", () => {
   test("builds Hermes resume commands from native session ids", () => {
@@ -21,5 +29,88 @@ describe("buildProviderCommand", () => {
         sessionId: "ses_abc123",
       }),
     ).toBe("opencode --session ses_abc123");
+  });
+
+  test("builds Claude resume commands for built-in Claude without a snapshot", () => {
+    expect(
+      buildProviderCommand({
+        provider: "claude",
+        id: "resume",
+        sessionId: "example-session",
+      }),
+    ).toBe("claude --resume example-session");
+  });
+
+  test("builds Codex resume commands for built-in Codex without a snapshot", () => {
+    expect(
+      buildProviderCommand({
+        provider: "codex",
+        id: "resume",
+        sessionId: "example-session",
+      }),
+    ).toBe("codex resume example-session");
+  });
+
+  test("builds Pi resume commands for built-in Pi without a snapshot", () => {
+    expect(
+      buildProviderCommand({
+        provider: "pi",
+        id: "resume",
+        sessionId: "example-session",
+      }),
+    ).toBe("pi --session example-session");
+  });
+
+  test("builds OMP resume commands for built-in OMP without a snapshot", () => {
+    expect(
+      buildProviderCommand({
+        provider: "omp",
+        id: "resume",
+        sessionId: "example-session",
+      }),
+    ).toBe("omp --session example-session");
+  });
+
+  test("falls back to the derived provider template for a custom Claude provider", () => {
+    expect(
+      buildProviderCommand({
+        provider: "my-claude",
+        id: "resume",
+        sessionId: "example-session",
+        providerSnapshot: [snapshotEntry("my-claude", "claude")],
+      }),
+    ).toBe("claude --resume example-session");
+  });
+
+  test("falls back to the derived provider template for a custom Codex provider", () => {
+    expect(
+      buildProviderCommand({
+        provider: "my-codex",
+        id: "resume",
+        sessionId: "example-session",
+        providerSnapshot: [snapshotEntry("my-codex", "codex")],
+      }),
+    ).toBe("codex resume example-session");
+  });
+
+  test("returns null for an unknown provider with no derivable template", () => {
+    expect(
+      buildProviderCommand({
+        provider: "unknown",
+        id: "resume",
+        sessionId: "example-session",
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for a custom ACP provider that does not extend a templated provider", () => {
+    expect(
+      buildProviderCommand({
+        provider: "my-agent",
+        id: "resume",
+        sessionId: "example-session",
+        providerSnapshot: [snapshotEntry("my-agent", null)],
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/app/src/utils/provider-command-templates.test.ts
+++ b/packages/app/src/utils/provider-command-templates.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import type { ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
 
 import {
   buildProviderCommand,
+  ProviderResumeCommandUnavailableError,
   resolveProviderResumeCommand,
 } from "@/utils/provider-command-templates";
 
@@ -13,6 +14,9 @@ function snapshotEntry(
 ): Pick<ProviderSnapshotEntry, "provider" | "derivedFromProviderId" | "launchSource"> {
   return { provider, derivedFromProviderId, launchSource };
 }
+
+const neverCalledSnapshot = () =>
+  Promise.reject(new Error("getProviderSnapshot should not have been called"));
 
 describe("buildProviderCommand", () => {
   test("builds Hermes resume commands from native session ids", () => {
@@ -154,84 +158,114 @@ describe("buildProviderCommand", () => {
 
 describe("resolveProviderResumeCommand", () => {
   test("resolves built-in Codex immediately without a snapshot", async () => {
-    const getProviderSnapshot = vi.fn().mockResolvedValue(undefined);
     await expect(
       resolveProviderResumeCommand({
         provider: "codex",
         sessionId: "example-session",
         supportsProviderAncestry: false,
-        getProviderSnapshot,
+        getProviderSnapshot: neverCalledSnapshot,
       }),
     ).resolves.toBe("codex resume example-session");
-    expect(getProviderSnapshot).not.toHaveBeenCalled();
   });
 
   test("resolves built-in Claude immediately without a snapshot", async () => {
-    const getProviderSnapshot = vi.fn().mockResolvedValue(undefined);
     await expect(
       resolveProviderResumeCommand({
         provider: "claude",
         sessionId: "example-session",
         supportsProviderAncestry: false,
-        getProviderSnapshot,
+        getProviderSnapshot: neverCalledSnapshot,
       }),
     ).resolves.toBe("claude --resume example-session");
-    expect(getProviderSnapshot).not.toHaveBeenCalled();
   });
 
-  test("rejects a built-in Codex whose cached snapshot launch source is overridden", async () => {
-    const getProviderSnapshot = vi.fn().mockResolvedValue(undefined);
+  test("resolves built-in Codex with providerAncestry without a snapshot", async () => {
     await expect(
       resolveProviderResumeCommand({
         provider: "codex",
         sessionId: "example-session",
         supportsProviderAncestry: true,
-        cachedProviderSnapshot: [snapshotEntry("codex", null, "override")],
-        getProviderSnapshot,
+        getProviderSnapshot: neverCalledSnapshot,
       }),
-    ).rejects.toThrow("Resume command not available");
-    expect(getProviderSnapshot).not.toHaveBeenCalled();
+    ).resolves.toBe("codex resume example-session");
   });
 
-  test("rejects an inherited custom provider when the daemon does not advertise providerAncestry", async () => {
-    const getProviderSnapshot = vi.fn().mockResolvedValue(undefined);
+  test("rejects a custom provider when providerAncestry is not advertised", async () => {
     await expect(
       resolveProviderResumeCommand({
         provider: "my-codex",
         sessionId: "example-session",
         supportsProviderAncestry: false,
-        getProviderSnapshot,
+        getProviderSnapshot: neverCalledSnapshot,
       }),
-    ).rejects.toThrow("Resume command not available");
-    expect(getProviderSnapshot).not.toHaveBeenCalled();
+    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
   });
 
   test("falls back to the ancestor template for a custom provider when providerAncestry is advertised", async () => {
-    const getProviderSnapshot = vi
-      .fn()
-      .mockResolvedValue([snapshotEntry("my-codex", "codex", "default")]);
     await expect(
       resolveProviderResumeCommand({
         provider: "my-codex",
         sessionId: "example-session",
         supportsProviderAncestry: true,
-        getProviderSnapshot,
+        getProviderSnapshot: () => Promise.resolve([snapshotEntry("my-codex", "codex", "default")]),
       }),
     ).resolves.toBe("codex resume example-session");
-    expect(getProviderSnapshot).toHaveBeenCalledOnce();
   });
 
   test("rejects a custom provider with an overridden command even when ancestry is advertised", async () => {
-    const getProviderSnapshot = vi
-      .fn()
-      .mockResolvedValue([snapshotEntry("my-codex", "codex", "override")]);
     await expect(
       resolveProviderResumeCommand({
         provider: "my-codex",
         sessionId: "example-session",
         supportsProviderAncestry: true,
-        getProviderSnapshot,
+        getProviderSnapshot: () =>
+          Promise.resolve([snapshotEntry("my-codex", "codex", "override")]),
       }),
-    ).rejects.toThrow("Resume command not available");
+    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
+  });
+
+  test("rejects a custom provider that appends to its command", async () => {
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "my-codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        getProviderSnapshot: () => Promise.resolve([snapshotEntry("my-codex", "codex", "append")]),
+      }),
+    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
+  });
+
+  test("rejects a custom provider with an absent launchSource", async () => {
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "my-codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        getProviderSnapshot: () =>
+          Promise.resolve([{ ...snapshotEntry("my-codex", "codex"), launchSource: undefined }]),
+      }),
+    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
+  });
+
+  test("does not silently reuse a fallback command when the snapshot source is unavailable", async () => {
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "my-codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        getProviderSnapshot: () => Promise.resolve(undefined),
+      }),
+    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
+  });
+
+  test("propagates unexpected snapshot errors instead of masking them as unavailable", async () => {
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "my-codex",
+        sessionId: "example-session",
+        supportsProviderAncestry: true,
+        getProviderSnapshot: () => Promise.reject(new Error("network failure")),
+      }),
+    ).rejects.toThrow("network failure");
   });
 });

--- a/packages/app/src/utils/provider-command-templates.test.ts
+++ b/packages/app/src/utils/provider-command-templates.test.ts
@@ -172,7 +172,7 @@ describe("buildProviderCommand", () => {
 });
 
 describe("resolveProviderResumeCommand", () => {
-  test("rejects built-in Codex when providerAncestry is not advertised", async () => {
+  test("resolves built-in Codex locally when providerAncestry is not advertised", async () => {
     await expect(
       resolveProviderResumeCommand({
         provider: "codex",
@@ -180,16 +180,38 @@ describe("resolveProviderResumeCommand", () => {
         supportsProviderAncestry: false,
         getProviderSnapshot: neverCalledSnapshot,
       }),
-    ).rejects.toThrow(ProviderResumeCommandUnavailableError);
+    ).resolves.toBe("codex resume example-session");
   });
 
-  test("rejects built-in Claude when providerAncestry is not advertised", async () => {
+  test("resolves built-in Claude locally when providerAncestry is not advertised", async () => {
     await expect(
       resolveProviderResumeCommand({
         provider: "claude",
         sessionId: "example-session",
         supportsProviderAncestry: false,
         getProviderSnapshot: neverCalledSnapshot,
+      }),
+    ).resolves.toBe("claude --resume example-session");
+  });
+
+  test("resolves Hermes locally when providerAncestry is not advertised", async () => {
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "hermes",
+        sessionId: "20260813_111500_abc123",
+        supportsProviderAncestry: false,
+        getProviderSnapshot: neverCalledSnapshot,
+      }),
+    ).resolves.toBe("hermes --resume 20260813_111500_abc123");
+  });
+
+  test("keeps Hermes unavailable on current daemons when the snapshot reports an ACP transport launcher", async () => {
+    await expect(
+      resolveProviderResumeCommand({
+        provider: "hermes",
+        sessionId: "20260813_111500_abc123",
+        supportsProviderAncestry: true,
+        getProviderSnapshot: () => Promise.resolve([snapshotEntry("hermes", null, false)]),
       }),
     ).rejects.toThrow(ProviderResumeCommandUnavailableError);
   });

--- a/packages/app/src/utils/provider-command-templates.ts
+++ b/packages/app/src/utils/provider-command-templates.ts
@@ -7,6 +7,34 @@ type ResumeSnapshot = Pick<
   "provider" | "derivedFromProviderId" | "launchSource"
 >;
 
+export interface ResolveProviderCommandTemplateInput {
+  provider: string;
+  id: ProviderCommandId;
+  providerSnapshot?: readonly ResumeSnapshot[];
+}
+
+export interface BuildProviderCommandInput extends ResolveProviderCommandTemplateInput {
+  sessionId: string;
+}
+
+export interface ResolveProviderResumeCommandInput {
+  provider: string;
+  sessionId: string;
+  supportsProviderAncestry: boolean;
+  getProviderSnapshot: () => Promise<readonly ResumeSnapshot[] | undefined>;
+}
+
+/**
+ * Thrown when a resume command cannot be generated for the provider because it
+ * is overridden, unsupported, or ancestry metadata is unavailable.
+ */
+export class ProviderResumeCommandUnavailableError extends Error {
+  constructor(message = "Resume command not available") {
+    super(message);
+    this.name = "ProviderResumeCommandUnavailableError";
+  }
+}
+
 /**
  * Declarative command templates for provider-native CLIs.
  *
@@ -49,11 +77,9 @@ function isDefaultLaunch(entry: ResumeSnapshot | undefined): boolean {
   return entry == null || entry.launchSource == null || entry.launchSource === "default";
 }
 
-function resolveProviderCommandTemplate(input: {
-  provider: string;
-  id: ProviderCommandId;
-  providerSnapshot?: readonly ResumeSnapshot[];
-}): string | undefined {
+function resolveProviderCommandTemplate(
+  input: ResolveProviderCommandTemplateInput,
+): string | undefined {
   const entry = input.providerSnapshot?.find((candidate) => candidate.provider === input.provider);
 
   // Built-in providers keep their immediate local template unless the snapshot
@@ -64,20 +90,16 @@ function resolveProviderCommandTemplate(input: {
   }
 
   // Custom providers that extend a built-in can only use the inherited template
-  // when the snapshot is available and the command has not been overridden.
-  if (isDefaultLaunch(entry) && entry?.derivedFromProviderId) {
+  // when the snapshot explicitly identifies the ancestor and the command has
+  // not been overridden.
+  if (entry?.derivedFromProviderId && entry.launchSource === "default") {
     return PROVIDER_COMMAND_TEMPLATES[entry.derivedFromProviderId]?.[input.id];
   }
 
   return undefined;
 }
 
-export function buildProviderCommand(input: {
-  provider: string;
-  id: ProviderCommandId;
-  sessionId: string;
-  providerSnapshot?: readonly ResumeSnapshot[];
-}): string | null {
+export function buildProviderCommand(input: BuildProviderCommandInput): string | null {
   const template = resolveProviderCommandTemplate(input) ?? null;
   if (!template) {
     return null;
@@ -88,37 +110,27 @@ export function buildProviderCommand(input: {
 /**
  * Resolve the resume command for a provider.
  *
- * Built-in providers resolve from the local `PROVIDER_COMMAND_TEMPLATES`, but
- * the cached provider snapshot is consulted first to detect command overrides.
- * Custom providers that extend a built-in require the daemon's
- * `providerAncestry` capability and a provider snapshot to derive the inherited
- * template. If the command is not available, the returned promise rejects.
+ * Built-in providers resolve from the local `PROVIDER_COMMAND_TEMPLATES` without
+ * any snapshot, preserving the pre-existing immediate path. Custom providers
+ * that extend a built-in require the daemon's `providerAncestry` capability and
+ * the provider snapshot to derive the inherited template. If the command is not
+ * available, the returned promise rejects with
+ * {@link ProviderResumeCommandUnavailableError}.
  */
-export async function resolveProviderResumeCommand(input: {
-  provider: string;
-  sessionId: string;
-  supportsProviderAncestry: boolean;
-  cachedProviderSnapshot?: readonly ResumeSnapshot[];
-  getProviderSnapshot: () => Promise<readonly ResumeSnapshot[] | undefined>;
-}): Promise<string> {
+export async function resolveProviderResumeCommand(
+  input: ResolveProviderResumeCommandInput,
+): Promise<string> {
   const direct = buildProviderCommand({
     provider: input.provider,
     id: "resume",
     sessionId: input.sessionId,
-    providerSnapshot: input.cachedProviderSnapshot,
   });
   if (direct) {
     return direct;
   }
 
-  // A built-in provider is in the cached snapshot with a non-default launch
-  // source, so the stock resume command is not safe to copy.
-  if (PROVIDER_COMMAND_TEMPLATES[input.provider]?.resume) {
-    throw new Error("Resume command not available");
-  }
-
   if (!input.supportsProviderAncestry) {
-    throw new Error("Resume command not available");
+    throw new ProviderResumeCommandUnavailableError();
   }
 
   const providerSnapshot = await input.getProviderSnapshot();
@@ -129,7 +141,7 @@ export async function resolveProviderResumeCommand(input: {
     providerSnapshot,
   });
   if (!command) {
-    throw new Error("Resume command not available");
+    throw new ProviderResumeCommandUnavailableError();
   }
   return command;
 }

--- a/packages/app/src/utils/provider-command-templates.ts
+++ b/packages/app/src/utils/provider-command-templates.ts
@@ -112,18 +112,27 @@ export function buildProviderCommand(input: BuildProviderCommandInput): string |
 /**
  * Resolve the resume command for a provider.
  *
- * Daemons advertising `providerAncestry` provide the authoritative safety
- * classification for built-in and custom providers through their snapshot.
- * Without that capability, the action fails closed because provider launch
- * customization cannot be ruled out. If the command is not available, the
- * returned promise rejects with
+ * Built-in resume templates are existing functionality: without the
+ * `providerAncestry` capability, resolve them locally and never issue a
+ * snapshot RPC. Only ancestry-based inherited custom-provider resolution is
+ * gated on the capability. Daemons advertising `providerAncestry` provide the
+ * authoritative safety classification through their snapshot. If the command
+ * is not available, the returned promise rejects with
  * {@link ProviderResumeCommandUnavailableError}.
  */
 export async function resolveProviderResumeCommand(
   input: ResolveProviderResumeCommandInput,
 ): Promise<string> {
   if (!input.supportsProviderAncestry) {
-    throw new ProviderResumeCommandUnavailableError();
+    const localCommand = buildProviderCommand({
+      provider: input.provider,
+      id: "resume",
+      sessionId: input.sessionId,
+    });
+    if (!localCommand) {
+      throw new ProviderResumeCommandUnavailableError();
+    }
+    return localCommand;
   }
 
   const providerSnapshot = await input.getProviderSnapshot();

--- a/packages/app/src/utils/provider-command-templates.ts
+++ b/packages/app/src/utils/provider-command-templates.ts
@@ -88,8 +88,9 @@ export function buildProviderCommand(input: {
 /**
  * Resolve the resume command for a provider.
  *
- * Built-in providers resolve from the local `PROVIDER_COMMAND_TEMPLATES` without
- * a snapshot. Custom providers that extend a built-in require the daemon's
+ * Built-in providers resolve from the local `PROVIDER_COMMAND_TEMPLATES`, but
+ * the cached provider snapshot is consulted first to detect command overrides.
+ * Custom providers that extend a built-in require the daemon's
  * `providerAncestry` capability and a provider snapshot to derive the inherited
  * template. If the command is not available, the returned promise rejects.
  */
@@ -97,15 +98,23 @@ export async function resolveProviderResumeCommand(input: {
   provider: string;
   sessionId: string;
   supportsProviderAncestry: boolean;
+  cachedProviderSnapshot?: readonly ResumeSnapshot[];
   getProviderSnapshot: () => Promise<readonly ResumeSnapshot[] | undefined>;
 }): Promise<string> {
   const direct = buildProviderCommand({
     provider: input.provider,
     id: "resume",
     sessionId: input.sessionId,
+    providerSnapshot: input.cachedProviderSnapshot,
   });
   if (direct) {
     return direct;
+  }
+
+  // A built-in provider is in the cached snapshot with a non-default launch
+  // source, so the stock resume command is not safe to copy.
+  if (PROVIDER_COMMAND_TEMPLATES[input.provider]?.resume) {
+    throw new Error("Resume command not available");
   }
 
   if (!input.supportsProviderAncestry) {

--- a/packages/app/src/utils/provider-command-templates.ts
+++ b/packages/app/src/utils/provider-command-templates.ts
@@ -2,6 +2,11 @@ import type { ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
 
 export type ProviderCommandId = "resume";
 
+type ResumeSnapshot = Pick<
+  ProviderSnapshotEntry,
+  "provider" | "derivedFromProviderId" | "launchSource"
+>;
+
 /**
  * Declarative command templates for provider-native CLIs.
  *
@@ -37,21 +42,31 @@ function renderTemplate(template: string, vars: Record<string, string>): string 
   return template.replace(/\{(\w+)\}/g, (_match, key: string) => vars[key] ?? "");
 }
 
+function isDefaultLaunch(entry: ResumeSnapshot | undefined): boolean {
+  // launchSource is absent on old-daemons and pre-v3 caches; treat unknown as
+  // default so the feature degrades to the previous behavior rather than
+  // refusing a command for already-cached snapshots after this code ships.
+  return entry == null || entry.launchSource == null || entry.launchSource === "default";
+}
+
 function resolveProviderCommandTemplate(input: {
   provider: string;
   id: ProviderCommandId;
-  providerSnapshot?: readonly Pick<ProviderSnapshotEntry, "provider" | "derivedFromProviderId">[];
+  providerSnapshot?: readonly ResumeSnapshot[];
 }): string | undefined {
+  const entry = input.providerSnapshot?.find((candidate) => candidate.provider === input.provider);
+
+  // Built-in providers keep their immediate local template unless the snapshot
+  // explicitly says the command has been replaced/extended.
   const providerTemplate = PROVIDER_COMMAND_TEMPLATES[input.provider]?.[input.id];
   if (providerTemplate) {
-    return providerTemplate;
+    return isDefaultLaunch(entry) ? providerTemplate : undefined;
   }
 
-  const derivedFromProviderId = input.providerSnapshot?.find(
-    (entry) => entry.provider === input.provider,
-  )?.derivedFromProviderId;
-  if (derivedFromProviderId) {
-    return PROVIDER_COMMAND_TEMPLATES[derivedFromProviderId]?.[input.id];
+  // Custom providers that extend a built-in can only use the inherited template
+  // when the snapshot is available and the command has not been overridden.
+  if (isDefaultLaunch(entry) && entry?.derivedFromProviderId) {
+    return PROVIDER_COMMAND_TEMPLATES[entry.derivedFromProviderId]?.[input.id];
   }
 
   return undefined;
@@ -61,11 +76,51 @@ export function buildProviderCommand(input: {
   provider: string;
   id: ProviderCommandId;
   sessionId: string;
-  providerSnapshot?: readonly Pick<ProviderSnapshotEntry, "provider" | "derivedFromProviderId">[];
+  providerSnapshot?: readonly ResumeSnapshot[];
 }): string | null {
   const template = resolveProviderCommandTemplate(input) ?? null;
   if (!template) {
     return null;
   }
   return renderTemplate(template, { sessionId: input.sessionId });
+}
+
+/**
+ * Resolve the resume command for a provider.
+ *
+ * Built-in providers resolve from the local `PROVIDER_COMMAND_TEMPLATES` without
+ * a snapshot. Custom providers that extend a built-in require the daemon's
+ * `providerAncestry` capability and a provider snapshot to derive the inherited
+ * template. If the command is not available, the returned promise rejects.
+ */
+export async function resolveProviderResumeCommand(input: {
+  provider: string;
+  sessionId: string;
+  supportsProviderAncestry: boolean;
+  getProviderSnapshot: () => Promise<readonly ResumeSnapshot[] | undefined>;
+}): Promise<string> {
+  const direct = buildProviderCommand({
+    provider: input.provider,
+    id: "resume",
+    sessionId: input.sessionId,
+  });
+  if (direct) {
+    return direct;
+  }
+
+  if (!input.supportsProviderAncestry) {
+    throw new Error("Resume command not available");
+  }
+
+  const providerSnapshot = await input.getProviderSnapshot();
+  const command = buildProviderCommand({
+    provider: input.provider,
+    id: "resume",
+    sessionId: input.sessionId,
+    providerSnapshot,
+  });
+  if (!command) {
+    throw new Error("Resume command not available");
+  }
+  return command;
 }

--- a/packages/app/src/utils/provider-command-templates.ts
+++ b/packages/app/src/utils/provider-command-templates.ts
@@ -1,3 +1,5 @@
+import type { ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
+
 export type ProviderCommandId = "resume";
 
 /**
@@ -35,12 +37,33 @@ function renderTemplate(template: string, vars: Record<string, string>): string 
   return template.replace(/\{(\w+)\}/g, (_match, key: string) => vars[key] ?? "");
 }
 
+function resolveProviderCommandTemplate(input: {
+  provider: string;
+  id: ProviderCommandId;
+  providerSnapshot?: readonly Pick<ProviderSnapshotEntry, "provider" | "derivedFromProviderId">[];
+}): string | undefined {
+  const providerTemplate = PROVIDER_COMMAND_TEMPLATES[input.provider]?.[input.id];
+  if (providerTemplate) {
+    return providerTemplate;
+  }
+
+  const derivedFromProviderId = input.providerSnapshot?.find(
+    (entry) => entry.provider === input.provider,
+  )?.derivedFromProviderId;
+  if (derivedFromProviderId) {
+    return PROVIDER_COMMAND_TEMPLATES[derivedFromProviderId]?.[input.id];
+  }
+
+  return undefined;
+}
+
 export function buildProviderCommand(input: {
   provider: string;
   id: ProviderCommandId;
   sessionId: string;
+  providerSnapshot?: readonly Pick<ProviderSnapshotEntry, "provider" | "derivedFromProviderId">[];
 }): string | null {
-  const template = PROVIDER_COMMAND_TEMPLATES[input.provider]?.[input.id] ?? null;
+  const template = resolveProviderCommandTemplate(input) ?? null;
   if (!template) {
     return null;
   }

--- a/packages/app/src/utils/provider-command-templates.ts
+++ b/packages/app/src/utils/provider-command-templates.ts
@@ -4,7 +4,7 @@ export type ProviderCommandId = "resume";
 
 type ResumeSnapshot = Pick<
   ProviderSnapshotEntry,
-  "provider" | "derivedFromProviderId" | "launchSource"
+  "provider" | "derivedFromProviderId" | "canUseDefaultResumeCommand"
 >;
 
 export interface ResolveProviderCommandTemplateInput {
@@ -71,10 +71,10 @@ function renderTemplate(template: string, vars: Record<string, string>): string 
 }
 
 function isDefaultLaunch(entry: ResumeSnapshot | undefined): boolean {
-  // launchSource is absent on old-daemons and pre-v3 caches; treat unknown as
-  // default so the feature degrades to the previous behavior rather than
-  // refusing a command for already-cached snapshots after this code ships.
-  return entry == null || entry.launchSource == null || entry.launchSource === "default";
+  // Built-in providers can still resolve when the snapshot is absent or predates
+  // the canUseDefaultResumeCommand field. Custom providers require an explicit
+  // `true` value in the custom branch below.
+  return entry == null || entry.canUseDefaultResumeCommand !== false;
 }
 
 function resolveProviderCommandTemplate(
@@ -90,9 +90,9 @@ function resolveProviderCommandTemplate(
   }
 
   // Custom providers that extend a built-in can only use the inherited template
-  // when the snapshot explicitly identifies the ancestor and the command has
-  // not been overridden.
-  if (entry?.derivedFromProviderId && entry.launchSource === "default") {
+  // when the snapshot explicitly identifies the ancestor and reports that the
+  // default resume command is safe to use.
+  if (entry?.derivedFromProviderId && entry.canUseDefaultResumeCommand === true) {
     return PROVIDER_COMMAND_TEMPLATES[entry.derivedFromProviderId]?.[input.id];
   }
 

--- a/packages/app/src/utils/provider-command-templates.ts
+++ b/packages/app/src/utils/provider-command-templates.ts
@@ -24,6 +24,11 @@ export interface ResolveProviderResumeCommandInput {
   getProviderSnapshot: () => Promise<readonly ResumeSnapshot[] | undefined>;
 }
 
+export type ResolveProviderResumeCommandOutcome =
+  | { status: "ready"; command: string }
+  | { status: "unavailable" }
+  | { status: "failed"; error: unknown };
+
 /**
  * Thrown when a resume command cannot be generated for the provider because it
  * is overridden, unsupported, or ancestry metadata is unavailable.
@@ -71,10 +76,7 @@ function renderTemplate(template: string, vars: Record<string, string>): string 
 }
 
 function isDefaultLaunch(entry: ResumeSnapshot | undefined): boolean {
-  // Built-in providers can still resolve when the snapshot is absent or predates
-  // the canUseDefaultResumeCommand field. Custom providers require an explicit
-  // `true` value in the custom branch below.
-  return entry == null || entry.canUseDefaultResumeCommand !== false;
+  return entry?.canUseDefaultResumeCommand === true;
 }
 
 function resolveProviderCommandTemplate(
@@ -82,11 +84,11 @@ function resolveProviderCommandTemplate(
 ): string | undefined {
   const entry = input.providerSnapshot?.find((candidate) => candidate.provider === input.provider);
 
-  // Built-in providers keep their immediate local template unless the snapshot
-  // explicitly says the command has been replaced/extended.
   const providerTemplate = PROVIDER_COMMAND_TEMPLATES[input.provider]?.[input.id];
   if (providerTemplate) {
-    return isDefaultLaunch(entry) ? providerTemplate : undefined;
+    return input.providerSnapshot === undefined || isDefaultLaunch(entry)
+      ? providerTemplate
+      : undefined;
   }
 
   // Custom providers that extend a built-in can only use the inherited template
@@ -110,30 +112,24 @@ export function buildProviderCommand(input: BuildProviderCommandInput): string |
 /**
  * Resolve the resume command for a provider.
  *
- * Built-in providers resolve from the local `PROVIDER_COMMAND_TEMPLATES` without
- * any snapshot, preserving the pre-existing immediate path. Custom providers
- * that extend a built-in require the daemon's `providerAncestry` capability and
- * the provider snapshot to derive the inherited template. If the command is not
- * available, the returned promise rejects with
+ * Daemons advertising `providerAncestry` provide the authoritative safety
+ * classification for built-in and custom providers through their snapshot.
+ * Without that capability, the action fails closed because provider launch
+ * customization cannot be ruled out. If the command is not available, the
+ * returned promise rejects with
  * {@link ProviderResumeCommandUnavailableError}.
  */
 export async function resolveProviderResumeCommand(
   input: ResolveProviderResumeCommandInput,
 ): Promise<string> {
-  const direct = buildProviderCommand({
-    provider: input.provider,
-    id: "resume",
-    sessionId: input.sessionId,
-  });
-  if (direct) {
-    return direct;
-  }
-
   if (!input.supportsProviderAncestry) {
     throw new ProviderResumeCommandUnavailableError();
   }
 
   const providerSnapshot = await input.getProviderSnapshot();
+  if (!providerSnapshot) {
+    throw new ProviderResumeCommandUnavailableError();
+  }
   const command = buildProviderCommand({
     provider: input.provider,
     id: "resume",
@@ -144,4 +140,18 @@ export async function resolveProviderResumeCommand(
     throw new ProviderResumeCommandUnavailableError();
   }
   return command;
+}
+
+export async function resolveProviderResumeCommandOutcome(
+  input: ResolveProviderResumeCommandInput,
+): Promise<ResolveProviderResumeCommandOutcome> {
+  try {
+    const command = await resolveProviderResumeCommand(input);
+    return { status: "ready", command };
+  } catch (error) {
+    if (error instanceof ProviderResumeCommandUnavailableError) {
+      return { status: "unavailable" };
+    }
+    return { status: "failed", error };
+  }
 }

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -113,11 +113,11 @@ export interface ProviderSnapshotEntry {
    */
   derivedFromProviderId?: AgentProvider | null;
   /**
-   * Whether the provider's launch command is the built-in default, appended to,
-   * or fully overridden by a custom `command` array. Used by the client to decide
-   * whether built-in resume command templates are safe to use.
+   * Whether the provider can safely use its built-in resume command template.
+   * Built-in providers and faithful inherited providers report true; customized
+   * providers with an overridden command or custom environment do not.
    */
-  launchSource?: "default" | "append" | "override";
+  canUseDefaultResumeCommand?: boolean;
   error?: string;
   models?: AgentModelDefinition[];
   modes?: AgentMode[];

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -112,6 +112,12 @@ export interface ProviderSnapshotEntry {
    * they extend. null or undefined for built-in providers and generic ACP providers.
    */
   derivedFromProviderId?: AgentProvider | null;
+  /**
+   * Whether the provider's launch command is the built-in default, appended to,
+   * or fully overridden by a custom `command` array. Used by the client to decide
+   * whether built-in resume command templates are safe to use.
+   */
+  launchSource?: "default" | "append" | "override";
   error?: string;
   models?: AgentModelDefinition[];
   modes?: AgentMode[];

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -107,6 +107,11 @@ export interface ProviderSnapshotEntry {
   status: ProviderStatus;
   enabled: boolean;
   source?: "builtin" | "custom";
+  /**
+   * For custom providers that extend a built-in provider, the id of the provider
+   * they extend. null or undefined for built-in providers and generic ACP providers.
+   */
+  derivedFromProviderId?: AgentProvider | null;
   error?: string;
   models?: AgentModelDefinition[];
   modes?: AgentMode[];

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -375,7 +375,7 @@ export const ProviderSnapshotEntrySchema = z.object({
   enabled: z.boolean().optional().default(true),
   source: z.enum(["builtin", "custom"]).optional(),
   derivedFromProviderId: AgentProviderSchema.nullable().optional(),
-  launchSource: z.enum(["default", "append", "override"]).optional(),
+  canUseDefaultResumeCommand: z.boolean().optional(),
   error: z.string().optional(),
   models: z.array(AgentModelDefinitionSchema).optional(),
   modes: z.array(AgentModeSchema).optional(),

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -374,6 +374,7 @@ export const ProviderSnapshotEntrySchema = z.object({
   status: ProviderStatusSchema,
   enabled: z.boolean().optional().default(true),
   source: z.enum(["builtin", "custom"]).optional(),
+  derivedFromProviderId: AgentProviderSchema.nullable().optional(),
   error: z.string().optional(),
   models: z.array(AgentModelDefinitionSchema).optional(),
   modes: z.array(AgentModeSchema).optional(),

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -375,6 +375,7 @@ export const ProviderSnapshotEntrySchema = z.object({
   enabled: z.boolean().optional().default(true),
   source: z.enum(["builtin", "custom"]).optional(),
   derivedFromProviderId: AgentProviderSchema.nullable().optional(),
+  launchSource: z.enum(["default", "append", "override"]).optional(),
   error: z.string().optional(),
   models: z.array(AgentModelDefinitionSchema).optional(),
   modes: z.array(AgentModeSchema).optional(),
@@ -3441,6 +3442,8 @@ export const ServerInfoStatusPayloadSchema = z
         providersSnapshotCwd: z.boolean().optional(),
         // COMPAT(directorySync): added in v0.3.x, remove gate after 2027-02-12.
         directorySync: z.boolean().optional(),
+        // COMPAT(providerAncestry): added in v0.8.0, remove gate after 2027-03-15.
+        providerAncestry: z.boolean().optional(),
         // COMPAT(workspaceLabels): added in v0.5.0, remove after 2027-08-14.
         workspaceLabels: z.boolean().optional(),
         // COMPAT(workspaceSetupRun): added in v0.8.0, remove gate after 2027-09-02.

--- a/packages/protocol/src/provider-snapshot-codec.test.ts
+++ b/packages/protocol/src/provider-snapshot-codec.test.ts
@@ -68,7 +68,7 @@ describe("provider snapshot codec", () => {
         status: "ready",
         enabled: true,
         derivedFromProviderId: "claude",
-        launchSource: "default",
+        canUseDefaultResumeCommand: true,
       },
     ];
     const compact = compactProviderSnapshot(original);
@@ -78,8 +78,8 @@ describe("provider snapshot codec", () => {
     expect(expanded).toEqual(original);
     expect(compact.entries[0]?.derivedFromProviderId).toBe("claude");
     expect(expanded[0]?.derivedFromProviderId).toBe("claude");
-    expect(compact.entries[0]?.launchSource).toBe("default");
-    expect(expanded[0]?.launchSource).toBe("default");
+    expect(compact.entries[0]?.canUseDefaultResumeCommand).toBe(true);
+    expect(expanded[0]?.canUseDefaultResumeCommand).toBe(true);
   });
 
   it("shrinks catalogs dominated by one repeated thinking set", () => {

--- a/packages/protocol/src/provider-snapshot-codec.test.ts
+++ b/packages/protocol/src/provider-snapshot-codec.test.ts
@@ -68,6 +68,7 @@ describe("provider snapshot codec", () => {
         status: "ready",
         enabled: true,
         derivedFromProviderId: "claude",
+        launchSource: "default",
       },
     ];
     const compact = compactProviderSnapshot(original);
@@ -77,6 +78,8 @@ describe("provider snapshot codec", () => {
     expect(expanded).toEqual(original);
     expect(compact.entries[0]?.derivedFromProviderId).toBe("claude");
     expect(expanded[0]?.derivedFromProviderId).toBe("claude");
+    expect(compact.entries[0]?.launchSource).toBe("default");
+    expect(expanded[0]?.launchSource).toBe("default");
   });
 
   it("shrinks catalogs dominated by one repeated thinking set", () => {

--- a/packages/protocol/src/provider-snapshot-codec.test.ts
+++ b/packages/protocol/src/provider-snapshot-codec.test.ts
@@ -61,6 +61,24 @@ describe("provider snapshot codec", () => {
     );
   });
 
+  it("round-trips derivedFromProviderId on a custom provider entry", () => {
+    const original: ProviderSnapshotEntry[] = [
+      {
+        provider: "my-claude",
+        status: "ready",
+        enabled: true,
+        derivedFromProviderId: "claude",
+      },
+    ];
+    const compact = compactProviderSnapshot(original);
+    const expanded = expandProviderSnapshot(compact);
+
+    expect(CompactProviderSnapshotSchema.parse(compact)).toEqual(compact);
+    expect(expanded).toEqual(original);
+    expect(compact.entries[0]?.derivedFromProviderId).toBe("claude");
+    expect(expanded[0]?.derivedFromProviderId).toBe("claude");
+  });
+
   it("shrinks catalogs dominated by one repeated thinking set", () => {
     const model = providerEntry().models?.[0];
     if (!model) throw new Error("fixture model missing");

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -119,6 +119,11 @@ export interface ProviderSnapshotEntry {
   status: ProviderStatus;
   enabled: boolean;
   source?: "builtin" | "custom";
+  /**
+   * For custom providers that extend a built-in provider, the id of the provider
+   * they extend. null or undefined for built-in providers and generic ACP providers.
+   */
+  derivedFromProviderId?: AgentProvider | null;
   error?: string;
   models?: AgentModelDefinition[];
   modes?: AgentMode[];

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -3,12 +3,13 @@ import type {
   AgentTaskItem,
   JsonValue,
   ProviderOptions,
+  ProviderSnapshotEntry,
   ToolPolicy,
 } from "@getpaseo/protocol/agent-types";
 import type { AgentAttachment } from "@getpaseo/protocol/messages";
 import type { PaseoToolCatalog } from "./tools/types.js";
 
-export type { AgentProviderNotice, AgentTaskItem };
+export type { AgentProviderNotice, AgentTaskItem, ProviderSnapshotEntry };
 
 export type AgentProvider = string;
 
@@ -112,26 +113,6 @@ export function filterSelectableAgentModels(
   models: AgentModelDefinition[] | undefined,
 ): AgentModelDefinition[] {
   return models?.filter((model) => model.isSelectable !== false) ?? [];
-}
-
-export interface ProviderSnapshotEntry {
-  provider: AgentProvider;
-  status: ProviderStatus;
-  enabled: boolean;
-  source?: "builtin" | "custom";
-  /**
-   * For custom providers that extend a built-in provider, the id of the provider
-   * they extend. null or undefined for built-in providers and generic ACP providers.
-   */
-  derivedFromProviderId?: AgentProvider | null;
-  error?: string;
-  models?: AgentModelDefinition[];
-  modes?: AgentMode[];
-  fetchedAt?: string;
-  label?: string;
-  description?: string;
-  iconSvg?: string;
-  defaultModeId?: string | null;
 }
 
 export interface AgentCreateConfigParent {

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -298,9 +298,13 @@ describe("ProviderSnapshotManager public surface", () => {
       const qwenCodex = snapshot.find((entry) => entry.provider === "qwen-codex");
       const myAcp = snapshot.find((entry) => entry.provider === "my-acp");
       expect(claude?.derivedFromProviderId).toBeNull();
+      expect(claude?.launchSource).toBe("default");
       expect(zaiClaude?.derivedFromProviderId).toBe("claude");
+      expect(zaiClaude?.launchSource).toBe("default");
       expect(qwenCodex?.derivedFromProviderId).toBe("codex");
+      expect(qwenCodex?.launchSource).toBe("default");
       expect(myAcp?.derivedFromProviderId).toBeNull();
+      expect(myAcp?.launchSource).toBe("override");
     } finally {
       manager.destroy();
     }

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -310,10 +310,13 @@ describe("ProviderSnapshotManager public surface", () => {
     }
   });
 
-  test("snapshot entries report unsafe default resume for derived providers with custom env", () => {
+  test("snapshot entries report unsafe default resume without exposing custom env", () => {
     const manager = new ProviderSnapshotManager({
       logger: createTestLogger(),
       providerOverrides: {
+        codex: {
+          env: { OPENAI_API_KEY: "secret", OPENAI_BASE_URL: "https://example.com" },
+        },
         "zai-claude": {
           extends: "claude",
           label: "ZAI",
@@ -324,10 +327,40 @@ describe("ProviderSnapshotManager public surface", () => {
     });
     try {
       const snapshot = manager.getSnapshot("/tmp/project").records.map(({ entry }) => entry);
+      const codex = snapshot.find((entry) => entry.provider === "codex");
       const zaiClaude = snapshot.find((entry) => entry.provider === "zai-claude");
+      expect(codex?.canUseDefaultResumeCommand).toBe(false);
+      expect(codex).not.toMatchObject({ env: expect.anything() });
       expect(zaiClaude?.derivedFromProviderId).toBe("claude");
       expect(zaiClaude?.canUseDefaultResumeCommand).toBe(false);
       expect(zaiClaude).not.toMatchObject({ env: expect.anything() });
+    } finally {
+      manager.destroy();
+    }
+  });
+
+  test("snapshot entries report unsafe default resume for replaced and appended commands", () => {
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      runtimeSettings: {
+        codex: { command: { mode: "append", args: ["--profile", "work"] } },
+      },
+      providerOverrides: {
+        "my-codex": { extends: "codex", label: "My Codex", enabled: true },
+        "my-claude": {
+          extends: "claude",
+          label: "My Claude",
+          enabled: true,
+          command: ["claude-nightly"],
+        },
+      },
+    });
+    try {
+      const snapshot = manager.getSnapshot("/tmp/project").records.map(({ entry }) => entry);
+      const myCodex = snapshot.find((entry) => entry.provider === "my-codex");
+      const myClaude = snapshot.find((entry) => entry.provider === "my-claude");
+      expect(myCodex?.canUseDefaultResumeCommand).toBe(false);
+      expect(myClaude?.canUseDefaultResumeCommand).toBe(false);
     } finally {
       manager.destroy();
     }

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -298,13 +298,36 @@ describe("ProviderSnapshotManager public surface", () => {
       const qwenCodex = snapshot.find((entry) => entry.provider === "qwen-codex");
       const myAcp = snapshot.find((entry) => entry.provider === "my-acp");
       expect(claude?.derivedFromProviderId).toBeNull();
-      expect(claude?.launchSource).toBe("default");
+      expect(claude?.canUseDefaultResumeCommand).toBe(true);
       expect(zaiClaude?.derivedFromProviderId).toBe("claude");
-      expect(zaiClaude?.launchSource).toBe("default");
+      expect(zaiClaude?.canUseDefaultResumeCommand).toBe(true);
       expect(qwenCodex?.derivedFromProviderId).toBe("codex");
-      expect(qwenCodex?.launchSource).toBe("default");
+      expect(qwenCodex?.canUseDefaultResumeCommand).toBe(true);
       expect(myAcp?.derivedFromProviderId).toBeNull();
-      expect(myAcp?.launchSource).toBe("override");
+      expect(myAcp?.canUseDefaultResumeCommand).toBe(false);
+    } finally {
+      manager.destroy();
+    }
+  });
+
+  test("snapshot entries report unsafe default resume for derived providers with custom env", () => {
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        "zai-claude": {
+          extends: "claude",
+          label: "ZAI",
+          enabled: true,
+          env: { ANTHROPIC_API_KEY: "secret", ANTHROPIC_BASE_URL: "https://example.com" },
+        },
+      },
+    });
+    try {
+      const snapshot = manager.getSnapshot("/tmp/project").records.map(({ entry }) => entry);
+      const zaiClaude = snapshot.find((entry) => entry.provider === "zai-claude");
+      expect(zaiClaude?.derivedFromProviderId).toBe("claude");
+      expect(zaiClaude?.canUseDefaultResumeCommand).toBe(false);
+      expect(zaiClaude).not.toMatchObject({ env: expect.anything() });
     } finally {
       manager.destroy();
     }

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -282,6 +282,30 @@ describe("ProviderSnapshotManager public surface", () => {
     }
   });
 
+  test("snapshot entries include derivedFromProviderId for custom providers", () => {
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        "zai-claude": { extends: "claude", label: "ZAI", enabled: true },
+        "qwen-codex": { extends: "codex", label: "Qwen Code", enabled: true },
+        "my-acp": { extends: "acp", label: "My ACP", enabled: true, command: ["my-acp"] },
+      },
+    });
+    try {
+      const snapshot = manager.getSnapshot("/tmp/project").records.map(({ entry }) => entry);
+      const claude = snapshot.find((entry) => entry.provider === "claude");
+      const zaiClaude = snapshot.find((entry) => entry.provider === "zai-claude");
+      const qwenCodex = snapshot.find((entry) => entry.provider === "qwen-codex");
+      const myAcp = snapshot.find((entry) => entry.provider === "my-acp");
+      expect(claude?.derivedFromProviderId).toBeNull();
+      expect(zaiClaude?.derivedFromProviderId).toBe("claude");
+      expect(qwenCodex?.derivedFromProviderId).toBe("codex");
+      expect(myAcp?.derivedFromProviderId).toBeNull();
+    } finally {
+      manager.destroy();
+    }
+  });
+
   test("getSnapshot returns loading entries for built-in providers before warmup", () => {
     const manager = new ProviderSnapshotManager({ logger: createTestLogger() });
     try {

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -829,7 +829,7 @@ export class ProviderSnapshotManager {
       const custom =
         this.pluginProviders.has(provider) ||
         (!BUILTIN_PROVIDER_IDS.includes(provider) && !!overrides?.[provider]?.extends);
-      const launchSource = resolveLaunchSource(definition);
+      const canUseDefaultResumeCommand = resolveCanUseDefaultResumeCommand(definition);
       providerStates.set(provider, {
         discoveryLimit: previous?.discoveryLimit ?? pLimit({ concurrency: 4, rejectOnClear: true }),
         initial: identifyEntry({
@@ -838,7 +838,7 @@ export class ProviderSnapshotManager {
           enabled: definition.enabled,
           source: custom ? "custom" : "builtin",
           derivedFromProviderId: definition.derivedFromProviderId,
-          launchSource,
+          canUseDefaultResumeCommand,
           label: definition.label,
           description: definition.description,
           iconSvg: definition.iconSvg,
@@ -1166,18 +1166,17 @@ export function isGlobalProviderSnapshotKey(cwd: string): boolean {
   return cwd === GLOBAL_PROVIDER_SNAPSHOT_KEY;
 }
 
-function resolveLaunchSource(definition: ProviderDefinition): "default" | "append" | "override" {
-  const command = definition.configuration?.runtimeSettings?.command;
-  if (command == null) {
-    return "default";
+function resolveCanUseDefaultResumeCommand(definition: ProviderDefinition): boolean {
+  const runtimeSettings = definition.configuration?.runtimeSettings;
+  const command = runtimeSettings?.command;
+  if (command != null && command.mode !== "default") {
+    return false;
   }
-  if (command.mode === "replace") {
-    return "override";
+  const env = runtimeSettings?.env;
+  if (env != null && Object.keys(env).length > 0) {
+    return false;
   }
-  if (command.mode === "append") {
-    return "append";
-  }
-  return "default";
+  return true;
 }
 
 function identifyEntry(entry: ProviderSnapshotEntry): ProviderSnapshotRecord {

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -829,6 +829,7 @@ export class ProviderSnapshotManager {
       const custom =
         this.pluginProviders.has(provider) ||
         (!BUILTIN_PROVIDER_IDS.includes(provider) && !!overrides?.[provider]?.extends);
+      const launchSource = resolveLaunchSource(definition);
       providerStates.set(provider, {
         discoveryLimit: previous?.discoveryLimit ?? pLimit({ concurrency: 4, rejectOnClear: true }),
         initial: identifyEntry({
@@ -837,6 +838,7 @@ export class ProviderSnapshotManager {
           enabled: definition.enabled,
           source: custom ? "custom" : "builtin",
           derivedFromProviderId: definition.derivedFromProviderId,
+          launchSource,
           label: definition.label,
           description: definition.description,
           iconSvg: definition.iconSvg,
@@ -1162,6 +1164,20 @@ function createFetchCatalogOptions(
 
 export function isGlobalProviderSnapshotKey(cwd: string): boolean {
   return cwd === GLOBAL_PROVIDER_SNAPSHOT_KEY;
+}
+
+function resolveLaunchSource(definition: ProviderDefinition): "default" | "append" | "override" {
+  const command = definition.configuration?.runtimeSettings?.command;
+  if (command == null) {
+    return "default";
+  }
+  if (command.mode === "replace") {
+    return "override";
+  }
+  if (command.mode === "append") {
+    return "append";
+  }
+  return "default";
 }
 
 function identifyEntry(entry: ProviderSnapshotEntry): ProviderSnapshotRecord {

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -836,6 +836,7 @@ export class ProviderSnapshotManager {
           status: definition.enabled ? "loading" : "unavailable",
           enabled: definition.enabled,
           source: custom ? "custom" : "builtin",
+          derivedFromProviderId: definition.derivedFromProviderId,
           label: definition.label,
           description: definition.description,
           iconSvg: definition.iconSvg,

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1644,6 +1644,8 @@ export class VoiceAssistantWebSocketServer {
         providersSnapshot: true,
         // COMPAT(providersSnapshotCwd): added in v0.3.2, remove gate after 2027-02-10.
         providersSnapshotCwd: true,
+        // COMPAT(providerAncestry): added in v0.8.0, remove gate after 2027-03-15.
+        providerAncestry: true,
         // COMPAT(checkoutForgeSetAutoMerge): added in v0.2.0-beta.1. Remove the
         // feature gate and legacy fallback after 2027-01-17 once the supported
         // daemon floor is >= v0.2.0.


### PR DESCRIPTION
## Summary

Fixes #4648.

Custom providers extending a built-in provider (e.g., `my-codex extends codex`) could not produce a **Copy resume command** and showed "Resume command not available".

### Implementation

- Custom providers extending supported built-ins can inherit native resume commands when Paseo can prove the stock command is safe.
- Provider ancestry and resume-command safety metadata come from the daemon snapshot; only non-secret safety metadata crosses the protocol (environment values/secrets stay on the daemon).
- Built-in providers keep the existing local resume-command path. Older daemons without ancestry metadata continue to use that local path; inherited custom-provider resume commands require a daemon that advertises the `providerAncestry` capability.
- Provider snapshot cache is bumped to v3 so older stripped snapshot bodies cannot be reused.
- Concurrent **Copy resume command** attempts for the same agent are suppressed while a resolution is pending.
- Unsafe or customized launch configurations (`append`/`override`/absent launch sources) remain unavailable instead of producing a potentially misleading command.
- Hermes on current daemons remains conservatively unavailable where ACP transport/native-resume session compatibility cannot be proven.
- Per-session launch provenance is left as a documented follow-up/design concern and is intentionally not expanded into a new persistence/protocol subsystem in this focused #4648 fix.

### Test plan

- [x] `provider-command-templates.test.ts`: 30/30 pass
- [x] `provider-snapshot-manager.test.ts`: 90/90 pass
- [x] Focused command/cache/codec/tab-menu run: 44/44 pass
- [x] `npm run typecheck`: pass
- [x] `npm run lint`: zero warnings/errors
- [x] Touched-file formatting: pass
- [x] `git diff --check`: pass

Interactive isolated web UI QA was performed on the immediately preceding safety implementation and verified:

- built-in Codex → exact native resume command copied
- safe `my-codex extends codex` → exact native resume command copied
- environment-customized derived provider → Resume command not available

However, current HEAD `9e396575` was not re-run through the disposable browser harness after the final older-daemon compatibility change and concurrent-copy guard. Those final changes have focused automated regression coverage.

Generated with [Devin](https://devin.ai)
