### PR TITLE
fix: tolerate a UTF-8 BOM in config.json

### DIFF
--- a/packages/server/src/server/persisted-config.test.ts
+++ b/packages/server/src/server/persisted-config.test.ts
@@ -748,6 +748,21 @@ describe.skipIf(process.platform === "win32")("persisted config file permissions
     }
   });
 
+  test("tolerates a UTF-8 byte order mark in config.json", () => {
+    // Windows Notepad saves UTF-8 with a BOM; JSON.parse rejects it, and every
+    // new session went through loadPersistedConfig and failed (#4683).
+    const home = createTempHome();
+    try {
+      writeFileSync(path.join(home, "config.json"), '\uFEFF{\r\n  "version": 1,\r\n  "providers": {}\r\n}\r\n');
+
+      const config = loadPersistedConfig(home);
+
+      expect(config.providers).toEqual({});
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   test("repairs permissive config.json permissions when loading", () => {
     const home = createTempHome();
     const configPath = path.join(home, "config.json");

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -442,7 +442,9 @@ export function loadPersistedConfig(paseoHome: string, logger?: LoggerLike): Per
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    // Windows Notepad saves UTF-8 with a BOM, which JSON.parse rejects; it is
+    // not part of the document.
+    parsed = JSON.parse(raw.replace(/^\uFEFF/, ""));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`[Config] Invalid JSON in ${configPath}: ${message}`, {


### PR DESCRIPTION
### Linked issue

Closes #4683

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Windows Notepad saves UTF-8 with a byte order mark, and `JSON.parse` rejects a leading `U+FEFF`. Every new WebSocket session runs `loadPersistedConfig`, so a `config.json` that was edited once in Notepad made every `hello` handshake fail with `[Config] Invalid JSON in …: Unexpected token '﻿'` while the daemon itself kept running, and the desktop app reconnected forever. Stripping the BOM before parsing makes such a file load like any other; the BOM is not part of the document.

### Goals

- `loadPersistedConfig` accepts a `config.json` that starts with a UTF-8 BOM (with CRLF line endings, as Notepad writes it).
- Everything else about loading (permissions repair, validation, error messages for genuinely invalid JSON) is unchanged.

### Non-goals

- Rewriting or repairing the file on disk; the BOM is simply ignored on read.
- Other config readers (this loader is the one every session goes through).

### Validation

```
cd packages/server && npx vitest run src/server/persisted-config.test.ts   # 45 passed (1 new)
```

The new test writes `﻿{\r\n  "version": 1,\r\n  "providers": {}\r\n}\r\n` and loads it; it fails on `main` with the error from the report.
