### PR TITLE
fix(app): let touch workspace titles use the available width

### DIFF
--- a/packages/app/e2e/browser/sidebar-title-width.spec.ts
+++ b/packages/app/e2e/browser/sidebar-title-width.spec.ts
@@ -1,0 +1,124 @@
+import { rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
+import {
+  closeSidebarDisplayPreferences,
+  openMobileAgentSidebar,
+  openSidebarDisplayPage,
+  selectSidebarStatusGrouping,
+} from "../support/helpers/sidebar";
+
+const TITLE = "Linux desktop sandbox launch support";
+
+async function seedChangedWorkspace() {
+  const workspace = await seedWorkspace({
+    repoPrefix: "sidebar-title-",
+    title: TITLE,
+    repo: { withRemote: true },
+  });
+  try {
+    await rm(path.join(workspace.repoPath, "remote.git"), { recursive: true });
+    await workspace.client.renameProject(workspace.projectId, "Paseo");
+    await writeFile(path.join(workspace.repoPath, "README.md"), "Changed line\n".repeat(12345));
+    await workspace.client.checkoutRefresh(workspace.repoPath);
+    await expect
+      .poll(async () => {
+        const { entries } = await workspace.client.fetchWorkspaces();
+        return entries.find((entry) => entry.id === workspace.workspaceId)?.diffStat?.additions;
+      })
+      .toBe(12345);
+    return workspace;
+  } catch (error) {
+    await workspace.cleanup();
+    throw error;
+  }
+}
+
+function workspaceRow(page: Page) {
+  return page.getByRole("button", { name: new RegExp(TITLE) }).filter({ visible: true });
+}
+
+async function titleWidth(row: Locator) {
+  return row
+    .getByText(TITLE, { exact: true })
+    .evaluate((element) => element.getBoundingClientRect().width);
+}
+
+async function toggleTrailing(page: Page, label: "Diff stats" | "Last activity", touch = false) {
+  await openSidebarDisplayPage(page, "sidebar-display-show");
+  await page.getByRole("menuitem", { name: label, exact: true }).click();
+  if (touch) {
+    await page
+      .getByRole("button", { name: "Bottom sheet backdrop", exact: true })
+      .click({ position: { x: 5, y: 5 } });
+    await expect(
+      page.getByRole("button", { name: "Bottom sheet backdrop", exact: true }),
+    ).toHaveCount(0);
+  } else {
+    await closeSidebarDisplayPreferences(page);
+  }
+  await page.mouse.move(0, 0);
+}
+
+async function expectTouchTitleWidth(page: Page) {
+  const row = workspaceRow(page);
+  const withDiff = await titleWidth(row);
+  await toggleTrailing(page, "Diff stats", true);
+  const withoutStats = await titleWidth(row);
+  expect(withDiff).toBeCloseTo(withoutStats, 0);
+  await toggleTrailing(page, "Last activity", true);
+  expect(await titleWidth(row)).toBeCloseTo(withoutStats, 0);
+  await toggleTrailing(page, "Diff stats", true);
+}
+
+let workspace: SeededWorkspace;
+test.beforeEach(async () => {
+  workspace = await seedChangedWorkspace();
+});
+test.afterEach(async () => {
+  await workspace?.cleanup();
+});
+
+test("touch titles use the space occupied by hidden stats in every grouping", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.emulateMedia({ colorScheme: "dark" });
+  await gotoAppShell(page);
+  await openMobileAgentSidebar(page);
+  await expect(workspaceRow(page)).toBeVisible();
+  await page.mouse.move(0, 0);
+  await page.screenshot({ path: testInfo.outputPath("sidebar.png") });
+
+  await expectTouchTitleWidth(page);
+  await workspace.client.setWorkspacePinned(workspace.workspaceId, true);
+  await expect(page.getByTestId("sidebar-pinned-section")).toBeVisible();
+  await expectTouchTitleWidth(page);
+  await workspace.client.setWorkspacePinned(workspace.workspaceId, false);
+  await selectSidebarStatusGrouping(page);
+  await expectTouchTitleWidth(page);
+});
+
+test("desktop hover and shortcut hints preserve title width", async ({ page }, testInfo) => {
+  await gotoAppShell(page);
+  const row = workspaceRow(page);
+  await expect(row).toBeVisible();
+  await page.mouse.move(0, 0);
+  const initialWidth = await titleWidth(row);
+  await expect(row.getByText("+12.3k", { exact: true })).toBeVisible();
+  await row.hover();
+  await expect(row.getByLabel("Workspace actions", { exact: true })).toBeVisible();
+  expect(await titleWidth(row)).toBeCloseTo(initialWidth, 0);
+  await page.screenshot({ path: testInfo.outputPath("desktop-hover.png") });
+  await page.keyboard.down("Alt");
+  await expect(row.getByText("1", { exact: true })).toBeVisible();
+  expect(await titleWidth(row)).toBeCloseTo(initialWidth, 0);
+  await page.screenshot({ path: testInfo.outputPath("desktop-shortcuts.png") });
+  await page.keyboard.up("Alt");
+  await expect(row.getByText("1", { exact: true })).toHaveCount(0);
+  await toggleTrailing(page, "Diff stats");
+  expect(await titleWidth(row)).toBeGreaterThan(initialWidth);
+});

