### PR TITLE
fix(server): resolve the Claude provider config dir from the launch env, not the daemon's

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1581,8 +1581,15 @@ export class ClaudeAgentClient implements AgentClient {
     } catch (error) {
       this.logger.warn({ err: error }, "Failed to resolve Claude Code version for model catalog");
     }
+    // Fill the configDir seam from this client's launch environment so a custom provider's
+    // settings.json is read from its own dir; an explicit options.configDir (the test seam)
+    // still wins.
+    const configDir =
+      this.configDir ??
+      createProviderEnv({ baseEnv: process.env, runtimeSettings: this.runtimeSettings })
+        .CLAUDE_CONFIG_DIR;
     const models = await runProviderRefreshActivity(context, "settings", () =>
-      getClaudeModelsWithSettings(this.logger, this.configDir, claudeCodeVersion),
+      getClaudeModelsWithSettings(this.logger, configDir, claudeCodeVersion),
     );
     const modeCatalog = claudeModeCatalog(
       createProviderEnv({ baseEnv: process.env, runtimeSettings: this.runtimeSettings }),
@@ -1613,7 +1620,10 @@ export class ClaudeAgentClient implements AgentClient {
   async listImportableSessions(
     options?: ListImportableSessionsOptions,
   ): Promise<ImportableProviderSession[]> {
-    const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+    // Resolve against this client's own launch environment, not the daemon's process.env.
+    const configDir =
+      createProviderEnv({ baseEnv: process.env, runtimeSettings: this.runtimeSettings })
+        .CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
     const sessionsRoot = options?.cwd
       ? claudeProjectDirSync(options.cwd, { configDir })
       : path.join(configDir, "projects");
@@ -5018,10 +5028,17 @@ class ClaudeAgentSession implements AgentSession {
     }
   }
 
+  // The daemon's own process.env is not necessarily this session's launch environment — a
+  // custom provider can layer CLAUDE_CONFIG_DIR through runtimeSettings.env/launchEnv, and
+  // buildSdkEnv() already composes exactly that for the SDK call itself.
+  private resolveConfigDir(): string {
+    return this.buildSdkEnv().CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+  }
+
   private resolveHistoryPath(sessionId: string): string | null {
     const cwd = this.config.cwd;
     if (!cwd) return null;
-    const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+    const configDir = this.resolveConfigDir();
     const candidates = [cwd];
     try {
       const realCwd = fs.realpathSync(cwd);

--- a/packages/server/src/server/daemon-e2e/agent-refresh-follows-provider-env.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/agent-refresh-follows-provider-env.e2e.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+
+import { ClaudeAgentClient } from "../agent/providers/claude/agent.js";
+import { DaemonClient } from "../test-utils/daemon-client.js";
+import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo-daemon.js";
+
+function sanitizeClaudeProjectPath(cwd: string): string {
+  return cwd.replace(/[\\/._:]/g, "-");
+}
+
+interface ClaudeJsonlEntry {
+  type: "user" | "assistant";
+  uuid?: string;
+  sessionId: string;
+  cwd: string;
+  message: { role: "user" | "assistant"; content: string };
+}
+
+function userEntry(
+  sessionId: string,
+  cwd: string,
+  content: string,
+  uuid: string,
+): ClaudeJsonlEntry {
+  return {
+    type: "user",
+    uuid,
+    sessionId,
+    cwd,
+    message: { role: "user", content },
+  };
+}
+
+function assistantEntry(sessionId: string, cwd: string, content: string): ClaudeJsonlEntry {
+  return {
+    type: "assistant",
+    sessionId,
+    cwd,
+    message: { role: "assistant", content },
+  };
+}
+
+function timelineText(entries: ReadonlyArray<{ item: { type: string; text?: string } }>): string {
+  return entries
+    .filter(
+      (entry): entry is { item: { type: "user_message" | "assistant_message"; text: string } } =>
+        entry.item.type === "user_message" || entry.item.type === "assistant_message",
+    )
+    .map((entry) => entry.item.text)
+    .join("\n");
+}
+
+// The discriminating shape: a decoy directory sits at process.env.CLAUDE_CONFIG_DIR — the
+// daemon's own launch environment — and contains no transcript. The real transcript lives
+// under a second directory declared only through this provider's runtimeSettings.env. A test
+// that instead read the transcript directory from process.env would pass whether or not the
+// provider honours runtimeSettings.env on read-back, and would prove nothing.
+describe("daemon E2E - refresh follows the provider's own CLAUDE_CONFIG_DIR, not the daemon's", () => {
+  let decoyConfigDir: string;
+  let realConfigDir: string;
+  let prevClaudeConfigDir: string | undefined;
+  let cwd: string;
+  let sessionFile: string;
+  let daemon: TestPaseoDaemon | undefined;
+  let client: DaemonClient | undefined;
+
+  const sessionId = "provider-env-session";
+
+  beforeEach(() => {
+    prevClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    decoyConfigDir = mkdtempSync(path.join(tmpdir(), "claude-cfg-decoy-"));
+    process.env.CLAUDE_CONFIG_DIR = decoyConfigDir;
+
+    realConfigDir = mkdtempSync(path.join(tmpdir(), "claude-cfg-real-"));
+
+    cwd = mkdtempSync(path.join(tmpdir(), "claude-cwd-provider-env-"));
+    const projectsDir = path.join(realConfigDir, "projects", sanitizeClaudeProjectPath(cwd));
+    mkdirSync(projectsDir, { recursive: true });
+    sessionFile = path.join(projectsDir, `${sessionId}.jsonl`);
+
+    const initial: ClaudeJsonlEntry[] = [
+      userEntry(sessionId, cwd, "real dir hello", "user-uuid-1"),
+      assistantEntry(sessionId, cwd, "real dir reply"),
+    ];
+    writeFileSync(
+      sessionFile,
+      `${initial.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      "utf8",
+    );
+  });
+
+  afterEach(async () => {
+    await client?.close().catch(() => undefined);
+    await daemon?.close().catch(() => undefined);
+    client = undefined;
+    daemon = undefined;
+    rmSync(decoyConfigDir, { recursive: true, force: true });
+    rmSync(realConfigDir, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+    if (prevClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = prevClaudeConfigDir;
+    }
+  }, 60_000);
+
+  test("refresh rehydrates from runtimeSettings.env's CLAUDE_CONFIG_DIR, not process.env's", async () => {
+    const logger = pino({ level: "silent" });
+    daemon = await createTestPaseoDaemon({
+      agentClients: {
+        claude: new ClaudeAgentClient({
+          logger,
+          resolveBinary: async () => "/test/claude/bin",
+          runtimeSettings: { env: { CLAUDE_CONFIG_DIR: realConfigDir } },
+        }),
+      },
+      logger,
+    });
+    client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws` });
+    await client.connect();
+    await client.fetchAgents({
+      subscribe: { subscriptionId: "refresh-provider-env-test" },
+    });
+
+    const imported = await client.importAgent({ provider: "claude", sessionId, cwd });
+    expect(imported.id).toBeTruthy();
+
+    const before = await client.fetchAgentTimeline(imported.id, {
+      direction: "tail",
+      limit: 0,
+      projection: "canonical",
+    });
+    const beforeText = timelineText(before.entries);
+    // This is the discriminating assertion: it reads from realConfigDir (declared only via
+    // runtimeSettings.env), which the daemon's own process.env.CLAUDE_CONFIG_DIR (the decoy)
+    // never points at. Before the fix, resolveHistoryPath read process.env directly and found
+    // nothing in the decoy directory, so the timeline was empty here.
+    expect(beforeText).toContain("real dir hello");
+    expect(beforeText).toContain("real dir reply");
+    const epochBefore = before.epoch;
+    const countBefore = before.entries.length;
+
+    const additions: ClaudeJsonlEntry[] = [
+      userEntry(sessionId, cwd, "real dir second hello", "user-uuid-2"),
+      assistantEntry(sessionId, cwd, "real dir second reply"),
+    ];
+    appendFileSync(
+      sessionFile,
+      `${additions.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      "utf8",
+    );
+
+    await client.refreshAgent(imported.id);
+
+    const after = await client.fetchAgentTimeline(imported.id, {
+      direction: "tail",
+      limit: 0,
+      projection: "canonical",
+    });
+    const afterText = timelineText(after.entries);
+    expect(afterText).toContain("real dir second hello");
+    expect(afterText).toContain("real dir second reply");
+    expect(after.entries.length).toBeGreaterThan(countBefore);
+    expect(after.epoch).not.toBe(epochBefore);
+  }, 30_000);
+});


### PR DESCRIPTION
### Linked issue

None — found while running a daemon with three `extends: "claude"` providers, each with its own `env`.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

`docs/custom-providers.md` says a provider created with `extends` "gets its own entry in the provider list, with its own label, environment, and model definitions". Paseo honours that `env` when it **launches** the session, and ignores it when it **reads back** from disk.

For a user that means: configure `my-claude` with `env.CLAUDE_CONFIG_DIR` pointing at a separate config directory, and everything looks right while the agent runs. The transcript is written where you asked. Then restart the daemon. Every agent on that provider comes back with an empty timeline and the UI shows no activity, because the daemon looked for the transcript under its own `CLAUDE_CONFIG_DIR` instead of the provider's.

Nothing is lost — the `.jsonl` files are still there — but there is no way to get them back without either restarting the daemon with the right variable exported, which cannot be done for two providers that declare different directories, or editing the config to match.

Three read-back sites had the same defect. All three now compose the environment exactly the way the SDK launch already does, so a declaration that works at launch also works on read-back.

### Goals

- A Claude provider that declares `env.CLAUDE_CONFIG_DIR` has its history, importable sessions and `settings.json` models read from that directory.
- A provider that declares nothing keeps today's behaviour exactly: `process.env.CLAUDE_CONFIG_DIR`, then `~/.claude`. The composition used is `createProviderEnv({ baseEnv: process.env, … })`, so the existing chain is preserved rather than replaced.
- One regression test that fails on the broken version.

### Non-goals

- No change to how the environment is composed, or to `ProviderOverrideSchema`. The composition helper and `buildSdkEnv()` already existed; three call sites were not using them.
- No new tests for `listImportableSessions` or `fetchCatalog`. They are the same one-line shape as the fixed history path, and the covered path is the one users hit. Called out as a trade-off rather than left silent.
- `providers/claude/models.ts` is untouched: it already prefers an explicit `configDir` argument, so filling the seam at the call site was the whole fix.

### QA

Reproduced and confirmed by running it, not by reading the diff.

**Before.** On a daemon with a `claude`-extending provider declaring `env.CLAUDE_CONFIG_DIR`, every agent on that provider returned no activity after a restart, while `codex` agents on the same daemon returned full transcripts. The transcripts were on disk under the declared directory the whole time, 10 MB and 4,200 lines for the largest, last written minutes before the restart. The daemon's own `CLAUDE_CONFIG_DIR` was unset, so it was reading `~/.claude/projects/<encoded-cwd>/`, where those session files do not exist.

**Regression test.** `packages/server/src/server/daemon-e2e/agent-refresh-follows-provider-env.e2e.test.ts` points `process.env.CLAUDE_CONFIG_DIR` at a decoy directory containing no transcript, and declares the real transcript directory only through `new ClaudeAgentClient({ runtimeSettings: { env: { CLAUDE_CONFIG_DIR: realDir } } })`. A test that instead pointed `process.env` at the real directory would pass on both sides of this fix and prove nothing.

Red on the unfixed version, by reverting `resolveConfigDir` to `process.env.CLAUDE_CONFIG_DIR` on an otherwise identical tree:

```
AssertionError: expected '' to contain 'real dir hello'
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Green with the fix, on the same tree:

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Also re-ran `packages/server/src/server/agent/providers/claude/agent.test.ts` clean at 79 passed.

`npm run build:server` exit 0. `npm run typecheck` exit 0 across the workspace. `npm run lint` on the touched files: 0 warnings, 0 errors. `npm run format:files` on the touched files: already formatted.

No UI change, so no screenshots.

### Checklist

- [x] Plugin changes follow the SDK import boundaries (not applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)
