### PR TITLE
feat(app): provide SvgXml to plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -209,6 +209,27 @@ browser globals are not available across the plugin. Put sanctioned web-only API
 [public plugin reference](../public-docs/plugins/v0.8/reference.md#works-on-mobile) for the complete
 pattern.
 
+### Why drawing primitives are host-supplied
+
+`SvgXml` comes from `@getpaseo/plugin/client/react-native` because a plugin cannot bundle
+`react-native-svg` itself. Three things block it, in order:
+
+1. `compileTarget` in `packages/server/src/server/plugins/compiler.ts` builds with esbuild's
+   `neutral` platform and sets no `mainFields`, so a package without an `exports` map does not
+   resolve at all. `react-native-svg` has only `main`, `module`, and `react-native`.
+2. A deep import such as `react-native-svg/lib/module/index.js` skips that and compiles. The
+   resulting bundle still emits `require("react-native/Libraries/Utilities/codegenNativeComponent")`,
+   because esbuild's `react-native` external entry also covers subpaths. The host require shim in
+   `packages/app/src/plugins/evaluate.ts` allows exact specifiers only, so the plugin throws at load
+   on every platform, web included.
+3. The host's copy is compiled by Metro, so React Native's codegen transform has already replaced
+   those calls with static view configs, and it carries
+   `patches/react-native-svg+15.15.3.patch`. A bundled copy would get neither.
+
+Any future drawing primitive lands the same way: export it from the host runtime map in
+`packages/app/src/plugins/react-native/runtime.ts` and declare it in
+`packages/plugin/src/client/react-native.ts`.
+
 ```ts
 // index.server.ts
 import type { PluginServerContext } from "@getpaseo/plugin/server";

--- a/packages/app/src/plugins/evaluate.test.ts
+++ b/packages/app/src/plugins/evaluate.test.ts
@@ -514,6 +514,26 @@ describe("evaluatePluginClientBundle", () => {
     expect(plugin.surfaces.map((surface) => surface.id)).toEqual(["main"]);
   });
 
+  it("provides SvgXml through @getpaseo/plugin/client/react-native", () => {
+    const plugin = evaluatePluginClientBundle(
+      "example",
+      `(function(require) {
+        const { SvgXml } = require("@getpaseo/plugin/client/react-native");
+        const module = { exports: {} };
+        module.exports.default = function(plugin) {
+          if (typeof SvgXml !== "function" && typeof SvgXml !== "object") {
+            throw new Error("SvgXml is not provided");
+          }
+          plugin.addSurface("main", function Surface() { return null; });
+          return function() {};
+        };
+        return module.exports;
+      })`,
+    );
+
+    expect(plugin.surfaces.map((surface) => surface.id)).toEqual(["main"]);
+  });
+
   it("keeps shared and client runtime exports separate", () => {
     expect(() =>
       evaluatePluginClientBundle(

--- a/packages/app/src/plugins/react-native/runtime.ts
+++ b/packages/app/src/plugins/react-native/runtime.ts
@@ -1,3 +1,4 @@
+import { SvgXml } from "react-native-svg";
 import { Icon } from "../icons";
 import { Modal } from "./modal";
 import { ScrollView, FlatList } from "./scroll-view";
@@ -15,4 +16,5 @@ export const pluginReactNativeRuntime = {
   copyText,
   useRevealedText,
   useToast,
+  SvgXml,
 };

--- a/packages/plugin/src/client/react-native.ts
+++ b/packages/plugin/src/client/react-native.ts
@@ -74,3 +74,11 @@ export declare function copyText(text: string): Promise<void>;
 export declare const TextInput: ForwardRefExoticComponent<
   TextInputProps & RefAttributes<NativeTextInput>
 >;
+
+/** Renders an SVG document string. Narrower than react-native-svg's XmlProps by design. */
+export declare const SvgXml: ComponentType<{
+  xml: string | null;
+  width?: number | string;
+  height?: number | string;
+  color?: string;
+}>;

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -807,6 +807,18 @@ Showing another toast replaces the currently visible toast. An empty message is 
 | `size`  | `number` | No       | Icon width and height.                          |
 | `color` | `string` | No       | Icon color. Use a plugin theme token.           |
 
+### SvgXml
+
+`SvgXml` renders an SVG document string on every platform. It is the only vector-drawing primitive
+plugins get; a plugin bundle cannot import `react-native-svg` directly.
+
+| Prop     | Type               | Required | Behavior                                     |
+| -------- | ------------------ | -------- | -------------------------------------------- |
+| `xml`    | `string \| null`   | Yes      | The SVG document. `null` renders nothing.    |
+| `width`  | `number \| string` | No       | Rendered width.                              |
+| `height` | `number \| string` | No       | Rendered height.                             |
+| `color`  | `string`           | No       | Value of `currentColor` inside the document. |
+
 ## Timeline items
 
 A plugin can replace an agent timeline entry with its own data and React Native renderer. Both


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A plugin that needs to draw SVG (a formula, a badge, an icon) cannot ship `react-native-svg` itself. The plugin compiler uses esbuild `neutral` with no `mainFields`, so the package does not resolve; a deep import still emits `require("react-native/Libraries/Utilities/codegenNativeComponent")`, which the exact-match host shim rejects on every platform; and the host copy is the one Metro codegend and patched. `SvgXml` therefore comes from the existing `@getpaseo/plugin/client/react-native` runtime map. Nothing else changes.

### Goals

- Plugins can `import { SvgXml } from "@getpaseo/plugin/client/react-native"`
- The export is narrower than `react-native-svg`'s `XmlProps` on purpose

### Non-goals

- Does not add markdown extensions
- Does not add a copy-source wrapper for text-free drawings
- Does not add a new host module specifier

### QA

- `npx vitest run src/plugins/evaluate.test.ts --bail=1` from `packages/app`: 33 passed, including `provides SvgXml through @getpaseo/plugin/client/react-native`

Not tested on iOS or Android. Native `SvgXml` is the host's existing `react-native-svg` path; this PR only exposes it to plugins.

### Checklist

- [x] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (if applicable)
- [x] One focused change
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
