### PR TITLE
feat(plugins): add workspace file context menu actions

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -263,8 +263,8 @@ When the same plugin contribution exists on multiple hosts, Paseo shows it once 
 adds a host picker to the screen header. The selected host supplies the bundle, RPC transport, and
 query cache. Plugin code cannot address another host.
 
-Workspace panels, Command Center items, and client slash commands are client contributions. The
-daemon transports their compiled bundle without interpreting placement or callbacks. Panel props
+Workspace panels, Command Center items, file menu items, and client slash commands are client
+contributions. The daemon transports their compiled bundle without interpreting placement or callbacks. Panel props
 contain workspace and agent IDs. Required-selector hooks read normalized client state synchronously
 and use shallow equality, so a panel does not subscribe to fields it does not render. Command
 callbacks materialize their snapshots only when invoked. Contribution discovery and panel opening
@@ -276,6 +276,12 @@ Panels declare `locations: ["workspace", "explorer"]` to opt into Explorer hosti
 workspace only. Location controls hosting, not context. An agent panel target keeps its `agentId`
 when moved between hosts. Explorer configuration can create workspace-context panels and remove
 existing agent-context instances, but it cannot create an agent panel without an agent-aware command.
+
+File menu items appear in the Files context menu for existing files only. The row reads the plugin
+catalog once its menu first opens, and each selection creates a short-lived API runtime that is disposed
+when the callback settles. A selection is refused once its plugin unloads or its registration is removed,
+including panel navigation started late by that callback. `addFileMenuItem` is absent on older clients,
+so plugins check for it before calling it.
 
 Command Center callbacks use the selected host's existing `PaseoApi` for normal Paseo operations.
 They use typed plugin RPC only for plugin-specific backend work. Surface and panel props expose

