### PR TITLE
feat(app): organize project workspaces into sections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ At the start of non-trivial work, list `docs/` and skim anything relevant to the
 | [docs/mobile-testing.md](docs/mobile-testing.md)                     | Maestro and mobile test workflows                                                                                              |
 | [docs/mobile-panels.md](docs/mobile-panels.md)                       | Compact left/center/right panel ownership, worklet motion, gesture revisions, and Fabric constraints                           |
 | [docs/explorer-sidebar.md](docs/explorer-sidebar.md)                 | Explorer sidebar and ordinary side-pane host contracts, lifecycle, placement, and routing preferences                          |
+| [docs/workspace-organizer.md](docs/workspace-organizer.md)           | User-defined workspace sections: client-local scope, persistence boundary, prior work, and verification                        |
 | [docs/ad-hoc-daemon-testing.md](docs/ad-hoc-daemon-testing.md)       | Isolated in-process daemon test harness                                                                                        |
 | [docs/browser-capture-harness.md](docs/browser-capture-harness.md)   | Real-Electron browser screenshot harness and compositor-surface gotcha                                                         |
 | [docs/android.md](docs/android.md)                                   | App variants, local/cloud builds, EAS workflows, version codes, F-Droid source builds and store metadata                       |

--- a/docs/workspace-organizer.md
+++ b/docs/workspace-organizer.md
@@ -45,19 +45,3 @@ tests for section edits, persisted-state normalization, collapse, pinned precede
 reordering, empty-section retention, and moving a workspace through the menu. Preview project mode
 on desktop/web and compact native; exercise the menu move on native. Cross-device replication is
 out of scope until a server-backed layout exists.
-
-## Implementation checkpoint — 2026-09-11
-
-The first implementation stores sections in the existing local sidebar-order record and renders
-them only in Project mode. The unsectioned remainder now has the same persisted collapse behavior
-as named sections. The section menu enters a temporary select mode; selected workspaces move
-together through one section picker, then selection clears. Desktop Shift-click toggles a workspace
-pin without opening it. The isolated Electron preview used this worktree's `.dev/paseo-home` and
-port `6768`; it did not touch the active daemon on port `6767` or installed app data. Focused app
-tests cover normalization, section lifecycle, collapse persistence, bulk movement, pinned and
-filtered projection, shortcuts, and the no-section path. `npm run typecheck` and `npm run lint`
-pass.
-
-The source remains native-safe, but this checkpoint is desktop/web validation only. It does not
-ship the feature to the App Store or synchronize layouts to an iOS device; official iOS support
-requires upstream acceptance and a release.

--- a/docs/workspace-organizer.md
+++ b/docs/workspace-organizer.md
@@ -49,10 +49,14 @@ out of scope until a server-backed layout exists.
 ## Implementation checkpoint — 2026-09-11
 
 The first implementation stores sections in the existing local sidebar-order record and renders
-them only in Project mode. The isolated Electron preview used this worktree's `.dev/paseo-home` and
+them only in Project mode. The unsectioned remainder now has the same persisted collapse behavior
+as named sections. The section menu enters a temporary select mode; selected workspaces move
+together through one section picker, then selection clears. Desktop Shift-click toggles a workspace
+pin without opening it. The isolated Electron preview used this worktree's `.dev/paseo-home` and
 port `6768`; it did not touch the active daemon on port `6767` or installed app data. Focused app
-tests cover normalization, section lifecycle, collapse persistence, pinned and filtered projection,
-shortcuts, and the no-section path. `npm run typecheck` and `npm run lint` pass.
+tests cover normalization, section lifecycle, collapse persistence, bulk movement, pinned and
+filtered projection, shortcuts, and the no-section path. `npm run typecheck` and `npm run lint`
+pass.
 
 The source remains native-safe, but this checkpoint is desktop/web validation only. It does not
 ship the feature to the App Store or synchronize layouts to an iOS device; official iOS support

