### PR TITLE
fix(app): avoid raw object composer errors

### DIFF
--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -58,6 +58,7 @@ import type { ImageAttachment, MessagePayload, TextReplacement } from "./types";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
 import { encodeImages } from "@/utils/encode-images";
+import { toErrorMessage } from "@/utils/error-messages";
 import { focusWithRetries } from "@/utils/web-focus";
 import {
   cancelComposerAgent,
@@ -1312,7 +1313,7 @@ function ComposerContentImpl({
       void onClientSlashCommand(command)
         .catch((error) => {
           console.error("[Composer] Failed to run client slash command:", error);
-          setSendError(error instanceof Error ? error.message : String(error));
+          setSendError(toErrorMessage(error));
         })
         .finally(() => {
           setIsProcessing(false);
@@ -1342,7 +1343,7 @@ function ComposerContentImpl({
         args: resolved.args,
         onError(error) {
           console.error("[Composer] Failed to run plugin client slash command:", error);
-          toastErrorRef.current(error instanceof Error ? error.message : String(error));
+          toastErrorRef.current(toErrorMessage(error));
         },
       });
       return true;

--- a/packages/app/src/utils/error-messages.test.ts
+++ b/packages/app/src/utils/error-messages.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { toErrorMessage } from "./error-messages";
+
+describe("toErrorMessage", () => {
+  it("keeps an Error message", () => {
+    expect(toErrorMessage(new Error("Connection lost"))).toBe("Connection lost");
+  });
+
+  it("uses a serialized error message", () => {
+    expect(toErrorMessage({ message: "Request cancelled" })).toBe("Request cancelled");
+  });
+
+  it("uses a serialized error fallback", () => {
+    expect(toErrorMessage({ error: "Request cancelled" })).toBe("Request cancelled");
+  });
+
+  it("does not expose an object string as an inline error", () => {
+    expect(toErrorMessage({ code: "REQUEST_CANCELLED" })).toBe("Unknown error");
+  });
+});

--- a/packages/app/src/utils/error-messages.ts
+++ b/packages/app/src/utils/error-messages.ts
@@ -1,6 +1,26 @@
+const FALLBACK_ERROR_MESSAGE = "Unknown error";
+
+function getStringProperty(error: object, key: "message" | "error"): string | null {
+  const value = Reflect.get(error, key);
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
 export function toErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
+  if (error instanceof Error && error.message.trim().length > 0) {
     return error.message;
   }
-  return String(error);
+
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+
+  if (typeof error === "object" && error !== null) {
+    return (
+      getStringProperty(error, "message") ??
+      getStringProperty(error, "error") ??
+      FALLBACK_ERROR_MESSAGE
+    );
+  }
+
+  return FALLBACK_ERROR_MESSAGE;
 }


### PR DESCRIPTION
## Summary
- Replace composer command error coercion with the shared error-message formatter.
- Preserve `Error.message` and serialized `{ message }` / `{ error }` rejections.
- Use `Unknown error` for unstructured values so the inline composer field never renders `[object Object]`.

## Scope
This is a UI-only, protocol-neutral correction. It does not change OpenCode cancellation, agent lifecycle, daemon responses, or Android transport behavior.

## Evidence
Two Android reports rendered `[object Object]` in the red composer error field: one after an OpenCode force-cancel/resume attempt and one while starting a fresh Muse session. The exact rejection source was not captured, so this PR fixes the confirmed presentation failure without asserting a provider-specific root cause.

## Validation
- `npx vitest run packages/app/src/utils/error-messages.test.ts --bail=1`
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run lint --workspace=@getpaseo/app`
- `npm run build:app-deps`
- `npm run build --workspace=@getpaseo/server`
- `npm run build --workspace=@getpaseo/cli`
- pre-commit format and lint gates

Android runtime verification is not executed locally because this isolated worktree intentionally does not attach to the user's active daemon, session, or ports. CI should provide the routed app checks.

Closes #4722