### PR TITLE
Show raw ACP tool inputs in details

### DIFF
--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -3059,6 +3059,7 @@ export const ToolCall = memo(function ToolCall({
     }
     return undefined;
   }, [detail, args, result]);
+  const rawInput = metadata?.rawInput;
 
   const presentation = useMemo(
     () =>
@@ -3088,6 +3089,7 @@ export const ToolCall = memo(function ToolCall({
         displayName: presentation.displayName,
         summary: presentation.summary,
         detail: effectiveDetail,
+        rawInput,
         errorText: presentation.errorText,
         icon: presentation.icon,
         showLoadingSkeleton: presentation.isLoadingDetails,
@@ -3105,6 +3107,7 @@ export const ToolCall = memo(function ToolCall({
     presentation.icon,
     presentation.isLoadingDetails,
     effectiveDetail,
+    rawInput,
   ]);
 
   useEffect(() => {
@@ -3141,6 +3144,7 @@ export const ToolCall = memo(function ToolCall({
       <ToolCallDetailsContent
         toolName={toolName}
         detail={effectiveDetail}
+        rawInput={rawInput}
         errorText={presentation.errorText}
         maxHeight={maxDetailHeight}
         showLoadingSkeleton={presentation.isLoadingDetails}
@@ -3150,6 +3154,7 @@ export const ToolCall = memo(function ToolCall({
     shouldRenderInline,
     toolName,
     effectiveDetail,
+    rawInput,
     presentation.errorText,
     presentation.isLoadingDetails,
     maxDetailHeight,

--- a/packages/app/src/components/tool-call-details.tsx
+++ b/packages/app/src/components/tool-call-details.tsx
@@ -21,6 +21,7 @@ import { hasMeaningfulToolCallDetail } from "@/utils/tool-call-detail-state";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
 import { extensionFromPath, highlightToKeyedLines } from "@/utils/highlight-cache";
+import { deriveFallbackToolCallInput } from "@/utils/tool-call-details-input";
 import { HighlightedLines } from "./highlighted-content";
 import { DiffViewer } from "./diff-viewer";
 import { getCodeInsets } from "./code-insets";
@@ -33,6 +34,7 @@ const ScrollView = isWeb ? RNScrollView : GHScrollView;
 interface ToolCallDetailsContentProps {
   toolName?: string;
   detail?: ToolCallDetail;
+  rawInput?: unknown;
   errorText?: string;
   maxHeight?: number;
   fillAvailableHeight?: boolean;
@@ -783,6 +785,7 @@ function LoadingSkeleton({ containerStyle }: { containerStyle: StyleProp<ViewSty
 export function ToolCallDetailsContent({
   toolName,
   detail,
+  rawInput,
   errorText,
   maxHeight,
   fillAvailableHeight = false,
@@ -794,6 +797,13 @@ export function ToolCallDetailsContent({
   const diffLines = useDiffLines(detail);
 
   const sections: ReactNode[] = buildDetailSections(toolName, detail, diffLines, ds, t);
+  if (detail?.type !== "unknown") {
+    const input =
+      rawInput ?? (sections.length === 0 ? deriveFallbackToolCallInput(detail) : undefined);
+    if (input !== undefined) {
+      sections.unshift(...buildUnknownSections({ input, output: null }, ds, t));
+    }
+  }
 
   if (errorText) {
     sections.push(<ErrorSection key="error" errorText={errorText} ds={ds} />);

--- a/packages/app/src/components/tool-call-sheet.tsx
+++ b/packages/app/src/components/tool-call-sheet.tsx
@@ -21,6 +21,7 @@ export interface ToolCallSheetData {
   displayName: string;
   summary?: string;
   detail?: ToolCallDetail;
+  rawInput?: unknown;
   errorText?: string;
   icon: ToolCallIconComponent;
   showLoadingSkeleton?: boolean;
@@ -160,6 +161,7 @@ function ToolCallSheetContent({ data, onClose }: ToolCallSheetContentProps) {
     toolName,
     displayName,
     detail,
+    rawInput,
     errorText,
     icon: IconComponent,
     showLoadingSkeleton,
@@ -191,6 +193,7 @@ function ToolCallSheetContent({ data, onClose }: ToolCallSheetContentProps) {
         <ToolCallDetailsContent
           toolName={toolName}
           detail={detail}
+          rawInput={rawInput}
           errorText={errorText}
           fillAvailableHeight
           showLoadingSkeleton={showLoadingSkeleton}

--- a/packages/app/src/utils/tool-call-details-input.test.ts
+++ b/packages/app/src/utils/tool-call-details-input.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveFallbackToolCallInput } from "./tool-call-details-input";
+
+describe("tool call details input", () => {
+  it("derives read parameters when a daemon does not send raw input", () => {
+    expect(
+      deriveFallbackToolCallInput({
+        type: "read",
+        filePath: "/workspace/src/main.rs",
+        offset: 20,
+        limit: 40,
+      }),
+    ).toEqual({ path: "/workspace/src/main.rs", offset: 20, limit: 40 });
+  });
+
+  it("derives the search query without empty optional fields", () => {
+    expect(
+      deriveFallbackToolCallInput({
+        type: "search",
+        query: "/workspace",
+        toolName: "search",
+      }),
+    ).toEqual({ query: "/workspace" });
+  });
+
+  it("does not duplicate tool kinds that already render their inputs", () => {
+    expect(deriveFallbackToolCallInput({ type: "shell", command: "pwd" })).toBeUndefined();
+    expect(
+      deriveFallbackToolCallInput({ type: "unknown", input: { path: "/workspace" }, output: null }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/app/src/utils/tool-call-details-input.ts
+++ b/packages/app/src/utils/tool-call-details-input.ts
@@ -1,0 +1,24 @@
+import type { ToolCallDetail } from "@getpaseo/protocol/agent-types";
+
+export function deriveFallbackToolCallInput(detail: ToolCallDetail | undefined): unknown {
+  if (!detail) return undefined;
+
+  switch (detail.type) {
+    case "read":
+      return compactInput({ path: detail.filePath, offset: detail.offset, limit: detail.limit });
+    case "edit":
+    case "write":
+      return compactInput({ path: detail.filePath });
+    case "search":
+      return compactInput({ query: detail.query });
+    case "fetch":
+      return compactInput({ url: detail.url, prompt: detail.prompt });
+    default:
+      return undefined;
+  }
+}
+
+function compactInput(input: Record<string, unknown>): Record<string, unknown> | undefined {
+  const entries = Object.entries(input).filter(([, value]) => value !== undefined && value !== "");
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2655,6 +2655,38 @@ describe("ACPAgentSession", () => {
     ]);
   });
 
+  test("preserves raw ACP tool input for the details view", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        title: "List directory",
+        kind: "search",
+        status: "completed",
+        rawInput: { path: "/workspace", depth: 2 },
+      } as SessionUpdate,
+    });
+
+    const toolEvent = events.find(
+      (event) => event.type === "timeline" && event.item.type === "tool_call",
+    );
+    expect(toolEvent).toMatchObject({
+      type: "timeline",
+      item: {
+        type: "tool_call",
+        metadata: {
+          rawInput: { path: "/workspace", depth: 2 },
+        },
+      },
+    });
+  });
+
   test("assigns one fallback ID per contiguous assistant message", async () => {
     const session = createSession();
     const assistantMessages: Array<{ text: string; messageId?: string }> = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3521,6 +3521,7 @@ function mapToolSnapshotToTimeline(
     metadata: {
       kind: snapshot.kind ?? undefined,
       title: snapshot.title,
+      rawInput: snapshot.rawInput,
     },
   };
   if (status === "failed") {


### PR DESCRIPTION
Summary:
- Preserve raw ACP tool inputs in timeline metadata.
- Show those inputs in the tool details panel.
- Derive compact fallback inputs for read, edit, write, search, and fetch details when raw input is unavailable.

Validation:
- ACP agent tests: 103 passed.
- App fallback-input tests: 3 passed.
- Full lint and workspace typecheck passed.
- Changed files pass formatting checks.