### PR TITLE
fix(cli): preserve permission ids in JSON output

### DIFF
--- a/packages/cli/src/commands/permit/ls.test.ts
+++ b/packages/cli/src/commands/permit/ls.test.ts
@@ -1,0 +1,46 @@
+import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
+import { describe, expect, it } from "vitest";
+import { render } from "../../output/index.js";
+import { runLsCommandWithDependencies, type PermitLsDependencies } from "./ls.js";
+
+describe("permit ls output", () => {
+  it("keeps the full request id in JSON while shortening the table column", async () => {
+    const requestId = "permission-request-1234567890";
+    const agent = {
+      id: "agent-1234567890",
+      pendingPermissions: [
+        {
+          id: requestId,
+          name: "Bash",
+          description: "Run a command",
+        },
+      ],
+    } as AgentSnapshotPayload;
+    const dependencies: PermitLsDependencies = {
+      connectToDaemon: async () => ({
+        fetchAgents: async () => ({
+          entries: [{ agent }],
+          nextCursor: undefined,
+        }),
+        close: async () => undefined,
+      }),
+    };
+
+    const result = await runLsCommandWithDependencies(
+      { daemonTarget: { kind: "endpoint", host: "example.test:12345" } },
+      dependencies,
+    );
+
+    expect(JSON.parse(render(result, { format: "json" }))).toEqual([
+      {
+        id: requestId,
+        agentId: "agent-1234567890",
+        agentShortId: "agent-1",
+        name: "Bash",
+        description: "Run a command",
+      },
+    ]);
+    expect(render(result, { format: "table", noColor: true })).toContain("permissi");
+    expect(render(result, { format: "table", noColor: true })).not.toContain(requestId);
+  });
+});

--- a/packages/cli/src/commands/permit/ls.ts
+++ b/packages/cli/src/commands/permit/ls.ts
@@ -18,7 +18,7 @@ export const permitLsSchema: OutputSchema<PermissionListItem> = {
   idField: "id",
   columns: [
     { header: "AGENT", field: "agentShortId", width: 12 },
-    { header: "REQ_ID", field: "id", width: 12 },
+    { header: "REQ_ID", field: (item) => item.id.slice(0, 8), width: 12 },
     { header: "TOOL", field: "name", width: 20 },
     { header: "DESCRIPTION", field: "description", width: 50 },
   ],
@@ -30,7 +30,7 @@ function toListItem(
   permission: AgentPermissionRequest,
 ): PermissionListItem {
   return {
-    id: permission.id.slice(0, 8),
+    id: permission.id,
     agentId: agent.id,
     agentShortId: agent.id.slice(0, 7),
     name: permission.name,
@@ -44,11 +44,24 @@ export interface PermitLsOptions extends CommandOptions {
   host?: string;
 }
 
+type PermitLsClient = Pick<Awaited<ReturnType<typeof connectToDaemon>>, "fetchAgents" | "close">;
+
+export interface PermitLsDependencies {
+  connectToDaemon: (options: { target: CommandOptions["daemonTarget"] }) => Promise<PermitLsClient>;
+}
+
 export async function runLsCommand(
   options: PermitLsOptions,
   _command: Command,
 ): Promise<PermitLsResult> {
-  const client = await connectToDaemon({ target: options.daemonTarget });
+  return runLsCommandWithDependencies(options, { connectToDaemon });
+}
+
+export async function runLsCommandWithDependencies(
+  options: PermitLsOptions,
+  dependencies: PermitLsDependencies,
+): Promise<PermitLsResult> {
+  const client = await dependencies.connectToDaemon({ target: options.daemonTarget });
 
   try {
     const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });


### PR DESCRIPTION
### Linked issue

Closes #4732

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

`paseo permit ls --json` shortened permission request IDs to the same eight-character display value used by the table. Scripts could not feed that truncated value back to `paseo permit allow`. The result model now retains the complete ID; shortening occurs only while rendering the human table.

### Goals

- Emit the complete permission request ID from `paseo permit ls --json`.
- Preserve the existing short ID in table output.
- Cover both JSON and table rendering contracts with a regression test.

### Non-goals

- Do not change the human-readable table format.
- Do not change permission policy or the permit allow/deny behavior.

### QA

Regression coverage, which fails on the broken version because JSON receives `permissi` instead of the complete request ID:

```text
$ npx vitest run packages/cli/src/commands/permit/ls.test.ts --bail=1
Test Files  1 passed (1)
Tests       1 passed (1)
Duration    3.90s
```

End-to-end QA on macOS used the rebuilt CLI and an isolated daemon at `127.0.0.1:62559` under `/private/tmp/paseo-qa-4740.R1WTVc`; relay was disabled and the daemon was stopped after the run. A real imported Claude session in the default permission mode made one controlled Write request, producing a pending request.

```text
$ node packages/cli/dist/index.js permit ls --json --home /private/tmp/paseo-qa-4740.R1WTVc
[
  {
    "id": "permission-2e30a51d-29cc-47f9-845c-605158b42b6c",
    "agentId": "2f8e79ec-4e5a-4602-9a1f-020a92d96bde",
    "agentShortId": "2f8e79e",
    "name": "Write",
    "description": "-"
  }
]

$ node packages/cli/dist/index.js permit allow 2f8e79ec-4e5a-4602-9a1f-020a92d96bde permission-2e30a51d-29cc-47f9-845c-605158b42b6c --json --home /private/tmp/paseo-qa-4740.R1WTVc
[{"requestId":"permissi","agentId":"2f8e79ec-4e5a-4602-9a1f-020a92d96bde","name":"Write","result":"allowed"}]

$ node packages/cli/dist/index.js permit ls --json --home /private/tmp/paseo-qa-4740.R1WTVc
[]

$ sed -n '1p' /private/tmp/paseo-permit-json-qa-4740.txt
hello
```

The permit allow response retains its existing short display field; the full request ID from `permit ls --json` was accepted and completed the pending Write request.

Repository checks after rebuilding generated cross-package declarations:

```text
$ npm run typecheck
[all workspaces exit 0]

$ npm run lint
Found 0 warnings and 0 errors.
Finished in 707ms on 4220 files with 177 rules using 14 threads.

$ npm run format
Finished in 977ms on 4502 files using 14 threads.
```

| Platform | Tested | Notes |
| --- | --- | --- |
| macOS | Yes | Node 22.23.1; real CLI and isolated daemon permission request/allow workflow. |
| Windows | No | CLI rendering and request IDs are platform-independent. |
| Linux | No | CLI rendering and request IDs are platform-independent. |

### Checklist

- [ ] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (not applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
