### PR TITLE
fix(app): keep the attention reveal from erasing the workspace's saved tab

### DIFF
--- a/packages/app/src/panels/use-add-file-to-chat.ts
+++ b/packages/app/src/panels/use-add-file-to-chat.ts
@@ -2,19 +2,22 @@ import { useCallback, useMemo } from "react";
 import { createWorkspaceFileAttachment } from "@/attachments/workspace-file";
 import { resolveFocusedChatTarget } from "@/composer/focused-chat-target";
 import { useDraftStore } from "@/stores/draft-store";
-import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
+import {
+  useEffectiveWorkspaceLayout,
+  useWorkspaceLayoutStore,
+} from "@/stores/workspace-layout-store";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 
 export function useAddFileToChat(input: { serverId: string; workspaceId?: string | null }) {
   const workspaceKey = input.workspaceId
     ? buildWorkspaceTabPersistenceKey({ serverId: input.serverId, workspaceId: input.workspaceId })
     : null;
-  const layout = useWorkspaceLayoutStore((state) =>
-    workspaceKey ? state.layoutByWorkspace[workspaceKey] : undefined,
-  );
+  // The effective layout, not the persisted one: during an attention reveal the
+  // chat on screen is the revealed agent's, and "add to chat" must target it.
+  const layout = useEffectiveWorkspaceLayout(workspaceKey);
   const focusTab = useWorkspaceLayoutStore((state) => state.focusTab);
   const focusedChat = useMemo(
-    () => resolveFocusedChatTarget({ serverId: input.serverId, layout }),
+    () => resolveFocusedChatTarget({ serverId: input.serverId, layout: layout ?? undefined }),
     [input.serverId, layout],
   );
   const addFile = useCallback(

--- a/packages/app/src/plugins/command-center/registration.tsx
+++ b/packages/app/src/plugins/command-center/registration.tsx
@@ -6,7 +6,7 @@ import { useHostRuntimeClient } from "@/runtime/host-runtime";
 import { useActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
 import { useSessionStore } from "@/stores/session-store";
 import { useWorkspaceExists } from "@/stores/session-store-hooks";
-import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
+import { useEffectiveWorkspaceLayout } from "@/stores/workspace-layout-store";
 import { normalizeWorkspaceOpaqueId } from "@/utils/workspace-identity";
 import { createPluginClientStateSource } from "../client-state/source";
 import { hostIdFromPathname } from "../routes";
@@ -23,9 +23,9 @@ export function PluginCommandCenterActions() {
   const workspaceId = selection?.workspaceId ?? null;
   const workspaceExists = useWorkspaceExists(serverId, workspaceId);
   const workspaceKey = serverId && workspaceId ? `${serverId}:${workspaceId}` : null;
-  const layout = useWorkspaceLayoutStore((state) =>
-    workspaceKey ? (state.layoutByWorkspace[workspaceKey] ?? null) : null,
-  );
+  // The effective layout, not the persisted one: during an attention reveal the
+  // agent on screen is the revealed one, and plugin context must agree with it.
+  const layout = useEffectiveWorkspaceLayout(workspaceKey);
   const focusedAgentId = getFocusedAgentId(layout);
   const agentExists = useSessionStore((state) => {
     if (!serverId || !focusedAgentId) return null;

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -66,6 +66,7 @@ import {
   collectAllTabs,
   DEFAULT_PANE_ID,
   findPaneById,
+  focusWorkspaceTabEphemerally,
   getFocusedBrowserId,
   FOCUSED_PANE_PLACEMENT,
   selectExplorerSidebarPaneId,
@@ -1810,9 +1811,44 @@ function WorkspaceScreenContent({
     return () => handler.remove();
   }, [isExplorerSidebarShowing, isMobile, isRouteFocused, showMobileAgent]);
 
-  const workspaceLayout = useWorkspaceLayoutStore((state) =>
+  const persistedWorkspaceLayout = useWorkspaceLayoutStore((state) =>
     persistenceKey ? (state.layoutByWorkspace[persistenceKey] ?? null) : null,
   );
+  const ephemeralFocusTarget = useWorkspaceLayoutStore((state) =>
+    persistenceKey ? (state.ephemeralFocusTargetByWorkspace[persistenceKey] ?? null) : null,
+  );
+  const clearEphemeralWorkspaceFocus = useWorkspaceLayoutStore(
+    (state) => state.clearEphemeralFocusTab,
+  );
+  // The attention reveal must not overwrite the focus the user left behind:
+  // apply it to an in-memory copy so the persisted layout still restores their
+  // tab when they come back without interacting with the revealed agent.
+  const workspaceLayout = useMemo(
+    () =>
+      persistedWorkspaceLayout && ephemeralFocusTarget
+        ? focusWorkspaceTabEphemerally({
+            layout: persistedWorkspaceLayout,
+            target: ephemeralFocusTarget,
+          })
+        : persistedWorkspaceLayout,
+    [ephemeralFocusTarget, persistedWorkspaceLayout],
+  );
+  // The reveal lasts one visit: it ends when the user leaves the workspace (or
+  // the screen goes away entirely), not when the retained deck entry unmounts.
+  const wasRouteFocusedRef = useRef(isRouteFocused);
+  useEffect(() => {
+    if (wasRouteFocusedRef.current && !isRouteFocused && persistenceKey) {
+      clearEphemeralWorkspaceFocus(persistenceKey);
+    }
+    wasRouteFocusedRef.current = isRouteFocused;
+  }, [clearEphemeralWorkspaceFocus, isRouteFocused, persistenceKey]);
+  useEffect(() => {
+    return () => {
+      if (persistenceKey) {
+        clearEphemeralWorkspaceFocus(persistenceKey);
+      }
+    };
+  }, [clearEphemeralWorkspaceFocus, persistenceKey]);
   const unfocusedPaneId = useWorkspaceLayoutStore((state) =>
     persistenceKey ? state.focusRestorationByWorkspace[persistenceKey]?.restorePaneId : undefined,
   );

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -66,10 +66,10 @@ import {
   collectAllTabs,
   DEFAULT_PANE_ID,
   findPaneById,
-  focusWorkspaceTabEphemerally,
   getFocusedBrowserId,
   FOCUSED_PANE_PLACEMENT,
   selectExplorerSidebarPaneId,
+  useEffectiveWorkspaceLayout,
   type WorkspaceLayout,
   type WorkspaceTabPlacement,
   useWorkspaceLayoutStore,
@@ -1811,27 +1811,12 @@ function WorkspaceScreenContent({
     return () => handler.remove();
   }, [isExplorerSidebarShowing, isMobile, isRouteFocused, showMobileAgent]);
 
-  const persistedWorkspaceLayout = useWorkspaceLayoutStore((state) =>
-    persistenceKey ? (state.layoutByWorkspace[persistenceKey] ?? null) : null,
-  );
-  const ephemeralFocusTarget = useWorkspaceLayoutStore((state) =>
-    persistenceKey ? (state.ephemeralFocusTargetByWorkspace[persistenceKey] ?? null) : null,
-  );
+  // The layout the user is looking at: persisted focus with the ephemeral
+  // attention reveal applied, so what renders always agrees with what
+  // focus-derived consumers (add-to-chat, plugin context) resolve.
+  const workspaceLayout = useEffectiveWorkspaceLayout(persistenceKey);
   const clearEphemeralWorkspaceFocus = useWorkspaceLayoutStore(
     (state) => state.clearEphemeralFocusTab,
-  );
-  // The attention reveal must not overwrite the focus the user left behind:
-  // apply it to an in-memory copy so the persisted layout still restores their
-  // tab when they come back without interacting with the revealed agent.
-  const workspaceLayout = useMemo(
-    () =>
-      persistedWorkspaceLayout && ephemeralFocusTarget
-        ? focusWorkspaceTabEphemerally({
-            layout: persistedWorkspaceLayout,
-            target: ephemeralFocusTarget,
-          })
-        : persistedWorkspaceLayout,
-    [ephemeralFocusTarget, persistedWorkspaceLayout],
   );
   // The reveal lasts one visit: it ends when the user leaves the workspace (or
   // the screen goes away entirely), not when the retained deck entry unmounts.

--- a/packages/app/src/stores/navigation-active-workspace-store/index.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/index.ts
@@ -39,6 +39,8 @@ function navigateDeps(): NavigateToWorkspaceDeps {
       useSessionStore.getState().sessions[serverId]?.agents.values() ?? [],
     isWorkspaceLayoutHydrated: () => useWorkspaceLayoutStore.persist.hasHydrated(),
     openTab: (input) => useWorkspaceLayoutStore.getState().openTab(input),
+    revealEphemeralTab: (input) =>
+      useWorkspaceLayoutStore.getState().revealEphemeralTab(input.workspaceKey, input.target),
     rememberLastWorkspace: (selection) => lastWorkspaceSelectionStore.remember(selection),
     navigateToRoute: (route) => {
       navigateToHostWorkspaceRoute(route);

--- a/packages/app/src/stores/navigation-active-workspace-store/index.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/index.ts
@@ -48,6 +48,12 @@ function navigateDeps(): NavigateToWorkspaceDeps {
     openTab: (input) => useWorkspaceLayoutStore.getState().openTab(input),
     revealEphemeralTab: (input) =>
       useWorkspaceLayoutStore.getState().revealEphemeralTab(input.workspaceKey, input.target),
+    holdEphemeralTab: (input) =>
+      useWorkspaceLayoutStore.getState().holdEphemeralFocusTab(input.workspaceKey, input.target),
+    settleHeldEphemeralTab: (input) =>
+      useWorkspaceLayoutStore
+        .getState()
+        .settleHeldEphemeralFocusTab(input.workspaceKey, input.target, input.reveal),
     getLastWorkspaceSelection: () => lastWorkspaceSelectionStore.getSelection(),
     rememberLastWorkspace: (selection) => lastWorkspaceSelectionStore.remember(selection),
     navigateToRoute: (route) => {

--- a/packages/app/src/stores/navigation-active-workspace-store/index.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/index.ts
@@ -38,6 +38,13 @@ function navigateDeps(): NavigateToWorkspaceDeps {
     getSessionAgents: (serverId) =>
       useSessionStore.getState().sessions[serverId]?.agents.values() ?? [],
     isWorkspaceLayoutHydrated: () => useWorkspaceLayoutStore.persist.hasHydrated(),
+    onWorkspaceLayoutHydrated: (callback) => {
+      if (useWorkspaceLayoutStore.persist.hasHydrated()) {
+        callback();
+        return;
+      }
+      useWorkspaceLayoutStore.persist.onFinishHydration(callback);
+    },
     openTab: (input) => useWorkspaceLayoutStore.getState().openTab(input),
     revealEphemeralTab: (input) =>
       useWorkspaceLayoutStore.getState().revealEphemeralTab(input.workspaceKey, input.target),

--- a/packages/app/src/stores/navigation-active-workspace-store/index.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/index.ts
@@ -48,6 +48,7 @@ function navigateDeps(): NavigateToWorkspaceDeps {
     openTab: (input) => useWorkspaceLayoutStore.getState().openTab(input),
     revealEphemeralTab: (input) =>
       useWorkspaceLayoutStore.getState().revealEphemeralTab(input.workspaceKey, input.target),
+    getLastWorkspaceSelection: () => lastWorkspaceSelectionStore.getSelection(),
     rememberLastWorkspace: (selection) => lastWorkspaceSelectionStore.remember(selection),
     navigateToRoute: (route) => {
       navigateToHostWorkspaceRoute(route);
@@ -73,10 +74,7 @@ export function navigateToWorkspace(input: NavigateToWorkspaceInput): string {
 }
 
 export function navigateToLastWorkspace(): boolean {
-  return navigateToLastWorkspacePure({
-    ...navigateDeps(),
-    getLastWorkspaceSelection: () => lastWorkspaceSelectionStore.getSelection(),
-  });
+  return navigateToLastWorkspacePure(navigateDeps());
 }
 
 export function useActiveWorkspaceSelection(): ActiveWorkspaceSelection | null {

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
@@ -28,6 +28,7 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
   const openedTabs: RecordedTab[] = [];
   const ephemeralReveals: RecordedEphemeralReveal[] = [];
   const deferredUntilHydrated: Array<() => void> = [];
+  let lastSelection: ActiveWorkspaceSelection | null = null;
   const deps: NavigateToWorkspaceDeps = {
     getSessionWorkspaces: () => null,
     getSessionAgents: () => [] as Agent[],
@@ -40,7 +41,12 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
     revealEphemeralTab: ({ workspaceKey, target }) => {
       ephemeralReveals.push({ workspaceKey, target });
     },
-    rememberLastWorkspace: (selection) => remembered.push(selection),
+    // Mirrors the real store: every navigation updates the current selection.
+    getLastWorkspaceSelection: () => lastSelection,
+    rememberLastWorkspace: (selection) => {
+      lastSelection = selection;
+      remembered.push(selection);
+    },
     navigateToRoute: (route) => navigations.push(route),
     ...overrides,
   };
@@ -248,6 +254,65 @@ describe("workspace navigation", () => {
       },
     ]);
     expect(openedTabs).toEqual([]);
+  });
+
+  it("drops a deferred attention reveal when the user has moved on", () => {
+    const workspace = {
+      id: "workspace-a",
+      workspaceDirectory: "/repo/workspace-a",
+    } as WorkspaceDescriptor;
+    const agent = {
+      id: "agent-1",
+      cwd: "/repo/workspace-a",
+      workspaceId: "workspace-a",
+      requiresAttention: true,
+      attentionReason: "permission",
+    } as unknown as Agent;
+    const { deps, ephemeralReveals, deferredUntilHydrated } = createFakeDeps({
+      getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
+      getSessionAgents: () => [agent],
+      isWorkspaceLayoutHydrated: () => false,
+    });
+
+    navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-a" }, deps);
+    // The user leaves for another workspace before hydration finishes; the
+    // screen they left has nothing to clear yet, so the guard is the only
+    // thing standing between the deferred reveal and a stale ambush.
+    navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-b" }, deps);
+
+    deferredUntilHydrated[0]?.();
+
+    expect(ephemeralReveals).toEqual([]);
+  });
+
+  it("applies a deferred attention reveal when its workspace is still current", () => {
+    const workspace = {
+      id: "workspace-a",
+      workspaceDirectory: "/repo/workspace-a",
+    } as WorkspaceDescriptor;
+    const agent = {
+      id: "agent-1",
+      cwd: "/repo/workspace-a",
+      workspaceId: "workspace-a",
+      requiresAttention: true,
+      attentionReason: "permission",
+    } as unknown as Agent;
+    const { deps, ephemeralReveals, deferredUntilHydrated } = createFakeDeps({
+      getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
+      getSessionAgents: () => [agent],
+      isWorkspaceLayoutHydrated: () => false,
+    });
+
+    navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-a" }, deps);
+
+    deferredUntilHydrated[0]?.();
+
+    expect(ephemeralReveals).toEqual([
+      {
+        workspaceKey: "server-1:workspace-a",
+        target: { kind: "agent", agentId: "agent-1" },
+      },
+    ]);
   });
 
   it("reads the active workspace from the current route", () => {

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ActiveWorkspaceSelection } from "@/stores/last-workspace-selection";
 import type { WorkspaceTabTarget } from "@/workspace-tabs/model";
+import { workspaceTabTargetsEqual } from "@/workspace-tabs/identity";
 import { parseHostWorkspaceRouteFromPathname } from "@/utils/host-routes";
 import {
   navigateToLastWorkspace,
@@ -28,6 +29,10 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
   const openedTabs: RecordedTab[] = [];
   const ephemeralReveals: RecordedEphemeralReveal[] = [];
   const deferredUntilHydrated: Array<() => void> = [];
+  // Mirrors the layout store's memory-only reveal entries: a hold records the
+  // target, the workspace screen deletes it when the user leaves, and settling
+  // acts only on a target that is still held.
+  const heldReveals = new Map<string, WorkspaceTabTarget>();
   let lastSelection: ActiveWorkspaceSelection | null = null;
   const deps: NavigateToWorkspaceDeps = {
     getSessionWorkspaces: () => null,
@@ -41,6 +46,20 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
     revealEphemeralTab: ({ workspaceKey, target }) => {
       ephemeralReveals.push({ workspaceKey, target });
     },
+    holdEphemeralTab: ({ workspaceKey, target }) => {
+      heldReveals.set(workspaceKey, target);
+    },
+    settleHeldEphemeralTab: ({ workspaceKey, target, reveal }) => {
+      const held = heldReveals.get(workspaceKey);
+      if (!held || !workspaceTabTargetsEqual(held, target)) {
+        return;
+      }
+      if (reveal) {
+        ephemeralReveals.push({ workspaceKey, target });
+      } else {
+        heldReveals.delete(workspaceKey);
+      }
+    },
     // Mirrors the real store: every navigation updates the current selection.
     getLastWorkspaceSelection: () => lastSelection,
     rememberLastWorkspace: (selection) => {
@@ -50,7 +69,15 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
     navigateToRoute: (route) => navigations.push(route),
     ...overrides,
   };
-  return { deps, navigations, remembered, openedTabs, ephemeralReveals, deferredUntilHydrated };
+  return {
+    deps,
+    navigations,
+    remembered,
+    openedTabs,
+    ephemeralReveals,
+    deferredUntilHydrated,
+    heldReveals,
+  };
 }
 
 function createLastSelectionDeps(
@@ -232,11 +259,12 @@ describe("workspace navigation", () => {
       requiresAttention: true,
       attentionReason: "permission",
     } as unknown as Agent;
-    const { deps, openedTabs, ephemeralReveals, deferredUntilHydrated } = createFakeDeps({
-      getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
-      getSessionAgents: () => [agent],
-      isWorkspaceLayoutHydrated: () => false,
-    });
+    const { deps, openedTabs, ephemeralReveals, deferredUntilHydrated, heldReveals } =
+      createFakeDeps({
+        getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
+        getSessionAgents: () => [agent],
+        isWorkspaceLayoutHydrated: () => false,
+      });
 
     navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-a" }, deps);
 
@@ -244,6 +272,7 @@ describe("workspace navigation", () => {
     // the saved focus with nothing retrying the reveal, while an agent still
     // needs attention.
     expect(ephemeralReveals).toEqual([]);
+    expect(heldReveals.get("server-1:workspace-a")).toEqual({ kind: "agent", agentId: "agent-1" });
     expect(deferredUntilHydrated).toHaveLength(1);
 
     deferredUntilHydrated[0]?.();
@@ -268,17 +297,46 @@ describe("workspace navigation", () => {
       requiresAttention: true,
       attentionReason: "permission",
     } as unknown as Agent;
-    const { deps, ephemeralReveals, deferredUntilHydrated } = createFakeDeps({
+    const { deps, ephemeralReveals, deferredUntilHydrated, heldReveals } = createFakeDeps({
       getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
       getSessionAgents: () => [agent],
       isWorkspaceLayoutHydrated: () => false,
     });
 
     navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-a" }, deps);
-    // The user leaves for another workspace before hydration finishes; the
-    // screen they left has nothing to clear yet, so the guard is the only
-    // thing standing between the deferred reveal and a stale ambush.
+    // The user moves on to another workspace before hydration finishes and
+    // before the screen they left mounted to clear the held reveal, so the
+    // selection check is what drops it.
     navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-b" }, deps);
+
+    deferredUntilHydrated[0]?.();
+
+    expect(ephemeralReveals).toEqual([]);
+    expect(heldReveals.has("server-1:workspace-a")).toBe(false);
+  });
+
+  it("drops a deferred attention reveal whose visit ended on an app-wide route", () => {
+    const workspace = {
+      id: "workspace-a",
+      workspaceDirectory: "/repo/workspace-a",
+    } as WorkspaceDescriptor;
+    const agent = {
+      id: "agent-1",
+      cwd: "/repo/workspace-a",
+      workspaceId: "workspace-a",
+      requiresAttention: true,
+      attentionReason: "permission",
+    } as unknown as Agent;
+    const { deps, ephemeralReveals, deferredUntilHydrated, heldReveals } = createFakeDeps({
+      getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
+      getSessionAgents: () => [agent],
+      isWorkspaceLayoutHydrated: () => false,
+    });
+
+    navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-a" }, deps);
+    // Leaving for settings keeps the remembered selection on workspace-a, but
+    // the workspace screen clears the held reveal as the user leaves.
+    heldReveals.delete("server-1:workspace-a");
 
     deferredUntilHydrated[0]?.();
 

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
@@ -17,10 +17,16 @@ interface RecordedTab {
   pin: boolean;
 }
 
+interface RecordedEphemeralReveal {
+  workspaceKey: string;
+  target: WorkspaceTabTarget;
+}
+
 function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
   const navigations: string[] = [];
   const remembered: ActiveWorkspaceSelection[] = [];
   const openedTabs: RecordedTab[] = [];
+  const ephemeralReveals: RecordedEphemeralReveal[] = [];
   const deps: NavigateToWorkspaceDeps = {
     getSessionWorkspaces: () => null,
     getSessionAgents: () => [] as Agent[],
@@ -29,11 +35,14 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
       openedTabs.push({ workspaceKey, target, pin });
       return target.kind === "agent" ? target.agentId : null;
     },
+    revealEphemeralTab: ({ workspaceKey, target }) => {
+      ephemeralReveals.push({ workspaceKey, target });
+    },
     rememberLastWorkspace: (selection) => remembered.push(selection),
     navigateToRoute: (route) => navigations.push(route),
     ...overrides,
   };
-  return { deps, navigations, remembered, openedTabs };
+  return { deps, navigations, remembered, openedTabs, ephemeralReveals };
 }
 
 function createLastSelectionDeps(
@@ -75,7 +84,7 @@ describe("workspace navigation", () => {
     expect(remembered).toEqual([{ serverId: "server-1", workspaceId: "workspace-a" }]);
   });
 
-  it("focuses the attention agent's tab when a workspace has one", () => {
+  it("reveals the attention agent's tab without persisting a focus change", () => {
     const workspace = {
       id: "workspace-a",
       workspaceDirectory: "/repo/workspace-a",
@@ -87,20 +96,20 @@ describe("workspace navigation", () => {
       requiresAttention: true,
       attentionReason: "permission",
     } as unknown as Agent;
-    const { deps, openedTabs } = createFakeDeps({
+    const { deps, openedTabs, ephemeralReveals } = createFakeDeps({
       getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
       getSessionAgents: () => [agent],
     });
 
     navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-a" }, deps);
 
-    expect(openedTabs).toEqual([
+    expect(ephemeralReveals).toEqual([
       {
         workspaceKey: "server-1:workspace-a",
         target: { kind: "agent", agentId: "agent-1" },
-        pin: false,
       },
     ]);
+    expect(openedTabs).toEqual([]);
   });
 
   it("keeps an explicit tab authoritative over an attention agent", () => {
@@ -115,7 +124,7 @@ describe("workspace navigation", () => {
       requiresAttention: true,
       attentionReason: "permission",
     } as unknown as Agent;
-    const { deps, openedTabs } = createFakeDeps({
+    const { deps, openedTabs, ephemeralReveals } = createFakeDeps({
       getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
       getSessionAgents: () => [agent],
     });
@@ -136,6 +145,7 @@ describe("workspace navigation", () => {
         pin: false,
       },
     ]);
+    expect(ephemeralReveals).toEqual([]);
   });
 
   it("defers an agent tab until a missing workspace is recovered", () => {

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
@@ -27,10 +27,12 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
   const remembered: ActiveWorkspaceSelection[] = [];
   const openedTabs: RecordedTab[] = [];
   const ephemeralReveals: RecordedEphemeralReveal[] = [];
+  const deferredUntilHydrated: Array<() => void> = [];
   const deps: NavigateToWorkspaceDeps = {
     getSessionWorkspaces: () => null,
     getSessionAgents: () => [] as Agent[],
     isWorkspaceLayoutHydrated: () => true,
+    onWorkspaceLayoutHydrated: (callback) => deferredUntilHydrated.push(callback),
     openTab: ({ workspaceKey, target, pin = false }) => {
       openedTabs.push({ workspaceKey, target, pin });
       return target.kind === "agent" ? target.agentId : null;
@@ -42,7 +44,7 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
     navigateToRoute: (route) => navigations.push(route),
     ...overrides,
   };
-  return { deps, navigations, remembered, openedTabs, ephemeralReveals };
+  return { deps, navigations, remembered, openedTabs, ephemeralReveals, deferredUntilHydrated };
 }
 
 function createLastSelectionDeps(
@@ -212,7 +214,7 @@ describe("workspace navigation", () => {
     expect(openedTabs).toEqual([]);
   });
 
-  it("skips the attention reveal until the persisted workspace layout has hydrated", () => {
+  it("defers the attention reveal until the persisted workspace layout has hydrated", () => {
     const workspace = {
       id: "workspace-a",
       workspaceDirectory: "/repo/workspace-a",
@@ -224,7 +226,7 @@ describe("workspace navigation", () => {
       requiresAttention: true,
       attentionReason: "permission",
     } as unknown as Agent;
-    const { deps, openedTabs, ephemeralReveals } = createFakeDeps({
+    const { deps, openedTabs, ephemeralReveals, deferredUntilHydrated } = createFakeDeps({
       getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
       getSessionAgents: () => [agent],
       isWorkspaceLayoutHydrated: () => false,
@@ -232,7 +234,19 @@ describe("workspace navigation", () => {
 
     navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-a" }, deps);
 
+    // Deferred, not dropped: hydration would otherwise reconcile the tabs onto
+    // the saved focus with nothing retrying the reveal, while an agent still
+    // needs attention.
     expect(ephemeralReveals).toEqual([]);
+    expect(deferredUntilHydrated).toHaveLength(1);
+
+    deferredUntilHydrated[0]?.();
+    expect(ephemeralReveals).toEqual([
+      {
+        workspaceKey: "server-1:workspace-a",
+        target: { kind: "agent", agentId: "agent-1" },
+      },
+    ]);
     expect(openedTabs).toEqual([]);
   });
 

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
@@ -190,6 +190,52 @@ describe("workspace navigation", () => {
     expect(navigations).toEqual(["/h/server-1/workspace/workspace-a?open=agent%3Aagent-1"]);
   });
 
+  it("records no reveal when no agent needs attention", () => {
+    const workspace = {
+      id: "workspace-a",
+      workspaceDirectory: "/repo/workspace-a",
+    } as WorkspaceDescriptor;
+    const agent = {
+      id: "agent-1",
+      cwd: "/repo/workspace-a",
+      workspaceId: "workspace-a",
+      requiresAttention: false,
+    } as unknown as Agent;
+    const { deps, openedTabs, ephemeralReveals } = createFakeDeps({
+      getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
+      getSessionAgents: () => [agent],
+    });
+
+    navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-a" }, deps);
+
+    expect(ephemeralReveals).toEqual([]);
+    expect(openedTabs).toEqual([]);
+  });
+
+  it("skips the attention reveal until the persisted workspace layout has hydrated", () => {
+    const workspace = {
+      id: "workspace-a",
+      workspaceDirectory: "/repo/workspace-a",
+    } as WorkspaceDescriptor;
+    const agent = {
+      id: "agent-1",
+      cwd: "/repo/workspace-a",
+      workspaceId: "workspace-a",
+      requiresAttention: true,
+      attentionReason: "permission",
+    } as unknown as Agent;
+    const { deps, openedTabs, ephemeralReveals } = createFakeDeps({
+      getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
+      getSessionAgents: () => [agent],
+      isWorkspaceLayoutHydrated: () => false,
+    });
+
+    navigateToWorkspace({ serverId: "server-1", workspaceId: "workspace-a" }, deps);
+
+    expect(ephemeralReveals).toEqual([]);
+    expect(openedTabs).toEqual([]);
+  });
+
   it("reads the active workspace from the current route", () => {
     const selection = parseActiveWorkspaceSelection({
       pathname: "/h/server-1/workspace/workspace-a",

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
@@ -42,13 +42,13 @@ export interface NavigateToWorkspaceDeps extends PrepareWorkspaceTabDeps {
   onWorkspaceLayoutHydrated: (callback: () => void) => void;
   /** Reveals a tab for the current visit without persisting the focus change. */
   revealEphemeralTab: (input: { workspaceKey: string; target: WorkspaceTabTarget }) => void;
+  /** The workspace the user is on right now; every navigation and route change updates it. */
+  getLastWorkspaceSelection: () => ActiveWorkspaceSelection | null;
   rememberLastWorkspace: (selection: ActiveWorkspaceSelection) => void;
   navigateToRoute: (route: string) => void;
 }
 
-export interface NavigateToLastWorkspaceDeps extends NavigateToWorkspaceDeps {
-  getLastWorkspaceSelection: () => ActiveWorkspaceSelection | null;
-}
+export interface NavigateToLastWorkspaceDeps extends NavigateToWorkspaceDeps {}
 
 function getParamValue(value: string | string[] | undefined): string {
   if (typeof value === "string") {
@@ -138,7 +138,20 @@ export function navigateToWorkspace(
       if (deps.isWorkspaceLayoutHydrated()) {
         deps.revealEphemeralTab(reveal);
       } else {
-        deps.onWorkspaceLayoutHydrated(() => deps.revealEphemeralTab(reveal));
+        const selection = { serverId: input.serverId, workspaceId: input.workspaceId };
+        deps.onWorkspaceLayoutHydrated(() => {
+          // Hydration can finish after the user has moved on to another
+          // workspace; a reveal installed then would ambush their next visit.
+          // The remembered selection tracks every navigation and route change,
+          // so only a reveal whose workspace is still current may land.
+          const current = deps.getLastWorkspaceSelection();
+          if (
+            current?.serverId === selection.serverId &&
+            current?.workspaceId === selection.workspaceId
+          ) {
+            deps.revealEphemeralTab(reveal);
+          }
+        });
       }
     }
   }

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
@@ -35,6 +35,8 @@ export interface NavigateToWorkspaceDeps extends PrepareWorkspaceTabDeps {
   getSessionWorkspaces: (serverId: string) => Map<string, WorkspaceDescriptor> | null | undefined;
   getSessionAgents: (serverId: string) => Iterable<Agent>;
   isWorkspaceLayoutHydrated: () => boolean;
+  /** Reveals a tab for the current visit without persisting the focus change. */
+  revealEphemeralTab: (input: { workspaceKey: string; target: WorkspaceTabTarget }) => void;
   rememberLastWorkspace: (selection: ActiveWorkspaceSelection) => void;
   navigateToRoute: (route: string) => void;
 }
@@ -106,10 +108,12 @@ export function navigateToWorkspace(
       : [];
     const attentionAgentId = pickAttentionAgent(workspaceAgents);
     if (attentionAgentId && resolvedWorkspaceId) {
-      deps.openTab({
+      // Ephemeral, not a persisted reveal: the layout keeps the focus the user
+      // left behind, so returning to the workspace restores their tab once the
+      // attention flag clears or they move focus themselves.
+      deps.revealEphemeralTab({
         workspaceKey: `${input.serverId}:${resolvedWorkspaceId}`,
         target: { kind: "agent", agentId: attentionAgentId },
-        intent: "reveal",
       });
     }
   }

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
@@ -35,6 +35,11 @@ export interface NavigateToWorkspaceDeps extends PrepareWorkspaceTabDeps {
   getSessionWorkspaces: (serverId: string) => Map<string, WorkspaceDescriptor> | null | undefined;
   getSessionAgents: (serverId: string) => Iterable<Agent>;
   isWorkspaceLayoutHydrated: () => boolean;
+  /**
+   * Runs a callback once the persisted workspace layout has hydrated (immediately when it
+   * already has). Navigation that beats hydration defers work here rather than dropping it.
+   */
+  onWorkspaceLayoutHydrated: (callback: () => void) => void;
   /** Reveals a tab for the current visit without persisting the focus change. */
   revealEphemeralTab: (input: { workspaceKey: string; target: WorkspaceTabTarget }) => void;
   rememberLastWorkspace: (selection: ActiveWorkspaceSelection) => void;
@@ -119,15 +124,22 @@ export function navigateToWorkspace(
       : null;
     // Ephemeral, not a persisted reveal: the layout keeps the focus the user
     // left behind, so returning to the workspace restores their tab once the
-    // attention flag clears or they move focus themselves. Skipped until the
-    // persisted layout has hydrated — an early merge would discard the
-    // background-opened tab while the target lingered — and attention persists,
-    // so the next navigation reveals just as well.
-    if (attentionAgentId && attentionWorkspaceKey && deps.isWorkspaceLayoutHydrated()) {
-      deps.revealEphemeralTab({
+    // attention flag clears or they move focus themselves. Deferred until the
+    // persisted layout has hydrated — hydration's merge replaces the layout
+    // wholesale, so an early reveal would open the tab only for the merge to
+    // discard it — but deferred, not dropped: the user is navigating NOW
+    // because an agent needs attention, and once hydration settles them on
+    // their saved tab, nothing else would retry the reveal.
+    if (attentionAgentId && attentionWorkspaceKey) {
+      const reveal: { workspaceKey: string; target: WorkspaceTabTarget } = {
         workspaceKey: attentionWorkspaceKey,
         target: { kind: "agent", agentId: attentionAgentId },
-      });
+      };
+      if (deps.isWorkspaceLayoutHydrated()) {
+        deps.revealEphemeralTab(reveal);
+      } else {
+        deps.onWorkspaceLayoutHydrated(() => deps.revealEphemeralTab(reveal));
+      }
     }
   }
 

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
@@ -31,6 +31,11 @@ export interface NavigateToWorkspaceInput {
   placement?: WorkspaceTabPlacement;
 }
 
+export interface EphemeralTabReveal {
+  workspaceKey: string;
+  target: WorkspaceTabTarget;
+}
+
 export interface NavigateToWorkspaceDeps extends PrepareWorkspaceTabDeps {
   getSessionWorkspaces: (serverId: string) => Map<string, WorkspaceDescriptor> | null | undefined;
   getSessionAgents: (serverId: string) => Iterable<Agent>;
@@ -41,8 +46,21 @@ export interface NavigateToWorkspaceDeps extends PrepareWorkspaceTabDeps {
    */
   onWorkspaceLayoutHydrated: (callback: () => void) => void;
   /** Reveals a tab for the current visit without persisting the focus change. */
-  revealEphemeralTab: (input: { workspaceKey: string; target: WorkspaceTabTarget }) => void;
-  /** The workspace the user is on right now; every navigation and route change updates it. */
+  revealEphemeralTab: (input: EphemeralTabReveal) => void;
+  /**
+   * Holds a reveal whose layout has not hydrated yet, without opening its tab. The entry is
+   * memory-only, so hydration keeps it, and leaving the workspace clears it like any reveal.
+   */
+  holdEphemeralTab: (input: EphemeralTabReveal) => void;
+  /**
+   * Settles a held reveal after hydration: reveals it, or drops it when `reveal` is false. Does
+   * nothing once the entry no longer holds this target — the visit ended or a newer reveal won.
+   */
+  settleHeldEphemeralTab: (input: EphemeralTabReveal & { reveal: boolean }) => void;
+  /**
+   * The workspace most recently navigated to or shown. App-wide routes (settings) leave it
+   * unchanged, so it cannot tell on its own whether the user is still on that workspace.
+   */
   getLastWorkspaceSelection: () => ActiveWorkspaceSelection | null;
   rememberLastWorkspace: (selection: ActiveWorkspaceSelection) => void;
   navigateToRoute: (route: string) => void;
@@ -131,26 +149,30 @@ export function navigateToWorkspace(
     // because an agent needs attention, and once hydration settles them on
     // their saved tab, nothing else would retry the reveal.
     if (attentionAgentId && attentionWorkspaceKey) {
-      const reveal: { workspaceKey: string; target: WorkspaceTabTarget } = {
+      const reveal: EphemeralTabReveal = {
         workspaceKey: attentionWorkspaceKey,
         target: { kind: "agent", agentId: attentionAgentId },
       };
       if (deps.isWorkspaceLayoutHydrated()) {
         deps.revealEphemeralTab(reveal);
       } else {
+        // Hydration can finish after the user has moved on, and a reveal
+        // installed then would ambush their next visit. So the target is held
+        // now and only settled at hydration: the workspace screen clears a held
+        // entry when the user leaves — for any route, settings included — and
+        // settling an entry that is gone does nothing. The selection check
+        // covers the one departure the screen cannot see: moving on to another
+        // workspace before this one's screen mounted.
+        deps.holdEphemeralTab(reveal);
         const selection = { serverId: input.serverId, workspaceId: input.workspaceId };
         deps.onWorkspaceLayoutHydrated(() => {
-          // Hydration can finish after the user has moved on to another
-          // workspace; a reveal installed then would ambush their next visit.
-          // The remembered selection tracks every navigation and route change,
-          // so only a reveal whose workspace is still current may land.
           const current = deps.getLastWorkspaceSelection();
-          if (
-            current?.serverId === selection.serverId &&
-            current?.workspaceId === selection.workspaceId
-          ) {
-            deps.revealEphemeralTab(reveal);
-          }
+          deps.settleHeldEphemeralTab({
+            ...reveal,
+            reveal:
+              current?.serverId === selection.serverId &&
+              current.workspaceId === selection.workspaceId,
+          });
         });
       }
     }

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
@@ -11,7 +11,7 @@ import {
   resolveWorkspaceMapKeyByIdentity,
 } from "@/utils/workspace-identity";
 import type { ActiveWorkspaceSelection } from "@/stores/last-workspace-selection";
-import type { WorkspaceTabTarget } from "@/workspace-tabs/model";
+import { buildWorkspaceTabPersistenceKey, type WorkspaceTabTarget } from "@/workspace-tabs/model";
 import { prepareWorkspaceTab, type PrepareWorkspaceTabDeps } from "@/utils/prepare-workspace-tab";
 import type { WorkspaceTabPlacement } from "@/stores/workspace-layout-actions";
 
@@ -107,12 +107,25 @@ export function navigateToWorkspace(
         )
       : [];
     const attentionAgentId = pickAttentionAgent(workspaceAgents);
-    if (attentionAgentId && resolvedWorkspaceId) {
-      // Ephemeral, not a persisted reveal: the layout keeps the focus the user
-      // left behind, so returning to the workspace restores their tab once the
-      // attention flag clears or they move focus themselves.
+    // Keyed like the workspace screen keys it (from the route id, via
+    // buildWorkspaceTabPersistenceKey), not like the session-store map: a map
+    // key that differs from the route id would file the reveal where the screen
+    // never looks.
+    const attentionWorkspaceKey = attentionAgentId
+      ? buildWorkspaceTabPersistenceKey({
+          serverId: input.serverId,
+          workspaceId: input.workspaceId,
+        })
+      : null;
+    // Ephemeral, not a persisted reveal: the layout keeps the focus the user
+    // left behind, so returning to the workspace restores their tab once the
+    // attention flag clears or they move focus themselves. Skipped until the
+    // persisted layout has hydrated — an early merge would discard the
+    // background-opened tab while the target lingered — and attention persists,
+    // so the next navigation reveals just as well.
+    if (attentionAgentId && attentionWorkspaceKey && deps.isWorkspaceLayoutHydrated()) {
       deps.revealEphemeralTab({
-        workspaceKey: `${input.serverId}:${resolvedWorkspaceId}`,
+        workspaceKey: attentionWorkspaceKey,
         target: { kind: "agent", agentId: attentionAgentId },
       });
     }

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -1581,6 +1581,23 @@ export function closePaneInLayout(input: ClosePaneInLayoutInput): WorkspaceLayou
   });
 }
 
+/**
+ * Brings an already-open tab to the front of an in-memory layout copy. The
+ * caller renders the copy without writing it back, so the persisted layout
+ * keeps the focus the user left behind and the reveal ends with the visit.
+ * Returns the input untouched when no tab matches the target.
+ */
+export function focusWorkspaceTabEphemerally(input: {
+  layout: WorkspaceLayout;
+  target: WorkspaceTabTarget;
+}): WorkspaceLayout {
+  const existingTab = findExistingTabForTarget(asInternalLayout(input.layout).root, input.target);
+  if (!existingTab) {
+    return input.layout;
+  }
+  return focusTabInLayout({ layout: input.layout, tabId: existingTab.tabId }) ?? input.layout;
+}
+
 export function focusTabInLayout(input: FocusTabInLayoutInput): WorkspaceLayout | null {
   const layout = asInternalLayout(input.layout);
   const pane = findPaneContainingTab(layout.root, input.tabId);

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -4369,6 +4369,101 @@ describe("workspace-layout-store ephemeral attention focus", () => {
     ).toBeUndefined();
   });
 
+  it("clears the reveal when the user focuses a pane", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.focusPane(workspaceKey, "main");
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("clears the reveal when the user focuses the Explorer sidebar pane", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.focusPane(workspaceKey, "explorer");
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("clears the reveal when the user opens a tab with focus", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "new",
+    });
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("clears the reveal when a tab is retargeted", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const newTabId = store.openTab({
+      workspaceKey,
+      target: { kind: "new_tab" },
+      intent: "new",
+    });
+    expect(newTabId).toBeTruthy();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.replaceTab(workspaceKey, newTabId as string, { kind: "files" });
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("drops the reveal when the workspace is purged", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.purgeWorkspace(workspaceKey);
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
   it("never persists the ephemeral reveal", async () => {
     const workspaceKey = createWorkspaceKey();
     const store = workspaceLayoutStore.getState();

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -4479,6 +4479,7 @@ describe("workspace-layout-store ephemeral attention focus", () => {
       intent: "background",
     });
     store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
+    useWorkspaceLayoutIds("split-pane", "split-group");
 
     const splitPaneId = store.splitPane(workspaceKey, {
       tabId: "agent_agent-idle",
@@ -4486,7 +4487,7 @@ describe("workspace-layout-store ephemeral attention focus", () => {
       position: "right",
     });
 
-    expect(splitPaneId).toBeTruthy();
+    expect(splitPaneId).toBe("pane_split-pane");
     expect(
       workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
     ).toBeUndefined();
@@ -4501,13 +4502,14 @@ describe("workspace-layout-store ephemeral attention focus", () => {
       intent: "new",
     });
     store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+    useWorkspaceLayoutIds("split-pane", "split-group");
 
     const splitPaneId = store.splitPaneEmpty(workspaceKey, {
       targetPaneId: "main",
       position: "right",
     });
 
-    expect(splitPaneId).toBeTruthy();
+    expect(splitPaneId).toBe("pane_split-pane");
     expect(
       workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
     ).toBeUndefined();
@@ -4527,12 +4529,13 @@ describe("workspace-layout-store ephemeral attention focus", () => {
       intent: "background",
     });
     store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
+    useWorkspaceLayoutIds("split-pane", "split-group");
     const splitPaneId = store.splitPane(workspaceKey, {
       tabId: "agent_agent-idle",
       targetPaneId: "main",
       position: "right",
     });
-    expect(splitPaneId).toBeTruthy();
+    expect(splitPaneId).toBe("pane_split-pane");
 
     store.moveTabToPane(workspaceKey, "agent_agent-idle", "main");
 
@@ -4557,10 +4560,190 @@ describe("workspace-layout-store ephemeral attention focus", () => {
       }
       return value;
     });
-    const parsed = JSON.parse(persisted) as {
-      state: Record<string, unknown>;
-    };
-    expect(parsed.state).not.toHaveProperty("ephemeralFocusTargetByWorkspace");
-    expect(parsed.state.layoutByWorkspace).toHaveProperty(workspaceKey);
+    const parsed: unknown = JSON.parse(persisted);
+    expect(parsed).not.toHaveProperty(["state", "ephemeralFocusTargetByWorkspace"]);
+    expect(parsed).toHaveProperty(["state", "layoutByWorkspace", workspaceKey]);
+  });
+
+  it("holds a reveal through layout hydration and opens its tab when settled", async () => {
+    // Its own key: the shared module store persists this file's other layouts
+    // to the same storage entry, and a pre-existing layout here would make the
+    // assertions pass without hydration preserving anything.
+    const workspaceKey = "server-1:ws-hydration";
+    const restored = createWorkspaceLayoutStore(createDeterministicWorkspaceLayoutIds());
+    // Held before hydration, not revealed: the merge replaces the layout
+    // wholesale, so a tab opened early would be discarded. The memory-only
+    // entry has to survive instead, or nothing retries the reveal on arrival.
+    restored.getState().holdEphemeralFocusTab(workspaceKey, {
+      kind: "agent",
+      agentId: "agent-attention",
+    });
+    await restored.persist.rehydrate();
+
+    expect(restored.getState().ephemeralFocusTargetByWorkspace[workspaceKey]).toEqual({
+      kind: "agent",
+      agentId: "agent-attention",
+    });
+    expect(restored.getState().layoutByWorkspace[workspaceKey]).toBeUndefined();
+
+    restored
+      .getState()
+      .settleHeldEphemeralFocusTab(
+        workspaceKey,
+        { kind: "agent", agentId: "agent-attention" },
+        true,
+      );
+
+    expect(collectTabIds(restored.getState().layoutByWorkspace[workspaceKey].root)).toContain(
+      "agent_agent-attention",
+    );
+  });
+
+  it("ignores a settled reveal once the visit has ended", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "new",
+    });
+    store.holdEphemeralFocusTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+    // The workspace screen clears the entry as the user leaves, whichever route
+    // they leave for — including an app-wide one the remembered selection
+    // cannot see.
+    store.clearEphemeralFocusTab(workspaceKey);
+
+    store.settleHeldEphemeralFocusTab(
+      workspaceKey,
+      { kind: "agent", agentId: "agent-attention" },
+      true,
+    );
+
+    const state = workspaceLayoutStore.getState();
+    expect(state.ephemeralFocusTargetByWorkspace[workspaceKey]).toBeUndefined();
+    expect(collectTabIds(state.layoutByWorkspace[workspaceKey].root)).not.toContain(
+      "agent_agent-attention",
+    );
+  });
+
+  it("ignores a settled reveal that a newer reveal replaced", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.holdEphemeralFocusTab(workspaceKey, { kind: "agent", agentId: "agent-first" });
+    store.holdEphemeralFocusTab(workspaceKey, { kind: "agent", agentId: "agent-second" });
+
+    store.settleHeldEphemeralFocusTab(
+      workspaceKey,
+      { kind: "agent", agentId: "agent-first" },
+      true,
+    );
+
+    const state = workspaceLayoutStore.getState();
+    expect(state.ephemeralFocusTargetByWorkspace[workspaceKey]).toEqual({
+      kind: "agent",
+      agentId: "agent-second",
+    });
+    expect(
+      collectTabIds(state.layoutByWorkspace[workspaceKey]?.root ?? createDefaultLayout().root),
+    ).not.toContain("agent_agent-first");
+  });
+
+  it("drops a held reveal settled as no longer current", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "new",
+    });
+    store.holdEphemeralFocusTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.settleHeldEphemeralFocusTab(
+      workspaceKey,
+      { kind: "agent", agentId: "agent-attention" },
+      false,
+    );
+
+    const state = workspaceLayoutStore.getState();
+    expect(state.ephemeralFocusTargetByWorkspace[workspaceKey]).toBeUndefined();
+    expect(collectTabIds(state.layoutByWorkspace[workspaceKey].root)).not.toContain(
+      "agent_agent-attention",
+    );
+  });
+
+  it("clears the reveal when its own tab is closed", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "new",
+    });
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "background",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.closeTab(workspaceKey, "agent_agent-attention");
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("keeps the reveal when another tab is closed", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "background",
+    });
+    store.openTab({
+      workspaceKey,
+      target: { kind: "draft", draftId: "draft-1" },
+      intent: "background",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.closeTab(workspaceKey, "draft-1");
+
+    expect(workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey]).toEqual({
+      kind: "agent",
+      agentId: "agent-attention",
+    });
+  });
+
+  it("clears the reveal when the pane holding its tab is closed", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "background",
+    });
+    useWorkspaceLayoutIds("split-pane", "split-group");
+    const splitPaneId = store.splitPane(workspaceKey, {
+      tabId: "agent_agent-idle",
+      targetPaneId: "main",
+      position: "right",
+    });
+    expect(splitPaneId).toBe("pane_split-pane");
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
+
+    store.closePane(workspaceKey, "pane_split-pane");
+
+    const state = workspaceLayoutStore.getState();
+    expect(collectTabIds(state.layoutByWorkspace[workspaceKey].root)).not.toContain(
+      "agent_agent-idle",
+    );
+    expect(state.ephemeralFocusTargetByWorkspace[workspaceKey]).toBeUndefined();
   });
 });

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -28,6 +28,7 @@ import {
   createWorkspaceLayoutWithExplorerSidebar,
   findPaneById,
   findPaneContainingTab,
+  focusWorkspaceTabEphemerally,
   FOCUSED_PANE_PLACEMENT,
   getFocusedBrowserId,
   getTreeDepth,
@@ -4159,5 +4160,233 @@ describe("workspace-layout-store actions", () => {
     expect(layout).toBe(before);
     expect(findPaneById(layout.root, "main")?.tabIds).toEqual([agentTabId]);
     expect(collectAllPanes(layout.root).map((pane) => pane.id)).toEqual(["main"]);
+  });
+});
+
+describe("workspace-layout-store ephemeral attention focus", () => {
+  beforeEach(() => {
+    workspaceLayoutIds.reset();
+    workspaceLayoutStore.setState({
+      layoutByWorkspace: {},
+      splitSizesByWorkspace: {},
+      pinnedAgentIdsByWorkspace: {},
+      hiddenAgentIdsByWorkspace: {},
+      ephemeralFocusTargetByWorkspace: {},
+      focusRestorationByWorkspace: {},
+      explorerSidebarPaneIdByWorkspace: {},
+    });
+  });
+
+  it("reveals an open attention tab without moving persisted focus", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const idleTabId = store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "new",
+    });
+    const attentionTabId = store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
+
+    const state = workspaceLayoutStore.getState();
+    expect(state.ephemeralFocusTargetByWorkspace[workspaceKey]).toEqual({
+      kind: "agent",
+      agentId: "agent-idle",
+    });
+    const persistedLayout = state.layoutByWorkspace[workspaceKey];
+    expect(findPaneById(persistedLayout.root, "main")?.focusedTabId).toBe(attentionTabId);
+
+    const revealedLayout = focusWorkspaceTabEphemerally({
+      layout: persistedLayout,
+      target: { kind: "agent", agentId: "agent-idle" },
+    });
+    expect(findPaneById(revealedLayout.root, "main")?.focusedTabId).toBe(idleTabId);
+    expect(revealedLayout.focusedPaneId).toBe("main");
+    // The persisted layout is untouched: returning without interacting must
+    // still restore the tab the user had focused.
+    expect(findPaneById(persistedLayout.root, "main")?.focusedTabId).toBe(attentionTabId);
+  });
+
+  it("returns the layout unchanged when the reveal target has no tab", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    const persistedLayout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+
+    const revealedLayout = focusWorkspaceTabEphemerally({
+      layout: persistedLayout,
+      target: { kind: "agent", agentId: "agent-unknown" },
+    });
+
+    expect(revealedLayout).toBe(persistedLayout);
+  });
+
+  it("clears the reveal when the user focuses a tab", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const idleTabId = store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "new",
+    });
+    expect(idleTabId).toBeTruthy();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-other" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
+
+    store.focusTab(workspaceKey, idleTabId as string);
+
+    const state = workspaceLayoutStore.getState();
+    expect(state.ephemeralFocusTargetByWorkspace[workspaceKey]).toBeUndefined();
+    expect(findPaneById(state.layoutByWorkspace[workspaceKey].root, "main")?.focusedTabId).toBe(
+      idleTabId,
+    );
+  });
+
+  it("clears the reveal when the user selects a tab inside a pane", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "new",
+    });
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-other" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
+    const idleTabId = collectAllTabs(
+      workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey].root,
+    ).find((tab) => tab.target.kind === "agent" && tab.target.agentId === "agent-idle")?.tabId;
+    expect(idleTabId).toBeTruthy();
+
+    store.selectTabInPane(workspaceKey, "main", idleTabId as string);
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("opens a missing attention tab in the background and unhides the agent", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const initialLayout = createWorkspaceLayoutWithExplorerSidebar();
+    workspaceLayoutStore.setState({ layoutByWorkspace: { [workspaceKey]: initialLayout } });
+    store.hideAgent(workspaceKey, "agent-attention");
+
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    const state = workspaceLayoutStore.getState();
+    expect(state.hiddenAgentIdsByWorkspace[workspaceKey]).toBeUndefined();
+    expect(collectTabIds(state.layoutByWorkspace[workspaceKey].root)).toContain(
+      "agent_agent-attention",
+    );
+    expect(state.ephemeralFocusTargetByWorkspace[workspaceKey]).toEqual({
+      kind: "agent",
+      agentId: "agent-attention",
+    });
+  });
+
+  it("clears the reveal on demand", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.clearEphemeralFocusTab(workspaceKey);
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("keeps the reveal when a tab opens in the background", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-background" },
+      intent: "background",
+    });
+
+    const state = workspaceLayoutStore.getState();
+    expect(state.ephemeralFocusTargetByWorkspace[workspaceKey]).toEqual({
+      kind: "agent",
+      agentId: "agent-attention",
+    });
+    expect(findPaneById(state.layoutByWorkspace[workspaceKey].root, "main")?.focusedTabId).toBe(
+      collectAllTabs(state.layoutByWorkspace[workspaceKey].root).find(
+        (tab) => tab.target.kind === "agent" && tab.target.agentId === "agent-idle",
+      )?.tabId,
+    );
+  });
+
+  it("clears the reveal when a draft submission converts its tab", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const draftTabId = store.openTab({
+      workspaceKey,
+      target: { kind: "draft", draftId: "draft-1" },
+      intent: "new",
+    });
+    expect(draftTabId).toBeTruthy();
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    store.convertDraftToAgent(workspaceKey, draftTabId as string, "agent-created");
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("never persists the ephemeral reveal", async () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+    const persisted = await vi.waitFor(async () => {
+      const value = await AsyncStorage.getItem("workspace-layout-state");
+      expect(value).toBeTruthy();
+      return value as string;
+    });
+    const parsed = JSON.parse(persisted) as {
+      state: Record<string, unknown>;
+    };
+    expect(parsed.state).not.toHaveProperty("ephemeralFocusTargetByWorkspace");
+    expect(parsed.state.layoutByWorkspace).toHaveProperty(workspaceKey);
   });
 });

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -4233,12 +4233,13 @@ describe("workspace-layout-store ephemeral attention focus", () => {
   it("clears the reveal when the user focuses a tab", () => {
     const workspaceKey = createWorkspaceKey();
     const store = workspaceLayoutStore.getState();
-    const idleTabId = store.openTab({
+    // A background open uses the deterministic target identity, so the test
+    // never has to narrow a random tab id.
+    store.openTab({
       workspaceKey,
       target: { kind: "agent", agentId: "agent-idle" },
-      intent: "new",
+      intent: "background",
     });
-    expect(idleTabId).toBeTruthy();
     store.openTab({
       workspaceKey,
       target: { kind: "agent", agentId: "agent-other" },
@@ -4246,12 +4247,12 @@ describe("workspace-layout-store ephemeral attention focus", () => {
     });
     store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
 
-    store.focusTab(workspaceKey, idleTabId as string);
+    store.focusTab(workspaceKey, "agent_agent-idle");
 
     const state = workspaceLayoutStore.getState();
     expect(state.ephemeralFocusTargetByWorkspace[workspaceKey]).toBeUndefined();
     expect(findPaneById(state.layoutByWorkspace[workspaceKey].root, "main")?.focusedTabId).toBe(
-      idleTabId,
+      "agent_agent-idle",
     );
   });
 
@@ -4261,7 +4262,7 @@ describe("workspace-layout-store ephemeral attention focus", () => {
     store.openTab({
       workspaceKey,
       target: { kind: "agent", agentId: "agent-idle" },
-      intent: "new",
+      intent: "background",
     });
     store.openTab({
       workspaceKey,
@@ -4269,12 +4270,8 @@ describe("workspace-layout-store ephemeral attention focus", () => {
       intent: "new",
     });
     store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
-    const idleTabId = collectAllTabs(
-      workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey].root,
-    ).find((tab) => tab.target.kind === "agent" && tab.target.agentId === "agent-idle")?.tabId;
-    expect(idleTabId).toBeTruthy();
 
-    store.selectTabInPane(workspaceKey, "main", idleTabId as string);
+    store.selectTabInPane(workspaceKey, "main", "agent_agent-idle");
 
     expect(
       workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
@@ -4354,15 +4351,19 @@ describe("workspace-layout-store ephemeral attention focus", () => {
   it("clears the reveal when a draft submission converts its tab", () => {
     const workspaceKey = createWorkspaceKey();
     const store = workspaceLayoutStore.getState();
-    const draftTabId = store.openTab({
+    store.openTab({
       workspaceKey,
       target: { kind: "draft", draftId: "draft-1" },
+      intent: "background",
+    });
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
       intent: "new",
     });
-    expect(draftTabId).toBeTruthy();
     store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
 
-    store.convertDraftToAgent(workspaceKey, draftTabId as string, "agent-created");
+    store.convertDraftToAgent(workspaceKey, "draft-1", "agent-created");
 
     expect(
       workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
@@ -4427,12 +4428,11 @@ describe("workspace-layout-store ephemeral attention focus", () => {
   it("clears the reveal when a tab is retargeted", () => {
     const workspaceKey = createWorkspaceKey();
     const store = workspaceLayoutStore.getState();
-    const newTabId = store.openTab({
+    store.openTab({
       workspaceKey,
-      target: { kind: "new_tab" },
-      intent: "new",
+      target: { kind: "draft", draftId: "draft-1" },
+      intent: "background",
     });
-    expect(newTabId).toBeTruthy();
     store.openTab({
       workspaceKey,
       target: { kind: "agent", agentId: "agent-attention" },
@@ -4440,8 +4440,9 @@ describe("workspace-layout-store ephemeral attention focus", () => {
     });
     store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
 
-    store.replaceTab(workspaceKey, newTabId as string, { kind: "files" });
+    const replacedTabId = store.replaceTab(workspaceKey, "draft-1", { kind: "files" });
 
+    expect(replacedTabId).toBe("draft-1");
     expect(
       workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
     ).toBeUndefined();
@@ -4464,6 +4465,82 @@ describe("workspace-layout-store ephemeral attention focus", () => {
     ).toBeUndefined();
   });
 
+  it("clears the reveal when the user splits a tab into a new pane", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "background",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
+
+    const splitPaneId = store.splitPane(workspaceKey, {
+      tabId: "agent_agent-idle",
+      targetPaneId: "main",
+      position: "right",
+    });
+
+    expect(splitPaneId).toBeTruthy();
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("clears the reveal when the user splits an empty pane", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
+
+    const splitPaneId = store.splitPaneEmpty(workspaceKey, {
+      targetPaneId: "main",
+      position: "right",
+    });
+
+    expect(splitPaneId).toBeTruthy();
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("clears the reveal when the user moves a tab to another pane", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-attention" },
+      intent: "new",
+    });
+    store.openTab({
+      workspaceKey,
+      target: { kind: "agent", agentId: "agent-idle" },
+      intent: "background",
+    });
+    store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-idle" });
+    const splitPaneId = store.splitPane(workspaceKey, {
+      tabId: "agent_agent-idle",
+      targetPaneId: "main",
+      position: "right",
+    });
+    expect(splitPaneId).toBeTruthy();
+
+    store.moveTabToPane(workspaceKey, "agent_agent-idle", "main");
+
+    expect(
+      workspaceLayoutStore.getState().ephemeralFocusTargetByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
   it("never persists the ephemeral reveal", async () => {
     const workspaceKey = createWorkspaceKey();
     const store = workspaceLayoutStore.getState();
@@ -4475,8 +4552,10 @@ describe("workspace-layout-store ephemeral attention focus", () => {
     store.revealEphemeralTab(workspaceKey, { kind: "agent", agentId: "agent-attention" });
     const persisted = await vi.waitFor(async () => {
       const value = await AsyncStorage.getItem("workspace-layout-state");
-      expect(value).toBeTruthy();
-      return value as string;
+      if (value === null) {
+        throw new Error("workspace-layout-state was not persisted");
+      }
+      return value;
     });
     const parsed = JSON.parse(persisted) as {
       state: Record<string, unknown>;

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -1383,6 +1383,8 @@ export function createWorkspaceLayoutStore(
 
           set((state) => ({
             ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+            // Splitting moves persisted focus to the new pane; the reveal ends.
+            ...withoutEphemeralFocusTarget(state, normalizedWorkspaceKey),
             layoutByWorkspace: {
               ...state.layoutByWorkspace,
               [normalizedWorkspaceKey]: result.layout,
@@ -1420,6 +1422,8 @@ export function createWorkspaceLayoutStore(
 
           set((state) => ({
             ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+            // Splitting moves persisted focus to the new pane; the reveal ends.
+            ...withoutEphemeralFocusTarget(state, normalizedWorkspaceKey),
             layoutByWorkspace: {
               ...state.layoutByWorkspace,
               [normalizedWorkspaceKey]: result.layout,
@@ -1479,6 +1483,8 @@ export function createWorkspaceLayoutStore(
 
             return {
               ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+              // Moving a tab focuses its destination pane; the reveal ends.
+              ...withoutEphemeralFocusTarget(state, normalizedWorkspaceKey),
               layoutByWorkspace: {
                 ...state.layoutByWorkspace,
                 [normalizedWorkspaceKey]: normalizedNextLayout,

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -58,7 +58,7 @@ import {
   type WorkspaceTabSnapshot,
   type WorkspaceLayout,
 } from "@/stores/workspace-layout-actions";
-import { normalizeWorkspaceTabTarget } from "@/workspace-tabs/identity";
+import { normalizeWorkspaceTabTarget, workspaceTabTargetsEqual } from "@/workspace-tabs/identity";
 import { createValidatedPersistStorage } from "@/storage/validated-persist-storage";
 import { panelTargetSupportsHostForWorkspaceKey } from "@/plugins/workspace-panels/locations";
 
@@ -171,6 +171,23 @@ interface WorkspaceLayoutStore {
    * the workspace screen to focus on an in-memory layout copy.
    */
   revealEphemeralTab: (workspaceKey: string, target: WorkspaceTabTarget) => void;
+  /**
+   * Holds a reveal target for a visit whose layout has not hydrated yet, without
+   * opening its tab. Hydration's merge replaces the layout but keeps this
+   * memory-only entry, and leaving the workspace clears it like any reveal.
+   */
+  holdEphemeralFocusTab: (workspaceKey: string, target: WorkspaceTabTarget) => void;
+  /**
+   * Settles a held reveal once the layout has hydrated: reveals it, or drops it
+   * when `reveal` is false. A no-op once the entry no longer holds this target —
+   * the visit ended or a newer reveal replaced it — so a late settlement never
+   * resurrects a finished visit.
+   */
+  settleHeldEphemeralFocusTab: (
+    workspaceKey: string,
+    target: WorkspaceTabTarget,
+    reveal: boolean,
+  ) => void;
   /** Drops a workspace's ephemeral reveal target; a no-op when none is set. */
   clearEphemeralFocusTab: (workspaceKey: string) => void;
   unfocusPane: (workspaceKey: string) => string | null;
@@ -730,6 +747,23 @@ function withoutEphemeralFocusTarget(
   return { ephemeralFocusTargetByWorkspace };
 }
 
+// The reveal ends with its tab: a target left without one would otherwise
+// linger and snap focus back if that tab reappears later in the visit.
+function withoutOrphanedEphemeralFocusTarget(
+  state: WorkspaceLayoutStore,
+  workspaceKey: string,
+  layout: WorkspaceLayout,
+): Pick<WorkspaceLayoutStore, "ephemeralFocusTargetByWorkspace"> | null {
+  const target = state.ephemeralFocusTargetByWorkspace[workspaceKey];
+  if (
+    !target ||
+    collectAllTabs(layout.root).some((tab) => workspaceTabTargetsEqual(tab.target, target))
+  ) {
+    return null;
+  }
+  return withoutEphemeralFocusTarget(state, workspaceKey);
+}
+
 function reconcileRememberedSidePane(
   state: WorkspaceLayoutStore,
   workspaceKey: string,
@@ -1028,6 +1062,7 @@ export function createWorkspaceLayoutStore(
               }
               return {
                 ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+                ...withoutOrphanedEphemeralFocusTarget(state, normalizedWorkspaceKey, nextLayout),
                 ...reconcileRememberedSidePane(state, normalizedWorkspaceKey, nextLayout),
                 layoutByWorkspace: {
                   ...state.layoutByWorkspace,
@@ -1067,6 +1102,7 @@ export function createWorkspaceLayoutStore(
 
             return {
               ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+              ...withoutOrphanedEphemeralFocusTarget(state, normalizedWorkspaceKey, nextLayout),
               ...reconcileRememberedSidePane(state, normalizedWorkspaceKey, nextLayout),
               layoutByWorkspace: {
                 ...state.layoutByWorkspace,
@@ -1526,6 +1562,7 @@ export function createWorkspaceLayoutStore(
 
             return {
               ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+              ...withoutOrphanedEphemeralFocusTarget(state, normalizedWorkspaceKey, nextLayout),
               layoutByWorkspace: {
                 ...state.layoutByWorkspace,
                 [normalizedWorkspaceKey]: nextLayout,
@@ -1627,6 +1664,37 @@ export function createWorkspaceLayoutStore(
               },
             };
           });
+        },
+        holdEphemeralFocusTab: (workspaceKey, target) => {
+          const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+          const normalizedTarget = normalizeWorkspaceTabTarget(target);
+          if (!normalizedWorkspaceKey || !normalizedTarget) {
+            return;
+          }
+
+          set((state) => ({
+            ephemeralFocusTargetByWorkspace: {
+              ...state.ephemeralFocusTargetByWorkspace,
+              [normalizedWorkspaceKey]: normalizedTarget,
+            },
+          }));
+        },
+        settleHeldEphemeralFocusTab: (workspaceKey, target, reveal) => {
+          const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+          const normalizedTarget = normalizeWorkspaceTabTarget(target);
+          if (!normalizedWorkspaceKey || !normalizedTarget) {
+            return;
+          }
+
+          const heldTarget = get().ephemeralFocusTargetByWorkspace[normalizedWorkspaceKey];
+          if (!heldTarget || !workspaceTabTargetsEqual(heldTarget, normalizedTarget)) {
+            return;
+          }
+          if (reveal) {
+            get().revealEphemeralTab(normalizedWorkspaceKey, normalizedTarget);
+          } else {
+            get().clearEphemeralFocusTab(normalizedWorkspaceKey);
+          }
         },
         clearEphemeralFocusTab: (workspaceKey) => {
           const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -28,6 +28,7 @@ import {
   findPaneContainingTab,
   focusPaneInLayout,
   focusTabInLayout,
+  focusWorkspaceTabEphemerally,
   getFocusedBrowserId,
   getTreeDepth,
   insertSplit,
@@ -72,6 +73,7 @@ export {
   FOCUSED_PANE_PLACEMENT,
   findPaneById,
   findPaneContainingTab,
+  focusWorkspaceTabEphemerally,
   getFocusedBrowserId,
   getTreeDepth,
   insertSplit,
@@ -109,6 +111,13 @@ interface WorkspaceLayoutStore {
   pinnedAgentIdsByWorkspace: Record<string, Set<string>>;
   pendingAgentIdsByWorkspace: Record<string, Set<string>>;
   hiddenAgentIdsByWorkspace: Record<string, Set<string>>;
+  /**
+   * Attention-driven reveal targets, one per workspace, held in memory only.
+   * The screen focuses this target on a layout copy; the persisted layout keeps
+   * the focus the user left behind so returning restores their tab. Anything
+   * that moves persisted focus, or leaving the workspace, clears the entry.
+   */
+  ephemeralFocusTargetByWorkspace: Record<string, WorkspaceTabTarget>;
   focusRestorationByWorkspace: Record<string, WorkspaceFocusRestorationState>;
   explorerSidebarPaneIdByWorkspace: Record<string, string | null>;
   sidePaneIdByWorkspace: Record<string, string | null>;
@@ -156,6 +165,14 @@ interface WorkspaceLayoutStore {
    */
   closePane: (workspaceKey: string, paneId: string) => void;
   focusPane: (workspaceKey: string, paneId: string) => void;
+  /**
+   * Reveals a tab for the current visit without persisting the focus change:
+   * opens the tab in the background when missing and remembers the target for
+   * the workspace screen to focus on an in-memory layout copy.
+   */
+  revealEphemeralTab: (workspaceKey: string, target: WorkspaceTabTarget) => void;
+  /** Drops a workspace's ephemeral reveal target; a no-op when none is set. */
+  clearEphemeralFocusTab: (workspaceKey: string) => void;
   unfocusPane: (workspaceKey: string) => string | null;
   restorePaneFocus: (workspaceKey: string, token: string) => void;
   resizeSplit: (workspaceKey: string, groupId: string, sizes: number[]) => void;
@@ -701,6 +718,18 @@ function withoutFocusRestoration(
   return { focusRestorationByWorkspace };
 }
 
+function withoutEphemeralFocusTarget(
+  state: WorkspaceLayoutStore,
+  workspaceKey: string,
+): Pick<WorkspaceLayoutStore, "ephemeralFocusTargetByWorkspace"> | null {
+  if (!(workspaceKey in state.ephemeralFocusTargetByWorkspace)) {
+    return null;
+  }
+  const { [workspaceKey]: _removed, ...ephemeralFocusTargetByWorkspace } =
+    state.ephemeralFocusTargetByWorkspace;
+  return { ephemeralFocusTargetByWorkspace };
+}
+
 function reconcileRememberedSidePane(
   state: WorkspaceLayoutStore,
   workspaceKey: string,
@@ -766,6 +795,7 @@ export function createWorkspaceLayoutStore(
         pinnedAgentIdsByWorkspace: {},
         pendingAgentIdsByWorkspace: {},
         hiddenAgentIdsByWorkspace: {},
+        ephemeralFocusTargetByWorkspace: {},
         focusRestorationByWorkspace: {},
         explorerSidebarPaneIdByWorkspace: {},
         sidePaneIdByWorkspace: {},
@@ -815,6 +845,11 @@ export function createWorkspaceLayoutStore(
           const shouldPinAgent = input.pin === true && normalizedTarget.kind === "agent";
           set((state) => ({
             ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+            // A focused open ends the reveal; a background open must not, since
+            // the user explicitly chose not to move focus to the new tab.
+            ...(input.intent === "background"
+              ? {}
+              : (withoutEphemeralFocusTarget(state, normalizedWorkspaceKey) ?? {})),
             hiddenAgentIdsByWorkspace:
               normalizedTarget.kind !== "agent"
                 ? state.hiddenAgentIdsByWorkspace
@@ -1071,12 +1106,19 @@ export function createWorkspaceLayoutStore(
             } else {
               nextLayout = focusTabInLayout({ layout, tabId: normalizedTabId });
             }
+            // An explicit focus ends the ephemeral reveal even when the
+            // persisted layout already agrees: the click is the user's say.
+            const clearedEphemeralFocus = withoutEphemeralFocusTarget(
+              state,
+              normalizedWorkspaceKey,
+            );
             if (!nextLayout) {
-              return state;
+              return clearedEphemeralFocus ?? state;
             }
 
             return {
               ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+              ...clearedEphemeralFocus,
               layoutByWorkspace: {
                 ...state.layoutByWorkspace,
                 [normalizedWorkspaceKey]: nextLayout,
@@ -1098,14 +1140,21 @@ export function createWorkspaceLayoutStore(
               paneId: normalizedPaneId,
               tabId: normalizedTabId,
             });
+            // Selecting a tab is an explicit focus move: it ends the reveal
+            // even when the pane already shows that tab in the persisted layout.
+            const clearedEphemeralFocus = withoutEphemeralFocusTarget(
+              state,
+              normalizedWorkspaceKey,
+            );
             return nextLayout
               ? {
+                  ...clearedEphemeralFocus,
                   layoutByWorkspace: {
                     ...state.layoutByWorkspace,
                     [normalizedWorkspaceKey]: nextLayout,
                   },
                 }
-              : state;
+              : (clearedEphemeralFocus ?? state);
           });
         },
         replaceTab: (workspaceKey, tabId, target, tabState) => {
@@ -1123,6 +1172,8 @@ export function createWorkspaceLayoutStore(
           if (!result) return null;
           set((state) => ({
             ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+            // Choosing content for a tab is a user focus commitment; the reveal ends.
+            ...withoutEphemeralFocusTarget(state, normalizedWorkspaceKey),
             hiddenAgentIdsByWorkspace:
               normalizedTarget.kind !== "agent"
                 ? state.hiddenAgentIdsByWorkspace
@@ -1178,6 +1229,8 @@ export function createWorkspaceLayoutStore(
             ...(result.layout.focusedPaneId !== null
               ? (withoutFocusRestoration(state, normalizedWorkspaceKey) ?? {})
               : {}),
+            // Submitting the draft commits the user to that tab; the reveal ends.
+            ...withoutEphemeralFocusTarget(state, normalizedWorkspaceKey),
             hiddenAgentIdsByWorkspace: removeAgentIdFromWorkspaceSet(
               state.hiddenAgentIdsByWorkspace,
               normalizedWorkspaceKey,
@@ -1501,18 +1554,82 @@ export function createWorkspaceLayoutStore(
               layout,
               paneId: normalizedPaneId,
             });
+            // Focusing a pane is an explicit focus move: it ends the reveal
+            // even when the pane is already the persisted focused pane.
+            const clearedEphemeralFocus = withoutEphemeralFocusTarget(
+              state,
+              normalizedWorkspaceKey,
+            );
             if (!nextLayout) {
-              return state;
+              return clearedEphemeralFocus ?? state;
             }
 
             return {
               ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+              ...clearedEphemeralFocus,
               layoutByWorkspace: {
                 ...state.layoutByWorkspace,
                 [normalizedWorkspaceKey]: nextLayout,
               },
             };
           });
+        },
+        revealEphemeralTab: (workspaceKey, target) => {
+          const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+          const normalizedTarget = normalizeWorkspaceTabTarget(target);
+          if (!normalizedWorkspaceKey || !normalizedTarget) {
+            return;
+          }
+
+          set((state) => {
+            const placement = getOpenTabPlacement(
+              state,
+              normalizedWorkspaceKey,
+              normalizedTarget,
+              undefined,
+            );
+            const opened = openTabInLayoutBackground({
+              ...placement,
+              target: normalizedTarget,
+              now: Date.now(),
+            });
+            if (!opened) {
+              return state;
+            }
+
+            return {
+              hiddenAgentIdsByWorkspace:
+                normalizedTarget.kind !== "agent"
+                  ? state.hiddenAgentIdsByWorkspace
+                  : removeAgentIdFromWorkspaceSet(
+                      state.hiddenAgentIdsByWorkspace,
+                      normalizedWorkspaceKey,
+                      normalizedTarget.agentId,
+                    ),
+              layoutByWorkspace: {
+                ...state.layoutByWorkspace,
+                [normalizedWorkspaceKey]: keepWorkspaceFocusOutOfExplorerSidebar(
+                  opened.layout,
+                  placement.explorerSidebarPaneId,
+                  placement.layout.focusedPaneId,
+                ),
+              },
+              ephemeralFocusTargetByWorkspace: {
+                ...state.ephemeralFocusTargetByWorkspace,
+                [normalizedWorkspaceKey]: normalizedTarget,
+              },
+            };
+          });
+        },
+        clearEphemeralFocusTab: (workspaceKey) => {
+          const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+          if (!normalizedWorkspaceKey) {
+            return;
+          }
+
+          set((state) => ({
+            ...withoutEphemeralFocusTarget(state, normalizedWorkspaceKey),
+          }));
         },
         unfocusPane: (workspaceKey) => {
           const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
@@ -1758,6 +1875,7 @@ export function createWorkspaceLayoutStore(
               normalizedWorkspaceKey in state.pinnedAgentIdsByWorkspace ||
               normalizedWorkspaceKey in state.pendingAgentIdsByWorkspace ||
               normalizedWorkspaceKey in state.hiddenAgentIdsByWorkspace ||
+              normalizedWorkspaceKey in state.ephemeralFocusTargetByWorkspace ||
               normalizedWorkspaceKey in state.focusRestorationByWorkspace ||
               normalizedWorkspaceKey in state.explorerSidebarPaneIdByWorkspace ||
               normalizedWorkspaceKey in state.sidePaneIdByWorkspace;
@@ -1778,6 +1896,8 @@ export function createWorkspaceLayoutStore(
               state.pendingAgentIdsByWorkspace;
             const { [normalizedWorkspaceKey]: _hidden, ...hiddenAgentIdsByWorkspace } =
               state.hiddenAgentIdsByWorkspace;
+            const { [normalizedWorkspaceKey]: _ephemeral, ...ephemeralFocusTargetByWorkspace } =
+              state.ephemeralFocusTargetByWorkspace;
             const { [normalizedWorkspaceKey]: _restoration, ...focusRestorationByWorkspace } =
               state.focusRestorationByWorkspace;
             const {
@@ -1793,6 +1913,7 @@ export function createWorkspaceLayoutStore(
               pinnedAgentIdsByWorkspace,
               pendingAgentIdsByWorkspace,
               hiddenAgentIdsByWorkspace,
+              ephemeralFocusTargetByWorkspace,
               focusRestorationByWorkspace,
               explorerSidebarPaneIdByWorkspace,
               sidePaneIdByWorkspace,

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { z } from "zod";
@@ -1547,19 +1547,20 @@ export function createWorkspaceLayoutStore(
               layout,
               state.explorerSidebarPaneIdByWorkspace[normalizedWorkspaceKey],
             );
+            // Focusing a pane is an explicit focus move: it ends the reveal even
+            // when the pane is already the persisted focused pane — and even when
+            // the target is the Explorer sidebar, which only toggles visibility.
+            const clearedEphemeralFocus = withoutEphemeralFocusTarget(
+              state,
+              normalizedWorkspaceKey,
+            );
             if (normalizedPaneId === explorerSidebarPaneId) {
-              return state;
+              return clearedEphemeralFocus ?? state;
             }
             const nextLayout = focusPaneInLayout({
               layout,
               paneId: normalizedPaneId,
             });
-            // Focusing a pane is an explicit focus move: it ends the reveal
-            // even when the pane is already the persisted focused pane.
-            const clearedEphemeralFocus = withoutEphemeralFocusTarget(
-              state,
-              normalizedWorkspaceKey,
-            );
             if (!nextLayout) {
               return clearedEphemeralFocus ?? state;
             }
@@ -1994,6 +1995,36 @@ export function createWorkspaceLayoutStore(
 }
 
 export const useWorkspaceLayoutStore = createWorkspaceLayoutStore();
+
+/**
+ * The layout the user is looking at: the persisted layout with the ephemeral
+ * attention reveal applied. Focus-derived consumers (the workspace screen, the
+ * composer's add-to-chat target, plugin command-center context) must read this
+ * so their idea of "focused" matches what is on screen during a reveal.
+ */
+export function useEffectiveWorkspaceLayout(
+  workspaceKey: string | null | undefined,
+): WorkspaceLayout | null {
+  const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+  const persistedLayout = useWorkspaceLayoutStore((state) =>
+    normalizedWorkspaceKey ? (state.layoutByWorkspace[normalizedWorkspaceKey] ?? null) : null,
+  );
+  const ephemeralFocusTarget = useWorkspaceLayoutStore((state) =>
+    normalizedWorkspaceKey
+      ? (state.ephemeralFocusTargetByWorkspace[normalizedWorkspaceKey] ?? null)
+      : null,
+  );
+  return useMemo(
+    () =>
+      persistedLayout && ephemeralFocusTarget
+        ? focusWorkspaceTabEphemerally({
+            layout: persistedLayout,
+            target: ephemeralFocusTarget,
+          })
+        : persistedLayout,
+    [ephemeralFocusTarget, persistedLayout],
+  );
+}
 
 export function useWorkspaceLayoutStoreHydrated(): boolean {
   const [hasHydrated, setHasHydrated] = useState(() =>


### PR DESCRIPTION
## Problem

Switching to another workspace and coming back sometimes does not restore the tab you left. The cause is the attention auto-focus from #828: `navigateToWorkspace` reveals the tab of whichever agent needs attention (permission > error > finished) via `openTab(intent: "reveal")`, which writes `pane.focusedTabId` into the **persisted** layout. The tab you actually had focused is then lost for every later visit, not just the revealing one — and it happens exactly in the moments an agent finished or errored while you were away, which is the most common reason to switch back.

## Change

The reveal is now **ephemeral**:

- `navigateToWorkspace` records the attention target in a memory-only `ephemeralFocusTargetByWorkspace` entry in the layout store (`revealEphemeralTab`). When the tab is missing it is opened in the background and the agent unhidden, matching what the persisted reveal did — only the focus change is dropped.
- The workspace screen focuses that target on an **in-memory layout copy** via the new pure `focusWorkspaceTabEphemerally` and renders that copy. Tab row, pane content, document title, visible-agent sync, and attention clearing all flow from the same copy, so the reveal looks identical to before — but the persisted layout keeps the focus the user left behind.

The reveal ends when:

- the user commits to a focus themselves (`focusTab`, `selectTabInPane`, `focusPane`, a focused `openTab`, `replaceTab`, or a draft submission converting its tab) — even when the persisted layout already agrees, since the click is the user's say. A background `openTab` deliberately does **not** end it, because the user chose not to move focus.
- the user leaves the workspace: the screen clears its entry on the focused→unfocused transition (and on unmount), not on every inactive render, so a reveal set for a retained deck workspace survives until the route actually switches to it.

Attention itself still clears through the existing focus-entry path once the revealed agent is on screen, which normally ends the cycle during the first visit. The feature from #828 is preserved: arriving at a workspace with an agent that needs you still lands on that agent's tab.

## Testing

- Store unit tests: reveal keeps persisted focus, opens missing tabs in the background, unhides hidden agents, clears on every user focus commitment (including no-op focuses and background-open exclusion), never reaches disk.
- Pure-function tests for `focusWorkspaceTabEphemerally` (focuses an open tab on a copy without mutating the input; returns the input when the target has no tab).
- Navigation tests updated: the attention branch now records an ephemeral reveal instead of a persisted `openTab`; an explicit target stays authoritative.
- Full app unit suite: 5217 passing.