### PR TITLE
fix: keep the last visible pane when its final tab closes

### DIFF
--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -1471,9 +1471,17 @@ export function closeTabInLayout(input: CloseTabInLayoutInput): WorkspaceLayout 
   if (!pane) {
     return null;
   }
+  // A workspace always has somewhere to look (see setPaneHiddenInLayout). A pane born
+  // from a split carries a generated id, so when it is the only visible pane left,
+  // dropping it with its last tab would persist a layout whose sole pane is the hidden
+  // explorer; keep it, like the default pane, and let it fall back to a New tab.
+  const visiblePaneIds = listPaneIds(internalLayout.root);
+  const isLastVisiblePane = visiblePaneIds.length === 1 && visiblePaneIds[0] === pane.id;
   const preserveEmptyPaneId =
     input.preserveEmptyPaneId ??
-    (pane.id === DEFAULT_PANE_ID || pane.id === EXPLORER_SIDEBAR_PANE_ID ? pane.id : null);
+    (pane.id === DEFAULT_PANE_ID || pane.id === EXPLORER_SIDEBAR_PANE_ID || isLastVisiblePane
+      ? pane.id
+      : null);
 
   const closeSuccessorTabId = getCloseSuccessorTabId({
     pane,

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -16,6 +16,7 @@ vi.mock("@react-native-async-storage/async-storage", () => {
 });
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { closeTabInLayout } from "./workspace-layout-actions";
 import { buildWorkspaceTabPersistenceKey, type WorkspaceTab } from "@/workspace-tabs/model";
 import { defaultChangesState, type ChangesState } from "@/panels/changes/state";
 import { defaultFileState, type FileState } from "@/panels/file/state";
@@ -1082,6 +1083,73 @@ describe("workspace-layout-store actions", () => {
     store.closeTab(workspaceKey, finalNewTabId);
 
     expect(workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey]).toBe(before);
+  });
+
+  it("keeps a split-born pane when it is the last visible pane and its final tab closes", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const agentTabId = store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-1" },
+      intent: "reveal",
+    }) as string;
+    useWorkspaceLayoutIds("new-pane", "new-group");
+    const splitPaneId = store.splitPaneEmpty(workspaceKey, {
+      targetPaneId: "main",
+      position: "right",
+    }) as string;
+    // Moving main's only tab into the split drops the default pane, so the split-born pane
+    // (generated id) is now the only visible pane next to the hidden explorer.
+    store.moveTabToPane(workspaceKey, agentTabId, splitPaneId);
+    let layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    expect(findPaneById(layout.root, "main")).toBeNull();
+    const splitNewTabId = findPaneById(layout.root, splitPaneId)?.tabIds.find(
+      (tabId) => tabId !== agentTabId,
+    ) as string;
+    store.closeTab(workspaceKey, splitNewTabId);
+
+    store.closeTab(workspaceKey, agentTabId);
+
+    layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    expect(collectAllPanes(layout.root).map((pane) => pane.id)).toEqual([splitPaneId]);
+    const retained = findPaneById(layout.root, splitPaneId);
+    expect(retained?.tabIds).toHaveLength(1);
+    expect(retained?.focusedTabId).toBe(retained?.tabIds[0]);
+    expect(layout.focusedPaneId).toBe(splitPaneId);
+  });
+
+  it("closeTabInLayout never leaves a layout whose only pane is hidden", () => {
+    const layout = normalizeLayout({
+      root: {
+        kind: "group",
+        group: {
+          id: "workspace-root",
+          direction: "horizontal",
+          sizes: [0.3, 0.7],
+          children: [
+            createPane({
+              id: "explorer",
+              tabIds: ["files"],
+              hidden: true,
+              targetsByTabId: { files: { kind: "files" } },
+            }),
+            createPane({
+              id: "pane_split",
+              tabIds: ["tab-a"],
+              targetsByTabId: { "tab-a": { kind: "agent", agentId: "agent-a" } },
+            }),
+          ],
+        },
+      },
+      focusedPaneId: "pane_split",
+    });
+
+    const next = closeTabInLayout({ layout, tabId: "tab-a" });
+
+    expect(next).not.toBeNull();
+    expect(collectAllPanes(next!.root).map((pane) => pane.id)).toEqual(["pane_split"]);
+    expect(findPaneById(next!.root, "pane_split")?.tabIds).toHaveLength(1);
+    expect(findPaneById(next!.root, "explorer")?.hidden).toBe(true);
   });
 
   it("migrates legacy layouts to include the hidden registered explorer pane", async () => {


### PR DESCRIPTION
### Linked issue

Closes #4677

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

`closeTabInLayout` only preserved an emptied pane when its id was the default pane or the explorer sidebar. A pane born from a split carries a generated `pane_<uuid>` id, so once the default pane had been dropped (its only tab moved into the split), closing the split's last tab removed the split as well and the layout was persisted with the hidden explorer as its only pane. The next render loop filled that hidden pane with draft tabs until React failed with #185. The healing from #3826/#3861 repairs such a layout on load but did not stop it from being written in the first place, which is the follow-up #3806 left open.

The fix treats "the only visible pane" like the default pane: it is kept and falls back to a New tab, mirroring the last-visible-pane gate that `setPaneHiddenInLayout` already applies to hiding. For users this means closing the last tab in the last pane always leaves a usable New tab, and the crash loop cannot be produced at runtime any more.

### Goals

- Closing the final tab of the only visible pane retains that pane with a New tab, regardless of the pane's id.
- A layout whose only pane is hidden is never produced by `closeTab`.
- Existing behaviour is unchanged when another visible pane exists: closing the sole New tab of a split next to a visible default pane still removes the split (existing test "closes a split through its sole New tab but keeps the final visible split" still passes).

### Non-goals

- Changing how tabs are moved between panes (`moveTabToPane` dropping the emptied source pane is untouched).
- Changing the load-time healing from #3826/#3861.

### Validation

```
npm ci && npm run build -w packages/protocol -w packages/plugin ...
cd packages/app && npx vitest run src/stores/workspace-layout-store.test.ts   # 125 passed (2 new)
cd packages/app && npx tsgo --noEmit   # 1 error in src/components/draggable-list.native.tsx, identical on main
```

New tests: a store-level flow that reproduces the report (open agent tab, split right, move the tab into the split so `main` is dropped, close the New tab, close the last tab) and a pure `closeTabInLayout` case on a `{explorer hidden, pane_split}` layout.