--- a/packages/app/e2e/browser/sidebar-title-width.spec.ts
+++ b/packages/app/e2e/browser/sidebar-title-width.spec.ts
@@ -1,6 +1,6 @@
 import { rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { Locator, Page } from "@playwright/test";
+import type { Locator, Page, TestInfo } from "@playwright/test";
 import { expect, test } from "../support/fixtures";
 import { gotoAppShell } from "../support/helpers/app";
 import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
@@ -82,9 +82,7 @@ test.afterEach(async () => {
   await workspace?.cleanup();
 });
 
-test("touch titles use the space occupied by hidden stats in every grouping", async ({
-  page,
-}, testInfo) => {
+async function openTouchWorkspaceList(page: Page, testInfo: TestInfo) {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.emulateMedia({ colorScheme: "dark" });
   await gotoAppShell(page);
@@ -92,33 +90,64 @@ test("touch titles use the space occupied by hidden stats in every grouping", as
   await expect(workspaceRow(page)).toBeVisible();
   await page.mouse.move(0, 0);
   await page.screenshot({ path: testInfo.outputPath("sidebar.png") });
+}
 
-  await expectTouchTitleWidth(page);
+async function pinWorkspaceForLayout(page: Page) {
   await workspace.client.setWorkspacePinned(workspace.workspaceId, true);
   await expect(page.getByTestId("sidebar-pinned-section")).toBeVisible();
-  await expectTouchTitleWidth(page);
+}
+
+async function moveWorkspaceToStatusGrouping(page: Page) {
   await workspace.client.setWorkspacePinned(workspace.workspaceId, false);
   await selectSidebarStatusGrouping(page);
-  await expectTouchTitleWidth(page);
-});
+}
 
-test("desktop hover and shortcut hints preserve title width", async ({ page }, testInfo) => {
+async function openDesktopWorkspaceList(page: Page) {
   await gotoAppShell(page);
   const row = workspaceRow(page);
   await expect(row).toBeVisible();
   await page.mouse.move(0, 0);
-  const initialWidth = await titleWidth(row);
   await expect(row.getByText("+12.3k", { exact: true })).toBeVisible();
+  return titleWidth(row);
+}
+
+async function expectHoverKeepsTitleWidth(page: Page, width: number, testInfo: TestInfo) {
+  const row = workspaceRow(page);
   await row.hover();
   await expect(row.getByLabel("Workspace actions", { exact: true })).toBeVisible();
-  expect(await titleWidth(row)).toBeCloseTo(initialWidth, 0);
+  expect(await titleWidth(row)).toBeCloseTo(width, 0);
   await page.screenshot({ path: testInfo.outputPath("desktop-hover.png") });
+}
+
+async function expectShortcutHintsKeepTitleWidth(page: Page, width: number, testInfo: TestInfo) {
+  const row = workspaceRow(page);
   await page.keyboard.down("Alt");
   await expect(row.getByText("1", { exact: true })).toBeVisible();
-  expect(await titleWidth(row)).toBeCloseTo(initialWidth, 0);
+  expect(await titleWidth(row)).toBeCloseTo(width, 0);
   await page.screenshot({ path: testInfo.outputPath("desktop-shortcuts.png") });
   await page.keyboard.up("Alt");
   await expect(row.getByText("1", { exact: true })).toHaveCount(0);
+}
+
+async function expectDisablingStatsExpandsTitle(page: Page, width: number) {
   await toggleTrailing(page, "Diff stats");
-  expect(await titleWidth(row)).toBeGreaterThan(initialWidth);
+  expect(await titleWidth(workspaceRow(page))).toBeGreaterThan(width);
+}
+
+test("touch titles use the space occupied by hidden stats in every grouping", async ({
+  page,
+}, testInfo) => {
+  await openTouchWorkspaceList(page, testInfo);
+  await expectTouchTitleWidth(page);
+  await pinWorkspaceForLayout(page);
+  await expectTouchTitleWidth(page);
+  await moveWorkspaceToStatusGrouping(page);
+  await expectTouchTitleWidth(page);
+});
+
+test("desktop hover and shortcut hints preserve title width", async ({ page }, testInfo) => {
+  const width = await openDesktopWorkspaceList(page);
+  await expectHoverKeepsTitleWidth(page, width, testInfo);
+  await expectShortcutHintsKeepTitleWidth(page, width, testInfo);
+  await expectDisablingStatsExpandsTitle(page, width);
 });

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -645,7 +645,7 @@ function WorkspaceRowRightGroup({
   const trailing = useSidebarWorkspaceTrailing();
   const showShortcut = showShortcutBadge && shortcutNumber !== null;
   const {
-    showTrailing,
+    trailingPresentation,
     showKebab: showKebabInSlot,
     showScrim,
     renderSlot,
@@ -667,7 +667,7 @@ function WorkspaceRowRightGroup({
       ) : null}
       {renderSlot ? (
         <SidebarWorkspaceTrailingActionSlot reserveWidth={reserveSlotWidth}>
-          <SidebarWorkspaceTrailingActionBase visible={showTrailing}>
+          <SidebarWorkspaceTrailingActionBase presentation={trailingPresentation}>
             <SidebarWorkspaceTrailingContent workspace={workspace} trailing={trailing} />
           </SidebarWorkspaceTrailingActionBase>
           <SidebarWorkspaceTrailingActionOverlay

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -53,6 +53,7 @@ import {
   SidebarWorkspaceRowFrame,
   SidebarWorkspaceRowContent,
   resolveTrailingActionVisibility,
+  type SidebarWorkspaceTrailingPresentation,
   SidebarWorkspaceTrailingActionBase,
   SidebarWorkspaceTrailingActionOverlay,
   SidebarWorkspaceTrailingActionSlot,
@@ -828,7 +829,7 @@ function StatusWorkspaceRowInnerContent({
       {({ isHovered, contextMenuOpen, onContextMenuOpenChange, hoverHandlers }) => {
         const showShortcut = showShortcutBadge && shortcutNumber !== null;
         const {
-          showTrailing,
+          trailingPresentation,
           showKebab: showKebabInSlot,
           showScrim,
           renderSlot,
@@ -907,7 +908,7 @@ function StatusWorkspaceRowInnerContent({
                     workspace={workspace}
                     backdrop={backdrop}
                     trailing={trailing}
-                    showBase={showTrailing}
+                    trailingPresentation={trailingPresentation}
                     showKebab={showKebabInSlot}
                     showScrim={showScrim}
                     reserveSlotWidth={reserveSlotWidth}
@@ -938,7 +939,7 @@ function StatusWorkspaceActionSlot({
   workspace,
   backdrop,
   trailing,
-  showBase,
+  trailingPresentation,
   showKebab,
   showScrim,
   reserveSlotWidth,
@@ -958,7 +959,7 @@ function StatusWorkspaceActionSlot({
   workspace: SidebarWorkspaceEntry;
   backdrop: SidebarSurfaceBackdrop;
   trailing: SidebarWorkspaceTrailing;
-  showBase: boolean;
+  trailingPresentation: SidebarWorkspaceTrailingPresentation;
   showKebab: boolean;
   showScrim: boolean;
   reserveSlotWidth: boolean;
@@ -978,7 +979,7 @@ function StatusWorkspaceActionSlot({
   const kebab = useOpenKebabMenuVisibility(showKebab);
   return (
     <SidebarWorkspaceTrailingActionSlot reserveWidth={reserveSlotWidth}>
-      <SidebarWorkspaceTrailingActionBase visible={showBase}>
+      <SidebarWorkspaceTrailingActionBase presentation={trailingPresentation}>
         <SidebarWorkspaceTrailingContent workspace={workspace} trailing={trailing} />
       </SidebarWorkspaceTrailingActionBase>
       <SidebarWorkspaceTrailingActionOverlay

--- a/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
@@ -343,6 +343,8 @@ export function SidebarWorkspaceShortcutBadge({ number }: { number: number }) {
   );
 }
 
+export type SidebarWorkspaceTrailingPresentation = "visible" | "hidden" | "absent";
+
 /**
  * What the trailing slot shows for a row. Derived in one place because three row renderers
  * share it: the two project-mode rows and the status-mode row. The rule used to be copied
@@ -368,7 +370,7 @@ export function resolveTrailingActionVisibility({
   isTouchPlatform: boolean;
   showShortcut: boolean;
 }): {
-  showTrailing: boolean;
+  trailingPresentation: SidebarWorkspaceTrailingPresentation;
   showKebab: boolean;
   showScrim: boolean;
   renderSlot: boolean;
@@ -376,9 +378,13 @@ export function resolveTrailingActionVisibility({
 } {
   const hasTrailing = hasSidebarWorkspaceTrailing({ workspace, trailing });
   const showKebab = Boolean(hasArchiveAction && (isHovered || isTouchPlatform)) && !showShortcut;
-  const showTrailing = hasTrailing && !showShortcut && (isHovered || !showKebab);
+  // Touch permanently replaces the stats with the menu. Only temporary shortcut hints
+  // conceal content while retaining its width, so desktop rows do not shift.
+  const hasContent = hasTrailing && !(hasArchiveAction && isTouchPlatform);
+  let trailingPresentation: SidebarWorkspaceTrailingPresentation = "absent";
+  if (hasContent) trailingPresentation = showShortcut ? "hidden" : "visible";
   return {
-    showTrailing,
+    trailingPresentation,
     showKebab,
     // The scrim paints the row's own hover background, so it can only be drawn on a hovered
     // row — over an unhovered one the gradient fades to the wrong color. That is also why
@@ -389,7 +395,7 @@ export function resolveTrailingActionVisibility({
     // does; the kebab only does on touch, where there is no hover for it to appear on and so
     // no scrim to let it overlay the title. Everywhere else the width goes back to the title
     // and the kebab fades in over its tail.
-    reserveSlotWidth: hasTrailing || (hasArchiveAction && isTouchPlatform),
+    reserveSlotWidth: hasContent || (hasArchiveAction && isTouchPlatform),
   };
 }
 
@@ -414,14 +420,18 @@ export function SidebarWorkspaceTrailingActionSlot({
 }
 
 export function SidebarWorkspaceTrailingActionBase({
-  visible,
+  presentation,
   children,
 }: {
-  visible: boolean;
+  presentation: SidebarWorkspaceTrailingPresentation;
   children: ReactNode;
 }) {
-  if (!children) return null;
-  return <View style={visible ? undefined : sidebarWorkspaceRowStyles.hidden}>{children}</View>;
+  if (presentation === "absent") return null;
+  return (
+    <View style={presentation === "hidden" ? sidebarWorkspaceRowStyles.hidden : undefined}>
+      {children}
+    </View>
+  );
 }
 
 export function SidebarWorkspaceTrailingActionOverlay({

--- a/packages/app/src/components/sidebar/sidebar-workspace-row.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row.tsx
@@ -403,7 +403,7 @@ function WorkspaceRowTrailingActions({
   const { t } = useTranslation();
   const showShortcut = showShortcutBadge && shortcutNumber !== null;
   const {
-    showTrailing,
+    trailingPresentation,
     showKebab: showKebabInSlot,
     showScrim,
     renderSlot,
@@ -425,7 +425,7 @@ function WorkspaceRowTrailingActions({
       ) : null}
       {renderSlot ? (
         <SidebarWorkspaceTrailingActionSlot reserveWidth={reserveSlotWidth}>
-          <SidebarWorkspaceTrailingActionBase visible={showTrailing}>
+          <SidebarWorkspaceTrailingActionBase presentation={trailingPresentation}>
             <SidebarWorkspaceTrailingContent workspace={workspace} trailing={trailing} />
           </SidebarWorkspaceTrailingActionBase>
           <SidebarWorkspaceTrailingActionOverlay


### PR DESCRIPTION
### Linked issue

Reported directly with an Android sidebar screenshot. No matching issue or superseded PR found.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Workspace titles on touch layouts truncate early because the diff stats hidden behind the permanent menu button still occupy their full width. With a 390px viewport, a real workspace with +12.3k/-1 changes had only 262px for its title; disabling stats gave it 304px.

The shared trailing renderer now distinguishes absent content from content temporarily hidden for shortcut hints. Touch menus omit the replaced stats, while desktop hover and shortcut hints preserve their existing geometry.

### Goals

- Let touch titles fill the space up to the menu button, independent of concealed diff stats or timestamps.
- Apply the same behavior to project, pinned, and status-grouped workspace rows.
- Preserve desktop hover fades and prevent shortcut hints from shifting titles.

### Non-goals

- Change title typography, menu geometry, or trailing-content preferences.
- Change protocol or daemon behavior.

### QA

- Failing-first browser regression against a real isolated daemon and Git repository: expected title width 304px, received 262.28125px before the fix. After the fix, toggling diff stats or timestamps preserves title width across project, pinned, and status grouping.
- `npx playwright test e2e/browser/sidebar-title-width.spec.ts --project=browser`: both new journeys passed in targeted runs (compact journey; desktop hover/Alt shortcut journey).
- `npx playwright test e2e/browser/sidebar-title-width.spec.ts e2e/browser/sidebar-reorder.spec.ts --project=browser --grep 'desktop|reorder'`: 2 passed. Includes the existing project/workspace/pinned-row reorder journey.
- Android emulator: loaded the changed checkout through the installed dev client and confirmed a previously truncated cached workspace title is fully readable with Diff stats still enabled. Host connectivity prevented a fresh native fixture; native verification covers cached row rendering. The original diagnosis also reproduced the defect in the installed Android app by toggling Diff stats.
- Before/after 390px browser screenshots captured with the same title and Diff stats enabled. The new spec also writes sidebar, desktop-hover, and desktop-shortcut screenshots to its Playwright output directory.
- `npm run typecheck`, `npm run lint`, and `npm run format` passed.
- iOS and Electron wrappers were not exercised. The main regression risk is desktop shortcut/hover spacing, covered in the browser journey.

### Checklist

- [ ] Plugin changes follow the SDK import boundaries (not applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
