### PR TITLE
fix: hide plugin and speech worker consoles on Windows

### DIFF
--- a/packages/server/src/server/plugins/runtime.ts
+++ b/packages/server/src/server/plugins/runtime.ts
@@ -1,6 +1,6 @@
 import type { PluginBeforeRequests, PluginLifecycleEvents } from "@getpaseo/plugin/server";
 import { validateBeforeRequest, validateBeforeResult } from "./lifecycle/index.js";
-import { fork } from "node:child_process";
+import { fork, type ForkOptions } from "node:child_process";
 import { stat } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,6 +35,9 @@ const MAX_LOG_ENTRIES = 500;
 const MAX_LOG_BYTES = 256 * 1024;
 const MAX_LOG_LINE_BYTES = 16 * 1024;
 const SOFT_SHUTDOWN_TIMEOUT_MS = 2_000;
+
+// fork() forwards its options to spawn(), but @types/node omits windowsHide from ForkOptions.
+type ForkOptionsWithWindowsHide = ForkOptions & { windowsHide: boolean };
 
 interface PluginOutputStream {
   on(event: "data", listener: (chunk: Buffer | string) => void): this;
@@ -205,11 +208,13 @@ function resolveWorkerExecArgv(): string[] {
 }
 
 function spawnPluginChild(): PluginChild {
-  return fork(fileURLToPath(resolveWorkerUrl()), [], {
+  const options = {
     execArgv: resolveWorkerExecArgv(),
     serialization: "advanced",
     stdio: ["ignore", "pipe", "pipe", "ipc"],
-  }) as PluginChild;
+    windowsHide: true,
+  } satisfies ForkOptionsWithWindowsHide;
+  return fork(fileURLToPath(resolveWorkerUrl()), [], options) as PluginChild;
 }
 
 function terminatePluginChild(child: PluginChild): void {

--- a/packages/server/src/server/speech/providers/local/worker-client.ts
+++ b/packages/server/src/server/speech/providers/local/worker-client.ts
@@ -1,4 +1,4 @@
-import { fork } from "node:child_process";
+import { fork, type ForkOptions } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
@@ -30,6 +30,9 @@ const DEFAULT_IDLE_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_LOCAL_SAMPLE_RATE = 16000;
 const STDERR_TAIL_MAX_CHARS = 8000;
 const USER_ERROR_STDERR_MAX_CHARS = 1000;
+
+// fork() forwards its options to spawn(), but @types/node omits windowsHide from ForkOptions.
+type ForkOptionsWithWindowsHide = ForkOptions & { windowsHide: boolean };
 
 type LocalSpeechWorkerRequestInput = LocalSpeechWorkerRequest extends infer Request
   ? Request extends LocalSpeechWorkerRequest
@@ -94,12 +97,14 @@ function resolveWorkerExecArgv(): string[] {
 function forkLocalSpeechWorker(): LocalSpeechWorkerProcess {
   const env = { ...process.env };
   applySherpaLoaderEnv(env);
-  return fork(fileURLToPath(resolveWorkerUrl()), [], {
+  const options = {
     env,
     execArgv: resolveWorkerExecArgv(),
     serialization: "advanced",
     stdio: ["ignore", "ignore", "pipe", "ipc"],
-  }) as LocalSpeechWorkerProcess;
+    windowsHide: true,
+  } satisfies ForkOptionsWithWindowsHide;
+  return fork(fileURLToPath(resolveWorkerUrl()), [], options) as LocalSpeechWorkerProcess;
 }
 
 function isResponse(


### PR DESCRIPTION
### Linked issue

Closes #4685

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The daemon's plugin and local speech workers are Node subprocesses started with `fork()`. When the daemon has no console on Windows, those workers can be given visible consoles because their fork options did not request hidden windows. Pass the same Windows setting used by the daemon launch path so these feature-specific workers stay headless.

This is a follow-up to #1947. The supervisor and terminal worker paths are intentionally not repeated here.

### Goals

- Keep plugin workers from opening a console window on Windows.
- Keep local speech workers from opening a console window on Windows.
- Leave non-Windows behavior unchanged.

### Non-goals

- This does not change the daemon supervisor or terminal worker fix tracked by #1947.
- This does not change external command launching or console output handling.

### QA

- Windows 10 IoT Enterprise LTSC x64: the daemon-worker fix was previously verified against the installed package; it ran without a visible Paseo Daemon window and remained reachable.
- `npm run build:server-deps`
- `npm run build --workspace=@getpaseo/server`
- `npm run typecheck:server`
- `npm run test:unit --workspace=@getpaseo/server -- src/server/plugins/runtime.posix.test.ts src/server/speech/providers/local/worker-client.test.ts` — 2 files, 43 tests passed
- `npm run lint -- packages/server/src/server/plugins/runtime.ts packages/server/src/server/speech/providers/local/worker-client.ts`
- `npm run format`

Node 22's `fork()` implementation forwards its options to `spawn()`, while the published Node type omits `windowsHide` from `ForkOptions`. The narrow local intersection keeps the runtime option explicit without changing the dependency types.

### Checklist

- [ ] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (not applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [ ] Tests added or updated where it made sense

