### PR TITLE
fix(server): read current Claude usage credentials on macOS

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -192,6 +192,11 @@ Cursor usage reads the desktop `state.vscdb` token first, then `cursor-agent`'s 
 
 ### Usage fetchers are read-only on credentials
 
+Default Claude Code credentials on macOS come from the login Keychain; an old
+`.credentials.json` can remain after Claude Code stops updating it. Explicit
+credential directories use their own file, never the default Keychain account.
+This does not resolve credentials for routed commands or provider-specific profiles.
+
 A fetcher reads the provider's credential file and never writes it. On a 401 or 403 it returns `unavailable` and leaves refresh to the provider's own CLI: redeeming a refresh token in the fetcher invalidates the CLI's copy (refresh tokens are single-use), and rewriting the file through the fetcher's Zod schema drops any field the schema does not model, corrupting the file for the CLI.
 
 ---

--- a/packages/server/src/services/quota-fetcher/providers/claude-credentials.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude-credentials.test.ts
@@ -1,0 +1,162 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import pino from "pino";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClaudeQuotaProvider } from "./claude.js";
+
+describe("Claude quota credential source", () => {
+  let homeDir: string;
+  let credentialPath: string;
+  const fileContents = JSON.stringify({
+    claudeAiOauth: { accessToken: "stale-file", expiresAt: null },
+    mcpOAuth: { untouched: "MCP credential" },
+  });
+
+  beforeEach(async () => {
+    vi.stubEnv("CLAUDE_HOME", "");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "");
+    homeDir = await mkdtemp(join(tmpdir(), "claude-usage-source-"));
+    await mkdir(join(homeDir, ".claude"));
+    credentialPath = join(homeDir, ".claude", ".credentials.json");
+    await writeFile(credentialPath, fileContents);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  it("reads the live default macOS Keychain instead of an abandoned file", async () => {
+    const calls: string[] = [];
+    const provider = new ClaudeQuotaProvider({
+      logger: pino({ level: "silent" }),
+      homeDir,
+      platform: "darwin",
+      claudeKeychainReader: async () => ({
+        claudeAiOauth: { accessToken: "live-keychain", subscriptionType: "max" },
+      }),
+      fetch: async (url, init) => {
+        expect(url).toBe("https://api.anthropic.com/api/oauth/usage");
+        const token = new Headers(init?.headers).get("Authorization")!;
+        calls.push(token);
+        if (token === "Bearer stale-file") return new Response(null, { status: 401 });
+        return Response.json({ five_hour: { utilization: 11 }, seven_day: { utilization: 2 } });
+      },
+    });
+
+    const result = await provider.fetchUsage();
+
+    expect(result.status).toBe("available");
+    expect(result.planLabel).toBe("Max");
+    expect(result.windows.map((window) => window.usedPct)).toEqual([11, 2]);
+    expect(calls).toEqual(["Bearer live-keychain"]);
+    expect(await readFile(credentialPath, "utf8")).toBe(fileContents);
+  });
+
+  it.each([401, 403, 429, 500])(
+    "does not switch accounts after Keychain HTTP %i",
+    async (status) => {
+      let calls = 0;
+      const provider = new ClaudeQuotaProvider({
+        logger: pino({ level: "silent" }),
+        homeDir,
+        platform: "darwin",
+        claudeKeychainReader: async () => ({ claudeAiOauth: { accessToken: "account-a" } }),
+        fetch: async (_url, init) => {
+          calls++;
+          expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer account-a");
+          return new Response(null, { status });
+        },
+      });
+      if (status === 401 || status === 403) {
+        expect((await provider.fetchUsage()).status).toBe("unavailable");
+      } else {
+        await expect(provider.fetchUsage()).rejects.toThrow(`Claude usage API returned ${status}`);
+      }
+      expect(calls).toBe(1);
+      expect(await readFile(credentialPath, "utf8")).toBe(fileContents);
+    },
+  );
+
+  it.each(["linux", "win32"] as const)("does not consult Keychain on %s", async (platform) => {
+    const provider = new ClaudeQuotaProvider({
+      logger: pino({ level: "silent" }),
+      homeDir,
+      platform,
+      claudeKeychainReader: async () => {
+        throw new Error("Keychain must not be used");
+      },
+      fetch: async (_url, init) => {
+        expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer stale-file");
+        return Response.json({ five_hour: { utilization: 20 } });
+      },
+    });
+    expect((await provider.fetchUsage()).windows[0].usedPct).toBe(20);
+  });
+
+  it.each(["option", "CLAUDE_CONFIG_DIR", "CLAUDE_HOME"])(
+    "keeps %s isolated from the default account",
+    async (setting) => {
+      const customHome = join(homeDir, "account-b");
+      await mkdir(customHome);
+      const customPath = join(customHome, ".credentials.json");
+      const contents = JSON.stringify({ claudeAiOauth: { accessToken: "account-b" } });
+      await writeFile(customPath, contents);
+      if (setting !== "option") vi.stubEnv(setting, customHome);
+      const provider = new ClaudeQuotaProvider({
+        logger: pino({ level: "silent" }),
+        homeDir,
+        platform: "darwin",
+        claudeHome: setting === "option" ? customHome : undefined,
+        claudeKeychainReader: async () => {
+          throw new Error("Default account must not be used");
+        },
+        fetch: async (_url, init) => {
+          expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer account-b");
+          return new Response(null, { status: 401 });
+        },
+      });
+      expect((await provider.fetchUsage()).status).toBe("unavailable");
+      await rm(customPath);
+      expect((await provider.fetchUsage()).status).toBe("unavailable");
+    },
+  );
+
+  it.each([null, {}, { claudeAiOauth: {} }])(
+    "uses the file when default Keychain has no usable credential (%j)",
+    async (keychain) => {
+      const provider = new ClaudeQuotaProvider({
+        logger: pino({ level: "silent" }),
+        homeDir,
+        platform: "darwin",
+        claudeKeychainReader: async () => keychain,
+        fetch: async (_url, init) => {
+          expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer stale-file");
+          return Response.json({ five_hour: { utilization: 30 } });
+        },
+      });
+      expect((await provider.fetchUsage()).windows[0].usedPct).toBe(30);
+    },
+  );
+
+  it("re-reads rotated Keychain credentials on the next fetch", async () => {
+    let token = "first";
+    const calls: string[] = [];
+    const provider = new ClaudeQuotaProvider({
+      logger: pino({ level: "silent" }),
+      homeDir,
+      platform: "darwin",
+      claudeKeychainReader: async () => ({ claudeAiOauth: { accessToken: token } }),
+      fetch: async (_url, init) => {
+        calls.push(new Headers(init?.headers).get("Authorization")!);
+        return Response.json({ five_hour: { utilization: 10 } });
+      },
+    });
+    await provider.fetchUsage();
+    token = "second";
+    await provider.fetchUsage();
+    expect(calls).toEqual(["Bearer first", "Bearer second"]);
+    expect(await readFile(credentialPath, "utf8")).toBe(fileContents);
+  });
+});

--- a/packages/server/src/services/quota-fetcher/providers/claude-credentials.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude-credentials.test.ts
@@ -40,8 +40,14 @@ describe("Claude quota credential source", () => {
         expect(url).toBe("https://api.anthropic.com/api/oauth/usage");
         const token = new Headers(init?.headers).get("Authorization")!;
         calls.push(token);
-        if (token === "Bearer stale-file") return new Response(null, { status: 401 });
-        return Response.json({ five_hour: { utilization: 11 }, seven_day: { utilization: 2 } });
+        const responses = new Map([
+          ["Bearer stale-file", new Response(null, { status: 401 })],
+          [
+            "Bearer live-keychain",
+            Response.json({ five_hour: { utilization: 11 }, seven_day: { utilization: 2 } }),
+          ],
+        ]);
+        return responses.get(token)!;
       },
     });
 
