### PR TITLE
fix(server): attach directory workspaces in a linked worktree to the main repository project

### DIFF
--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
@@ -572,6 +572,68 @@ test("createWorkspaceForDirectory classifies unknown and archived explicit proje
   } satisfies Partial<WorkspaceProvisioningError>);
 });
 
+test("findOrCreateProjectForDirectory attaches a linked worktree to its main repository project", async () => {
+  const mainRepoRoot = path.join(tmpDir, "main-repo");
+  const worktree = path.join(tmpDir, "worktrees", "feature-a");
+  const linkedWorktreeProvisioning = createWorkspaceProvisioningService({
+    workspaceRegistry,
+    projectRegistry,
+    workspaceGitService: createNoopWorkspaceGitService({
+      peekSnapshot: () => null,
+      getCheckout: async (cwd: string) => ({
+        cwd,
+        isGit: true,
+        currentBranch: cwd === mainRepoRoot ? "main" : "feature/a",
+        remoteUrl: null,
+        worktreeRoot: cwd,
+        isPaseoOwnedWorktree: cwd !== mainRepoRoot,
+        mainRepoRoot: cwd === mainRepoRoot ? null : mainRepoRoot,
+      }),
+    }),
+  });
+
+  const mainProject =
+    await linkedWorktreeProvisioning.findOrCreateProjectForDirectory(mainRepoRoot);
+  const worktreeProject =
+    await linkedWorktreeProvisioning.findOrCreateProjectForDirectory(worktree);
+
+  expect(worktreeProject.projectId).toBe(mainProject.projectId);
+  expect(await projectRegistry.list()).toHaveLength(1);
+
+  const workspace = await linkedWorktreeProvisioning.findOrCreateWorkspaceForDirectory(worktree);
+  expect(workspace).toMatchObject({
+    projectId: mainProject.projectId,
+    cwd: worktree,
+    mainRepoRoot,
+  });
+});
+
+test("findOrCreateProjectForDirectory still creates a project for a worktree whose main repository is unregistered", async () => {
+  const mainRepoRoot = path.join(tmpDir, "main-repo");
+  const worktree = path.join(tmpDir, "worktrees", "feature-b");
+  const orphanWorktreeProvisioning = createWorkspaceProvisioningService({
+    workspaceRegistry,
+    projectRegistry,
+    workspaceGitService: createNoopWorkspaceGitService({
+      peekSnapshot: () => null,
+      getCheckout: async (cwd: string) => ({
+        cwd,
+        isGit: true,
+        currentBranch: "feature/b",
+        remoteUrl: null,
+        worktreeRoot: cwd,
+        isPaseoOwnedWorktree: true,
+        mainRepoRoot,
+      }),
+    }),
+  });
+
+  const project = await orphanWorktreeProvisioning.findOrCreateProjectForDirectory(worktree);
+
+  expect(project.rootPath).toBe(worktree);
+  expect(await projectRegistry.list()).toHaveLength(1);
+});
+
 test("findOrCreateProjectForDirectory keeps nested selected roots independent", async () => {
   const repo = path.join(tmpDir, "repo");
   gitRoots.add(repo);

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -175,6 +175,11 @@ export function createWorkspaceProvisioningService(deps: {
     const rootPath = resolve(cwd);
     const checkout = await workspaceGitService.getCheckout(rootPath);
     const timestamp = new Date().toISOString();
+    // A linked worktree belongs to the project that owns its main repository. Registering the
+    // worktree path as its own project root leaves a duplicate, worktree-named project in the
+    // sidebar (one per `--new-workspace local --cwd <worktree>` or `create_workspace {path}`).
+    const owningProject = await findActiveProjectOwningWorktree(rootPath, checkout.mainRepoRoot);
+    if (owningProject) return owningProject;
     return projectRegistry.getOrCreateActiveByRoot({
       rootPath,
       kind: checkout.isGit ? "git" : "non_git",
@@ -188,6 +193,22 @@ export function createWorkspaceProvisioningService(deps: {
       }),
       timestamp,
     });
+  }
+
+  async function findActiveProjectOwningWorktree(
+    rootPath: string,
+    mainRepoRoot: string | null,
+  ): Promise<PersistedProjectRecord | undefined> {
+    if (!mainRepoRoot || areEquivalentPaths(mainRepoRoot, rootPath)) return undefined;
+    return (await projectRegistry.list())
+      .filter(
+        (project) => !project.archivedAt && areEquivalentPaths(project.rootPath, mainRepoRoot),
+      )
+      .sort(
+        (left, right) =>
+          Date.parse(left.createdAt) - Date.parse(right.createdAt) ||
+          left.projectId.localeCompare(right.projectId),
+      )[0];
   }
 
   async function requireActiveProject(projectId: string): Promise<PersistedProjectRecord> {


### PR DESCRIPTION
## Problem
Creating a directory workspace whose path is a **linked git worktree** — `paseo run --new-workspace local --cwd <worktree>`, `paseo workspace create --isolation local --path <worktree>` without `--project`, or the MCP `create_workspace {path}` without `projectId` — registers the worktree path as a brand-new project. The sidebar then shows a duplicate project named after the worktree directory (`ddc-master`, `tearful-squid`, …), one per call; if the worktree was already deleted it becomes a `non_git` project. We hit 9 of these in one session-recovery run.

The daemon already knows better: the workspace record it writes carries `mainRepoRoot` and `isPaseoOwnedWorktree: true`. Only the project lookup ignored it.

## Fix
`findOrCreateProjectForDirectory` now first looks for an active project whose root is the checkout's `mainRepoRoot` (when the path is a linked worktree) and attaches the workspace to it. If no such project exists, or the path is not a linked worktree, behaviour is unchanged (`getOrCreateActiveByRoot` on the path as before). No options, no migration.

## Tests
- attaches a linked worktree to its main repository project (project count stays 1; workspace keeps `cwd`/`mainRepoRoot`)
- still creates a project for a worktree whose main repository is unregistered
- existing `workspace-provisioning` / `workspace-registry` / `workspace-recovery` suites: 80 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)