### PR TITLE
fix(acp): report context window usage for ACP providers

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2800,6 +2800,84 @@ describe("ACPAgentSession", () => {
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
   });
 
+  test("usage_update fills the context window meter without dropping token counts", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let resolvePrompt!: (value: PromptResponse) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    const { turnId } = await session.startTurn("hello");
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: { sessionUpdate: "usage_update", used: 18_538, size: 256_000 } as SessionUpdate,
+    });
+
+    expect(events.find((event) => event.type === "usage_updated")).toMatchObject({
+      type: "usage_updated",
+      turnId,
+      usage: { contextWindowUsedTokens: 18_538, contextWindowMaxTokens: 256_000 },
+    });
+
+    resolvePrompt({ stopReason: "end_turn", usage: { inputTokens: 12, outputTokens: 3 } });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The turn's token counts and the context meter coexist.
+    expect(events.find((event) => event.type === "turn_completed")).toMatchObject({
+      type: "turn_completed",
+      usage: {
+        inputTokens: 12,
+        outputTokens: 3,
+        contextWindowUsedTokens: 18_538,
+        contextWindowMaxTokens: 256_000,
+      },
+    });
+  });
+
+  test("ignores unusable window sizes and repeated identical usage reports", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    const prompt = vi.fn(() => new Promise<PromptResponse>(() => {}));
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+    session.subscribe((event) => {
+      events.push(event);
+    });
+    await session.startTurn("hello");
+
+    const send = async (used: number, size: number) => {
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: { sessionUpdate: "usage_update", used, size } as SessionUpdate,
+      });
+    };
+
+    // A zero window would render as a divide-by-zero meter.
+    await send(10, 0);
+    expect(events.filter((event) => event.type === "usage_updated")).toHaveLength(0);
+
+    // Real movement is published, an identical repeat is not.
+    await send(10, 1_000);
+    await send(10, 1_000);
+    expect(events.filter((event) => event.type === "usage_updated")).toHaveLength(1);
+
+    await send(20, 1_000);
+    expect(events.filter((event) => event.type === "usage_updated")).toHaveLength(2);
+  });
+
   test("startTurn emits the submitted user message even when ACP does not echo it", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3070,11 +3070,42 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private handleUsageUpdate(update: UsageUpdate): void {
-    void update;
+    // A window size of zero (or worse) cannot be rendered as a meter, so treat
+    // it as "unknown" rather than publishing a bar that divides by zero.
+    if (!Number.isFinite(update.size) || update.size <= 0 || !Number.isFinite(update.used)) {
+      return;
+    }
+
+    const unchanged =
+      this.currentTurnUsage?.contextWindowUsedTokens === update.used &&
+      this.currentTurnUsage?.contextWindowMaxTokens === update.size;
+    if (unchanged) {
+      // Agents may report on every chunk; only publish real movement.
+      return;
+    }
+
+    // Merge rather than replace: `usage_updated` overwrites `lastUsage`
+    // wholesale downstream, and the token counts come from the prompt response.
+    this.currentTurnUsage = {
+      ...this.currentTurnUsage,
+      contextWindowUsedTokens: update.used,
+      contextWindowMaxTokens: update.size,
+    };
+    this.pushEvent({
+      type: "usage_updated",
+      provider: this.provider,
+      usage: this.currentTurnUsage,
+      turnId: this.activeForegroundTurnId ?? undefined,
+    });
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
-    this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
+    const responseUsage = mapACPUsage(response.usage);
+    if (responseUsage) {
+      // Merge, so the turn's token counts do not wipe the context window
+      // figures that `usage_update` reported during the turn.
+      this.currentTurnUsage = { ...this.currentTurnUsage, ...responseUsage };
+    }
 
     switch (response.stopReason) {
       case "cancelled":


### PR DESCRIPTION
Fixes #1390

## Problem

The composer's context window meter never renders for ACP providers. The agent delivers the data and Paseo discards it, because the `session/update` handler for `usage_update` is a no-op:

```ts
// packages/server/src/server/agent/providers/acp-agent.ts
private handleUsageUpdate(update: UsageUpdate): void {
  void update;
}
```

`UsageUpdate.size` and `UsageUpdate.used` never reach `contextWindowMaxTokens` / `contextWindowUsedTokens`, so the meter's render guard hides it permanently. The issue has confirmations from several different agents (Hermes, MiMo, MiniMax via opencode, maple-gpui).

## Fix

- Map `used` and `size` onto `contextWindowUsedTokens` / `contextWindowMaxTokens` and emit `usage_updated`, which the manager and projections already understand.
- Merge instead of replace on both usage paths. `usage_updated` assigns `agent.lastUsage` wholesale in the manager, and `handlePromptResponse` previously rebuilt the object from `mapACPUsage`. Without merging, the turn's token counts and the context figures overwrite each other, and the meter blanks the moment a turn ends.
- Ignore an unusable window size (zero or non-finite) instead of publishing a bar that divides by zero.
- Skip republishing identical values, since agents may report usage on every chunk.

No UI code is touched. This feeds data to the existing meter.

## QA evidence

Unit tests, `packages/server/src/server/agent/providers/acp-agent.test.ts`:

```
main (untouched):        Tests  102 passed (102)
this branch:             Tests  104 passed (104)
```

Two tests added: one asserting the meter payload reaches `usage_updated` and that the turn's token counts and context figures survive together on `turn_completed`; one covering the zero size and identical repeat guards.

Checks on this branch:

```
npx oxlint <changed files>      Found 0 warnings and 0 errors.
npx oxfmt --check <changed>     All matched files use the correct format.
npm run typecheck -w @getpaseo/server
                                5 errors, identical to untouched main
                                (speech/providers/openai, terminal/node-pty:
                                 missing optional modules in my environment),
                                0 in acp-agent.ts
```

Real frames from two ACP agents that already emit this and currently show no meter:

```
ZCode (GLM-5.3):     {"sessionUpdate":"usage_update","used":14879,"size":1000000}
Command Code adapter:{"sessionUpdate":"usage_update","used":18538,"size":256000}
```

Tested on macOS 26.4 arm64, Node 26. Not tested on Linux or Windows.

## Note

This touches `handlePromptResponse`, which is also touched by my other PR for #3256. Happy to rebase whichever lands second.
