### PR TITLE
fix(app): guard workspace archive shortcuts

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -109,6 +109,11 @@ archived workspace. History navigation must not infer workspace lifecycle from `
 or mutate either lifecycle. The workspace route asks the daemon for authoritative recovery state;
 only the route's explicit Unarchive or Restore action changes the archived workspace.
 
+Workspace archive shortcuts are disabled while focus is in an editable field or terminal, and they
+always require destructive confirmation, including for clean workspaces. Archive requests carry an
+optional source (`shortcut`, `menu`, `git-primary`, or `api`) for server audit logs. Older clients may
+omit the source; the server records those requests as `unknown`.
+
 History navigation preserves the selected agent as an explicit recovery target. If both that agent
 and its workspace are archived, the workspace recovery action restores the workspace and unarchives
 the selected agent as one user action. Other archived agents in the restored workspace remain

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -1269,7 +1269,7 @@ function WorkspaceRowWithMenu({
     if (isArchiving) {
       return;
     }
-    archiveController.archive();
+    archiveController.archive("menu");
   }, [archiveController, isArchiving]);
 
   const clipboard = useWorkspaceClipboardActions();
@@ -1318,7 +1318,7 @@ function WorkspaceRowWithMenu({
     enabled: selected && !isArchiving,
     priority: 0,
     handle: () => {
-      handleArchive();
+      archiveController.archive("shortcut");
       return true;
     },
   });

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -620,7 +620,7 @@ function StatusWorkspaceRowWithMenu({
 
   const handleArchive = useCallback(() => {
     if (isArchiving) return;
-    archiveController.archive();
+    archiveController.archive("menu");
   }, [archiveController, isArchiving]);
 
   const clipboard = useWorkspaceClipboardActions();
@@ -663,7 +663,7 @@ function StatusWorkspaceRowWithMenu({
     enabled: selected && !isArchiving,
     priority: 0,
     handle: () => {
-      handleArchive();
+      archiveController.archive("shortcut");
       return true;
     },
   });

--- a/packages/app/src/components/sidebar/sidebar-workspace-row.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row.tsx
@@ -102,7 +102,7 @@ export function SidebarWorkspaceRow({
     if (isArchiving) {
       return;
     }
-    archiveController.archive();
+    archiveController.archive("menu");
   }, [archiveController, isArchiving]);
 
   const clipboard = useWorkspaceClipboardActions();
@@ -145,7 +145,7 @@ export function SidebarWorkspaceRow({
     enabled: selected && !isArchiving,
     priority: 0,
     handle: () => {
-      handleArchive();
+      archiveController.archive("shortcut");
       return true;
     },
   });

--- a/packages/app/src/git/use-actions.tsx
+++ b/packages/app/src/git/use-actions.tsx
@@ -642,7 +642,7 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
   });
 
   const handleArchiveWorkspace = useCallback(() => {
-    archiveController.archive();
+    archiveController.archive("git-primary");
   }, [archiveController]);
 
   const derived = deriveGitActionsState({
@@ -1100,6 +1100,7 @@ function getWorktreeArchiveWarningLabels(
     title: (workspaceName) => t("workspace.git.actions.archiveWarning.title", { workspaceName }),
     confirm: t("workspace.git.actions.archiveWarning.confirm"),
     cancel: t("workspace.git.actions.archiveWarning.cancel"),
+    cleanWorkspace: t("workspace.git.actions.archiveWarning.cleanWorkspace"),
     uncommittedChanges: t("workspace.git.actions.archiveWarning.uncommittedChanges"),
     uncommittedChangesWithDiff: (diffStat) =>
       t("workspace.git.actions.archiveWarning.uncommittedChangesWithDiff", { diffStat }),

--- a/packages/app/src/git/worktree-archive-warning.test.ts
+++ b/packages/app/src/git/worktree-archive-warning.test.ts
@@ -10,26 +10,27 @@ describe("workspace archive warning for worktree backing", () => {
   it("does not require a confirmation for clean and pushed worktrees", () => {
     expect(
       buildWorktreeArchiveConfirmationMessage({
-        workspaceName: "feature",
-        isDirty: false,
-        aheadOfOrigin: 0,
-        diffStat: null,
+        input: {
+          workspaceName: "feature",
+          isDirty: false,
+          aheadOfOrigin: 0,
+          diffStat: null,
+        },
       }),
     ).toBeNull();
   });
 
   it("requires a confirmation for clean workspaces when explicitly requested", () => {
     expect(
-      buildWorktreeArchiveConfirmationMessage(
-        {
+      buildWorktreeArchiveConfirmationMessage({
+        input: {
           workspaceName: "feature",
           isDirty: false,
           aheadOfOrigin: 0,
           diffStat: null,
         },
-        undefined,
-        { confirmClean: true },
-      ),
+        confirmClean: true,
+      }),
     ).toBe("This will archive the workspace and its agents.");
   });
 
@@ -66,10 +67,12 @@ describe("workspace archive warning for worktree backing", () => {
   it("includes every archive risk in the confirmation copy", () => {
     expect(
       buildWorktreeArchiveConfirmationMessage({
-        workspaceName: "risky-feature",
-        isDirty: true,
-        aheadOfOrigin: 1,
-        diffStat: { additions: 1, deletions: 3 },
+        input: {
+          workspaceName: "risky-feature",
+          isDirty: true,
+          aheadOfOrigin: 1,
+          diffStat: { additions: 1, deletions: 3 },
+        },
       }),
     ).toBe("Uncommitted changes (1 added line, 3 deleted lines)\n1 unpushed commit");
   });

--- a/packages/app/src/git/worktree-archive-warning.test.ts
+++ b/packages/app/src/git/worktree-archive-warning.test.ts
@@ -18,6 +18,21 @@ describe("workspace archive warning for worktree backing", () => {
     ).toBeNull();
   });
 
+  it("requires a confirmation for clean workspaces when explicitly requested", () => {
+    expect(
+      buildWorktreeArchiveConfirmationMessage(
+        {
+          workspaceName: "feature",
+          isDirty: false,
+          aheadOfOrigin: 0,
+          diffStat: null,
+        },
+        undefined,
+        { confirmClean: true },
+      ),
+    ).toBe("This will archive the workspace and its agents.");
+  });
+
   it("explains uncommitted line changes", () => {
     expect(
       buildWorktreeArchiveRiskReasons({

--- a/packages/app/src/git/worktree-archive-warning.ts
+++ b/packages/app/src/git/worktree-archive-warning.ts
@@ -103,25 +103,29 @@ export function buildWorktreeArchiveRiskReasons(
   return reasons;
 }
 
-export function buildWorktreeArchiveConfirmationMessage(
-  input: WorktreeArchiveConfirmationInput,
-  labels: WorktreeArchiveWarningLabels = DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS,
-  options: { confirmClean?: boolean } = {},
-): string | null {
+export function buildWorktreeArchiveConfirmationMessage(options: {
+  input: WorktreeArchiveConfirmationInput;
+  labels?: WorktreeArchiveWarningLabels;
+  confirmClean?: boolean;
+}): string | null {
+  const labels = options.labels ?? DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS;
+  const input = options.input;
   const reasons = buildWorktreeArchiveRiskReasons(input, labels);
   if (reasons.length === 0) {
-    return options.confirmClean ? labels.cleanWorkspace : null;
+    return options.confirmClean === true ? labels.cleanWorkspace : null;
   }
 
   return reasons.join("\n");
 }
 
-export async function confirmRiskyWorktreeArchive(
-  input: WorktreeArchiveConfirmationInput,
-  labels: WorktreeArchiveWarningLabels = DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS,
-  options: { confirmClean?: boolean } = {},
-): Promise<boolean> {
-  const message = buildWorktreeArchiveConfirmationMessage(input, labels, options);
+export async function confirmRiskyWorktreeArchive(options: {
+  input: WorktreeArchiveConfirmationInput;
+  labels?: WorktreeArchiveWarningLabels;
+  confirmClean?: boolean;
+}): Promise<boolean> {
+  const labels = options.labels ?? DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS;
+  const input = options.input;
+  const message = buildWorktreeArchiveConfirmationMessage(options);
   if (!message) {
     return true;
   }

--- a/packages/app/src/git/worktree-archive-warning.ts
+++ b/packages/app/src/git/worktree-archive-warning.ts
@@ -21,6 +21,7 @@ export interface WorktreeArchiveWarningLabels {
   title: (workspaceName: string) => string;
   confirm: string;
   cancel: string;
+  cleanWorkspace: string;
   uncommittedChanges: string;
   uncommittedChangesWithDiff: (diffStat: string) => string;
   addedLine: (count: number) => string;
@@ -32,6 +33,7 @@ export const DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS: WorktreeArchiveWarningLabe
   title: (workspaceName) => i18n.t("workspace.git.actions.archiveWarning.title", { workspaceName }),
   confirm: i18n.t("workspace.git.actions.archiveWarning.confirm"),
   cancel: i18n.t("workspace.git.actions.archiveWarning.cancel"),
+  cleanWorkspace: i18n.t("workspace.git.actions.archiveWarning.cleanWorkspace"),
   uncommittedChanges: i18n.t("workspace.git.actions.archiveWarning.uncommittedChanges"),
   uncommittedChangesWithDiff: (diffStat) =>
     i18n.t("workspace.git.actions.archiveWarning.uncommittedChangesWithDiff", { diffStat }),
@@ -104,10 +106,11 @@ export function buildWorktreeArchiveRiskReasons(
 export function buildWorktreeArchiveConfirmationMessage(
   input: WorktreeArchiveConfirmationInput,
   labels: WorktreeArchiveWarningLabels = DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS,
+  options: { confirmClean?: boolean } = {},
 ): string | null {
   const reasons = buildWorktreeArchiveRiskReasons(input, labels);
   if (reasons.length === 0) {
-    return null;
+    return options.confirmClean ? labels.cleanWorkspace : null;
   }
 
   return reasons.join("\n");
@@ -116,8 +119,9 @@ export function buildWorktreeArchiveConfirmationMessage(
 export async function confirmRiskyWorktreeArchive(
   input: WorktreeArchiveConfirmationInput,
   labels: WorktreeArchiveWarningLabels = DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS,
+  options: { confirmClean?: boolean } = {},
 ): Promise<boolean> {
-  const message = buildWorktreeArchiveConfirmationMessage(input, labels);
+  const message = buildWorktreeArchiveConfirmationMessage(input, labels, options);
   if (!message) {
     return true;
   }

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -865,6 +865,7 @@ export const ar: TranslationResources = {
           title: 'الأرشيف "{{workspaceName}}"؟',
           confirm: "أرشيف",
           cancel: "يلغي",
+          cleanWorkspace: "ستتم أرشفة مساحة العمل ووكلائها.",
           uncommittedChanges: "تغييرات غير ملتزم بها",
           uncommittedChangesWithDiff: "التغييرات غير الملتزم بها ({{diffStat}})",
           addedLine: "تمت إضافة خط{{count}}",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -874,6 +874,7 @@ export const en = {
           title: 'Archive "{{workspaceName}}"?',
           confirm: "Archive",
           cancel: "Cancel",
+          cleanWorkspace: "This will archive the workspace and its agents.",
           uncommittedChanges: "Uncommitted changes",
           uncommittedChangesWithDiff: "Uncommitted changes ({{diffStat}})",
           addedLine: "{{count}} added line",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -896,6 +896,7 @@ export const es: TranslationResources = {
           title: '¿Archivo "{{workspaceName}}"?',
           confirm: "Archivo",
           cancel: "Cancelar",
+          cleanWorkspace: "Se archivarán el espacio de trabajo y sus agentes.",
           uncommittedChanges: "Cambios no confirmados",
           uncommittedChangesWithDiff: "Cambios no confirmados ({{diffStat}})",
           addedLine: "Línea añadida{{count}}",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -895,6 +895,7 @@ export const fr: TranslationResources = {
           title: "Archiver «{{workspaceName}}»?",
           confirm: "Archive",
           cancel: "Annuler",
+          cleanWorkspace: "L’espace de travail et ses agents seront archivés.",
           uncommittedChanges: "Modifications non validées",
           uncommittedChangesWithDiff: "Modifications non validées ({{diffStat}})",
           addedLine: "Ligne ajoutée{{count}}",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -876,6 +876,7 @@ export const ja: TranslationResources = {
           title: '"{{workspaceName}}"をアーカイブしますか？',
           confirm: "アーカイブ",
           cancel: "キャンセル",
+          cleanWorkspace: "ワークスペースとそのエージェントがアーカイブされます。",
           uncommittedChanges: "未コミットの変更",
           uncommittedChangesWithDiff: "未コミットの変更（{{diffStat}}）",
           addedLine: "{{count}}行追加",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -872,6 +872,7 @@ export const ko: TranslationResources = {
           title: '"{{workspaceName}}"를 보관하시겠습니까?',
           confirm: "보관",
           cancel: "취소",
+          cleanWorkspace: "워크스페이스와 그 안의 에이전트가 보관됩니다.",
           uncommittedChanges: "커밋되지 않은 변경 사항",
           uncommittedChangesWithDiff: "커밋되지 않은 변경 사항 ({{diffStat}})",
           addedLine: "추가된 줄 {{count}}개",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -887,6 +887,7 @@ export const ptBR: TranslationResources = {
           title: 'Arquivar "{{workspaceName}}"?',
           confirm: "Arquivar",
           cancel: "Cancelar",
+          cleanWorkspace: "O workspace e seus agentes serão arquivados.",
           uncommittedChanges: "Alterações sem commit",
           uncommittedChangesWithDiff: "Alterações sem commit ({{diffStat}})",
           addedLine: "{{count}} linha adicionada",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -880,6 +880,7 @@ export const ru: TranslationResources = {
           title: "Архивировать «{{workspaceName}}»?",
           confirm: "Архивировать",
           cancel: "Отмена",
+          cleanWorkspace: "Рабочее пространство и его агенты будут архивированы.",
           uncommittedChanges: "Незафиксированные изменения",
           uncommittedChangesWithDiff: "Незафиксированные изменения ({{diffStat}})",
           addedLine: "Добавлено строк: {{count}}",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -857,6 +857,7 @@ export const zhCN: TranslationResources = {
           title: "归档「{{workspaceName}}」？",
           confirm: "归档",
           cancel: "取消",
+          cleanWorkspace: "这将归档工作区及其中的代理。",
           uncommittedChanges: "未 commit 的变更",
           uncommittedChangesWithDiff: "未 commit 的变更（{{diffStat}}）",
           addedLine: "新增 {{count}} 行",

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -295,6 +295,12 @@ describe("keyboard-shortcuts", () => {
       action: "workspace.pane.close",
     },
     {
+      name: "matches Cmd+Shift+Backspace to archive outside protected focus scopes",
+      event: { key: "Backspace", code: "Backspace", metaKey: true, shiftKey: true },
+      context: { isMac: true, focusScope: "other" },
+      action: "workspace.archive",
+    },
+    {
       name: "matches Cmd+B sidebar toggle on macOS",
       event: { key: "b", code: "KeyB", metaKey: true },
       context: { isMac: true },
@@ -410,6 +416,16 @@ describe("keyboard-shortcuts", () => {
       context: { focusScope: "editable" },
     });
   });
+
+  it.each(["message-input", "editable", "terminal"] as const)(
+    "does not archive a workspace while focus is in the %s scope",
+    (focusScope) => {
+      expectNoShortcutResolution({
+        event: { key: "Backspace", code: "Backspace", metaKey: true, shiftKey: true },
+        context: { isMac: true, focusScope },
+      });
+    },
+  );
 
   const nonMatchingCases: NonMatchingShortcutCase[] = [
     {

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -301,6 +301,12 @@ describe("keyboard-shortcuts", () => {
       action: "workspace.archive",
     },
     {
+      name: "matches Ctrl+Shift+Backspace to archive on non-macOS",
+      event: { key: "Backspace", code: "Backspace", ctrlKey: true, shiftKey: true },
+      context: { isMac: false, focusScope: "other" },
+      action: "workspace.archive",
+    },
+    {
       name: "matches Cmd+B sidebar toggle on macOS",
       event: { key: "b", code: "KeyB", metaKey: true },
       context: { isMac: true },
@@ -423,6 +429,16 @@ describe("keyboard-shortcuts", () => {
       expectNoShortcutResolution({
         event: { key: "Backspace", code: "Backspace", metaKey: true, shiftKey: true },
         context: { isMac: true, focusScope },
+      });
+    },
+  );
+
+  it.each(["message-input", "editable", "terminal"] as const)(
+    "does not archive a workspace on non-macOS while focus is in the %s scope",
+    (focusScope) => {
+      expectNoShortcutResolution({
+        event: { key: "Backspace", code: "Backspace", ctrlKey: true, shiftKey: true },
+        context: { isMac: false, focusScope },
       });
     },
   );

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -339,7 +339,7 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
     id: "worktree-archive-cmd-shift-backspace-mac",
     action: "workspace.archive",
     combo: "Cmd+Shift+Backspace",
-    when: { mac: true, commandCenter: false },
+    when: { mac: true, commandCenter: false, editable: false, terminal: false },
     help: {
       id: "archive-workspace",
       section: "workspaces",
@@ -352,7 +352,7 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
     id: "worktree-archive-ctrl-shift-backspace-non-mac",
     action: "workspace.archive",
     combo: "Ctrl+Shift+Backspace",
-    when: { mac: false, commandCenter: false, terminal: false },
+    when: { mac: false, commandCenter: false, editable: false, terminal: false },
     help: {
       id: "archive-workspace",
       section: "workspaces",

--- a/packages/app/src/workspace/project-workspace-archive.test.ts
+++ b/packages/app/src/workspace/project-workspace-archive.test.ts
@@ -31,10 +31,12 @@ describe("selectProjectWorkspacesToArchive", () => {
 
     expect(confirmWorktreeArchive).toHaveBeenCalledOnce();
     expect(confirmWorktreeArchive).toHaveBeenCalledWith({
-      workspaceName: "feature/risky",
-      isDirty: true,
-      aheadOfOrigin: 2,
-      diffStat: { additions: 5, deletions: 1 },
+      input: {
+        workspaceName: "feature/risky",
+        isDirty: true,
+        aheadOfOrigin: 2,
+        diffStat: { additions: 5, deletions: 1 },
+      },
     });
     expect(targets).toEqual([
       {
@@ -73,10 +75,12 @@ describe("selectProjectWorkspacesToArchive", () => {
 
     expect(confirmWorktreeArchive).toHaveBeenCalledOnce();
     expect(confirmWorktreeArchive).toHaveBeenCalledWith({
-      workspaceName: "feature/risky",
-      isDirty: true,
-      aheadOfOrigin: 2,
-      diffStat: { additions: 5, deletions: 1 },
+      input: {
+        workspaceName: "feature/risky",
+        isDirty: true,
+        aheadOfOrigin: 2,
+        diffStat: { additions: 5, deletions: 1 },
+      },
     });
     expect(targets).toEqual([
       {

--- a/packages/app/src/workspace/project-workspace-archive.ts
+++ b/packages/app/src/workspace/project-workspace-archive.ts
@@ -24,8 +24,10 @@ export async function selectProjectWorkspacesToArchive(
   for (const workspace of workspaces) {
     if (workspace.workspaceKind === "worktree") {
       const shouldArchive = await confirmWorktreeArchive({
-        workspaceName: workspace.name,
-        ...toWorktreeArchiveRisk(workspace),
+        input: {
+          workspaceName: workspace.name,
+          ...toWorktreeArchiveRisk(workspace),
+        },
       });
       if (!shouldArchive) {
         continue;

--- a/packages/app/src/workspace/use-workspace-archive.ts
+++ b/packages/app/src/workspace/use-workspace-archive.ts
@@ -11,6 +11,7 @@ import type { WorkspaceDescriptor } from "@/stores/session-store";
 import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 import { archiveWorkspaceOptimistically } from "@/workspace/workspace-archive";
+import type { ArchiveWorkspaceTrigger } from "@getpaseo/protocol/messages";
 
 function purgeArchivedWorkspaceState(input: { serverId: string; workspaceId: string }): void {
   const workspaceKey = buildWorkspaceTabPersistenceKey(input);
@@ -33,7 +34,7 @@ export interface ArchiveWorkspaceInput {
 }
 
 export interface WorkspaceArchiveController {
-  archive: () => void;
+  archive: (trigger: ArchiveWorkspaceTrigger) => void;
 }
 
 export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArchiveController {
@@ -52,59 +53,59 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
   const { t } = useTranslation();
   const toast = useToast();
 
-  const archiveWorkspaceRecord = useCallback(async () => {
-    const client = getHostRuntimeStore().getClient(serverId);
-    if (!client) {
-      toast.error(t("sidebar.workspace.toasts.hostDisconnected"));
-      return;
-    }
-    onSetHiding?.(true);
-    try {
-      onArchiveStarted();
-      await archiveWorkspaceOptimistically({
-        client,
-        workspace: {
-          serverId,
-          workspaceId,
-        },
-      });
-      purgeArchivedWorkspaceState({ serverId, workspaceId });
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : t("sidebar.workspace.toasts.archiveFailed"),
-      );
-    } finally {
-      onSetHiding?.(false);
-    }
-  }, [onArchiveStarted, onSetHiding, serverId, t, toast, workspaceId]);
-
-  const archive = useCallback(() => {
-    void (async () => {
-      if (workspaceKind === "worktree") {
-        const confirmed = await confirmRiskyWorktreeArchive(
-          {
-            workspaceName: name,
-            isDirty,
-            aheadOfOrigin,
-            diffStat,
-          },
-          warningLabels,
-        );
-        if (!confirmed) {
-          return;
-        }
+  const archiveWorkspaceRecord = useCallback(
+    async (trigger: ArchiveWorkspaceTrigger) => {
+      const client = getHostRuntimeStore().getClient(serverId);
+      if (!client) {
+        toast.error(t("sidebar.workspace.toasts.hostDisconnected"));
+        return;
       }
-      await archiveWorkspaceRecord();
-    })();
-  }, [
-    aheadOfOrigin,
-    archiveWorkspaceRecord,
-    diffStat,
-    isDirty,
-    name,
-    warningLabels,
-    workspaceKind,
-  ]);
+      onSetHiding?.(true);
+      try {
+        onArchiveStarted();
+        await archiveWorkspaceOptimistically({
+          client,
+          workspace: {
+            serverId,
+            workspaceId,
+          },
+          trigger,
+        });
+        purgeArchivedWorkspaceState({ serverId, workspaceId });
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : t("sidebar.workspace.toasts.archiveFailed"),
+        );
+      } finally {
+        onSetHiding?.(false);
+      }
+    },
+    [onArchiveStarted, onSetHiding, serverId, t, toast, workspaceId],
+  );
+
+  const archive = useCallback(
+    (trigger: ArchiveWorkspaceTrigger) => {
+      void (async () => {
+        if (workspaceKind === "worktree" || trigger === "shortcut") {
+          const confirmed = await confirmRiskyWorktreeArchive(
+            {
+              workspaceName: name,
+              isDirty,
+              aheadOfOrigin,
+              diffStat,
+            },
+            warningLabels,
+            { confirmClean: trigger === "shortcut" },
+          );
+          if (!confirmed) {
+            return;
+          }
+        }
+        await archiveWorkspaceRecord(trigger);
+      })();
+    },
+    [aheadOfOrigin, archiveWorkspaceRecord, diffStat, isDirty, name, warningLabels, workspaceKind],
+  );
 
   return {
     archive,

--- a/packages/app/src/workspace/use-workspace-archive.ts
+++ b/packages/app/src/workspace/use-workspace-archive.ts
@@ -87,16 +87,16 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
     (trigger: ArchiveWorkspaceTrigger) => {
       void (async () => {
         if (workspaceKind === "worktree" || trigger === "shortcut") {
-          const confirmed = await confirmRiskyWorktreeArchive(
-            {
+          const confirmed = await confirmRiskyWorktreeArchive({
+            input: {
               workspaceName: name,
               isDirty,
               aheadOfOrigin,
               diffStat,
             },
-            warningLabels,
-            { confirmClean: trigger === "shortcut" },
-          );
+            labels: warningLabels,
+            confirmClean: trigger === "shortcut",
+          });
           if (!confirmed) {
             return;
           }

--- a/packages/app/src/workspace/workspace-archive.test.ts
+++ b/packages/app/src/workspace/workspace-archive.test.ts
@@ -126,6 +126,21 @@ describe("archiveWorkspaceOptimistically", () => {
     expect(storedWorkspace(archived.id)).toBeUndefined();
   });
 
+  it("forwards the archive trigger to the daemon", async () => {
+    const archived = workspace();
+    getHostRuntimeStore().acceptWorkspaceSnapshots(SERVER_ID, [archived]);
+    const archiveWorkspace = vi.fn(async () => archivePayload({ workspaceId: archived.id }));
+    const client = createClient(archiveWorkspace);
+
+    await archiveWorkspaceOptimistically({
+      client,
+      workspace: target(),
+      trigger: "shortcut",
+    });
+
+    expect(archiveWorkspace).toHaveBeenCalledWith(archived.id, undefined, "shortcut");
+  });
+
   it("restores the workspace and clears pending state when the daemon rejects the archive", async () => {
     const archived = workspace();
     getHostRuntimeStore().acceptWorkspaceSnapshots(SERVER_ID, [archived]);

--- a/packages/app/src/workspace/workspace-archive.test.ts
+++ b/packages/app/src/workspace/workspace-archive.test.ts
@@ -59,9 +59,9 @@ function target(input?: Partial<WorkspaceArchiveTarget>): WorkspaceArchiveTarget
 }
 
 function createClient(
-  archiveWorkspace: DaemonClient["archiveWorkspace"],
-): Pick<DaemonClient, "archiveWorkspace"> {
-  return { archiveWorkspace };
+  archiveWorkspaceWithOptions: DaemonClient["archiveWorkspaceWithOptions"],
+): Pick<DaemonClient, "archiveWorkspaceWithOptions"> {
+  return { archiveWorkspaceWithOptions };
 }
 
 function deferred<T>(): {
@@ -110,6 +110,7 @@ describe("archiveWorkspaceOptimistically", () => {
     const archive = archiveWorkspaceOptimistically({
       client,
       workspace: target(),
+      trigger: "menu",
     });
 
     expect(storedWorkspace(archived.id)).toBeUndefined();
@@ -129,8 +130,10 @@ describe("archiveWorkspaceOptimistically", () => {
   it("forwards the archive trigger to the daemon", async () => {
     const archived = workspace();
     getHostRuntimeStore().acceptWorkspaceSnapshots(SERVER_ID, [archived]);
-    const archiveWorkspace = vi.fn(async () => archivePayload({ workspaceId: archived.id }));
-    const client = createClient(archiveWorkspace);
+    const archiveWorkspaceWithOptions = vi.fn(async () =>
+      archivePayload({ workspaceId: archived.id }),
+    );
+    const client = createClient(archiveWorkspaceWithOptions);
 
     await archiveWorkspaceOptimistically({
       client,
@@ -138,7 +141,10 @@ describe("archiveWorkspaceOptimistically", () => {
       trigger: "shortcut",
     });
 
-    expect(archiveWorkspace).toHaveBeenCalledWith(archived.id, undefined, "shortcut");
+    expect(archiveWorkspaceWithOptions).toHaveBeenCalledWith({
+      workspaceId: archived.id,
+      trigger: "shortcut",
+    });
   });
 
   it("restores the workspace and clears pending state when the daemon rejects the archive", async () => {
@@ -152,6 +158,7 @@ describe("archiveWorkspaceOptimistically", () => {
       archiveWorkspaceOptimistically({
         client,
         workspace: target(),
+        trigger: "menu",
       }),
     ).rejects.toThrow("nope");
 
@@ -175,7 +182,7 @@ describe("archiveWorkspacesOptimistically", () => {
     });
     getHostRuntimeStore().acceptWorkspaceSnapshots(SERVER_ID, [first, second]);
     const client = createClient(
-      vi.fn(async (workspaceId) =>
+      vi.fn(async ({ workspaceId }) =>
         archivePayload({
           workspaceId,
           error: workspaceId === second.id ? "failed" : null,
@@ -207,7 +214,7 @@ describe("archiveWorkspacesOptimistically", () => {
 
     const archivedByServer = new Map<string, string[]>();
     const clientFor = (serverId: string) =>
-      createClient(async (workspaceId) => {
+      createClient(async ({ workspaceId }) => {
         archivedByServer.set(serverId, [...(archivedByServer.get(serverId) ?? []), workspaceId]);
         return archivePayload({ workspaceId });
       });

--- a/packages/app/src/workspace/workspace-archive.ts
+++ b/packages/app/src/workspace/workspace-archive.ts
@@ -6,6 +6,7 @@ import {
 import { useSessionStore, type WorkspaceDescriptor } from "@/stores/session-store";
 import { resolveWorkspaceMapKeyByIdentity } from "@/utils/workspace-identity";
 import { i18n } from "@/i18n/i18next";
+import type { ArchiveWorkspaceTrigger } from "@getpaseo/protocol/messages";
 
 export interface WorkspaceArchiveTarget {
   serverId: string;
@@ -13,7 +14,11 @@ export interface WorkspaceArchiveTarget {
 }
 
 interface WorkspaceArchiveClient {
-  archiveWorkspace: (workspaceId: string) => Promise<{ error: string | null }>;
+  archiveWorkspace: (
+    workspaceId: string,
+    requestId?: string,
+    trigger?: ArchiveWorkspaceTrigger,
+  ) => Promise<{ error: string | null }>;
 }
 
 interface OptimisticWorkspaceArchiveSnapshot {
@@ -72,8 +77,9 @@ function restoreOptimisticallyHiddenWorkspace(input: {
 async function archiveWorkspaceOrThrow(input: {
   client: WorkspaceArchiveClient;
   workspaceId: string;
+  trigger?: ArchiveWorkspaceTrigger;
 }): Promise<void> {
-  const payload = await input.client.archiveWorkspace(input.workspaceId);
+  const payload = await input.client.archiveWorkspace(input.workspaceId, undefined, input.trigger);
   if (payload.error) {
     throw new Error(payload.error);
   }
@@ -82,6 +88,7 @@ async function archiveWorkspaceOrThrow(input: {
 export async function archiveWorkspaceOptimistically(input: {
   client: WorkspaceArchiveClient;
   workspace: WorkspaceArchiveTarget;
+  trigger?: ArchiveWorkspaceTrigger;
 }): Promise<void> {
   const snapshot = hideWorkspaceOptimistically(input.workspace);
 
@@ -89,6 +96,7 @@ export async function archiveWorkspaceOptimistically(input: {
     await archiveWorkspaceOrThrow({
       client: input.client,
       workspaceId: input.workspace.workspaceId,
+      trigger: input.trigger,
     });
   } catch (error) {
     restoreOptimisticallyHiddenWorkspace({

--- a/packages/app/src/workspace/workspace-archive.ts
+++ b/packages/app/src/workspace/workspace-archive.ts
@@ -14,11 +14,10 @@ export interface WorkspaceArchiveTarget {
 }
 
 interface WorkspaceArchiveClient {
-  archiveWorkspace: (
-    workspaceId: string,
-    requestId?: string,
-    trigger?: ArchiveWorkspaceTrigger,
-  ) => Promise<{ error: string | null }>;
+  archiveWorkspaceWithOptions: (options: {
+    workspaceId: string;
+    trigger: ArchiveWorkspaceTrigger;
+  }) => Promise<{ error: string | null }>;
 }
 
 interface OptimisticWorkspaceArchiveSnapshot {
@@ -77,9 +76,12 @@ function restoreOptimisticallyHiddenWorkspace(input: {
 async function archiveWorkspaceOrThrow(input: {
   client: WorkspaceArchiveClient;
   workspaceId: string;
-  trigger?: ArchiveWorkspaceTrigger;
+  trigger: ArchiveWorkspaceTrigger;
 }): Promise<void> {
-  const payload = await input.client.archiveWorkspace(input.workspaceId, undefined, input.trigger);
+  const payload = await input.client.archiveWorkspaceWithOptions({
+    workspaceId: input.workspaceId,
+    trigger: input.trigger,
+  });
   if (payload.error) {
     throw new Error(payload.error);
   }
@@ -88,7 +90,7 @@ async function archiveWorkspaceOrThrow(input: {
 export async function archiveWorkspaceOptimistically(input: {
   client: WorkspaceArchiveClient;
   workspace: WorkspaceArchiveTarget;
-  trigger?: ArchiveWorkspaceTrigger;
+  trigger: ArchiveWorkspaceTrigger;
 }): Promise<void> {
   const snapshot = hideWorkspaceOptimistically(input.workspace);
 
@@ -127,6 +129,7 @@ export async function archiveWorkspacesOptimistically(input: {
         await archiveWorkspaceOptimistically({
           client,
           workspace,
+          trigger: "api",
         });
       } catch (error) {
         throw {

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -111,6 +111,7 @@ import type {
   PaseoConfigRevision,
   WorkspaceCreateRequest,
   WorkspaceRecoveryState,
+  ArchiveWorkspaceTrigger,
   PluginListItem,
   PluginLogEntry,
   PluginSourceStatusItem,
@@ -2419,12 +2420,14 @@ export class DaemonClient {
   async archiveWorkspace(
     workspaceId: string,
     requestId?: string,
+    trigger?: ArchiveWorkspaceTrigger,
   ): Promise<ArchiveWorkspacePayload> {
     return this.sendCorrelatedSessionRequest({
       requestId,
       message: {
         type: "archive_workspace_request",
         workspaceId,
+        trigger,
       },
       responseType: "archive_workspace_response",
     });

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2420,14 +2420,21 @@ export class DaemonClient {
   async archiveWorkspace(
     workspaceId: string,
     requestId?: string,
-    trigger?: ArchiveWorkspaceTrigger,
   ): Promise<ArchiveWorkspacePayload> {
+    return this.archiveWorkspaceWithOptions({ workspaceId, requestId, trigger: "api" });
+  }
+
+  async archiveWorkspaceWithOptions(options: {
+    workspaceId: string;
+    requestId?: string;
+    trigger: ArchiveWorkspaceTrigger;
+  }): Promise<ArchiveWorkspacePayload> {
     return this.sendCorrelatedSessionRequest({
-      requestId,
+      requestId: options.requestId,
       message: {
         type: "archive_workspace_request",
-        workspaceId,
-        trigger,
+        workspaceId: options.workspaceId,
+        trigger: options.trigger,
       },
       responseType: "archive_workspace_response",
     });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -537,7 +537,7 @@ export function createPaseoApi(daemonClient: DaemonClient): PaseoApi {
         return createWorkspaceHandle(result.workspace);
       },
       archive: (workspace, requestId) =>
-        daemonClient.archiveWorkspace(resolveWorkspaceId(workspace), requestId),
+        daemonClient.archiveWorkspace(resolveWorkspaceId(workspace), requestId, "api"),
       subscribe: (handler) =>
         daemonClient.on("workspace_update", (message) => {
           handler(message.payload);
@@ -647,7 +647,7 @@ function createWorkspaceHandleFactory(
       refresh,
       setTitle: (title, requestId) => daemonClient.setWorkspaceTitle(id, title, requestId),
       archive: async (requestId) => {
-        const result = await daemonClient.archiveWorkspace(id, requestId);
+        const result = await daemonClient.archiveWorkspace(id, requestId, "api");
         if (current) {
           current = { ...current, archivingAt: result.archivedAt };
         }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -537,7 +537,7 @@ export function createPaseoApi(daemonClient: DaemonClient): PaseoApi {
         return createWorkspaceHandle(result.workspace);
       },
       archive: (workspace, requestId) =>
-        daemonClient.archiveWorkspace(resolveWorkspaceId(workspace), requestId, "api"),
+        daemonClient.archiveWorkspace(resolveWorkspaceId(workspace), requestId),
       subscribe: (handler) =>
         daemonClient.on("workspace_update", (message) => {
           handler(message.payload);
@@ -647,7 +647,7 @@ function createWorkspaceHandleFactory(
       refresh,
       setTitle: (title, requestId) => daemonClient.setWorkspaceTitle(id, title, requestId),
       archive: async (requestId) => {
-        const result = await daemonClient.archiveWorkspace(id, requestId, "api");
+        const result = await daemonClient.archiveWorkspace(id, requestId);
         if (current) {
           current = { ...current, archivingAt: result.archivedAt };
         }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2543,10 +2543,13 @@ export const ProjectGithubCloneRequestSchema = z.object({
   requestId: z.string(),
 });
 
+export const ArchiveWorkspaceTriggerSchema = z.enum(["shortcut", "menu", "git-primary", "api"]);
+
 export const ArchiveWorkspaceRequestSchema = z.object({
   type: z.literal("archive_workspace_request"),
   workspaceId: z.string(),
   requestId: z.string(),
+  trigger: ArchiveWorkspaceTriggerSchema.optional(),
 });
 
 // Create a new workspace record. Unlike open_project, this never deduplicates by
@@ -7045,6 +7048,7 @@ export type WorkspaceGithubSearchRepositoriesRequest = z.infer<
 >;
 export type ProjectGithubCloneRequest = z.infer<typeof ProjectGithubCloneRequestSchema>;
 export type ProjectGithubCloneProtocol = z.infer<typeof ProjectGithubCloneProtocolSchema>;
+export type ArchiveWorkspaceTrigger = z.infer<typeof ArchiveWorkspaceTriggerSchema>;
 export type ArchiveWorkspaceRequest = z.infer<typeof ArchiveWorkspaceRequestSchema>;
 export type WorkspaceClearAttentionRequest = z.infer<typeof WorkspaceClearAttentionRequestSchema>;
 export type WorkspaceMarkUnreadRequest = z.infer<typeof WorkspaceMarkUnreadRequestSchema>;

--- a/packages/protocol/src/messages.workspaces.test.ts
+++ b/packages/protocol/src/messages.workspaces.test.ts
@@ -10,6 +10,34 @@ import {
 } from "./messages.js";
 
 describe("workspace message schemas", () => {
+  test("parses workspace archive source while preserving legacy requests", () => {
+    expect(
+      SessionInboundMessageSchema.parse({
+        type: "archive_workspace_request",
+        workspaceId: "workspace-1",
+        requestId: "req-archive",
+        trigger: "shortcut",
+      }),
+    ).toMatchObject({ trigger: "shortcut" });
+
+    expect(
+      SessionInboundMessageSchema.parse({
+        type: "archive_workspace_request",
+        workspaceId: "workspace-1",
+        requestId: "req-archive-legacy",
+      }),
+    ).not.toHaveProperty("trigger");
+
+    expect(() =>
+      SessionInboundMessageSchema.parse({
+        type: "archive_workspace_request",
+        workspaceId: "workspace-1",
+        requestId: "req-archive-invalid",
+        trigger: "automatic",
+      }),
+    ).toThrow();
+  });
+
   test("parses mark-unread request and response", () => {
     expect(
       SessionInboundMessageSchema.parse({

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -6834,6 +6834,15 @@ export class Session {
         throw new Error(`Workspace not found: ${request.workspaceId}`);
       }
 
+      this.sessionLogger.info(
+        {
+          workspaceId: request.workspaceId,
+          requestId: request.requestId,
+          trigger: request.trigger ?? "unknown",
+        },
+        "Workspace archive requested",
+      );
+
       await archiveByScope(
         {
           paseoHome: this.paseoHome,

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -554,6 +554,7 @@ function createSessionForWorkspaceTests(
     appVersion?: string | null;
     onMessage?: (message: SessionOutboundMessage) => void;
     onWorkspaceRecovered?: SessionOptions["onWorkspaceRecovered"];
+    logger?: SessionOptions["logger"];
     workspaceGitService?: ReturnType<typeof createNoopWorkspaceGitService>;
     terminalManager?: TerminalManager | null;
     agentManager?: { [K in keyof SessionOptions["agentManager"]]?: unknown };
@@ -648,7 +649,7 @@ function createSessionForWorkspaceTests(
       appVersion: options.appVersion ?? null,
       onMessage: options.onMessage ?? vi.fn(),
       onWorkspaceRecovered: options.onWorkspaceRecovered,
-      logger: asSessionLogger(logger),
+      logger: options.logger ?? asSessionLogger(logger),
       downloadTokenStore: asDownloadTokenStore(),
       pushNotifications: asPushNotifications(),
       paseoHome: options.paseoHome ?? "/tmp/paseo-test",
@@ -5925,7 +5926,15 @@ test("legacy editor RPC requests return daemon unsupported errors", async () => 
 
 test("archive_workspace_request hides non-destructive workspace records", async () => {
   const emitted: SessionOutboundMessage[] = [];
-  const session = createSessionForWorkspaceTests();
+  const logger = {
+    child: () => logger,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  const session = createSessionForWorkspaceTests({ logger: asSessionLogger(logger) });
   const workspace = createPersistedWorkspaceRecord({
     workspaceId: "ws-repo-archive",
     projectId: "proj-repo-archive",
@@ -5957,6 +5966,57 @@ test("archive_workspace_request hides non-destructive workspace records", async 
     | { payload: Record<string, unknown> }
     | undefined;
   expect(response?.payload.error).toBeNull();
+  expect(logger.info).toHaveBeenCalledWith(
+    {
+      workspaceId: "ws-repo-archive",
+      requestId: "req-archive",
+      trigger: "unknown",
+    },
+    "Workspace archive requested",
+  );
+});
+
+test("archive_workspace_request logs its client trigger", async () => {
+  const logger = {
+    child: () => logger,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-trigger-audit",
+    projectId: "proj-trigger-audit",
+    cwd: REPO_CWD,
+    kind: "directory",
+    displayName: "repo",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const session = createSessionForWorkspaceTests({ logger: asSessionLogger(logger) });
+  session.workspaceRegistry.get = async () => workspace;
+  session.workspaceRegistry.archive = async (_workspaceId: string, archivedAt: string) => {
+    workspace.archivedAt = archivedAt;
+  };
+  session.workspaceRegistry.list = async () => [workspace];
+  session.projectRegistry.archive = async () => {};
+
+  await session.handleMessage({
+    type: "archive_workspace_request",
+    workspaceId: "ws-trigger-audit",
+    requestId: "req-trigger-audit",
+    trigger: "shortcut",
+  });
+
+  expect(logger.info).toHaveBeenCalledWith(
+    {
+      workspaceId: "ws-trigger-audit",
+      requestId: "req-trigger-audit",
+      trigger: "shortcut",
+    },
+    "Workspace archive requested",
+  );
 });
 
 test("archive_workspace_request archives a worktree-kind workspace and removes the directory on last reference", async () => {


### PR DESCRIPTION
## Why

Workspace archive shortcuts could fire while focus was in an editable field or terminal. Clean workspaces then archived without confirmation, and the daemon recorded no source for the archive request. That combination made accidental archive gestures both easy to trigger and hard to diagnose.

## What changed

- Disable workspace archive shortcuts in editable and terminal focus scopes on every platform.
- Require destructive confirmation for shortcut-triggered archives, including clean workspaces.
- Carry an optional archive trigger through the protocol and client: shortcut, menu, git-primary, or api. Log it with the workspace and request IDs. Legacy clients remain compatible and log as unknown.
- Document the lifecycle safety contract and add localized confirmation copy.

## Verification

- Protocol workspace tests: 42 passed
- App shortcut and archive tests: 143 passed
- App locale and resource tests: 51 passed
- Server audit tests: both legacy and trigger-aware cases passed
- Full monorepo pre-commit lint, format, and typecheck passed

A broader server test selection also exercised a worktree-spawn case that is blocked by the sandbox with spawnSync git EPERM. The directly affected server tests pass independently.