### PR TITLE
fix(relay): publish resolvable runtime exports

### DIFF
--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -12,20 +12,20 @@
     ".": {
       "types": "./dist/index.d.ts",
       "node": "./dist/index.js",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./e2ee": {
       "types": "./dist/e2ee.d.ts",
       "node": "./dist/e2ee.js",
-      "import": "./src/e2ee.ts",
-      "default": "./src/e2ee.ts"
+      "import": "./dist/e2ee.js",
+      "default": "./dist/e2ee.js"
     },
     "./cloudflare": {
       "types": "./dist/cloudflare-adapter.d.ts",
       "node": "./dist/cloudflare-adapter.js",
-      "import": "./src/cloudflare-adapter.ts",
-      "default": "./src/cloudflare-adapter.ts"
+      "import": "./dist/cloudflare-adapter.js",
+      "default": "./dist/cloudflare-adapter.js"
     }
   },
   "publishConfig": {

--- a/packages/relay/src/package-exports.test.ts
+++ b/packages/relay/src/package-exports.test.ts
@@ -1,0 +1,60 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+interface PackageManifest {
+  exports: Record<string, Record<string, string>>;
+}
+
+interface PackResult {
+  files: Array<{ path: string }>;
+}
+
+function runtimeExportTargets(manifest: PackageManifest): string[] {
+  const targets: string[] = [];
+  for (const conditions of Object.values(manifest.exports)) {
+    for (const condition of ["node", "import", "default"]) {
+      const target = conditions[condition];
+      if (target) targets.push(target);
+    }
+  }
+  return targets;
+}
+
+describe("published package exports", () => {
+  it("includes every runtime export target in the npm package", async () => {
+    const npmCli = process.env.npm_execpath;
+    if (!npmCli) throw new Error("npm_execpath is required to inspect the package artifact");
+
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), "paseo-relay-pack-"));
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [npmCli, "pack", "--dry-run", "--json", "--silent"],
+        {
+          cwd: packageRoot,
+          env: { ...process.env, npm_config_cache: join(temporaryDirectory, "npm-cache") },
+        },
+      );
+      const [packResult] = JSON.parse(stdout) as PackResult[];
+      const packedFiles = new Set(packResult.files.map((file) => file.path));
+      const manifest = JSON.parse(
+        await readFile(join(packageRoot, "package.json"), "utf8"),
+      ) as PackageManifest;
+      const missingTargets = runtimeExportTargets(manifest)
+        .map((target) => target.replace(/^\.\//, ""))
+        .filter((target) => !packedFiles.has(target));
+
+      expect(missingTargets).toEqual([]);
+    } finally {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
### Linked issue

Closes #4730

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The package export map directed ESM/bundler consumers to TypeScript source files that are excluded from the published artifact. Importing `@getpaseo/relay/e2ee` from an installed package therefore failed even though the Node condition pointed at compiled output. Every runtime condition now resolves to its matching published `dist/` module.

### Goals

- Make the root, `./e2ee`, and `./cloudflare` runtime exports resolvable from the packed package.
- Preserve the existing type declaration and Node export targets.
- Cover the published-artifact contract with a regression test.

### Non-goals

- Do not change the relay runtime API or its TypeScript declaration targets.
- Do not change package contents beyond making existing runtime export conditions point at compiled files.

### QA

Regression coverage, which fails against the broken export map because its runtime targets are absent from `npm pack --dry-run`:

```text
$ npx vitest run packages/relay/src/package-exports.test.ts --bail=1
Test Files  1 passed (1)
Tests       1 passed (1)
Duration    1.19s
```

Packed-package QA on macOS: `npm pack ./packages/relay --pack-destination /private/tmp/paseo-qa-4741.OifcCi --json --silent` produced `getpaseo-relay-0.8.0.tgz` with 17 files, including `dist/e2ee.js`. I installed that tarball into an isolated consumer and bundled this entry with the repository's esbuild:

```js
import { generateKeyPair } from "@getpaseo/relay/e2ee";

console.log(generateKeyPair);
```

```text
$ node_modules/.bin/esbuild /private/tmp/paseo-qa-4741.OifcCi/consumer/index.js --bundle --platform=browser --external:base64-js --external:tweetnacl --external:ws --outfile=/private/tmp/paseo-qa-4741.OifcCi/consumer/bundle.js
../../../../private/tmp/paseo-qa-4741.OifcCi/consumer/bundle.js  3.0kb
Done in 8ms

$ rg -n "generateKeyPair" /private/tmp/paseo-qa-4741.OifcCi/consumer/bundle.js
62:  function generateKeyPair() {
72:  console.log(generateKeyPair);
```

Repository checks after merging current `upstream/main`:

```text
$ npm run typecheck
[all workspaces exit 0]

$ npm run lint
Found 0 warnings and 0 errors.
Finished in 651ms on 4220 files with 177 rules using 14 threads.

$ npm run format
Finished in 920ms on 4502 files using 14 threads.
```

| Platform | Tested | Notes |
| --- | --- | --- |
| macOS | Yes | Node 22.23.1; packed tarball installed in an isolated consumer and bundled with esbuild. |
| Windows | No | The export map and package artifact contract are platform-independent. |
| Linux | No | The export map and package artifact contract are platform-independent. |

### Checklist

- [ ] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (not applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
