### PR TITLE
feat(plugin): open workspace panels beside native agent chat

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -272,6 +272,13 @@ never fetch active context through plugin RPC. Snapshot DTOs are deeply readonly
 runtime so plugin code cannot mutate normalized app state or a memoized selection. Panels use one persisted
 `plugin` workspace-tab target, so reload, disable, removal, and restoration resolve through the
 current installed-plugin catalog. A missing contribution renders unavailable inside the tab.
+`client.openPanelWithAgent?.(panelId, { workspaceId, agentId })` opens a workspace-context panel in
+main and the native agent chat in Paseo's right-side pane. It moves existing tabs, including a panel
+previously hosted in Explorer, rather than duplicating them. The native side pane and its saved
+width are reused. Compact/native layouts open only the chat. The method is optional on older
+clients; feature-detect it before calling. Both the workspace and an agent belonging to it must be
+in the rendering host's cached state, and the panel must support workspace hosting.
+
 Panels declare `locations: ["workspace", "explorer"]` to opt into Explorer hosting; omission means
 workspace only. Location controls hosting, not context. An agent panel target keeps its `agentId`
 when moved between hosts. Explorer configuration can create workspace-context panels and remove

--- a/packages/app/e2e/browser/plugin-panel-with-agent.spec.ts
+++ b/packages/app/e2e/browser/plugin-panel-with-agent.spec.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "../support/fixtures";
+import { buildAgentRoute } from "../support/helpers/mock-agent";
+import { connectNewWorkspaceDaemonClient } from "../support/helpers/new-workspace";
+import { seedWorkspace } from "../support/helpers/seed-client";
+import { pluginRequirements } from "../support/helpers/plugin-fixture";
+
+const PLUGIN_ID = "panel-with-agent-e2e";
+
+test("opens a plugin reader left of an existing native chat and keeps its draft", async ({
+  page,
+}) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "paseo-panel-with-agent-"));
+  const client = await connectNewWorkspaceDaemonClient({ ownProjects: false });
+  const previous = await client.getDaemonConfig();
+  const workspace = await seedWorkspace({ repoPrefix: "panel-with-agent-" });
+  let installed = false;
+  try {
+    const agent = await workspace.client.createAgent({
+      provider: "mock",
+      cwd: workspace.repoPath,
+      workspaceId: workspace.workspaceId,
+      title: "Native companion chat",
+      model: "ten-second-stream",
+      modeId: "load-test",
+    });
+    await writeFile(
+      path.join(directory, "paseo-plugin.json"),
+      JSON.stringify({ id: PLUGIN_ID, requirements: pluginRequirements }),
+    );
+    await writeFile(
+      path.join(directory, "index.client.tsx"),
+      `
+import React from "react";
+import { Pressable, Text, View } from "react-native";
+export default function contribute(client) {
+  const workspaceId = ${JSON.stringify(workspace.workspaceId)};
+  const agentId = ${JSON.stringify(agent.id)};
+  function Reader() {
+    return <View><Text>Companion reader content</Text>
+      <Pressable accessibilityRole="button" onPress={() => client.openPanelWithAgent("reader", { workspaceId, agentId })}><Text>Open companion chat</Text></Pressable>
+    </View>;
+  }
+  function Surface() {
+    return <View>
+      <Pressable accessibilityRole="button" onPress={() => client.openPanel("reader", { workspaceId, location: "explorer" })}><Text>Put reader in Explorer</Text></Pressable>
+    </View>;
+  }
+  client.addSurface("start", Surface);
+  client.addSidebarItem({ id: "start", title: "Companion test", icon: "BookOpen", surface: "start" });
+  client.addWorkspacePanel({ id: "reader", title: "Companion reader", icon: "BookOpen", context: "workspace", locations: ["workspace", "explorer"], Component: Reader });
+  return () => {};
+}`,
+    );
+    await client.patchDaemonConfig({ pluginsEnabled: true });
+    await client.installDirectoryPlugin(directory);
+    installed = true;
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await page.goto(buildAgentRoute(workspace.workspaceId, agent.id));
+    const composer = page.getByRole("textbox", { name: "Message agent..." });
+    await expect(composer).toBeVisible();
+    await composer.fill("Keep my existing draft");
+    await page.getByText("Companion test", { exact: true }).first().click();
+    await page.getByRole("button", { name: "Put reader in Explorer", exact: true }).click();
+    await expect(
+      page
+        .getByTestId("workspace-explorer-sidebar")
+        .getByText("Companion reader content", { exact: true }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Open companion chat", exact: true }).click();
+    const reader = page.getByText("Companion reader content", { exact: true });
+    await expect(reader).toBeVisible();
+    await expect(composer).toHaveValue("Keep my existing draft");
+    const readerBox = await reader.boundingBox();
+    const chatBox = await composer.boundingBox();
+    if (!readerBox || !chatBox) throw new Error("Reader or chat missing");
+    expect(readerBox.x + readerBox.width).toBeLessThanOrEqual(chatBox.x);
+    await page.getByRole("button", { name: "Open companion chat", exact: true }).click();
+    await expect(composer).toHaveValue("Keep my existing draft");
+    await expect(reader).toHaveCount(1);
+    await expect(
+      page.getByTestId(`workspace-tab-agent_${agent.id}`).filter({ visible: true }),
+    ).toHaveCount(1);
+    await expect(page.getByTestId("workspace-split-resize-handle")).toHaveCount(1);
+  } finally {
+    if (installed) await client.removePlugin(PLUGIN_ID);
+    await client.patchDaemonConfig({
+      pluginsEnabled: previous.config.pluginsEnabled ?? false,
+    });
+    await client.close();
+    await workspace.cleanup();
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/app/src/plugins/client-runtime.ts
+++ b/packages/app/src/plugins/client-runtime.ts
@@ -1,5 +1,12 @@
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
-import type { PluginClientOpenPanelOptions } from "@getpaseo/plugin/client";
+import type {
+  PluginClientOpenPanelOptions,
+  PluginClientOpenPanelWithAgentOptions,
+} from "@getpaseo/plugin/client";
+import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store";
+import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
+import { navigateToAgent } from "@/utils/navigate-to-agent";
+import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 import {
   createPluginAgentActionContext,
   createPluginCapabilities,
@@ -11,6 +18,11 @@ import { createPluginNavigation } from "./navigation";
 import { pluginButtonStore } from "./buttons";
 import { createPluginSurfaceRuntime } from "./surface-runtime";
 import type { InstalledPlugin } from "./types";
+import {
+  arrangePanelWithAgent,
+  canOpenPanelBesideAgent,
+  resolvePanelWithAgent,
+} from "./workspace-panels/open-with-agent";
 
 export function createPluginClientRuntime(
   installation: InstalledPlugin,
@@ -35,7 +47,43 @@ export function createPluginClientRuntime(
     openPanel(panelId, options) {
       openClientPanel({ installation, runtime, state, panelId, options });
     },
+    openPanelWithAgent(panelId, options) {
+      openClientPanelWithAgent({ installation, state, panelId, options });
+    },
   };
+}
+
+function openClientPanelWithAgent(input: {
+  installation: InstalledPlugin;
+  state: ReturnType<typeof createPluginClientStateSource>;
+  panelId: string;
+  options: PluginClientOpenPanelWithAgentOptions;
+}): void {
+  const { installation, state } = input;
+  const { workspaceId, panel, agent } = resolvePanelWithAgent({
+    plugin: installation,
+    state,
+    panelId: input.panelId,
+    workspaceId: input.options.workspaceId,
+    agentId: input.options.agentId,
+  });
+  const serverId = installation.serverId;
+  const workspaceKey = buildWorkspaceTabPersistenceKey({ serverId, workspaceId });
+  if (
+    !workspaceKey ||
+    !canOpenPanelBesideAgent() ||
+    !useWorkspaceLayoutStore.persist.hasHydrated()
+  ) {
+    navigateToAgent({ serverId, agentId: agent.agentId, workspaceId });
+    return;
+  }
+  const agentPaneId = arrangePanelWithAgent({ workspaceKey, panel, agent });
+  navigateToWorkspace({
+    serverId,
+    workspaceId,
+    target: agent,
+    placement: agentPaneId ? { mode: "pane", paneId: agentPaneId } : undefined,
+  });
 }
 
 function openClientPanel(input: {

--- a/packages/app/src/plugins/evaluate.ts
+++ b/packages/app/src/plugins/evaluate.ts
@@ -76,6 +76,7 @@ export type PluginClientRuntime = Pick<
   | "openSettings"
   | "openSurface"
   | "openPanel"
+  | "openPanelWithAgent"
   | "addComposerPill"
   | "addHeaderButton"
 >;

--- a/packages/app/src/plugins/workspace-panels/open-with-agent.test.ts
+++ b/packages/app/src/plugins/workspace-panels/open-with-agent.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(async () => null),
+    setItem: vi.fn(async () => undefined),
+    removeItem: vi.fn(async () => undefined),
+  },
+}));
+
+import { QueryClient } from "@tanstack/react-query";
+import type { PluginAgentSnapshot, PluginWorkspaceSnapshot } from "@getpaseo/plugin";
+import {
+  collectAllPanes,
+  collectAllTabs,
+  useWorkspaceLayoutStore,
+  type WorkspaceTabPlacement,
+} from "@/stores/workspace-layout-store";
+import type { WorkspaceTabTarget } from "@/workspace-tabs/model";
+import type { InstalledPlugin } from "../types";
+import { arrangePanelWithAgent, resolvePanelWithAgent } from "./open-with-agent";
+
+const KEY = "server-1:workspace-1";
+const panel = {
+  kind: "plugin",
+  pluginId: "reader",
+  panelId: "view",
+  context: "workspace",
+} as const;
+const agent = { kind: "agent", agentId: "agent-1" } as const;
+
+beforeEach(() => {
+  useWorkspaceLayoutStore.setState({
+    layoutByWorkspace: {},
+    explorerSidebarPaneIdByWorkspace: {},
+    sidePaneIdByWorkspace: {},
+    splitSizesByWorkspace: {},
+  });
+});
+
+function layout() {
+  const current = useWorkspaceLayoutStore.getState().layoutByWorkspace[KEY];
+  if (!current) throw new Error("Workspace layout was not created");
+  return current;
+}
+const panes = () => collectAllPanes(layout().root);
+const paneWithTab = (tabId: string) => panes().find((pane) => pane.tabIds.includes(tabId));
+const tabs = (kind: WorkspaceTabTarget["kind"]) =>
+  collectAllTabs(layout().root).filter((tab) => tab.target.kind === kind);
+const sidePaneId = () => useWorkspaceLayoutStore.getState().sidePaneIdByWorkspace[KEY] ?? null;
+const explorerPaneId = () =>
+  useWorkspaceLayoutStore.getState().explorerSidebarPaneIdByWorkspace[KEY] ?? null;
+
+function open(target: WorkspaceTabTarget, placement?: WorkspaceTabPlacement): string {
+  const tabId = useWorkspaceLayoutStore
+    .getState()
+    .openTab({ workspaceKey: KEY, target, intent: "reveal", placement });
+  if (!tabId) throw new Error("Tab did not open");
+  return tabId;
+}
+
+function arrange() {
+  return arrangePanelWithAgent({ workspaceKey: KEY, panel, agent });
+}
+
+/** The reader sits in a main pane with focus, and the only chat tab sits in the right-hand side pane. */
+function expectReaderLeftChatRight() {
+  const [reader] = tabs("plugin");
+  const [chat] = tabs("agent");
+  expect(tabs("plugin")).toHaveLength(1);
+  expect(tabs("agent")).toHaveLength(1);
+  const side = sidePaneId();
+  const readerPane = paneWithTab(reader.tabId);
+  expect(readerPane?.id).not.toBe(side);
+  expect(readerPane?.id).not.toBe(explorerPaneId());
+  expect(readerPane?.focusedTabId).toBe(reader.tabId);
+  expect(paneWithTab(chat.tabId)?.id).toBe(side);
+  expect(paneWithTab(chat.tabId)?.focusedTabId).toBe(chat.tabId);
+  const root = layout().root;
+  expect(root.kind).toBe("group");
+  if (root.kind !== "group") return { reader, chat };
+  expect(root.group.direction).toBe("horizontal");
+  const right = root.group.children.at(-1);
+  expect(right?.kind === "pane" ? right.pane.id : null).toBe(side);
+  return { reader, chat };
+}
+
+describe("arrangePanelWithAgent", () => {
+  it("opens the panel in the main pane and the chat in a new side pane on the right", () => {
+    const agentPaneId = arrange();
+    expect(agentPaneId).toBe(sidePaneId());
+    expectReaderLeftChatRight();
+  });
+
+  it("moves a reader docked in Explorer back to main and moves the existing chat tab beside it", () => {
+    const chatTabId = open(agent);
+    const explorer = useWorkspaceLayoutStore.getState().showExplorerSidebar(KEY);
+    expect(explorer).toBeTruthy();
+    const readerTabId = open(panel, { mode: "pane", paneId: explorer as string });
+    expect(paneWithTab(readerTabId)?.id).toBe(explorer);
+
+    arrange();
+
+    const { reader, chat } = expectReaderLeftChatRight();
+    expect(reader.tabId).toBe(readerTabId);
+    expect(chat.tabId).toBe(chatTabId);
+  });
+
+  it("keeps the reader focused in main when the focused chat moves out of that pane", () => {
+    const readerTabId = open(panel);
+    const chatTabId = open(agent);
+    expect(paneWithTab(readerTabId)?.focusedTabId).toBe(chatTabId);
+
+    arrange();
+
+    const { reader, chat } = expectReaderLeftChatRight();
+    expect(reader.tabId).toBe(readerTabId);
+    expect(chat.tabId).toBe(chatTabId);
+  });
+
+  it("swaps a reader in the side pane with a chat in main without duplicating either tab", () => {
+    const chatTabId = open(agent);
+    const side = useWorkspaceLayoutStore.getState().ensureSidePane(KEY);
+    const readerTabId = open(panel, { mode: "pane", paneId: side as string });
+    expect(paneWithTab(readerTabId)?.id).toBe(side);
+
+    arrange();
+
+    const { reader, chat } = expectReaderLeftChatRight();
+    expect(reader.tabId).toBe(readerTabId);
+    expect(chat.tabId).toBe(chatTabId);
+  });
+
+  it("reuses an existing right side pane that already holds the chat", () => {
+    open(panel);
+    const side = useWorkspaceLayoutStore.getState().ensureSidePane(KEY);
+    open(agent, { mode: "pane", paneId: side as string });
+    const paneIds = panes().map((pane) => pane.id);
+
+    expect(arrange()).toBe(side);
+
+    expect(panes().map((pane) => pane.id)).toEqual(paneIds);
+    expectReaderLeftChatRight();
+  });
+
+  it("is stable across repeated opens", () => {
+    arrange();
+    const first = { panes: panes().map((pane) => [pane.id, [...pane.tabIds]]), side: sidePaneId() };
+    arrange();
+    arrange();
+    expect({
+      panes: panes().map((pane) => [pane.id, [...pane.tabIds]]),
+      side: sidePaneId(),
+    }).toEqual(first);
+    expectReaderLeftChatRight();
+  });
+});
+
+const workspace: PluginWorkspaceSnapshot = {
+  id: "workspace-1",
+  projectId: "project-1",
+  projectDisplayName: "Paseo",
+  projectRootPath: "/repo/paseo",
+  directory: "/repo/paseo",
+  projectKind: "git",
+  kind: "local_checkout",
+  name: "main",
+  title: null,
+  status: "running",
+  statusEnteredAt: null,
+  archivingAt: null,
+  diffStat: null,
+};
+
+function agentSnapshot(id: string, workspaceId: string): PluginAgentSnapshot {
+  return {
+    id,
+    workspaceId,
+    provider: "claude",
+    status: "idle",
+    createdAt: "2026-09-11T10:00:00.000Z",
+    updatedAt: "2026-09-11T10:00:00.000Z",
+    lastActivityAt: "2026-09-11T10:00:00.000Z",
+    title: "Chat",
+    cwd: workspace.directory,
+    model: null,
+    currentModeId: null,
+    thinkingOptionId: null,
+    requiresAttention: false,
+    attentionReason: null,
+    parentAgentId: null,
+    labels: {},
+  };
+}
+
+function installed(): InstalledPlugin {
+  const Component = () => null;
+  return {
+    id: "reader",
+    serverId: "server-1",
+    clientBundle: "bundle",
+    lifetime: new AbortController(),
+    queryClient: new QueryClient(),
+    cleanup: () => {},
+    surfaces: [],
+    settingsScreens: [],
+    sidebarItems: [],
+    workspacePanels: [
+      {
+        id: "view",
+        title: "View",
+        icon: "Scan",
+        context: "workspace",
+        locations: ["workspace", "explorer"],
+        Component,
+      },
+      {
+        id: "agent-view",
+        title: "Agent",
+        icon: "Scan",
+        context: "agent",
+        locations: ["workspace"],
+        Component,
+      },
+      {
+        id: "dock-only",
+        title: "Dock",
+        icon: "Scan",
+        context: "workspace",
+        locations: ["explorer"],
+        Component,
+      },
+    ],
+    commandCenterItems: [],
+    clientSlashCommands: [],
+    attachmentSources: [],
+    themes: [],
+    timelineTransformers: [],
+    timelineRenderers: [],
+  };
+}
+
+const state = {
+  subscribe: () => () => {},
+  getWorkspace: (id: string) => (id === workspace.id ? workspace : null),
+  getAgent: (id: string) => {
+    if (id === "agent-1") return agentSnapshot(id, workspace.id);
+    if (id === "elsewhere") return agentSnapshot(id, "workspace-2");
+    return null;
+  },
+};
+
+describe("resolvePanelWithAgent", () => {
+  const request = {
+    plugin: installed(),
+    state,
+    panelId: "view",
+    workspaceId: "workspace-1",
+    agentId: "agent-1",
+  };
+
+  it("returns the workspace panel and agent targets", () => {
+    expect(resolvePanelWithAgent({ ...request, panelId: " view ", agentId: " agent-1 " })).toEqual({
+      workspaceId: "workspace-1",
+      panel: { kind: "plugin", pluginId: "reader", panelId: "view", context: "workspace" },
+      agent: { kind: "agent", agentId: "agent-1" },
+    });
+  });
+
+  it("rejects panels that cannot be hosted in the main pane", () => {
+    for (const panelId of ["missing", "agent-view", "dock-only"]) {
+      expect(() => resolvePanelWithAgent({ ...request, panelId })).toThrow(
+        `Workspace panel is unavailable: ${panelId}`,
+      );
+    }
+  });
+
+  it("rejects agents outside the workspace and unknown workspaces", () => {
+    expect(() => resolvePanelWithAgent({ ...request, agentId: "elsewhere" })).toThrow(
+      "Agent is unavailable in this workspace",
+    );
+    expect(() => resolvePanelWithAgent({ ...request, agentId: "missing" })).toThrow(
+      "Agent is unavailable in this workspace",
+    );
+    expect(() => resolvePanelWithAgent({ ...request, workspaceId: "workspace-2" })).toThrow(
+      "Agent is unavailable in this workspace",
+    );
+  });
+});

--- a/packages/app/src/plugins/workspace-panels/open-with-agent.ts
+++ b/packages/app/src/plugins/workspace-panels/open-with-agent.ts
@@ -1,0 +1,93 @@
+import { UnistylesRuntime } from "react-native-unistyles";
+import type { PluginClientStateSource } from "@getpaseo/plugin/client/host";
+import { supportsDesktopPaneSplits } from "@/constants/layout";
+import {
+  collectAllPanes,
+  DEFAULT_PANE_ID,
+  resolveExplorerSidebarPaneId,
+  useWorkspaceLayoutStore,
+} from "@/stores/workspace-layout-store";
+import type { PluginWorkspaceTabTarget, WorkspaceTabTarget } from "@/workspace-tabs/model";
+import type { InstalledPlugin } from "../types";
+
+type AgentTabTarget = Extract<WorkspaceTabTarget, { kind: "agent" }>;
+type WorkspacePanelTarget = Extract<PluginWorkspaceTabTarget, { context: "workspace" }>;
+
+/** Validates a panel-with-agent request against the installation and the host's cached state. */
+export function resolvePanelWithAgent(input: {
+  plugin: InstalledPlugin;
+  state: PluginClientStateSource;
+  panelId: string;
+  workspaceId: string;
+  agentId: string;
+}): { workspaceId: string; panel: WorkspacePanelTarget; agent: AgentTabTarget } {
+  const panelId = input.panelId.trim();
+  const panel = input.plugin.workspacePanels.find((candidate) => candidate.id === panelId);
+  if (!panel || panel.context !== "workspace" || !panel.locations.includes("workspace")) {
+    throw new Error(`Workspace panel is unavailable: ${panelId}`);
+  }
+  const workspace = input.state.getWorkspace(input.workspaceId.trim());
+  const agent = input.state.getAgent(input.agentId.trim());
+  if (!workspace || !agent || agent.workspaceId !== workspace.id) {
+    throw new Error("Agent is unavailable in this workspace");
+  }
+  return {
+    workspaceId: workspace.id,
+    panel: { kind: "plugin", pluginId: input.plugin.id, panelId, context: "workspace" },
+    agent: { kind: "agent", agentId: agent.id },
+  };
+}
+
+/** Side panes need desktop pane splits and a wide layout; elsewhere only the chat opens. */
+export function canOpenPanelBesideAgent(): boolean {
+  const breakpoint = UnistylesRuntime.breakpoint;
+  return supportsDesktopPaneSplits() && breakpoint !== "xs" && breakpoint !== "sm";
+}
+
+function resolveMainPaneId(workspaceKey: string): string | null {
+  const state = useWorkspaceLayoutStore.getState();
+  const layout = state.layoutByWorkspace[workspaceKey];
+  if (!layout) return null;
+  const explorerPaneId = resolveExplorerSidebarPaneId(
+    layout,
+    state.explorerSidebarPaneIdByWorkspace[workspaceKey],
+  );
+  const sidePaneId = state.sidePaneIdByWorkspace[workspaceKey] ?? null;
+  const candidates = collectAllPanes(layout.root).filter(
+    (pane) => pane.hidden !== true && pane.id !== explorerPaneId && pane.id !== sidePaneId,
+  );
+  return (candidates.find((pane) => pane.id === DEFAULT_PANE_ID) ?? candidates[0])?.id ?? null;
+}
+
+/**
+ * Moves the panel into the main pane, then the agent tab into the side pane on its right. The panel
+ * moves first because taking the last tab out of the side pane removes that pane. Existing tabs move
+ * rather than duplicate, so the chat keeps its tab and agent-keyed draft. Returns the agent's pane.
+ */
+export function arrangePanelWithAgent(input: {
+  workspaceKey: string;
+  panel: WorkspacePanelTarget;
+  agent: AgentTabTarget;
+}): string | null {
+  const store = useWorkspaceLayoutStore.getState();
+  const mainPaneId = resolveMainPaneId(input.workspaceKey);
+  const panelTabId = store.openTab({
+    workspaceKey: input.workspaceKey,
+    target: input.panel,
+    intent: "reveal",
+    placement: mainPaneId ? { mode: "pane", paneId: mainPaneId } : undefined,
+  });
+  const sidePaneId = useWorkspaceLayoutStore.getState().ensureSidePane(input.workspaceKey);
+  const layout = useWorkspaceLayoutStore.getState().layoutByWorkspace[input.workspaceKey];
+  const panelPaneId = layout
+    ? collectAllPanes(layout.root).find((pane) => pane.focusedTabId === panelTabId)?.id
+    : undefined;
+  const agentPaneId = sidePaneId && sidePaneId !== panelPaneId ? sidePaneId : null;
+  useWorkspaceLayoutStore.getState().openTab({
+    workspaceKey: input.workspaceKey,
+    target: input.agent,
+    intent: "reveal",
+    placement: agentPaneId ? { mode: "pane", paneId: agentPaneId } : undefined,
+  });
+  return agentPaneId;
+}

--- a/packages/plugin/src/client/contracts.ts
+++ b/packages/plugin/src/client/contracts.ts
@@ -75,6 +75,11 @@ export interface PluginClientOpenPanelOptions extends PluginOpenPanelOptions {
   agentId?: string;
 }
 
+export interface PluginClientOpenPanelWithAgentOptions {
+  workspaceId: string;
+  agentId: string;
+}
+
 export interface PluginClientContext extends PluginCommandCapabilities {
   addSettingsScreen(contribution: PluginSettingsScreenContribution): PluginCleanup;
   addSurface(id: string, Component: ComponentType<PluginSurfaceProps>): PluginCleanup;
@@ -93,6 +98,12 @@ export interface PluginClientContext extends PluginCommandCapabilities {
     contribution: PluginTimelineRendererContribution<Schema>,
   ): PluginCleanup;
   openPanel(id: string, options: PluginClientOpenPanelOptions): void;
+  /**
+   * Opens a workspace panel in the main pane with the agent's chat beside it on the right. Existing
+   * tabs move instead of duplicating. Compact and native layouts open only the chat. Undefined on
+   * older hosts; check before calling.
+   */
+  openPanelWithAgent?(id: string, options: PluginClientOpenPanelWithAgentOptions): void;
 }
 
 export type PluginClientContribution = (client: PluginClientContext) => PluginCleanup;

--- a/packages/plugin/src/client/index.ts
+++ b/packages/plugin/src/client/index.ts
@@ -7,6 +7,7 @@ export type {
   PluginWorkspacePanelProps,
   PluginAgentPanelProps,
   PluginClientOpenPanelOptions,
+  PluginClientOpenPanelWithAgentOptions,
   PluginClientContext,
   PluginClientContribution,
   PluginWorkspacePanelContribution,

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -1162,6 +1162,26 @@ Read cached state with `useWorkspace(workspaceId, selector)` and `useAgent(agent
 
 Both hooks return `null` when the record is unavailable. Otherwise they run synchronously against normalized client state. Snapshot DTOs and their nested values are deeply readonly and frozen at runtime. Do not call plugin RPC to discover the current workspace or agent. Fetch optional or vendor-specific enrichment after the component renders.
 
+### Open a panel beside native chat
+
+For a panel registered with `context: "workspace"` and workspace hosting, call:
+
+```ts
+if (client.openPanelWithAgent) {
+  client.openPanelWithAgent("reader", { workspaceId, agentId });
+}
+```
+
+This places the panel in the main pane and the agent's native chat in the right-side pane. Existing
+tabs are moved and reused, including a panel previously opened in Explorer; repeated calls do not
+create duplicate tabs. Paseo reuses its native side pane and any user-adjusted width. On compact or
+native layouts, it opens only the chat. The optional method is absent on older clients, so check
+for it before calling and provide your existing navigation fallback.
+
+The workspace and agent must already be available in the rendering host's cached state, the agent
+must belong to that workspace, and the panel must support workspace hosting. Invalid requests
+throw before changing the layout. Agent-context and Explorer-only panels are not accepted.
+
 Workspace snapshot fields:
 
 | Field                | Type                                                              |


### PR DESCRIPTION
Plugins can now open a workspace reader in the main pane with native agent chat in the right-side pane through the optional `client.openPanelWithAgent` capability. Existing reader and agent tabs are moved and reused, including readers previously docked in Explorer, so repeated opens retain chat drafts and do not create duplicate panes. Compact/native layouts open the chat normally; older clients can be detected before calling the API.

Validation: app and plugin SDK typechecks; changed-source lint; 43 unit tests; a committed browser test covering an existing reader in Explorer and a chat draft; and a separate local Code Mirror integration test covering left/right geometry, retained selection/question, native resizing, repeated opens, and sending from the native composer. Both browser tests passed. Native devices were not exercised.