--- a/docs/workspace-organizer.md
+++ b/docs/workspace-organizer.md
@@ -1,0 +1,59 @@
+# Workspace organizer
+
+The workspace organizer is a client-side presentation of workspaces. It does not change a
+workspace's `projectId`, directory, lifecycle, or daemon ownership.
+
+## Scope
+
+Start with named sections inside one project. A section has a stable local ID, a name, and an
+ordered list of workspace keys. The unsectioned remainder is a first-class section. Workspace
+placement is per device, alongside the existing sidebar order and collapse preferences.
+
+Project mode renders the sections. Status mode remains a derived view and ignores them. Pinned
+workspaces remain in Pinned while retaining their section placement for when they are unpinned.
+
+Create, rename, collapse, reorder, and delete sections. Move a workspace through its existing row
+menu on every platform. Desktop/web drag between sections is a later enhancement: native list drag
+does not support cross-list moves.
+
+## Persistence boundary
+
+`workspaceOrderByProject` already scopes display order by `projectViewKey`; sections should use
+the same key and workspace key shape. Do not add a group field to workspace records: project
+membership is server-owned and stable, while a user-defined section is an empty-capable,
+order-bearing display object.
+
+This makes the first release local to each client. If sections must synchronize across devices or
+daemons, add a revisioned sidebar-layout document and protocol capability. Do not fan out client
+preferences or infer ownership from members.
+
+## Prior art
+
+PR [#2635](https://github.com/getpaseo/paseo/pull/2635), opened 2026-07-30 and closed unmerged on
+2026-08-11, explored replicated project and workspace groups. Its useful constraints are retained:
+groups must be entities to survive empty and carry order; disconnected keys must stay stored; and
+cross-list drag needs a menu path on native. It was superseded by the labels direction, not shipped
+code. Shipped labels and filters are complementary, not an implementation of manual sections.
+
+The plugin API contributes a top-level sidebar item and its own surface. It cannot insert a section
+or row into the native workspace list, so this feature belongs in the app source.
+
+## Verification
+
+Keep the no-section projection byte-for-byte equivalent to today's project view. Add deterministic
+tests for section edits, persisted-state normalization, collapse, pinned precedence, filtered
+reordering, empty-section retention, and moving a workspace through the menu. Preview project mode
+on desktop/web and compact native; exercise the menu move on native. Cross-device replication is
+out of scope until a server-backed layout exists.
+
+## Implementation checkpoint — 2026-09-11
+
+The first implementation stores sections in the existing local sidebar-order record and renders
+them only in Project mode. The isolated Electron preview used this worktree's `.dev/paseo-home` and
+port `6768`; it did not touch the active daemon on port `6767` or installed app data. Focused app
+tests cover normalization, section lifecycle, collapse persistence, pinned and filtered projection,
+shortcuts, and the no-section path. `npm run typecheck` and `npm run lint` pass.
+
+The source remains native-safe, but this checkpoint is desktop/web validation only. It does not
+ship the feature to the App Store or synchronize layouts to an iOS device; official iOS support
+requires upstream acceptance and a release.

--- a/packages/app/e2e/browser/sidebar-workspace-sections.spec.ts
+++ b/packages/app/e2e/browser/sidebar-workspace-sections.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from "@playwright/test";
+import { test } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import { projectEquivalenceViewKey } from "../support/helpers/project-view-key";
+import { seedWorkspace } from "../support/helpers/seed-client";
+import { getServerId } from "../support/helpers/server-id";
+
+function workspaceKey(workspaceId: string): string {
+  return `${getServerId()}:${workspaceId}`;
+}
+
+test("organizes project workspaces through sections without changing daemon membership", async ({
+  page,
+}) => {
+  const first = await seedWorkspace({ repoPrefix: "sidebar-sections-", title: "First" });
+  const secondResult = await first.client.createWorkspace({
+    source: { kind: "directory", path: first.repoPath, projectId: first.projectId },
+    title: "Second",
+  });
+  const second = secondResult.workspace;
+  if (!second) throw new Error(secondResult.error ?? "Failed to create second workspace");
+
+  const projectViewKey = projectEquivalenceViewKey(first.projectKey);
+  const firstRow = page.getByTestId(`sidebar-workspace-row-${workspaceKey(first.workspaceId)}`);
+  const secondRow = page.getByTestId(`sidebar-workspace-row-${workspaceKey(second.id)}`);
+
+  try {
+    await gotoAppShell(page);
+    await expect(firstRow).toBeVisible({ timeout: 30_000 });
+    await expect(secondRow).toBeVisible({ timeout: 30_000 });
+
+    await page.getByTestId(`sidebar-project-row-${projectViewKey}`).hover();
+    await page.getByTestId(`sidebar-project-kebab-${projectViewKey}`).click();
+    await page.getByTestId(`sidebar-project-menu-new-section-${projectViewKey}`).click();
+    const dialog = page.getByTestId(`sidebar-workspace-section-dialog-${projectViewKey}`);
+    await dialog
+      .getByTestId(`sidebar-workspace-section-dialog-${projectViewKey}-input`)
+      .fill("Finance");
+    await dialog.getByTestId(`sidebar-workspace-section-dialog-${projectViewKey}-submit`).click();
+
+    const financeHeader = page.locator(
+      `[data-testid^="sidebar-workspace-section-header-section_"][data-testid$="-${projectViewKey}"]`,
+    );
+    await expect(financeHeader).toHaveText("Finance");
+    const financeHeaderId = await financeHeader.getAttribute("data-testid");
+    if (!financeHeaderId) throw new Error("Missing Finance section test id");
+    const financeSectionId = financeHeaderId
+      .replace("sidebar-workspace-section-header-", "")
+      .replace(`-${projectViewKey}`, "");
+
+    await secondRow.hover();
+    await page.getByTestId(`sidebar-workspace-kebab-${workspaceKey(second.id)}`).click();
+    await page.getByTestId(`sidebar-workspace-menu-sections-${workspaceKey(second.id)}`).click();
+    await page
+      .getByTestId(`sidebar-workspace-section-${financeSectionId}-${workspaceKey(second.id)}`)
+      .click();
+
+    const unsectionedHeader = page.getByTestId(
+      `sidebar-workspace-section-header-unsectioned-${projectViewKey}`,
+    );
+    await unsectionedHeader.click();
+    await expect(firstRow).toHaveCount(0);
+    await unsectionedHeader.click();
+    await expect(firstRow).toBeVisible();
+
+    await page
+      .getByTestId(`sidebar-workspace-section-menu-${financeSectionId}-${projectViewKey}`)
+      .click();
+    page.once("dialog", (confirmDialog) => confirmDialog.accept());
+    await page
+      .getByTestId(`sidebar-workspace-section-delete-${financeSectionId}-${projectViewKey}`)
+      .click();
+    await expect(financeHeader).toHaveCount(0);
+    await expect(secondRow).toBeVisible();
+    const remaining = await first.client.fetchWorkspaces({
+      filter: { projectId: first.projectId },
+    });
+    expect(remaining.entries.map((entry) => entry.id)).toEqual(
+      expect.arrayContaining([first.workspaceId, second.id]),
+    );
+  } finally {
+    await first.cleanup();
+  }
+});

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -41,6 +41,7 @@ import type { PinnedSidebarGroups } from "@/hooks/use-sidebar-pins";
 import { RetainedPanelActivity } from "@/components/retained-panel";
 import type { SidebarWorkspaceGroup } from "@/components/sidebar/sidebar-labels";
 import type { SidebarProjectIconTarget } from "@/utils/sidebar-project-row-model";
+import type { SidebarProjectWorkspaceSection } from "@/components/sidebar/sidebar-projection";
 import { type SidebarGroupMode, useSidebarViewStore } from "@/stores/sidebar-view-store";
 import { useHosts } from "@/runtime/host-runtime";
 import { usePanelStore } from "@/stores/panel-store";
@@ -71,8 +72,11 @@ interface SidebarSharedProps {
   isManualRefresh: boolean;
   groupMode: SidebarGroupMode;
   collapsedProjectKeys: ReadonlySet<string>;
+  projectSections: Map<string, SidebarProjectWorkspaceSection[]>;
+  collapsedWorkspaceSectionKeys: ReadonlySet<string>;
   shortcutIndexByWorkspaceKey: Map<string, number>;
   toggleProjectCollapsed: (projectViewKey: string) => void;
+  toggleWorkspaceSectionCollapsed: (workspaceSectionKey: string) => void;
   handleRefresh: () => void;
   handleOpenProject: () => void;
   handleImportSession: () => void;
@@ -122,7 +126,10 @@ export const LeftSidebar = memo(function LeftSidebar({ active }: { active: boole
     projectIconTargets,
     pinnedGroups,
     collapsedProjectKeys,
+    projectSections,
+    collapsedWorkspaceSectionKeys,
     toggleProjectCollapsed,
+    toggleWorkspaceSectionCollapsed,
     groupMode,
     shortcutModel,
   } = useSidebarModel();
@@ -214,8 +221,11 @@ export const LeftSidebar = memo(function LeftSidebar({ active }: { active: boole
     isManualRefresh,
     groupMode,
     collapsedProjectKeys,
+    projectSections,
+    collapsedWorkspaceSectionKeys,
     shortcutIndexByWorkspaceKey,
     toggleProjectCollapsed,
+    toggleWorkspaceSectionCollapsed,
     handleRefresh,
     labels,
   };
@@ -518,8 +528,11 @@ function MobileSidebar({
   isManualRefresh,
   groupMode,
   collapsedProjectKeys,
+  projectSections,
+  collapsedWorkspaceSectionKeys,
   shortcutIndexByWorkspaceKey,
   toggleProjectCollapsed,
+  toggleWorkspaceSectionCollapsed,
   handleRefresh,
   handleOpenProject,
   handleImportSession,
@@ -582,6 +595,9 @@ function MobileSidebar({
           <SidebarWorkspaceList
             collapsedProjectKeys={collapsedProjectKeys}
             onToggleProjectCollapsed={toggleProjectCollapsed}
+            projectSections={projectSections}
+            collapsedWorkspaceSectionKeys={collapsedWorkspaceSectionKeys}
+            onToggleWorkspaceSectionCollapsed={toggleWorkspaceSectionCollapsed}
             shortcutIndexByWorkspaceKey={shortcutIndexByWorkspaceKey}
             groupMode={groupMode}
             workspaceGroups={workspaceGroups}
@@ -630,8 +646,11 @@ function DesktopSidebar({
   isManualRefresh,
   groupMode,
   collapsedProjectKeys,
+  projectSections,
+  collapsedWorkspaceSectionKeys,
   shortcutIndexByWorkspaceKey,
   toggleProjectCollapsed,
+  toggleWorkspaceSectionCollapsed,
   handleRefresh,
   handleOpenProject,
   handleImportSession,
@@ -760,6 +779,9 @@ function DesktopSidebar({
           <SidebarWorkspaceList
             collapsedProjectKeys={collapsedProjectKeys}
             onToggleProjectCollapsed={toggleProjectCollapsed}
+            projectSections={projectSections}
+            collapsedWorkspaceSectionKeys={collapsedWorkspaceSectionKeys}
+            onToggleWorkspaceSectionCollapsed={toggleWorkspaceSectionCollapsed}
             shortcutIndexByWorkspaceKey={shortcutIndexByWorkspaceKey}
             groupMode={groupMode}
             workspaceGroups={workspaceGroups}

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -1658,7 +1658,6 @@ function WorkspaceRow({
 function WorkspaceSectionBlock({
   projectViewKey,
   section,
-  showHeader,
   collapsed,
   onToggleCollapsed,
   onRenameSection,
@@ -1678,7 +1677,6 @@ function WorkspaceSectionBlock({
 }: {
   projectViewKey: string;
   section: SidebarProjectWorkspaceSection;
-  showHeader: boolean;
   collapsed: boolean;
   onToggleCollapsed: (workspaceSectionKey: string) => void;
   onRenameSection: (section: SidebarProjectWorkspaceSection) => void;
@@ -1713,14 +1711,10 @@ function WorkspaceSectionBlock({
     toggleExpanded: toggleWorkspacesExpanded,
   } = useLimitedSidebarGroup(section.workspaces);
   const namedSection = section.id !== null;
-  const collapsible = section.collapseKey !== null;
   const Chevron = collapsed ? ThemedChevronRight : ThemedChevronDown;
-  const accessibilityState = useMemo(
-    () => (collapsible ? { expanded: !collapsed } : undefined),
-    [collapsed, collapsible],
-  );
+  const accessibilityState = useMemo(() => ({ expanded: !collapsed }), [collapsed]);
   const handleToggle = useCallback(() => {
-    if (section.collapseKey) onToggleCollapsed(section.collapseKey);
+    onToggleCollapsed(section.collapseKey);
   }, [onToggleCollapsed, section.collapseKey]);
   const handleRename = useCallback(() => onRenameSection(section), [onRenameSection, section]);
   const handleMoveUp = useCallback(() => onMoveSection(section, -1), [onMoveSection, section]);
@@ -1746,65 +1740,62 @@ function WorkspaceSectionBlock({
       style={styles.workspaceSectionBlock}
       testID={`sidebar-workspace-section-${section.id ?? "unsectioned"}-${projectViewKey}`}
     >
-      {showHeader ? (
-        <View style={styles.workspaceSectionHeader}>
-          <Pressable
-            accessibilityRole={collapsible ? "button" : undefined}
-            accessibilityState={accessibilityState}
-            disabled={!collapsible}
-            onPress={handleToggle}
-            style={styles.workspaceSectionTitleButton}
-            testID={`sidebar-workspace-section-header-${section.id ?? "unsectioned"}-${projectViewKey}`}
-          >
-            <Text style={styles.workspaceSectionTitle} numberOfLines={1}>
-              {section.name ?? "Unsectioned"}
-            </Text>
-            {collapsible ? <Chevron size={12} uniProps={foregroundMutedColorMapping} /> : null}
-          </Pressable>
-          {namedSection ? (
-            <DropdownMenu compactMode="sheet">
-              <DropdownMenuTrigger
-                hitSlop={8}
-                style={styles.workspaceSectionMenuTrigger}
-                accessibilityRole={platformIsWeb ? undefined : "button"}
-                accessibilityLabel={`Actions for ${section.name}`}
-                testID={`sidebar-workspace-section-menu-${section.id}-${projectViewKey}`}
+      <View style={styles.workspaceSectionHeader}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={accessibilityState}
+          onPress={handleToggle}
+          style={styles.workspaceSectionTitleButton}
+          testID={`sidebar-workspace-section-header-${section.id ?? "unsectioned"}-${projectViewKey}`}
+        >
+          <Text style={styles.workspaceSectionTitle} numberOfLines={1}>
+            {section.name ?? "Unsectioned"}
+          </Text>
+          <Chevron size={12} uniProps={foregroundMutedColorMapping} />
+        </Pressable>
+        {namedSection ? (
+          <DropdownMenu compactMode="sheet">
+            <DropdownMenuTrigger
+              hitSlop={8}
+              style={styles.workspaceSectionMenuTrigger}
+              accessibilityRole={platformIsWeb ? undefined : "button"}
+              accessibilityLabel={`Actions for ${section.name}`}
+              testID={`sidebar-workspace-section-menu-${section.id}-${projectViewKey}`}
+            >
+              {renderKebabTriggerIcon}
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" width={200} sheetTitle={section.name ?? "Section"}>
+              {!selectionMode ? (
+                <DropdownMenuItem onSelect={onStartSelection}>Select workspaces</DropdownMenuItem>
+              ) : null}
+              <DropdownMenuItem leading={pencilLeadingIcon} onSelect={handleRename}>
+                Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                leading={arrowUpLeadingIcon}
+                disabled={!canMoveUp}
+                onSelect={handleMoveUp}
               >
-                {renderKebabTriggerIcon}
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" width={200} sheetTitle={section.name ?? "Section"}>
-                {!selectionMode ? (
-                  <DropdownMenuItem onSelect={onStartSelection}>Select workspaces</DropdownMenuItem>
-                ) : null}
-                <DropdownMenuItem leading={pencilLeadingIcon} onSelect={handleRename}>
-                  Rename
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  leading={arrowUpLeadingIcon}
-                  disabled={!canMoveUp}
-                  onSelect={handleMoveUp}
-                >
-                  Move up
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  leading={arrowDownLeadingIcon}
-                  disabled={!canMoveDown}
-                  onSelect={handleMoveDown}
-                >
-                  Move down
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  leading={trash2LeadingIcon}
-                  onSelect={handleDelete}
-                  testID={`sidebar-workspace-section-delete-${section.id}-${projectViewKey}`}
-                >
-                  Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : null}
-        </View>
-      ) : null}
+                Move up
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                leading={arrowDownLeadingIcon}
+                disabled={!canMoveDown}
+                onSelect={handleMoveDown}
+              >
+                Move down
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                leading={trash2LeadingIcon}
+                onSelect={handleDelete}
+                testID={`sidebar-workspace-section-delete-${section.id}-${projectViewKey}`}
+              >
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+      </View>
       {collapsed ? null : (
         <>
           {section.workspaces.length > 0 ? (
@@ -1958,12 +1949,6 @@ function ProjectBlock({
   supportsPinningByServerId: ReadonlyMap<string, boolean>;
   onToggleWorkspacePin: ToggleSidebarWorkspacePin;
 }) {
-  const {
-    visibleItems: visibleWorkspaces,
-    expanded: workspacesExpanded,
-    canToggle: canToggleWorkspaces,
-    toggleExpanded: toggleWorkspacesExpanded,
-  } = useLimitedSidebarGroup(project.workspaces);
   const createWorkspaceSection = useSidebarOrderStore((state) => state.createWorkspaceSection);
   const renameWorkspaceSection = useSidebarOrderStore((state) => state.renameWorkspaceSection);
   const reorderWorkspaceSections = useSidebarOrderStore((state) => state.reorderWorkspaceSections);
@@ -2083,29 +2068,6 @@ function ProjectBlock({
       showShortcutBadges,
       workspaceEntriesByKey,
     ],
-  );
-
-  const renderWorkspace = useCallback(
-    ({
-      item,
-      drag: workspaceDrag,
-      isActive,
-      dragHandleProps: workspaceDragHandleProps,
-    }: DraggableRenderItemInfo<SidebarWorkspacePlacement>) => {
-      return renderWorkspaceRow(item, {
-        drag: workspaceDrag,
-        isDragging: isActive,
-        dragHandleProps: workspaceDragHandleProps,
-      });
-    },
-    [renderWorkspaceRow],
-  );
-
-  const handleWorkspaceDragEnd = useCallback(
-    (workspaces: SidebarWorkspacePlacement[]) => {
-      onWorkspaceReorder(project.viewKey, workspaces);
-    },
-    [onWorkspaceReorder, project.viewKey],
   );
 
   const toast = useToast();
@@ -2240,7 +2202,7 @@ function ProjectBlock({
 
   let projectChildren = null;
   if (!collapsed) {
-    if (hasNamedSections) {
+    if (hasNamedSections || project.workspaces.length > 0) {
       projectChildren = (
         <>
           {sections.map((section, index) => (
@@ -2248,11 +2210,7 @@ function ProjectBlock({
               key={section.id ?? "unsectioned"}
               projectViewKey={project.viewKey}
               section={section}
-              showHeader
-              collapsed={
-                section.collapseKey !== null &&
-                collapsedWorkspaceSectionKeys.has(section.collapseKey)
-              }
+              collapsed={collapsedWorkspaceSectionKeys.has(section.collapseKey)}
               onToggleCollapsed={onToggleWorkspaceSectionCollapsed}
               onRenameSection={handleRenameSection}
               onMoveSection={handleMoveSection}
@@ -2270,32 +2228,6 @@ function ProjectBlock({
               dragGestureHostActive={dragGestureHostActive}
             />
           ))}
-        </>
-      );
-    } else if (project.workspaces.length > 0) {
-      projectChildren = (
-        <>
-          <DraggableList
-            testID={`sidebar-workspace-list-${project.viewKey}`}
-            data={visibleWorkspaces}
-            keyExtractor={workspaceKeyExtractor}
-            renderItem={renderWorkspace}
-            onDragEnd={handleWorkspaceDragEnd}
-            extraData={activeWorkspaceSelectionKey(activeWorkspaceSelection)}
-            scrollEnabled={false}
-            useDragHandle
-            nestable={useNestable}
-            simultaneousGestureRef={parentGestureRef}
-            gestureHostPresented={dragGestureHostActive}
-            containerStyle={styles.workspaceListContainer}
-          />
-          {canToggleWorkspaces ? (
-            <SidebarGroupToggleRow
-              expanded={workspacesExpanded}
-              onPress={toggleWorkspacesExpanded}
-              testID={`sidebar-project-show-more-${project.viewKey}`}
-            />
-          ) : null}
         </>
       );
     } else if (rowModel.trailingAction.kind === "new_workspace") {
@@ -3270,6 +3202,7 @@ const styles = StyleSheet.create((theme) => ({
   workspaceSectionTitle: {
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
     flexShrink: 1,
   },
   workspaceSectionMenuTrigger: {

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -36,7 +36,18 @@ import { getSidebarRowBackdrop } from "@/components/sidebar/sidebar-row-backdrop
 import { type GestureType } from "react-native-gesture-handler";
 import { WorkspaceRenameModal } from "@/components/workspace-rename-modal";
 import { useWorkspaceClipboardActions } from "@/hooks/use-workspace-clipboard-actions";
-import { ExternalLink, Settings, MoreVertical, Plus, Trash2 } from "lucide-react-native";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  MoreVertical,
+  Pencil,
+  Plus,
+  Settings,
+  Trash2,
+} from "lucide-react-native";
 import { NestableScrollContainer } from "react-native-draggable-flatlist";
 import { DraggableList, type DraggableRenderItemInfo } from "./draggable-list";
 import type { DraggableListDragHandleProps } from "./draggable-list.types";
@@ -91,6 +102,7 @@ import { confirmDialog } from "@/utils/confirm-dialog";
 import type { SidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { SidebarStatusWorkspaceList } from "@/components/sidebar/sidebar-status-list";
 import type { SidebarWorkspaceGroup } from "@/components/sidebar/sidebar-labels";
+import type { SidebarProjectWorkspaceSection } from "@/components/sidebar/sidebar-projection";
 import {
   SidebarWorkspaceContextMenu,
   SidebarWorkspaceMenu,
@@ -151,6 +163,7 @@ import type { HostBadgeModel } from "@/hosts/appearance";
 import { useHostBadges } from "@/hosts/use-host-badges";
 import { useSidebarRowItems } from "@/components/sidebar/display-preferences/model";
 import { PullRequestStateIcon } from "@/git/pull-request-state-icon";
+import { AdaptiveRenameModal } from "@/components/rename-modal";
 
 const workspaceKeyExtractor = (workspace: SidebarWorkspacePlacement) => workspace.workspaceKey;
 
@@ -163,6 +176,11 @@ const ThemedPlus = withUnistyles(Plus);
 const ThemedMoreVertical = withUnistyles(MoreVertical);
 const ThemedTrash2 = withUnistyles(Trash2);
 const ThemedSettings = withUnistyles(Settings);
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedChevronRight = withUnistyles(ChevronRight);
+const ThemedPencil = withUnistyles(Pencil);
+const ThemedArrowUp = withUnistyles(ArrowUp);
+const ThemedArrowDown = withUnistyles(ArrowDown);
 
 const foregroundColorMapping = (theme: Theme) => ({
   color: theme.colors.foreground,
@@ -222,6 +240,9 @@ interface SidebarWorkspaceListProps {
   workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
   collapsedProjectKeys: ReadonlySet<string>;
   onToggleProjectCollapsed: (projectViewKey: string) => void;
+  projectSections: Map<string, SidebarProjectWorkspaceSection[]>;
+  collapsedWorkspaceSectionKeys: ReadonlySet<string>;
+  onToggleWorkspaceSectionCollapsed: (workspaceSectionKey: string) => void;
   shortcutIndexByWorkspaceKey: Map<string, number>;
   groupMode: SidebarGroupMode;
   isRefreshing?: boolean;
@@ -257,6 +278,7 @@ interface ProjectHeaderRowProps {
   isArchiving?: boolean;
   menuController: ReturnType<typeof useContextMenu> | null;
   onRemoveProject?: () => void;
+  onCreateSection?: () => void;
   removeProjectStatus?: "idle" | "pending";
   dragHandleProps?: DraggableListDragHandleProps;
 }
@@ -412,6 +434,7 @@ function ProjectRowTrailingActions({
   isProjectActive,
   onBeginWorkspaceSetup,
   onRemoveProject,
+  onCreateSection,
   removeProjectStatus,
 }: {
   projectViewKey: string;
@@ -424,6 +447,7 @@ function ProjectRowTrailingActions({
   isProjectActive: boolean;
   onBeginWorkspaceSetup: () => void;
   onRemoveProject?: () => void;
+  onCreateSection?: () => void;
   removeProjectStatus: "idle" | "pending" | "success";
 }) {
   const actionsVisible = isHovered || platformIsNative || isMobileBreakpoint;
@@ -448,6 +472,7 @@ function ProjectRowTrailingActions({
             settingsTarget={settingsTarget}
             projectPath={projectPath}
             onRemoveProject={onRemoveProject}
+            onCreateSection={onCreateSection}
             removeProjectStatus={removeProjectStatus}
           />
         </View>
@@ -458,6 +483,9 @@ function ProjectRowTrailingActions({
 
 const trash2LeadingIcon = <ThemedTrash2 size={14} uniProps={foregroundMutedColorMapping} />;
 const settingsLeadingIcon = <ThemedSettings size={14} uniProps={foregroundMutedColorMapping} />;
+const pencilLeadingIcon = <ThemedPencil size={14} uniProps={foregroundMutedColorMapping} />;
+const arrowUpLeadingIcon = <ThemedArrowUp size={14} uniProps={foregroundMutedColorMapping} />;
+const arrowDownLeadingIcon = <ThemedArrowDown size={14} uniProps={foregroundMutedColorMapping} />;
 const openInNewWindowLeadingIcon = (
   <ThemedExternalLink size={14} uniProps={foregroundMutedColorMapping} />
 );
@@ -476,12 +504,14 @@ function ProjectKebabMenu({
   settingsTarget,
   projectPath,
   onRemoveProject,
+  onCreateSection,
   removeProjectStatus,
 }: {
   projectViewKey: string;
   settingsTarget: { serverId: string; projectId: string } | null;
   projectPath: string;
   onRemoveProject: () => void;
+  onCreateSection?: () => void;
   removeProjectStatus: "idle" | "pending" | "success";
 }) {
   const { t } = useTranslation();
@@ -503,6 +533,7 @@ function ProjectKebabMenu({
           settingsTarget={settingsTarget}
           projectPath={projectPath}
           onRemoveProject={onRemoveProject}
+          onCreateSection={onCreateSection}
           removeProjectStatus={removeProjectStatus}
         />
       </DropdownMenuContent>
@@ -531,6 +562,7 @@ function ProjectMenuItems({
   settingsTarget,
   projectPath,
   onRemoveProject,
+  onCreateSection,
   removeProjectStatus,
 }: {
   surface: ProjectMenuSurface;
@@ -538,6 +570,7 @@ function ProjectMenuItems({
   settingsTarget: { serverId: string; projectId: string } | null;
   projectPath: string;
   onRemoveProject: () => void;
+  onCreateSection?: () => void;
   removeProjectStatus: "idle" | "pending" | "success";
 }) {
   const { t } = useTranslation();
@@ -560,6 +593,15 @@ function ProjectMenuItems({
 
   return (
     <>
+      {onCreateSection ? (
+        <ProjectMenuItem
+          surface={surface}
+          testID={`sidebar-project-menu-new-section-${projectViewKey}`}
+          onSelect={onCreateSection}
+        >
+          New section
+        </ProjectMenuItem>
+      ) : null}
       {settingsTarget ? (
         <ProjectMenuItem
           surface={surface}
@@ -678,6 +720,7 @@ function WorkspaceRowRightGroup({
               <SidebarWorkspaceMenu
                 {...kebab.menuProps}
                 workspaceKey={workspace.workspaceKey}
+                projectViewKey={workspace.projectViewKey}
                 serverId={workspace.serverId}
                 workspaceId={workspace.workspaceId}
                 workspaceLabels={workspace.labels}
@@ -866,6 +909,7 @@ function ProjectHeaderRow({
   isArchiving = false,
   menuController,
   onRemoveProject,
+  onCreateSection,
   removeProjectStatus = "idle",
   dragHandleProps,
 }: ProjectHeaderRowProps) {
@@ -971,6 +1015,7 @@ function ProjectHeaderRow({
         isProjectActive={isProjectActive}
         onBeginWorkspaceSetup={handleBeginWorkspaceSetup}
         onRemoveProject={onRemoveProject}
+        onCreateSection={onCreateSection}
         removeProjectStatus={removeProjectStatus}
       />
       {showShortcutBadge && shortcutNumber !== null ? (
@@ -1040,6 +1085,7 @@ function ProjectHeaderRow({
           settingsTarget={settingsTarget}
           projectPath={projectPath}
           onRemoveProject={onRemoveProject}
+          onCreateSection={onCreateSection}
           removeProjectStatus={removeProjectStatus}
         />
       </ContextMenuContent>
@@ -1540,10 +1586,183 @@ function WorkspaceRow({
   );
 }
 
+function WorkspaceSectionBlock({
+  projectViewKey,
+  section,
+  showHeader,
+  collapsed,
+  onToggleCollapsed,
+  onRenameSection,
+  onMoveSection,
+  canMoveUp,
+  canMoveDown,
+  onDeleteSection,
+  renderWorkspaceRow,
+  onSectionWorkspaceReorder,
+  activeWorkspaceSelection,
+  useNestable,
+  parentGestureRef,
+  dragGestureHostActive,
+}: {
+  projectViewKey: string;
+  section: SidebarProjectWorkspaceSection;
+  showHeader: boolean;
+  collapsed: boolean;
+  onToggleCollapsed: (workspaceSectionKey: string) => void;
+  onRenameSection: (section: SidebarProjectWorkspaceSection) => void;
+  onMoveSection: (section: SidebarProjectWorkspaceSection, direction: -1 | 1) => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onDeleteSection: (section: SidebarProjectWorkspaceSection) => void;
+  renderWorkspaceRow: (
+    workspace: SidebarWorkspacePlacement,
+    input?: {
+      drag?: () => void;
+      isDragging?: boolean;
+      dragHandleProps?: DraggableListDragHandleProps;
+    },
+  ) => ReactElement;
+  onSectionWorkspaceReorder: (
+    section: SidebarProjectWorkspaceSection,
+    workspaces: SidebarWorkspacePlacement[],
+  ) => void;
+  activeWorkspaceSelection: ActiveWorkspaceSelection | null;
+  useNestable: boolean;
+  parentGestureRef?: MutableRefObject<GestureType | undefined>;
+  dragGestureHostActive?: boolean;
+}) {
+  const {
+    visibleItems: visibleWorkspaces,
+    expanded: workspacesExpanded,
+    canToggle: canToggleWorkspaces,
+    toggleExpanded: toggleWorkspacesExpanded,
+  } = useLimitedSidebarGroup(section.workspaces);
+  const namedSection = section.id !== null;
+  const Chevron = collapsed ? ThemedChevronRight : ThemedChevronDown;
+  const accessibilityState = useMemo(
+    () => (namedSection ? { expanded: !collapsed } : undefined),
+    [collapsed, namedSection],
+  );
+  const handleToggle = useCallback(() => {
+    if (section.collapseKey) onToggleCollapsed(section.collapseKey);
+  }, [onToggleCollapsed, section.collapseKey]);
+  const handleRename = useCallback(() => onRenameSection(section), [onRenameSection, section]);
+  const handleMoveUp = useCallback(() => onMoveSection(section, -1), [onMoveSection, section]);
+  const handleMoveDown = useCallback(() => onMoveSection(section, 1), [onMoveSection, section]);
+  const handleDelete = useCallback(() => onDeleteSection(section), [onDeleteSection, section]);
+  const handleWorkspaceReorder = useCallback(
+    (workspaces: SidebarWorkspacePlacement[]) => onSectionWorkspaceReorder(section, workspaces),
+    [onSectionWorkspaceReorder, section],
+  );
+  const renderWorkspace = useCallback(
+    ({
+      item,
+      drag,
+      isActive,
+      dragHandleProps,
+    }: DraggableRenderItemInfo<SidebarWorkspacePlacement>) =>
+      renderWorkspaceRow(item, { drag, isDragging: isActive, dragHandleProps }),
+    [renderWorkspaceRow],
+  );
+
+  return (
+    <View
+      style={styles.workspaceSectionBlock}
+      testID={`sidebar-workspace-section-${section.id ?? "unsectioned"}-${projectViewKey}`}
+    >
+      {showHeader ? (
+        <View style={styles.workspaceSectionHeader}>
+          <Pressable
+            accessibilityRole={namedSection ? "button" : undefined}
+            accessibilityState={accessibilityState}
+            disabled={!namedSection}
+            onPress={handleToggle}
+            style={styles.workspaceSectionTitleButton}
+            testID={`sidebar-workspace-section-header-${section.id ?? "unsectioned"}-${projectViewKey}`}
+          >
+            <Text style={styles.workspaceSectionTitle} numberOfLines={1}>
+              {section.name ?? "Unsectioned"}
+            </Text>
+            {namedSection ? <Chevron size={12} uniProps={foregroundMutedColorMapping} /> : null}
+          </Pressable>
+          {namedSection ? (
+            <DropdownMenu compactMode="sheet">
+              <DropdownMenuTrigger
+                hitSlop={8}
+                style={styles.workspaceSectionMenuTrigger}
+                accessibilityRole={platformIsWeb ? undefined : "button"}
+                accessibilityLabel={`Actions for ${section.name}`}
+                testID={`sidebar-workspace-section-menu-${section.id}-${projectViewKey}`}
+              >
+                {renderKebabTriggerIcon}
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" width={200} sheetTitle={section.name ?? "Section"}>
+                <DropdownMenuItem leading={pencilLeadingIcon} onSelect={handleRename}>
+                  Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  leading={arrowUpLeadingIcon}
+                  disabled={!canMoveUp}
+                  onSelect={handleMoveUp}
+                >
+                  Move up
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  leading={arrowDownLeadingIcon}
+                  disabled={!canMoveDown}
+                  onSelect={handleMoveDown}
+                >
+                  Move down
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  leading={trash2LeadingIcon}
+                  onSelect={handleDelete}
+                  testID={`sidebar-workspace-section-delete-${section.id}-${projectViewKey}`}
+                >
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+        </View>
+      ) : null}
+      {collapsed ? null : (
+        <>
+          {section.workspaces.length > 0 ? (
+            <DraggableList
+              testID={`sidebar-workspace-list-${projectViewKey}-${section.id ?? "unsectioned"}`}
+              data={visibleWorkspaces}
+              keyExtractor={workspaceKeyExtractor}
+              renderItem={renderWorkspace}
+              onDragEnd={handleWorkspaceReorder}
+              extraData={activeWorkspaceSelectionKey(activeWorkspaceSelection)}
+              scrollEnabled={false}
+              useDragHandle
+              nestable={useNestable}
+              simultaneousGestureRef={parentGestureRef}
+              gestureHostPresented={dragGestureHostActive}
+              containerStyle={styles.workspaceListContainer}
+            />
+          ) : null}
+          {canToggleWorkspaces ? (
+            <SidebarGroupToggleRow
+              expanded={workspacesExpanded}
+              onPress={toggleWorkspacesExpanded}
+              testID={`sidebar-workspace-section-show-more-${section.id ?? "unsectioned"}-${projectViewKey}`}
+            />
+          ) : null}
+        </>
+      )}
+    </View>
+  );
+}
+
 function ProjectBlock({
   project,
+  sections,
   workspaceEntriesByKey,
   collapsed,
+  collapsedWorkspaceSectionKeys,
   displayName,
   iconDataUri,
   selectionEnabled,
@@ -1551,6 +1770,7 @@ function ProjectBlock({
   shortcutIndexByWorkspaceKey,
   parentGestureRef,
   onToggleCollapsed,
+  onToggleWorkspaceSectionCollapsed,
   onWorkspacePress,
   onWorkspaceReorder,
   onWorktreeCreated,
@@ -1567,8 +1787,10 @@ function ProjectBlock({
   onToggleWorkspacePin,
 }: {
   project: SidebarProjectEntry;
+  sections: SidebarProjectWorkspaceSection[];
   workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
   collapsed: boolean;
+  collapsedWorkspaceSectionKeys: ReadonlySet<string>;
   displayName: string;
   iconDataUri: string | null;
   selectionEnabled: boolean;
@@ -1576,6 +1798,7 @@ function ProjectBlock({
   shortcutIndexByWorkspaceKey: Map<string, number>;
   parentGestureRef?: MutableRefObject<GestureType | undefined>;
   onToggleCollapsed: (projectViewKey: string) => void;
+  onToggleWorkspaceSectionCollapsed: (workspaceSectionKey: string) => void;
   onWorkspacePress?: () => void;
   onWorkspaceReorder: (projectViewKey: string, workspaces: SidebarWorkspacePlacement[]) => void;
   onWorktreeCreated?: (workspaceId: string) => void;
@@ -1597,6 +1820,16 @@ function ProjectBlock({
     canToggle: canToggleWorkspaces,
     toggleExpanded: toggleWorkspacesExpanded,
   } = useLimitedSidebarGroup(project.workspaces);
+  const createWorkspaceSection = useSidebarOrderStore((state) => state.createWorkspaceSection);
+  const renameWorkspaceSection = useSidebarOrderStore((state) => state.renameWorkspaceSection);
+  const reorderWorkspaceSections = useSidebarOrderStore((state) => state.reorderWorkspaceSections);
+  const deleteWorkspaceSection = useSidebarOrderStore((state) => state.deleteWorkspaceSection);
+  const setWorkspaceSectionWorkspaceOrder = useSidebarOrderStore(
+    (state) => state.setWorkspaceSectionWorkspaceOrder,
+  );
+  const [sectionDialog, setSectionDialog] = useState<
+    { mode: "create" } | { mode: "rename"; section: SidebarProjectWorkspaceSection } | null
+  >(null);
   const rowModel = useMemo(
     () =>
       buildSidebarProjectRowModel({
@@ -1747,9 +1980,108 @@ function ProjectBlock({
     onToggleCollapsed(project.viewKey);
   }, [onToggleCollapsed, project.viewKey]);
 
+  const hasNamedSections = sections.some((section) => section.id !== null);
+  const handleCreateSection = useCallback(() => {
+    setSectionDialog({ mode: "create" });
+  }, []);
+  const handleRenameSection = useCallback((section: SidebarProjectWorkspaceSection) => {
+    setSectionDialog({ mode: "rename", section });
+  }, []);
+  const handleSectionDialogSubmit = useCallback(
+    (name: string) => {
+      if (!sectionDialog) return;
+      if (sectionDialog.mode === "create") {
+        createWorkspaceSection(project.viewKey, name);
+        return;
+      }
+      if (sectionDialog.section.id) {
+        renameWorkspaceSection(project.viewKey, sectionDialog.section.id, name);
+      }
+    },
+    [createWorkspaceSection, project.viewKey, renameWorkspaceSection, sectionDialog],
+  );
+  const handleSectionReorder = useCallback(
+    (sectionId: string, direction: -1 | 1) => {
+      const sectionIds = sections.flatMap((section) => (section.id ? [section.id] : []));
+      const index = sectionIds.indexOf(sectionId);
+      const destination = index + direction;
+      if (index < 0 || destination < 0 || destination >= sectionIds.length) return;
+      const [moved] = sectionIds.splice(index, 1);
+      sectionIds.splice(destination, 0, moved);
+      reorderWorkspaceSections(project.viewKey, sectionIds);
+    },
+    [project.viewKey, reorderWorkspaceSections, sections],
+  );
+  const handleDeleteSection = useCallback(
+    (section: SidebarProjectWorkspaceSection) => {
+      const sectionId = section.id;
+      if (!sectionId) return;
+      void confirmDialog({
+        title: "Delete section?",
+        message: `Move the workspaces in ${section.name} to Unsectioned?`,
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        destructive: true,
+      }).then((confirmed) => {
+        if (confirmed) deleteWorkspaceSection(project.viewKey, sectionId);
+        return undefined;
+      });
+    },
+    [deleteWorkspaceSection, project.viewKey],
+  );
+  const handleSectionWorkspaceReorder = useCallback(
+    (section: SidebarProjectWorkspaceSection, workspaces: SidebarWorkspacePlacement[]) => {
+      onWorkspaceReorder(project.viewKey, workspaces);
+      if (section.id) {
+        setWorkspaceSectionWorkspaceOrder(
+          project.viewKey,
+          section.id,
+          workspaces.map((workspace) => workspace.workspaceKey),
+        );
+      }
+    },
+    [onWorkspaceReorder, project.viewKey, setWorkspaceSectionWorkspaceOrder],
+  );
+  const handleMoveSection = useCallback(
+    (section: SidebarProjectWorkspaceSection, direction: -1 | 1) => {
+      if (section.id) handleSectionReorder(section.id, direction);
+    },
+    [handleSectionReorder],
+  );
+  const handleCloseSectionDialog = useCallback(() => setSectionDialog(null), []);
+
   let projectChildren = null;
   if (!collapsed) {
-    if (project.workspaces.length > 0) {
+    if (hasNamedSections) {
+      projectChildren = (
+        <>
+          {sections.map((section, index) => (
+            <WorkspaceSectionBlock
+              key={section.id ?? "unsectioned"}
+              projectViewKey={project.viewKey}
+              section={section}
+              showHeader
+              collapsed={
+                section.collapseKey !== null &&
+                collapsedWorkspaceSectionKeys.has(section.collapseKey)
+              }
+              onToggleCollapsed={onToggleWorkspaceSectionCollapsed}
+              onRenameSection={handleRenameSection}
+              onMoveSection={handleMoveSection}
+              canMoveUp={section.id !== null && index > 0}
+              canMoveDown={section.id !== null && index < sections.length - 2}
+              onDeleteSection={handleDeleteSection}
+              renderWorkspaceRow={renderWorkspaceRow}
+              onSectionWorkspaceReorder={handleSectionWorkspaceReorder}
+              activeWorkspaceSelection={activeWorkspaceSelection}
+              useNestable={useNestable}
+              parentGestureRef={parentGestureRef}
+              dragGestureHostActive={dragGestureHostActive}
+            />
+          ))}
+        </>
+      );
+    } else if (project.workspaces.length > 0) {
       projectChildren = (
         <>
           <DraggableList
@@ -1812,11 +2144,24 @@ function ProjectBlock({
         isArchiving={isRemovingProject}
         menuController={null}
         onRemoveProject={handleRemoveProject}
+        onCreateSection={handleCreateSection}
         removeProjectStatus={isRemovingProject ? "pending" : "idle"}
         dragHandleProps={dragHandleProps}
       />
 
       {projectChildren}
+      {sectionDialog ? (
+        <AdaptiveRenameModal
+          visible
+          title={sectionDialog.mode === "create" ? "New section" : "Rename section"}
+          initialValue={sectionDialog.mode === "create" ? "" : (sectionDialog.section.name ?? "")}
+          placeholder="Section name"
+          submitLabel={sectionDialog.mode === "create" ? "Create" : "Rename"}
+          onClose={handleCloseSectionDialog}
+          onSubmit={handleSectionDialogSubmit}
+          testID={`sidebar-workspace-section-dialog-${project.viewKey}`}
+        />
+      ) : null}
     </View>
   );
 }
@@ -1827,8 +2172,10 @@ type ProjectBlockProps = Parameters<typeof ProjectBlock>[0];
 function areProjectBlockPropsEqual(previous: ProjectBlockProps, next: ProjectBlockProps): boolean {
   return (
     previous.project === next.project &&
+    previous.sections === next.sections &&
     previous.workspaceEntriesByKey === next.workspaceEntriesByKey &&
     previous.collapsed === next.collapsed &&
+    previous.collapsedWorkspaceSectionKeys === next.collapsedWorkspaceSectionKeys &&
     previous.displayName === next.displayName &&
     previous.iconDataUri === next.iconDataUri &&
     previous.selectionEnabled === next.selectionEnabled &&
@@ -1840,6 +2187,7 @@ function areProjectBlockPropsEqual(previous: ProjectBlockProps, next: ProjectBlo
     previous.onToggleWorkspacePin === next.onToggleWorkspacePin &&
     previous.parentGestureRef === next.parentGestureRef &&
     previous.onToggleCollapsed === next.onToggleCollapsed &&
+    previous.onToggleWorkspaceSectionCollapsed === next.onToggleWorkspaceSectionCollapsed &&
     previous.onWorkspacePress === next.onWorkspacePress &&
     previous.onWorkspaceReorder === next.onWorkspaceReorder &&
     previous.onWorktreeCreated === next.onWorktreeCreated &&
@@ -1886,11 +2234,14 @@ export function SidebarWorkspaceList({
   projectIconTargets,
   pinnedGroups,
   projects,
+  projectSections,
   hasProjectsBeforeFilter,
   hasActiveProjectFilter,
   workspaceEntriesByKey,
   collapsedProjectKeys,
   onToggleProjectCollapsed,
+  collapsedWorkspaceSectionKeys,
+  onToggleWorkspaceSectionCollapsed,
   shortcutIndexByWorkspaceKey,
   groupMode,
   isRefreshing: _isRefreshing = false,
@@ -1983,11 +2334,14 @@ export function SidebarWorkspaceList({
     ) : (
       <ProjectModeList
         projects={projects}
+        projectSections={projectSections}
         pinnedGroups={pinnedGroups}
         workspaceEntriesByKey={workspaceEntriesByKey}
         projectIconByProjectViewKey={projectIconByProjectViewKey}
         collapsedProjectKeys={collapsedProjectKeys}
         onToggleProjectCollapsed={onToggleProjectCollapsed}
+        collapsedWorkspaceSectionKeys={collapsedWorkspaceSectionKeys}
+        onToggleWorkspaceSectionCollapsed={onToggleWorkspaceSectionCollapsed}
         shortcutIndexByWorkspaceKey={shortcutIndexByWorkspaceKey}
         onWorkspacePress={onWorkspacePress}
         onAddProject={onAddProject}
@@ -2079,11 +2433,14 @@ function SidebarGroupedModeList({
 
 function ProjectModeList({
   projects,
+  projectSections,
   pinnedGroups,
   workspaceEntriesByKey,
   projectIconByProjectViewKey,
   collapsedProjectKeys,
   onToggleProjectCollapsed,
+  collapsedWorkspaceSectionKeys,
+  onToggleWorkspaceSectionCollapsed,
   shortcutIndexByWorkspaceKey,
   onWorkspacePress,
   onAddProject,
@@ -2294,8 +2651,10 @@ function ProjectModeList({
         <MemoProjectBlock
           key={item.viewKey}
           project={item}
+          sections={projectSections.get(item.viewKey) ?? []}
           workspaceEntriesByKey={workspaceEntriesByKey}
           collapsed={collapsedProjectKeys.has(item.viewKey)}
+          collapsedWorkspaceSectionKeys={collapsedWorkspaceSectionKeys}
           displayName={item.projectName}
           iconDataUri={projectIconByProjectViewKey.get(item.viewKey) ?? null}
           selectionEnabled={selectionEnabled}
@@ -2303,6 +2662,7 @@ function ProjectModeList({
           shortcutIndexByWorkspaceKey={shortcutIndexByWorkspaceKey}
           parentGestureRef={parentGestureRef}
           onToggleCollapsed={onToggleProjectCollapsed}
+          onToggleWorkspaceSectionCollapsed={onToggleWorkspaceSectionCollapsed}
           onWorkspacePress={onWorkspacePress}
           onWorkspaceReorder={handleWorkspaceReorder}
           onWorktreeCreated={handleWorktreeCreated}
@@ -2322,6 +2682,7 @@ function ProjectModeList({
     },
     [
       collapsedProjectKeys,
+      collapsedWorkspaceSectionKeys,
       activeWorkspaceSelection,
       handleWorktreeCreated,
       handleWorkspaceReorder,
@@ -2331,9 +2692,11 @@ function ProjectModeList({
       onToggleWorkspacePin,
       onWorkspacePress,
       onToggleProjectCollapsed,
+      onToggleWorkspaceSectionCollapsed,
       parentGestureRef,
       dragGestureHostActive,
       projectIconByProjectViewKey,
+      projectSections,
       selectionEnabled,
       shortcutIndexByWorkspaceKey,
       showShortcutBadges,
@@ -2687,6 +3050,32 @@ const styles = StyleSheet.create((theme) => ({
     position: "absolute",
     top: theme.spacing[2] + 1,
     right: theme.spacing[2],
+  },
+  workspaceSectionBlock: {
+    marginTop: theme.spacing[1],
+  },
+  workspaceSectionHeader: {
+    minHeight: 28,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingLeft: theme.spacing[2],
+    paddingRight: theme.spacing[2],
+  },
+  workspaceSectionTitleButton: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+  },
+  workspaceSectionTitle: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    flexShrink: 1,
+  },
+  workspaceSectionMenuTrigger: {
+    padding: 2,
+    borderRadius: 4,
   },
   workspaceRow: {
     minHeight: 36,

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -164,6 +164,11 @@ import { useHostBadges } from "@/hosts/use-host-badges";
 import { useSidebarRowItems } from "@/components/sidebar/display-preferences/model";
 import { PullRequestStateIcon } from "@/git/pull-request-state-icon";
 import { AdaptiveRenameModal } from "@/components/rename-modal";
+import {
+  retainVisibleSidebarWorkspaceSelection,
+  shouldToggleSidebarWorkspacePin,
+  toggleSidebarWorkspaceSelection,
+} from "@/components/sidebar/sidebar-workspace-selection";
 
 const workspaceKeyExtractor = (workspace: SidebarWorkspacePlacement) => workspace.workspaceKey;
 
@@ -311,6 +316,9 @@ interface WorkspaceRowInnerProps {
   isPinned?: boolean;
   onTogglePin?: () => void;
   reserveIdleStatusIndicatorSpace?: boolean;
+  selectionMode?: boolean;
+  bulkSelected?: boolean;
+  onToggleBulkSelection?: () => void;
 }
 
 export function PrBadge({ hint, style }: { hint: PrHint; style?: StyleProp<ViewStyle> }) {
@@ -402,6 +410,10 @@ function getProjectWorkspaceRowStyle({
 }
 
 function noop() {}
+
+function isShiftClick(event: GestureResponderEvent): boolean {
+  return "shiftKey" in event.nativeEvent && event.nativeEvent.shiftKey === true;
+}
 
 const prBadgeStyles = StyleSheet.create((theme) => ({
   badge: {
@@ -1121,12 +1133,15 @@ function WorkspaceRowInner({
   isPinned,
   onTogglePin,
   reserveIdleStatusIndicatorSpace = true,
+  selectionMode = false,
+  bulkSelected = false,
+  onToggleBulkSelection,
 }: WorkspaceRowInnerProps) {
   const isCompact = useIsCompactFormFactor();
   const [isPressed, setIsPressed] = useState(false);
   const isTouchPlatform = platformIsNative || isCompact;
   const interaction = useLongPressDragInteraction({
-    drag,
+    drag: selectionMode ? noop : drag,
     menuController,
   });
   const {
@@ -1136,13 +1151,32 @@ function WorkspaceRowInner({
     ...dragAttributes
   } = dragHandleProps?.attributes ?? {};
 
-  const handlePress = useCallback(() => {
-    if (interaction.didLongPressRef.current) {
-      interaction.didLongPressRef.current = false;
-      return;
-    }
-    onPress();
-  }, [interaction.didLongPressRef, onPress]);
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      if (interaction.didLongPressRef.current) {
+        interaction.didLongPressRef.current = false;
+        return;
+      }
+      if (selectionMode) {
+        onToggleBulkSelection?.();
+        return;
+      }
+      if (
+        onTogglePin &&
+        shouldToggleSidebarWorkspacePin({
+          selectionMode,
+          isElectron: getIsElectron(),
+          shiftKey: isShiftClick(event),
+          canPin: onTogglePin !== undefined,
+        })
+      ) {
+        onTogglePin();
+        return;
+      }
+      onPress();
+    },
+    [interaction.didLongPressRef, onPress, onToggleBulkSelection, onTogglePin, selectionMode],
+  );
   const handleWorkspacePressIn = useCallback(
     (event: GestureResponderEvent) => {
       setIsPressed(true);
@@ -1221,6 +1255,8 @@ function WorkspaceRowInner({
                 isCreating={isCreating}
                 shortcutNumber={shortcutNumber}
                 showShortcutBadge={showShortcutBadge}
+                selectionMode={selectionMode}
+                bulkSelected={bulkSelected}
                 reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
               >
                 <WorkspaceRowRightGroup
@@ -1270,6 +1306,9 @@ function WorkspaceRowWithMenu({
   onToggleWorkspacePin,
   reserveIdleStatusIndicatorSpace = true,
   isCreating = false,
+  selectionMode = false,
+  bulkSelected = false,
+  onToggleBulkSelection,
 }: {
   workspace: SidebarWorkspaceEntry;
   hostBadge?: HostBadgeModel | null;
@@ -1287,6 +1326,9 @@ function WorkspaceRowWithMenu({
   onToggleWorkspacePin: ToggleSidebarWorkspacePin;
   reserveIdleStatusIndicatorSpace?: boolean;
   isCreating?: boolean;
+  selectionMode?: boolean;
+  bulkSelected?: boolean;
+  onToggleBulkSelection?: () => void;
 }) {
   const { t } = useTranslation();
   const toast = useToast();
@@ -1399,6 +1441,9 @@ function WorkspaceRowWithMenu({
         isPinned={isPinned}
         onTogglePin={onTogglePin}
         reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
+        selectionMode={selectionMode}
+        bulkSelected={bulkSelected}
+        onToggleBulkSelection={onToggleBulkSelection}
       />
       <WorkspaceRenameModal
         visible={isRenameOpen}
@@ -1423,6 +1468,9 @@ interface WorkspaceRowItemProps {
   onToggleWorkspacePin: ToggleSidebarWorkspacePin;
   reserveIdleStatusIndicatorSpace?: boolean;
   isCreating?: boolean;
+  selectionMode?: boolean;
+  bulkSelected?: boolean;
+  onToggleBulkSelection?: (workspaceKey: string) => void;
   selectionEnabled: boolean;
   activeWorkspaceSelection: ActiveWorkspaceSelection | null;
   onWorkspacePress?: () => void;
@@ -1444,6 +1492,9 @@ function WorkspaceRowItem({
   onToggleWorkspacePin,
   reserveIdleStatusIndicatorSpace = true,
   isCreating = false,
+  selectionMode = false,
+  bulkSelected = false,
+  onToggleBulkSelection,
   selectionEnabled,
   activeWorkspaceSelection,
   onWorkspacePress,
@@ -1458,6 +1509,9 @@ function WorkspaceRowItem({
     onWorkspacePress?.();
     navigateToWorkspace({ serverId: workspace.serverId, workspaceId: workspace.workspaceId });
   }, [onWorkspacePress, workspace.serverId, workspace.workspaceId]);
+  const handleToggleBulkSelection = useCallback(() => {
+    onToggleBulkSelection?.(workspace.workspaceKey);
+  }, [onToggleBulkSelection, workspace.workspaceKey]);
 
   return (
     <WorkspaceRow
@@ -1472,6 +1526,9 @@ function WorkspaceRowItem({
       onToggleWorkspacePin={onToggleWorkspacePin}
       reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
       isCreating={isCreating}
+      selectionMode={selectionMode}
+      bulkSelected={bulkSelected}
+      onToggleBulkSelection={onToggleBulkSelection ? handleToggleBulkSelection : undefined}
       selected={isWorkspaceSelected({
         selection: activeWorkspaceSelection,
         serverId: workspace.serverId,
@@ -1515,6 +1572,9 @@ function areWorkspaceRowItemPropsEqual(
     previous.onToggleWorkspacePin === next.onToggleWorkspacePin &&
     previous.reserveIdleStatusIndicatorSpace === next.reserveIdleStatusIndicatorSpace &&
     previous.isCreating === next.isCreating &&
+    previous.selectionMode === next.selectionMode &&
+    previous.bulkSelected === next.bulkSelected &&
+    previous.onToggleBulkSelection === next.onToggleBulkSelection &&
     previous.onWorkspacePress === next.onWorkspacePress &&
     previous.drag === next.drag &&
     previous.isDragging === next.isDragging &&
@@ -1541,6 +1601,9 @@ function WorkspaceRow({
   onToggleWorkspacePin,
   reserveIdleStatusIndicatorSpace = true,
   isCreating = false,
+  selectionMode = false,
+  bulkSelected = false,
+  onToggleBulkSelection,
   selected,
 }: {
   workspaceEntry: SidebarWorkspaceEntry | null;
@@ -1558,6 +1621,9 @@ function WorkspaceRow({
   onToggleWorkspacePin: ToggleSidebarWorkspacePin;
   reserveIdleStatusIndicatorSpace?: boolean;
   isCreating?: boolean;
+  selectionMode?: boolean;
+  bulkSelected?: boolean;
+  onToggleBulkSelection?: () => void;
   selected: boolean;
 }) {
   if (!workspaceEntry) {
@@ -1582,6 +1648,9 @@ function WorkspaceRow({
       onToggleWorkspacePin={onToggleWorkspacePin}
       reserveIdleStatusIndicatorSpace={reserveIdleStatusIndicatorSpace}
       isCreating={isCreating}
+      selectionMode={selectionMode}
+      bulkSelected={bulkSelected}
+      onToggleBulkSelection={onToggleBulkSelection}
     />
   );
 }
@@ -1597,6 +1666,9 @@ function WorkspaceSectionBlock({
   canMoveUp,
   canMoveDown,
   onDeleteSection,
+  onStartSelection,
+  selectionMode,
+  bulkSelectionKey,
   renderWorkspaceRow,
   onSectionWorkspaceReorder,
   activeWorkspaceSelection,
@@ -1614,6 +1686,9 @@ function WorkspaceSectionBlock({
   canMoveUp: boolean;
   canMoveDown: boolean;
   onDeleteSection: (section: SidebarProjectWorkspaceSection) => void;
+  onStartSelection: () => void;
+  selectionMode: boolean;
+  bulkSelectionKey: string;
   renderWorkspaceRow: (
     workspace: SidebarWorkspacePlacement,
     input?: {
@@ -1638,10 +1713,11 @@ function WorkspaceSectionBlock({
     toggleExpanded: toggleWorkspacesExpanded,
   } = useLimitedSidebarGroup(section.workspaces);
   const namedSection = section.id !== null;
+  const collapsible = section.collapseKey !== null;
   const Chevron = collapsed ? ThemedChevronRight : ThemedChevronDown;
   const accessibilityState = useMemo(
-    () => (namedSection ? { expanded: !collapsed } : undefined),
-    [collapsed, namedSection],
+    () => (collapsible ? { expanded: !collapsed } : undefined),
+    [collapsed, collapsible],
   );
   const handleToggle = useCallback(() => {
     if (section.collapseKey) onToggleCollapsed(section.collapseKey);
@@ -1673,9 +1749,9 @@ function WorkspaceSectionBlock({
       {showHeader ? (
         <View style={styles.workspaceSectionHeader}>
           <Pressable
-            accessibilityRole={namedSection ? "button" : undefined}
+            accessibilityRole={collapsible ? "button" : undefined}
             accessibilityState={accessibilityState}
-            disabled={!namedSection}
+            disabled={!collapsible}
             onPress={handleToggle}
             style={styles.workspaceSectionTitleButton}
             testID={`sidebar-workspace-section-header-${section.id ?? "unsectioned"}-${projectViewKey}`}
@@ -1683,7 +1759,7 @@ function WorkspaceSectionBlock({
             <Text style={styles.workspaceSectionTitle} numberOfLines={1}>
               {section.name ?? "Unsectioned"}
             </Text>
-            {namedSection ? <Chevron size={12} uniProps={foregroundMutedColorMapping} /> : null}
+            {collapsible ? <Chevron size={12} uniProps={foregroundMutedColorMapping} /> : null}
           </Pressable>
           {namedSection ? (
             <DropdownMenu compactMode="sheet">
@@ -1697,6 +1773,9 @@ function WorkspaceSectionBlock({
                 {renderKebabTriggerIcon}
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" width={200} sheetTitle={section.name ?? "Section"}>
+                {!selectionMode ? (
+                  <DropdownMenuItem onSelect={onStartSelection}>Select workspaces</DropdownMenuItem>
+                ) : null}
                 <DropdownMenuItem leading={pencilLeadingIcon} onSelect={handleRename}>
                   Rename
                 </DropdownMenuItem>
@@ -1735,7 +1814,7 @@ function WorkspaceSectionBlock({
               keyExtractor={workspaceKeyExtractor}
               renderItem={renderWorkspace}
               onDragEnd={handleWorkspaceReorder}
-              extraData={activeWorkspaceSelectionKey(activeWorkspaceSelection)}
+              extraData={`${activeWorkspaceSelectionKey(activeWorkspaceSelection)}:${selectionMode}:${bulkSelectionKey}`}
               scrollEnabled={false}
               useDragHandle
               nestable={useNestable}
@@ -1753,6 +1832,71 @@ function WorkspaceSectionBlock({
           ) : null}
         </>
       )}
+    </View>
+  );
+}
+
+function WorkspaceSectionMoveMenuItem({
+  sectionId,
+  name,
+  onMove,
+}: {
+  sectionId: string | null;
+  name: string;
+  onMove: (sectionId: string | null) => void;
+}) {
+  const handleSelect = useCallback(() => onMove(sectionId), [onMove, sectionId]);
+  return <DropdownMenuItem onSelect={handleSelect}>{name}</DropdownMenuItem>;
+}
+
+function ProjectWorkspaceSelectionBar({
+  selectedCount,
+  sections,
+  onMove,
+  onCancel,
+}: {
+  selectedCount: number;
+  sections: SidebarProjectWorkspaceSection[];
+  onMove: (sectionId: string | null) => void;
+  onCancel: () => void;
+}) {
+  return (
+    <View style={styles.workspaceSelectionBar} testID="sidebar-workspace-selection-bar">
+      <Text style={styles.workspaceSelectionCount}>{selectedCount} selected</Text>
+      <DropdownMenu compactMode="sheet">
+        <DropdownMenuTrigger
+          disabled={selectedCount === 0}
+          style={styles.workspaceSelectionMoveTrigger}
+          accessibilityRole={platformIsWeb ? undefined : "button"}
+          testID="sidebar-workspace-selection-move"
+        >
+          <Text style={styles.workspaceSelectionMoveText}>Move to section</Text>
+          <ThemedChevronDown size={12} uniProps={foregroundMutedColorMapping} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" width={200} sheetTitle="Move to section">
+          <WorkspaceSectionMoveMenuItem sectionId={null} name="Unsectioned" onMove={onMove} />
+          {sections.flatMap((section) =>
+            section.id ? (
+              <WorkspaceSectionMoveMenuItem
+                key={section.id}
+                sectionId={section.id}
+                name={section.name ?? "Section"}
+                onMove={onMove}
+              />
+            ) : (
+              []
+            ),
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Pressable
+        style={styles.workspaceSelectionCancel}
+        onPress={onCancel}
+        accessibilityRole={platformIsWeb ? undefined : "button"}
+        testID="sidebar-workspace-selection-cancel"
+      >
+        <Text style={styles.workspaceSelectionCancelText}>Cancel</Text>
+      </Pressable>
     </View>
   );
 }
@@ -1824,12 +1968,31 @@ function ProjectBlock({
   const renameWorkspaceSection = useSidebarOrderStore((state) => state.renameWorkspaceSection);
   const reorderWorkspaceSections = useSidebarOrderStore((state) => state.reorderWorkspaceSections);
   const deleteWorkspaceSection = useSidebarOrderStore((state) => state.deleteWorkspaceSection);
+  const moveWorkspacesToSection = useSidebarOrderStore((state) => state.moveWorkspacesToSection);
   const setWorkspaceSectionWorkspaceOrder = useSidebarOrderStore(
     (state) => state.setWorkspaceSectionWorkspaceOrder,
   );
   const [sectionDialog, setSectionDialog] = useState<
     { mode: "create" } | { mode: "rename"; section: SidebarProjectWorkspaceSection } | null
   >(null);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedWorkspaceKeys, setSelectedWorkspaceKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const visibleWorkspaceKeys = useMemo(
+    () => new Set(project.workspaces.map((workspace) => workspace.workspaceKey)),
+    [project.workspaces],
+  );
+  const bulkSelectionKey = useMemo(
+    () => [...selectedWorkspaceKeys].sort().join(","),
+    [selectedWorkspaceKeys],
+  );
+  useEffect(() => {
+    setSelectedWorkspaceKeys((current) => {
+      const next = retainVisibleSidebarWorkspaceSelection(current, visibleWorkspaceKeys);
+      return next.size === current.size ? current : next;
+    });
+  }, [visibleWorkspaceKeys]);
   const rowModel = useMemo(
     () =>
       buildSidebarProjectRowModel({
@@ -1852,6 +2015,25 @@ function ProjectBlock({
     project,
     enabled: selectionEnabled,
   });
+  const handleStartSelection = useCallback(() => {
+    setSelectionMode(true);
+    setSelectedWorkspaceKeys(new Set());
+  }, []);
+  const handleCancelSelection = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedWorkspaceKeys(new Set());
+  }, []);
+  const handleToggleBulkSelection = useCallback((workspaceKey: string) => {
+    setSelectedWorkspaceKeys((current) => toggleSidebarWorkspaceSelection(current, workspaceKey));
+  }, []);
+  const handleMoveSelectedWorkspaces = useCallback(
+    (sectionId: string | null) => {
+      if (selectedWorkspaceKeys.size === 0) return;
+      moveWorkspacesToSection(project.viewKey, [...selectedWorkspaceKeys], sectionId);
+      handleCancelSelection();
+    },
+    [handleCancelSelection, moveWorkspacesToSection, project.viewKey, selectedWorkspaceKeys],
+  );
 
   const renderWorkspaceRow = useCallback(
     (
@@ -1873,6 +2055,9 @@ function ProjectBlock({
           canPin={supportsPinningByServerId.get(item.serverId) === true}
           onToggleWorkspacePin={onToggleWorkspacePin}
           isCreating={creatingWorkspaceIds.has(item.workspaceId)}
+          selectionMode={selectionMode}
+          bulkSelected={selectedWorkspaceKeys.has(item.workspaceKey)}
+          onToggleBulkSelection={selectionMode ? handleToggleBulkSelection : undefined}
           selectionEnabled={selectionEnabled}
           activeWorkspaceSelection={activeWorkspaceSelection}
           onWorkspacePress={onWorkspacePress}
@@ -1890,7 +2075,10 @@ function ProjectBlock({
       creatingWorkspaceIds,
       hostBadgeByServerId,
       onWorkspacePress,
+      handleToggleBulkSelection,
       selectionEnabled,
+      selectionMode,
+      selectedWorkspaceKeys,
       shortcutIndexByWorkspaceKey,
       showShortcutBadges,
       workspaceEntriesByKey,
@@ -2074,6 +2262,9 @@ function ProjectBlock({
               renderWorkspaceRow={renderWorkspaceRow}
               onSectionWorkspaceReorder={handleSectionWorkspaceReorder}
               activeWorkspaceSelection={activeWorkspaceSelection}
+              onStartSelection={handleStartSelection}
+              selectionMode={selectionMode}
+              bulkSelectionKey={bulkSelectionKey}
               useNestable={useNestable}
               parentGestureRef={parentGestureRef}
               dragGestureHostActive={dragGestureHostActive}
@@ -2149,6 +2340,14 @@ function ProjectBlock({
         dragHandleProps={dragHandleProps}
       />
 
+      {selectionMode ? (
+        <ProjectWorkspaceSelectionBar
+          selectedCount={selectedWorkspaceKeys.size}
+          sections={sections}
+          onMove={handleMoveSelectedWorkspaces}
+          onCancel={handleCancelSelection}
+        />
+      ) : null}
       {projectChildren}
       {sectionDialog ? (
         <AdaptiveRenameModal
@@ -3076,6 +3275,40 @@ const styles = StyleSheet.create((theme) => ({
   workspaceSectionMenuTrigger: {
     padding: 2,
     borderRadius: 4,
+  },
+  workspaceSelectionBar: {
+    minHeight: 36,
+    marginHorizontal: theme.spacing[2],
+    marginTop: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.surface2,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  workspaceSelectionCount: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    flex: 1,
+  },
+  workspaceSelectionMoveTrigger: {
+    minHeight: 28,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+  },
+  workspaceSelectionMoveText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  workspaceSelectionCancel: {
+    minHeight: 28,
+    justifyContent: "center",
+  },
+  workspaceSelectionCancelText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
   },
   workspaceRow: {
     minHeight: 36,

--- a/packages/app/src/components/sidebar/sidebar-model.tsx
+++ b/packages/app/src/components/sidebar/sidebar-model.tsx
@@ -16,6 +16,7 @@ import {
 import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
 import type { SidebarShortcutModel } from "@/utils/sidebar-shortcuts";
 import { buildSidebarProjection } from "./sidebar-projection";
+import type { SidebarProjectWorkspaceSection } from "./sidebar-projection";
 import type { SidebarProjectIconTarget } from "@/utils/sidebar-project-row-model";
 import { filterWorkspacesByLabels, type SidebarWorkspaceGroup } from "./sidebar-labels";
 import { filterWorkspacesByProjects, resolveActiveProjectFilters } from "./sidebar-project-filter";
@@ -42,6 +43,9 @@ interface SidebarModel extends SidebarWorkspacesListResult {
   pinnedGroups: PinnedSidebarGroups;
   collapsedProjectKeys: ReadonlySet<string>;
   toggleProjectCollapsed: (projectViewKey: string) => void;
+  collapsedWorkspaceSectionKeys: ReadonlySet<string>;
+  toggleWorkspaceSectionCollapsed: (workspaceSectionKey: string) => void;
+  projectSections: Map<string, SidebarProjectWorkspaceSection[]>;
   shortcutModel: SidebarShortcutModel;
 }
 
@@ -66,10 +70,19 @@ export function SidebarModelProvider({
   const collapsedWorkspaceGroupKeys = useSidebarCollapsedSectionsStore(
     (state) => state.collapsedWorkspaceGroupKeys,
   );
+  const collapsedWorkspaceSectionKeys = useSidebarCollapsedSectionsStore(
+    (state) => state.collapsedWorkspaceSectionKeys,
+  );
   const pinnedCollapsed = useSidebarCollapsedSectionsStore((state) => state.collapsedPinned);
   const pinnedWorkspaceOrder = useSidebarOrderStore((state) => state.pinnedWorkspaceOrder);
+  const workspaceSectionsByProject = useSidebarOrderStore(
+    (state) => state.workspaceSectionsByProject,
+  );
   const toggleProjectCollapsed = useSidebarCollapsedSectionsStore(
     (state) => state.toggleProjectCollapsed,
+  );
+  const toggleWorkspaceSectionCollapsed = useSidebarCollapsedSectionsStore(
+    (state) => state.toggleWorkspaceSectionCollapsed,
   );
   const availableLabelNames = useMemo(
     () => labelHosts.flatMap((host) => host.labels.map((label) => label.name)),
@@ -150,16 +163,20 @@ export function SidebarModelProvider({
       pinnedCollapsed,
       collapsedProjectKeys,
       collapsedWorkspaceGroupKeys,
+      collapsedWorkspaceSectionKeys,
+      workspaceSectionsByProject,
     }),
     [
       collapsedProjectKeys,
       collapsedWorkspaceGroupKeys,
+      collapsedWorkspaceSectionKeys,
       groupMode,
       list.projectNamesByViewKey,
       filteredProjects,
       pinnedCollapsed,
       pinnedKeys,
       pinnedWorkspaceOrder,
+      workspaceSectionsByProject,
       filteredWorkspaceEntriesByKey,
     ],
   );
@@ -178,16 +195,21 @@ export function SidebarModelProvider({
       pinnedGroups: projection.pinnedGroups,
       collapsedProjectKeys,
       toggleProjectCollapsed,
+      collapsedWorkspaceSectionKeys,
+      toggleWorkspaceSectionCollapsed,
+      projectSections: projection.projectSections,
       shortcutModel: projection.shortcutModel,
     }),
     [
       resolvedProjectFilters,
       collapsedProjectKeys,
+      collapsedWorkspaceSectionKeys,
       groupMode,
       list,
       filteredProjects,
       projection,
       toggleProjectCollapsed,
+      toggleWorkspaceSectionCollapsed,
       filteredWorkspaceEntriesByKey,
     ],
   );

--- a/packages/app/src/components/sidebar/sidebar-projection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.test.ts
@@ -66,6 +66,10 @@ function makeProject(
 function projectionInput(options?: {
   groupMode?: "project" | "status";
   pinnedCollapsed?: boolean;
+  workspaceSectionsByProject?: Record<
+    string,
+    { id: string; name: string; workspaceKeys: string[] }[]
+  >;
 }) {
   const pinned = makeWorkspace("pinned", "running");
   const unpinned = makeWorkspace("unpinned", "needs_input");
@@ -85,6 +89,8 @@ function projectionInput(options?: {
     pinnedCollapsed: options?.pinnedCollapsed ?? false,
     collapsedProjectKeys: new Set<string>(),
     collapsedWorkspaceGroupKeys: new Set<string>(),
+    collapsedWorkspaceSectionKeys: new Set<string>(),
+    workspaceSectionsByProject: options?.workspaceSectionsByProject ?? {},
   };
 }
 
@@ -108,6 +114,25 @@ function twoProjectInput(groupMode: "project" | "status") {
       ["other-project", "Other project"],
     ]),
   };
+}
+
+function sectionWorkspaceSummary(
+  sections: readonly { id: string | null; workspaces: SidebarWorkspacePlacement[] }[],
+) {
+  return sections.map((section) => ({
+    id: section.id,
+    workspaceKeys: section.workspaces.map((workspace) => workspace.workspaceKey),
+  }));
+}
+
+function sectionWorkspaceKeys(
+  sections: readonly { workspaces: SidebarWorkspacePlacement[] }[],
+): string[] {
+  const workspaceKeys: string[] = [];
+  for (const section of sections) {
+    for (const workspace of section.workspaces) workspaceKeys.push(workspace.workspaceKey);
+  }
+  return workspaceKeys;
 }
 
 describe("buildSidebarProjection", () => {
@@ -148,6 +173,67 @@ describe("buildSidebarProjection", () => {
     expect(projection.shortcutModel.shortcutTargets).toEqual([
       { serverId: "srv", workspaceId: "pinned" },
       { serverId: "srv", workspaceId: "unpinned" },
+    ]);
+  });
+
+  it("retains empty sections and keeps pinned workspaces out of project sections", () => {
+    const projection = buildSidebarProjection(
+      projectionInput({
+        workspaceSectionsByProject: {
+          project: [
+            { id: "finance", name: "Finance", workspaceKeys: ["srv:pinned", "srv:unpinned"] },
+            { id: "waiting", name: "Waiting", workspaceKeys: [] },
+          ],
+        },
+      }),
+    );
+    expect(sectionWorkspaceSummary(projection.projectSections.get("project") ?? [])).toEqual([
+      { id: "finance", workspaceKeys: ["srv:unpinned"] },
+      { id: "waiting", workspaceKeys: [] },
+      { id: null, workspaceKeys: [] },
+    ]);
+  });
+
+  it("keeps the no-section project projection equivalent to the existing unpinned rows", () => {
+    const projection = buildSidebarProjection(projectionInput());
+
+    expect(projection.projectSections.get("project")?.map((section) => section.id)).toEqual([null]);
+    expect(sectionWorkspaceKeys(projection.projectSections.get("project") ?? [])).toEqual([
+      "srv:unpinned",
+    ]);
+  });
+
+  it("retains a configured section when filters remove all of its workspace keys", () => {
+    const visible = makeWorkspace("visible");
+    const input = projectionInput({
+      workspaceSectionsByProject: {
+        project: [{ id: "finance", name: "Finance", workspaceKeys: ["srv:filtered-out"] }],
+      },
+    });
+    input.projects = [makeProject([visible.placement])];
+    input.pinnedKeys = { pinnedWorkspaceKeys: [], pinnedAtByKey: {} };
+    input.workspaceEntriesByKey = new Map([[visible.entry.workspaceKey, visible.entry]]);
+
+    const projection = buildSidebarProjection(input);
+
+    expect(sectionWorkspaceSummary(projection.projectSections.get("project") ?? [])).toEqual([
+      { id: "finance", workspaceKeys: [] },
+      { id: null, workspaceKeys: ["srv:visible"] },
+    ]);
+  });
+
+  it("removes collapsed section rows from keyboard shortcuts", () => {
+    const input = projectionInput({
+      workspaceSectionsByProject: {
+        project: [{ id: "finance", name: "Finance", workspaceKeys: ["srv:unpinned"] }],
+      },
+    });
+    input.collapsedWorkspaceSectionKeys = new Set(["project::finance"]);
+
+    const projection = buildSidebarProjection(input);
+
+    expect(projection.shortcutModel.shortcutTargets).toEqual([
+      { serverId: "srv", workspaceId: "pinned" },
     ]);
   });
 

--- a/packages/app/src/components/sidebar/sidebar-projection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.test.ts
@@ -237,6 +237,17 @@ describe("buildSidebarProjection", () => {
     ]);
   });
 
+  it("removes collapsed unsectioned rows from keyboard shortcuts", () => {
+    const input = projectionInput();
+    input.collapsedWorkspaceSectionKeys = new Set(["project::unsectioned"]);
+
+    const projection = buildSidebarProjection(input);
+
+    expect(projection.shortcutModel.shortcutTargets).toEqual([
+      { serverId: "srv", workspaceId: "pinned" },
+    ]);
+  });
+
   it("keeps pinned chats above status groups and removes them from those groups", () => {
     const projection = buildSidebarProjection(projectionInput({ groupMode: "status" }));
 

--- a/packages/app/src/components/sidebar/sidebar-projection.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.ts
@@ -7,8 +7,10 @@ import {
 import type {
   SidebarProjectEntry,
   SidebarWorkspaceEntry,
+  SidebarWorkspacePlacement,
 } from "@/hooks/use-sidebar-workspaces-list";
 import type { SidebarGroupMode } from "@/stores/sidebar-view-store";
+import type { SidebarWorkspaceSection } from "@/stores/sidebar-order-store";
 import {
   resolveSidebarProjectIconTargets,
   type SidebarProjectIconTarget,
@@ -23,6 +25,7 @@ import { statusWorkspaceGroups, type SidebarWorkspaceGroup } from "./sidebar-lab
 export interface SidebarProjection {
   pinnedGroups: PinnedSidebarGroups;
   workspaceGroups: SidebarWorkspaceGroup[];
+  projectSections: Map<string, SidebarProjectWorkspaceSection[]>;
   /**
    * The project icons this projection needs fetched, keyed by `projectViewKey` — one per project,
    * whatever the mode groups by. It sits here rather than beside `useProjectIcons` in the list
@@ -35,6 +38,13 @@ export interface SidebarProjection {
   shortcutModel: SidebarShortcutModel;
 }
 
+export interface SidebarProjectWorkspaceSection {
+  id: string | null;
+  name: string | null;
+  collapseKey: string | null;
+  workspaces: SidebarWorkspacePlacement[];
+}
+
 export interface SidebarProjectionInput {
   projects: SidebarProjectEntry[];
   pinnedKeys: PinnedSidebarKeys;
@@ -45,6 +55,8 @@ export interface SidebarProjectionInput {
   pinnedCollapsed: boolean;
   collapsedProjectKeys: ReadonlySet<string>;
   collapsedWorkspaceGroupKeys: ReadonlySet<string>;
+  collapsedWorkspaceSectionKeys: ReadonlySet<string>;
+  workspaceSectionsByProject: Readonly<Record<string, SidebarWorkspaceSection[]>>;
 }
 
 export function buildSidebarProjection(input: SidebarProjectionInput): SidebarProjection {
@@ -57,6 +69,10 @@ export function buildSidebarProjection(input: SidebarProjectionInput): SidebarPr
   const unpinnedWorkspaces = Array.from(input.workspaceEntriesByKey.values()).filter(
     (workspace) => !pinnedWorkspaceKeys.has(workspace.workspaceKey),
   );
+  const projectSections = buildProjectSections({
+    projects: pinnedGroups.unpinnedProjects,
+    workspaceSectionsByProject: input.workspaceSectionsByProject,
+  });
   // One switch decides both what the list groups by and what the keyboard shortcuts walk, so the
   // two cannot disagree and a new grouping mode is a compile error here rather than a silent
   // fall-through to the project rows.
@@ -68,10 +84,16 @@ export function buildSidebarProjection(input: SidebarProjectionInput): SidebarPr
   }
   if (input.groupMode === "project") {
     sections.push(
-      ...pinnedGroups.unpinnedProjects.map((project) => ({
-        workspaces: project.workspaces,
-        collapsed: input.collapsedProjectKeys.has(project.viewKey),
-      })),
+      ...pinnedGroups.unpinnedProjects.flatMap((project) => {
+        const projectCollapsed = input.collapsedProjectKeys.has(project.viewKey);
+        return (projectSections.get(project.viewKey) ?? []).map((section) => ({
+          workspaces: section.workspaces,
+          collapsed:
+            projectCollapsed ||
+            (section.collapseKey !== null &&
+              input.collapsedWorkspaceSectionKeys.has(section.collapseKey)),
+        }));
+      }),
     );
   } else {
     sections.push(
@@ -85,9 +107,47 @@ export function buildSidebarProjection(input: SidebarProjectionInput): SidebarPr
   return {
     pinnedGroups,
     workspaceGroups,
+    projectSections,
     projectIconTargets: resolveSidebarProjectIconTargets(input.projects),
     shortcutModel: buildSidebarShortcutSections({ sections }),
   };
+}
+
+function buildProjectSections(input: {
+  projects: PinnedSidebarGroups["unpinnedProjects"];
+  workspaceSectionsByProject: Readonly<Record<string, SidebarWorkspaceSection[]>>;
+}): Map<string, SidebarProjectWorkspaceSection[]> {
+  const projectSections = new Map<string, SidebarProjectWorkspaceSection[]>();
+
+  for (const project of input.projects) {
+    const workspacesByKey = new Map(
+      project.workspaces.map((workspace) => [workspace.workspaceKey, workspace]),
+    );
+    const assignedWorkspaceKeys = new Set<string>();
+    const sections = (input.workspaceSectionsByProject[project.viewKey] ?? []).map((section) => {
+      const workspaces = section.workspaceKeys.flatMap((workspaceKey) => {
+        const workspace = workspacesByKey.get(workspaceKey);
+        if (!workspace || assignedWorkspaceKeys.has(workspaceKey)) return [];
+        assignedWorkspaceKeys.add(workspaceKey);
+        return [workspace];
+      });
+      return {
+        id: section.id,
+        name: section.name,
+        collapseKey: `${project.viewKey}::${section.id}`,
+        workspaces,
+      };
+    });
+    const unsectionedWorkspaces = project.workspaces.filter(
+      (workspace) => !assignedWorkspaceKeys.has(workspace.workspaceKey),
+    );
+    projectSections.set(project.viewKey, [
+      ...sections,
+      { id: null, name: null, collapseKey: null, workspaces: unsectionedWorkspaces },
+    ]);
+  }
+
+  return projectSections;
 }
 
 /** Project mode keeps its project headers and groups nothing; status mode groups the rows. */

--- a/packages/app/src/components/sidebar/sidebar-projection.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.ts
@@ -143,7 +143,12 @@ function buildProjectSections(input: {
     );
     projectSections.set(project.viewKey, [
       ...sections,
-      { id: null, name: null, collapseKey: null, workspaces: unsectionedWorkspaces },
+      {
+        id: null,
+        name: null,
+        collapseKey: `${project.viewKey}::unsectioned`,
+        workspaces: unsectionedWorkspaces,
+      },
     ]);
   }
 

--- a/packages/app/src/components/sidebar/sidebar-projection.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.ts
@@ -41,7 +41,7 @@ export interface SidebarProjection {
 export interface SidebarProjectWorkspaceSection {
   id: string | null;
   name: string | null;
-  collapseKey: string | null;
+  collapseKey: string;
   workspaces: SidebarWorkspacePlacement[];
 }
 
@@ -89,9 +89,7 @@ export function buildSidebarProjection(input: SidebarProjectionInput): SidebarPr
         return (projectSections.get(project.viewKey) ?? []).map((section) => ({
           workspaces: section.workspaces,
           collapsed:
-            projectCollapsed ||
-            (section.collapseKey !== null &&
-              input.collapsedWorkspaceSectionKeys.has(section.collapseKey)),
+            projectCollapsed || input.collapsedWorkspaceSectionKeys.has(section.collapseKey),
         }));
       }),
     );

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -990,6 +990,7 @@ function StatusWorkspaceActionSlot({
           <SidebarWorkspaceMenu
             {...kebab.menuProps}
             workspaceKey={workspace.workspaceKey}
+            projectViewKey={workspace.projectViewKey}
             serverId={workspace.serverId}
             workspaceId={workspace.workspaceId}
             workspaceLabels={workspace.labels}

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
@@ -1,4 +1,10 @@
-import { useMemo, type ComponentProps, type PropsWithChildren, type ReactNode } from "react";
+import {
+  useCallback,
+  useMemo,
+  type ComponentProps,
+  type PropsWithChildren,
+  type ReactNode,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { type PressableStateCallbackType } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
@@ -17,6 +23,7 @@ import { isWeb } from "@/constants/platform";
 import { getForgePresentation, normalizeForge } from "@/git/forge";
 import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
 import { useAppSettings } from "@/hooks/use-settings";
+import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
 import type { Theme } from "@/styles/theme";
 import type { ShortcutKey } from "@/utils/format-shortcut";
 import {
@@ -44,6 +51,7 @@ import {
   WORKSPACE_LABEL_PAGE_ID,
   type WorkspaceLabelTarget,
 } from "@/workspace-labels/picker";
+import { MenuItem, type MenuPageDefinition } from "@/components/ui/menu";
 
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 const foregroundMutedColorMapping = (theme: Theme) => ({
@@ -69,6 +77,9 @@ const markAsUnreadLeadingIcon = <ThemedCircle size={14} uniProps={foregroundMute
 const archiveLeadingIcon = <ThemedArchive size={14} uniProps={foregroundMutedColorMapping} />;
 const pinLeadingIcon = <ThemedPin size={14} uniProps={foregroundMutedColorMapping} />;
 const unpinLeadingIcon = <ThemedPinOff size={14} uniProps={foregroundMutedColorMapping} />;
+const WORKSPACE_SECTION_PAGE_ID = "workspaceSections";
+const EMPTY_WORKSPACE_SECTIONS: readonly { id: string; name: string; workspaceKeys: string[] }[] =
+  [];
 
 function renderTriggerIcon({ hovered }: { hovered?: boolean }) {
   return (
@@ -81,6 +92,7 @@ function renderTriggerIcon({ hovered }: { hovered?: boolean }) {
 
 export interface SidebarWorkspaceMenuProps {
   workspaceKey: string;
+  projectViewKey?: string;
   serverId?: string;
   workspaceId?: string;
   workspaceLabels?: readonly string[];
@@ -130,6 +142,7 @@ function WorkspaceMenuItem({
 function SidebarWorkspaceMenuItems({
   surface,
   workspaceKey,
+  projectViewKey,
   serverId,
   workspaceId,
   onCopyPath,
@@ -154,6 +167,11 @@ function SidebarWorkspaceMenuItems({
   const labelLeading = useMemo(
     () => <ThemedTag size={14} uniProps={foregroundMutedColorMapping} />,
     [],
+  );
+  const workspaceSections = useSidebarOrderStore((state) =>
+    projectViewKey
+      ? (state.workspaceSectionsByProject[projectViewKey] ?? EMPTY_WORKSPACE_SECTIONS)
+      : EMPTY_WORKSPACE_SECTIONS,
   );
 
   return (
@@ -218,6 +236,14 @@ function SidebarWorkspaceMenuItems({
           {isPinned ? t("sidebar.workspace.actions.unpin") : t("sidebar.workspace.actions.pin")}
         </WorkspaceMenuItem>
       ) : null}
+      {projectViewKey && workspaceSections.length > 0 ? (
+        <DropdownMenuSubTrigger
+          id={WORKSPACE_SECTION_PAGE_ID}
+          testID={`sidebar-workspace-menu-sections-${workspaceKey}`}
+        >
+          Move to section
+        </DropdownMenuSubTrigger>
+      ) : null}
       {serverId && workspaceId ? (
         <DropdownMenuSubTrigger
           id={WORKSPACE_LABEL_PAGE_ID}
@@ -249,8 +275,92 @@ function SidebarWorkspaceMenuItems({
   );
 }
 
+function WorkspaceSectionPickerPage({
+  projectViewKey,
+  workspaceKey,
+}: {
+  projectViewKey: string;
+  workspaceKey: string;
+}): ReactNode {
+  const workspaceSections = useSidebarOrderStore(
+    (state) => state.workspaceSectionsByProject[projectViewKey] ?? EMPTY_WORKSPACE_SECTIONS,
+  );
+  const currentSectionId =
+    workspaceSections.find((section) => section.workspaceKeys.includes(workspaceKey))?.id ?? null;
+
+  return (
+    <>
+      <WorkspaceSectionMenuItem
+        projectViewKey={projectViewKey}
+        workspaceKey={workspaceKey}
+        sectionId={null}
+        selected={currentSectionId === null}
+      />
+      {workspaceSections.map((section) => (
+        <WorkspaceSectionMenuItem
+          key={section.id}
+          projectViewKey={projectViewKey}
+          workspaceKey={workspaceKey}
+          sectionId={section.id}
+          name={section.name}
+          selected={currentSectionId === section.id}
+        />
+      ))}
+    </>
+  );
+}
+
+function WorkspaceSectionMenuItem({
+  projectViewKey,
+  workspaceKey,
+  sectionId,
+  name = "Unsectioned",
+  selected,
+}: {
+  projectViewKey: string;
+  workspaceKey: string;
+  sectionId: string | null;
+  name?: string;
+  selected: boolean;
+}): ReactNode {
+  const moveWorkspaceToSection = useSidebarOrderStore((state) => state.moveWorkspaceToSection);
+  const handleSelect = useCallback(() => {
+    moveWorkspaceToSection(projectViewKey, workspaceKey, sectionId);
+  }, [moveWorkspaceToSection, projectViewKey, sectionId, workspaceKey]);
+  const sectionKey = sectionId ?? "unsectioned";
+
+  return (
+    <MenuItem
+      selected={selected}
+      onSelect={handleSelect}
+      testID={`sidebar-workspace-section-${sectionKey}-${workspaceKey}`}
+    >
+      {name}
+    </MenuItem>
+  );
+}
+
+function useWorkspaceSectionMenuPages(
+  projectViewKey: string | undefined,
+  workspaceKey: string,
+): readonly MenuPageDefinition[] {
+  return useMemo(() => {
+    if (!projectViewKey) return [];
+    return [
+      {
+        id: WORKSPACE_SECTION_PAGE_ID,
+        title: "Move to section",
+        content: (
+          <WorkspaceSectionPickerPage projectViewKey={projectViewKey} workspaceKey={workspaceKey} />
+        ),
+      },
+    ];
+  }, [projectViewKey, workspaceKey]);
+}
+
 export function SidebarWorkspaceMenu({
   workspaceKey,
+  projectViewKey,
   serverId,
   workspaceId,
   workspaceLabels,
@@ -277,6 +387,11 @@ export function SidebarWorkspaceMenu({
     [serverId, workspaceId, workspaceLabels],
   );
   const pages = useWorkspaceLabelMenuPages(workspaceTarget);
+  const workspaceSectionPages = useWorkspaceSectionMenuPages(projectViewKey, workspaceKey);
+  const menuPages = useMemo(
+    () => [...pages, ...workspaceSectionPages],
+    [pages, workspaceSectionPages],
+  );
   return (
     <DropdownMenu compactMode="sheet" open={open} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger
@@ -291,12 +406,13 @@ export function SidebarWorkspaceMenu({
       <DropdownMenuContent
         align="end"
         width={260}
-        pages={pages}
+        pages={menuPages}
         sheetTitle={t("sidebar.workspace.actions.menu")}
       >
         <SidebarWorkspaceMenuItems
           surface="dropdown"
           workspaceKey={workspaceKey}
+          projectViewKey={projectViewKey}
           serverId={serverId}
           workspaceId={workspaceId}
           workspaceLabels={workspaceLabels}
@@ -333,6 +449,7 @@ export function SidebarWorkspaceContextMenu({
   hostBadgeLabel,
   serviceSummary,
   workspaceKey,
+  projectViewKey: _projectViewKey,
   onCopyPath,
   onCopyBranchName,
   onRename,
@@ -390,6 +507,14 @@ export function SidebarWorkspaceContextMenu({
     [workspace],
   );
   const pages = useWorkspaceLabelMenuPages(workspaceTarget);
+  const workspaceSectionPages = useWorkspaceSectionMenuPages(
+    workspace.projectViewKey,
+    workspaceKey,
+  );
+  const menuPages = useMemo(
+    () => [...pages, ...workspaceSectionPages],
+    [pages, workspaceSectionPages],
+  );
 
   return (
     <ContextMenu open={contextMenuOpen} onOpenChange={onContextMenuOpenChange}>
@@ -405,11 +530,12 @@ export function SidebarWorkspaceContextMenu({
         align="start"
         width={260}
         testID={`sidebar-workspace-context-menu-${workspaceKey}`}
-        pages={pages}
+        pages={menuPages}
       >
         <SidebarWorkspaceMenuItems
           surface="context"
           workspaceKey={workspaceKey}
+          projectViewKey={workspace.projectViewKey}
           serverId={workspaceTarget.serverId}
           workspaceId={workspaceTarget.workspaceId}
           workspaceLabels={workspaceTarget.labels}

--- a/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo, useCallback, useState, type ReactNode } from "react";
 import { Text, View, type ViewStyle } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import { CircleAlert, Folder, FolderGit2, Monitor } from "lucide-react-native";
+import { CircleAlert, Folder, FolderGit2, Monitor, Square, SquareCheck } from "lucide-react-native";
 import { ProjectStatusIndicator } from "@/components/sidebar/project-leading-visual";
 import type { SidebarSurfaceBackdrop } from "@/styles/surface-backdrop";
 import {
@@ -40,6 +40,8 @@ const ThemedCircleAlert = withUnistyles(CircleAlert);
 const ThemedMonitor = withUnistyles(Monitor);
 const ThemedFolder = withUnistyles(Folder);
 const ThemedFolderGit2 = withUnistyles(FolderGit2);
+const ThemedSquare = withUnistyles(Square);
+const ThemedSquareCheck = withUnistyles(SquareCheck);
 
 export function SidebarWorkspaceRowFrame({
   workspace,
@@ -99,6 +101,8 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
   isCreating = false,
   shortcutNumber = null,
   showShortcutBadge = false,
+  selectionMode = false,
+  bulkSelected = false,
   reserveIdleStatusIndicatorSpace = true,
   children,
 }: {
@@ -115,6 +119,8 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
   isCreating?: boolean;
   shortcutNumber?: number | null;
   showShortcutBadge?: boolean;
+  selectionMode?: boolean;
+  bulkSelected?: boolean;
   /** Keep the empty leading slot when the workspace has no active status. */
   reserveIdleStatusIndicatorSpace?: boolean;
   children?: ReactNode;
@@ -134,28 +140,38 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
     ],
     [isHovered, isCreating],
   );
+  let leadingVisual: ReactNode;
+  if (selectionMode) {
+    leadingVisual = (
+      <WorkspaceSelectionIndicator selected={bulkSelected} workspaceKey={workspace.workspaceKey} />
+    );
+  } else if (leadingProjectName) {
+    leadingVisual = (
+      <ProjectStatusIndicator
+        iconDataUri={leadingProjectIconDataUri}
+        displayName={leadingProjectName}
+        projectViewKey={workspace.projectViewKey}
+        statusBucket={workspace.statusBucket}
+        backdrop={backdrop}
+        loading={isLoading}
+        testID={`sidebar-row-project-icon-${workspace.workspaceKey}`}
+      />
+    );
+  } else {
+    leadingVisual = (
+      <WorkspaceStatusIndicator
+        bucket={workspace.statusBucket}
+        workspaceKind={workspace.workspaceKind}
+        loading={isLoading}
+        reserveIdleSpace={reserveIdleStatusIndicatorSpace}
+      />
+    );
+  }
 
   return (
     <View style={styles.workspaceRowContent}>
       <View style={styles.workspaceRowMain}>
-        {leadingProjectName ? (
-          <ProjectStatusIndicator
-            iconDataUri={leadingProjectIconDataUri}
-            displayName={leadingProjectName}
-            projectViewKey={workspace.projectViewKey}
-            statusBucket={workspace.statusBucket}
-            backdrop={backdrop}
-            loading={isLoading}
-            testID={`sidebar-row-project-icon-${workspace.workspaceKey}`}
-          />
-        ) : (
-          <WorkspaceStatusIndicator
-            bucket={workspace.statusBucket}
-            workspaceKind={workspace.workspaceKind}
-            loading={isLoading}
-            reserveIdleSpace={reserveIdleStatusIndicatorSpace}
-          />
-        )}
+        {leadingVisual}
         <View style={styles.workspaceContentColumn}>
           <View style={styles.workspaceTitleRow}>
             <Text style={workspaceBranchTextStyle} numberOfLines={1}>
@@ -251,6 +267,21 @@ function WorkspaceStatusIndicator({
     <View style={styles.workspaceStatusDot} testID={`workspace-status-indicator-${bucket}`}>
       <KindIcon size={14} uniProps={foregroundMutedColorMapping} />
       {dotColorStyle ? <StatusDotOverlay dotColorStyle={dotColorStyle} /> : null}
+    </View>
+  );
+}
+
+function WorkspaceSelectionIndicator({
+  selected,
+  workspaceKey,
+}: {
+  selected: boolean;
+  workspaceKey: string;
+}) {
+  const Icon = selected ? ThemedSquareCheck : ThemedSquare;
+  return (
+    <View style={styles.workspaceStatusDot} testID={`sidebar-workspace-selected-${workspaceKey}`}>
+      <Icon size={14} uniProps={foregroundMutedColorMapping} />
     </View>
   );
 }

--- a/packages/app/src/components/sidebar/sidebar-workspace-row.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row.tsx
@@ -436,6 +436,7 @@ function WorkspaceRowTrailingActions({
               <SidebarWorkspaceMenu
                 {...kebab.menuProps}
                 workspaceKey={workspace.workspaceKey}
+                projectViewKey={workspace.projectViewKey}
                 serverId={workspace.serverId}
                 workspaceId={workspace.workspaceId}
                 workspaceLabels={workspace.labels}

--- a/packages/app/src/components/sidebar/sidebar-workspace-selection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-workspace-selection.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  retainVisibleSidebarWorkspaceSelection,
+  shouldToggleSidebarWorkspacePin,
+  toggleSidebarWorkspaceSelection,
+} from "./sidebar-workspace-selection";
+
+describe("sidebar workspace selection", () => {
+  it("toggles one workspace without changing the other selected keys", () => {
+    expect(toggleSidebarWorkspaceSelection(new Set(["srv:one"]), "srv:two")).toEqual(
+      new Set(["srv:one", "srv:two"]),
+    );
+    expect(toggleSidebarWorkspaceSelection(new Set(["srv:one", "srv:two"]), "srv:one")).toEqual(
+      new Set(["srv:two"]),
+    );
+  });
+
+  it("removes selections hidden by a project filter", () => {
+    expect(
+      retainVisibleSidebarWorkspaceSelection(
+        new Set(["srv:one", "srv:two"]),
+        new Set(["srv:two", "srv:three"]),
+      ),
+    ).toEqual(new Set(["srv:two"]));
+  });
+
+  it("reserves Shift-click pinning for desktop rows outside select mode", () => {
+    expect(
+      shouldToggleSidebarWorkspacePin({
+        selectionMode: false,
+        isElectron: true,
+        shiftKey: true,
+        canPin: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldToggleSidebarWorkspacePin({
+        selectionMode: true,
+        isElectron: true,
+        shiftKey: true,
+        canPin: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldToggleSidebarWorkspacePin({
+        selectionMode: false,
+        isElectron: false,
+        shiftKey: true,
+        canPin: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/components/sidebar/sidebar-workspace-selection.ts
+++ b/packages/app/src/components/sidebar/sidebar-workspace-selection.ts
@@ -1,0 +1,27 @@
+export function toggleSidebarWorkspaceSelection(
+  selectedWorkspaceKeys: ReadonlySet<string>,
+  workspaceKey: string,
+): Set<string> {
+  const next = new Set(selectedWorkspaceKeys);
+  if (next.has(workspaceKey)) next.delete(workspaceKey);
+  else next.add(workspaceKey);
+  return next;
+}
+
+export function retainVisibleSidebarWorkspaceSelection(
+  selectedWorkspaceKeys: ReadonlySet<string>,
+  visibleWorkspaceKeys: ReadonlySet<string>,
+): Set<string> {
+  return new Set(
+    [...selectedWorkspaceKeys].filter((workspaceKey) => visibleWorkspaceKeys.has(workspaceKey)),
+  );
+}
+
+export function shouldToggleSidebarWorkspacePin(input: {
+  selectionMode: boolean;
+  isElectron: boolean;
+  shiftKey: boolean;
+  canPin: boolean;
+}): boolean {
+  return !input.selectionMode && input.isElectron && input.shiftKey && input.canPin;
+}

--- a/packages/app/src/stores/sidebar-collapsed-sections-store/index.ts
+++ b/packages/app/src/stores/sidebar-collapsed-sections-store/index.ts
@@ -12,12 +12,14 @@ import {
   togglePinnedCollapsed,
   toggleProjectCollapsed,
   toggleWorkspaceGroupCollapsed,
+  toggleWorkspaceSectionCollapsed,
 } from "./state";
 
 interface SidebarCollapsedSectionsState extends CollapsedProjectsState {
   toggleProjectCollapsed: (projectKey: string) => void;
   setProjectCollapsed: (projectKey: string, collapsed: boolean) => void;
   toggleWorkspaceGroupCollapsed: (workspaceGroupKey: string) => void;
+  toggleWorkspaceSectionCollapsed: (workspaceSectionKey: string) => void;
   togglePinnedCollapsed: () => void;
 }
 
@@ -26,6 +28,7 @@ export const useSidebarCollapsedSectionsStore = create<SidebarCollapsedSectionsS
     (set) => ({
       collapsedProjectKeys: new Set(),
       collapsedWorkspaceGroupKeys: new Set(),
+      collapsedWorkspaceSectionKeys: new Set(),
       collapsedPinned: false,
       toggleProjectCollapsed: (projectKey) =>
         set((state) => toggleProjectCollapsed(state, projectKey)),
@@ -33,6 +36,8 @@ export const useSidebarCollapsedSectionsStore = create<SidebarCollapsedSectionsS
         set((state) => setProjectCollapsed(state, projectKey, collapsed)),
       toggleWorkspaceGroupCollapsed: (workspaceGroupKey) =>
         set((state) => toggleWorkspaceGroupCollapsed(state, workspaceGroupKey)),
+      toggleWorkspaceSectionCollapsed: (workspaceSectionKey) =>
+        set((state) => toggleWorkspaceSectionCollapsed(state, workspaceSectionKey)),
       togglePinnedCollapsed: () => set((state) => togglePinnedCollapsed(state)),
     }),
     {

--- a/packages/app/src/stores/sidebar-collapsed-sections-store/state.test.ts
+++ b/packages/app/src/stores/sidebar-collapsed-sections-store/state.test.ts
@@ -13,6 +13,7 @@ function emptyState(): CollapsedProjectsState {
   return {
     collapsedProjectKeys: new Set(),
     collapsedWorkspaceGroupKeys: new Set(),
+    collapsedWorkspaceSectionKeys: new Set(),
     collapsedPinned: false,
   };
 }
@@ -34,12 +35,14 @@ describe("sidebar collapsed projects transitions", () => {
     const state: CollapsedProjectsState = {
       collapsedProjectKeys: new Set(["project-a", "project-b"]),
       collapsedWorkspaceGroupKeys: new Set(["running"]),
+      collapsedWorkspaceSectionKeys: new Set(["project-a::finance"]),
       collapsedPinned: true,
     };
 
     expect(serializeCollapsedProjects(state)).toEqual({
       collapsedProjectKeys: ["project-a", "project-b"],
       collapsedWorkspaceGroupKeys: ["running"],
+      collapsedWorkspaceSectionKeys: ["project-a::finance"],
       collapsedPinned: true,
     });
   });
@@ -50,6 +53,17 @@ describe("sidebar collapsed projects transitions", () => {
 
     const restored = mergePersistedCollapsedProjects({ collapsedPinned: true }, emptyState());
     expect(restored.collapsedPinned).toBe(true);
+  });
+
+  it("restores collapsed workspace section keys independently from status groups", () => {
+    const restored = mergePersistedCollapsedProjects(
+      { collapsedWorkspaceSectionKeys: ["project-a::finance"] },
+      emptyState(),
+    );
+
+    expect(Reflect.get(restored, "collapsedWorkspaceSectionKeys")).toEqual(
+      new Set(["project-a::finance"]),
+    );
   });
 
   it("rejects the complete value when a persisted project key is invalid", () => {

--- a/packages/app/src/stores/sidebar-collapsed-sections-store/state.ts
+++ b/packages/app/src/stores/sidebar-collapsed-sections-store/state.ts
@@ -3,12 +3,14 @@ import { z } from "zod";
 export interface CollapsedProjectsState {
   collapsedProjectKeys: Set<string>;
   collapsedWorkspaceGroupKeys: Set<string>;
+  collapsedWorkspaceSectionKeys: Set<string>;
   collapsedPinned: boolean;
 }
 
 export interface PersistedCollapsedProjects {
   collapsedProjectKeys?: string[];
   collapsedWorkspaceGroupKeys?: string[];
+  collapsedWorkspaceSectionKeys?: string[];
   collapsedStatusGroupKeys?: string[];
   collapsedPinned?: boolean;
 }
@@ -17,6 +19,7 @@ export const PersistedCollapsedProjectsSchema: z.ZodType<PersistedCollapsedProje
   z.strictObject({
     collapsedProjectKeys: z.array(z.string()).optional(),
     collapsedWorkspaceGroupKeys: z.array(z.string()).optional(),
+    collapsedWorkspaceSectionKeys: z.array(z.string()).optional(),
     // COMPAT(sidebarWorkspaceGroupCollapse): added in v0.4.0, remove after 2027-02-14.
     collapsedStatusGroupKeys: z.array(z.string()).optional(),
     collapsedPinned: z.boolean().optional(),
@@ -52,6 +55,19 @@ export function toggleWorkspaceGroupCollapsed(
   return { ...state, collapsedWorkspaceGroupKeys: next };
 }
 
+export function toggleWorkspaceSectionCollapsed(
+  state: CollapsedProjectsState,
+  workspaceSectionKey: string,
+): CollapsedProjectsState {
+  const next = new Set(state.collapsedWorkspaceSectionKeys);
+  if (next.has(workspaceSectionKey)) {
+    next.delete(workspaceSectionKey);
+  } else {
+    next.add(workspaceSectionKey);
+  }
+  return { ...state, collapsedWorkspaceSectionKeys: next };
+}
+
 export function setProjectCollapsed(
   state: CollapsedProjectsState,
   projectKey: string,
@@ -69,11 +85,13 @@ export function setProjectCollapsed(
 export function serializeCollapsedProjects(state: CollapsedProjectsState): {
   collapsedProjectKeys: string[];
   collapsedWorkspaceGroupKeys: string[];
+  collapsedWorkspaceSectionKeys: string[];
   collapsedPinned: boolean;
 } {
   return {
     collapsedProjectKeys: Array.from(state.collapsedProjectKeys),
     collapsedWorkspaceGroupKeys: Array.from(state.collapsedWorkspaceGroupKeys),
+    collapsedWorkspaceSectionKeys: Array.from(state.collapsedWorkspaceSectionKeys),
     collapsedPinned: state.collapsedPinned,
   };
 }
@@ -95,10 +113,14 @@ export function mergePersistedCollapsedProjects<S extends CollapsedProjectsState
       persisted.collapsedStatusGroupKeys ??
       Array.from(current.collapsedWorkspaceGroupKeys),
   );
+  const restoredWorkspaceSections = deserializeCollapsedKeys(
+    persisted.collapsedWorkspaceSectionKeys ?? Array.from(current.collapsedWorkspaceSectionKeys),
+  );
   const restoredPinned = persisted.collapsedPinned ?? current.collapsedPinned;
   if (
     areSetsEqual(current.collapsedProjectKeys, restoredProjects) &&
     areSetsEqual(current.collapsedWorkspaceGroupKeys, restoredWorkspaceGroups) &&
+    areSetsEqual(current.collapsedWorkspaceSectionKeys, restoredWorkspaceSections) &&
     current.collapsedPinned === restoredPinned
   ) {
     return current;
@@ -107,6 +129,7 @@ export function mergePersistedCollapsedProjects<S extends CollapsedProjectsState
     ...current,
     collapsedProjectKeys: restoredProjects,
     collapsedWorkspaceGroupKeys: restoredWorkspaceGroups,
+    collapsedWorkspaceSectionKeys: restoredWorkspaceSections,
     collapsedPinned: restoredPinned,
   };
 }

--- a/packages/app/src/stores/sidebar-order-store.test.ts
+++ b/packages/app/src/stores/sidebar-order-store.test.ts
@@ -95,6 +95,27 @@ describe("migrateSidebarOrderState", () => {
     useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
   });
 
+  it("moves selected workspaces together and preserves their selection order", () => {
+    useSidebarOrderStore.setState({
+      workspaceSectionsByProject: {
+        project: [
+          { id: "finance", name: "Finance", workspaceKeys: ["srv:one"] },
+          { id: "research", name: "Research", workspaceKeys: ["srv:two"] },
+        ],
+      },
+    });
+
+    useSidebarOrderStore
+      .getState()
+      .moveWorkspacesToSection("project", ["srv:two", "srv:one"], "finance");
+
+    expect(useSidebarOrderStore.getState().getWorkspaceSections("project")).toEqual([
+      { id: "finance", name: "Finance", workspaceKeys: ["srv:two", "srv:one"] },
+      { id: "research", name: "Research", workspaceKeys: [] },
+    ]);
+    useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
+  });
+
   it("creates, renames, and reorders sections while retaining empty sections", () => {
     useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
     const store = useSidebarOrderStore.getState();

--- a/packages/app/src/stores/sidebar-order-store.test.ts
+++ b/packages/app/src/stores/sidebar-order-store.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { migrateSidebarOrderState } from "./sidebar-order-store";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+import { migrateSidebarOrderState, useSidebarOrderStore } from "./sidebar-order-store";
 
 describe("migrateSidebarOrderState", () => {
   it("prefixes legacy per-server workspace order with the source server id", () => {
@@ -20,6 +29,7 @@ describe("migrateSidebarOrderState", () => {
       workspaceOrderByProject: {
         "project-a": ["host-a:main", "host-a:feature", "host-b:main"],
       },
+      workspaceSectionsByProject: {},
     });
   });
 
@@ -29,5 +39,82 @@ describe("migrateSidebarOrderState", () => {
     });
 
     expect(migrated.pinnedWorkspaceOrder).toEqual(["host-a:one", "host-b:two"]);
+  });
+
+  it("normalizes project-scoped section layouts without duplicate workspace placement", () => {
+    const migrated = migrateSidebarOrderState({
+      workspaceSectionsByProject: {
+        " project-a ": [
+          {
+            id: " finance ",
+            name: " Finance ",
+            workspaceKeys: ["host-a:one", "host-a:one", ""],
+          },
+          {
+            id: "research",
+            name: "Research",
+            workspaceKeys: ["host-a:one", "host-a:two"],
+          },
+        ],
+      },
+    });
+
+    expect(migrated).toMatchObject({
+      workspaceSectionsByProject: {
+        "project-a": [
+          { id: "finance", name: "Finance", workspaceKeys: ["host-a:one"] },
+          { id: "research", name: "Research", workspaceKeys: ["host-a:two"] },
+        ],
+      },
+    });
+  });
+
+  it("moves a workspace between sections and leaves it unsectioned when its section is deleted", () => {
+    useSidebarOrderStore.setState({
+      workspaceSectionsByProject: {
+        project: [
+          { id: "finance", name: "Finance", workspaceKeys: ["srv:one"] },
+          { id: "research", name: "Research", workspaceKeys: [] },
+        ],
+      },
+    });
+    const store = useSidebarOrderStore.getState();
+
+    store.moveWorkspaceToSection("project", "srv:one", "research");
+
+    expect(useSidebarOrderStore.getState().getWorkspaceSections("project")).toEqual([
+      { id: "finance", name: "Finance", workspaceKeys: [] },
+      { id: "research", name: "Research", workspaceKeys: ["srv:one"] },
+    ]);
+
+    useSidebarOrderStore.getState().deleteWorkspaceSection("project", "research");
+
+    expect(useSidebarOrderStore.getState().getWorkspaceSections("project")).toEqual([
+      { id: "finance", name: "Finance", workspaceKeys: [] },
+    ]);
+    useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
+  });
+
+  it("creates, renames, and reorders sections while retaining empty sections", () => {
+    useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
+    const store = useSidebarOrderStore.getState();
+
+    store.createWorkspaceSection("project", " Finance ");
+    store.createWorkspaceSection("project", "Research");
+    const [finance, research] = useSidebarOrderStore.getState().getWorkspaceSections("project");
+    expect(finance?.name).toBe("Finance");
+    expect(research?.name).toBe("Research");
+    expect(finance?.workspaceKeys).toEqual([]);
+
+    useSidebarOrderStore.getState().renameWorkspaceSection("project", finance?.id ?? "", "Waiting");
+    useSidebarOrderStore
+      .getState()
+      .reorderWorkspaceSections("project", [research?.id ?? "", finance?.id ?? ""]);
+
+    expect(useSidebarOrderStore.getState().getWorkspaceSections("project")).toMatchObject([
+      { name: "Research", workspaceKeys: [] },
+      { name: "Waiting", workspaceKeys: [] },
+    ]);
+    useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
   });
 });

--- a/packages/app/src/stores/sidebar-order-store.test.ts
+++ b/packages/app/src/stores/sidebar-order-store.test.ts
@@ -8,7 +8,7 @@ vi.mock("@react-native-async-storage/async-storage", () => ({
   },
 }));
 
-import { migrateSidebarOrderState, useSidebarOrderStore } from "./sidebar-order-store";
+import { migrateSidebarOrderState } from "./sidebar-order-store";
 
 describe("migrateSidebarOrderState", () => {
   it("prefixes legacy per-server workspace order with the source server id", () => {
@@ -67,75 +67,5 @@ describe("migrateSidebarOrderState", () => {
         ],
       },
     });
-  });
-
-  it("moves a workspace between sections and leaves it unsectioned when its section is deleted", () => {
-    useSidebarOrderStore.setState({
-      workspaceSectionsByProject: {
-        project: [
-          { id: "finance", name: "Finance", workspaceKeys: ["srv:one"] },
-          { id: "research", name: "Research", workspaceKeys: [] },
-        ],
-      },
-    });
-    const store = useSidebarOrderStore.getState();
-
-    store.moveWorkspaceToSection("project", "srv:one", "research");
-
-    expect(useSidebarOrderStore.getState().getWorkspaceSections("project")).toEqual([
-      { id: "finance", name: "Finance", workspaceKeys: [] },
-      { id: "research", name: "Research", workspaceKeys: ["srv:one"] },
-    ]);
-
-    useSidebarOrderStore.getState().deleteWorkspaceSection("project", "research");
-
-    expect(useSidebarOrderStore.getState().getWorkspaceSections("project")).toEqual([
-      { id: "finance", name: "Finance", workspaceKeys: [] },
-    ]);
-    useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
-  });
-
-  it("moves selected workspaces together and preserves their selection order", () => {
-    useSidebarOrderStore.setState({
-      workspaceSectionsByProject: {
-        project: [
-          { id: "finance", name: "Finance", workspaceKeys: ["srv:one"] },
-          { id: "research", name: "Research", workspaceKeys: ["srv:two"] },
-        ],
-      },
-    });
-
-    useSidebarOrderStore
-      .getState()
-      .moveWorkspacesToSection("project", ["srv:two", "srv:one"], "finance");
-
-    expect(useSidebarOrderStore.getState().getWorkspaceSections("project")).toEqual([
-      { id: "finance", name: "Finance", workspaceKeys: ["srv:two", "srv:one"] },
-      { id: "research", name: "Research", workspaceKeys: [] },
-    ]);
-    useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
-  });
-
-  it("creates, renames, and reorders sections while retaining empty sections", () => {
-    useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
-    const store = useSidebarOrderStore.getState();
-
-    store.createWorkspaceSection("project", " Finance ");
-    store.createWorkspaceSection("project", "Research");
-    const [finance, research] = useSidebarOrderStore.getState().getWorkspaceSections("project");
-    expect(finance?.name).toBe("Finance");
-    expect(research?.name).toBe("Research");
-    expect(finance?.workspaceKeys).toEqual([]);
-
-    useSidebarOrderStore.getState().renameWorkspaceSection("project", finance?.id ?? "", "Waiting");
-    useSidebarOrderStore
-      .getState()
-      .reorderWorkspaceSections("project", [research?.id ?? "", finance?.id ?? ""]);
-
-    expect(useSidebarOrderStore.getState().getWorkspaceSections("project")).toMatchObject([
-      { name: "Research", workspaceKeys: [] },
-      { name: "Waiting", workspaceKeys: [] },
-    ]);
-    useSidebarOrderStore.setState({ workspaceSectionsByProject: {} });
   });
 });

--- a/packages/app/src/stores/sidebar-order-store.ts
+++ b/packages/app/src/stores/sidebar-order-store.ts
@@ -8,27 +8,54 @@ interface SidebarOrderStoreState {
   projectOrder: string[];
   pinnedWorkspaceOrder: string[];
   workspaceOrderByProject: Record<string, string[]>;
+  workspaceSectionsByProject: Record<string, SidebarWorkspaceSection[]>;
   getProjectOrder: () => string[];
   setProjectOrder: (keys: string[]) => void;
   getPinnedWorkspaceOrder: () => string[];
   setPinnedWorkspaceOrder: (keys: string[]) => void;
   getWorkspaceOrder: (projectViewKey: string) => string[];
   setWorkspaceOrder: (projectViewKey: string, keys: string[]) => void;
+  getWorkspaceSections: (projectViewKey: string) => SidebarWorkspaceSection[];
+  createWorkspaceSection: (projectViewKey: string, name: string) => void;
+  renameWorkspaceSection: (projectViewKey: string, sectionId: string, name: string) => void;
+  reorderWorkspaceSections: (projectViewKey: string, sectionIds: string[]) => void;
+  setWorkspaceSectionWorkspaceOrder: (
+    projectViewKey: string,
+    sectionId: string,
+    workspaceKeys: string[],
+  ) => void;
+  deleteWorkspaceSection: (projectViewKey: string, sectionId: string) => void;
+  moveWorkspaceToSection: (
+    projectViewKey: string,
+    workspaceKey: string,
+    sectionId: string | null,
+  ) => void;
 }
 
 interface SidebarOrderPersistedState {
   projectOrder?: string[];
   pinnedWorkspaceOrder?: string[];
   workspaceOrderByProject?: Record<string, string[]>;
+  workspaceSectionsByProject?: Record<string, SidebarWorkspaceSection[]>;
   projectOrderByServerId?: Record<string, string[]>;
   workspaceOrderByServerAndProject?: Record<string, string[]>;
 }
 
+const SidebarWorkspaceSectionSchema = z.strictObject({
+  id: z.string(),
+  name: z.string(),
+  workspaceKeys: z.array(z.string()),
+});
+
+export type SidebarWorkspaceSection = z.infer<typeof SidebarWorkspaceSectionSchema>;
+
 const StringArrayRecordSchema = z.record(z.string(), z.array(z.string()));
+const WorkspaceSectionsRecordSchema = z.record(z.string(), z.array(SidebarWorkspaceSectionSchema));
 const SidebarOrderPersistedStateSchema = z.strictObject({
   projectOrder: z.array(z.string()).optional(),
   pinnedWorkspaceOrder: z.array(z.string()).optional(),
   workspaceOrderByProject: StringArrayRecordSchema.optional(),
+  workspaceSectionsByProject: WorkspaceSectionsRecordSchema.optional(),
   projectOrderByServerId: StringArrayRecordSchema.optional(),
   workspaceOrderByServerAndProject: StringArrayRecordSchema.optional(),
 });
@@ -66,6 +93,117 @@ function normalizeWorkspaceOrderByProject(
   return normalized;
 }
 
+function normalizeWorkspaceSections(
+  sections: readonly SidebarWorkspaceSection[],
+): SidebarWorkspaceSection[] {
+  const seenSectionIds = new Set<string>();
+  const placedWorkspaceKeys = new Set<string>();
+  const normalized: SidebarWorkspaceSection[] = [];
+
+  for (const section of sections) {
+    const id = section.id.trim();
+    const name = section.name.trim();
+    if (!id || !name || seenSectionIds.has(id)) continue;
+
+    const workspaceKeys = normalizeKeys(section.workspaceKeys).filter((workspaceKey) => {
+      if (placedWorkspaceKeys.has(workspaceKey)) return false;
+      placedWorkspaceKeys.add(workspaceKey);
+      return true;
+    });
+    seenSectionIds.add(id);
+    normalized.push({ id, name, workspaceKeys });
+  }
+
+  return normalized;
+}
+
+function normalizeWorkspaceSectionsByProject(
+  workspaceSectionsByProject: Record<string, SidebarWorkspaceSection[]> | undefined,
+): Record<string, SidebarWorkspaceSection[]> {
+  const normalized: Record<string, SidebarWorkspaceSection[]> = {};
+  for (const [projectViewKey, sections] of Object.entries(workspaceSectionsByProject ?? {})) {
+    const scope = projectViewKey.trim();
+    if (!scope) continue;
+    normalized[scope] = normalizeWorkspaceSections(sections);
+  }
+  return normalized;
+}
+
+function withWorkspaceSections(
+  workspaceSectionsByProject: Record<string, SidebarWorkspaceSection[]>,
+  projectViewKey: string,
+  update: (sections: SidebarWorkspaceSection[]) => SidebarWorkspaceSection[],
+): Record<string, SidebarWorkspaceSection[]> {
+  const scope = projectViewKey.trim();
+  if (!scope) return workspaceSectionsByProject;
+  const current = workspaceSectionsByProject[scope] ?? [];
+  const next = normalizeWorkspaceSections(update(current));
+  return { ...workspaceSectionsByProject, [scope]: next };
+}
+
+function renameSection(
+  sections: SidebarWorkspaceSection[],
+  sectionId: string,
+  name: string,
+): SidebarWorkspaceSection[] {
+  return sections.map((section) => (section.id === sectionId ? { ...section, name } : section));
+}
+
+function reorderSections(
+  sections: SidebarWorkspaceSection[],
+  sectionIds: readonly string[],
+): SidebarWorkspaceSection[] {
+  const byId = new Map(sections.map((section) => [section.id, section]));
+  const reordered: SidebarWorkspaceSection[] = [];
+  for (const id of sectionIds) {
+    const section = byId.get(id);
+    if (section) reordered.push(section);
+  }
+  const reorderedIds = new Set(reordered.map((section) => section.id));
+  return [...reordered, ...sections.filter((section) => !reorderedIds.has(section.id))];
+}
+
+function reorderSectionWorkspaceKeys(
+  sections: SidebarWorkspaceSection[],
+  sectionId: string,
+  workspaceKeys: readonly string[],
+): SidebarWorkspaceSection[] {
+  return sections.map((section) => {
+    if (section.id !== sectionId) return section;
+    const currentKeys = new Set(section.workspaceKeys);
+    const orderedKeys = workspaceKeys.filter((key) => currentKeys.has(key));
+    const orderedKeySet = new Set(orderedKeys);
+    return {
+      ...section,
+      workspaceKeys: [
+        ...orderedKeys,
+        ...section.workspaceKeys.filter((key) => !orderedKeySet.has(key)),
+      ],
+    };
+  });
+}
+
+function removeSection(
+  sections: SidebarWorkspaceSection[],
+  sectionId: string,
+): SidebarWorkspaceSection[] {
+  return sections.filter((section) => section.id !== sectionId);
+}
+
+function moveWorkspaceSection(
+  sections: SidebarWorkspaceSection[],
+  workspaceKey: string,
+  sectionId: string | null,
+): SidebarWorkspaceSection[] {
+  const targetExists = sectionId === null || sections.some((section) => section.id === sectionId);
+  if (!targetExists) return sections;
+  return sections.map((section) => {
+    const workspaceKeys = section.workspaceKeys.filter((key) => key !== workspaceKey);
+    if (section.id !== sectionId) return { ...section, workspaceKeys };
+    return { ...section, workspaceKeys: [...workspaceKeys, workspaceKey] };
+  });
+}
+
 function extractWorkspaceOrderScope(scopeKey: string): SidebarWorkspaceOrderScope | null {
   const separatorIndex = scopeKey.indexOf("::");
   if (separatorIndex < 0) return null;
@@ -86,10 +224,16 @@ export function migrateSidebarOrderState(persistedState: unknown): {
   projectOrder: string[];
   pinnedWorkspaceOrder: string[];
   workspaceOrderByProject: Record<string, string[]>;
+  workspaceSectionsByProject: Record<string, SidebarWorkspaceSection[]>;
 } {
   const result = SidebarOrderPersistedStateSchema.safeParse(persistedState);
   if (!result.success) {
-    return { projectOrder: [], pinnedWorkspaceOrder: [], workspaceOrderByProject: {} };
+    return {
+      projectOrder: [],
+      pinnedWorkspaceOrder: [],
+      workspaceOrderByProject: {},
+      workspaceSectionsByProject: {},
+    };
   }
   const state: SidebarOrderPersistedState = result.data;
 
@@ -123,6 +267,9 @@ export function migrateSidebarOrderState(persistedState: unknown): {
     projectOrder,
     pinnedWorkspaceOrder: normalizeKeys(state.pinnedWorkspaceOrder ?? []),
     workspaceOrderByProject,
+    workspaceSectionsByProject: normalizeWorkspaceSectionsByProject(
+      state.workspaceSectionsByProject,
+    ),
   };
 }
 
@@ -132,6 +279,7 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
       projectOrder: [],
       pinnedWorkspaceOrder: [],
       workspaceOrderByProject: {},
+      workspaceSectionsByProject: {},
       getProjectOrder: () => get().projectOrder,
       setProjectOrder: (keys) => {
         const normalized = normalizeKeys(keys);
@@ -158,6 +306,91 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
           },
         }));
       },
+      getWorkspaceSections: (projectViewKey) => {
+        const scope = projectViewKey.trim();
+        if (!scope) return [];
+        return get().workspaceSectionsByProject[scope] ?? [];
+      },
+      createWorkspaceSection: (projectViewKey, name) => {
+        const sectionName = name.trim();
+        if (!sectionName || !projectViewKey.trim()) return;
+        const randomId =
+          typeof globalThis.crypto?.randomUUID === "function"
+            ? globalThis.crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        const section: SidebarWorkspaceSection = {
+          id: `section_${randomId}`,
+          name: sectionName,
+          workspaceKeys: [],
+        };
+        set((state) => ({
+          workspaceSectionsByProject: withWorkspaceSections(
+            state.workspaceSectionsByProject,
+            projectViewKey,
+            (sections) => [...sections, section],
+          ),
+        }));
+      },
+      renameWorkspaceSection: (projectViewKey, sectionId, name) => {
+        const sectionName = name.trim();
+        const normalizedSectionId = sectionId.trim();
+        if (!sectionName || !normalizedSectionId || !projectViewKey.trim()) return;
+        set((state) => ({
+          workspaceSectionsByProject: withWorkspaceSections(
+            state.workspaceSectionsByProject,
+            projectViewKey,
+            (sections) => renameSection(sections, normalizedSectionId, sectionName),
+          ),
+        }));
+      },
+      reorderWorkspaceSections: (projectViewKey, sectionIds) => {
+        const normalizedSectionIds = normalizeKeys(sectionIds);
+        if (!projectViewKey.trim()) return;
+        set((state) => ({
+          workspaceSectionsByProject: withWorkspaceSections(
+            state.workspaceSectionsByProject,
+            projectViewKey,
+            (sections) => reorderSections(sections, normalizedSectionIds),
+          ),
+        }));
+      },
+      setWorkspaceSectionWorkspaceOrder: (projectViewKey, sectionId, workspaceKeys) => {
+        const normalizedSectionId = sectionId.trim();
+        const reorderedWorkspaceKeys = normalizeKeys(workspaceKeys);
+        if (!normalizedSectionId || !projectViewKey.trim()) return;
+        set((state) => ({
+          workspaceSectionsByProject: withWorkspaceSections(
+            state.workspaceSectionsByProject,
+            projectViewKey,
+            (sections) =>
+              reorderSectionWorkspaceKeys(sections, normalizedSectionId, reorderedWorkspaceKeys),
+          ),
+        }));
+      },
+      deleteWorkspaceSection: (projectViewKey, sectionId) => {
+        const normalizedSectionId = sectionId.trim();
+        if (!normalizedSectionId || !projectViewKey.trim()) return;
+        set((state) => ({
+          workspaceSectionsByProject: withWorkspaceSections(
+            state.workspaceSectionsByProject,
+            projectViewKey,
+            (sections) => removeSection(sections, normalizedSectionId),
+          ),
+        }));
+      },
+      moveWorkspaceToSection: (projectViewKey, workspaceKey, sectionId) => {
+        const normalizedWorkspaceKey = workspaceKey.trim();
+        const normalizedSectionId = sectionId?.trim() || null;
+        if (!normalizedWorkspaceKey || !projectViewKey.trim()) return;
+        set((state) => ({
+          workspaceSectionsByProject: withWorkspaceSections(
+            state.workspaceSectionsByProject,
+            projectViewKey,
+            (sections) =>
+              moveWorkspaceSection(sections, normalizedWorkspaceKey, normalizedSectionId),
+          ),
+        }));
+      },
     }),
     {
       name: "sidebar-project-workspace-order",
@@ -166,6 +399,7 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
         projectOrder: state.projectOrder,
         pinnedWorkspaceOrder: state.pinnedWorkspaceOrder,
         workspaceOrderByProject: state.workspaceOrderByProject,
+        workspaceSectionsByProject: state.workspaceSectionsByProject,
       }),
       version: 1,
       migrate: migrateSidebarOrderState,

--- a/packages/app/src/stores/sidebar-order-store.ts
+++ b/packages/app/src/stores/sidebar-order-store.ts
@@ -3,6 +3,18 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { z } from "zod";
 import { createValidatedPersistStorage } from "@/storage/validated-persist-storage";
+import {
+  moveWorkspaceToSection,
+  moveWorkspacesToSection,
+  normalizeWorkspaceSections,
+  removeWorkspaceSection,
+  renameWorkspaceSection,
+  reorderSectionWorkspaceKeys,
+  reorderWorkspaceSections,
+  type SidebarWorkspaceSection,
+} from "./sidebar-workspace-sections";
+
+export type { SidebarWorkspaceSection } from "./sidebar-workspace-sections";
 
 interface SidebarOrderStoreState {
   projectOrder: string[];
@@ -15,7 +27,6 @@ interface SidebarOrderStoreState {
   setPinnedWorkspaceOrder: (keys: string[]) => void;
   getWorkspaceOrder: (projectViewKey: string) => string[];
   setWorkspaceOrder: (projectViewKey: string, keys: string[]) => void;
-  getWorkspaceSections: (projectViewKey: string) => SidebarWorkspaceSection[];
   createWorkspaceSection: (projectViewKey: string, name: string) => void;
   renameWorkspaceSection: (projectViewKey: string, sectionId: string, name: string) => void;
   reorderWorkspaceSections: (projectViewKey: string, sectionIds: string[]) => void;
@@ -51,8 +62,6 @@ const SidebarWorkspaceSectionSchema = z.strictObject({
   name: z.string(),
   workspaceKeys: z.array(z.string()),
 });
-
-export type SidebarWorkspaceSection = z.infer<typeof SidebarWorkspaceSectionSchema>;
 
 const StringArrayRecordSchema = z.record(z.string(), z.array(z.string()));
 const WorkspaceSectionsRecordSchema = z.record(z.string(), z.array(SidebarWorkspaceSectionSchema));
@@ -98,30 +107,6 @@ function normalizeWorkspaceOrderByProject(
   return normalized;
 }
 
-function normalizeWorkspaceSections(
-  sections: readonly SidebarWorkspaceSection[],
-): SidebarWorkspaceSection[] {
-  const seenSectionIds = new Set<string>();
-  const placedWorkspaceKeys = new Set<string>();
-  const normalized: SidebarWorkspaceSection[] = [];
-
-  for (const section of sections) {
-    const id = section.id.trim();
-    const name = section.name.trim();
-    if (!id || !name || seenSectionIds.has(id)) continue;
-
-    const workspaceKeys = normalizeKeys(section.workspaceKeys).filter((workspaceKey) => {
-      if (placedWorkspaceKeys.has(workspaceKey)) return false;
-      placedWorkspaceKeys.add(workspaceKey);
-      return true;
-    });
-    seenSectionIds.add(id);
-    normalized.push({ id, name, workspaceKeys });
-  }
-
-  return normalized;
-}
-
 function normalizeWorkspaceSectionsByProject(
   workspaceSectionsByProject: Record<string, SidebarWorkspaceSection[]> | undefined,
 ): Record<string, SidebarWorkspaceSection[]> {
@@ -144,84 +129,6 @@ function withWorkspaceSections(
   const current = workspaceSectionsByProject[scope] ?? [];
   const next = normalizeWorkspaceSections(update(current));
   return { ...workspaceSectionsByProject, [scope]: next };
-}
-
-function renameSection(
-  sections: SidebarWorkspaceSection[],
-  sectionId: string,
-  name: string,
-): SidebarWorkspaceSection[] {
-  return sections.map((section) => (section.id === sectionId ? { ...section, name } : section));
-}
-
-function reorderSections(
-  sections: SidebarWorkspaceSection[],
-  sectionIds: readonly string[],
-): SidebarWorkspaceSection[] {
-  const byId = new Map(sections.map((section) => [section.id, section]));
-  const reordered: SidebarWorkspaceSection[] = [];
-  for (const id of sectionIds) {
-    const section = byId.get(id);
-    if (section) reordered.push(section);
-  }
-  const reorderedIds = new Set(reordered.map((section) => section.id));
-  return [...reordered, ...sections.filter((section) => !reorderedIds.has(section.id))];
-}
-
-function reorderSectionWorkspaceKeys(
-  sections: SidebarWorkspaceSection[],
-  sectionId: string,
-  workspaceKeys: readonly string[],
-): SidebarWorkspaceSection[] {
-  return sections.map((section) => {
-    if (section.id !== sectionId) return section;
-    const currentKeys = new Set(section.workspaceKeys);
-    const orderedKeys = workspaceKeys.filter((key) => currentKeys.has(key));
-    const orderedKeySet = new Set(orderedKeys);
-    return {
-      ...section,
-      workspaceKeys: [
-        ...orderedKeys,
-        ...section.workspaceKeys.filter((key) => !orderedKeySet.has(key)),
-      ],
-    };
-  });
-}
-
-function removeSection(
-  sections: SidebarWorkspaceSection[],
-  sectionId: string,
-): SidebarWorkspaceSection[] {
-  return sections.filter((section) => section.id !== sectionId);
-}
-
-function moveWorkspaceSection(
-  sections: SidebarWorkspaceSection[],
-  workspaceKey: string,
-  sectionId: string | null,
-): SidebarWorkspaceSection[] {
-  const targetExists = sectionId === null || sections.some((section) => section.id === sectionId);
-  if (!targetExists) return sections;
-  return sections.map((section) => {
-    const workspaceKeys = section.workspaceKeys.filter((key) => key !== workspaceKey);
-    if (section.id !== sectionId) return { ...section, workspaceKeys };
-    return { ...section, workspaceKeys: [...workspaceKeys, workspaceKey] };
-  });
-}
-
-function moveWorkspaceSections(
-  sections: SidebarWorkspaceSection[],
-  workspaceKeys: readonly string[],
-  sectionId: string | null,
-): SidebarWorkspaceSection[] {
-  const targetExists = sectionId === null || sections.some((section) => section.id === sectionId);
-  if (!targetExists) return sections;
-  const movedKeys = new Set(workspaceKeys);
-  return sections.map((section) => {
-    const remainingKeys = section.workspaceKeys.filter((key) => !movedKeys.has(key));
-    if (section.id !== sectionId) return { ...section, workspaceKeys: remainingKeys };
-    return { ...section, workspaceKeys: [...remainingKeys, ...workspaceKeys] };
-  });
 }
 
 function extractWorkspaceOrderScope(scopeKey: string): SidebarWorkspaceOrderScope | null {
@@ -326,11 +233,6 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
           },
         }));
       },
-      getWorkspaceSections: (projectViewKey) => {
-        const scope = projectViewKey.trim();
-        if (!scope) return [];
-        return get().workspaceSectionsByProject[scope] ?? [];
-      },
       createWorkspaceSection: (projectViewKey, name) => {
         const sectionName = name.trim();
         if (!sectionName || !projectViewKey.trim()) return;
@@ -359,7 +261,7 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
           workspaceSectionsByProject: withWorkspaceSections(
             state.workspaceSectionsByProject,
             projectViewKey,
-            (sections) => renameSection(sections, normalizedSectionId, sectionName),
+            (sections) => renameWorkspaceSection(sections, normalizedSectionId, sectionName),
           ),
         }));
       },
@@ -370,7 +272,7 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
           workspaceSectionsByProject: withWorkspaceSections(
             state.workspaceSectionsByProject,
             projectViewKey,
-            (sections) => reorderSections(sections, normalizedSectionIds),
+            (sections) => reorderWorkspaceSections(sections, normalizedSectionIds),
           ),
         }));
       },
@@ -394,7 +296,7 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
           workspaceSectionsByProject: withWorkspaceSections(
             state.workspaceSectionsByProject,
             projectViewKey,
-            (sections) => removeSection(sections, normalizedSectionId),
+            (sections) => removeWorkspaceSection(sections, normalizedSectionId),
           ),
         }));
       },
@@ -407,7 +309,7 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
             state.workspaceSectionsByProject,
             projectViewKey,
             (sections) =>
-              moveWorkspaceSection(sections, normalizedWorkspaceKey, normalizedSectionId),
+              moveWorkspaceToSection(sections, normalizedWorkspaceKey, normalizedSectionId),
           ),
         }));
       },
@@ -420,7 +322,7 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
             state.workspaceSectionsByProject,
             projectViewKey,
             (sections) =>
-              moveWorkspaceSections(sections, normalizedWorkspaceKeys, normalizedSectionId),
+              moveWorkspacesToSection(sections, normalizedWorkspaceKeys, normalizedSectionId),
           ),
         }));
       },

--- a/packages/app/src/stores/sidebar-order-store.ts
+++ b/packages/app/src/stores/sidebar-order-store.ts
@@ -30,6 +30,11 @@ interface SidebarOrderStoreState {
     workspaceKey: string,
     sectionId: string | null,
   ) => void;
+  moveWorkspacesToSection: (
+    projectViewKey: string,
+    workspaceKeys: string[],
+    sectionId: string | null,
+  ) => void;
 }
 
 interface SidebarOrderPersistedState {
@@ -201,6 +206,21 @@ function moveWorkspaceSection(
     const workspaceKeys = section.workspaceKeys.filter((key) => key !== workspaceKey);
     if (section.id !== sectionId) return { ...section, workspaceKeys };
     return { ...section, workspaceKeys: [...workspaceKeys, workspaceKey] };
+  });
+}
+
+function moveWorkspaceSections(
+  sections: SidebarWorkspaceSection[],
+  workspaceKeys: readonly string[],
+  sectionId: string | null,
+): SidebarWorkspaceSection[] {
+  const targetExists = sectionId === null || sections.some((section) => section.id === sectionId);
+  if (!targetExists) return sections;
+  const movedKeys = new Set(workspaceKeys);
+  return sections.map((section) => {
+    const remainingKeys = section.workspaceKeys.filter((key) => !movedKeys.has(key));
+    if (section.id !== sectionId) return { ...section, workspaceKeys: remainingKeys };
+    return { ...section, workspaceKeys: [...remainingKeys, ...workspaceKeys] };
   });
 }
 
@@ -388,6 +408,19 @@ export const useSidebarOrderStore = create<SidebarOrderStoreState>()(
             projectViewKey,
             (sections) =>
               moveWorkspaceSection(sections, normalizedWorkspaceKey, normalizedSectionId),
+          ),
+        }));
+      },
+      moveWorkspacesToSection: (projectViewKey, workspaceKeys, sectionId) => {
+        const normalizedWorkspaceKeys = normalizeKeys(workspaceKeys);
+        const normalizedSectionId = sectionId?.trim() || null;
+        if (normalizedWorkspaceKeys.length === 0 || !projectViewKey.trim()) return;
+        set((state) => ({
+          workspaceSectionsByProject: withWorkspaceSections(
+            state.workspaceSectionsByProject,
+            projectViewKey,
+            (sections) =>
+              moveWorkspaceSections(sections, normalizedWorkspaceKeys, normalizedSectionId),
           ),
         }));
       },

--- a/packages/app/src/stores/sidebar-workspace-sections.test.ts
+++ b/packages/app/src/stores/sidebar-workspace-sections.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  moveWorkspaceToSection,
+  moveWorkspacesToSection,
+  normalizeWorkspaceSections,
+  removeWorkspaceSection,
+  renameWorkspaceSection,
+  reorderWorkspaceSections,
+} from "./sidebar-workspace-sections";
+
+describe("workspace sections", () => {
+  it("normalizes names, ids, and workspace placement", () => {
+    expect(
+      normalizeWorkspaceSections([
+        { id: " finance ", name: " Finance ", workspaceKeys: ["srv:one", "srv:one", ""] },
+        { id: "research", name: "Research", workspaceKeys: ["srv:one", "srv:two"] },
+      ]),
+    ).toEqual([
+      { id: "finance", name: "Finance", workspaceKeys: ["srv:one"] },
+      { id: "research", name: "Research", workspaceKeys: ["srv:two"] },
+    ]);
+  });
+
+  it("moves one or many workspaces and returns deleted-section workspaces to Unsectioned", () => {
+    const sections = [
+      { id: "finance", name: "Finance", workspaceKeys: ["srv:one"] },
+      { id: "research", name: "Research", workspaceKeys: ["srv:two"] },
+    ];
+    const movedOne = moveWorkspaceToSection(sections, "srv:one", "research");
+    expect(movedOne).toEqual([
+      { id: "finance", name: "Finance", workspaceKeys: [] },
+      { id: "research", name: "Research", workspaceKeys: ["srv:two", "srv:one"] },
+    ]);
+
+    const movedMany = moveWorkspacesToSection(movedOne, ["srv:two", "srv:one"], "finance");
+    expect(removeWorkspaceSection(movedMany, "finance")).toEqual([
+      { id: "research", name: "Research", workspaceKeys: [] },
+    ]);
+  });
+
+  it("renames and reorders empty sections", () => {
+    const sections = [
+      { id: "finance", name: "Finance", workspaceKeys: [] },
+      { id: "research", name: "Research", workspaceKeys: [] },
+    ];
+    expect(
+      reorderWorkspaceSections(renameWorkspaceSection(sections, "finance", "Waiting"), [
+        "research",
+        "finance",
+      ]),
+    ).toMatchObject([
+      { name: "Research", workspaceKeys: [] },
+      { name: "Waiting", workspaceKeys: [] },
+    ]);
+  });
+});

--- a/packages/app/src/stores/sidebar-workspace-sections.ts
+++ b/packages/app/src/stores/sidebar-workspace-sections.ts
@@ -1,0 +1,114 @@
+export interface SidebarWorkspaceSection {
+  id: string;
+  name: string;
+  workspaceKeys: string[];
+}
+
+function normalizeKeys(keys: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const rawKey of keys) {
+    const key = rawKey.trim();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(key);
+  }
+
+  return normalized;
+}
+
+export function normalizeWorkspaceSections(
+  sections: readonly SidebarWorkspaceSection[],
+): SidebarWorkspaceSection[] {
+  const seenSectionIds = new Set<string>();
+  const placedWorkspaceKeys = new Set<string>();
+  const normalized: SidebarWorkspaceSection[] = [];
+
+  for (const section of sections) {
+    const id = section.id.trim();
+    const name = section.name.trim();
+    if (!id || !name || seenSectionIds.has(id)) continue;
+
+    const workspaceKeys = normalizeKeys(section.workspaceKeys).filter((workspaceKey) => {
+      if (placedWorkspaceKeys.has(workspaceKey)) return false;
+      placedWorkspaceKeys.add(workspaceKey);
+      return true;
+    });
+    seenSectionIds.add(id);
+    normalized.push({ id, name, workspaceKeys });
+  }
+
+  return normalized;
+}
+
+export function renameWorkspaceSection(
+  sections: SidebarWorkspaceSection[],
+  sectionId: string,
+  name: string,
+): SidebarWorkspaceSection[] {
+  return sections.map((section) => (section.id === sectionId ? { ...section, name } : section));
+}
+
+export function reorderWorkspaceSections(
+  sections: SidebarWorkspaceSection[],
+  sectionIds: readonly string[],
+): SidebarWorkspaceSection[] {
+  const byId = new Map(sections.map((section) => [section.id, section]));
+  const reordered = sectionIds.flatMap((id) => {
+    const section = byId.get(id);
+    return section ? [section] : [];
+  });
+  const reorderedIds = new Set(reordered.map((section) => section.id));
+  return [...reordered, ...sections.filter((section) => !reorderedIds.has(section.id))];
+}
+
+export function reorderSectionWorkspaceKeys(
+  sections: SidebarWorkspaceSection[],
+  sectionId: string,
+  workspaceKeys: readonly string[],
+): SidebarWorkspaceSection[] {
+  return sections.map((section) => {
+    if (section.id !== sectionId) return section;
+    const currentKeys = new Set(section.workspaceKeys);
+    const orderedKeys = workspaceKeys.filter((key) => currentKeys.has(key));
+    const orderedKeySet = new Set(orderedKeys);
+    return {
+      ...section,
+      workspaceKeys: [
+        ...orderedKeys,
+        ...section.workspaceKeys.filter((key) => !orderedKeySet.has(key)),
+      ],
+    };
+  });
+}
+
+export function removeWorkspaceSection(
+  sections: SidebarWorkspaceSection[],
+  sectionId: string,
+): SidebarWorkspaceSection[] {
+  return sections.filter((section) => section.id !== sectionId);
+}
+
+export function moveWorkspaceToSection(
+  sections: SidebarWorkspaceSection[],
+  workspaceKey: string,
+  sectionId: string | null,
+): SidebarWorkspaceSection[] {
+  return moveWorkspacesToSection(sections, [workspaceKey], sectionId);
+}
+
+export function moveWorkspacesToSection(
+  sections: SidebarWorkspaceSection[],
+  workspaceKeys: readonly string[],
+  sectionId: string | null,
+): SidebarWorkspaceSection[] {
+  const targetExists = sectionId === null || sections.some((section) => section.id === sectionId);
+  if (!targetExists) return sections;
+  const movedKeys = new Set(workspaceKeys);
+  return sections.map((section) => {
+    const remainingKeys = section.workspaceKeys.filter((key) => !movedKeys.has(key));
+    if (section.id !== sectionId) return { ...section, workspaceKeys: remainingKeys };
+    return { ...section, workspaceKeys: [...remainingKeys, ...workspaceKeys] };
+  });
+}


### PR DESCRIPTION
## Linked discussion

Workflow discussion: https://github.com/getpaseo/paseo/discussions/4714

## What this adds

Client-local, ordered workspace sections inside each project in the native **Project** sidebar.

- Create, rename, collapse, reorder, and delete sections.
- Keep empty sections visible. Deleting a section returns its workspaces to **Unsectioned**; it never archives, deletes, or changes daemon project membership.
- Make **Unsectioned** visible and collapsible even before the first named section exists.
- Move one workspace from its existing row menu, or use Select workspaces to move a set together.
- On desktop, Shift-click pins or unpins a workspace without opening it.

Pinned rows retain precedence while their placement is preserved. Status mode, filters, and existing shortcuts retain their behavior.

## Scope and maintenance

The layout is persisted in the existing client-side sidebar store, keyed by `projectViewKey`. There are no daemon, protocol, dependency, migration, or workspace-record changes. Layout is local to this client and does not sync between devices.

Cross-section drag is deferred: the existing draggable-list primitive only reorders within a list. The row-menu and bulk-move paths cover v1 without a new drag model.

This is desktop-first. The shared source remains native-safe, but no iOS or Android device build has been tested; official mobile delivery needs maintainer agreement, native QA, and a release.

## Verification

- Targeted Vitest: 6 files / 30 tests passed, covering persistence normalization, sections, collapsed state, projection/filter/pinned behavior, and sidebar regressions.
- Browser E2E: 1 passed against an isolated daemon. It creates a section, moves a workspace, collapses and restores Unsectioned, deletes the section, and confirms both workspaces remain daemon project members.
- `npm run typecheck` passed across all workspaces.
- Targeted `npm run lint` passed with 0 warnings and 0 errors.
- `npm run format:check` passed.

The local macOS v0.8 compatibility preview continues to attach to the existing host on port 6767 without requiring a host update. It uses isolated app state and does not modify the installed app or daemon.
