### PR TITLE
feat(providers): add Qoder CLI CN to the ACP provider catalog

### DIFF
--- a/packages/app/src/components/provider-icon-name.test.ts
+++ b/packages/app/src/components/provider-icon-name.test.ts
@@ -19,6 +19,10 @@ describe("resolveProviderIconName", () => {
     expect(resolveProviderIconName("amp-acp")).toEqual({ kind: "catalog", id: "amp-acp" });
     expect(resolveProviderIconName("gemini")).toEqual({ kind: "catalog", id: "gemini" });
     expect(resolveProviderIconName("gjc")).toEqual({ kind: "catalog", id: "gjc" });
+    expect(resolveProviderIconName("qoder-cli-cn")).toEqual({
+      kind: "catalog",
+      id: "qoder-cli-cn",
+    });
     expect(resolveProviderIconName("traecli")).toEqual({ kind: "catalog", id: "traecli" });
   });
 

--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -330,6 +330,16 @@ const CATALOG_DATA = [
     command: ["npx", "-y", "@qoder-ai/qodercli@1.1.4", "--acp"],
   },
   {
+    id: "qoder-cli-cn",
+    title: "Qoder CLI CN",
+    description:
+      "China edition of Qoder's agentic coding assistant, with session resume, image input, and MCP support over ACP.",
+    version: "1.1.49",
+    iconId: "qoder",
+    installLink: "https://qoder.com.cn",
+    command: ["npx", "-y", "@qodercn-ai/qoderclicn@1.1.49", "--acp"],
+  },
+  {
     id: "qwen-code",
     title: "Qwen Code",
     description: "Alibaba's Qwen coding assistant",

--- a/packages/app/src/hooks/use-acp-provider-catalog.test.ts
+++ b/packages/app/src/hooks/use-acp-provider-catalog.test.ts
@@ -59,6 +59,15 @@ describe("ACP provider catalog", () => {
     expect(findProvider("minimax-code").iconSvg).toContain("<svg");
   });
 
+  it("offers Qoder CLI CN through its pinned ACP package", () => {
+    expect(findProvider("qoder-cli-cn")).toMatchObject({
+      title: "Qoder CLI CN",
+      version: "1.1.49",
+      command: ["npx", "-y", "@qodercn-ai/qoderclicn@1.1.49", "--acp"],
+    });
+    expect(findProvider("qoder-cli-cn").iconSvg).toContain("<svg");
+  });
+
   it("maps a catalog entry to the daemon provider config patch", () => {
     expect(buildAcpProviderConfigPatch(findProvider("amp-acp"))).toEqual({
       providers: {

--- a/packages/protocol/src/provider-icon-names.ts
+++ b/packages/protocol/src/provider-icon-names.ts
@@ -40,6 +40,7 @@ export const ACP_PROVIDER_ICON_NAMES = [
   "nova",
   "poolside",
   "qoder",
+  "qoder-cli-cn",
   "qwen-code",
   "sigit",
   "stakpak",

--- a/public-docs/supported-providers.md
+++ b/public-docs/supported-providers.md
@@ -54,6 +54,7 @@ Pick any of these from the in-app provider catalog. Each entry is a one-click in
 - [Nova](https://www.compassap.ai/portfolio/nova.html), Compass AI's software engineer.
 - [Poolside](https://docs.poolside.ai/cli/pool), Poolside's coding agent.
 - [Qoder](https://qoder.com), agentic coding assistant.
+- [Qoder CLI CN](https://qoder.com.cn), China edition of Qoder's agentic coding assistant.
 - [Qwen Code](https://qwenlm.github.io/qwen-code-docs/en/users/overview), Alibaba's Qwen coding assistant.
 - [siGit Code](https://github.com/getsigit/sigit), local-first coding agent with optional on-device LLM.
 - [Stakpak](https://stakpak.dev/), Rust-based DevOps agent.


### PR DESCRIPTION
## Problem

[Qoder CLI CN](https://qoder.com.cn) (`qoderclicn`) is the China edition of Qoder's agentic coding assistant. It speaks ACP natively (`qoderclicn --acp`), but Paseo's in-app provider catalog only ships the international edition (`qoder`, `npx @qoder-ai/qodercli … --acp`). Users in mainland China who want Qoder CLI CN under Paseo must hand-author an `agents.providers` entry in `~/.paseo/config.json` today.

This makes it a one-click catalog install like Qoder, Cursor, Gemini, MiniMax Code, Gajae Code and the rest.

## Change

- Adds `qoder-cli-cn` to the built-in ACP catalog with `command: ["npx", "-y", "@qodercn-ai/qoderclicn@1.1.49", "--acp"]` and `version: "1.1.49"`, so `npm run acp:version-drift:update` keeps the pin current like the other npx-distributed entries.
- Reuses the existing Qoder mark via `iconId: "qoder"` (no new SVG asset) and registers `qoder-cli-cn` in `KNOWN_PROVIDER_ICON_NAMES`, which the bidirectional icon test requires for any catalog entry that resolves to an icon.
- Adds catalog/config-patch test coverage and a row in the supported-provider docs.

The generic ACP provider already owns this workflow — no server-side integration is needed.

## Protocol evidence

`initialize` against the exact pinned command (`npx -y @qodercn-ai/qoderclicn@1.1.49 --acp`), protocolVersion 1:

```json
{
  "protocolVersion": 1,
  "authMethods": [
    {
      "id": "qoderclicn-login",
      "name": "Use qoderclicn login",
      "description": "Use your existing qoderclicn login for this agent. If needed, sign in from qoderclicn first."
    }
  ],
  "agentInfo": { "name": "qoder-cli-cn", "title": "Qoder CLI CN", "version": "1.1.49" },
  "agentCapabilities": {
    "_meta": { "qoder": { "promptQueueing": true } },
    "loadSession": true,
    "sessionCapabilities": {
      "additionalDirectories": {},
      "close": {},
      "delete": {},
      "fork": {},
      "list": {},
      "resume": {}
    },
    "promptCapabilities": { "image": true, "embeddedContext": true },
    "mcpCapabilities": { "http": true, "sse": true }
  }
}
```

The advertised `agentInfo.name` is `qoder-cli-cn`, which is why the catalog id matches it. Session resume/fork/list/delete, image and embedded-context prompts, and MCP over http/sse are all covered by the generic ACP client.

## Relationship to the existing `qoder` entry

Same product family, different distribution and account system: the international entry pins `@qoder-ai/qodercli` and qoder.com accounts, this one pins `@qodercn-ai/qoderclicn` (npm scope verified published, latest 1.1.49) and qoder.com.cn accounts with its own `qoderclicn-login` auth method. Login state is reused from the CLI, so users must have run `qoderclicn` login once — the same prerequisite the international entry has for `qoder`.

## QA evidence

```console
$ npx vitest run packages/app/src/components/provider-icon-name.test.ts --bail=1
Test Files  1 passed (1)
Tests       7 passed (7)

$ npx vitest run packages/app/src/hooks/use-acp-provider-catalog.test.ts --bail=1
Test Files  1 passed (1)
Tests       10 passed (10)

$ npm run typecheck
passed (0 errors across all workspaces)

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format
passed

$ npm run acp:version-drift:check -- --no-network
qoder-cli-cn: package @qodercn-ai/qoderclicn, selector 1.1.49, status ok
```

In-app QA against a dev daemon (`npm run dev:server` + `npm run dev:app`), screenshots captured at each step:

1. Settings → Providers, catalog search "Qoder" lists **Qoder CLI CN** with the Qoder mark and an Add button.
2. Add writes `providers["qoder-cli-cn"] = { extends: "acp", label, description, command: ["npx","-y","@qodercn-ai/qoderclicn@1.1.49","--acp"], env: {} }` into the daemon config.
3. The provider row reaches ready state and the model picker lists the 14 models the agent advertises.
4. New workspace with provider Qoder CLI CN: prompt "Reply with exactly this text and nothing else: PASEO-QA-OK" → the agent replies exactly `PASEO-QA-OK` (turn ~3s).
5. Second turn in the same agent ("…PASEO-QA-RESUME") → exact reply again, exercising session continuity through the generic ACP client.
6. The persisted agent record shows `"provider": "qoder-cli-cn"`.
