### PR TITLE
fix(acp): release the turn when an agent never answers a cancelled prompt

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2800,6 +2800,84 @@ describe("ACPAgentSession", () => {
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
   });
 
+  test("a cancel the agent never answers releases the turn instead of wedging the session", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = createSession();
+      const events: AgentStreamEvent[] = [];
+      // An agent that ignores the spec and never settles the cancelled prompt.
+      const prompt = vi.fn(() => new Promise<PromptResponse>(() => {}));
+      const cancel = vi.fn(async () => {});
+
+      asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+      asInternals<ACPSessionInternals>(session).connection = { prompt, cancel } as never;
+      session.subscribe((event) => {
+        events.push(event);
+      });
+
+      const { turnId } = await session.startTurn("hello");
+      await session.interrupt();
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBe(turnId);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(events.find((event) => event.type === "turn_canceled")).toMatchObject({
+        type: "turn_canceled",
+        turnId,
+      });
+      expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+
+      // The session is usable again rather than stuck on "A foreground turn is already active".
+      await expect(session.startTurn("second")).resolves.toMatchObject({
+        turnId: expect.any(String),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("a settle that arrives after the cancel watchdog does not end the turn twice", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = createSession();
+      const events: AgentStreamEvent[] = [];
+      let resolvePrompt!: (value: PromptResponse) => void;
+      const prompt = vi.fn(
+        () =>
+          new Promise<PromptResponse>((resolve) => {
+            resolvePrompt = resolve;
+          }),
+      );
+      const cancel = vi.fn(async () => {});
+
+      asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+      asInternals<ACPSessionInternals>(session).connection = { prompt, cancel } as never;
+      session.subscribe((event) => {
+        events.push(event);
+      });
+
+      await session.startTurn("hello");
+      await session.interrupt();
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      resolvePrompt({ stopReason: "cancelled" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const terminal = events.filter(
+        (event) =>
+          event.type === "turn_completed" ||
+          event.type === "turn_failed" ||
+          event.type === "turn_canceled",
+      );
+      expect(terminal).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("startTurn emits the submitted user message even when ACP does not echo it", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2819,7 +2819,6 @@ describe("ACPAgentSession", () => {
       await session.interrupt();
 
       expect(cancel).toHaveBeenCalledOnce();
-      expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBe(turnId);
 
       await vi.advanceTimersByTimeAsync(30_000);
 
@@ -2827,12 +2826,88 @@ describe("ACPAgentSession", () => {
         type: "turn_canceled",
         turnId,
       });
-      expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
 
       // The session is usable again rather than stuck on "A foreground turn is already active".
       await expect(session.startTurn("second")).resolves.toMatchObject({
         turnId: expect.any(String),
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("a cancel request that never settles still releases the turn", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = createSession();
+      const events: AgentStreamEvent[] = [];
+      const prompt = vi.fn(() => new Promise<PromptResponse>(() => {}));
+      // The agent acknowledges nothing: session/cancel stays pending forever.
+      const cancel = vi.fn(() => new Promise<void>(() => {}));
+
+      asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+      asInternals<ACPSessionInternals>(session).connection = { prompt, cancel } as never;
+      session.subscribe((event) => {
+        events.push(event);
+      });
+
+      const { turnId } = await session.startTurn("hello");
+      void session.interrupt();
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(events.find((event) => event.type === "turn_canceled")).toMatchObject({
+        type: "turn_canceled",
+        turnId,
+      });
+      await expect(session.startTurn("second")).resolves.toMatchObject({
+        turnId: expect.any(String),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("a late response cannot attribute its usage to the turn that replaced it", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = createSession();
+      const events: AgentStreamEvent[] = [];
+      const settlers: Array<(value: PromptResponse) => void> = [];
+      const prompt = vi.fn(
+        () =>
+          new Promise<PromptResponse>((resolve) => {
+            settlers.push(resolve);
+          }),
+      );
+      const cancel = vi.fn(async () => {});
+
+      asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+      asInternals<ACPSessionInternals>(session).connection = { prompt, cancel } as never;
+      session.subscribe((event) => {
+        events.push(event);
+      });
+
+      await session.startTurn("first");
+      await session.interrupt();
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      const second = await session.startTurn("second");
+
+      // The abandoned first turn answers late, carrying its own token counts.
+      settlers[0]({ stopReason: "end_turn", usage: { inputTokens: 999, outputTokens: 999 } });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The replacement turn reports no usage of its own.
+      settlers[1]({ stopReason: "end_turn" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const completed = events.find(
+        (event) => event.type === "turn_completed" && event.turnId === second.turnId,
+      );
+      expect(completed).toMatchObject({ type: "turn_completed" });
+      expect((completed as { usage?: { inputTokens?: number } }).usage?.inputTokens).not.toBe(999);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -280,6 +280,14 @@ const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
 const ACP_PROBE_CLOSE_TIMEOUT_MS = 2_000;
 const ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS = 30_000;
 const ACP_IMPORT_HISTORY_BUDGET_MS = 60_000;
+/**
+ * How long to wait for an agent to answer the in-flight `session/prompt` after
+ * `session/cancel`. The spec requires that answer, and compliant agents send it
+ * within a couple of seconds even while unwinding a tool call, so this is set
+ * well beyond that: it exists to unstick a session that would otherwise stay
+ * broken forever, not to police slow agents.
+ */
+const ACP_CANCEL_SETTLE_TIMEOUT_MS = 30_000;
 
 function summarizeMalformedACPStdoutError(error: unknown): { type: string; message: string } {
   return {
@@ -1683,6 +1691,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
+  private cancelSettleTimer: ReturnType<typeof setTimeout> | null = null;
   private fallbackAssistantMessageId: string | null = null;
   private closed = false;
   private historyPending = false;
@@ -1867,6 +1876,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         return;
       })
       .catch((error) => {
+        if (this.activeForegroundTurnId !== turnId) {
+          return;
+        }
         const summary = summarizeACPRequestError(error);
         this.finishTurn({
           type: "turn_failed",
@@ -2403,8 +2415,44 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
     this.pendingPermissions.clear();
 
-    if (this.activeForegroundTurnId) {
+    const cancelledTurnId = this.activeForegroundTurnId;
+    if (cancelledTurnId) {
       await this.connection.cancel({ sessionId: this.sessionId });
+      this.armCancelSettleTimer(cancelledTurnId);
+    }
+  }
+
+  /**
+   * Ends the turn locally if the agent never answers the cancelled prompt.
+   * Without this the turn slot stays occupied forever and every later prompt
+   * fails with "A foreground turn is already active".
+   */
+  private armCancelSettleTimer(turnId: string): void {
+    this.clearCancelSettleTimer();
+    this.cancelSettleTimer = setTimeout(() => {
+      this.cancelSettleTimer = null;
+      if (this.activeForegroundTurnId !== turnId) {
+        return;
+      }
+      this.logger.warn(
+        { agentId: this.agentId, provider: this.provider, sessionId: this.sessionId, turnId },
+        "ACP agent did not answer the cancelled prompt; ending the turn locally",
+      );
+      this.synthesizeCanceledToolCalls();
+      this.finishTurn({
+        type: "turn_canceled",
+        provider: this.provider,
+        reason: "Interrupted",
+        turnId,
+      });
+    }, ACP_CANCEL_SETTLE_TIMEOUT_MS);
+    this.cancelSettleTimer.unref?.();
+  }
+
+  private clearCancelSettleTimer(): void {
+    if (this.cancelSettleTimer) {
+      clearTimeout(this.cancelSettleTimer);
+      this.cancelSettleTimer = null;
     }
   }
 
@@ -2452,6 +2500,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
 
     this.subscribers.clear();
+    this.clearCancelSettleTimer();
     this.connection = null;
     this.child = null;
     this.activeForegroundTurnId = null;
@@ -3076,6 +3125,12 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
     this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
 
+    if (this.activeForegroundTurnId !== turnId) {
+      // The turn already ended, most likely through the cancel watchdog above.
+      // Emitting a second terminal event for it would corrupt the timeline.
+      return;
+    }
+
     switch (response.stopReason) {
       case "cancelled":
         this.synthesizeCanceledToolCalls();
@@ -3168,6 +3223,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
   ): void {
     this.deliverTranslatedEvents(this.flushPendingUserMessage());
+    this.clearCancelSettleTimer();
     this.activeForegroundTurnId = null;
     this.fallbackAssistantMessageId = null;
     if (this.submittedUserMessageTurnId === event.turnId) {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2417,8 +2417,11 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     const cancelledTurnId = this.activeForegroundTurnId;
     if (cancelledTurnId) {
-      await this.connection.cancel({ sessionId: this.sessionId });
+      // Armed before the request, not after: an agent that leaves
+      // `session/cancel` itself pending would otherwise never reach this and
+      // the turn slot would stay occupied. Normal settlement clears the timer.
       this.armCancelSettleTimer(cancelledTurnId);
+      await this.connection.cancel({ sessionId: this.sessionId });
     }
   }
 
@@ -3123,13 +3126,14 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
-    this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
-
     if (this.activeForegroundTurnId !== turnId) {
       // The turn already ended, most likely through the cancel watchdog above.
-      // Emitting a second terminal event for it would corrupt the timeline.
+      // Returning before any state is touched keeps a late response from
+      // attributing the old turn's usage to the turn that replaced it.
       return;
     }
+
+    this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
 
     switch (response.stopReason) {
       case "cancelled":


### PR DESCRIPTION
Relates to #3256 (case A: cancel then retry leaves the agent stuck with an ACP active-turn rejection)

## Problem

After `session/cancel` the spec requires the agent to answer the in-flight `session/prompt`, and compliant agents do so within a couple of seconds. An agent that acknowledges the cancel but never answers leaves `activeForegroundTurnId` set forever, so every later prompt on that session throws:

```
A foreground turn is already active
```

The session is then unusable until it is recreated. `cancelAgentRunNow` force-cancels at the manager level after its 2 second wait, which updates the manager's own bookkeeping, but nothing clears the bridge's turn slot.

Observed in the daemon log, followed by four failed sends:

```
cancelAgentRun: acknowledged turn still active after timeout, force-canceling
handleStreamEvent: turn_failed | err=A foreground turn is already active
```

## Fix

- Arm a 30 second watchdog when cancelling. If the answer never arrives, end the turn locally so the session stays usable.
- Ignore a settle that arrives for an already-ended turn, on both the resolve and reject paths, so the watchdog cannot produce a second terminal event for the same turn.

The timeout is deliberately well past normal settle time, including agents unwinding a long tool call. It exists to unstick a session that would otherwise stay broken forever, not to police slow agents.

## QA evidence

Reproduced against a real third-party ACP agent (Google's Antigravity ACP server, `agy_acp_server` 1.1.1) by cancelling in three situations and measuring when `session/prompt` settled:

| Cancel during | Result |
| --- | --- |
| plain text generation | settles in 2.5s, session keeps working |
| a pending permission request | settles in 2.5s with `stopReason: cancelled` |
| a running shell command | never settles, still pending 35s after the cancel |

The third case is what wedges the session.

Unit tests, `packages/server/src/server/agent/providers/acp-agent.test.ts`:

```
main (untouched):        Tests  102 passed (102)
this branch:             Tests  104 passed (104)
```

Two tests added: one driving a prompt that never settles, asserting the turn is released after the watchdog and that a subsequent `startTurn` succeeds rather than throwing; one asserting a late settle produces no second terminal event.

Checks on this branch:

```
npx oxlint <changed files>      Found 0 warnings and 0 errors.
npx oxfmt --check <changed>     All matched files use the correct format.
npm run typecheck -w @getpaseo/server
                                5 errors, identical to untouched main
                                (speech/providers/openai, terminal/node-pty:
                                 missing optional modules in my environment),
                                0 in acp-agent.ts
```

Tested on macOS 26.4 arm64, Node 26. Not tested on Linux or Windows. This does not address the other cases tracked in #3256 (concurrent send/fan-out, persistence across restart).

## Note

This touches `handlePromptResponse`, which is also touched by my other PR for #1390. Happy to rebase whichever lands second.
