### PR TITLE
fix(desktop): write a Windows CLI shim that cmd.exe can read

### DIFF
--- a/packages/desktop/src/integrations/cli-install/install.ts
+++ b/packages/desktop/src/integrations/cli-install/install.ts
@@ -4,6 +4,7 @@ import log from "electron-log/main";
 import { resolveCliInstallSourcePath } from "./path.js";
 import { getBundledCliShimPath, getCliTargetPath, getLocalBinDir } from "./paths.js";
 import { ensurePathInShellRc } from "./shell-rc.js";
+import { renderWindowsCliShim } from "./windows-shim.js";
 
 interface InstallStatus {
   installed: boolean;
@@ -39,17 +40,9 @@ export async function installCli(): Promise<InstallStatus> {
     // Generate a thin .cmd trampoline that delegates to the bundled shim.
     // Only the app install path is baked in — internal details (asar layout,
     // entrypoint scripts) live in the bundled shim and update with the app.
-    const cmdContent = [
-      "@echo off",
-      `set "BUNDLED_CLI=${shimPath}"`,
-      `if not exist "%BUNDLED_CLI%" (`,
-      `  echo Paseo CLI not found at %BUNDLED_CLI% — is Paseo installed? 1>&2`,
-      `  exit /b 1`,
-      `)`,
-      `call "%BUNDLED_CLI%" %*`,
-      `exit /b %errorlevel%`,
-    ].join("\r\n");
-    await fs.writeFile(targetPath, cmdContent, "utf-8");
+    // cmd.exe reads the file in the OEM code page, so the content is kept
+    // ASCII-only and the path goes through %LOCALAPPDATA% & co. (#4684).
+    await fs.writeFile(targetPath, renderWindowsCliShim(shimPath), "ascii");
   } else {
     if (await pathOrSymlinkExists(targetPath)) {
       await fs.unlink(targetPath);

--- a/packages/desktop/src/integrations/cli-install/install.ts
+++ b/packages/desktop/src/integrations/cli-install/install.ts
@@ -40,9 +40,11 @@ export async function installCli(): Promise<InstallStatus> {
     // Generate a thin .cmd trampoline that delegates to the bundled shim.
     // Only the app install path is baked in — internal details (asar layout,
     // entrypoint scripts) live in the bundled shim and update with the app.
-    // cmd.exe reads the file in the OEM code page, so the content is kept
-    // ASCII-only and the path goes through %LOCALAPPDATA% & co. (#4684).
-    await fs.writeFile(targetPath, renderWindowsCliShim(shimPath), "ascii");
+    // cmd.exe reads the file in the OEM code page, so the path goes through
+    // %LOCALAPPDATA% & co. and the content stays ASCII (#4684); a non-ASCII
+    // path outside every root is written as UTF-8 and the shim switches the
+    // code page for that line itself.
+    await fs.writeFile(targetPath, renderWindowsCliShim(shimPath));
   } else {
     if (await pathOrSymlinkExists(targetPath)) {
       await fs.unlink(targetPath);

--- a/packages/desktop/src/integrations/cli-install/windows-shim.test.ts
+++ b/packages/desktop/src/integrations/cli-install/windows-shim.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { renderWindowsCliShim, windowsShimPathExpression } from "./windows-shim";
+
+const env = {
+  USERPROFILE: "C:\\Users\\卢泓锦",
+  LOCALAPPDATA: "C:\\Users\\卢泓锦\\AppData\\Local",
+  APPDATA: "C:\\Users\\卢泓锦\\AppData\\Roaming",
+  PROGRAMFILES: "C:\\Program Files",
+};
+
+describe("windowsShimPathExpression", () => {
+  it("expresses a per-user install through %LOCALAPPDATA%", () => {
+    expect(
+      windowsShimPathExpression("C:\\Users\\卢泓锦\\AppData\\Local\\Programs\\Paseo\\resources\\bin\\paseo.cmd", env),
+    ).toBe("%LOCALAPPDATA%\\Programs\\Paseo\\resources\\bin\\paseo.cmd");
+  });
+
+  it("prefers the most specific root and compares case-insensitively", () => {
+    expect(windowsShimPathExpression("c:\\users\\卢泓锦\\appdata\\roaming\\Paseo\\bin\\paseo.cmd", env)).toBe(
+      "%APPDATA%\\Paseo\\bin\\paseo.cmd",
+    );
+    expect(windowsShimPathExpression("C:\\Users\\卢泓锦\\Paseo\\bin\\paseo.cmd", env)).toBe(
+      "%USERPROFILE%\\Paseo\\bin\\paseo.cmd",
+    );
+  });
+
+  it("leaves a path outside every known root as it is", () => {
+    expect(windowsShimPathExpression("D:\\Tools\\Paseo\\resources\\bin\\paseo.cmd", env)).toBe(
+      "D:\\Tools\\Paseo\\resources\\bin\\paseo.cmd",
+    );
+  });
+
+  it("does not treat a sibling directory with a common prefix as the root", () => {
+    expect(windowsShimPathExpression("C:\\Users\\卢泓锦2\\Paseo\\bin\\paseo.cmd", env)).toBe(
+      "C:\\Users\\卢泓锦2\\Paseo\\bin\\paseo.cmd",
+    );
+  });
+});
+
+describe("renderWindowsCliShim", () => {
+  it("writes an ASCII-only, CRLF-terminated trampoline for a per-user install", () => {
+    const content = renderWindowsCliShim(
+      "C:\\Users\\卢泓锦\\AppData\\Local\\Programs\\Paseo\\resources\\bin\\paseo.cmd",
+      env,
+    );
+    // cmd.exe reads batch files in the OEM code page; any non-ASCII byte is mojibake.
+    expect([...content].every((char) => char.charCodeAt(0) < 128)).toBe(true);
+    expect(content.split("\r\n")).toEqual([
+      "@echo off",
+      'set "BUNDLED_CLI=%LOCALAPPDATA%\\Programs\\Paseo\\resources\\bin\\paseo.cmd"',
+      'if not exist "%BUNDLED_CLI%" (',
+      "  echo Paseo CLI not found at %BUNDLED_CLI% - is Paseo installed? 1>&2",
+      "  exit /b 1",
+      ")",
+      'call "%BUNDLED_CLI%" %*',
+      "exit /b %errorlevel%",
+    ]);
+    expect(content).not.toContain("\n\n");
+  });
+});

--- a/packages/desktop/src/integrations/cli-install/windows-shim.test.ts
+++ b/packages/desktop/src/integrations/cli-install/windows-shim.test.ts
@@ -11,14 +11,17 @@ const env = {
 describe("windowsShimPathExpression", () => {
   it("expresses a per-user install through %LOCALAPPDATA%", () => {
     expect(
-      windowsShimPathExpression("C:\\Users\\卢泓锦\\AppData\\Local\\Programs\\Paseo\\resources\\bin\\paseo.cmd", env),
+      windowsShimPathExpression(
+        "C:\\Users\\卢泓锦\\AppData\\Local\\Programs\\Paseo\\resources\\bin\\paseo.cmd",
+        env,
+      ),
     ).toBe("%LOCALAPPDATA%\\Programs\\Paseo\\resources\\bin\\paseo.cmd");
   });
 
   it("prefers the most specific root and compares case-insensitively", () => {
-    expect(windowsShimPathExpression("c:\\users\\卢泓锦\\appdata\\roaming\\Paseo\\bin\\paseo.cmd", env)).toBe(
-      "%APPDATA%\\Paseo\\bin\\paseo.cmd",
-    );
+    expect(
+      windowsShimPathExpression("c:\\users\\卢泓锦\\appdata\\roaming\\Paseo\\bin\\paseo.cmd", env),
+    ).toBe("%APPDATA%\\Paseo\\bin\\paseo.cmd");
     expect(windowsShimPathExpression("C:\\Users\\卢泓锦\\Paseo\\bin\\paseo.cmd", env)).toBe(
       "%USERPROFILE%\\Paseo\\bin\\paseo.cmd",
     );
@@ -56,5 +59,27 @@ describe("renderWindowsCliShim", () => {
       "exit /b %errorlevel%",
     ]);
     expect(content).not.toContain("\n\n");
+  });
+
+  it("keeps an ASCII path outside every root free of the code-page switch", () => {
+    const content = renderWindowsCliShim("D:\\Tools\\Paseo\\resources\\bin\\paseo.cmd", env);
+    expect(content).not.toContain("chcp");
+    expect(content).toContain('set "BUNDLED_CLI=D:\\Tools\\Paseo\\resources\\bin\\paseo.cmd"');
+  });
+
+  it("switches to UTF-8 around a non-ASCII path that lies outside every root", () => {
+    const content = renderWindowsCliShim("D:\\软件\\Paseo\\resources\\bin\\paseo.cmd", env);
+    const lines = content.split("\r\n");
+    expect(lines.slice(0, 7)).toEqual([
+      "@echo off",
+      'for /f "tokens=2 delims=:." %%c in (\'chcp\') do set "PASEO_CODEPAGE=%%c"',
+      ">nul chcp 65001",
+      'set "BUNDLED_CLI=D:\\软件\\Paseo\\resources\\bin\\paseo.cmd"',
+      ">nul chcp %PASEO_CODEPAGE%",
+      'set "PASEO_CODEPAGE="',
+      'if not exist "%BUNDLED_CLI%" (',
+    ]);
+    // The path is the only non-ASCII content; the caller writes the file as UTF-8 without a BOM.
+    expect(lines.filter((line) => /[\u0080-\uffff]/.test(line))).toEqual([lines[3]]);
   });
 });

--- a/packages/desktop/src/integrations/cli-install/windows-shim.ts
+++ b/packages/desktop/src/integrations/cli-install/windows-shim.ts
@@ -22,10 +22,14 @@ function normalizeWindowsPath(value: string): string {
 /** Rewrites the leading root of `shimPath` as `%VARIABLE%` when it lies under one. */
 export function windowsShimPathExpression(shimPath: string, env: NodeJS.ProcessEnv): string {
   const normalizedShim = normalizeWindowsPath(shimPath);
-  const candidates = ROOT_VARIABLES.map((name) => ({ name, value: env[name] }))
-    .filter((entry): entry is { name: string; value: string } => typeof entry.value === "string" && entry.value.length > 0)
-    .map((entry) => ({ ...entry, normalized: normalizeWindowsPath(entry.value) }))
-    .sort((a, b) => b.normalized.length - a.normalized.length);
+  const candidates: Array<{ name: string; value: string; normalized: string }> = [];
+  for (const name of ROOT_VARIABLES) {
+    const value = env[name];
+    if (typeof value === "string" && value.length > 0) {
+      candidates.push({ name, value, normalized: normalizeWindowsPath(value) });
+    }
+  }
+  candidates.sort((a, b) => b.normalized.length - a.normalized.length);
   for (const candidate of candidates) {
     if (normalizedShim === candidate.normalized || normalizedShim.startsWith(`${candidate.normalized}\\`)) {
       const rest = shimPath.slice(candidate.value.replace(/[\\/]+$/, "").length).replace(/^[\\/]+/, "");

--- a/packages/desktop/src/integrations/cli-install/windows-shim.ts
+++ b/packages/desktop/src/integrations/cli-install/windows-shim.ts
@@ -9,11 +9,24 @@
  * variable it lives under (`%LOCALAPPDATA%`, `%APPDATA%`, `%USERPROFILE%`,
  * `%PROGRAMFILES%`, ...): cmd.exe expands the variable in memory, so its
  * bytes on disk stay ASCII. Everything else in the file is ASCII as well.
+ *
+ * A custom install directory outside every known root can still carry
+ * non-ASCII characters. cmd.exe decodes each batch line in the code page that
+ * is active when it reads that line, so for that case the literal path is
+ * written as UTF-8 and the console is switched to code page 65001 for that
+ * one line; the value is held as UTF-16 in memory afterwards and the previous
+ * code page is put back before anything else runs.
  */
 
 // Ordered longest-first so the most specific root wins when several nest
 // (%LOCALAPPDATA% and %APPDATA% both live under %USERPROFILE%).
-const ROOT_VARIABLES = ["LOCALAPPDATA", "APPDATA", "PROGRAMFILES(X86)", "PROGRAMFILES", "USERPROFILE"] as const;
+const ROOT_VARIABLES = [
+  "LOCALAPPDATA",
+  "APPDATA",
+  "PROGRAMFILES(X86)",
+  "PROGRAMFILES",
+  "USERPROFILE",
+] as const;
 
 function normalizeWindowsPath(value: string): string {
   return value.replace(/\//g, "\\").replace(/\\+$/, "").toLowerCase();
@@ -31,20 +44,39 @@ export function windowsShimPathExpression(shimPath: string, env: NodeJS.ProcessE
   }
   candidates.sort((a, b) => b.normalized.length - a.normalized.length);
   for (const candidate of candidates) {
-    if (normalizedShim === candidate.normalized || normalizedShim.startsWith(`${candidate.normalized}\\`)) {
-      const rest = shimPath.slice(candidate.value.replace(/[\\/]+$/, "").length).replace(/^[\\/]+/, "");
+    if (
+      normalizedShim === candidate.normalized ||
+      normalizedShim.startsWith(`${candidate.normalized}\\`)
+    ) {
+      const rest = shimPath
+        .slice(candidate.value.replace(/[\\/]+$/, "").length)
+        .replace(/^[\\/]+/, "");
       return `%${candidate.name}%\\${rest.replace(/\//g, "\\")}`;
     }
   }
   return shimPath;
 }
 
-/** The complete `paseo.cmd` content, CRLF-terminated and ASCII only. */
-export function renderWindowsCliShim(shimPath: string, env: NodeJS.ProcessEnv = process.env): string {
+const NON_ASCII = /[\u0080-\uffff]/;
+
+/** The complete `paseo.cmd` content, CRLF-terminated; ASCII only unless the path forces the UTF-8 fallback. */
+export function renderWindowsCliShim(
+  shimPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
   const bundled = windowsShimPathExpression(shimPath, env);
+  const setBundled = `set "BUNDLED_CLI=${bundled}"`;
   return [
     "@echo off",
-    `set "BUNDLED_CLI=${bundled}"`,
+    ...(NON_ASCII.test(bundled)
+      ? [
+          `for /f "tokens=2 delims=:." %%c in ('chcp') do set "PASEO_CODEPAGE=%%c"`,
+          ">nul chcp 65001",
+          setBundled,
+          ">nul chcp %PASEO_CODEPAGE%",
+          `set "PASEO_CODEPAGE="`,
+        ]
+      : [setBundled]),
     `if not exist "%BUNDLED_CLI%" (`,
     `  echo Paseo CLI not found at %BUNDLED_CLI% - is Paseo installed? 1>&2`,
     `  exit /b 1`,

--- a/packages/desktop/src/integrations/cli-install/windows-shim.ts
+++ b/packages/desktop/src/integrations/cli-install/windows-shim.ts
@@ -1,0 +1,51 @@
+/**
+ * Renders the `paseo.cmd` trampoline the desktop app installs into
+ * `%USERPROFILE%\.local\bin` on Windows.
+ *
+ * cmd.exe reads batch files in the console's OEM code page, not UTF-8, so a
+ * non-ASCII character in the baked-in install path (a user name such as
+ * `C:\Users\卢泓锦\...`) is decoded as mojibake and the shim never finds the
+ * bundled CLI. The path is therefore expressed through the environment
+ * variable it lives under (`%LOCALAPPDATA%`, `%APPDATA%`, `%USERPROFILE%`,
+ * `%PROGRAMFILES%`, ...): cmd.exe expands the variable in memory, so its
+ * bytes on disk stay ASCII. Everything else in the file is ASCII as well.
+ */
+
+// Ordered longest-first so the most specific root wins when several nest
+// (%LOCALAPPDATA% and %APPDATA% both live under %USERPROFILE%).
+const ROOT_VARIABLES = ["LOCALAPPDATA", "APPDATA", "PROGRAMFILES(X86)", "PROGRAMFILES", "USERPROFILE"] as const;
+
+function normalizeWindowsPath(value: string): string {
+  return value.replace(/\//g, "\\").replace(/\\+$/, "").toLowerCase();
+}
+
+/** Rewrites the leading root of `shimPath` as `%VARIABLE%` when it lies under one. */
+export function windowsShimPathExpression(shimPath: string, env: NodeJS.ProcessEnv): string {
+  const normalizedShim = normalizeWindowsPath(shimPath);
+  const candidates = ROOT_VARIABLES.map((name) => ({ name, value: env[name] }))
+    .filter((entry): entry is { name: string; value: string } => typeof entry.value === "string" && entry.value.length > 0)
+    .map((entry) => ({ ...entry, normalized: normalizeWindowsPath(entry.value) }))
+    .sort((a, b) => b.normalized.length - a.normalized.length);
+  for (const candidate of candidates) {
+    if (normalizedShim === candidate.normalized || normalizedShim.startsWith(`${candidate.normalized}\\`)) {
+      const rest = shimPath.slice(candidate.value.replace(/[\\/]+$/, "").length).replace(/^[\\/]+/, "");
+      return `%${candidate.name}%\\${rest.replace(/\//g, "\\")}`;
+    }
+  }
+  return shimPath;
+}
+
+/** The complete `paseo.cmd` content, CRLF-terminated and ASCII only. */
+export function renderWindowsCliShim(shimPath: string, env: NodeJS.ProcessEnv = process.env): string {
+  const bundled = windowsShimPathExpression(shimPath, env);
+  return [
+    "@echo off",
+    `set "BUNDLED_CLI=${bundled}"`,
+    `if not exist "%BUNDLED_CLI%" (`,
+    `  echo Paseo CLI not found at %BUNDLED_CLI% - is Paseo installed? 1>&2`,
+    `  exit /b 1`,
+    `)`,
+    `call "%BUNDLED_CLI%" %*`,
+    `exit /b %errorlevel%`,
+  ].join("\r\n");
+}


### PR DESCRIPTION
### Linked issue

Refs #4684 (defect 1, the encoding; see Non-goals for defect 2)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The Install CLI integration wrote `%USERPROFILE%\.local\bin\paseo.cmd` as UTF-8 with the literal app install path baked in. `cmd.exe` reads batch files in the console's OEM code page, not UTF-8, so any non-ASCII character in that path (a user name such as `C:\Users\卢泓锦\…`) was decoded as mojibake and the shim reported `Paseo CLI not found at …` for a perfectly installed app. The generated file also contained a non-ASCII em dash in that message.

A Windows user with a non-ASCII profile name can now run `paseo` from the shim: the path is expressed through the environment variable it lives under (`%LOCALAPPDATA%\Programs\Paseo\resources\bin\paseo.cmd` for the per-user installer; `%APPDATA%`, `%USERPROFILE%`, `%PROGRAMFILES%` are handled the same way), which `cmd.exe` expands in memory, so the bytes on disk stay ASCII. The message is ASCII too. A custom install directory outside every known root that still contains non-ASCII characters is written as UTF-8, and the shim switches the console to code page 65001 for the single line that bakes in the path and restores the previous code page right after.

### Goals

- `paseo.cmd` contains only ASCII bytes for installs under any of the known roots, and resolves the bundled shim through `%VARIABLE%`.
- Root matching is case-insensitive, prefers the most specific root (`%LOCALAPPDATA%` over `%USERPROFILE%`), and does not match a sibling directory that merely shares a prefix.
- The rendering is a pure function (`windows-shim.ts`) with unit tests, so it runs without Electron.
- A non-ASCII path outside every root is not lost either: it is kept as UTF-8 and read under code page 65001 for that one line (review follow-up; verified by rendering tests only, see below).

### Non-goals

- Defect 2 of #4684 (the user `PATH` is never updated on Windows because `detectShellRcInfo` returns `null` there). That needs a registry write plus a `WM_SETTINGCHANGE` broadcast and deserves its own change; I can follow up if wanted.

### Validation

```
cd packages/desktop && npx vitest run src/integrations/cli-install   # 11 passed (7 new)
cd packages/desktop && npx tsc --noEmit -p tsconfig.json   # the only errors are two pre-existing ones in src/daemon/daemon-manager.ts, identical on main
```

I cannot run the generated `paseo.cmd` on a Windows console here, so the code-page fallback branch is verified by the rendering tests only; a smoke test on a non-ASCII custom install directory would be welcome.


