### PR TITLE
fix(server): keep an archived agent's workspace when its session is re-imported

### DIFF
--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -119,11 +119,11 @@ function makeManagedAgent(args: {
 
 function createImportWorkspace(
   workspaceId: string,
-  unarchivedWorkspaceIds: string[] = [],
+  options: { unarchivedWorkspaceIds?: string[] } = {},
 ): Pick<WorkspaceProvisioningService, "runInImportWorkspace" | "ensureWorkspaceRecordUnarchived"> {
   return {
     async ensureWorkspaceRecordUnarchived(workspace) {
-      unarchivedWorkspaceIds.push(workspace.workspaceId);
+      options.unarchivedWorkspaceIds?.push(workspace.workspaceId);
       return { ...workspace, archivedAt: null };
     },
     async runInImportWorkspace(input, operation) {
@@ -779,7 +779,9 @@ class ProviderImportHarness {
         cwd: input.cwd,
         labels: input.labels,
       },
-      workspaceProvisioning: createImportWorkspace("ws-restored", this.unarchivedWorkspaceIds),
+      workspaceProvisioning: createImportWorkspace("ws-restored", {
+        unarchivedWorkspaceIds: this.unarchivedWorkspaceIds,
+      }),
       workspaceRegistry: {
         get: async (workspaceId: string) => this.workspaceRecords.get(workspaceId) ?? null,
       },

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -11,7 +11,10 @@ import { AgentStorage, type StoredAgentRecord } from "./agent-storage.js";
 import type { FetchRecentProviderSessionsRequestMessage } from "@getpaseo/protocol/messages";
 import { PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 import type { AgentTimelineItem } from "./agent-sdk-types.js";
-import { createPersistedWorkspaceRecord } from "../workspace-registry.js";
+import {
+  createPersistedWorkspaceRecord,
+  type PersistedWorkspaceRecord,
+} from "../workspace-registry.js";
 import type { WorkspaceProvisioningService } from "../session/workspace-provisioning/workspace-provisioning-service.js";
 import { createTestLogger } from "../../test-utils/test-logger.js";
 import {
@@ -116,8 +119,13 @@ function makeManagedAgent(args: {
 
 function createImportWorkspace(
   workspaceId: string,
-): Pick<WorkspaceProvisioningService, "runInImportWorkspace"> {
+  unarchivedWorkspaceIds: string[] = [],
+): Pick<WorkspaceProvisioningService, "runInImportWorkspace" | "ensureWorkspaceRecordUnarchived"> {
   return {
+    async ensureWorkspaceRecordUnarchived(workspace) {
+      unarchivedWorkspaceIds.push(workspace.workspaceId);
+      return { ...workspace, archivedAt: null };
+    },
     async runInImportWorkspace(input, operation) {
       const workspace = createPersistedWorkspaceRecord({
         workspaceId,
@@ -615,6 +623,8 @@ class ProviderImportHarness {
   readonly snapshot: ManagedAgent;
   readonly freshImports: unknown[] = [];
   readonly closedAgentIds: string[] = [];
+  readonly unarchivedWorkspaceIds: string[] = [];
+  private readonly workspaceRecords = new Map<string, PersistedWorkspaceRecord>();
   timeline: AgentTimelineItem[] = [];
   activeAgent: ManagedAgent | null = null;
   resumeError: Error | null = null;
@@ -721,7 +731,32 @@ class ProviderImportHarness {
   }
 
   async seed(record: StoredAgentRecord): Promise<void> {
+    // The registry knows every workspace an agent record points at, active
+    // unless a test registers it as archived.
+    if (record.workspaceId && !this.workspaceRecords.has(record.workspaceId)) {
+      this.registerWorkspace(record.workspaceId);
+    }
     await this.storage.upsert(record);
+  }
+
+  registerWorkspace(workspaceId: string, input: { archivedAt?: string } = {}): void {
+    this.workspaceRecords.set(
+      workspaceId,
+      createPersistedWorkspaceRecord({
+        workspaceId,
+        projectId: `project-${workspaceId}`,
+        cwd: this.snapshot.cwd,
+        kind: "directory",
+        displayName: workspaceId,
+        createdAt: "2026-04-30T00:00:00.000Z",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+        ...(input.archivedAt ? { archivedAt: input.archivedAt } : {}),
+      }),
+    );
+  }
+
+  forgetWorkspace(workspaceId: string): void {
+    this.workspaceRecords.delete(workspaceId);
   }
 
   blockUnarchive(): () => void {
@@ -744,7 +779,10 @@ class ProviderImportHarness {
         cwd: input.cwd,
         labels: input.labels,
       },
-      workspaceProvisioning: createImportWorkspace("ws-restored"),
+      workspaceProvisioning: createImportWorkspace("ws-restored", this.unarchivedWorkspaceIds),
+      workspaceRegistry: {
+        get: async (workspaceId: string) => this.workspaceRecords.get(workspaceId) ?? null,
+      },
       agentManager: this.manager,
       agentStorage: this.storage,
       logger: createTestLogger(),
@@ -849,6 +887,50 @@ test("importProviderSession keeps an archived session in the workspace it was ar
 
   expect(await harness.storage.get(harness.snapshot.id)).toMatchObject({
     workspaceId: "ws-original",
+    archivedAt: null,
+  });
+});
+
+test("importProviderSession restores the workspace an archived session kept", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-archived-ws" });
+  await harness.seed(
+    makeStoredProviderSession({
+      id: harness.snapshot.id,
+      cwd: harness.snapshot.cwd,
+      sessionId: "thread-archived-ws",
+      workspaceId: "ws-original",
+    }),
+  );
+  // The agent was archived as part of archiving its own workspace.
+  harness.registerWorkspace("ws-original", { archivedAt: "2026-05-01T00:00:00.000Z" });
+
+  await harness.import({ providerHandleId: "thread-archived-ws", cwd: harness.snapshot.cwd });
+
+  // Keeping the workspace is only useful if the workspace is listed again.
+  expect(harness.unarchivedWorkspaceIds).toEqual(["ws-original"]);
+  expect(await harness.storage.get(harness.snapshot.id)).toMatchObject({
+    workspaceId: "ws-original",
+    archivedAt: null,
+  });
+});
+
+test("importProviderSession falls back to the import workspace when the kept one is gone", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-dangling-ws" });
+  await harness.seed(
+    makeStoredProviderSession({
+      id: harness.snapshot.id,
+      cwd: harness.snapshot.cwd,
+      sessionId: "thread-dangling-ws",
+      workspaceId: "ws-deleted",
+    }),
+  );
+  harness.forgetWorkspace("ws-deleted");
+
+  await harness.import({ providerHandleId: "thread-dangling-ws", cwd: harness.snapshot.cwd });
+
+  expect(harness.unarchivedWorkspaceIds).toEqual([]);
+  expect(await harness.storage.get(harness.snapshot.id)).toMatchObject({
+    workspaceId: "ws-restored",
     archivedAt: null,
   });
 });

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -624,6 +624,7 @@ class ProviderImportHarness {
   readonly freshImports: unknown[] = [];
   readonly closedAgentIds: string[] = [];
   readonly unarchivedWorkspaceIds: string[] = [];
+  readonly reArchivedWorkspaceIds: string[] = [];
   private readonly workspaceRecords = new Map<string, PersistedWorkspaceRecord>();
   timeline: AgentTimelineItem[] = [];
   activeAgent: ManagedAgent | null = null;
@@ -784,6 +785,11 @@ class ProviderImportHarness {
       }),
       workspaceRegistry: {
         get: async (workspaceId: string) => this.workspaceRecords.get(workspaceId) ?? null,
+        archive: async (workspaceId: string, archivedAt: string) => {
+          this.reArchivedWorkspaceIds.push(workspaceId);
+          const record = this.workspaceRecords.get(workspaceId);
+          if (record) this.workspaceRecords.set(workspaceId, { ...record, archivedAt });
+        },
       },
       agentManager: this.manager,
       agentStorage: this.storage,
@@ -913,6 +919,32 @@ test("importProviderSession restores the workspace an archived session kept", as
   expect(await harness.storage.get(harness.snapshot.id)).toMatchObject({
     workspaceId: "ws-original",
     archivedAt: null,
+  });
+});
+
+test("importProviderSession puts a restored workspace back when the agent fails to load", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-restore-rollback" });
+  await harness.seed(
+    makeStoredProviderSession({
+      id: harness.snapshot.id,
+      cwd: harness.snapshot.cwd,
+      sessionId: "thread-restore-rollback",
+      workspaceId: "ws-original",
+    }),
+  );
+  harness.registerWorkspace("ws-original", { archivedAt: "2026-05-01T00:00:00.000Z" });
+  harness.resumeError = new Error("provider resume failed");
+
+  await expect(
+    harness.import({ providerHandleId: "thread-restore-rollback", cwd: harness.snapshot.cwd }),
+  ).rejects.toThrow("provider resume failed");
+
+  // The import unarchived it for an agent that never loaded.
+  expect(harness.unarchivedWorkspaceIds).toEqual(["ws-original"]);
+  expect(harness.reArchivedWorkspaceIds).toEqual(["ws-original"]);
+  expect(await harness.storage.get(harness.snapshot.id)).toMatchObject({
+    workspaceId: "ws-original",
+    archivedAt: "2026-04-30T12:00:00.000Z",
   });
 });
 

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -822,7 +822,7 @@ test("importProviderSession restores an archived session as the same standalone 
   });
   expect(await harness.storage.get(harness.snapshot.id)).toMatchObject({
     id: harness.snapshot.id,
-    workspaceId: "ws-restored",
+    workspaceId: "ws-archived",
     labels: { existing: "label", source: "reimport" },
     archivedAt: null,
   });
@@ -831,6 +831,43 @@ test("importProviderSession restores an archived session as the same standalone 
   );
   expect(harness.resumeAttempts).toBe(1);
   expect(harness.freshImports).toEqual([]);
+});
+
+test("importProviderSession keeps an archived session in the workspace it was archived in", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-homed" });
+  await harness.seed(
+    makeStoredProviderSession({
+      id: harness.snapshot.id,
+      cwd: harness.snapshot.cwd,
+      sessionId: "thread-homed",
+      workspaceId: "ws-original",
+    }),
+  );
+
+  // The client asks for the workspace it is looking at; the import resolves to "ws-restored".
+  await harness.import({ providerHandleId: "thread-homed", cwd: harness.snapshot.cwd });
+
+  expect(await harness.storage.get(harness.snapshot.id)).toMatchObject({
+    workspaceId: "ws-original",
+    archivedAt: null,
+  });
+});
+
+test("importProviderSession places an archived session without a workspace into the import workspace", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-homeless" });
+  const record = makeStoredProviderSession({
+    id: harness.snapshot.id,
+    cwd: harness.snapshot.cwd,
+    sessionId: "thread-homeless",
+  });
+  await harness.seed({ ...record, workspaceId: undefined });
+
+  await harness.import({ providerHandleId: "thread-homeless", cwd: harness.snapshot.cwd });
+
+  expect(await harness.storage.get(harness.snapshot.id)).toMatchObject({
+    workspaceId: "ws-restored",
+    archivedAt: null,
+  });
 });
 
 test("importProviderSession rejects an archived session from a different cwd before restoring", async () => {

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -948,6 +948,38 @@ test("importProviderSession puts a restored workspace back when the agent fails 
   });
 });
 
+test("importProviderSession leaves a restored workspace alone when another agent took it", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-shared-ws" });
+  await harness.seed(
+    makeStoredProviderSession({
+      id: harness.snapshot.id,
+      cwd: harness.snapshot.cwd,
+      sessionId: "thread-shared-ws",
+      workspaceId: "ws-original",
+    }),
+  );
+  harness.registerWorkspace("ws-original", { archivedAt: "2026-05-01T00:00:00.000Z" });
+  // A concurrent create attached to the same workspace while the import ran:
+  // imports are serialized per agent, not per workspace.
+  await harness.storage.upsert({
+    ...makeStoredProviderSession({
+      id: "other-agent",
+      cwd: harness.snapshot.cwd,
+      sessionId: "thread-other",
+      workspaceId: "ws-original",
+    }),
+    archivedAt: null,
+  });
+  harness.resumeError = new Error("provider resume failed");
+
+  await expect(
+    harness.import({ providerHandleId: "thread-shared-ws", cwd: harness.snapshot.cwd }),
+  ).rejects.toThrow("provider resume failed");
+
+  expect(harness.unarchivedWorkspaceIds).toEqual(["ws-original"]);
+  expect(harness.reArchivedWorkspaceIds).toEqual([]);
+});
+
 test("importProviderSession falls back to the import workspace when the kept one is gone", async () => {
   const harness = await ProviderImportHarness.create({ sessionId: "thread-dangling-ws" });
   await harness.seed(

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -366,10 +366,28 @@ async function rollbackArchivedImport(
     // The import unarchived this workspace for an agent that never loaded, so it
     // goes back where it was rather than staying active with nothing in it.
     try {
-      await input.workspaceRegistry.archive(
-        restoredWorkspace.workspaceId,
-        restoredWorkspace.archivedAt,
-      );
+      // Unless something else took it meanwhile: imports are serialized per
+      // agent and per provider handle, not per workspace, so a concurrent create
+      // or import can attach to the workspace this rollback is about to put
+      // away. The failing agent itself is about to be re-archived below, so it
+      // does not count as an owner.
+      const owners = (
+        await input.agentStorage.listByWorkspace(restoredWorkspace.workspaceId)
+      ).filter((record) => record.id !== archivedRecord.id && !record.archivedAt);
+      if (owners.length > 0) {
+        input.logger.info(
+          {
+            workspaceId: restoredWorkspace.workspaceId,
+            agentIds: owners.map((record) => record.id),
+          },
+          "Leaving the restored workspace active: another agent attached to it",
+        );
+      } else {
+        await input.workspaceRegistry.archive(
+          restoredWorkspace.workspaceId,
+          restoredWorkspace.archivedAt,
+        );
+      }
     } catch (error) {
       input.logger.error(
         { err: error, workspaceId: restoredWorkspace.workspaceId },

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -227,8 +227,12 @@ async function importProviderSessionNow(
     ) {
       labelPatch[PARENT_AGENT_ID_LABEL] = requestedParentAgentId;
     }
+    // A registered agent keeps the workspace it was archived in: the client
+    // passes the workspace it is looking at, which is not where this agent
+    // and its subagents live (#4707). Only a record without one takes the
+    // import workspace.
     await unarchiveAgentState(input.agentStorage, input.agentManager, archivedRecord.id, {
-      workspaceId,
+      ...(archivedRecord.workspaceId ? {} : { workspaceId }),
       labels: Object.keys(labelPatch).length > 0 ? labelPatch : undefined,
     });
     try {

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -81,7 +81,7 @@ export interface ImportProviderSessionInput {
     WorkspaceProvisioningService,
     "runInImportWorkspace" | "ensureWorkspaceRecordUnarchived"
   >;
-  workspaceRegistry: Pick<WorkspaceRegistry, "get">;
+  workspaceRegistry: Pick<WorkspaceRegistry, "get" | "archive">;
   agentManager: ImportSessionAgentManager;
   agentStorage: AgentStorage;
   logger: Logger;
@@ -215,24 +215,31 @@ export async function importProviderSession(
  * is gone, or that cannot be restored because its project is gone, yields null
  * so the caller falls back to the resolved import workspace.
  */
-async function resolveRetainedWorkspaceId(
+interface RetainedWorkspace {
+  /** The workspace the agent keeps, or null when it has to take the import workspace. */
+  workspaceId: string | null;
+  /** The record this import unarchived, so a failed import can put it back. */
+  restored: PersistedWorkspaceRecord | null;
+}
+
+async function resolveRetainedWorkspace(
   input: ImportProviderSessionInput,
   retainedWorkspaceId: string | undefined,
-): Promise<string | null> {
-  if (!retainedWorkspaceId) return null;
+): Promise<RetainedWorkspace> {
+  if (!retainedWorkspaceId) return { workspaceId: null, restored: null };
   const retained = await input.workspaceRegistry.get(retainedWorkspaceId);
-  if (!retained) return null;
-  if (!retained.archivedAt) return retainedWorkspaceId;
+  if (!retained) return { workspaceId: null, restored: null };
+  if (!retained.archivedAt) return { workspaceId: retainedWorkspaceId, restored: null };
   try {
     await input.workspaceProvisioning.ensureWorkspaceRecordUnarchived(retained);
-    return retainedWorkspaceId;
+    return { workspaceId: retainedWorkspaceId, restored: retained };
   } catch (error) {
     input.logger.error(
       `Failed to restore workspace ${retainedWorkspaceId} for an imported provider session: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
-    return null;
+    return { workspaceId: null, restored: null };
   }
 }
 
@@ -268,9 +275,9 @@ async function importProviderSessionNow(
     // passes the workspace it is looking at, which is not where this agent
     // and its subagents live (#4707). Only a record without a usable workspace
     // takes the import workspace.
-    const retainedWorkspaceId = await resolveRetainedWorkspaceId(input, archivedRecord.workspaceId);
+    const retained = await resolveRetainedWorkspace(input, archivedRecord.workspaceId);
     await unarchiveAgentState(input.agentStorage, input.agentManager, archivedRecord.id, {
-      ...(retainedWorkspaceId ? {} : { workspaceId }),
+      ...(retained.workspaceId ? {} : { workspaceId }),
       labels: Object.keys(labelPatch).length > 0 ? labelPatch : undefined,
     });
     try {
@@ -284,7 +291,12 @@ async function importProviderSessionNow(
         timelineSize: input.agentManager.getTimeline(snapshot.id).length,
       };
     } catch (error) {
-      await rollbackArchivedImport(input, archivedRecord, archivedRecord.archivedAt);
+      await rollbackArchivedImport(
+        input,
+        archivedRecord,
+        archivedRecord.archivedAt,
+        retained.restored,
+      );
       throw error;
     }
   }
@@ -348,7 +360,24 @@ async function rollbackArchivedImport(
   input: ImportProviderSessionInput,
   archivedRecord: StoredAgentRecord,
   archivedAt: string,
+  restoredWorkspace: PersistedWorkspaceRecord | null = null,
 ): Promise<void> {
+  if (restoredWorkspace?.archivedAt) {
+    // The import unarchived this workspace for an agent that never loaded, so it
+    // goes back where it was rather than staying active with nothing in it.
+    try {
+      await input.workspaceRegistry.archive(
+        restoredWorkspace.workspaceId,
+        restoredWorkspace.archivedAt,
+      );
+    } catch (error) {
+      input.logger.error(
+        { err: error, workspaceId: restoredWorkspace.workspaceId },
+        "Failed to re-archive the restored workspace after import failure",
+      );
+    }
+  }
+
   try {
     if (input.agentManager.getAgent(archivedRecord.id)) {
       await input.agentManager.closeAgent(archivedRecord.id);

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -12,6 +12,7 @@ import { ensureAgentLoaded, type AgentLoaderManager } from "./agent-loading.js";
 import { unarchiveAgentState } from "./agent-prompt.js";
 import { toRecentProviderSessionDescriptorPayload } from "./agent-projections.js";
 import type { WorkspaceProvisioningService } from "../session/workspace-provisioning/workspace-provisioning-service.js";
+import type { WorkspaceRegistry } from "../workspace-registry.js";
 import type { PersistedWorkspaceRecord } from "../workspace-registry.js";
 import type {
   FetchRecentProviderSessionsRequestMessage,
@@ -76,7 +77,11 @@ export interface ListImportableProviderSessionsResult {
 
 export interface ImportProviderSessionInput {
   request: NormalizedImportAgentRequest;
-  workspaceProvisioning: Pick<WorkspaceProvisioningService, "runInImportWorkspace">;
+  workspaceProvisioning: Pick<
+    WorkspaceProvisioningService,
+    "runInImportWorkspace" | "ensureWorkspaceRecordUnarchived"
+  >;
+  workspaceRegistry: Pick<WorkspaceRegistry, "get">;
   agentManager: ImportSessionAgentManager;
   agentStorage: AgentStorage;
   logger: Logger;
@@ -199,6 +204,38 @@ export async function importProviderSession(
   });
 }
 
+/**
+ * The workspace an archived agent kept, when that workspace can still hold it.
+ *
+ * Archiving a workspace archives its agents, so the workspace a record keeps
+ * may itself be archived, and an archived workspace is filtered out of the
+ * workspace directory: the import would report success while the restored
+ * session is listed nowhere. An archived workspace is therefore restored the
+ * way findOrCreateWorkspaceForDirectory restores one. A workspace whose record
+ * is gone, or that cannot be restored because its project is gone, yields null
+ * so the caller falls back to the resolved import workspace.
+ */
+async function resolveRetainedWorkspaceId(
+  input: ImportProviderSessionInput,
+  retainedWorkspaceId: string | undefined,
+): Promise<string | null> {
+  if (!retainedWorkspaceId) return null;
+  const retained = await input.workspaceRegistry.get(retainedWorkspaceId);
+  if (!retained) return null;
+  if (!retained.archivedAt) return retainedWorkspaceId;
+  try {
+    await input.workspaceProvisioning.ensureWorkspaceRecordUnarchived(retained);
+    return retainedWorkspaceId;
+  } catch (error) {
+    input.logger.error(
+      `Failed to restore workspace ${retainedWorkspaceId} for an imported provider session: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
 async function importProviderSessionNow(
   input: ImportProviderSessionInput,
   cwd: string,
@@ -229,10 +266,11 @@ async function importProviderSessionNow(
     }
     // A registered agent keeps the workspace it was archived in: the client
     // passes the workspace it is looking at, which is not where this agent
-    // and its subagents live (#4707). Only a record without one takes the
-    // import workspace.
+    // and its subagents live (#4707). Only a record without a usable workspace
+    // takes the import workspace.
+    const retainedWorkspaceId = await resolveRetainedWorkspaceId(input, archivedRecord.workspaceId);
     await unarchiveAgentState(input.agentStorage, input.agentManager, archivedRecord.id, {
-      ...(archivedRecord.workspaceId ? {} : { workspaceId }),
+      ...(retainedWorkspaceId ? {} : { workspaceId }),
       labels: Object.keys(labelPatch).length > 0 ? labelPatch : undefined,
     });
     try {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4162,6 +4162,7 @@ export class Session {
       const { snapshot, timelineSize, createdWorkspace } = await importProviderSession({
         request: normalized,
         workspaceProvisioning: this.workspaceProvisioning,
+        workspaceRegistry: this.workspaceRegistry,
         agentManager: this.agentManager,
         agentStorage: this.agentStorage,
         logger: this.sessionLogger,


### PR DESCRIPTION
### Linked issue

Fixes #4707

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

`importProviderSessionNow` in `packages/server/src/server/agent/import-sessions.ts` handles a provider session that is already registered but archived by unarchiving that record. It passed the resolved import `workspaceId` unconditionally, and the desktop fills the request with the workspace currently open. So importing an archived agent from an unrelated workspace overwrote the agent's `workspaceId`: the parent thread appeared in the open workspace while its subagents stayed in the original one, exactly the stranded tree from the report.

The archived record now keeps the workspace it was archived in; only a record that has no `workspaceId` at all takes the import workspace. The result still carries the agent's snapshot, so a client that wants to follow the agent can read its real workspace from it.

### Goals

- Re-importing an archived, registered session restores it into its original workspace regardless of which workspace the client passed.
- A registered record without a workspace (legacy data) is placed into the import workspace as before.
- Labels, cwd validation, rollback and the fresh-import path are unchanged.

### Non-goals

- Switching the desktop to the agent's workspace after the import, or confirming the placement in the UI. The server no longer moves the agent; the client-side follow-up is a separate change if wanted.
- The import workspace that `runInImportWorkspace` resolves (or creates) is still resolved for this path; when the archived record keeps its own workspace that resolved one simply is not used.

### Validation

```
cd packages/server && npx vitest run src/server/agent/import-sessions.test.ts   # 18 passed (2 new)
npx oxlint / oxfmt --check on both files   # clean
```

The existing "restores an archived session as the same standalone agent" test asserted the overwritten `workspaceId: "ws-restored"`; it now expects the record's own `"ws-archived"`. The new "keeps an archived session in the workspace it was archived in" test fails on `main` with `ws-restored` instead of `ws-original`; "places an archived session without a workspace into the import workspace" covers the fallback.
