### PR TITLE
feat(plugins): report subagents under existing providers

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -294,6 +294,24 @@ Emit from the operation owner, not a client subscription. Provider history repla
 live hooks. Observers must not be awaited inside agent mutations: a callback can send a prompt or
 answer a permission through its own daemon session. Awaiting it there deadlocks that command.
 
+## Report externally owned subagents
+
+A server plugin can report child executions beneath an existing managed agent with
+`server.subagents.open({ parentAgentId })`. This does not register a provider or create managed
+agents. The [reporter reference](../public-docs/plugins/v0.8/reference.md#report-externally-owned-subagents)
+owns the event shapes, limits, and cleanup contract.
+
+The daemon owns reporting state. Each reporter has a private source in the provider-subagent store;
+native history refresh and native cancellation must select only native sources. Parent runtime
+closure invalidates reporters and removes their rows, without claiming that external workers stopped.
+Plugin stop and process failure do the same for that process's sources. Do not implement cleanup
+through client subscriptions or best-effort plugin lifecycle observers.
+
+The subprocess uses acknowledged private IPC, not a public WebSocket write RPC. Keep its modules
+compatible with Node's strip-only TypeScript loader; constructor parameter properties cannot run
+in the source subprocess. Report retries reuse their sequence and receipt; another `report()` call
+is a new event. The state is in memory and must be rebuilt by the external source after restart.
+
 ## Contribute a provider
 
 Register a provider from `index.server.ts`. The provider connection is callback-based and owns all

--- a/packages/plugin/src/server/contracts.ts
+++ b/packages/plugin/src/server/contracts.ts
@@ -4,12 +4,27 @@ import type { PluginRpcContract } from "../rpc.js";
 import type { PluginCleanup } from "../contracts.js";
 import type { ProviderRegistration } from "./provider.js";
 import type { PluginLifecycleRegistration } from "./lifecycle.js";
+import type { PluginSubagentEvent } from "./subagents.js";
+
+export interface PluginSubagentReporter {
+  report(event: PluginSubagentEvent): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface PluginSubagentOpenInput {
+  parentAgentId: string;
+}
+
+export interface PluginSubagentApi {
+  open(input: PluginSubagentOpenInput): Promise<PluginSubagentReporter>;
+}
 
 export interface PluginHandlerContext {
   paseo: PaseoApi;
 }
 
 export interface PluginServerContext extends PluginLifecycleRegistration {
+  subagents: PluginSubagentApi;
   registerSettings<Schema extends ZodType>(
     definition: import("../settings.js").SettingsDefinition<Schema>,
   ): void;

--- a/packages/plugin/src/server/index.ts
+++ b/packages/plugin/src/server/index.ts
@@ -2,7 +2,15 @@ export type {
   PluginHandlerContext,
   PluginServerContext,
   PluginServerContribution,
+  PluginSubagentReporter,
+  PluginSubagentOpenInput,
+  PluginSubagentApi,
 } from "./contracts.js";
+export {
+  PluginSubagentEventSchema,
+  PLUGIN_SUBAGENT_MAX_EVENT_BYTES,
+  type PluginSubagentEvent,
+} from "./subagents.js";
 export type {
   PluginHookContext,
   PluginHookWorkspace,

--- a/packages/plugin/src/server/subagents.ts
+++ b/packages/plugin/src/server/subagents.ts
@@ -1,0 +1,40 @@
+import {
+  AgentTimelineItemPayloadSchema,
+  ProviderSubagentDescriptorPayloadSchema,
+} from "@getpaseo/protocol/messages";
+import { z } from "zod";
+
+export const PLUGIN_SUBAGENT_MAX_EVENT_BYTES = 64 * 1024;
+
+const childId = z.string().min(1).max(256);
+const timestamp = z.iso.datetime({ offset: true }).optional();
+const presentation = ProviderSubagentDescriptorPayloadSchema.pick({
+  title: true,
+  description: true,
+  status: true,
+  toolCallId: true,
+  cwd: true,
+  subtitle: true,
+}).partial();
+
+export const PluginSubagentEventSchema = z.discriminatedUnion("type", [
+  presentation
+    .extend({
+      type: z.literal("upsert"),
+      id: childId,
+      parentSubagentId: childId.nullable().optional(),
+      timestamp,
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("timeline"),
+      id: childId,
+      item: AgentTimelineItemPayloadSchema,
+      timestamp,
+    })
+    .strict(),
+  z.object({ type: z.literal("remove"), id: childId }).strict(),
+]);
+
+export type PluginSubagentEvent = z.infer<typeof PluginSubagentEventSchema>;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1,6 +1,7 @@
 import type { PluginLifecycle } from "../plugins/lifecycle/index.js";
 import { describeHookAgent, publishAgentStream } from "../plugins/lifecycle/index.js";
-import type { PluginSessionOpenRequest } from "@getpaseo/plugin/server";
+import type { PluginSessionOpenRequest, PluginSubagentReporter } from "@getpaseo/plugin/server";
+import { PluginSubagentSources } from "./provider-subagents/reporters.js";
 import { randomUUID } from "node:crypto";
 import { basename, resolve } from "node:path";
 import { stat } from "node:fs/promises";
@@ -697,6 +698,12 @@ export class AgentManager {
   private readonly agents = new Map<string, LiveManagedAgent>();
   private readonly timelineStore = new InMemoryAgentTimelineStore();
   private readonly providerSubagents = new ProviderSubagentStore();
+  private readonly pluginSubagentSources = new PluginSubagentSources(
+    this.providerSubagents,
+    (event) => {
+      this.dispatch({ type: "provider_subagent", event });
+    },
+  );
   private readonly agentsAwaitingInitialSnapshotPersist = new Set<string>();
   private readonly sessionEventTails = new Map<string, Promise<void>>();
   private readonly steerEventBarriers = new Map<string, SteerEventBarrier>();
@@ -1164,6 +1171,20 @@ export class AgentManager {
     return this.timelineStore.fetch(id, options);
   }
 
+  openPluginSubagentReporter(pluginId: string, parentAgentId: string): PluginSubagentReporter {
+    this.assertAcceptingAgentRegistrations();
+    const parent = this.requirePublicAgent(parentAgentId);
+    if (parent.lifecycle === "initializing") throw new Error("Parent agent is not ready");
+    if (this.lifecycleMutationTails.has(parent.id) || this.inFlightAgentCloses.has(parent.id)) {
+      throw new Error("Parent agent lifecycle is changing");
+    }
+    return this.pluginSubagentSources.open(pluginId, {
+      id: parent.id,
+      provider: parent.provider,
+      isCurrent: () => this.agents.get(parent.id) === parent,
+    });
+  }
+
   listProviderSubagents(parentAgentId: string): ProviderSubagentDescriptor[] {
     this.requirePublicAgent(parentAgentId);
     return this.providerSubagents.list(parentAgentId);
@@ -1519,7 +1540,7 @@ export class AgentManager {
         // Wipe the in-memory timeline so registerSession mints a new epoch and
         // hydrateTimelineFromProvider re-streams the freshly read provider history.
         this.timelineStore.delete(agentId);
-        for (const event of this.providerSubagents.deleteParent(agentId)) {
+        for (const event of this.providerSubagents.deleteNativeParent(agentId)) {
           this.dispatch({ type: "provider_subagent", event });
         }
       }
@@ -1683,7 +1704,7 @@ export class AgentManager {
   }
 
   private cancelRunningProviderSubagents(parentAgentId: string): void {
-    for (const subagent of this.providerSubagents.list(parentAgentId)) {
+    for (const subagent of this.providerSubagents.listNative(parentAgentId)) {
       if (subagent.status !== "running") {
         continue;
       }
@@ -3593,6 +3614,7 @@ export class AgentManager {
     agent: LiveManagedAgent,
     cancelReason: string,
   ): ManagedAgentClosed {
+    this.pluginSubagentSources.deleteParent(agent.id);
     this.agentStreamCoalescer.flushAndDiscard(agent.id);
     this.agents.delete(agent.id);
     this.previousStatuses.delete(agent.id);
@@ -3625,6 +3647,7 @@ export class AgentManager {
   }
 
   private discardRetainedAgentState(agentId: string): void {
+    this.pluginSubagentSources.deleteParent(agentId);
     this.timelineStore.delete(agentId);
     this.paseoToolPolicies.delete(agentId);
     for (const event of this.providerSubagents.deleteParent(agentId)) {
@@ -3911,7 +3934,7 @@ export class AgentManager {
     this.timelineStore.initialize(agent.id, { timestamp: new Date().toISOString() });
     agent.historyPrimed = true;
 
-    for (const event of this.providerSubagents.deleteParent(agent.id)) {
+    for (const event of this.providerSubagents.deleteNativeParent(agent.id)) {
       if (broadcast) {
         this.dispatch({ type: "provider_subagent", event });
       }

--- a/packages/server/src/server/agent/provider-subagents/manager.test.ts
+++ b/packages/server/src/server/agent/provider-subagents/manager.test.ts
@@ -1,0 +1,119 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import pino from "pino";
+import { expect, test } from "vitest";
+import { createTestAgentClient } from "../../test-utils/fake-agent-client.js";
+import { AgentManager, type AgentManagerEvent } from "../agent-manager.js";
+import { AgentStorage } from "../agent-storage.js";
+
+async function setup() {
+  const cwd = await mkdtemp(path.join(tmpdir(), "paseo-plugin-subagents-"));
+  const logger = pino({ level: "silent" });
+  const registry = new AgentStorage(path.join(cwd, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { pi: createTestAgentClient("pi") },
+    registry,
+    logger,
+  });
+  const parent = await manager.createAgent({ provider: "pi", cwd }, undefined, {
+    workspaceId: undefined,
+  });
+  return {
+    manager,
+    parent,
+    cwd,
+    async close() {
+      await Promise.all(manager.listAgents().map((agent) => manager.closeAgent(agent.id)));
+      await registry.flush();
+      await rm(cwd, { recursive: true, force: true });
+    },
+  };
+}
+
+test("plugin reports keep a Pi parent literal and survive native history refresh", async () => {
+  const fixture = await setup();
+  const { manager, parent } = fixture;
+  try {
+    const reporter = manager.openPluginSubagentReporter("external", parent.id);
+    const events: AgentManagerEvent[] = [];
+    const unsubscribe = manager.subscribe((event) => events.push(event), { replayState: false });
+    const status = manager.getAgent(parent.id)?.lifecycle;
+    await reporter.report({ type: "upsert", id: "child", status: "running" });
+    await reporter.report({
+      type: "timeline",
+      id: "child",
+      item: { type: "assistant_message", text: "Independent child" },
+    });
+    const descriptor = manager.listProviderSubagents(parent.id)[0]!;
+    await manager.hydrateTimelineFromProvider(parent.id, { force: true, broadcast: true });
+    expect(manager.listProviderSubagents(parent.id)).toEqual([descriptor]);
+    expect(manager.fetchProviderSubagentTimeline(parent.id, descriptor.id).rows[0]?.item).toEqual({
+      type: "assistant_message",
+      text: "Independent child",
+    });
+    expect(manager.listProviderSubagentActivity()).toEqual([descriptor]);
+    expect(manager.getAgent(parent.id)?.lifecycle).toBe(status);
+    expect(manager.listAgents()).toHaveLength(1);
+    expect(
+      events.filter((event) => event.type === "provider_subagent").map((event) => event.event.type),
+    ).toEqual(["upsert", "timeline"]);
+    unsubscribe();
+  } finally {
+    await fixture.close();
+  }
+});
+
+test.each([
+  ["close", "closeAgent"],
+  ["reload", "reloadAgentSession"],
+  ["archive", "archiveAgent"],
+] as const)(
+  "parent %s removes plugin rows and rejects its old reporter",
+  async (_action, method) => {
+    const fixture = await setup();
+    const { manager, parent } = fixture;
+    try {
+      const reporter = manager.openPluginSubagentReporter("external", parent.id);
+      await reporter.report({ type: "upsert", id: "child", status: "running" });
+      const events: AgentManagerEvent[] = [];
+      const unsubscribe = manager.subscribe((event) => events.push(event), { replayState: false });
+      await manager[method](parent.id);
+      await reporter.close();
+      await reporter.close();
+      await expect(reporter.report({ type: "upsert", id: "child" })).rejects.toThrow("closed");
+      expect(
+        events
+          .filter((event) => event.type === "provider_subagent")
+          .map((event) => event.event.type),
+      ).toEqual(["remove"]);
+      expect(manager.listProviderSubagentActivity()).toEqual([]);
+      unsubscribe();
+    } finally {
+      await fixture.close();
+    }
+  },
+);
+
+test("reporter opening does not resume unknown or closed parents, or expose internal agents", async () => {
+  const fixture = await setup();
+  const { manager, parent, cwd } = fixture;
+  try {
+    expect(() => manager.openPluginSubagentReporter("external", randomUUID())).toThrow(
+      "Unknown agent",
+    );
+    const internal = await manager.createAgent({ provider: "pi", cwd, internal: true }, undefined, {
+      workspaceId: undefined,
+    });
+    expect(() => manager.openPluginSubagentReporter("external", internal.id)).toThrow(
+      "Unknown agent",
+    );
+    await manager.closeAgent(parent.id);
+    expect(() => manager.openPluginSubagentReporter("external", parent.id)).toThrow(
+      "Unknown agent",
+    );
+  } finally {
+    await fixture.close();
+  }
+});

--- a/packages/server/src/server/agent/provider-subagents/reporters.test.ts
+++ b/packages/server/src/server/agent/provider-subagents/reporters.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import { PluginSubagentSources } from "./reporters.js";
+import { ProviderSubagentStore, type ProviderSubagentStoreEvent } from "./store.js";
+
+function setup() {
+  const store = new ProviderSubagentStore();
+  const events: ProviderSubagentStoreEvent[] = [];
+  const sources = new PluginSubagentSources(store, (event) => events.push(event));
+  const parent = { id: "parent", provider: "pi", isCurrent: () => true };
+  return { store, events, sources, parent };
+}
+
+describe("plugin subagent sources", () => {
+  test("isolates native children and each reporter, while retaining the parent's provider", async () => {
+    const { store, sources, parent } = setup();
+    const first = sources.open("first", parent);
+    const second = sources.open("second", parent);
+    store.apply(parent.id, "pi", { type: "upsert", id: "child" });
+    await first.report({ type: "upsert", id: "child", title: "First", status: "running" });
+    await second.report({ type: "upsert", id: "child", title: "Second", status: "completed" });
+    const [native, one, two] = store.list(parent.id);
+    expect(native?.id).toBe("child");
+    expect(one).toMatchObject({ provider: "pi", parentAgentId: "parent", title: "First" });
+    expect(two).toMatchObject({ provider: "pi", parentAgentId: "parent", title: "Second" });
+    expect(one?.id).toMatch(/^plugin\/first\//);
+    expect(two?.id).toMatch(/^plugin\/second\//);
+    await first.close();
+    await first.close();
+    expect(store.list(parent.id)).toEqual([native, two]);
+    await expect(first.report({ type: "upsert", id: "late" })).rejects.toThrow("closed");
+  });
+
+  test("requires descriptors, namespaces nested parents, rejects cycles, and removes descendants", async () => {
+    const { store, sources, parent } = setup();
+    const reporter = sources.open("plugin", parent);
+    await expect(
+      reporter.report({
+        type: "timeline",
+        id: "child",
+        item: { type: "assistant_message", text: "Missing" },
+      }),
+    ).rejects.toThrow("Declare");
+    await expect(
+      reporter.report({ type: "upsert", id: "nested", parentSubagentId: "child" }),
+    ).rejects.toThrow("declared");
+    await reporter.report({ type: "upsert", id: "child", status: "completed", title: "Child" });
+    await reporter.report({ type: "upsert", id: "nested", parentSubagentId: "child" });
+    await reporter.report({ type: "upsert", id: "child", subtitle: "Updated" });
+    await expect(
+      reporter.report({ type: "upsert", id: "child", parentSubagentId: "nested" }),
+    ).rejects.toThrow("cycle");
+    const [child, nested] = store.list(parent.id);
+    expect(child).toMatchObject({ status: "completed", title: "Child", subtitle: "Updated" });
+    expect(nested?.parentSubagentId).toBe(child?.id);
+    await reporter.report({
+      type: "timeline",
+      id: "nested",
+      item: { type: "assistant_message", text: "Found it" },
+    });
+    expect(store.fetchTimeline(parent.id, nested!.id).rows[0]?.item).toEqual({
+      type: "assistant_message",
+      text: "Found it",
+    });
+    await reporter.report({ type: "remove", id: "child" });
+    await reporter.report({ type: "remove", id: "child" });
+    expect(store.list(parent.id)).toEqual([]);
+    expect(() => store.fetchTimeline(parent.id, nested!.id)).toThrow("Unknown agent");
+  });
+
+  test("parent invalidation removes reports without inventing worker cancellation", async () => {
+    const { store, events, sources, parent } = setup();
+    const reporter = sources.open("plugin", parent);
+    await reporter.report({ type: "upsert", id: "child", status: "running" });
+    const id = store.list(parent.id)[0]!.id;
+    sources.deleteParent(parent.id);
+    await reporter.close();
+    await expect(reporter.report({ type: "upsert", id: "child" })).rejects.toThrow("closed");
+    expect(events).toEqual([
+      { type: "upsert", subagent: expect.objectContaining({ status: "running" }) },
+      { type: "remove", parentAgentId: parent.id, subagentId: id },
+    ]);
+    expect(store.list(parent.id)).toEqual([]);
+  });
+});

--- a/packages/server/src/server/agent/provider-subagents/reporters.ts
+++ b/packages/server/src/server/agent/provider-subagents/reporters.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "node:crypto";
+import type { PluginSubagentEvent } from "@getpaseo/plugin/server";
+import type { PluginSubagentReporter } from "@getpaseo/plugin/server";
+import type { AgentProvider } from "../agent-sdk-types.js";
+import type { ProviderSubagentStore, ProviderSubagentStoreEvent } from "./store.js";
+
+interface ReporterParent {
+  id: string;
+  provider: AgentProvider;
+  isCurrent(): boolean;
+}
+
+interface ReporterSource {
+  parent: ReporterParent;
+  pluginId: string;
+  children: Map<string, string | null>;
+}
+
+export class PluginSubagentSources {
+  private readonly sources = new Map<string, ReporterSource>();
+
+  constructor(
+    private readonly store: ProviderSubagentStore,
+    private readonly publish: (event: ProviderSubagentStoreEvent) => void,
+  ) {}
+
+  open(pluginId: string, parent: ReporterParent): PluginSubagentReporter {
+    const sourceId = `plugin/${encodeURIComponent(pluginId)}/${randomUUID()}/`;
+    this.sources.set(sourceId, { parent, pluginId, children: new Map() });
+    return {
+      report: async (event) => {
+        const source = this.sources.get(sourceId);
+        if (!source || !source.parent.isCurrent()) {
+          this.close(sourceId);
+          throw new Error("Subagent reporter is closed");
+        }
+        this.report(sourceId, source, event);
+      },
+      close: async () => this.close(sourceId),
+    };
+  }
+
+  deleteParent(parentAgentId: string): void {
+    for (const [sourceId, source] of this.sources) {
+      if (source.parent.id === parentAgentId) this.close(sourceId);
+    }
+  }
+
+  private close(sourceId: string): void {
+    const source = this.sources.get(sourceId);
+    if (!source) return;
+    this.sources.delete(sourceId);
+    source.children.clear();
+    for (const event of this.store.deleteSource(source.parent.id, sourceId)) this.publish(event);
+  }
+
+  private report(sourceId: string, source: ReporterSource, event: PluginSubagentEvent): void {
+    const publicId = (id: string) => `${sourceId}${encodeURIComponent(id)}`;
+    const apply = (input: PluginSubagentEvent) => {
+      this.publish(this.store.apply(source.parent.id, source.parent.provider, input, sourceId));
+    };
+    if (event.type === "upsert") {
+      const parentId =
+        event.parentSubagentId === undefined
+          ? (source.children.get(event.id) ?? null)
+          : event.parentSubagentId;
+      if (parentId !== null && !source.children.has(parentId)) {
+        throw new Error("Subagent parent must be declared in this reporter first");
+      }
+      for (
+        let ancestor = parentId;
+        ancestor !== null;
+        ancestor = source.children.get(ancestor) ?? null
+      ) {
+        if (ancestor === event.id) throw new Error("Subagent parent would create a cycle");
+      }
+      apply({
+        ...event,
+        id: publicId(event.id),
+        parentSubagentId: parentId === null ? null : publicId(parentId),
+      });
+      source.children.set(event.id, parentId);
+      return;
+    }
+    if (event.type === "timeline") {
+      if (!source.children.has(event.id))
+        throw new Error("Declare the subagent before reporting its timeline");
+      const item =
+        event.item.type === "plugin" ? { ...event.item, pluginId: source.pluginId } : event.item;
+      apply({ ...event, id: publicId(event.id), item });
+      return;
+    }
+    const removed = new Set([event.id]);
+    // Parent links can change after declaration, so map insertion order is not tree order.
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const [id, parentId] of source.children) {
+        if (parentId !== null && removed.has(parentId) && !removed.has(id)) {
+          removed.add(id);
+          changed = true;
+        }
+      }
+    }
+    for (const id of removed) {
+      if (source.children.delete(id)) apply({ type: "remove", id: publicId(id) });
+    }
+  }
+}

--- a/packages/server/src/server/agent/provider-subagents/store.test.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.test.ts
@@ -60,6 +60,38 @@ describe("ProviderSubagentStore", () => {
     expect(subagents.list("parent-b")).toHaveLength(1);
   });
 
+  test("native history deletion preserves plugin children and timeline ownership", () => {
+    const store = new ProviderSubagentStore();
+    store.apply("parent", "pi", { type: "upsert", id: "native" });
+    store.apply("parent", "pi", { type: "upsert", id: "external" }, "reporter");
+    store.apply(
+      "parent",
+      "pi",
+      {
+        type: "timeline",
+        id: "external",
+        item: { type: "assistant_message", text: "External" },
+      },
+      "reporter",
+    );
+    expect(() => store.apply("parent", "pi", { type: "remove", id: "external" })).toThrow(
+      "different source",
+    );
+    expect(store.deleteNativeParent("parent")).toEqual([
+      { type: "remove", parentAgentId: "parent", subagentId: "native" },
+    ]);
+    expect(store.listNative("parent")).toEqual([]);
+    expect(store.fetchTimeline("parent", "external").rows[0]?.item).toEqual({
+      type: "assistant_message",
+      text: "External",
+    });
+    expect(store.deleteSource("parent", "reporter")).toEqual([
+      { type: "remove", parentAgentId: "parent", subagentId: "external" },
+    ]);
+    expect(store.list("parent")).toEqual([]);
+    expect(() => store.fetchTimeline("parent", "external")).toThrow("Unknown agent");
+  });
+
   test("limits oversized provider child tool output before storage", () => {
     const subagents = new ProviderSubagentStore();
     const output = "x".repeat(70 * 1024);

--- a/packages/server/src/server/agent/provider-subagents/store.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.ts
@@ -79,19 +79,26 @@ function stickyField<T>(next: T | undefined, previous: T | null | undefined): T 
 export class ProviderSubagentStore {
   private readonly descriptors = new Map<string, ProviderSubagentDescriptor>();
   private readonly timelines = new InMemoryAgentTimelineStore();
+  private readonly sources = new Map<string, string | null>();
 
   apply(
     parentAgentId: string,
     provider: AgentProvider,
     event: ProviderSubagentInputEvent,
+    source: string | null = null,
   ): ProviderSubagentStoreEvent {
     const key = storeKey(parentAgentId, event.id);
+    if (this.sources.has(key) && this.sources.get(key) !== source) {
+      throw new Error("Provider subagent belongs to a different source");
+    }
     if (event.type === "remove") {
+      this.sources.delete(key);
       this.descriptors.delete(key);
       this.timelines.delete(key);
       return { type: "remove", parentAgentId, subagentId: event.id };
     }
 
+    this.sources.set(key, source);
     if (event.type === "timeline") {
       if (!this.timelines.has(key)) {
         this.timelines.initialize(key);
@@ -177,13 +184,37 @@ export class ProviderSubagentStore {
     };
   }
 
+  listNative(parentAgentId: string): ProviderSubagentDescriptor[] {
+    return this.list(parentAgentId).filter(
+      (child) => this.sources.get(storeKey(parentAgentId, child.id)) === null,
+    );
+  }
+
+  deleteNativeParent(parentAgentId: string): ProviderSubagentStoreEvent[] {
+    return this.deleteSource(parentAgentId, null);
+  }
+
+  deleteSource(parentAgentId: string, source: string | null): ProviderSubagentStoreEvent[] {
+    return this.deleteMatching(parentAgentId, source);
+  }
+
   deleteParent(parentAgentId: string): ProviderSubagentStoreEvent[] {
+    return this.deleteMatching(parentAgentId);
+  }
+
+  private deleteMatching(
+    parentAgentId: string,
+    source?: string | null,
+  ): ProviderSubagentStoreEvent[] {
     const events: ProviderSubagentStoreEvent[] = [];
-    for (const subagent of this.list(parentAgentId)) {
-      const key = storeKey(parentAgentId, subagent.id);
+    // Include timeline-only native observations, which have no descriptor yet.
+    const prefix = `${parentAgentId}\0`;
+    for (const [key, owner] of this.sources) {
+      if (!key.startsWith(prefix) || (source !== undefined && source !== owner)) continue;
+      this.sources.delete(key);
       this.descriptors.delete(key);
       this.timelines.delete(key);
-      events.push({ type: "remove", parentAgentId, subagentId: subagent.id });
+      events.push({ type: "remove", parentAgentId, subagentId: key.slice(prefix.length) });
     }
     return events;
   }

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -933,6 +933,10 @@ export async function createPaseoDaemon(
       resolvePaseoToolPolicy(provider, daemonConfigStore.get().providers),
     logger,
   });
+  pluginRuntime.bindSubagentHost({
+    open: (pluginId, parentAgentId) =>
+      agentManager.openPluginSubagentReporter(pluginId, parentAgentId),
+  });
   const syncPluginProviders = () => {
     agentManager.updateProviderRegistry(
       providerSnapshotManager.replacePluginProviders(pluginRuntime.getProviderRegistrations()),

--- a/packages/server/src/server/plugins/index.ts
+++ b/packages/server/src/server/plugins/index.ts
@@ -40,6 +40,7 @@ interface PluginRuntimePort {
   stopAll(): Promise<void>;
   subscribe(listener: (pluginId: string, error?: string) => void): () => void;
   bindPaseoSessionHost(sessionHost: Parameters<PluginRuntime["bindPaseoSessionHost"]>[0]): void;
+  bindSubagentHost?: PluginRuntime["bindSubagentHost"];
 }
 
 interface PluginServiceDependencies {
@@ -117,6 +118,12 @@ export class PluginService {
 
   bindPaseoSessionHost(sessionHost: Parameters<PluginRuntime["bindPaseoSessionHost"]>[0]): void {
     this.runtime.bindPaseoSessionHost(sessionHost);
+  }
+
+  bindSubagentHost(host: Parameters<PluginRuntime["bindSubagentHost"]>[0]): void {
+    if (!this.runtime.bindSubagentHost)
+      throw new Error("Plugin runtime cannot bind a subagent host");
+    this.runtime.bindSubagentHost(host);
   }
 
   getProviderRegistrations(): readonly ProviderRegistration[] {

--- a/packages/server/src/server/plugins/plugin-process-protocol.ts
+++ b/packages/server/src/server/plugins/plugin-process-protocol.ts
@@ -6,6 +6,12 @@ import type {
 } from "@getpaseo/plugin/server/provider";
 import { ProviderEventSchema, ProviderInputSchema } from "@getpaseo/plugin/server/provider";
 import { z } from "zod";
+import {
+  PluginSubagentRequestSchema,
+  PluginSubagentResponseSchema,
+  type PluginSubagentRequest,
+  type PluginSubagentResponse,
+} from "./subagents/protocol.js";
 
 export interface PluginProviderMetadata {
   hasCatalogCacheKey?: boolean;
@@ -16,6 +22,7 @@ export interface PluginProviderMetadata {
 }
 
 export type PluginProcessRequest =
+  | PluginSubagentResponse
   | {
       type: "initialize";
       pluginId: string;
@@ -50,6 +57,7 @@ export type PluginProcessRequest =
   | { type: "paseo_close" };
 
 export type PluginProcessMessage =
+  | PluginSubagentRequest
   | { type: "settings.changed"; settingsId: string }
   | { type: "hooks.changed"; hooks: { events: string[]; before: string[] } }
   | {
@@ -105,6 +113,7 @@ const frameFields = {
 export const PluginProcessRequestSchema: z.ZodType<PluginProcessRequest> = z.discriminatedUnion(
   "type",
   [
+    PluginSubagentResponseSchema,
     z
       .object({
         type: z.literal("initialize"),
@@ -175,6 +184,7 @@ export const PluginProcessRequestSchema: z.ZodType<PluginProcessRequest> = z.dis
 export const PluginProcessMessageSchema: z.ZodType<PluginProcessMessage> = z.discriminatedUnion(
   "type",
   [
+    PluginSubagentRequestSchema,
     z.object({ type: z.literal("settings.changed"), settingsId: z.string() }).strict(),
     z.object({ type: z.literal("hooks.changed"), hooks: hooksSchema }).strict(),
     z

--- a/packages/server/src/server/plugins/plugin-process.ts
+++ b/packages/server/src/server/plugins/plugin-process.ts
@@ -6,6 +6,7 @@ import {
 } from "./plugin-process-protocol.js";
 import { createRequire } from "node:module";
 import * as pluginSharedRuntime from "@getpaseo/plugin";
+import * as pluginServerRuntime from "@getpaseo/plugin/server";
 import * as pluginProviderRuntime from "@getpaseo/plugin/server/provider";
 import * as pluginAcpRuntime from "@getpaseo/plugin/server/acp";
 import type { SettingsDefinition, PluginRpcContract } from "@getpaseo/plugin";
@@ -20,6 +21,25 @@ import { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { createPluginDaemonTransportFactory } from "./daemon-transport.js";
 import { isPluginClientOnlySdkSpecifier } from "./plugin-sdk-specifiers.js";
 import { createPluginClientId } from "./plugin-session-identity.js";
+import { PluginSubagentClient } from "./subagents/client.js";
+
+const subagents = new PluginSubagentClient(
+  (request) =>
+    new Promise((resolve, reject) => {
+      if (!process.connected || !process.send) {
+        reject(new Error("Plugin IPC is closed"));
+        return;
+      }
+      process.send(request, (error: Error | null) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    }),
+);
+process.on("disconnect", () => subagents.stop());
 
 import { PluginSettingsStore } from "./settings/index.js";
 let settingsStore: PluginSettingsStore | null = null;
@@ -213,7 +233,7 @@ function runtimeRequire(name: string): unknown {
     throw new Error(`${name} is available only in plugin client code`);
   }
   if (name === "@getpaseo/plugin") return pluginSharedRuntime;
-  if (name === "@getpaseo/plugin/server") return {};
+  if (name === "@getpaseo/plugin/server") return pluginServerRuntime;
   if (name === "@getpaseo/plugin/server/provider") return pluginProviderRuntime;
   if (name === "@getpaseo/plugin/server/acp") return pluginAcpRuntime;
   if (name === "@getpaseo/plugin/client/host")
@@ -232,6 +252,7 @@ function evaluateBundle(bundle: string): void {
     throw new Error("Plugin server bundle must default export a function");
   }
   const contributedCleanup = setup({
+    subagents: { open: subagents.open },
     handle: register,
     registerProvider,
     registerSettings,
@@ -282,6 +303,7 @@ async function initialize(message: Extract<PluginProcessRequest, { type: "initia
 async function shutdown(): Promise<void> {
   if (stopping) return;
   stopping = true;
+  subagents.stop();
   const releaseApi = paseo
     ?.dispose()
     .catch((error) => console.error("Plugin API cleanup failed", error));
@@ -322,6 +344,10 @@ process.on("message", (rawMessage: unknown) => {
     return;
   }
   const message = parsed.data;
+  if (message.type === "subagents.response") {
+    subagents.receive(message);
+    return;
+  }
   if (message.type === "initialize") {
     void initialize(message).catch(async (error) => {
       send({ type: "fatal", error: describeError(error) });
@@ -337,24 +363,7 @@ process.on("message", (rawMessage: unknown) => {
     return;
   }
   if (stopping) {
-    if (message.type === "provider.catalog_key") {
-      send({ type: "error", requestId: message.requestId, error: "Plugin is stopping" });
-    } else if (message.type === "provider.connect") {
-      send({
-        type: "provider.connect_failed",
-        connectionId: message.connectionId,
-        error: "Plugin is stopping",
-      });
-    } else if (message.type === "provider.send") {
-      send({
-        type: "provider.rejected",
-        connectionId: message.connectionId,
-        acceptanceId: message.acceptanceId,
-        error: "Plugin is stopping",
-      });
-    } else if (message.type === "provider.close") {
-      send({ type: "provider.closed", connectionId: message.connectionId });
-    }
+    rejectWhileStopping(message);
     return;
   }
   if (message.type === "provider.catalog_key") {
@@ -429,6 +438,27 @@ process.on("message", (rawMessage: unknown) => {
       (error) => send({ type: "error", requestId: message.requestId, error: describeError(error) }),
     );
 });
+
+function rejectWhileStopping(message: PluginProcessRequest): void {
+  if (message.type === "provider.catalog_key") {
+    send({ type: "error", requestId: message.requestId, error: "Plugin is stopping" });
+  } else if (message.type === "provider.connect") {
+    send({
+      type: "provider.connect_failed",
+      connectionId: message.connectionId,
+      error: "Plugin is stopping",
+    });
+  } else if (message.type === "provider.send") {
+    send({
+      type: "provider.rejected",
+      connectionId: message.connectionId,
+      acceptanceId: message.acceptanceId,
+      error: "Plugin is stopping",
+    });
+  } else if (message.type === "provider.close") {
+    send({ type: "provider.closed", connectionId: message.connectionId });
+  }
+}
 
 function handleHookMessage(
   message: Extract<PluginProcessRequest, { type: "hook" | "hook.cancel" }>,

--- a/packages/server/src/server/plugins/runtime.ts
+++ b/packages/server/src/server/plugins/runtime.ts
@@ -27,6 +27,8 @@ import type {
 } from "./plugin-process-protocol.js";
 import { PluginProcessMessageSchema } from "./plugin-process-protocol.js";
 import { PluginSessionSocket } from "./session-socket.js";
+import { PluginSubagentRequests, type PluginSubagentHost } from "./subagents/host.js";
+import { assertSubagentRequestSize, subagentRequestId } from "./subagents/protocol.js";
 
 const CLIENT_ENTRY_FILENAMES = ["index.client.ts", "index.client.tsx"] as const;
 const SERVER_ENTRY_FILENAMES = ["index.server.ts", "index.server.tsx"] as const;
@@ -72,6 +74,7 @@ interface LoadedPlugin {
   providerConnectionTombstones: Set<string>;
   sessionSocket: PluginSessionSocket | null;
   sessionClosed: Promise<void> | null;
+  subagents: PluginSubagentRequests | null;
 }
 
 interface PendingProviderSend {
@@ -100,6 +103,7 @@ interface PluginRuntimeDependencies {
   onSettingsChanged?: (pluginId: string, settingsId: string) => void;
   spawnChild?: () => PluginChild;
   sessionHost?: PluginPaseoSessionHost;
+  subagentHost?: PluginSubagentHost;
 }
 
 interface PluginLogTail {
@@ -274,6 +278,7 @@ export class PluginRuntime {
   private readonly logger: pino.Logger;
   private readonly spawnChild: () => PluginChild;
   private sessionHost: PluginPaseoSessionHost | null;
+  private subagentHost: PluginSubagentHost | null;
   private readonly listeners = new Set<(pluginId: string, error?: string) => void>();
 
   constructor(
@@ -284,12 +289,18 @@ export class PluginRuntime {
     this.logger = logger.child({ module: "plugins" });
     this.spawnChild = dependencies.spawnChild ?? spawnPluginChild;
     this.sessionHost = dependencies.sessionHost ?? null;
+    this.subagentHost = dependencies.subagentHost ?? null;
   }
 
   bindPaseoSessionHost(sessionHost: PluginPaseoSessionHost): void {
     if (this.plugins.size > 0)
       throw new Error("Cannot replace the plugin session host while running");
     this.sessionHost = sessionHost;
+  }
+
+  bindSubagentHost(host: PluginSubagentHost): void {
+    if (this.plugins.size > 0) throw new Error("Cannot replace the subagent host while running");
+    this.subagentHost = host;
   }
 
   subscribe(listener: (pluginId: string, error?: string) => void): () => void {
@@ -557,6 +568,7 @@ export class PluginRuntime {
         providerConnectionTombstones: new Set(),
         sessionSocket: null,
         sessionClosed: null,
+        subagents: null,
       };
     }
     const sessionHost = this.sessionHost;
@@ -590,8 +602,29 @@ export class PluginRuntime {
             reject(error);
           };
           child.on("message", (rawMessage) => {
+            const requestId = subagentRequestId(rawMessage);
+            if (requestId) {
+              try {
+                assertSubagentRequestSize(rawMessage);
+              } catch (error) {
+                void send(child, {
+                  type: "subagents.response",
+                  requestId,
+                  error: describeError(error),
+                }).catch(() => undefined);
+                return;
+              }
+            }
             const parsed = PluginProcessMessageSchema.safeParse(rawMessage);
             if (!parsed.success) {
+              if (requestId) {
+                void send(child, {
+                  type: "subagents.response",
+                  requestId,
+                  error: `Invalid subagent request: ${parsed.error.message.slice(0, 1024)}`,
+                }).catch(() => undefined);
+                return;
+              }
               const error = new Error(
                 `Plugin ${pluginId} sent an invalid message: ${parsed.error.message}`,
               );
@@ -613,6 +646,12 @@ export class PluginRuntime {
               fail(new Error(message.error));
             } else if (loaded) {
               this.handleChildMessage(loaded, message);
+            } else if (message.type === "subagents.request") {
+              void send(child, {
+                type: "subagents.response",
+                requestId: message.requestId,
+                error: "Plugin is not ready",
+              }).catch(() => undefined);
             }
           });
           child.on("close", () => {
@@ -654,7 +693,9 @@ export class PluginRuntime {
       providerConnectionTombstones: new Set(),
       sessionSocket,
       sessionClosed: sessionAttachment.closed,
+      subagents: null,
     };
+    loaded.subagents = new PluginSubagentRequests(loaded.id, this.subagentHost);
     this.logger.info(
       { pluginId, methods: ready.methods, providers: ready.providers },
       "Loaded plugin",
@@ -663,6 +704,25 @@ export class PluginRuntime {
   }
 
   private handleChildMessage(loaded: LoadedPlugin, message: PluginProcessMessage): void {
+    if (message.type === "subagents.request") {
+      const child = loaded.child;
+      const subagents = loaded.subagents;
+      if (!child || !subagents) return;
+      void subagents
+        .receive(message)
+        .then(
+          () =>
+            send(child, { type: "subagents.response", requestId: message.requestId, error: null }),
+          (error) =>
+            send(child, {
+              type: "subagents.response",
+              requestId: message.requestId,
+              error: describeError(error).slice(0, 1024),
+            }),
+        )
+        .catch(() => undefined);
+      return;
+    }
     if (message.type === "hooks.changed") {
       loaded.hooks = message.hooks;
       return;
@@ -974,6 +1034,7 @@ export class PluginRuntime {
   }
 
   private async handleChildClose(loaded: LoadedPlugin): Promise<void> {
+    await loaded.subagents?.stop();
     loaded.sessionSocket?.peerClosed();
     const wasPublished = this.plugins.get(loaded.id) === loaded;
     if (wasPublished) {
@@ -989,6 +1050,7 @@ export class PluginRuntime {
   }
 
   private async stopPlugin(loaded: LoadedPlugin): Promise<void> {
+    await loaded.subagents?.stop();
     this.appendLog(loaded.id, "stdout", "[paseo] Stopping plugin");
     for (const [connectionId, state] of loaded.providerConnections) {
       if (state.connected) continue;

--- a/packages/server/src/server/plugins/subagents.e2e.test.ts
+++ b/packages/server/src/server/plugins/subagents.e2e.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "vitest";
+import { DaemonClient } from "../test-utils/daemon-client.js";
+import { createTestPaseoDaemon } from "../test-utils/paseo-daemon.js";
+import { createTestAgentClient } from "../test-utils/fake-agent-client.js";
+
+const source = `
+import { defineRpc } from "@getpaseo/plugin";
+import { PluginSubagentEventSchema, PLUGIN_SUBAGENT_MAX_EVENT_BYTES } from "@getpaseo/plugin/server";
+import { z } from "zod";
+export default function contribute(server) {
+  let reporter;
+  server.handle(defineRpc({ name: "contract", input: z.null(), output: z.object({ limit: z.number(), acceptsDescriptor: z.boolean(), acceptsInvalidStatus: z.boolean() }) }), () => ({
+    limit: PLUGIN_SUBAGENT_MAX_EVENT_BYTES,
+    acceptsDescriptor: PluginSubagentEventSchema.safeParse({ type: "upsert", id: "child", status: "running" }).success,
+    acceptsInvalidStatus: PluginSubagentEventSchema.safeParse({ type: "upsert", id: "child", status: "invalid" }).success,
+  }));
+  server.handle(defineRpc({ name: "report", input: z.object({ parentAgentId: z.string() }), output: z.null() }), async ({ parentAgentId }) => {
+    reporter = await server.subagents.open({ parentAgentId });
+    await reporter.report({ type: "upsert", id: "child", title: "External worker", status: "running" });
+    await reporter.report({ type: "timeline", id: "child", item: { type: "assistant_message", text: "External output" } });
+    return null;
+  });
+  server.handle(defineRpc({ name: "late", input: z.null(), output: z.null() }), async () => {
+    await reporter.report({ type: "upsert", id: "late" });
+    return null;
+  });
+  server.handle(defineRpc({ name: "close", input: z.null(), output: z.null() }), async () => {
+    await reporter.close();
+    await reporter.close();
+    return null;
+  });
+  server.handle(defineRpc({ name: "crash", input: z.null(), output: z.null() }), async () => {
+    process.exit(17);
+  });
+  return () => {};
+}
+`;
+
+test("real plugin IPC publishes beneath an existing Pi parent and cleans each process source", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "paseo-subagent-ipc-"));
+  const daemon = await createTestPaseoDaemon({
+    daemonVersion: "0.8.0",
+    agentClients: { pi: createTestAgentClient("pi") },
+  });
+  const client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws`, appVersion: "0.8.0" });
+  const observer = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    appVersion: "0.8.0",
+  });
+  try {
+    await writeFile(
+      path.join(directory, "paseo-plugin.json"),
+      JSON.stringify({ id: "source-id", requirements: { paseo: ">=0.8.0" } }),
+    );
+    await writeFile(path.join(directory, "index.server.ts"), source);
+    await client.connect();
+    await observer.connect();
+    await client.patchDaemonConfig({ pluginsEnabled: true });
+    await client.installDirectoryPlugin(directory, "first");
+    await client.installDirectoryPlugin(directory, "second");
+    expect(await client.invokePluginRpc("first", "contract", null)).toEqual({
+      limit: 65_536,
+      acceptsDescriptor: true,
+      acceptsInvalidStatus: false,
+    });
+    const parent = await client.createAgent({
+      provider: "pi",
+      cwd: directory,
+      title: "Built-in parent",
+    });
+    await client.invokePluginRpc("first", "report", { parentAgentId: parent.id });
+    await client.invokePluginRpc("second", "report", { parentAgentId: parent.id });
+    const result = await observer.listProviderSubagents(parent.id);
+    expect(result.error).toBeNull();
+    expect(result.subagents).toHaveLength(2);
+    const first = result.subagents.find((child) => child.id.startsWith("plugin/first/"))!;
+    const second = result.subagents.find((child) => child.id.startsWith("plugin/second/"))!;
+    expect(first).toMatchObject({ parentAgentId: parent.id, provider: "pi", status: "running" });
+    expect(second).toMatchObject({ parentAgentId: parent.id, provider: "pi", status: "running" });
+    const timeline = await observer.fetchProviderSubagentTimeline(parent.id, first.id);
+    expect(timeline.error).toBeNull();
+    expect(timeline.rows.map((row) => row.item)).toEqual([
+      { type: "assistant_message", text: "External output" },
+    ]);
+    expect(daemon.daemon.agentManager.getAgent(parent.id)?.provider).toBe("pi");
+    expect(daemon.daemon.agentManager.listAgents()).toHaveLength(1);
+
+    await client.reloadPlugin("first");
+    expect((await observer.listProviderSubagents(parent.id)).subagents).toEqual([second]);
+    await client.invokePluginRpc("first", "report", { parentAgentId: parent.id });
+    await expect(client.invokePluginRpc("first", "crash", null)).rejects.toThrow();
+    await expect
+      .poll(async () => (await observer.listProviderSubagents(parent.id)).subagents)
+      .toEqual([second]);
+
+    await daemon.daemon.agentManager.closeAgent(parent.id);
+    await expect(client.invokePluginRpc("second", "late", null)).rejects.toThrow("closed");
+    await client.invokePluginRpc("second", "close", null);
+    expect(daemon.daemon.agentManager.listProviderSubagentActivity()).toEqual([]);
+    await client.disablePlugin("second");
+  } finally {
+    await observer.close();
+    await client.close();
+    await daemon.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/packages/server/src/server/plugins/subagents/client.test.ts
+++ b/packages/server/src/server/plugins/subagents/client.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "vitest";
+import type { PluginSubagentEvent } from "@getpaseo/plugin/server";
+import { PluginSubagentClient } from "./client.js";
+import { PluginSubagentRequests } from "./host.js";
+import { parseSubagentEvent } from "./protocol.js";
+
+function setup(dropFirstReportAck = false) {
+  const events: PluginSubagentEvent[] = [];
+  const sequences: number[] = [];
+  let closes = 0;
+  const host = new PluginSubagentRequests("installation", {
+    open: () => ({
+      report: async (event) => {
+        events.push(event);
+      },
+      close: async () => {
+        closes += 1;
+      },
+    }),
+  });
+  const client = new PluginSubagentClient(async (request) => {
+    await host.receive(request);
+    if (request.operation.type === "report") {
+      sequences.push(request.operation.sequence);
+      if (dropFirstReportAck) {
+        dropFirstReportAck = false;
+        return;
+      }
+    }
+    client.receive({ type: "subagents.response", requestId: request.requestId, error: null });
+  }, 20);
+  return { client, events, sequences, getCloses: () => closes };
+}
+
+test("retries a lost report acknowledgement with the same sequence and no duplicate effect", async () => {
+  const { client, events, sequences } = setup(true);
+  const reporter = await client.open({ parentAgentId: "parent" });
+  await reporter.report({ type: "upsert", id: "child" });
+  await reporter.report({ type: "upsert", id: "child", status: "completed" });
+  expect(events).toEqual([
+    { type: "upsert", id: "child" },
+    { type: "upsert", id: "child", status: "completed" },
+  ]);
+  expect(sequences).toEqual([1, 1, 2]);
+  await reporter.close();
+  client.stop();
+});
+
+test("serializes concurrent reports and closes idempotently", async () => {
+  const { client, events, sequences, getCloses } = setup();
+  const reporter = await client.open({ parentAgentId: "parent" });
+  await Promise.all([
+    reporter.report({ type: "upsert", id: "child" }),
+    reporter.report({
+      type: "timeline",
+      id: "child",
+      item: { type: "assistant_message", text: "Done" },
+    }),
+  ]);
+  expect(events).toHaveLength(2);
+  expect(sequences).toEqual([1, 2]);
+  await Promise.all([reporter.close(), reporter.close()]);
+  expect(getCloses()).toBe(1);
+  await expect(reporter.report({ type: "remove", id: "child" })).rejects.toThrow("closed");
+  client.stop();
+});
+
+test("rejects pending IPC when the process stops", async () => {
+  const client = new PluginSubagentClient(async () => undefined);
+  const opening = client.open({ parentAgentId: "parent" });
+  const rejected = expect(opening).rejects.toThrow("IPC is closed");
+  client.stop();
+  await rejected;
+  await expect(client.open({ parentAgentId: "parent" })).rejects.toThrow("stopped");
+});
+
+test("rejects oversized UTF-8 events instead of truncating content", () => {
+  expect(() =>
+    parseSubagentEvent({
+      type: "timeline",
+      id: "child",
+      item: { type: "assistant_message", text: "x".repeat(65536) },
+    }),
+  ).toThrow("exceeds");
+  expect(() =>
+    parseSubagentEvent({ type: "upsert", id: "child", title: "\u20ac".repeat(22000) }),
+  ).toThrow("exceeds");
+  expect(() => parseSubagentEvent({ type: "upsert", id: "child", status: "idle" })).toThrow();
+});

--- a/packages/server/src/server/plugins/subagents/client.ts
+++ b/packages/server/src/server/plugins/subagents/client.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "node:crypto";
+import type { PluginSubagentReporter, PluginServerContext } from "@getpaseo/plugin/server";
+import {
+  parseSubagentEvent,
+  type PluginSubagentRequest,
+  type PluginSubagentResponse,
+} from "./protocol.js";
+
+interface PendingRequest {
+  reject(error: Error): void;
+  resolve(): void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+class SubagentTransportError extends Error {}
+
+export class PluginSubagentClient {
+  private readonly pending = new Map<string, PendingRequest>();
+  private stopped = false;
+
+  private readonly send: (request: PluginSubagentRequest) => Promise<void>;
+  private readonly timeoutMs: number;
+
+  constructor(send: (request: PluginSubagentRequest) => Promise<void>, timeoutMs = 30_000) {
+    this.send = send;
+    this.timeoutMs = timeoutMs;
+  }
+
+  readonly open: PluginServerContext["subagents"]["open"] = async ({ parentAgentId }) => {
+    if (this.stopped) throw new Error("Plugin subagent reporting is stopped");
+    const reporterId = randomUUID();
+    try {
+      await this.request({
+        type: "subagents.request",
+        reporterId,
+        requestId: randomUUID(),
+        operation: { type: "open", parentAgentId },
+      });
+    } catch (error) {
+      this.release(reporterId);
+      throw error;
+    }
+    let closed = false;
+    let sequence = 0;
+    let queued = 0;
+    let tail = Promise.resolve();
+    let closing: Promise<void> | null = null;
+    const reporter: PluginSubagentReporter = {
+      report: async (input) => {
+        if (closed || this.stopped) throw new Error("Subagent reporter is closed");
+        if (queued >= 32) throw new Error("Subagent report queue limit reached");
+        const event = parseSubagentEvent(input);
+        queued += 1;
+        const result = tail.then(async () => {
+          if (closed || this.stopped) throw new Error("Subagent reporter is closed");
+          sequence += 1;
+          try {
+            await this.request({
+              type: "subagents.request",
+              reporterId,
+              requestId: randomUUID(),
+              operation: { type: "report", sequence, event },
+            });
+          } catch (error) {
+            if (error instanceof SubagentTransportError) {
+              closed = true;
+              this.release(reporterId);
+            }
+            throw error;
+          }
+          return;
+        });
+        tail = result.catch(() => undefined);
+        try {
+          await result;
+        } finally {
+          queued -= 1;
+        }
+      },
+      close: () => {
+        if (closing) return closing;
+        closed = true;
+        closing = tail.then(async () => {
+          if (this.stopped) return;
+          return this.request({
+            type: "subagents.request",
+            reporterId,
+            requestId: randomUUID(),
+            operation: { type: "close" },
+          });
+        });
+        return closing;
+      },
+    };
+    return reporter;
+  };
+
+  receive(response: PluginSubagentResponse): void {
+    const pending = this.pending.get(response.requestId);
+    if (!pending) return;
+    this.pending.delete(response.requestId);
+    clearTimeout(pending.timer);
+    if (response.error === null) pending.resolve();
+    else pending.reject(new Error(response.error));
+  }
+
+  stop(): void {
+    this.stopped = true;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new SubagentTransportError("Plugin subagent IPC is closed"));
+    }
+    this.pending.clear();
+  }
+
+  private release(reporterId: string): void {
+    if (this.stopped) return;
+    void this.send({
+      type: "subagents.request",
+      reporterId,
+      requestId: randomUUID(),
+      operation: { type: "close" },
+    }).catch(() => undefined);
+  }
+
+  private request(request: PluginSubagentRequest): Promise<void> {
+    if (this.stopped)
+      return Promise.reject(new SubagentTransportError("Plugin subagent IPC is closed"));
+    if (this.pending.size >= 128)
+      return Promise.reject(new SubagentTransportError("Subagent IPC request limit reached"));
+    return new Promise((resolve, reject) => {
+      let retries = request.operation.type === "report" ? 1 : 0;
+      const fail = (error: Error) => {
+        const pending = this.pending.get(request.requestId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pending.delete(request.requestId);
+        reject(error);
+      };
+      const transmit = () => {
+        void this.send(request).catch((error) => fail(new SubagentTransportError(String(error))));
+      };
+      const timeout = () => {
+        const pending = this.pending.get(request.requestId);
+        if (!pending) return;
+        if (retries > 0) {
+          retries -= 1;
+          pending.timer = setTimeout(timeout, this.timeoutMs);
+          transmit();
+          return;
+        }
+        fail(new SubagentTransportError("Subagent IPC request timed out"));
+      };
+      this.pending.set(request.requestId, {
+        resolve,
+        reject,
+        timer: setTimeout(timeout, this.timeoutMs),
+      });
+      transmit();
+    });
+  }
+}

--- a/packages/server/src/server/plugins/subagents/host.test.ts
+++ b/packages/server/src/server/plugins/subagents/host.test.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from "node:crypto";
+import { expect, test } from "vitest";
+import { PluginSubagentSources } from "../../agent/provider-subagents/reporters.js";
+import { ProviderSubagentStore } from "../../agent/provider-subagents/store.js";
+import { PluginSubagentRequests } from "./host.js";
+import type { PluginSubagentRequest } from "./protocol.js";
+
+function setup() {
+  const store = new ProviderSubagentStore();
+  const sources = new PluginSubagentSources(store, () => undefined);
+  const host = new PluginSubagentRequests("installation", {
+    open: (pluginId, parentAgentId) =>
+      sources.open(pluginId, { id: parentAgentId, provider: "pi", isCurrent: () => true }),
+  });
+  const reporterId = randomUUID();
+  const send = (operation: PluginSubagentRequest["operation"]) =>
+    host.receive({ type: "subagents.request", requestId: randomUUID(), reporterId, operation });
+  return { store, host, send };
+}
+
+test("acknowledges a retried sequence once and rejects changed or skipped sequences", async () => {
+  const { store, host, send } = setup();
+  await send({ type: "open", parentAgentId: "parent" });
+  await send({ type: "report", sequence: 1, event: { type: "upsert", id: "child" } });
+  const timeline = {
+    type: "report",
+    sequence: 2,
+    event: { type: "timeline", id: "child", item: { type: "assistant_message", text: "One row" } },
+  } as const;
+  await Promise.all([send(timeline), send(timeline)]);
+  const child = store.list("parent")[0]!;
+  expect(child.id).toMatch(/^plugin\/installation\//);
+  expect(store.fetchTimeline("parent", child.id).rows).toHaveLength(1);
+  await expect(
+    send({
+      ...timeline,
+      event: { ...timeline.event, item: { type: "assistant_message", text: "Different" } },
+    }),
+  ).rejects.toThrow("different data");
+  await expect(send({ ...timeline, sequence: 4 })).rejects.toThrow("out of order");
+  await send({ type: "close" });
+  await send({ type: "close" });
+  await expect(send({ ...timeline, sequence: 3 })).rejects.toThrow("closed");
+  await host.stop();
+});
+
+test("failed reports consume a sequence and retries preserve the error", async () => {
+  const { send } = setup();
+  await send({ type: "open", parentAgentId: "parent" });
+  const operation = {
+    type: "report",
+    sequence: 1,
+    event: {
+      type: "timeline",
+      id: "missing",
+      item: { type: "assistant_message", text: "Unknown" },
+    },
+  } as const;
+  await expect(send(operation)).rejects.toThrow("Declare");
+  await expect(send(operation)).rejects.toThrow("Declare");
+  await send({ type: "report", sequence: 2, event: { type: "upsert", id: "missing" } });
+  await send({ type: "close" });
+});
+
+test("process stop removes only its reports and rejects late opens and reports", async () => {
+  const { store, host, send } = setup();
+  store.apply("parent", "pi", { type: "upsert", id: "native" });
+  await send({ type: "open", parentAgentId: "parent" });
+  await send({ type: "report", sequence: 1, event: { type: "upsert", id: "external" } });
+  await host.stop();
+  await host.stop();
+  await send({ type: "close" });
+  await expect(send({ type: "open", parentAgentId: "parent" })).rejects.toThrow("stopped");
+  await expect(
+    send({ type: "report", sequence: 2, event: { type: "upsert", id: "late" } }),
+  ).rejects.toThrow("stopped");
+  expect(store.list("parent").map((child) => child.id)).toEqual(["native"]);
+});

--- a/packages/server/src/server/plugins/subagents/host.ts
+++ b/packages/server/src/server/plugins/subagents/host.ts
@@ -1,0 +1,92 @@
+import type { PluginSubagentReporter } from "@getpaseo/plugin/server";
+import { parseSubagentEvent, type PluginSubagentRequest } from "./protocol.js";
+
+export interface PluginSubagentHost {
+  open(pluginId: string, parentAgentId: string): PluginSubagentReporter;
+}
+
+interface ReportReceipt {
+  sequence: number;
+  encoded: string;
+  error: string | null;
+}
+
+interface Reporter {
+  reporter: PluginSubagentReporter;
+  tail: Promise<void>;
+  receipt: ReportReceipt | null;
+  closed: boolean;
+}
+
+/** One instance per subprocess. Never reuse it for a replacement installation. */
+export class PluginSubagentRequests {
+  private readonly reporters = new Map<string, Reporter>();
+  private stopped = false;
+
+  constructor(
+    private readonly pluginId: string,
+    private readonly host: PluginSubagentHost | null,
+  ) {}
+
+  async receive(request: PluginSubagentRequest): Promise<void> {
+    const { reporterId, operation } = request;
+    if (operation.type === "close") {
+      const state = this.reporters.get(reporterId);
+      if (!state) return;
+      this.reporters.delete(reporterId);
+      state.closed = true;
+      await state.reporter.close();
+      return;
+    }
+    if (this.stopped) throw new Error("Plugin subagent reporting is stopped");
+    if (operation.type === "open") {
+      if (!this.host) throw new Error("Plugin subagent reporting is unavailable");
+      if (this.reporters.has(reporterId)) throw new Error("Duplicate subagent reporter");
+      if (this.reporters.size >= 128) throw new Error("Plugin subagent reporter limit reached");
+      const reporter = this.host.open(this.pluginId, operation.parentAgentId);
+      this.reporters.set(reporterId, {
+        reporter,
+        tail: Promise.resolve(),
+        receipt: null,
+        closed: false,
+      });
+      return;
+    }
+    const state = this.reporters.get(reporterId);
+    if (!state) throw new Error("Subagent reporter is closed");
+    const result = state.tail.then(async () => {
+      if (this.stopped || state.closed) throw new Error("Subagent reporter is closed");
+      const event = parseSubagentEvent(operation.event);
+      const encoded = JSON.stringify(event);
+      const previous = state.receipt;
+      if (previous?.sequence === operation.sequence) {
+        if (previous.encoded !== encoded)
+          throw new Error("Subagent sequence reused with different data");
+        if (previous.error !== null) throw new Error(previous.error);
+        return;
+      }
+      if (operation.sequence !== (previous?.sequence ?? 0) + 1) {
+        throw new Error("Subagent report sequence is out of order");
+      }
+      const receipt: ReportReceipt = { sequence: operation.sequence, encoded, error: null };
+      state.receipt = receipt;
+      try {
+        await state.reporter.report(event);
+      } catch (error) {
+        receipt.error = error instanceof Error ? error.message : String(error);
+        throw error;
+      }
+      return;
+    });
+    state.tail = result.catch(() => undefined);
+    await result;
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    const states = [...this.reporters.values()];
+    this.reporters.clear();
+    for (const state of states) state.closed = true;
+    await Promise.all(states.map((state) => state.reporter.close()));
+  }
+}

--- a/packages/server/src/server/plugins/subagents/protocol.ts
+++ b/packages/server/src/server/plugins/subagents/protocol.ts
@@ -1,0 +1,57 @@
+import {
+  PluginSubagentEventSchema,
+  PLUGIN_SUBAGENT_MAX_EVENT_BYTES,
+} from "@getpaseo/plugin/server";
+import { z } from "zod";
+
+const id = z.string().uuid();
+export const PluginSubagentRequestSchema = z
+  .object({
+    type: z.literal("subagents.request"),
+    requestId: id,
+    reporterId: id,
+    operation: z.discriminatedUnion("type", [
+      z.object({ type: z.literal("open"), parentAgentId: z.string().min(1).max(256) }).strict(),
+      z
+        .object({
+          type: z.literal("report"),
+          sequence: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+          event: PluginSubagentEventSchema,
+        })
+        .strict(),
+      z.object({ type: z.literal("close") }).strict(),
+    ]),
+  })
+  .strict();
+
+export const PluginSubagentResponseSchema = z
+  .object({
+    type: z.literal("subagents.response"),
+    requestId: id,
+    error: z.string().nullable(),
+  })
+  .strict();
+
+export type PluginSubagentRequest = z.infer<typeof PluginSubagentRequestSchema>;
+export type PluginSubagentResponse = z.infer<typeof PluginSubagentResponseSchema>;
+
+export function parseSubagentEvent(event: unknown) {
+  const encoded = JSON.stringify(event);
+  if (encoded === undefined || Buffer.byteLength(encoded) > PLUGIN_SUBAGENT_MAX_EVENT_BYTES) {
+    throw new Error(`Subagent event exceeds ${PLUGIN_SUBAGENT_MAX_EVENT_BYTES} bytes`);
+  }
+  return PluginSubagentEventSchema.parse(JSON.parse(encoded));
+}
+
+export function subagentRequestId(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  if (Reflect.get(value, "type") !== "subagents.request") return null;
+  const result = id.safeParse(Reflect.get(value, "requestId"));
+  return result.success ? result.data : null;
+}
+
+export function assertSubagentRequestSize(value: unknown): void {
+  if (Buffer.byteLength(JSON.stringify(value)) > PLUGIN_SUBAGENT_MAX_EVENT_BYTES + 4096) {
+    throw new Error("Subagent IPC request exceeds its payload limit");
+  }
+}

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -561,6 +561,83 @@ saved; environment overrides are not persisted with it.
 
 Read logger output with `paseo plugin logs lifecycle-logger` or the host's `daemon.log`.
 
+## Report externally owned subagents
+
+This API requires a daemon build with the subagent reporter API; the original v0.8.0 release does
+not include it. It is server-only. No client entry or replacement provider is required.
+
+Use `server.subagents.open({ parentAgentId })` to report external child executions beneath an
+existing managed agent, including a built-in Pi agent. It returns a `Promise<PluginSubagentReporter>`.
+Import `PluginSubagentApi`, `PluginSubagentOpenInput`, `PluginSubagentReporter`, and
+`PluginSubagentEvent` from `@getpaseo/plugin/server`. That entry also exports
+`PluginSubagentEventSchema` and `PLUGIN_SUBAGENT_MAX_EVENT_BYTES`. Reporting belongs to server
+code; these exports are not available from the shared SDK entry.
+
+```ts
+const reporter = await server.subagents.open({ parentAgentId });
+await reporter.report({ type: "upsert", id: "worker-1", title: "Review", status: "running" });
+await reporter.report({
+  type: "timeline",
+  id: "worker-1",
+  item: { type: "assistant_message", text: "Review complete." },
+});
+await reporter.report({ type: "upsert", id: "worker-1", status: "completed" });
+
+// Keep the reporter open while its history must remain available.
+// Release it when the source is no longer needed:
+await reporter.close();
+```
+
+`open()` does not start, resume, or change the parent. Unknown, internal, and closed parents are
+rejected, as are parents undergoing a lifecycle mutation. Wait until parent registration completes;
+opening a reporter from `before("agent.session_open")` is too early. A companion process can use
+`PASEO_AGENT_ID` to identify its managed parent. Do not infer parentage from cwd or a provider session
+ID. Opening during plugin initialization, before the plugin is ready, is also rejected.
+
+### Reporter events
+
+`report(event): Promise<void>` accepts these events:
+
+| Type       | Fields                                                                                                                     | Behavior                                                                                                                                        |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `upsert`   | Required `id`; optional `title`, `description`, `status`, `toolCallId`, `cwd`, `subtitle`, `parentSubagentId`, `timestamp` | Creates or updates the descriptor. Omitted fields retain their values; `null` clears nullable fields. The initial status defaults to `running`. |
+| `timeline` | Required `id` and `item`; optional `timestamp`                                                                             | Appends one structural protocol timeline item to a declared child.                                                                              |
+| `remove`   | Required `id`                                                                                                              | Removes the child and its descendants, including their timelines. An absent child is a no-op.                                                   |
+
+Status is `running`, `completed`, `failed`, or `canceled`. Report only worker states the source knows.
+Child IDs are non-empty strings, at most 256 characters, local to that reporter. Declare a nested
+parent before using its local ID as `parentSubagentId`. Omission retains the existing relationship;
+`null` makes the child a direct child of the managed agent. Cycles and cross-reporter relationships
+are rejected. Timestamps are ISO date-time strings with a timezone; omission uses daemon time.
+
+The daemon assigns public child IDs, the parent ID, and the parent's provider. It also assigns timeline
+sequences and epochs. A plugin timeline item's `pluginId` is stamped with the calling installation ID.
+Do not parse the public child ID or use it as a managed agent ID. Children use the existing read-only
+subagent tabs. They do not change the parent's literal agent status; running children contribute to
+its workspace activity.
+
+### Limits, retries, and cleanup
+
+Each event must serialize to at most 64 KiB of UTF-8 JSON, including its fields and timeline payload.
+Larger events reject instead of being truncated. This limit is exported as
+`PLUGIN_SUBAGENT_MAX_EVENT_BYTES`. There are at most 128 open reporters per plugin process and
+32 queued reports per reporter. Await reports to apply backpressure.
+
+Calls on one reporter are ordered. The SDK retries one lost report acknowledgement with the same
+sequence; the daemon does not apply it twice. Calling `report()` again yourself creates a new event,
+not a retry. Validation and application errors reject the promise. If the transport still fails after
+the retry, the SDK closes that reporter. Resolve the transport failure before opening a new source.
+There is no persistence or automatic replay across reporter, plugin, or daemon restarts.
+
+`close(): Promise<void>` removes that reporter's descriptors and timelines. It is idempotent,
+including after parent invalidation. New and queued reports reject after closure. Reload, disable,
+removal, process crash, and daemon shutdown remove that process's sources. Parent runtime closure,
+refresh, and archive also invalidate its reporters. Later writes cannot restore those rows.
+Native-provider history refresh does not delete plugin-owned rows.
+
+Removing reports does not kill, cancel, or archive an external worker. The external owner must stop
+its own processes and resources. Paseo does not manufacture a canceled worker status during cleanup.
+
 ## Surfaces and sidebar items
 
 Register a component, then point a sidebar item at its surface ID:


### PR DESCRIPTION
### Linked issue

Discussion: https://github.com/getpaseo/paseo/discussions/3789

Our workflow comparison and extension-point question: https://github.com/getpaseo/paseo/discussions/3789#discussioncomment-18374085

This proposes the shared capability discussed there, not the provider-specific integration from #3650. It complements the plugin-owned provider support in #4314.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A Pi extension can launch children inside an existing built-in Pi session. A display plugin can format their tool output, but cannot report those children to Paseo's native Subagents track, child timeline, or workspace activity. Registering a complete replacement provider makes the plugin responsible for unrelated Pi integration work.

Discussion #3789 describes this need for one Pi subagent extension; our Tintinweb workflow provides another example. This PR adds a server-plugin reporting boundary so extension-specific observation and transport can stay outside core. It does not assume maintainer approval of the proposed API.

```ts
const reporter = await server.subagents.open({ parentAgentId });
await reporter.report({
  type: "upsert",
  id: "worker-1",
  title: "Review",
  status: "running",
});
await reporter.report({
  type: "timeline",
  id: "worker-1",
  item: { type: "assistant_message", text: "Review complete." },
});
await reporter.report({ type: "upsert", id: "worker-1", status: "completed" });
// Close when this reporting source ends, not after each child completes.
await reporter.close();
```

### Goals

- Let server plugins report child descriptors and structural timelines beneath an existing managed parent, without replacing its provider.
- Keep the parent lifecycle literal and reuse daemon-owned provider-subagent storage, broadcasts, and workspace activity.
- Assign child namespaces and provider identity in the daemon; require a descriptor before timeline writes and validate nested child relationships.
- Use acknowledged private subprocess IPC, sequence-based duplicate detection, bounded queues, and a 64 KiB event limit. No public WebSocket write RPC is added.
- Isolate plugin sources from each other and from native provider history refresh/cancellation.
- Remove a source's rows on reporter close, plugin teardown/crash, or parent runtime closure. Reject late writes. Cleanup does not claim to stop external workers.
- Document the server API, ownership, and lifecycle requirements.

### Non-goals

- Include Tintinweb code, a Pi companion, or any provider-specific payload parser.
- Change built-in Pi, app rendering, or public WebSocket schemas.
- Add Stop/Steer/Resume controls.
- Persist external child history across daemon restarts. Plugins remain responsible for replay.
- Transfer child ownership across plugin reloads or parent runtime replacement.

### QA

The API implementation passed 20 focused tests across six files before extraction from the combined plugin branch. Coverage includes source isolation, descriptor ordering, nested relationships, native history preservation, parent teardown, IPC validation, duplicate reports, and timeout handling.

After applying the API-only commit to current `main`, I resolved a plugin shutdown conflict by retaining both upstream API disposal and reporter shutdown. I then reran the real-daemon/private-IPC test on this PR branch:

```text
npx --no-install vitest run packages/server/src/server/plugins/subagents.e2e.test.ts --bail=1
Test Files  1 passed
Tests       1 passed
```

That test starts an isolated real daemon and real plugin subprocesses, with a deterministic Pi provider test double. It installs the same plugin twice, reports identically named children, and uses a second client to fetch their separate descriptors and timeline. It verifies source-specific cleanup after reload and process crash, rejects writes after parent closure, and confirms the parent remains the only managed agent.

Separately, the combined local branch passed a real Pi 0.85.1 / Tintinweb 0.19.0 smoke test: a background child completed through this API with a shell result, assistant result, subtitle, and parent tool-call link. The companion and that integration test are deliberately excluded from this PR.

On this PR branch:

- `npm run build:server` passed.
- Full `npm run typecheck` passed through the commit hook.
- `npm run lint` passed with zero warnings and errors.
- `npm run format` and `npm run format:check` passed.
- `git diff --check origin/main...HEAD` passed.

Tested on macOS. No new UI is included; manual mobile/desktop visual QA was not performed. The main daemon on port 6767 was not restarted.

### Checklist

- [x] Plugin changes follow the SDK import boundaries
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
