### PR TITLE
feat(app): reveal file links in the system file manager

### DIFF
--- a/packages/app/src/assistant-file-links/context-menu.tsx
+++ b/packages/app/src/assistant-file-links/context-menu.tsx
@@ -1,0 +1,117 @@
+import { useState, type ReactNode } from "react";
+import type { ViewStyle } from "react-native";
+import { useMutation } from "@tanstack/react-query";
+import * as Clipboard from "expo-clipboard";
+import { Copy, FileText, FolderOpen } from "lucide-react-native";
+import { withUnistyles } from "react-native-unistyles";
+import { useTranslation } from "react-i18next";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { ICON_SIZE, type Theme } from "@/styles/theme";
+import { useStableEvent } from "@/hooks/use-stable-event";
+import { openDesktopTarget, type DesktopOpenTarget } from "@/workspace/desktop-open-targets";
+import { useAssistantFileLinkResolverContext } from "./provider";
+import type { UseFileLinkResult } from "./use-file-link";
+
+const ThemedCopy = withUnistyles(Copy);
+const ThemedFileText = withUnistyles(FileText);
+const ThemedFolderOpen = withUnistyles(FolderOpen);
+const mutedMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+const triggerStyle: ViewStyle = { display: "contents" };
+const copyIcon = <ThemedCopy size={ICON_SIZE.sm} uniProps={mutedMapping} />;
+const fileIcon = <ThemedFileText size={ICON_SIZE.sm} uniProps={mutedMapping} />;
+const folderIcon = <ThemedFolderOpen size={ICON_SIZE.sm} uniProps={mutedMapping} />;
+
+interface AssistantFileLinkContextMenuProps {
+  fileLink: UseFileLinkResult;
+  fileManagerTarget: DesktopOpenTarget;
+  children: ReactNode;
+}
+
+export function AssistantFileLinkContextMenu({
+  fileLink,
+  fileManagerTarget,
+  children,
+}: AssistantFileLinkContextMenuProps) {
+  const { t } = useTranslation();
+  const { configRef } = useAssistantFileLinkResolverContext();
+  const [open, setOpen] = useState(false);
+  const action = useMutation({
+    mutationFn: async (kind: "reveal" | "copy") => {
+      const capturedConfig = configRef.current;
+      const target = await fileLink.resolve();
+      const current = configRef.current;
+      const contextChanged =
+        current.serverId !== capturedConfig.serverId ||
+        current.workspaceRoot !== capturedConfig.workspaceRoot;
+      if (!target || contextChanged) {
+        return;
+      }
+      if (kind === "copy") {
+        await Clipboard.setStringAsync(target.path);
+        current.toast?.copied();
+        return;
+      }
+      await openDesktopTarget({
+        editorId: fileManagerTarget.id,
+        workspacePath: capturedConfig.workspaceRoot ?? target.path,
+        filePath: target.path,
+      });
+    },
+    onSuccess: () => setOpen(false),
+  });
+
+  const handleOpenChange = useStableEvent((nextOpen: boolean) => {
+    if (nextOpen && !action.isPending) {
+      action.reset();
+    }
+    setOpen(nextOpen);
+  });
+  const handleCopy = useStableEvent(() => action.mutate("copy"));
+  const handleReveal = useStableEvent(() => action.mutate("reveal"));
+
+  const revealPending = action.isPending && action.variables === "reveal";
+  const copyPending = action.isPending && action.variables === "copy";
+  const error = action.isError ? action.error.message : undefined;
+
+  return (
+    <ContextMenu open={open} onOpenChange={handleOpenChange}>
+      <ContextMenuTrigger contextOnly style={triggerStyle} onContextMenu={fileLink.onHoverIn}>
+        {children}
+      </ContextMenuTrigger>
+      <ContextMenuContent align="start" width={240} testID="assistant-file-link-context-menu">
+        <ContextMenuItem leading={fileIcon} onSelect={fileLink.onPress} disabled={action.isPending}>
+          {t("workspace.fileActions.openFile")}
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          leading={copyIcon}
+          onSelect={handleCopy}
+          closeOnSelect={false}
+          disabled={action.isPending}
+          status={copyPending ? "pending" : "idle"}
+          description={action.variables === "copy" ? error : undefined}
+          testID="assistant-file-link-copy-path"
+        >
+          {t("workspace.fileActions.copyPath")}
+        </ContextMenuItem>
+        <ContextMenuItem
+          leading={folderIcon}
+          onSelect={handleReveal}
+          closeOnSelect={false}
+          disabled={action.isPending}
+          status={revealPending ? "pending" : "idle"}
+          description={action.variables === "reveal" ? error : undefined}
+          testID="assistant-file-link-reveal"
+        >
+          {t("workspace.fileActions.revealIn", { target: fileManagerTarget.label })}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/packages/app/src/assistant-file-links/link.tsx
+++ b/packages/app/src/assistant-file-links/link.tsx
@@ -11,6 +11,7 @@ import { markdownCopyDataSet } from "@/assistant-selection-copy/markup";
 import { useAssistantFileLinkResolverContext } from "./provider";
 import type { AssistantFileLinkSource } from "./resolver";
 import { useFileLink } from "./use-file-link";
+import { AssistantFileLinkContextMenu } from "./context-menu";
 
 interface AssistantMarkdownLinkProps {
   source: AssistantFileLinkSource;
@@ -30,8 +31,9 @@ export function AssistantMarkdownLink({
   monoSurface,
   children,
 }: AssistantMarkdownLinkProps) {
-  const { target, onHoverIn, onPress } = useFileLink(source);
-  const { configRef } = useAssistantFileLinkResolverContext();
+  const fileLink = useFileLink(source);
+  const { target, onHoverIn, onPress } = fileLink;
+  const { configRef, fileManagerTarget } = useAssistantFileLinkResolverContext();
   const workspaceRoot = configRef.current.workspaceRoot;
   const tooltipPath = useMemo(
     () => (target ? formatInlinePathTargetForTooltip(target, workspaceRoot) : null),
@@ -98,7 +100,15 @@ export function AssistantMarkdownLink({
     </a>
   );
 
-  return <FileLinkHoverTooltip filePath={tooltipPath}>{anchor}</FileLinkHoverTooltip>;
+  const link = <FileLinkHoverTooltip filePath={tooltipPath}>{anchor}</FileLinkHoverTooltip>;
+  if (fileLink.isFile && fileManagerTarget) {
+    return (
+      <AssistantFileLinkContextMenu fileLink={fileLink} fileManagerTarget={fileManagerTarget}>
+        {link}
+      </AssistantFileLinkContextMenu>
+    );
+  }
+  return link;
 }
 
 interface AssistantMarkdownCodeLinkProps {

--- a/packages/app/src/assistant-file-links/parse.test.ts
+++ b/packages/app/src/assistant-file-links/parse.test.ts
@@ -65,6 +65,29 @@ describe("parseInlinePathToken", () => {
 });
 
 describe("parseFileProtocolUrl", () => {
+  it("parses encoded file URLs with colon line suffixes", () => {
+    expect(parseFileProtocolUrl("file:///C:/Downloads/sample%20report.txt:2")).toEqual({
+      raw: "file:///C:/Downloads/sample%20report.txt:2",
+      path: "C:/Downloads/sample report.txt",
+      lineStart: 2,
+      lineEnd: undefined,
+    });
+  });
+
+  it("keeps URL-encoded colons in filenames and gives explicit line fragments precedence", () => {
+    expect(parseFileProtocolUrl("file:///tmp/report%3A2")).toEqual({
+      raw: "file:///tmp/report%3A2",
+      path: "/tmp/report:2",
+      lineStart: undefined,
+      lineEnd: undefined,
+    });
+    expect(parseFileProtocolUrl("file:///tmp/report.txt:2-4#L8")).toEqual({
+      raw: "file:///tmp/report.txt:2-4#L8",
+      path: "/tmp/report.txt",
+      lineStart: 8,
+      lineEnd: undefined,
+    });
+  });
   it("parses file URLs with line fragments", () => {
     expect(parseFileProtocolUrl("file:///Users/test/project/src/app.tsx#L81")).toEqual({
       raw: "file:///Users/test/project/src/app.tsx#L81",
@@ -108,6 +131,20 @@ describe("parseFileProtocolUrl", () => {
 });
 
 describe("classifyAssistantFileLink", () => {
+  it("decodes Windows link paths without retaining line markers", () => {
+    expect(parseAssistantFileLink("C:/Downloads/sample%20report.txt:2")).toEqual({
+      raw: "C:/Downloads/sample%20report.txt:2",
+      path: "C:/Downloads/sample report.txt",
+      lineStart: 2,
+      lineEnd: undefined,
+    });
+    expect(parseAssistantFileLink("C:/Downloads/sample%20report.txt#L2")).toEqual({
+      raw: "C:/Downloads/sample%20report.txt#L2",
+      path: "C:/Downloads/sample report.txt",
+      lineStart: 2,
+      lineEnd: undefined,
+    });
+  });
   it("keeps explicit external URLs out of file parsing", () => {
     expect(
       classifyAssistantFileLink("http://dumm.md", {

--- a/packages/app/src/assistant-file-links/parse.ts
+++ b/packages/app/src/assistant-file-links/parse.ts
@@ -217,7 +217,8 @@ export function parseFileProtocolUrl(value: string): InlinePathTarget | null {
     return null;
   }
 
-  const normalizedPath = normalizeFileUrlPath(parsedUrl.pathname);
+  const inlinePathTarget = parseInlinePathToken(parsedUrl.pathname);
+  const normalizedPath = normalizeFileUrlPath(inlinePathTarget?.path ?? parsedUrl.pathname);
   if (!normalizedPath) {
     return null;
   }
@@ -230,7 +231,8 @@ export function parseFileProtocolUrl(value: string): InlinePathTarget | null {
   return {
     raw: value,
     path: normalizedPath,
-    ...lines,
+    lineStart: lines.lineStart ?? inlinePathTarget?.lineStart,
+    lineEnd: parsedUrl.hash ? lines.lineEnd : inlinePathTarget?.lineEnd,
   };
 }
 
@@ -247,7 +249,7 @@ function parseAssistantInlinePathLink(value: string): InlinePathTarget | null {
 
   return {
     ...inlinePathTarget,
-    path: normalizedPath,
+    path: safeDecodeURIComponent(normalizedPath),
   };
 }
 
@@ -327,7 +329,7 @@ export function parseAssistantFileLink(
 
     return {
       raw: value,
-      path: normalizedPath,
+      path: safeDecodeURIComponent(normalizedPath),
       ...lines,
     };
   }

--- a/packages/app/src/assistant-file-links/provider.tsx
+++ b/packages/app/src/assistant-file-links/provider.tsx
@@ -12,6 +12,8 @@ import type { ToastApi } from "@/components/toast-host";
 import type { OpenFileDisposition } from "@/workspace/file-open";
 import type { InlinePathTarget } from "./parse";
 import type { AssistantFileLinkContext, GetDirectorySuggestions } from "./resolver";
+import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
+import { useDesktopOpenTargets, type DesktopOpenTarget } from "@/workspace/desktop-open-targets";
 
 export interface AssistantFileLinkDaemonClient {
   getDirectorySuggestions: GetDirectorySuggestions;
@@ -32,6 +34,7 @@ export interface AssistantFileLinkResolverProviderProps extends AssistantFileLin
 export interface AssistantFileLinkResolverContextValue {
   configRef: MutableRefObject<AssistantFileLinkResolverConfig>;
   getDirectorySuggestions: GetDirectorySuggestions;
+  fileManagerTarget: DesktopOpenTarget | null;
 }
 
 const AssistantFileLinkResolverContext =
@@ -45,6 +48,9 @@ export function AssistantFileLinkResolverProvider({
   toast,
   children,
 }: AssistantFileLinkResolverProviderProps) {
+  const isLocalDaemon = useIsLocalDaemon(serverId ?? "");
+  const { targets } = useDesktopOpenTargets({ isLocalExecution: isLocalDaemon });
+  const fileManagerTarget = targets.find((target) => target.kind === "file-manager") ?? null;
   const configRef = useRef<AssistantFileLinkResolverConfig>({
     client,
     serverId,
@@ -65,8 +71,8 @@ export function AssistantFileLinkResolverProvider({
   }, []);
 
   const value = useMemo<AssistantFileLinkResolverContextValue>(
-    () => ({ configRef, getDirectorySuggestions }),
-    [getDirectorySuggestions],
+    () => ({ configRef, getDirectorySuggestions, fileManagerTarget }),
+    [getDirectorySuggestions, fileManagerTarget],
   );
 
   return (

--- a/packages/app/src/assistant-file-links/use-file-link.ts
+++ b/packages/app/src/assistant-file-links/use-file-link.ts
@@ -18,6 +18,8 @@ import {
 
 export interface UseFileLinkResult {
   target: InlinePathTarget | null;
+  isFile: boolean;
+  resolve: () => Promise<InlinePathTarget | null>;
   onHoverIn: () => void;
   onPress: () => void;
   open: (source: AssistantFileLinkSource, disposition: OpenFileDisposition) => void;
@@ -127,7 +129,30 @@ export function useFileLink(source: AssistantFileLinkSource): UseFileLinkResult 
     return query.data ?? null;
   }, [query.data, resolution]);
 
-  return useMemo(() => ({ target, onHoverIn, onPress, open }), [target, onHoverIn, onPress, open]);
+  const isFile = resolution.kind === "needsLookup" || resolution.value.kind === "file";
+  const resolve = useStableEvent(async () => {
+    if (resolution.kind === "resolved") {
+      return resolution.value.kind === "file" ? resolution.value.target : null;
+    }
+    return await queryClient.fetchQuery({
+      queryKey,
+      queryFn: () =>
+        fetchDaemonResolution({
+          ambiguousQuery: resolution.ambiguousQuery,
+          token: resolution.token,
+          target: resolution.target,
+          workspaceRoot,
+          getDirectorySuggestions: context.getDirectorySuggestions,
+        }),
+      retry: 0,
+      staleTime: Infinity,
+    });
+  });
+
+  return useMemo(
+    () => ({ target, isFile, resolve, onHoverIn, onPress, open }),
+    [target, isFile, resolve, onHoverIn, onPress, open],
+  );
 }
 
 export function useAssistantFileLinkActions(): AssistantFileLinkActions {

--- a/packages/desktop/e2e/assistant-file-link-reveal.spec.ts
+++ b/packages/desktop/e2e/assistant-file-link-reveal.spec.ts
@@ -1,0 +1,154 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "../../app/e2e/support/fixtures";
+import { openAgentRoute, seedMockAgentWorkspace } from "../../app/e2e/support/helpers/mock-agent";
+import { getServerId } from "../../app/e2e/support/helpers/server-id";
+import { installDesktopRuntime, type DesktopRuntimeConfig } from "./support/runtime";
+
+const editorTargets: DesktopRuntimeConfig["editorTargets"] = [
+  {
+    id: "explorer",
+    label: "Explorer",
+    kind: "file-manager",
+    icon: { kind: "symbol", name: "folder" },
+  },
+];
+
+test("reveals an assistant file link outside the workspace without its line suffix", async ({
+  page,
+  context,
+}) => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "paseo-link-reveal-"));
+  const filePath = path.join(directory, "sample report.txt");
+  const recordPath = path.join(directory, "opens.jsonl");
+  await writeFile(filePath, "First line\nSecond line\n");
+  await writeFile(recordPath, "");
+  await installDesktopRuntime(page, {
+    serverId: getServerId(),
+    editorTargets,
+    editorRecordPath: recordPath,
+  });
+  const href = `${filePath.replace(/\\/g, "/")}:2`;
+  const agent = await seedMockAgentWorkspace({
+    repoPrefix: "assistant-reveal-",
+    title: "Reveal file link",
+    initialPrompt: "Show the report.",
+    featureValues: { mockAssistantResponse: `[Report](<${href}>)` },
+  });
+  try {
+    await openAgentRoute(page, agent);
+    const link = page.getByTestId("assistant-message").locator("a").filter({ hasText: "Report" });
+    await link.click({ button: "right" });
+    const reveal = page.getByTestId("assistant-file-link-reveal");
+    await expect(reveal).toHaveText("Reveal in Explorer");
+    await expect
+      .poll(() =>
+        reveal.evaluate((element) => {
+          let opacity = 1;
+          for (let node: Element | null = element; node; node = node.parentElement) {
+            opacity *= Number(getComputedStyle(node).opacity);
+          }
+          return opacity;
+        }),
+      )
+      .toBe(1);
+    await page.screenshot({ path: test.info().outputPath("file-link-menu.png") });
+    await reveal.click();
+    await expect.poll(async () => (await readFile(recordPath, "utf8")).trim()).not.toBe("");
+    const records = (await readFile(recordPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(records).toEqual([
+      { editorId: "explorer", workspacePath: agent.cwd, filePath: filePath.replace(/\\/g, "/") },
+    ]);
+    await expect(page.getByTestId("assistant-file-link-context-menu")).not.toBeVisible();
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await link.click({ button: "right" });
+    await page.getByTestId("assistant-file-link-copy-path").click();
+    await expect
+      .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe(filePath.replace(/\\/g, "/"));
+  } finally {
+    await agent.cleanup();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("resolves relative and inline-code links, and retries a missing file", async ({ page }) => {
+  const recordPath = test.info().outputPath("opens.jsonl");
+  await writeFile(recordPath, "");
+  await installDesktopRuntime(page, {
+    serverId: getServerId(),
+    editorTargets,
+    editorRecordPath: recordPath,
+  });
+  const agent = await seedMockAgentWorkspace({
+    repoPrefix: "assistant-reveal-relative-",
+    title: "Reveal relative links",
+    repo: { files: [{ path: "docs/report.txt", content: "First line\nSecond line\n" }] },
+    initialPrompt: "Show the file links.",
+    featureValues: {
+      mockAssistantResponse:
+        "[Relative](docs/report.txt#L2)\n\n`report.txt:2`\n\n`missing.txt:2`\n\n[Web](https://example.com/report.txt)",
+    },
+  });
+  try {
+    await openAgentRoute(page, agent);
+    const message = page.getByTestId("assistant-message");
+    const reveal = page.getByTestId("assistant-file-link-reveal");
+    for (const label of ["Relative", "report.txt:2"]) {
+      await message.locator("a").filter({ hasText: label }).click({ button: "right" });
+      await reveal.click();
+      await expect(page.getByTestId("assistant-file-link-context-menu")).not.toBeVisible();
+    }
+    const reportPath = `${agent.cwd.replace(/\\/g, "/")}/docs/report.txt`;
+    const expectedOpen = { editorId: "explorer", workspacePath: agent.cwd, filePath: reportPath };
+    expect(
+      (await readFile(recordPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([expectedOpen, expectedOpen]);
+
+    await message.locator("a").filter({ hasText: "missing.txt:2" }).click({ button: "right" });
+    await reveal.click();
+    await expect(reveal).toContainText("No file found for missing.txt:2");
+    await expect(reveal).toBeEnabled();
+    await writeFile(path.join(agent.cwd, "docs", "missing.txt"), "Now available\n");
+    await reveal.click();
+    await expect(page.getByTestId("assistant-file-link-context-menu")).not.toBeVisible();
+    const records = (await readFile(recordPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(records).toEqual([
+      expectedOpen,
+      expectedOpen,
+      { ...expectedOpen, filePath: `${agent.cwd.replace(/\\/g, "/")}/docs/missing.txt` },
+    ]);
+
+    await message.locator("a").filter({ hasText: "Web" }).click({ button: "right" });
+    await expect(page.getByTestId("assistant-file-link-context-menu")).not.toBeVisible();
+  } finally {
+    await agent.cleanup();
+  }
+});
+
+test("does not offer a local file manager for a remote host", async ({ page }) => {
+  await installDesktopRuntime(page, { serverId: "another-desktop-host", editorTargets });
+  const agent = await seedMockAgentWorkspace({
+    repoPrefix: "assistant-reveal-remote-",
+    title: "Remote file link",
+    initialPrompt: "Show a file link.",
+    featureValues: { mockAssistantResponse: "[Remote file](docs/report.txt)" },
+  });
+  try {
+    await openAgentRoute(page, agent);
+    await page.getByTestId("assistant-message").locator("a").click({ button: "right" });
+    await expect(page.getByTestId("assistant-file-link-context-menu")).not.toBeVisible();
+  } finally {
+    await agent.cleanup();
+  }
+});


### PR DESCRIPTION
﻿Assistant file links currently have no action for locating the file in the system file manager. For example, after an agent generates a report or video, users have to copy its path and find the containing directory themselves.

This adds a file-link context menu with **Open file**, **Copy path**, and **Reveal in Explorer / Finder / Files**, using the existing desktop file-manager target. The menu is available for the local desktop host; HTTPS links, remote hosts, and native mobile link rendering retain their current behavior. Relative and inline-code links use the existing daemon resolver, with pending state and a visible, retryable lookup error.

The end-to-end test also exposed line suffixes being retained in file URLs. The parser now strips those markers before revealing the file and decodes encoded Windows filenames, while preserving encoded literal colons.

### Verification

- Regression reproduced before implementation: the reveal menu item was absent.
- 3 Playwright tests passed against an isolated real daemon: outside-workspace paths with spaces and line suffixes, copying paths, relative/inline-code resolution, missing-file retry, external links, and remote-host exclusion.
- 40 parser tests and 6 existing resolver-hook tests passed.
- Full workspace typecheck, changed-file lint, and formatting checks passed.
- Windows 11 + Electron 44.2.0 native smoke: the production file-manager target opened Explorer in the expected directory and selected the file, confirmed through Windows Shell COM.
- macOS, Linux, iOS, and Android were not exercised. Desktop renderer tests record IPC calls through the existing test adapter; the real Explorer smoke was separate.

[Commands, output, platform coverage, and native verification](https://github.com/iikawa0918/paseo/blob/qa/file-link-reveal/README.md) · [Interaction recording](https://github.com/iikawa0918/paseo/blob/qa/file-link-reveal/file-link-menu.webm)

![File link context menu](https://raw.githubusercontent.com/iikawa0918/paseo/qa/file-link-reveal/file-link-menu.png)