--- a/packages/app/e2e/browser/plugin-file-menu.spec.ts
+++ b/packages/app/e2e/browser/plugin-file-menu.spec.ts
@@ -1,0 +1,106 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "../support/fixtures";
+import { openFileExplorer } from "../support/helpers/file-explorer";
+import { gotoWorkspace } from "../support/helpers/launcher";
+import { connectNewWorkspaceDaemonClient } from "../support/helpers/new-workspace";
+import { pluginRequirements } from "../support/helpers/plugin-fixture";
+import { seedWorkspace } from "../support/helpers/seed-client";
+
+test("file menu contributions open and update a workspace panel", async ({ page }, testInfo) => {
+  const client = await connectNewWorkspaceDaemonClient({ ownProjects: false });
+  const previous = await client.getDaemonConfig();
+  const workspace = await seedWorkspace({ repoPrefix: "plugin-file-menu-" });
+  const directory = await mkdtemp(path.join(tmpdir(), "paseo-file-menu-"));
+  await writeFile(
+    path.join(directory, "paseo-plugin.json"),
+    JSON.stringify({
+      id: "file-menu-test",
+      requirements: pluginRequirements,
+    }),
+  );
+  await writeFile(
+    path.join(directory, "index.client.tsx"),
+    `
+import React, { useSyncExternalStore } from "react";
+import { Text } from "react-native";
+let selection = null;
+const listeners = new Set();
+const subscribe = (listener) => { listeners.add(listener); return () => listeners.delete(listener); };
+function Panel({ workspaceId }) {
+  const current = useSyncExternalStore(subscribe, () => selection);
+  return <Text testID="selected-plugin-file">{current ? workspaceId + ":" + current.path + ":" + current.sequence : "No selection"}</Text>;
+}
+export default function contribute(client) {
+  client.addWorkspacePanel({ id: "reader", title: "File reader", icon: "BookOpen", context: "workspace", Component: Panel });
+  client.addFileMenuItem({ id: "read", title: "Read in plugin", icon: "BookOpen", onSelect(ctx) {
+    ctx.openPanel("reader", { location: "workspace" });
+    selection = { path: ctx.file.path, sequence: (selection?.sequence ?? 0) + 1 };
+    listeners.forEach(listener => listener());
+  }});
+  return () => {};
+}`,
+  );
+  let installed = false;
+  try {
+    await writeFile(path.join(workspace.repoPath, "first.ts"), "export const first = 1;\n");
+    await writeFile(path.join(workspace.repoPath, "second.ts"), "export const second = 2;\n");
+    await mkdir(path.join(workspace.repoPath, "folder"));
+    await client.patchDaemonConfig({ pluginsEnabled: true });
+    await client.installDirectoryPlugin(directory);
+    installed = true;
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await gotoWorkspace(page, workspace.workspaceId);
+    await openFileExplorer(page);
+    const openMenu = async (name: string) => {
+      await page
+        .getByTestId("file-explorer-tree-scroll")
+        .getByText(name, { exact: true })
+        .first()
+        .click({ button: "right" });
+      const menu = page.getByTestId(/file-explorer-row-\d+-context-menu$/);
+      await expect(menu).toBeVisible();
+      return menu;
+    };
+    for (const [index, name] of ["first.ts", "second.ts", "second.ts"].entries()) {
+      const menu = await openMenu(name);
+      if (index === 0)
+        await testInfo.attach("file-menu", {
+          body: await page.screenshot(),
+          contentType: "image/png",
+        });
+      await menu.getByRole("menuitem", { name: "Read in plugin", exact: true }).click();
+      await expect(page.getByTestId("selected-plugin-file")).toHaveText(
+        `${workspace.workspaceId}:${name}:${index + 1}`,
+      );
+      await expect(page.getByTestId("selected-plugin-file")).toHaveCount(1);
+      await expect(
+        page
+          .getByTestId("workspace-tab-plugin_workspace_14_file-menu-test_6_reader")
+          .filter({ visible: true }),
+      ).toHaveCount(1);
+    }
+    const folderMenu = await openMenu("folder");
+    await expect(
+      folderMenu.getByRole("menuitem", { name: "Read in plugin", exact: true }),
+    ).toHaveCount(0);
+    await page.keyboard.press("Escape");
+    await testInfo.attach("selected-file-panel", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    });
+    await client.removePlugin("file-menu-test");
+    installed = false;
+    const unloadedMenu = await openMenu("first.ts");
+    await expect(
+      unloadedMenu.getByRole("menuitem", { name: "Read in plugin", exact: true }),
+    ).toHaveCount(0);
+  } finally {
+    if (installed) await client.removePlugin("file-menu-test");
+    await client.patchDaemonConfig({ pluginsEnabled: previous.config.pluginsEnabled ?? false });
+    await client.close();
+    await workspace.cleanup();
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/app/src/components/file-actions-menu.tsx
+++ b/packages/app/src/components/file-actions-menu.tsx
@@ -40,6 +40,14 @@ interface FileAction {
   testID?: string;
 }
 
+/** An action supplied by the caller for an existing file, listed after the built-in open actions. */
+export interface FileMenuExtraAction {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  onSelect: () => void;
+}
+
 function optionalFileAction(
   available: boolean,
   onSelect: (() => void) | undefined,
@@ -68,6 +76,7 @@ interface FileActionsContextMenuContentProps {
   onDuplicate?: () => void;
   onRevert?: () => void;
   onDelete?: () => void;
+  extraActions?: readonly FileMenuExtraAction[];
   testIDPrefix?: string;
 }
 
@@ -95,6 +104,7 @@ export function FileActionsContextMenuContent({
   onDuplicate,
   onRevert,
   onDelete,
+  extraActions,
   testIDPrefix,
 }: FileActionsContextMenuContentProps): ReactElement | null {
   const { t } = useTranslation();
@@ -110,6 +120,19 @@ export function FileActionsContextMenuContent({
           }
         : null,
     [editorTargetName, fileKind, onOpenInEditor, t],
+  );
+  const extraFileActions = useMemo<FileAction[]>(
+    () =>
+      fileKind === "file" && fileExists && extraActions
+        ? extraActions.map((action) => ({
+            key: `extra-${action.key}`,
+            group: "open",
+            label: action.label,
+            icon: action.icon,
+            onSelect: action.onSelect,
+          }))
+        : [],
+    [extraActions, fileExists, fileKind],
   );
   const actions = useMemo<FileAction[]>(() => {
     const availableFile = fileKind === "file" && fileExists;
@@ -157,6 +180,7 @@ export function FileActionsContextMenuContent({
         label: t("workspace.fileActions.openToSide"),
         icon: ArrowRightToLine,
       }),
+      ...extraFileActions,
       onCopyPath
         ? {
             key: "copy-path",
@@ -249,6 +273,7 @@ export function FileActionsContextMenuContent({
       }),
     );
   }, [
+    extraFileActions,
     fileExists,
     fileKind,
     onAddToChat,

--- a/packages/app/src/components/file-explorer-pane.tsx
+++ b/packages/app/src/components/file-explorer-pane.tsx
@@ -1,4 +1,5 @@
 import {
+  type ComponentProps,
   useCallback,
   useEffect,
   useMemo,
@@ -57,6 +58,7 @@ import type {
 } from "@/stores/session-store";
 import { useSessionStore } from "@/stores/session-store";
 import { FileActionsContextMenuContent } from "@/components/file-actions-menu";
+import { usePluginFileMenuActions } from "@/plugins/file-menu/use-plugin-file-menu-actions";
 import { ContextMenu, ContextMenuTrigger, useContextMenu } from "@/components/ui/context-menu";
 import { useFileDownload } from "@/hooks/use-file-download";
 import { useFileExplorerActions } from "@/hooks/use-file-explorer-actions";
@@ -228,6 +230,29 @@ function EntryNameInputRow({
   );
 }
 
+type TreeRowFileActionsProps = ComponentProps<typeof FileActionsContextMenuContent> & {
+  serverId: string;
+  workspaceId?: string | null;
+  path: string;
+};
+
+/**
+ * Plugin items join the row menu once it has opened; rows that were never opened hold no plugin
+ * catalog subscription. The latch keeps items stable while the menu animates closed.
+ */
+function TreeRowFileActions({ serverId, workspaceId, path, ...menu }: TreeRowFileActionsProps) {
+  const { open } = useContextMenu();
+  const [opened, setOpened] = useState(false);
+  if (open && !opened) setOpened(true);
+  const pluginActions = usePluginFileMenuActions({
+    enabled: opened && menu.fileKind === "file",
+    serverId,
+    workspaceId,
+    path,
+  });
+  return <FileActionsContextMenuContent {...menu} extraActions={pluginActions} />;
+}
+
 function TreeRowItem({
   serverId,
   workspaceId,
@@ -373,7 +398,10 @@ function TreeRowItem({
           </Text>
         </View>
       </ContextMenuTrigger>
-      <FileActionsContextMenuContent
+      <TreeRowFileActions
+        serverId={serverId}
+        workspaceId={workspaceId}
+        path={entry.path}
         fileKind={entry.kind}
         onOpenInEditor={isDirectory && onOpenInEditor ? handleOpenInEditor : undefined}
         editorTargetName={editorTargetName}

--- a/packages/app/src/plugins/buttons/model.test.ts
+++ b/packages/app/src/plugins/buttons/model.test.ts
@@ -17,6 +17,7 @@ function installation(): InstalledPlugin {
     sidebarItems: [],
     workspacePanels: [],
     commandCenterItems: [],
+    fileMenuItems: [],
     clientSlashCommands: [],
     attachmentSources: [],
     themes: [],

--- a/packages/app/src/plugins/command-center/contributions.test.ts
+++ b/packages/app/src/plugins/command-center/contributions.test.ts
@@ -99,6 +99,7 @@ function plugin(onAgentSelect: AgentCommandItem["onSelect"]): InstalledPlugin {
         onSelect: onAgentSelect,
       },
     ],
+    fileMenuItems: [],
     clientSlashCommands: [],
     attachmentSources: [],
     themes: [],

--- a/packages/app/src/plugins/evaluate.test.ts
+++ b/packages/app/src/plugins/evaluate.test.ts
@@ -77,6 +77,7 @@ describe("evaluatePluginClientBundle", () => {
           plugin.addSidebarItem({ id: "main", title: "Main", icon: "Blocks", surface: "main" }),
           plugin.addWorkspacePanel({ id: "panel", title: "Panel", icon: "Blocks", context: "workspace", Component }),
           plugin.addCommandCenterItem({ id: "command", title: "Command", icon: "Blocks", context: "global", onSelect() {} }),
+          plugin.addFileMenuItem({ id: "file", title: "File", icon: "Blocks", onSelect() {} }),
           plugin.addSlashCommand({ name: "review", description: "Review", argumentHint: "", context: "workspace", onSubmit() {} }),
           plugin.addComposerPill({ id: "pill", workspaceId: "workspace", agentId: "agent", button: { title: "Pill", icon: "Scan", behavior: { kind: "action", onPress() {} } } }).remove,
           plugin.addAttachmentSource({ id: "issues", title: "Issues", icon: "Blocks", pickerTitle: "Attach issue", searchPlaceholder: "Search", search: { name: "issues.search", input: {}, output: {} } }),
@@ -107,6 +108,7 @@ describe("evaluatePluginClientBundle", () => {
         plugin.sidebarItems,
         plugin.workspacePanels,
         plugin.commandCenterItems,
+        plugin.fileMenuItems,
         plugin.clientSlashCommands,
         plugin.attachmentSources,
         plugin.themes,
@@ -126,6 +128,7 @@ describe("evaluatePluginClientBundle", () => {
         plugin.sidebarItems,
         plugin.workspacePanels,
         plugin.commandCenterItems,
+        plugin.fileMenuItems,
         plugin.clientSlashCommands,
         plugin.attachmentSources,
         plugin.themes,
@@ -337,6 +340,46 @@ describe("evaluatePluginClientBundle", () => {
         `),
       ),
     ).toThrow("Duplicate Command Center item: review");
+  });
+
+  it("collects and validates file menu items", () => {
+    const plugin = evaluatePluginClientBundle(
+      "reader",
+      bundle(
+        `plugin.addFileMenuItem({ id: " open ", title: " Open in Reader ", icon: " Scan ", onSelect() {} })`,
+      ),
+    );
+    expect(plugin.fileMenuItems.map(({ id, title, icon }) => ({ id, title, icon }))).toEqual([
+      { id: "open", title: "Open in Reader", icon: "Scan" },
+    ]);
+    const invalid: Array<[string, string]> = [
+      [
+        `{ id: "Open", title: "Open", icon: "Scan", onSelect() {} }`,
+        "Invalid file menu item id: Open",
+      ],
+      [
+        `{ id: "open", title: " ", icon: "Scan", onSelect() {} }`,
+        "File menu item open has no title",
+      ],
+      [`{ id: "open", title: "Open", icon: "", onSelect() {} }`, "File menu item open has no icon"],
+      [`{ id: "open", title: "Open", icon: "Scan" }`, "File menu item open has no callback"],
+      [`{ id: "open", title: "Open", icon: "NoSuchIcon", onSelect() {} }`, "NoSuchIcon"],
+    ];
+    for (const [item, message] of invalid) {
+      expect(() =>
+        evaluatePluginClientBundle("reader", bundle(`plugin.addFileMenuItem(${item})`)),
+      ).toThrow(message);
+    }
+    expect(() =>
+      evaluatePluginClientBundle(
+        "reader",
+        bundle(`
+          const item = { id: "open", title: "Open", icon: "Scan", onSelect() {} };
+          plugin.addFileMenuItem(item);
+          plugin.addFileMenuItem(item);
+        `),
+      ),
+    ).toThrow("Duplicate file menu item: open");
   });
 
   it("runs the client entry with the full runtime context", () => {

--- a/packages/app/src/plugins/evaluate.ts
+++ b/packages/app/src/plugins/evaluate.ts
@@ -17,6 +17,7 @@ import {
 import {
   type PluginCommandCenterItemContribution,
   type PluginClientContext,
+  type PluginFileMenuItemContribution,
   type PluginClientSlashCommandContribution,
   type PluginSidebarContribution,
   type PluginSurfaceProps,
@@ -92,6 +93,7 @@ export function runPluginClientBundle(
     sidebarItems: [],
     workspacePanels: [],
     commandCenterItems: [],
+    fileMenuItems: [],
     clientSlashCommands: [],
     attachmentSources: [],
     themes: [],
@@ -103,6 +105,7 @@ export function runPluginClientBundle(
   const sidebarItemIds = new Set<string>();
   const workspacePanelIds = new Set<string>();
   const commandCenterItemIds = new Set<string>();
+  const fileMenuItemIds = new Set<string>();
   const clientSlashCommandNames = new Set<string>();
   const attachmentSourceIds = new Set<string>();
   const themeIds = new Set<string>();
@@ -249,6 +252,26 @@ export function runPluginClientBundle(
           keywords: contribution.keywords?.map((keyword) => keyword.trim()).filter(Boolean),
         },
         () => commandCenterItemIds.delete(normalizedId),
+      );
+    },
+    addFileMenuItem(contribution: PluginFileMenuItemContribution) {
+      const normalizedId = requireId(contribution.id, "file menu item id");
+      if (fileMenuItemIds.has(normalizedId)) {
+        throw new Error(`Duplicate file menu item: ${normalizedId}`);
+      }
+      const title = contribution.title.trim();
+      const icon = contribution.icon.trim();
+      if (!title) throw new Error(`File menu item ${normalizedId} has no title`);
+      if (!icon) throw new Error(`File menu item ${normalizedId} has no icon`);
+      if (typeof contribution.onSelect !== "function") {
+        throw new Error(`File menu item ${normalizedId} has no callback`);
+      }
+      resolvePluginIcon(icon);
+      fileMenuItemIds.add(normalizedId);
+      return register(
+        collector.fileMenuItems,
+        { id: normalizedId, title, icon, onSelect: contribution.onSelect },
+        () => fileMenuItemIds.delete(normalizedId),
       );
     },
     addSlashCommand(contribution: PluginClientSlashCommandContribution) {
@@ -436,6 +459,7 @@ export function runPluginClientBundle(
     sidebarItems: collector.sidebarItems,
     workspacePanels: collector.workspacePanels as EvaluatedPlugin["workspacePanels"],
     commandCenterItems: collector.commandCenterItems,
+    fileMenuItems: collector.fileMenuItems,
     clientSlashCommands: collector.clientSlashCommands,
     attachmentSources: collector.attachmentSources,
     themes: collector.themes,

--- a/packages/app/src/plugins/file-menu/actions.test.ts
+++ b/packages/app/src/plugins/file-menu/actions.test.ts
@@ -1,0 +1,238 @@
+import { QueryClient } from "@tanstack/react-query";
+import type { PaseoApi } from "@getpaseo/client";
+import type { PluginWorkspaceSnapshot } from "@getpaseo/plugin";
+import type {
+  PluginFileMenuContext,
+  PluginFileMenuItemContribution,
+} from "@getpaseo/plugin/client";
+import { describe, expect, it } from "vitest";
+import type { PluginNavigation } from "../actions";
+import type { InstalledPlugin } from "../types";
+import { buildPluginFileMenuActions, type PluginFileMenuSource } from "./actions";
+
+const workspace: PluginWorkspaceSnapshot = {
+  id: "workspace-1",
+  projectId: "project-1",
+  projectDisplayName: "Paseo",
+  projectRootPath: "/repo/paseo",
+  directory: "/repo/paseo/review",
+  projectKind: "git",
+  kind: "worktree",
+  name: "Review",
+  title: null,
+  status: "running",
+  statusEnteredAt: null,
+  archivingAt: null,
+  diffStat: null,
+};
+
+function plugin(
+  onSelect: PluginFileMenuItemContribution["onSelect"],
+  overrides: Partial<InstalledPlugin> = {},
+): InstalledPlugin {
+  return {
+    id: "reader",
+    serverId: "host-1",
+    clientBundle: "bundle",
+    lifetime: new AbortController(),
+    queryClient: new QueryClient(),
+    cleanup: () => {},
+    settingsScreens: [],
+    surfaces: [],
+    sidebarItems: [],
+    workspacePanels: [
+      {
+        id: "view",
+        title: "View",
+        icon: "Scan",
+        context: "workspace",
+        locations: ["workspace"],
+        Component: () => null,
+      },
+      {
+        id: "agent-view",
+        title: "Agent",
+        icon: "Scan",
+        context: "agent",
+        locations: ["workspace"],
+        Component: () => null,
+      },
+    ],
+    commandCenterItems: [],
+    fileMenuItems: [{ id: "open", title: "Open in Reader", icon: "Scan", onSelect }],
+    clientSlashCommands: [],
+    attachmentSources: [],
+    themes: [],
+    timelineTransformers: [],
+    timelineRenderers: [],
+    ...overrides,
+  };
+}
+
+function harness(plugins: InstalledPlugin[], overrides: Partial<PluginFileMenuSource> = {}) {
+  const errors: string[] = [];
+  const opened: string[] = [];
+  let runtimes = 0;
+  let disposed = 0;
+  const navigation: PluginNavigation = {
+    openSettings() {},
+    openSurface() {},
+    openWorkspacePanel(pluginId, panelId, location) {
+      opened.push(`${pluginId}/${panelId}/${location}`);
+    },
+    openAgentPanel() {},
+  };
+  const source: PluginFileMenuSource = {
+    serverId: "host-1",
+    workspaceId: workspace.id,
+    file: { path: "src/app.ts" },
+    plugins,
+    runtime() {
+      runtimes += 1;
+      // The file menu never uses the API itself; it only owns disposal of the per-selection runtime.
+      const paseo = {
+        async dispose() {
+          disposed += 1;
+        },
+      } as unknown as PaseoApi;
+      return { paseo, invoke: async () => undefined };
+    },
+    state: {
+      subscribe: () => () => {},
+      getWorkspace: (id) => (id === workspace.id ? workspace : null),
+      getAgent: () => null,
+    },
+    navigation,
+    reportError(error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    },
+    ...overrides,
+  };
+  return {
+    actions: () => buildPluginFileMenuActions(source),
+    errors,
+    opened,
+    counts: () => ({ runtimes, disposed }),
+  };
+}
+
+describe("plugin file menu actions", () => {
+  it("lists only this host's items for workspace-relative paths", () => {
+    const local = plugin(() => {});
+    const remote = plugin(() => {}, { id: "remote", serverId: "host-2" });
+    expect(
+      harness([local, remote])
+        .actions()
+        .map((action) => [action.key, action.label]),
+    ).toEqual([["reader-open", "Open in Reader"]]);
+    for (const path of [
+      "",
+      "/etc/passwd",
+      "../outside.ts",
+      "src//app.ts",
+      "src/./app.ts",
+      "C:/app.ts",
+    ]) {
+      expect(harness([local], { file: { path } }).actions()).toEqual([]);
+    }
+  });
+
+  it("runs with the workspace snapshot and file, opens a workspace panel, then disposes the runtime", async () => {
+    let received: PluginFileMenuContext | null = null;
+    const installed = plugin((context) => {
+      received = context;
+      context.openPanel("view");
+    });
+    const test = harness([installed]);
+    await test.actions()[0]?.run();
+
+    expect(received).not.toBeNull();
+    const context = received as unknown as PluginFileMenuContext;
+    expect(context.context).toBe("workspace");
+    expect(context.workspace).toBe(workspace);
+    expect(context.file).toEqual({ path: "src/app.ts" });
+    expect(Object.isFrozen(context.file)).toBe(true);
+    expect(() => context.openPanel("agent-view")).toThrow(
+      "Workspace panel is unavailable: agent-view",
+    );
+    expect(test.opened).toEqual(["reader/view/workspace"]);
+    expect(test.errors).toEqual([]);
+    expect(test.counts()).toEqual({ runtimes: 1, disposed: 1 });
+  });
+
+  it("reports a failing callback and still disposes its runtime", async () => {
+    const test = harness([
+      plugin(async () => {
+        throw new Error("Reader failed");
+      }),
+    ]);
+    await test.actions()[0]?.run();
+    expect(test.errors).toEqual(["Reader failed"]);
+    expect(test.counts()).toEqual({ runtimes: 1, disposed: 1 });
+  });
+
+  it("reports an offline host or missing workspace without calling the plugin", async () => {
+    let calls = 0;
+    const installed = plugin(() => {
+      calls += 1;
+    });
+    const offline = harness([installed], { runtime: () => null });
+    await offline.actions()[0]?.run();
+    expect(offline.errors).toEqual(["Plugin host is offline"]);
+
+    const missing = harness([installed], { workspaceId: "workspace-gone" });
+    await missing.actions()[0]?.run();
+    expect(missing.errors).toEqual(["Workspace is unavailable"]);
+    expect(missing.counts()).toEqual({ runtimes: 1, disposed: 1 });
+    expect(calls).toBe(0);
+  });
+
+  it("does not run an item after its plugin unloads", async () => {
+    let calls = 0;
+    const installed = plugin(() => {
+      calls += 1;
+    });
+    const test = harness([installed]);
+    const [action] = test.actions();
+    installed.lifetime.abort();
+    await action?.run();
+    expect(calls).toBe(0);
+    expect(test.errors).toEqual(["Plugin reader is no longer loaded"]);
+    expect(test.counts().runtimes).toBe(0);
+    expect(harness([installed]).actions()).toEqual([]);
+  });
+
+  it("does not run an item whose registration was removed while the plugin stays loaded", async () => {
+    let calls = 0;
+    const installed = plugin(() => {
+      calls += 1;
+    });
+    const test = harness([installed]);
+    const [action] = test.actions();
+    installed.fileMenuItems.splice(0, 1);
+    await action?.run();
+    expect(calls).toBe(0);
+    expect(installed.lifetime.signal.aborted).toBe(false);
+    expect(test.errors).toEqual(["File menu item reader/open is no longer available"]);
+    expect(test.counts().runtimes).toBe(0);
+  });
+
+  it("refuses late navigation once the item or plugin is gone", async () => {
+    let resume!: () => void;
+    const paused = new Promise<void>((resolve) => {
+      resume = resolve;
+    });
+    const installed = plugin(async (context) => {
+      await paused;
+      context.openPanel("view");
+    });
+    const test = harness([installed]);
+    const running = test.actions()[0]?.run();
+    installed.fileMenuItems.splice(0, 1);
+    resume();
+    await running;
+    expect(test.opened).toEqual([]);
+    expect(test.errors).toEqual(["File menu item reader/open is no longer available"]);
+    expect(test.counts()).toEqual({ runtimes: 1, disposed: 1 });
+  });
+});

--- a/packages/app/src/plugins/file-menu/actions.ts
+++ b/packages/app/src/plugins/file-menu/actions.ts
@@ -1,0 +1,131 @@
+import type { LucideIcon } from "lucide-react-native";
+import type { PluginFileMenuContext } from "@getpaseo/plugin/client";
+import type { PluginClientStateSource } from "@getpaseo/plugin/client/host";
+import { createPluginWorkspaceActionContext, type PluginNavigation } from "../actions";
+import { resolvePluginIcon } from "../icons";
+import type { PluginSurfaceRuntime } from "../surface-runtime";
+import type { InstalledPlugin } from "../types";
+
+export interface PluginFileMenuAction {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  onSelect(): void;
+  run(): Promise<void>;
+}
+
+export interface PluginFileMenuSource {
+  serverId: string;
+  workspaceId: string;
+  file: { path: string };
+  plugins: readonly InstalledPlugin[];
+  runtime(plugin: InstalledPlugin): PluginSurfaceRuntime | null;
+  state: PluginClientStateSource;
+  navigation: PluginNavigation;
+  reportError(error: unknown): void;
+}
+
+function isWorkspaceRelativePath(path: string): boolean {
+  if (!path || path.startsWith("/") || /^[A-Za-z]:/.test(path) || path.includes("\0")) return false;
+  return path.split("/").every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
+type FileMenuItem = InstalledPlugin["fileMenuItems"][number];
+
+/** The item may run only while its installation is loaded and its registration is still present. */
+function unavailableReason(plugin: InstalledPlugin, item: FileMenuItem): Error | null {
+  if (plugin.lifetime.signal.aborted) return new Error(`Plugin ${plugin.id} is no longer loaded`);
+  if (!plugin.fileMenuItems.includes(item)) {
+    return new Error(`File menu item ${plugin.id}/${item.id} is no longer available`);
+  }
+  return null;
+}
+
+/** Navigation that refuses to act once the item's installation or registration is gone. */
+function guardNavigation(
+  plugin: InstalledPlugin,
+  item: FileMenuItem,
+  navigation: PluginNavigation,
+): PluginNavigation {
+  const alive = () => {
+    const reason = unavailableReason(plugin, item);
+    if (reason) throw reason;
+  };
+  return {
+    openSettings(pluginId, screenId) {
+      alive();
+      navigation.openSettings(pluginId, screenId);
+    },
+    openSurface(pluginId, surfaceId) {
+      alive();
+      navigation.openSurface(pluginId, surfaceId);
+    },
+    openWorkspacePanel(pluginId, panelId, location) {
+      alive();
+      navigation.openWorkspacePanel(pluginId, panelId, location);
+    },
+    openAgentPanel(pluginId, panelId, agentId, location) {
+      alive();
+      navigation.openAgentPanel(pluginId, panelId, agentId, location);
+    },
+  };
+}
+
+/**
+ * Items for one file row on one host. Each selection creates its own API runtime and disposes it
+ * when the callback settles; nothing is created while the menu is only displayed.
+ */
+export function buildPluginFileMenuActions(source: PluginFileMenuSource): PluginFileMenuAction[] {
+  const path = source.file.path;
+  if (!isWorkspaceRelativePath(path)) return [];
+  const actions: PluginFileMenuAction[] = [];
+  for (const plugin of source.plugins) {
+    if (plugin.serverId !== source.serverId || plugin.lifetime.signal.aborted) continue;
+    for (const item of plugin.fileMenuItems) {
+      const run = async () => {
+        const unavailable = unavailableReason(plugin, item);
+        if (unavailable) {
+          source.reportError(unavailable);
+          return;
+        }
+        let runtime: PluginSurfaceRuntime | null;
+        try {
+          runtime = source.runtime(plugin);
+        } catch (error) {
+          source.reportError(error);
+          return;
+        }
+        if (!runtime) {
+          source.reportError(new Error("Plugin host is offline"));
+          return;
+        }
+        try {
+          const workspace = createPluginWorkspaceActionContext({
+            plugin,
+            runtime,
+            navigation: guardNavigation(plugin, item, source.navigation),
+            state: source.state,
+            workspaceId: source.workspaceId,
+          });
+          if (!workspace) throw new Error("Workspace is unavailable");
+          const context: PluginFileMenuContext = { ...workspace, file: Object.freeze({ path }) };
+          await item.onSelect(context);
+        } catch (error) {
+          source.reportError(error);
+        } finally {
+          await runtime.paseo.dispose().catch(source.reportError);
+        }
+      };
+      actions.push({
+        key: `${plugin.id}-${item.id}`,
+        label: item.title,
+        icon: resolvePluginIcon(item.icon),
+        run,
+        onSelect: () => {
+          void run();
+        },
+      });
+    }
+  }
+  return actions;
+}

--- a/packages/app/src/plugins/file-menu/use-plugin-file-menu-actions.ts
+++ b/packages/app/src/plugins/file-menu/use-plugin-file-menu-actions.ts
@@ -1,0 +1,50 @@
+import { useMemo, useSyncExternalStore } from "react";
+import { useToast } from "@/contexts/toast-context";
+import { getHostRuntimeStore } from "@/runtime/host-runtime";
+import { createPluginClientStateSource } from "../client-state/source";
+import { createPluginNavigation } from "../navigation";
+import { pluginRegistry } from "../registry";
+import { createPluginSurfaceRuntime } from "../surface-runtime";
+import type { InstalledPlugin } from "../types";
+import { buildPluginFileMenuActions, type PluginFileMenuAction } from "./actions";
+
+const NO_PLUGINS: InstalledPlugin[] = [];
+const NO_ACTIONS: PluginFileMenuAction[] = [];
+const subscribeNothing = () => () => {};
+const readNothing = () => NO_PLUGINS;
+
+/**
+ * Plugin actions for one Files row. Rows subscribe to the plugin catalog only once `enabled`, and
+ * the host client is read when an item is selected, so closed rows hold no plugin subscriptions.
+ */
+export function usePluginFileMenuActions(input: {
+  enabled: boolean;
+  serverId: string;
+  workspaceId: string | null | undefined;
+  path: string;
+}): PluginFileMenuAction[] {
+  const { enabled, serverId, workspaceId, path } = input;
+  const plugins = useSyncExternalStore(
+    enabled ? pluginRegistry.subscribe : subscribeNothing,
+    enabled ? pluginRegistry.getSnapshot : readNothing,
+    enabled ? pluginRegistry.getSnapshot : readNothing,
+  );
+  const toast = useToast();
+  return useMemo(() => {
+    if (!enabled || !workspaceId) return NO_ACTIONS;
+    return buildPluginFileMenuActions({
+      serverId,
+      workspaceId,
+      file: { path },
+      plugins,
+      runtime: (plugin) =>
+        createPluginSurfaceRuntime(
+          getHostRuntimeStore().getSnapshot(serverId)?.client ?? null,
+          plugin,
+        ),
+      state: createPluginClientStateSource(serverId),
+      navigation: createPluginNavigation({ serverId, workspaceId }),
+      reportError: (error) => toast.error(error instanceof Error ? error.message : String(error)),
+    });
+  }, [enabled, path, plugins, serverId, toast, workspaceId]);
+}

--- a/packages/app/src/plugins/registry.ts
+++ b/packages/app/src/plugins/registry.ts
@@ -90,6 +90,7 @@ export class PluginRegistry {
           sidebarItems: [],
           workspacePanels: [],
           commandCenterItems: [],
+          fileMenuItems: [],
           clientSlashCommands: [],
           attachmentSources: [],
           themes: [],

--- a/packages/app/src/plugins/sidebar-groups.test.ts
+++ b/packages/app/src/plugins/sidebar-groups.test.ts
@@ -23,6 +23,7 @@ function installed(serverId: string, contributionId = "main"): InstalledPlugin {
     ],
     workspacePanels: [],
     commandCenterItems: [],
+    fileMenuItems: [],
     clientSlashCommands: [],
     attachmentSources: [],
     themes: [],

--- a/packages/app/src/plugins/surface-contribution.test.ts
+++ b/packages/app/src/plugins/surface-contribution.test.ts
@@ -28,6 +28,7 @@ function installation(
     })),
     workspacePanels: [],
     commandCenterItems: [],
+    fileMenuItems: [],
     clientSlashCommands: [],
     attachmentSources: [],
     themes: [],

--- a/packages/app/src/plugins/theme.test.ts
+++ b/packages/app/src/plugins/theme.test.ts
@@ -56,6 +56,7 @@ function installed(serverId: string, themes: PluginThemeContribution[]): Install
     sidebarItems: [],
     workspacePanels: [],
     commandCenterItems: [],
+    fileMenuItems: [],
     clientSlashCommands: [],
     attachmentSources: [],
     themes,

--- a/packages/app/src/plugins/timeline/model.test.ts
+++ b/packages/app/src/plugins/timeline/model.test.ts
@@ -19,6 +19,7 @@ function plugin(input: {
     sidebarItems: [],
     workspacePanels: [],
     commandCenterItems: [],
+    fileMenuItems: [],
     clientSlashCommands: [],
     attachmentSources: [],
     themes: [],

--- a/packages/app/src/plugins/types.ts
+++ b/packages/app/src/plugins/types.ts
@@ -9,6 +9,7 @@ import type {
   PluginCommandCenterItemContribution,
   PluginClientSlashCommandContribution,
   PluginComposerPillContribution,
+  PluginFileMenuItemContribution,
   PluginSidebarContribution,
   PluginSurfaceContribution,
   PluginSettingsScreenContribution,
@@ -30,6 +31,7 @@ export interface EvaluatedPlugin {
   sidebarItems: PluginSidebarContribution[];
   workspacePanels: EvaluatedPluginWorkspacePanelContribution[];
   commandCenterItems: PluginCommandCenterItemContribution[];
+  fileMenuItems: PluginFileMenuItemContribution[];
   clientSlashCommands: PluginClientSlashCommandContribution[];
   attachmentSources: PluginAttachmentSourceContribution[];
   themes: PluginThemeContribution[];
@@ -50,6 +52,7 @@ export type {
   PluginCommandCenterItemContribution,
   PluginClientSlashCommandContribution,
   PluginComposerPillContribution,
+  PluginFileMenuItemContribution,
   PluginSidebarContribution,
   PluginSurfaceContribution,
   PluginSettingsScreenContribution,

--- a/packages/app/src/plugins/workspace-panels/resolution.test.ts
+++ b/packages/app/src/plugins/workspace-panels/resolution.test.ts
@@ -25,6 +25,7 @@ function installed(): InstalledPlugin {
       },
     ],
     commandCenterItems: [],
+    fileMenuItems: [],
     clientSlashCommands: [],
     attachmentSources: [],
     themes: [],

--- a/packages/plugin/src/client/contracts.ts
+++ b/packages/plugin/src/client/contracts.ts
@@ -81,6 +81,11 @@ export interface PluginClientContext extends PluginCommandCapabilities {
   addSidebarItem(contribution: PluginSidebarContribution): PluginCleanup;
   addWorkspacePanel(contribution: PluginWorkspacePanelContribution): PluginCleanup;
   addCommandCenterItem(contribution: PluginCommandCenterItemContribution): PluginCleanup;
+  /**
+   * Adds an item to the Files context menu for existing files. Undefined on older hosts; check
+   * before calling.
+   */
+  addFileMenuItem?(contribution: PluginFileMenuItemContribution): PluginCleanup;
   addSlashCommand(contribution: PluginClientSlashCommandContribution): PluginCleanup;
   addHeaderButton(contribution: PluginHeaderButtonContribution): PluginButtonRegistration;
   addComposerPill(contribution: PluginComposerPillContribution): PluginButtonRegistration;
@@ -184,6 +189,19 @@ export interface PluginAgentCommandContext extends PluginCommandCapabilities {
   workspace: PluginWorkspaceSnapshot;
   agent: PluginAgentSnapshot;
   openPanel(id: string, options?: PluginOpenPanelOptions): void;
+}
+
+/** Workspace context for a file chosen from the Files context menu. */
+export interface PluginFileMenuContext extends PluginWorkspaceCommandContext {
+  /** `path` is relative to the workspace directory. */
+  file: { readonly path: string };
+}
+
+export interface PluginFileMenuItemContribution {
+  id: string;
+  title: string;
+  icon: string;
+  onSelect(context: PluginFileMenuContext): void | Promise<void>;
 }
 
 interface PluginCommandCenterItemBase {

--- a/packages/plugin/src/client/index.ts
+++ b/packages/plugin/src/client/index.ts
@@ -21,6 +21,8 @@ export type {
   PluginWorkspaceCommandContext,
   PluginAgentCommandContext,
   PluginCommandCenterItemContribution,
+  PluginFileMenuContext,
+  PluginFileMenuItemContribution,
   PluginClientSlashCommandContribution,
   SettingsState,
 } from "./contracts.js";

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -1260,6 +1260,44 @@ Every callback receives:
 
 An agent callback may open either an agent panel or a workspace panel. A workspace callback may open only a workspace panel. Unknown surface and panel IDs fail visibly. Use `paseo` for normal workspace, agent, provider, and daemon-config operations. Use `rpc` for plugin-specific filesystem, credential, vendor, or daemon-local work.
 
+## File menu items
+
+Add an item to the Files context menu. It appears for existing files in the workspace whose Files
+panel you right-click or long-press, never for folders:
+
+```tsx
+client.addFileMenuItem?.({
+  id: "open-in-reader",
+  title: "Open in Reader",
+  icon: "BookOpen",
+  onSelect({ workspace, file, openPanel }) {
+    rememberRequestedFile(workspace.id, file.path);
+    openPanel("reader");
+  },
+});
+```
+
+`addFileMenuItem` is undefined on Paseo clients that predate it. Call it with `?.` or check for it
+first, and keep another way to reach the same panel.
+
+`addFileMenuItem` fields:
+
+| Field      | Required | Meaning                            |
+| ---------- | -------- | ---------------------------------- |
+| `id`       | Yes      | Plugin-local item ID.              |
+| `title`    | Yes      | Menu item label.                   |
+| `icon`     | Yes      | Lucide icon name.                  |
+| `onSelect` | Yes      | Client-side callback for the file. |
+
+The callback receives the workspace callback fields from [Command Center items](#command-center-items)
+plus `file.path`, the file's path relative to the workspace directory. `openPanel` opens a workspace
+panel in that workspace. Panels receive no file argument: keep the requested path in your own client
+state keyed by `workspace.id` and read it from the panel. Paseo does not check the file's type or
+contents; validate the path before you use it.
+
+The item only runs while its plugin is loaded and its registration is present. Navigation the callback
+starts after either one goes away is refused, and errors thrown by the callback are shown to the user.
+
 ## Slash commands
 
 Register a command that runs in the Paseo client when the user submits `/name args` from the


### PR DESCRIPTION
Plugins can now add actions to the Files context menu through `client.addFileMenuItem`. Selecting an action supplies the selected workspace-relative file path and the workspace action context, so a plugin can open its existing workspace panel for that file.

Items appear beside the built-in open actions for existing files. Each invocation uses the selected host/workspace, creates its runtime on demand, and disposes it after the callback. Removed contributions and unloaded plugins cannot run retained menu actions. Callback failures appear as a toast.

Validation: app and plugin SDK typechecks pass; lint passes for all changed code; 69 focused unit tests pass across the nine affected test files. The real-browser test selects two files, repeats a selection in one existing panel, checks folder exclusion, and removes the plugin. A separate local consumer-plugin smoke also opens real source files successfully. Native device interaction has not been exercised.
