### PR TITLE
feat: add commit-and-create-pr git action

### DIFF
--- a/packages/app/src/git/actions-store.ts
+++ b/packages/app/src/git/actions-store.ts
@@ -16,6 +16,7 @@ export type CheckoutGitAsyncActionId =
   | "pull-and-push"
   | "refresh"
   | "create-pr"
+  | "commit-and-create-pr"
   | "merge-pr-squash"
   | "merge-pr-merge"
   | "merge-pr-rebase"
@@ -108,6 +109,7 @@ interface CheckoutGitActionsStoreState {
   pullAndPush: (params: { serverId: string; cwd: string }) => Promise<void>;
   refresh: (params: { serverId: string; cwd: string }) => Promise<void>;
   createPr: (params: { serverId: string; cwd: string }) => Promise<void>;
+  commitAndCreatePr: (params: { serverId: string; cwd: string }) => Promise<void>;
   mergePr: (params: {
     serverId: string;
     cwd: string;
@@ -271,6 +273,25 @@ export const useCheckoutGitActionsStore = create<CheckoutGitActionsStoreState>()
         const payload = await client.checkoutPrCreate(cwd, {});
         if (payload.error) {
           throw new Error(payload.error.message);
+        }
+      },
+    });
+  },
+
+  commitAndCreatePr: async ({ serverId, cwd }) => {
+    await runCheckoutAction({
+      serverId,
+      cwd,
+      actionId: "commit-and-create-pr",
+      run: async () => {
+        const client = resolveClient(serverId);
+        const commitPayload = await client.checkoutCommit(cwd, { addAll: true });
+        if (commitPayload.error) {
+          throw new Error(commitPayload.error.message);
+        }
+        const prPayload = await client.checkoutPrCreate(cwd, {});
+        if (prPayload.error) {
+          throw new Error(prPayload.error.message);
         }
       },
     });

--- a/packages/app/src/git/policy.test.ts
+++ b/packages/app/src/git/policy.test.ts
@@ -107,6 +107,11 @@ function createInput(
         status: "idle",
         handler: () => undefined,
       },
+      "commit-and-create-pr": {
+        disabled: false,
+        status: "idle",
+        handler: () => undefined,
+      },
       "merge-pr-squash": {
         disabled: false,
         status: "idle",
@@ -313,6 +318,58 @@ describe("git-actions-policy", () => {
     expect(
       actions.secondary.some((action) => action.id === "pr" && action.label === "View PR"),
     ).toBe(true);
+  });
+
+  it("offers commit-and-create-pr only while dirty and before a PR exists", () => {
+    const dirty = createInput({
+      hasRemote: true,
+      isOnBaseBranch: false,
+      aheadCount: 1,
+      hasUncommittedChanges: true,
+    });
+
+    expect(buildGitActions(dirty).secondary.map((action) => action.id)).toContain(
+      "commit-and-create-pr",
+    );
+    expect(
+      buildGitActions({ ...dirty, hasUncommittedChanges: false }).secondary.map(
+        (action) => action.id,
+      ),
+    ).not.toContain("commit-and-create-pr");
+    expect(
+      buildGitActions({
+        ...dirty,
+        hasPullRequest: true,
+        pullRequestUrl: "https://example.com/pr/789",
+        pullRequestState: "open",
+      }).secondary.map((action) => action.id),
+    ).not.toContain("commit-and-create-pr");
+    expect(
+      buildGitActions({ ...dirty, githubFeaturesEnabled: false }).secondary.map(
+        (action) => action.id,
+      ),
+    ).not.toContain("commit-and-create-pr");
+  });
+
+  it("keeps commit-and-create-pr visible while its own run is still pending, even after the commit clears hasUncommittedChanges", () => {
+    const pending = createInput({
+      hasRemote: true,
+      isOnBaseBranch: false,
+      aheadCount: 1,
+      hasUncommittedChanges: false,
+      runtime: {
+        ...createInput().runtime,
+        "commit-and-create-pr": {
+          disabled: false,
+          status: "pending",
+          handler: () => undefined,
+        },
+      },
+    });
+
+    expect(buildGitActions(pending).secondary.map((action) => action.id)).toContain(
+      "commit-and-create-pr",
+    );
   });
 
   it("enables pull-and-push when the branch has both incoming and outgoing commits", () => {

--- a/packages/app/src/git/policy.ts
+++ b/packages/app/src/git/policy.ts
@@ -12,6 +12,7 @@ export type GitActionId =
   | "push"
   | "pull-and-push"
   | "pr"
+  | "commit-and-create-pr"
   | "merge-pr-squash"
   | "merge-pr-merge"
   | "merge-pr-rebase"
@@ -252,6 +253,18 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
     allActions.set(model.id, model.build(input));
   }
 
+  allActions.set("commit-and-create-pr", {
+    id: "commit-and-create-pr",
+    label: i18n.t("workspace.git.actions.commitAndCreatePr.label"),
+    pendingLabel: i18n.t("workspace.git.actions.commitAndCreatePr.pending"),
+    successLabel: i18n.t("workspace.git.actions.commitAndCreatePr.success"),
+    disabled: input.runtime["commit-and-create-pr"].disabled,
+    status: input.runtime["commit-and-create-pr"].status,
+    icon: input.runtime["commit-and-create-pr"].icon,
+    startsGroup: false,
+    handler: input.runtime["commit-and-create-pr"].handler,
+  });
+
   allActions.set("merge-branch", {
     id: "merge-branch",
     label: i18n.t("workspace.git.actions.mergeBranch.label"),
@@ -370,7 +383,16 @@ function getFeatureActionIds(input: BuildGitActionsInput): GitActionId[] {
     "merge-from-base",
     "merge-branch",
     ...getPullRequestActionIds({ roles: ["status", "direct", "auto"], input }),
+    ...(canCommitAndCreatePr(input) ? (["commit-and-create-pr"] as const) : []),
   ];
+}
+
+function canCommitAndCreatePr(input: BuildGitActionsInput): boolean {
+  return (
+    input.githubFeaturesEnabled &&
+    !input.hasPullRequest &&
+    (input.hasUncommittedChanges || input.runtime["commit-and-create-pr"].status === "pending")
+  );
 }
 
 function getDefaultDirectPullRequestMergeActionId(

--- a/packages/app/src/git/use-actions.tsx
+++ b/packages/app/src/git/use-actions.tsx
@@ -411,6 +411,9 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
   const prCreateStatus = useCheckoutGitActionsStore((s) =>
     s.getStatus({ serverId, cwd, actionId: "create-pr" }),
   );
+  const commitAndCreatePrStatus = useCheckoutGitActionsStore((s) =>
+    s.getStatus({ serverId, cwd, actionId: "commit-and-create-pr" }),
+  );
   const mergePrStatuses: Record<CheckoutPrMergeMethod, CheckoutGitActionStatus> = {
     squash: useCheckoutGitActionsStore((s) =>
       s.getStatus({ serverId, cwd, actionId: "merge-pr-squash" }),
@@ -448,6 +451,7 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
   const runPush = useCheckoutGitActionsStore((s) => s.push);
   const runPullAndPush = useCheckoutGitActionsStore((s) => s.pullAndPush);
   const runCreatePr = useCheckoutGitActionsStore((s) => s.createPr);
+  const runCommitAndCreatePr = useCheckoutGitActionsStore((s) => s.commitAndCreatePr);
   const runMergePr = useCheckoutGitActionsStore((s) => s.mergePr);
   const runEnablePrAutoMerge = useCheckoutGitActionsStore((s) => s.enablePrAutoMerge);
   const runDisablePrAutoMerge = useCheckoutGitActionsStore((s) => s.disablePrAutoMerge);
@@ -534,6 +538,29 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
     forge,
     persistShipDefault,
     runCreatePr,
+    serverId,
+    t,
+    toastActionError,
+    toastActionSuccess,
+  ]);
+
+  const handleCommitAndCreatePr = useCallback(() => {
+    void persistShipDefault("pr");
+    void runCommitAndCreatePr({ serverId, cwd })
+      .then(() => {
+        toastActionSuccess(
+          t("workspace.git.actions.commitAndCreatePr.success", forgeVocabulary(forge)),
+        );
+        return;
+      })
+      .catch((err) => {
+        toastActionError(err, t("workspace.git.actions.toasts.failedCommitAndCreatePr"));
+      });
+  }, [
+    cwd,
+    forge,
+    persistShipDefault,
+    runCommitAndCreatePr,
     serverId,
     t,
     toastActionError,
@@ -730,10 +757,18 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
           handler: handlePullAndPush,
         },
         pr: {
-          disabled: isActionDisabled(actionsDisabled, prCreateStatus),
+          disabled:
+            isActionDisabled(actionsDisabled, prCreateStatus) ||
+            commitAndCreatePrStatus === "pending",
           status: hasPullRequest ? "idle" : prCreateStatus,
           icon: prIcon,
           handler: handlePrAction,
+        },
+        "commit-and-create-pr": {
+          disabled: isActionDisabled(actionsDisabled, commitAndCreatePrStatus),
+          status: commitAndCreatePrStatus,
+          icon: icons.commit,
+          handler: handleCommitAndCreatePr,
         },
         "merge-pr-squash": {
           disabled: isActionDisabled(actionsDisabled, mergePrStatuses.squash),
@@ -827,6 +862,7 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
     pushStatus,
     pullAndPushStatus,
     prCreateStatus,
+    commitAndCreatePrStatus,
     mergePrStatuses.squash,
     mergePrStatuses.merge,
     mergePrStatuses.rebase,
@@ -843,6 +879,7 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
     handlePush,
     handlePullAndPush,
     handlePrAction,
+    handleCommitAndCreatePr,
     handleMergePr,
     handleEnablePrAutoMerge,
     handleDisablePrAutoMerge,
@@ -960,6 +997,12 @@ function getTranslatedGitActionLabels(
             pendingLabel: t("workspace.git.actions.createPr.pending", forgeVocabulary(forge)),
             successLabel: t("workspace.git.actions.createPr.success", forgeVocabulary(forge)),
           };
+    case "commit-and-create-pr":
+      return {
+        label: t("workspace.git.actions.commitAndCreatePr.label", forgeVocabulary(forge)),
+        pendingLabel: t("workspace.git.actions.commitAndCreatePr.pending", forgeVocabulary(forge)),
+        successLabel: t("workspace.git.actions.commitAndCreatePr.success", forgeVocabulary(forge)),
+      };
     case "merge-pr-squash":
       return {
         label: t("workspace.git.actions.mergePr.squash", forgeVocabulary(forge)),

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -774,6 +774,14 @@ export const ar: TranslationResources = {
           pending_mr: "إنشاء MR...",
           success_mr: "تم إنشاء MR",
         },
+        commitAndCreatePr: {
+          label: "الالتزام وإنشاء PR",
+          pending: "جارٍ الالتزام وإنشاء PR...",
+          success: "تم الالتزام وإنشاء PR",
+          label_mr: "الالتزام وإنشاء MR",
+          pending_mr: "جارٍ الالتزام وإنشاء MR...",
+          success_mr: "تم الالتزام وإنشاء MR",
+        },
         mergeBranch: {
           label: "دمج محليا",
           pending: "جار الدمج...",
@@ -854,6 +862,7 @@ export const ar: TranslationResources = {
           failedPush: "فشل في الدفع",
           failedPullAndPush: "فشل في السحب والدفع",
           failedCreatePr: "فشل في إنشاء PR",
+          failedCommitAndCreatePr: "فشل في الالتزام وإنشاء PR",
           failedMergePr: "فشل دمج PR",
           failedEnableAutoMerge: "فشل في تمكين الدمج التلقائي",
           failedDisableAutoMerge: "فشل في تعطيل الدمج التلقائي",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -771,6 +771,14 @@ export const en = {
           pending_mr: "Creating MR...",
           success_mr: "MR Created",
         },
+        commitAndCreatePr: {
+          label: "Commit and create PR",
+          pending: "Committing and creating PR...",
+          success: "Committed and PR created",
+          label_mr: "Commit and create MR",
+          pending_mr: "Committing and creating MR...",
+          success_mr: "Committed and MR created",
+        },
         mergeBranch: {
           label: "Merge locally",
           pending: "Merging...",
@@ -863,6 +871,7 @@ export const en = {
           failedPush: "Failed to push",
           failedPullAndPush: "Failed to pull and push",
           failedCreatePr: "Failed to create PR",
+          failedCommitAndCreatePr: "Failed to commit and create PR",
           failedMergePr: "Failed to merge PR",
           failedEnableAutoMerge: "Failed to enable auto-merge",
           failedDisableAutoMerge: "Failed to disable auto-merge",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -780,6 +780,14 @@ export const es: TranslationResources = {
           pending_mr: "Creando MR...",
           success_mr: "MR creado",
         },
+        commitAndCreatePr: {
+          label: "Comprometerse y crear PR",
+          pending: "Comprometiéndose y creando PR...",
+          success: "Comprometido y PR creado",
+          label_mr: "Comprometerse y crear MR",
+          pending_mr: "Comprometiéndose y creando MR...",
+          success_mr: "Comprometido y MR creado",
+        },
         mergeBranch: {
           label: "Fusionar localmente",
           pending: "Fusionando...",
@@ -885,6 +893,7 @@ export const es: TranslationResources = {
           failedPush: "No se pudo empujar",
           failedPullAndPush: "No se pudo tirar y empujar",
           failedCreatePr: "No se pudo crearPR",
+          failedCommitAndCreatePr: "No se pudo comprometerse y crear PR",
           failedMergePr: "No se pudo fusionarPR",
           failedEnableAutoMerge: "No se pudo habilitar la combinación automática",
           failedDisableAutoMerge: "No se pudo deshabilitar la combinación automática",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -780,6 +780,14 @@ export const fr: TranslationResources = {
           pending_mr: "Création de MR...",
           success_mr: "MR créé",
         },
+        commitAndCreatePr: {
+          label: "Commettre et créer une PR",
+          pending: "Engagement et création de la PR...",
+          success: "Engagé et PR créée",
+          label_mr: "Commettre et créer une MR",
+          pending_mr: "Engagement et création de la MR...",
+          success_mr: "Engagé et MR créée",
+        },
         mergeBranch: {
           label: "Fusionner localement",
           pending: "Fusion...",
@@ -884,6 +892,7 @@ export const fr: TranslationResources = {
           failedPush: "Échec de la poussée",
           failedPullAndPush: "Impossible de tirer et de pousser",
           failedCreatePr: "Échec de la création dePR",
+          failedCommitAndCreatePr: "Échec de l'engagement et de la création de la PR",
           failedMergePr: "Échec de la fusion dePR",
           failedEnableAutoMerge: "Échec de l'activation de la fusion automatique",
           failedDisableAutoMerge: "Échec de la désactivation de la fusion automatique",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -776,6 +776,14 @@ export const ja: TranslationResources = {
           pending_mr: "MRを作成中...",
           success_mr: "MRが作成されました",
         },
+        commitAndCreatePr: {
+          label: "コミットしてPRを作成",
+          pending: "コミットしてPRを作成中...",
+          success: "コミットしてPRを作成しました",
+          label_mr: "コミットしてMRを作成",
+          pending_mr: "コミットしてMRを作成中...",
+          success_mr: "コミットしてMRを作成しました",
+        },
         mergeBranch: {
           label: "ローカルでマージ",
           pending: "マージ中...",
@@ -865,6 +873,7 @@ export const ja: TranslationResources = {
           failedPush: "プッシュに失敗しました",
           failedPullAndPush: "プル＆プッシュに失敗しました",
           failedCreatePr: "PRの作成に失敗しました",
+          failedCommitAndCreatePr: "コミットしてPRの作成に失敗しました",
           failedMergePr: "PRのマージに失敗しました",
           failedEnableAutoMerge: "自動マージの有効化に失敗しました",
           failedDisableAutoMerge: "自動マージの無効化に失敗しました",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -775,6 +775,14 @@ export const ko: TranslationResources = {
           pending_mr: "MR 생성 중...",
           success_mr: "MR 생성됨",
         },
+        commitAndCreatePr: {
+          label: "커밋 후 PR 생성",
+          pending: "커밋하고 PR 생성 중...",
+          success: "커밋 후 PR 생성됨",
+          label_mr: "커밋 후 MR 생성",
+          pending_mr: "커밋하고 MR 생성 중...",
+          success_mr: "커밋 후 MR 생성됨",
+        },
         mergeBranch: {
           label: "로컬에서 병합",
           pending: "병합하는 중...",
@@ -861,6 +869,7 @@ export const ko: TranslationResources = {
           failedPush: "푸시하지 못했습니다",
           failedPullAndPush: "풀 후 푸시하지 못했습니다",
           failedCreatePr: "PR을 생성하지 못했습니다",
+          failedCommitAndCreatePr: "커밋 후 PR을 생성하지 못했습니다",
           failedMergePr: "PR을 병합하지 못했습니다",
           failedEnableAutoMerge: "자동 병합을 사용 설정하지 못했습니다",
           failedDisableAutoMerge: "자동 병합을 해제하지 못했습니다",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -777,6 +777,14 @@ export const ptBR: TranslationResources = {
           pending_mr: "Criando MR...",
           success_mr: "MR criada",
         },
+        commitAndCreatePr: {
+          label: "Commit e criar PR",
+          pending: "Fazendo commit e criando PR...",
+          success: "Commit feito e PR criada",
+          label_mr: "Commit e criar MR",
+          pending_mr: "Fazendo commit e criando MR...",
+          success_mr: "Commit feito e MR criada",
+        },
         mergeBranch: {
           label: "Fazer merge localmente",
           pending: "Fazendo merge...",
@@ -876,6 +884,7 @@ export const ptBR: TranslationResources = {
           failedPush: "Falha ao fazer push",
           failedPullAndPush: "Falha ao fazer pull e push",
           failedCreatePr: "Falha ao criar PR",
+          failedCommitAndCreatePr: "Falha ao fazer commit e criar PR",
           failedMergePr: "Falha ao fazer merge da PR",
           failedEnableAutoMerge: "Falha ao ativar merge automático",
           failedDisableAutoMerge: "Falha ao desativar merge automático",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -780,6 +780,14 @@ export const ru: TranslationResources = {
           pending_mr: "Создание MR...",
           success_mr: "MR создан",
         },
+        commitAndCreatePr: {
+          label: "Закоммитить и создать PR",
+          pending: "Создание коммита и PR...",
+          success: "Коммит создан и PR создан",
+          label_mr: "Закоммитить и создать MR",
+          pending_mr: "Создание коммита и MR...",
+          success_mr: "Коммит создан и MR создан",
+        },
         mergeBranch: {
           label: "Выполнить слияние локально",
           pending: "Слияние...",
@@ -869,6 +877,7 @@ export const ru: TranslationResources = {
           failedPush: "Не удалось отправить изменения",
           failedPullAndPush: "Не удалось получить и отправить изменения",
           failedCreatePr: "Не удалось создать PR.",
+          failedCommitAndCreatePr: "Не удалось закоммитить и создать PR.",
           failedMergePr: "Не удалось выполнить слияние PR",
           failedEnableAutoMerge: "Не удалось включить автослияние",
           failedDisableAutoMerge: "Не удалось отключить автослияние",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -770,6 +770,14 @@ export const zhCN: TranslationResources = {
           pending_mr: "正在创建 MR...",
           success_mr: "MR 已创建",
         },
+        commitAndCreatePr: {
+          label: "Commit 并创建 PR",
+          pending: "正在 commit 并创建 PR...",
+          success: "已 commit 并创建 PR",
+          label_mr: "Commit 并创建 MR",
+          pending_mr: "正在 commit 并创建 MR...",
+          success_mr: "已 commit 并创建 MR",
+        },
         mergeBranch: {
           label: "本地 merge",
           pending: "正在 merge...",
@@ -846,6 +854,7 @@ export const zhCN: TranslationResources = {
           failedPush: "Push 失败",
           failedPullAndPush: "Pull 并 push 失败",
           failedCreatePr: "创建 PR 失败",
+          failedCommitAndCreatePr: "Commit 并创建 PR 失败",
           failedMergePr: "Merge PR 失败",
           failedEnableAutoMerge: "启用 auto-merge 失败",
           failedDisableAutoMerge: "禁用 auto-merge 失败",


### PR DESCRIPTION
Discussion: https://github.com/getpaseo/paseo/discussions/4966

## Summary
- Add a `commit-and-create-pr` action to the git dropdown that commits staged/all changes and creates a PR in one step, sequencing the existing `checkoutCommit` and `checkoutPrCreate` RPCs client-side.
- Show it only when there are uncommitted changes and no PR exists yet.
- Add en/es/fr/ja/ko/pt-BR/ru/zh-CN/ar translations.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` / `npm run format`
- [x] `npx vitest run packages/app/src/git/policy.test.ts packages/app/src/git/actions-store.test.ts packages/app/src/i18n/resources.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)