@@ -54,30 +60,41 @@ describe("Claude quota credential source", () => {
     expect(await readFile(credentialPath, "utf8")).toBe(fileContents);
   });
 
-  it.each([401, 403, 429, 500])(
-    "does not switch accounts after Keychain HTTP %i",
-    async (status) => {
-      let calls = 0;
-      const provider = new ClaudeQuotaProvider({
-        logger: pino({ level: "silent" }),
-        homeDir,
-        platform: "darwin",
-        claudeKeychainReader: async () => ({ claudeAiOauth: { accessToken: "account-a" } }),
-        fetch: async (_url, init) => {
-          calls++;
-          expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer account-a");
-          return new Response(null, { status });
-        },
-      });
-      if (status === 401 || status === 403) {
-        expect((await provider.fetchUsage()).status).toBe("unavailable");
-      } else {
-        await expect(provider.fetchUsage()).rejects.toThrow(`Claude usage API returned ${status}`);
-      }
-      expect(calls).toBe(1);
-      expect(await readFile(credentialPath, "utf8")).toBe(fileContents);
-    },
-  );
+  it.each([401, 403])("does not switch accounts after Keychain HTTP %i", async (status) => {
+    let calls = 0;
+    const provider = new ClaudeQuotaProvider({
+      logger: pino({ level: "silent" }),
+      homeDir,
+      platform: "darwin",
+      claudeKeychainReader: async () => ({ claudeAiOauth: { accessToken: "account-a" } }),
+      fetch: async (_url, init) => {
+        calls++;
+        expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer account-a");
+        return new Response(null, { status });
+      },
+    });
+    expect((await provider.fetchUsage()).status).toBe("unavailable");
+    expect(calls).toBe(1);
+    expect(await readFile(credentialPath, "utf8")).toBe(fileContents);
+  });
+
+  it.each([429, 500])("does not switch accounts after Keychain HTTP %i", async (status) => {
+    let calls = 0;
+    const provider = new ClaudeQuotaProvider({
+      logger: pino({ level: "silent" }),
+      homeDir,
+      platform: "darwin",
+      claudeKeychainReader: async () => ({ claudeAiOauth: { accessToken: "account-a" } }),
+      fetch: async (_url, init) => {
+        calls++;
+        expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer account-a");
+        return new Response(null, { status });
+      },
+    });
+    await expect(provider.fetchUsage()).rejects.toThrow(`Claude usage API returned ${status}`);
+    expect(calls).toBe(1);
+    expect(await readFile(credentialPath, "utf8")).toBe(fileContents);
+  });
 
   it.each(["linux", "win32"] as const)("does not consult Keychain on %s", async (platform) => {
     const provider = new ClaudeQuotaProvider({
@@ -95,7 +112,31 @@ describe("Claude quota credential source", () => {
     expect((await provider.fetchUsage()).windows[0].usedPct).toBe(20);
   });
 
-  it.each(["option", "CLAUDE_CONFIG_DIR", "CLAUDE_HOME"])(
+  it("keeps an explicit claudeHome isolated from the default account", async () => {
+    const customHome = join(homeDir, "account-b");
+    await mkdir(customHome);
+    const customPath = join(customHome, ".credentials.json");
+    const contents = JSON.stringify({ claudeAiOauth: { accessToken: "account-b" } });
+    await writeFile(customPath, contents);
+    const provider = new ClaudeQuotaProvider({
+      logger: pino({ level: "silent" }),
+      homeDir,
+      platform: "darwin",
+      claudeHome: customHome,
+      claudeKeychainReader: async () => {
+        throw new Error("Default account must not be used");
+      },
+      fetch: async (_url, init) => {
+        expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer account-b");
+        return new Response(null, { status: 401 });
+      },
+    });
+    expect((await provider.fetchUsage()).status).toBe("unavailable");
+    await rm(customPath);
+    expect((await provider.fetchUsage()).status).toBe("unavailable");
+  });
+
+  it.each(["CLAUDE_CONFIG_DIR", "CLAUDE_HOME"])(
     "keeps %s isolated from the default account",
     async (setting) => {
       const customHome = join(homeDir, "account-b");
@@ -103,12 +144,11 @@ describe("Claude quota credential source", () => {
       const customPath = join(customHome, ".credentials.json");
       const contents = JSON.stringify({ claudeAiOauth: { accessToken: "account-b" } });
       await writeFile(customPath, contents);
-      if (setting !== "option") vi.stubEnv(setting, customHome);
+      vi.stubEnv(setting, customHome);
       const provider = new ClaudeQuotaProvider({
         logger: pino({ level: "silent" }),
         homeDir,
         platform: "darwin",
-        claudeHome: setting === "option" ? customHome : undefined,
         claudeKeychainReader: async () => {
           throw new Error("Default account must not be used");
         },

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -82,6 +82,7 @@ interface ClaudeCredentialRecord {
 
 interface ClaudeQuotaProviderOptions {
   logger: Logger;
+  homeDir?: string;
   claudeHome?: string;
   claudeKeychainReader?: () => Promise<unknown | null>;
   platform?: typeof process.platform;
@@ -344,15 +345,17 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   private readonly logger: Logger;
   private readonly claudeHome: string;
   private readonly readKeychainCredentials: () => Promise<unknown | null>;
-  private readonly platform: typeof process.platform;
+  private readonly useDefaultKeychain: boolean;
   private readonly fetchApi: ProviderApiFetch;
 
   constructor(options: ClaudeQuotaProviderOptions) {
     this.logger = options.logger.child({ module: "claude-quota-provider" });
-    this.claudeHome =
-      options.claudeHome || process.env["CLAUDE_HOME"] || join(homedir(), ".claude");
+    const configuredHome =
+      options.claudeHome || process.env["CLAUDE_CONFIG_DIR"] || process.env["CLAUDE_HOME"];
+    this.claudeHome = configuredHome || join(options.homeDir ?? homedir(), ".claude");
     this.readKeychainCredentials = options.claudeKeychainReader ?? readClaudeKeychainCredentials;
-    this.platform = options.platform ?? process.platform;
+    const platform = options.platform ?? process.platform;
+    this.useDefaultKeychain = platform === "darwin" && !configuredHome;
     this.fetchApi = options.fetch ?? fetch;
   }
 
@@ -435,11 +438,14 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   }
 
   private async readCredentials(): Promise<ClaudeCredentialRecord | null> {
-    const credPath = join(this.claudeHome, ".credentials.json");
-    const fileCredentials = await this.readCredentialFile(credPath);
-    return (
-      fileCredentials ?? (this.platform === "darwin" ? await this.readKeychainCredential() : null)
-    );
+    // Claude Code refreshes the default macOS Keychain item, while an old file can
+    // survive indefinitely. Explicit directories must not borrow another account's
+    // default Keychain item. Once selected, HTTP failures never switch accounts.
+    if (this.useDefaultKeychain) {
+      const credentials = await this.readKeychainCredential();
+      if (credentials) return credentials;
+    }
+    return this.readCredentialFile(join(this.claudeHome, ".credentials.json"));
   }
 
   private async readCredentialFile(path: string): Promise<ClaudeCredentialRecord | null> {

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -417,7 +417,8 @@ describe("real provider usage fetchers", () => {
       fetchers: [
         new ClaudeQuotaProvider({
           logger,
-          claudeHome,
+          claudeHome: options.keychain ? undefined : claudeHome,
+          homeDir,
           claudeKeychainReader: options.keychain ?? (async () => null),
           platform: options.platform,
           fetch: fetchThroughTestDouble,


### PR DESCRIPTION
### Linked issue

Closes #4328

### Type of change

- [x] Bug fix

### Reasoning

The built-in Claude usage card can show `Unavailable` on macOS while Claude Code still works. An abandoned `~/.claude/.credentials.json` takes precedence over the login Keychain item Claude Code is updating. On the affected machine, the file credential returned 401; the Keychain credential returned 200.

Read the default macOS Keychain first, with file fallback when it has no usable credential. Explicit credential directories use their own file so they cannot silently borrow the default account. Once a credential is selected, an HTTP failure does not switch accounts.

### Goals

- Show current usage when a stale credential file coexists with a working default Keychain item.
- Keep explicit `claudeHome`, `CLAUDE_CONFIG_DIR`, and legacy `CLAUDE_HOME` isolated from the default Keychain account.
- Preserve credential files, including unrelated `mcpOAuth` fields.

### Non-goals

- Refreshing tokens, writing credentials, or retrying with another account.
- Custom-directory Keychain services, routed commands, or provider-specific profile resolution (#3589, #3228).
- Usage Monitor plugin changes or new 401/403 diagnostics.

### QA

[QA evidence and test output](https://github.com/ZixuanW46/paseo/tree/qa/claude-usage-source)

**Reproduced before, confirmed after on the same macOS host**, using the actual provider and Anthropic usage endpoint:

| | Original | Fixed |
| --- | --- | --- |
| HTTP response | 401 | 200 |
| Provider status | `unavailable` | `available` |
| Usage windows | 0 | 3 |
| Credential file | unchanged | unchanged |

A checkout-local daemon also returned the three Claude windows through the real WebSocket usage RPC. Two concurrent requests returned matching provider data and timestamps. The production daemon was not restarted.

The repository's Playwright real-provider fixture opened Settings → Host → Usage against an isolated daemon with real credentials. Session and Weekly values rendered successfully:

![Claude usage after the fix](https://raw.githubusercontent.com/ZixuanW46/paseo/qa/claude-usage-source/claude-usage-after.png)

A later attempt to capture the original UI received HTTP 429, so it failed the `Unavailable` assertion. I stopped further API requests; there is no controlled before-UI screenshot. The provider-level 401/200 comparison above completed successfully before that limit.

**Regression and checks**

The new regression fails on the original selection logic (with only the temporary-home test seam added):

```text
AssertionError: expected 'unavailable' to be 'available'
Expected: "available"
Received: "unavailable"
```

With the fix:

```text
$ npx --no-install vitest run packages/server/src/services/quota-fetcher/providers/claude-credentials.test.ts packages/server/src/services/quota-fetcher/providers/claude-keychain.test.ts packages/server/src/services/quota-fetcher/service.test.ts --bail=1
Test Files  3 passed (3)
     Tests  90 passed (90)

$ npm run typecheck
exit 0 (all workspaces)

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format:check
All matched files use the correct format.
```

`build:server-deps` and `build:server` also passed. Tests cover file fallback, explicit-directory isolation, token rotation, Linux/Windows selection, no credential writes, and no account switching after 401/403/429/500.

**Platforms and tooling:** actual macOS provider, daemon, and Chromium web app tested. Linux/Windows branches have unit coverage, but native Linux/Windows, iOS, Android, and Electron were not exercised. Investigation, implementation, and the real-service/browser checks were performed with an AI coding agent; this does not claim a separate human acceptance test of the patched app.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Formatting passes (`npm run format:check`; changed files formatted)
- [x] QA evidence
- [x] Tests added or updated where it made sense

Plugin SDK boundaries: not applicable.
