### PR TITLE
feat(app): let plugins extend assistant markdown rendering

### DIFF
--- a/docs/agent-stream-performance.md
+++ b/docs/agent-stream-performance.md
@@ -40,6 +40,11 @@ So arrival sets a _target_ and the reveal rate is derived from the backlog inste
   through that hook; the web viewport once skipped it and history hosts of a live tool group went
   stale. A new field on `StreamLayoutItem` must be added to `areLayoutItemsEquivalent`, or sharing
   silently stops.
+- **A render block never splits inside an open fence or an open extension-declared pair.** The
+  splitter runs before any parser, and markdown-it emits no token for an unclosed fence or a
+  streaming `$$` block, so the splitter tracks them itself. Plugins declare pairs through
+  `addMarkdownExtension`'s `blockDelimiters`; the registry pushes the current list into
+  `split-markdown-blocks.ts` on every publish. An unclosed region runs to the end of the text.
 
 ## Measuring
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -426,6 +426,18 @@ must be at most 64 KiB; the daemon rejects a larger append instead of storing a 
 be rendered intact. The daemon advertises this RPC through
 `server_info.features.pluginTimelineItems`.
 
+## Contribute markdown extensions
+
+`addMarkdownExtension` is the client contribution for assistant markdown: a markdown-it plugin,
+render rules merged after the built-ins, and block delimiters the streaming splitter protects.
+`packages/app/src/plugins/markdown-extensions.ts` composes installed extensions; `AssistantMessage`
+applies them, and `PluginRegistry.publish()` pushes the delimiters into
+`packages/app/src/utils/split-markdown-blocks.ts` because the splitter also runs in the stream
+reducer and the height estimator, where no hook is available.
+
+See the [public reference](../public-docs/plugins/v0.8/reference.md#markdown-extensions) and
+`plugin-examples/markdown-extension`, which exercises every field of the contribution.
+
 ## Contribute client slash commands
 
 `addSlashCommand` registers an agent- or workspace-context command in the composer. The

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -209,6 +209,27 @@ browser globals are not available across the plugin. Put sanctioned web-only API
 [public plugin reference](../public-docs/plugins/v0.8/reference.md#works-on-mobile) for the complete
 pattern.
 
+### Why drawing primitives are host-supplied
+
+`SvgXml` comes from `@getpaseo/plugin/client/react-native` because a plugin cannot bundle
+`react-native-svg` itself. Three things block it, in order:
+
+1. `compileTarget` in `packages/server/src/server/plugins/compiler.ts` builds with esbuild's
+   `neutral` platform and sets no `mainFields`, so a package without an `exports` map does not
+   resolve at all. `react-native-svg` has only `main`, `module`, and `react-native`.
+2. A deep import such as `react-native-svg/lib/module/index.js` skips that and compiles. The
+   resulting bundle still emits `require("react-native/Libraries/Utilities/codegenNativeComponent")`,
+   because esbuild's `react-native` external entry also covers subpaths. The host require shim in
+   `packages/app/src/plugins/evaluate.ts` allows exact specifiers only, so the plugin throws at load
+   on every platform, web included.
+3. The host's copy is compiled by Metro, so React Native's codegen transform has already replaced
+   those calls with static view configs, and it carries
+   `patches/react-native-svg+15.15.3.patch`. A bundled copy would get neither.
+
+Any future drawing primitive lands the same way: export it from the host runtime map in
+`packages/app/src/plugins/react-native/runtime.ts` and declare it in
+`packages/plugin/src/client/react-native.ts`.
+
 ```ts
 // index.server.ts
 import type { PluginServerContext } from "@getpaseo/plugin/server";

--- a/package-lock.json
+++ b/package-lock.json
@@ -12825,6 +12825,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/highlight.js": {
+      "version": "9.12.4",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
+      "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -12916,17 +12923,6 @@
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -23245,6 +23241,18 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.29.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "9.18.5",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
+      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
+      "deprecated": "Support has ended for 9.x series. Upgrade to @latest",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -36297,7 +36305,7 @@
         "@playwright/test": "^1.56.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
-        "@types/markdown-it": "^14.1.2",
+        "@types/markdown-it": "^10.0.3",
         "@types/node": "~22.19.0",
         "@types/qrcode": "^1.5.6",
         "@types/react": "~19.2.0",
@@ -36848,6 +36856,19 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/app/node_modules/@types/markdown-it": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-10.0.3.tgz",
+      "integrity": "sha512-daHJk22isOUvNssVGF2zDnnSyxHhFYhtjeX4oQaKD6QzL3ZR1QSgiD1g+Q6/WSWYVogNXYDXODtbgW/WiFCtyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/highlight.js": "^9.7.0",
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*",
+        "highlight.js": "^9.7.0"
       }
     },
     "packages/app/node_modules/@types/node": {
@@ -38704,10 +38725,12 @@
       "devDependencies": {
         "@getpaseo/client": "0.8.0",
         "@getpaseo/protocol": "0.8.0",
+        "@types/markdown-it": "^10.0.3",
         "@types/node": "^20.9.0",
         "@types/react": "~19.2.0",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-markdown-display": "^7.0.2",
         "typescript": "^5.9.3",
         "vitest": "^4.1.6",
         "zod": "^4.4.3"
@@ -38715,12 +38738,20 @@
       "peerDependencies": {
         "@getpaseo/client": "0.8.0",
         "@getpaseo/protocol": "0.8.0",
+        "@types/markdown-it": "^10.0.3",
         "react": "~19.1.0",
         "react-native": ">=0.81.5",
+        "react-native-markdown-display": "^7.0.2",
         "zod": "^4.4.3"
       },
       "peerDependenciesMeta": {
+        "@types/markdown-it": {
+          "optional": true
+        },
         "react-native": {
+          "optional": true
+        },
+        "react-native-markdown-display": {
           "optional": true
         }
       }
@@ -38732,6 +38763,19 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "packages/plugin/node_modules/@types/markdown-it": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-10.0.3.tgz",
+      "integrity": "sha512-daHJk22isOUvNssVGF2zDnnSyxHhFYhtjeX4oQaKD6QzL3ZR1QSgiD1g+Q6/WSWYVogNXYDXODtbgW/WiFCtyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/highlight.js": "^9.7.0",
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*",
+        "highlight.js": "^9.7.0"
       }
     },
     "packages/protocol": {

--- a/packages/app/e2e/browser/plugin-markdown-extension.spec.ts
+++ b/packages/app/e2e/browser/plugin-markdown-extension.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "../support/fixtures";
+import { openAgentRoute, seedMockAgentWorkspace } from "../support/helpers/mock-agent";
+import { connectNewWorkspaceDaemonClient } from "../support/helpers/new-workspace";
+import { copyPluginExample } from "../support/helpers/plugin-fixture";
+
+const PLUGIN_ID = "markdown-extension";
+
+// A backslash and an underscore: markdown-it's escape rule eats the backslash when the
+// extension is gone, so this is how we tell host rendering from the extension's leaf token.
+const INLINE_SOURCE = "::a\\_b::";
+const INLINE_LINE = `Inline ${INLINE_SOURCE} renders as a badge.`;
+// A `:::` block with no closing fence is what a still-streaming block looks like. Without the
+// extension's declared delimiter the splitter cuts it at the blank line and the block rule only
+// ever sees "still".
+const BLOCK_SOURCE = ":::\nstill\n\nstreaming";
+const RESPONSE = `${INLINE_LINE}\n\n${BLOCK_SOURCE}`;
+
+test("renders assistant markdown through an installed extension", async ({ page }) => {
+  const example = await copyPluginExample(PLUGIN_ID);
+  const client = await connectNewWorkspaceDaemonClient({ ownProjects: false });
+  const previousConfig = await client.getDaemonConfig();
+  const agent = await seedMockAgentWorkspace({
+    repoPrefix: "plugin-markdown-extension-",
+    title: "Markdown extension",
+    initialPrompt: "Render the configured markdown response.",
+    featureValues: { mockAssistantResponse: RESPONSE },
+  });
+
+  try {
+    await client.patchDaemonConfig({ pluginsEnabled: true });
+    await client.installDirectoryPlugin(example.directory);
+    await agent.client.waitForFinish(agent.agentId, 30_000);
+    await openAgentRoute(page, agent);
+
+    const assistantMessage = page.getByTestId("assistant-message").last();
+    await expect(assistantMessage).toBeVisible({ timeout: 30_000 });
+
+    await test.step("the extension's parser and rules render through the assistant message", async () => {
+      await expect(assistantMessage).toContainText("[a\\_b]", { timeout: 30_000 });
+      await expect(assistantMessage).toContainText("renders as a badge.");
+      await expect(assistantMessage).not.toContainText(INLINE_SOURCE);
+      await expect(assistantMessage).not.toContainText(":::");
+    });
+
+    await test.step("a declared block delimiter keeps an unclosed block in one render token", async () => {
+      // The block rule sets accessibilityLabel to the inner content. Without blockDelimiters
+      // the splitter cuts at the blank line and the label is only "still".
+      await expect(assistantMessage.getByLabel("still\n\nstreaming")).toBeVisible();
+    });
+
+    await test.step("removing the plugin restores the built-in rendering", async () => {
+      await client.removePlugin(PLUGIN_ID);
+      // markdown-it's own escape rule eats the backslash once the extension no longer claims
+      // the run — the built-in rendering, restored.
+      await expect(assistantMessage).toContainText("::a_b::", { timeout: 30_000 });
+      await expect(assistantMessage).toContainText(":::");
+    });
+  } finally {
+    await client.removePlugin(PLUGIN_ID).catch(() => undefined);
+    await client
+      .patchDaemonConfig({ pluginsEnabled: previousConfig.config.pluginsEnabled ?? false })
+      .catch(() => undefined);
+    await client.close().catch(() => undefined);
+    await agent.cleanup().catch(() => undefined);
+    await example.cleanup();
+  }
+});

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -138,7 +138,7 @@
     "@playwright/test": "^1.56.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
-    "@types/markdown-it": "^14.1.2",
+    "@types/markdown-it": "^10.0.3",
     "@types/node": "~22.19.0",
     "@types/qrcode": "^1.5.6",
     "@types/react": "~19.2.0",

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -376,7 +376,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     getItemKey: (index: number) => segments.historyVirtualized[index]?.id ?? index,
     estimateSize: (index: number) => {
       const row = segments.historyVirtualized[index];
-      return row ? estimateStreamItemHeight(row) : 120;
+      return row ? estimateStreamItemHeight(row, props.serverId) : 120;
     },
     measureElement: measureVirtualElement,
     scrollMargin: VIRTUALIZER_SCROLL_MARGIN_PX,

--- a/packages/app/src/agent-stream/strategy.ts
+++ b/packages/app/src/agent-stream/strategy.ts
@@ -61,6 +61,7 @@ export interface StreamHistoryRowRevision {
 
 export interface StreamRenderInput {
   agentId: string;
+  serverId?: string;
   segments: StreamRenderSegments;
   historyRowRevision?: StreamHistoryRowRevision;
   liveHeadRowRevision?: unknown;

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -1093,6 +1093,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           <MessageOuterSpacingProvider disableOuterSpacing>
             {streamRenderStrategy.render({
               agentId,
+              serverId: resolvedServerId,
               segments: renderModel.segments,
               historyRowRevision,
               liveHeadRowRevision: expandedToolCallGroupIds,

--- a/packages/app/src/agent-stream/web-virtualization.test.ts
+++ b/packages/app/src/agent-stream/web-virtualization.test.ts
@@ -5,6 +5,10 @@ import {
   setAssistantImageMetadata,
 } from "@/utils/assistant-image-metadata";
 import {
+  clearAssistantMessageHeightEstimateCache,
+  setAssistantMarkdownBlockHeight,
+} from "@/utils/assistant-message-height-estimate";
+import {
   DEFAULT_WEB_MOUNTED_RECENT_STREAM_ITEMS,
   DEFAULT_WEB_PARTIAL_VIRTUALIZATION_THRESHOLD,
   estimateStreamItemHeight,
@@ -166,6 +170,25 @@ describe("estimateStreamItemHeight", () => {
     };
 
     expect(estimateStreamItemHeight(item)).toBeGreaterThan(220);
+  });
+
+  it("finds a host-keyed markdown block measurement", () => {
+    clearAssistantMessageHeightEstimateCache();
+    setAssistantMarkdownBlockHeight({
+      block: "$$x$$",
+      width: 804,
+      height: 100,
+      serverId: "host-a",
+    });
+
+    const item: StreamItem = {
+      kind: "assistant_message",
+      id: "a-math",
+      text: "$$x$$",
+      timestamp: createTimestamp(3),
+    };
+
+    expect(estimateStreamItemHeight(item, "host-a")).toBe(124);
   });
 });
 

--- a/packages/app/src/agent-stream/web-virtualization.ts
+++ b/packages/app/src/agent-stream/web-virtualization.ts
@@ -58,12 +58,12 @@ export interface WebVirtualizedHistoryWindow {
   mountedEntries: IndexedStreamItem[];
 }
 
-export function estimateStreamItemHeight(item: StreamItem): number {
+export function estimateStreamItemHeight(item: StreamItem, serverId?: string): number {
   switch (item.kind) {
     case "user_message":
       return item.images && item.images.length > 0 ? 220 : 96;
     case "assistant_message":
-      return estimateAssistantMessageHeightFromCache(item.text) ?? 220;
+      return estimateAssistantMessageHeightFromCache(item.text, serverId) ?? 220;
     case "tool_call":
       return COLLAPSED_TOOL_SEQUENCE_ROW_HEIGHT_ESTIMATE;
     case "thought":

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -1369,21 +1369,23 @@ function NativeShimmerPeakSvg({ gradientId }: { gradientId: string }) {
 interface AssistantMessageBlockContainerProps {
   block: string;
   marginBottom: number;
+  serverId?: string;
   children: ReactNode;
 }
 
 function AssistantMessageBlockContainer({
   block,
   marginBottom,
+  serverId,
   children,
 }: AssistantMessageBlockContainerProps) {
   const style = useMemo(() => (marginBottom > 0 ? { marginBottom } : undefined), [marginBottom]);
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
       const { width, height } = event.nativeEvent.layout;
-      setAssistantMarkdownBlockHeight({ block, width, height });
+      setAssistantMarkdownBlockHeight({ block, width, height, serverId });
     },
-    [block],
+    [block, serverId],
   );
   return (
     <View style={style} onLayout={isWeb ? handleLayout : undefined}>
@@ -1510,8 +1512,8 @@ export const AssistantMessage = memo(function AssistantMessage({
   // one must not rewrite the other's messages.
   const hostPlugins = useHostPlugins(serverId);
   const markdownExtensions = useMemo(() => collectMarkdownExtensions(hostPlugins), [hostPlugins]);
-  const markdownParser = useMemo(
-    () => applyMarkdownExtensionParsers(createAssistantMarkdownParser(), markdownExtensions),
+  const { parser: markdownParser, extensions: appliedMarkdownExtensions } = useMemo(
+    () => applyMarkdownExtensionParsers(createAssistantMarkdownParser, markdownExtensions),
     [markdownExtensions],
   );
   const renderedMessage = useMemo(() => capAssistantMessageForRender(message), [message]);
@@ -1958,11 +1960,11 @@ export const AssistantMessage = memo(function AssistantMessage({
         );
       },
     };
-    return mergeMarkdownExtensionRules(baseRules, markdownExtensions);
+    return mergeMarkdownExtensionRules(baseRules, appliedMarkdownExtensions);
   }, [
+    appliedMarkdownExtensions,
     client,
     fileLinkActions,
-    markdownExtensions,
     markdownParser,
     occurrenceKey,
     phase,
@@ -1971,15 +1973,8 @@ export const AssistantMessage = memo(function AssistantMessage({
   ]);
 
   const blocks = useMemo(
-    () => splitMarkdownBlocks(revealedMessage),
-    // markdownExtensions isn't read inside the callback, but splitMarkdownBlocks reads
-    // module-global delimiters that PluginRegistry.publish() mutates on every
-    // install/remove. The splitter itself takes no extension argument because it also
-    // runs in the stream reducer and height estimator, where no hook is available.
-    // Depending on markdownExtensions here keeps an already-rendered message's block
-    // boundaries in sync when the plugin set changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [revealedMessage, markdownExtensions],
+    () => splitMarkdownBlocks(revealedMessage, { serverId }),
+    [revealedMessage, markdownExtensions, serverId],
   );
   const keyedBlocks = useMemo(
     () => blocks.map((block, index) => ({ key: `block:${index}`, block })),
@@ -2011,6 +2006,7 @@ export const AssistantMessage = memo(function AssistantMessage({
           key={key}
           block={block}
           marginBottom={index < keyedBlocks.length - 1 ? 12 : 0}
+          serverId={serverId}
         >
           <MemoizedMarkdownBlock
             text={block}

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -66,6 +66,12 @@ import { getMarkdownListMarker, getMarkdownListSpacing } from "@/utils/markdown-
 import { markdownNodeContainsType } from "@/utils/markdown-ast";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import { HighlightedCodeBlock } from "@/components/highlighted-code-block";
+import { useHostPlugins } from "@/plugins/registry";
+import {
+  applyMarkdownExtensionParsers,
+  collectMarkdownExtensions,
+  mergeMarkdownExtensionRules,
+} from "@/plugins/markdown-extensions";
 import { MarkdownFenceBlock } from "@/components/markdown/fence";
 import type { MarkdownPhase } from "@/components/markdown/fence/types";
 import { splitMarkdownBlocks } from "@/utils/split-markdown-blocks";
@@ -1500,7 +1506,14 @@ export const AssistantMessage = memo(function AssistantMessage({
   phase,
 }: AssistantMessageProps) {
   const { t } = useTranslation();
-  const markdownParser = useMemo(createAssistantMarkdownParser, []);
+  // Scoped to the host this message came from: with two hosts connected, a plugin installed on
+  // one must not rewrite the other's messages.
+  const hostPlugins = useHostPlugins(serverId);
+  const markdownExtensions = useMemo(() => collectMarkdownExtensions(hostPlugins), [hostPlugins]);
+  const markdownParser = useMemo(
+    () => applyMarkdownExtensionParsers(createAssistantMarkdownParser(), markdownExtensions),
+    [markdownExtensions],
+  );
   const renderedMessage = useMemo(() => capAssistantMessageForRender(message), [message]);
   // Paint a paced prefix while the turn is streaming so text arrives at a steady
   // rate instead of in whatever lumps the daemon's coalescing window produced.
@@ -1519,7 +1532,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   });
 
   const markdownRules = useMemo<RenderRules>(() => {
-    return {
+    const baseRules: RenderRules = {
       heading1: (
         node: ASTNode,
         children: ReactNode[],
@@ -1945,9 +1958,29 @@ export const AssistantMessage = memo(function AssistantMessage({
         );
       },
     };
-  }, [client, fileLinkActions, markdownParser, occurrenceKey, phase, serverId, workspaceRoot]);
+    return mergeMarkdownExtensionRules(baseRules, markdownExtensions);
+  }, [
+    client,
+    fileLinkActions,
+    markdownExtensions,
+    markdownParser,
+    occurrenceKey,
+    phase,
+    serverId,
+    workspaceRoot,
+  ]);
 
-  const blocks = useMemo(() => splitMarkdownBlocks(revealedMessage), [revealedMessage]);
+  const blocks = useMemo(
+    () => splitMarkdownBlocks(revealedMessage),
+    // markdownExtensions isn't read inside the callback, but splitMarkdownBlocks reads
+    // module-global delimiters that PluginRegistry.publish() mutates on every
+    // install/remove. The splitter itself takes no extension argument because it also
+    // runs in the stream reducer and height estimator, where no hook is available.
+    // Depending on markdownExtensions here keeps an already-rendered message's block
+    // boundaries in sync when the plugin set changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [revealedMessage, markdownExtensions],
+  );
   const keyedBlocks = useMemo(
     () => blocks.map((block, index) => ({ key: `block:${index}`, block })),
     [blocks],

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -1972,10 +1972,10 @@ export const AssistantMessage = memo(function AssistantMessage({
     workspaceRoot,
   ]);
 
-  const blocks = useMemo(
-    () => splitMarkdownBlocks(revealedMessage, { serverId }),
-    [revealedMessage, markdownExtensions, serverId],
-  );
+  const blocks = useMemo(() => {
+    void markdownExtensions;
+    return splitMarkdownBlocks(revealedMessage, { serverId });
+  }, [revealedMessage, markdownExtensions, serverId]);
   const keyedBlocks = useMemo(
     () => blocks.map((block, index) => ({ key: `block:${index}`, block })),
     [blocks],

--- a/packages/app/src/plugins/buttons/model.test.ts
+++ b/packages/app/src/plugins/buttons/model.test.ts
@@ -21,6 +21,7 @@ function installation(): InstalledPlugin {
     attachmentSources: [],
     themes: [],
     timelineTransformers: [],
+    markdownExtensions: [],
     timelineRenderers: [],
   };
 }

--- a/packages/app/src/plugins/catalog-sync.tsx
+++ b/packages/app/src/plugins/catalog-sync.tsx
@@ -42,6 +42,7 @@ export function PluginCatalogSync({
           .catch((error) => {
             if (!cancelled) {
               console.warn(`[Plugins] Failed to load catalog for ${serverId}`, error);
+              pluginRegistry.acknowledgeEmptyHost(serverId);
             }
             return undefined;
           }),

--- a/packages/app/src/plugins/command-center/contributions.test.ts
+++ b/packages/app/src/plugins/command-center/contributions.test.ts
@@ -104,6 +104,7 @@ function plugin(onAgentSelect: AgentCommandItem["onSelect"]): InstalledPlugin {
     themes: [],
     timelineTransformers: [],
     timelineRenderers: [],
+    markdownExtensions: [],
   };
 }
 

--- a/packages/app/src/plugins/evaluate.test.ts
+++ b/packages/app/src/plugins/evaluate.test.ts
@@ -494,6 +494,69 @@ describe("evaluatePluginClientBundle", () => {
     expect(element).toMatchObject({ props: { size: 18, color: "#123456" } });
   });
 
+  it("collects markdown extensions and rejects a duplicate id", () => {
+    const plugin = evaluatePluginClientBundle(
+      "example",
+      `(function(require) {
+        const module = { exports: {} };
+        module.exports.default = function(plugin) {
+          plugin.addMarkdownExtension({
+            id: "math",
+            blockDelimiters: [{ open: "$$", close: "$$" }],
+          });
+          let message = null;
+          try {
+            plugin.addMarkdownExtension({ id: "math" });
+          } catch (error) {
+            message = error.message;
+          }
+          if (message !== "Duplicate markdown extension: math") {
+            throw new Error("expected duplicate rejection, got " + message);
+          }
+          return function() {};
+        };
+        return module.exports;
+      })`,
+    );
+
+    expect(plugin.markdownExtensions.map((extension) => extension.id)).toEqual(["math"]);
+    expect(plugin.markdownExtensions[0]?.blockDelimiters).toEqual([{ open: "$$", close: "$$" }]);
+  });
+
+  it("rejects a markdown extension with an empty block delimiter", () => {
+    expect(() =>
+      evaluatePluginClientBundle(
+        "example",
+        `(function(require) {
+          const module = { exports: {} };
+          module.exports.default = function(plugin) {
+            plugin.addMarkdownExtension({ id: "math", blockDelimiters: [{ open: "", close: "$$" }] });
+            return function() {};
+          };
+          return module.exports;
+        })`,
+      ),
+    ).toThrow("Markdown extension math has an empty block delimiter");
+  });
+
+  it("removes a markdown extension through its cleanup", () => {
+    const plugin = evaluatePluginClientBundle(
+      "example",
+      `(function(require) {
+        const module = { exports: {} };
+        module.exports.default = function(plugin) {
+          const remove = plugin.addMarkdownExtension({ id: "math" });
+          remove();
+          remove();
+          return function() {};
+        };
+        return module.exports;
+      })`,
+    );
+
+    expect(plugin.markdownExtensions).toEqual([]);
+  });
+
   it("provides Paseo UI through @getpaseo/plugin/client/react-native", () => {
     const plugin = evaluatePluginClientBundle(
       "example",

--- a/packages/app/src/plugins/evaluate.test.ts
+++ b/packages/app/src/plugins/evaluate.test.ts
@@ -514,6 +514,26 @@ describe("evaluatePluginClientBundle", () => {
     expect(plugin.surfaces.map((surface) => surface.id)).toEqual(["main"]);
   });
 
+  it("provides SvgXml through @getpaseo/plugin/client/react-native", () => {
+    const plugin = evaluatePluginClientBundle(
+      "example",
+      `(function(require) {
+        const { SvgXml } = require("@getpaseo/plugin/client/react-native");
+        const module = { exports: {} };
+        module.exports.default = function(plugin) {
+          if (typeof SvgXml !== "function" && typeof SvgXml !== "object") {
+            throw new Error("SvgXml is not provided");
+          }
+          plugin.addSurface("main", function Surface() { return null; });
+          return function() {};
+        };
+        return module.exports;
+      })`,
+    );
+
+    expect(plugin.surfaces.map((surface) => surface.id)).toEqual(["main"]);
+  });
+
   it("keeps shared and client runtime exports separate", () => {
     expect(() =>
       evaluatePluginClientBundle(

--- a/packages/app/src/plugins/evaluate.ts
+++ b/packages/app/src/plugins/evaluate.ts
@@ -16,6 +16,7 @@ import {
 } from "@getpaseo/plugin";
 import {
   type PluginCommandCenterItemContribution,
+  type PluginMarkdownExtension,
   type PluginClientContext,
   type PluginClientSlashCommandContribution,
   type PluginSidebarContribution,
@@ -97,6 +98,7 @@ export function runPluginClientBundle(
     themes: [],
     timelineTransformers: [],
     timelineRenderers: [],
+    markdownExtensions: [],
   };
   const surfaceIds = new Set<string>();
   const settingsScreenIds = new Set<string>();
@@ -108,6 +110,7 @@ export function runPluginClientBundle(
   const themeIds = new Set<string>();
   const timelineTransformerIds = new Set<string>();
   const timelineRendererIds = new Set<string>();
+  const markdownExtensionIds = new Set<string>();
   const removals = new Set<PluginCleanup>();
   let setupComplete = false;
   let stopped = false;
@@ -359,6 +362,21 @@ export function runPluginClientBundle(
         timelineRendererIds.delete(rendererId),
       );
     },
+    addMarkdownExtension(contribution: PluginMarkdownExtension) {
+      const normalizedId = requireId(contribution.id, "markdown extension id");
+      if (markdownExtensionIds.has(normalizedId)) {
+        throw new Error(`Duplicate markdown extension: ${normalizedId}`);
+      }
+      for (const pair of contribution.blockDelimiters ?? []) {
+        if (!pair.open || !pair.close) {
+          throw new Error(`Markdown extension ${normalizedId} has an empty block delimiter`);
+        }
+      }
+      markdownExtensionIds.add(normalizedId);
+      return register(collector.markdownExtensions, { ...contribution, id: normalizedId }, () =>
+        markdownExtensionIds.delete(normalizedId),
+      );
+    },
     addComposerPill(contribution) {
       if (stopped) throw new Error("Plugin has stopped");
       return trackButton(runtime.addComposerPill(contribution));
@@ -441,5 +459,6 @@ export function runPluginClientBundle(
     themes: collector.themes,
     timelineTransformers: collector.timelineTransformers,
     timelineRenderers: collector.timelineRenderers,
+    markdownExtensions: collector.markdownExtensions,
   };
 }

--- a/packages/app/src/plugins/markdown-extension-example.test.tsx
+++ b/packages/app/src/plugins/markdown-extension-example.test.tsx
@@ -1,0 +1,51 @@
+import React, { isValidElement, type ReactElement } from "react";
+
+(globalThis as { React?: typeof React }).React = React;
+import { Text } from "react-native";
+import MarkdownIt from "markdown-it";
+import { describe, expect, it } from "vitest";
+import type { PluginClientContext, PluginMarkdownExtension } from "@getpaseo/plugin/client";
+import contribute from "../../../../plugin-examples/markdown-extension/index.client";
+import { applyMarkdownExtensionParsers } from "./markdown-extensions";
+
+function installExample(): PluginMarkdownExtension {
+  let extension: PluginMarkdownExtension | undefined;
+  contribute({
+    addMarkdownExtension(next: PluginMarkdownExtension) {
+      extension = next;
+      return () => undefined;
+    },
+  } as PluginClientContext);
+  if (!extension) throw new Error("example did not register a markdown extension");
+  return extension;
+}
+
+describe("plugin-examples/markdown-extension", () => {
+  it("closes a badge_block when an unescaped ::: appears on a line", () => {
+    const extension = installExample();
+    const { parser } = applyMarkdownExtensionParsers(() => new MarkdownIt(), [extension]);
+    const tokens = parser.parse(":::\ntext ::: literal\n\nstill inside\n:::", {});
+    const blocks = tokens.filter((token) => token.type === "badge_block");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.content).not.toContain("still inside");
+    expect(tokens.some((token) => token.content.includes("still inside"))).toBe(true);
+  });
+
+  it("applies inherited prose styles to badge_block text", () => {
+    const extension = installExample();
+    const inheritedStyles = { color: "#abc123" };
+    const node = { key: "badge", content: "hello" };
+    const rendered = extension.rules?.badge_block?.(
+      node as never,
+      [],
+      [],
+      {} as never,
+      inheritedStyles as never,
+    );
+    expect(isValidElement(rendered)).toBe(true);
+    const view = rendered as ReactElement<{ children?: unknown }>;
+    const text = view.props.children as ReactElement<{ style?: { color?: string } }>;
+    expect(text.type).toBe(Text);
+    expect(text.props.style).toEqual(inheritedStyles);
+  });
+});

--- a/packages/app/src/plugins/markdown-extension-wiring.test.tsx
+++ b/packages/app/src/plugins/markdown-extension-wiring.test.tsx
@@ -60,7 +60,7 @@ function collectProbeColors(markdown: string, theme: Theme): (string | undefined
     [probeExtension],
   );
   const renderer = new AstRenderer(rules, createMarkdownStyles(theme));
-  const markdownIt = applyMarkdownExtensionParsers(createAssistantMarkdownParser(), [
+  const { parser: markdownIt } = applyMarkdownExtensionParsers(createAssistantMarkdownParser, [
     probeExtension,
   ]);
 

--- a/packages/app/src/plugins/markdown-extension-wiring.test.tsx
+++ b/packages/app/src/plugins/markdown-extension-wiring.test.tsx
@@ -1,0 +1,125 @@
+import type { PluginMarkdownExtension } from "@getpaseo/plugin/client";
+import {
+  createElement,
+  Fragment,
+  isValidElement,
+  type ComponentType,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { StyleSheet, type StyleProp, type TextStyle } from "react-native";
+import AstRenderer from "react-native-markdown-display/src/lib/AstRenderer";
+import parser from "react-native-markdown-display/src/lib/parser";
+import { describe, expect, it } from "vitest";
+import {
+  applyMarkdownExtensionParsers,
+  mergeMarkdownExtensionRules,
+} from "@/plugins/markdown-extensions";
+import { createMarkdownStyles } from "@/styles/markdown-styles";
+import { darkTheme, lightTheme, type Theme } from "@/styles/theme";
+import { createAssistantMarkdownParser } from "@/utils/assistant-markdown-parser";
+
+// Stands in for whatever a plugin renders. `plugin-examples/markdown-extension` is the shipped
+// worked example; this file pins the host wiring underneath it, which no example can assert:
+// that a contributed parser and rule reach a real AstRenderer, and that the rule's fifth
+// argument carries the text style it inherited — the only way prose color reaches a token that
+// has no text of its own.
+const Probe: ComponentType<{ textStyle?: StyleProp<TextStyle> }> = () => null;
+
+const PROBE_MARKER = "@@";
+const probeExtension: PluginMarkdownExtension = {
+  id: "probe",
+  parser: (markdown) => {
+    markdown.inline.ruler.before("escape", "probe_inline", (state, silent) => {
+      if (!state.src.startsWith(PROBE_MARKER, state.pos)) return false;
+      if (!silent) state.push("probe_inline", "span", 0);
+      state.pos += PROBE_MARKER.length;
+      return true;
+    });
+  },
+  rules: {
+    probe_inline: (node, _children, _parent, _styles, inheritedStyles) =>
+      createElement(Probe, { key: node.key, textStyle: inheritedStyles }),
+  },
+};
+
+function collectProbeColors(markdown: string, theme: Theme): (string | undefined)[] {
+  const passThrough = (node: { key: string }, children: ReactNode[]) =>
+    createElement(Fragment, { key: node.key }, children);
+  const rules = mergeMarkdownExtensionRules(
+    {
+      body: passThrough,
+      paragraph: passThrough,
+      textgroup: passThrough,
+      blockquote: passThrough,
+      text: () => null,
+      // Collides with the extension's rule on purpose: the extension has to win, or a token
+      // type the host already knows could never be re-rendered by a plugin.
+      probe_inline: () => null,
+    },
+    [probeExtension],
+  );
+  const renderer = new AstRenderer(rules, createMarkdownStyles(theme));
+  const markdownIt = applyMarkdownExtensionParsers(createAssistantMarkdownParser(), [
+    probeExtension,
+  ]);
+
+  const colors: (string | undefined)[] = [];
+  const walk = (node: ReactNode) => {
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (!isValidElement(node)) return;
+    const element = node as ReactElement<{
+      textStyle?: StyleProp<TextStyle>;
+      children?: ReactNode;
+    }>;
+    if (element.type === Probe) {
+      colors.push(StyleSheet.flatten(element.props.textStyle)?.color as string | undefined);
+      return;
+    }
+    walk(element.props.children);
+  };
+  walk(parser(markdown, renderer.render, markdownIt));
+  return colors;
+}
+
+const colorOf = (style: StyleProp<TextStyle>) => StyleSheet.flatten(style)?.color;
+
+describe.each<[string, Theme]>([
+  ["dark", darkTheme],
+  ["light", lightTheme],
+])("a markdown extension through the host (%s theme)", (_name, theme) => {
+  it("routes a contributed token to the contributed rule", () => {
+    expect(collectProbeColors("Prose @@ and more.\n", theme)).toHaveLength(1);
+  });
+
+  it("hands the rule the prose text style around it", () => {
+    const styles = createMarkdownStyles(theme);
+
+    expect(collectProbeColors("Prose @@ and @@ again.\n", theme)).toEqual([
+      colorOf(styles.body),
+      colorOf(styles.body),
+    ]);
+  });
+
+  it("follows a blockquote's color override when nested in one", () => {
+    const styles = createMarkdownStyles(theme);
+
+    expect(collectProbeColors("> @@\n", theme)).toEqual([
+      colorOf(styles.blockquote) ?? colorOf(styles.body),
+    ]);
+  });
+});
+
+describe("a markdown extension through the host", () => {
+  it("uses a different color in each theme, so a rendered token stays legible on either background", () => {
+    const dark = collectProbeColors("@@\n", darkTheme);
+    const light = collectProbeColors("@@\n", lightTheme);
+
+    expect(dark[0]).toBe(darkTheme.colors.foreground);
+    expect(light[0]).toBe(lightTheme.colors.foreground);
+    expect(dark[0]).not.toBe(light[0]);
+  });
+});

--- a/packages/app/src/plugins/markdown-extensions.test.ts
+++ b/packages/app/src/plugins/markdown-extensions.test.ts
@@ -1,0 +1,125 @@
+import MarkdownIt from "markdown-it";
+import type { PluginMarkdownExtension } from "@getpaseo/plugin/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyMarkdownExtensionParsers,
+  collectMarkdownBlockDelimiters,
+  collectMarkdownExtensions,
+  mergeMarkdownExtensionRules,
+} from "./markdown-extensions";
+
+const shout: PluginMarkdownExtension = {
+  id: "shout",
+  parser: (markdown) => {
+    markdown.core.ruler.push("shout", (state) => {
+      for (const token of state.tokens) {
+        if (token.type === "inline") token.content = token.content.toUpperCase();
+      }
+      // markdown-it ignores a core rule's return value; the v10 types require one anyway.
+      return true;
+    });
+  },
+  rules: { paragraph: () => null },
+  blockDelimiters: [{ open: "$$", close: "$$" }],
+};
+
+const quiet: PluginMarkdownExtension = {
+  id: "quiet",
+  rules: { paragraph: () => "quiet", heading1: () => "h1" },
+};
+
+describe("collectMarkdownExtensions", () => {
+  it("flattens extensions across installed plugins in order", () => {
+    const plugins = [{ markdownExtensions: [shout] }, { markdownExtensions: [quiet] }];
+    expect(collectMarkdownExtensions(plugins)).toEqual([shout, quiet]);
+  });
+
+  it("flattens declared block delimiters and skips extensions without any", () => {
+    const plugins = [{ markdownExtensions: [shout, quiet] }];
+    expect(collectMarkdownBlockDelimiters(plugins)).toEqual([{ open: "$$", close: "$$" }]);
+  });
+});
+
+describe("applyMarkdownExtensionParsers", () => {
+  it("applies each parser to the same instance and returns it", () => {
+    const parser = new MarkdownIt();
+    const result = applyMarkdownExtensionParsers(parser, [shout, quiet]);
+    expect(result).toBe(parser);
+    const inline = parser.parse("hello", {}).find((token) => token.type === "inline");
+    expect(inline?.content).toBe("HELLO");
+  });
+});
+
+describe("mergeMarkdownExtensionRules", () => {
+  it("spreads extension rules after the base so a later extension wins", () => {
+    const base = { paragraph: () => "base", text: () => "text" };
+    const merged = mergeMarkdownExtensionRules(base, [shout, quiet]);
+    const call = (rule: (typeof merged)[string]) =>
+      rule?.({} as never, [], [], {} as never, {} as never);
+    // Plugin rules come back wrapped, so compare what they render rather than identity.
+    expect(call(merged.paragraph)).toBe("quiet");
+    expect(call(merged.heading1)).toBe("h1");
+    expect(merged.text).toBe(base.text);
+  });
+
+  it("returns a new object and leaves the base untouched", () => {
+    const base = { text: () => "text" };
+    const merged = mergeMarkdownExtensionRules(base, [quiet]);
+    expect(merged).not.toBe(base);
+    expect(Object.keys(base)).toEqual(["text"]);
+  });
+});
+
+describe("isolating a failing extension", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Both run while an assistant message renders, so an escaping error reaches the root boundary
+  // and replaces the whole app. Every other kind of plugin contribution is already wrapped.
+  it("keeps a throwing parser from escaping, and still applies the others", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const broken: PluginMarkdownExtension = {
+      id: "broken",
+      parser: () => {
+        throw new Error("boom");
+      },
+    };
+
+    const applied: string[] = [];
+    const healthy: PluginMarkdownExtension = {
+      id: "healthy",
+      parser: () => {
+        applied.push("healthy");
+      },
+    };
+
+    applyMarkdownExtensionParsers(new MarkdownIt(), [broken, healthy]);
+
+    expect(applied).toEqual(["healthy"]);
+    expect(warn).toHaveBeenCalledWith(
+      "[Plugins] Markdown extension broken failed to install",
+      expect.any(Error),
+    );
+  });
+
+  it("renders nothing for a rule that throws instead of failing the message", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const broken: PluginMarkdownExtension = {
+      id: "broken",
+      rules: {
+        paragraph: () => {
+          throw new Error("boom");
+        },
+      },
+    };
+
+    const rules = mergeMarkdownExtensionRules({}, [broken]);
+
+    expect(rules.paragraph?.({} as never, [], [], {} as never, {} as never)).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      "[Plugins] Markdown rule broken/paragraph failed",
+      expect.any(Error),
+    );
+  });
+});

--- a/packages/app/src/plugins/markdown-extensions.test.ts
+++ b/packages/app/src/plugins/markdown-extensions.test.ts
@@ -41,10 +41,12 @@ describe("collectMarkdownExtensions", () => {
 });
 
 describe("applyMarkdownExtensionParsers", () => {
-  it("applies each parser to the same instance and returns it", () => {
-    const parser = new MarkdownIt();
-    const result = applyMarkdownExtensionParsers(parser, [shout, quiet]);
-    expect(result).toBe(parser);
+  it("applies each parser to the created instance and returns successful extensions", () => {
+    const { parser, extensions } = applyMarkdownExtensionParsers(
+      () => new MarkdownIt(),
+      [shout, quiet],
+    );
+    expect(extensions).toEqual([shout, quiet]);
     const inline = parser.parse("hello", {}).find((token) => token.type === "inline");
     expect(inline?.content).toBe("HELLO");
   });
@@ -94,9 +96,10 @@ describe("isolating a failing extension", () => {
       },
     };
 
-    applyMarkdownExtensionParsers(new MarkdownIt(), [broken, healthy]);
+    const installed = applyMarkdownExtensionParsers(() => new MarkdownIt(), [broken, healthy]);
 
     expect(applied).toEqual(["healthy"]);
+    expect(installed.extensions.map((extension) => extension.id)).toEqual(["healthy"]);
     expect(warn).toHaveBeenCalledWith(
       "[Plugins] Markdown extension broken failed to install",
       expect.any(Error),
@@ -117,6 +120,69 @@ describe("isolating a failing extension", () => {
     const rules = mergeMarkdownExtensionRules({}, [broken]);
 
     expect(rules.paragraph?.({} as never, [], [], {} as never, {} as never)).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      "[Plugins] Markdown rule broken/paragraph failed",
+      expect.any(Error),
+    );
+  });
+
+  it("drops an extension whose parser mutates then throws, and keeps paragraphs", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const broken: PluginMarkdownExtension = {
+      id: "broken",
+      parser: (markdown) => {
+        markdown.block.ruler.at("paragraph", () => false);
+        throw new Error("boom");
+      },
+      rules: { paragraph: () => "broken" },
+      blockDelimiters: [{ open: "$$", close: "$$" }],
+    };
+    const healthy: PluginMarkdownExtension = {
+      id: "healthy",
+      parser: (markdown) => {
+        markdown.core.ruler.push("healthy", (state) => {
+          for (const token of state.tokens) {
+            if (token.type === "inline") token.content = `${token.content}!`;
+          }
+          return true;
+        });
+      },
+    };
+
+    const { parser, extensions } = applyMarkdownExtensionParsers(
+      () => new MarkdownIt(),
+      [broken, healthy],
+    );
+
+    expect(extensions.map((extension) => extension.id)).toEqual(["healthy"]);
+    expect(
+      collectMarkdownBlockDelimiters(
+        extensions.map((extension) => ({ markdownExtensions: [extension] })),
+      ),
+    ).toEqual([]);
+    const tokens = parser.parse("hello", {});
+    expect(tokens.some((token) => token.type === "paragraph_open")).toBe(true);
+    expect(tokens.find((token) => token.type === "inline")?.content).toBe("hello!");
+    expect(warn).toHaveBeenCalledWith(
+      "[Plugins] Markdown extension broken failed to install",
+      expect.any(Error),
+    );
+  });
+
+  it("falls back to the previous rule when an overriding rule throws", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const broken: PluginMarkdownExtension = {
+      id: "broken",
+      rules: {
+        paragraph: () => {
+          throw new Error("boom");
+        },
+      },
+    };
+
+    const rules = mergeMarkdownExtensionRules({ paragraph: () => "base" }, [broken]);
+
+    expect(rules.paragraph?.({} as never, [], [], {} as never, {} as never)).toBe("base");
     expect(warn).toHaveBeenCalledWith(
       "[Plugins] Markdown rule broken/paragraph failed",
       expect.any(Error),

--- a/packages/app/src/plugins/markdown-extensions.test.ts
+++ b/packages/app/src/plugins/markdown-extensions.test.ts
@@ -106,6 +106,36 @@ describe("isolating a failing extension", () => {
     );
   });
 
+  it("keeps a previously accepted parser from escaping when rebuild throws", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let installs = 0;
+    const flaky: PluginMarkdownExtension = {
+      id: "flaky",
+      parser: () => {
+        installs += 1;
+        if (installs > 1) throw new Error("rebuild boom");
+      },
+    };
+    const broken: PluginMarkdownExtension = {
+      id: "broken",
+      parser: () => {
+        throw new Error("boom");
+      },
+    };
+
+    expect(() =>
+      applyMarkdownExtensionParsers(() => new MarkdownIt(), [flaky, broken]),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      "[Plugins] Markdown extension broken failed to install",
+      expect.any(Error),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "[Plugins] Markdown extension flaky failed to install",
+      expect.any(Error),
+    );
+  });
+
   it("renders nothing for a rule that throws instead of failing the message", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const broken: PluginMarkdownExtension = {

--- a/packages/app/src/plugins/markdown-extensions.test.ts
+++ b/packages/app/src/plugins/markdown-extensions.test.ts
@@ -136,6 +136,37 @@ describe("isolating a failing extension", () => {
     );
   });
 
+  it("discards rebuild mutations when a previously accepted parser throws", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let installs = 0;
+    const flaky: PluginMarkdownExtension = {
+      id: "flaky",
+      parser: (markdown) => {
+        installs += 1;
+        markdown.block.ruler.at("paragraph", () => false);
+        if (installs > 1) throw new Error("rebuild boom");
+      },
+    };
+    const broken: PluginMarkdownExtension = {
+      id: "broken",
+      parser: () => {
+        throw new Error("boom");
+      },
+    };
+
+    const { parser, extensions } = applyMarkdownExtensionParsers(
+      () => new MarkdownIt(),
+      [flaky, broken],
+    );
+
+    expect(extensions).toEqual([]);
+    expect(parser.parse("hello", {}).some((token) => token.type === "paragraph_open")).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      "[Plugins] Markdown extension flaky failed to install",
+      expect.any(Error),
+    );
+  });
+
   it("renders nothing for a rule that throws instead of failing the message", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const broken: PluginMarkdownExtension = {

--- a/packages/app/src/plugins/markdown-extensions.ts
+++ b/packages/app/src/plugins/markdown-extensions.ts
@@ -1,0 +1,68 @@
+import type MarkdownIt from "markdown-it";
+import type { RenderRules } from "react-native-markdown-display";
+import type { PluginMarkdownExtension } from "@getpaseo/plugin/client";
+import type { MarkdownBlockDelimiter } from "@/utils/split-markdown-blocks";
+
+interface MarkdownExtensionHost {
+  markdownExtensions: PluginMarkdownExtension[];
+}
+
+type MarkdownRenderRule = NonNullable<RenderRules[string]>;
+
+export function collectMarkdownExtensions(
+  plugins: readonly MarkdownExtensionHost[],
+): PluginMarkdownExtension[] {
+  return plugins.flatMap((plugin) => plugin.markdownExtensions);
+}
+
+export function collectMarkdownBlockDelimiters(
+  plugins: readonly MarkdownExtensionHost[],
+): MarkdownBlockDelimiter[] {
+  return collectMarkdownExtensions(plugins).flatMap((extension) => extension.blockDelimiters ?? []);
+}
+
+/**
+ * Applies every extension parser to `parser` in registration order and returns it. A parser that
+ * throws loses only its own extension: this runs while rendering an assistant message, so an
+ * escaping error would otherwise reach the root boundary and replace the whole app.
+ */
+export function applyMarkdownExtensionParsers(
+  parser: MarkdownIt,
+  extensions: readonly PluginMarkdownExtension[],
+): MarkdownIt {
+  for (const extension of extensions) {
+    if (!extension.parser) continue;
+    try {
+      parser.use(extension.parser);
+    } catch (error) {
+      console.warn(`[Plugins] Markdown extension ${extension.id} failed to install`, error);
+    }
+  }
+  return parser;
+}
+
+/** A rule that throws renders nothing rather than taking the message down with it. */
+function isolateRule(extensionId: string, name: string, rule: MarkdownRenderRule) {
+  return (...args: Parameters<MarkdownRenderRule>) => {
+    try {
+      return rule(...args);
+    } catch (error) {
+      console.warn(`[Plugins] Markdown rule ${extensionId}/${name} failed`, error);
+      return null;
+    }
+  };
+}
+
+/** Built-in rules first, then each extension in order, so a plugin rule wins on collision. */
+export function mergeMarkdownExtensionRules(
+  baseRules: RenderRules,
+  extensions: readonly PluginMarkdownExtension[],
+): RenderRules {
+  const merged: RenderRules = { ...baseRules };
+  for (const extension of extensions) {
+    for (const [name, rule] of Object.entries(extension.rules ?? {})) {
+      if (rule) merged[name] = isolateRule(extension.id, name, rule);
+    }
+  }
+  return merged;
+}

--- a/packages/app/src/plugins/markdown-extensions.ts
+++ b/packages/app/src/plugins/markdown-extensions.ts
@@ -46,13 +46,10 @@ export function applyMarkdownExtensionParsers(
   let parser = createParser();
   for (const extension of extensions) {
     if (!tryInstallParser(parser, extension)) {
-      parser = createParser();
-      const surviving: PluginMarkdownExtension[] = [];
-      for (const previous of applied) {
-        if (tryInstallParser(parser, previous)) surviving.push(previous);
-      }
+      const rebuilt = applyMarkdownExtensionParsers(createParser, applied);
+      parser = rebuilt.parser;
       applied.length = 0;
-      applied.push(...surviving);
+      applied.push(...rebuilt.extensions);
       continue;
     }
     applied.push(extension);

--- a/packages/app/src/plugins/markdown-extensions.ts
+++ b/packages/app/src/plugins/markdown-extensions.ts
@@ -22,33 +22,49 @@ export function collectMarkdownBlockDelimiters(
 }
 
 /**
- * Applies every extension parser to `parser` in registration order and returns it. A parser that
- * throws loses only its own extension: this runs while rendering an assistant message, so an
- * escaping error would otherwise reach the root boundary and replace the whole app.
+ * Applies every extension parser in registration order. A parser that throws loses only its own
+ * extension, including any ruler mutations it made before throwing: this runs while rendering an
+ * assistant message, so an escaping error would otherwise reach the root boundary and replace the
+ * whole app.
  */
 export function applyMarkdownExtensionParsers(
-  parser: MarkdownIt,
+  createParser: () => MarkdownIt,
   extensions: readonly PluginMarkdownExtension[],
-): MarkdownIt {
+): { parser: MarkdownIt; extensions: PluginMarkdownExtension[] } {
+  const applied: PluginMarkdownExtension[] = [];
+  let parser = createParser();
   for (const extension of extensions) {
-    if (!extension.parser) continue;
+    if (!extension.parser) {
+      applied.push(extension);
+      continue;
+    }
     try {
       parser.use(extension.parser);
+      applied.push(extension);
     } catch (error) {
       console.warn(`[Plugins] Markdown extension ${extension.id} failed to install`, error);
+      parser = createParser();
+      for (const previous of applied) {
+        if (previous.parser) parser.use(previous.parser);
+      }
     }
   }
-  return parser;
+  return { parser, extensions: applied };
 }
 
-/** A rule that throws renders nothing rather than taking the message down with it. */
-function isolateRule(extensionId: string, name: string, rule: MarkdownRenderRule) {
+/** A rule that throws falls back to the previous rule rather than taking the message down with it. */
+function isolateRule(
+  extensionId: string,
+  name: string,
+  rule: MarkdownRenderRule,
+  previous: MarkdownRenderRule | undefined,
+) {
   return (...args: Parameters<MarkdownRenderRule>) => {
     try {
       return rule(...args);
     } catch (error) {
       console.warn(`[Plugins] Markdown rule ${extensionId}/${name} failed`, error);
-      return null;
+      return previous ? previous(...args) : null;
     }
   };
 }
@@ -61,7 +77,10 @@ export function mergeMarkdownExtensionRules(
   const merged: RenderRules = { ...baseRules };
   for (const extension of extensions) {
     for (const [name, rule] of Object.entries(extension.rules ?? {})) {
-      if (rule) merged[name] = isolateRule(extension.id, name, rule);
+      if (rule) {
+        const previous = merged[name];
+        merged[name] = isolateRule(extension.id, name, rule, previous);
+      }
     }
   }
   return merged;

--- a/packages/app/src/plugins/markdown-extensions.ts
+++ b/packages/app/src/plugins/markdown-extensions.ts
@@ -25,8 +25,19 @@ export function collectMarkdownBlockDelimiters(
  * Applies every extension parser in registration order. A parser that throws loses only its own
  * extension, including any ruler mutations it made before throwing: this runs while rendering an
  * assistant message, so an escaping error would otherwise reach the root boundary and replace the
- * whole app.
+ * whole app. Rebuild of previously accepted parsers uses the same catch.
  */
+function tryInstallParser(parser: MarkdownIt, extension: PluginMarkdownExtension): boolean {
+  if (!extension.parser) return true;
+  try {
+    parser.use(extension.parser);
+    return true;
+  } catch (error) {
+    console.warn(`[Plugins] Markdown extension ${extension.id} failed to install`, error);
+    return false;
+  }
+}
+
 export function applyMarkdownExtensionParsers(
   createParser: () => MarkdownIt,
   extensions: readonly PluginMarkdownExtension[],
@@ -34,20 +45,17 @@ export function applyMarkdownExtensionParsers(
   const applied: PluginMarkdownExtension[] = [];
   let parser = createParser();
   for (const extension of extensions) {
-    if (!extension.parser) {
-      applied.push(extension);
+    if (!tryInstallParser(parser, extension)) {
+      parser = createParser();
+      const surviving: PluginMarkdownExtension[] = [];
+      for (const previous of applied) {
+        if (tryInstallParser(parser, previous)) surviving.push(previous);
+      }
+      applied.length = 0;
+      applied.push(...surviving);
       continue;
     }
-    try {
-      parser.use(extension.parser);
-      applied.push(extension);
-    } catch (error) {
-      console.warn(`[Plugins] Markdown extension ${extension.id} failed to install`, error);
-      parser = createParser();
-      for (const previous of applied) {
-        if (previous.parser) parser.use(previous.parser);
-      }
-    }
+    applied.push(extension);
   }
   return { parser, extensions: applied };
 }

--- a/packages/app/src/plugins/react-native/runtime.ts
+++ b/packages/app/src/plugins/react-native/runtime.ts
@@ -1,3 +1,4 @@
+import { SvgXml } from "react-native-svg";
 import { Icon } from "../icons";
 import { Modal } from "./modal";
 import { ScrollView, FlatList } from "./scroll-view";
@@ -15,4 +16,5 @@ export const pluginReactNativeRuntime = {
   copyText,
   useRevealedText,
   useToast,
+  SvgXml,
 };

--- a/packages/app/src/plugins/registry.test.ts
+++ b/packages/app/src/plugins/registry.test.ts
@@ -237,13 +237,16 @@ describe("PluginRegistry", () => {
       })`;
 
     pluginRegistry.installCatalog("host-a", [{ id: "math-plugin", clientBundle }]);
-    expect(getMarkdownBlockDelimiters()).toEqual([
+    pluginRegistry.installCatalog("host-b", []);
+    expect(getMarkdownBlockDelimiters("host-a")).toEqual([
       { open: "$$", close: "$$" },
       { open: "\\[", close: "\\]" },
     ]);
+    expect(getMarkdownBlockDelimiters("host-b")).toEqual([]);
 
     pluginRegistry.removeHost("host-a");
-    expect(getMarkdownBlockDelimiters()).toEqual([]);
+    expect(getMarkdownBlockDelimiters("host-a")).toEqual([]);
+    expect(getMarkdownBlockDelimiters("host-b")).toEqual([]);
   });
 });
 

--- a/packages/app/src/plugins/registry.test.ts
+++ b/packages/app/src/plugins/registry.test.ts
@@ -1,7 +1,7 @@
 import appPackage from "../../package.json";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
-import { getMarkdownBlockDelimiters } from "@/utils/split-markdown-blocks";
+import { getMarkdownBlockDelimiters, splitMarkdownBlocks } from "@/utils/split-markdown-blocks";
 import { pluginRegistry as registry, selectHostPlugins } from "./registry";
 import type { InstalledPlugin } from "./types";
 
@@ -247,6 +247,31 @@ describe("PluginRegistry", () => {
     pluginRegistry.removeHost("host-a");
     expect(getMarkdownBlockDelimiters("host-a")).toEqual([]);
     expect(getMarkdownBlockDelimiters("host-b")).toEqual([]);
+  });
+
+  it("does not publish delimiters from an extension whose parser throws", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const clientBundle = `(function() {
+        const module = { exports: {} };
+        module.exports.default = function(plugin) {
+          plugin.addMarkdownExtension({
+            id: "broken",
+            blockDelimiters: [{ open: "$$", close: "$$" }],
+            parser: function() { throw new Error("boom"); },
+          });
+          return function() {};
+        };
+        return module.exports;
+      })`;
+
+    pluginRegistry.installCatalog("host-a", [{ id: "broken-plugin", clientBundle }]);
+    expect(splitMarkdownBlocks("Before\n\n$$\na\n\nb\n$$", { serverId: "host-a" })).toEqual([
+      "Before",
+      "$$\na",
+      "b\n$$",
+    ]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });
 

--- a/packages/app/src/plugins/registry.test.ts
+++ b/packages/app/src/plugins/registry.test.ts
@@ -1,7 +1,9 @@
 import appPackage from "../../package.json";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
-import { pluginRegistry as registry } from "./registry";
+import { getMarkdownBlockDelimiters } from "@/utils/split-markdown-blocks";
+import { pluginRegistry as registry, selectHostPlugins } from "./registry";
+import type { InstalledPlugin } from "./types";
 
 vi.mock("./navigation", () => ({
   createPluginNavigation: () => ({}),
@@ -219,5 +221,44 @@ describe("PluginRegistry", () => {
 
     expect(() => pluginRegistry.removeHost("host-a")).not.toThrow();
     expect(pluginRegistry.getSnapshot()).toEqual([]);
+  });
+
+  it("pushes declared block delimiters into the markdown splitter on publish", () => {
+    const clientBundle = `(function() {
+        const module = { exports: {} };
+        module.exports.default = function(plugin) {
+          plugin.addMarkdownExtension({
+            id: "math",
+            blockDelimiters: [{ open: "$$", close: "$$" }, { open: "\\\\[", close: "\\\\]" }],
+          });
+          return function() {};
+        };
+        return module.exports;
+      })`;
+
+    pluginRegistry.installCatalog("host-a", [{ id: "math-plugin", clientBundle }]);
+    expect(getMarkdownBlockDelimiters()).toEqual([
+      { open: "$$", close: "$$" },
+      { open: "\\[", close: "\\]" },
+    ]);
+
+    pluginRegistry.removeHost("host-a");
+    expect(getMarkdownBlockDelimiters()).toEqual([]);
+  });
+});
+
+describe("selectHostPlugins", () => {
+  const alpha = { serverId: "alpha", id: "math" } as InstalledPlugin;
+  const beta = { serverId: "beta", id: "math" } as InstalledPlugin;
+
+  // Markdown extensions rewrite assistant messages, so with two hosts connected a plugin
+  // installed on one must not reach the other's messages.
+  it("returns only the named host's plugins", () => {
+    expect(selectHostPlugins([alpha, beta], "alpha")).toEqual([alpha]);
+  });
+
+  it("returns nothing when the host is unknown", () => {
+    expect(selectHostPlugins([alpha, beta], undefined)).toEqual([]);
+    expect(selectHostPlugins([alpha, beta], "")).toEqual([]);
   });
 });

--- a/packages/app/src/plugins/registry.test.ts
+++ b/packages/app/src/plugins/registry.test.ts
@@ -1,7 +1,12 @@
 import appPackage from "../../package.json";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
-import { getMarkdownBlockDelimiters, splitMarkdownBlocks } from "@/utils/split-markdown-blocks";
+import {
+  clearMarkdownBlockDelimiters,
+  getMarkdownBlockDelimiters,
+  hasPublishedMarkdownBlockDelimiters,
+  splitMarkdownBlocks,
+} from "@/utils/split-markdown-blocks";
 import { pluginRegistry as registry, selectHostPlugins } from "./registry";
 import type { InstalledPlugin } from "./types";
 
@@ -72,6 +77,7 @@ function installedPluginIds(): string[] {
 afterEach(() => {
   pluginRegistry.removeHost("host-a");
   pluginRegistry.removeHost("host-b");
+  clearMarkdownBlockDelimiters();
   Reflect.deleteProperty(globalThis, "__pluginCleanups");
 });
 
@@ -247,6 +253,21 @@ describe("PluginRegistry", () => {
     pluginRegistry.removeHost("host-a");
     expect(getMarkdownBlockDelimiters("host-a")).toEqual([]);
     expect(getMarkdownBlockDelimiters("host-b")).toEqual([]);
+  });
+
+  it("publishes empty delimiters when a host never had a catalog", () => {
+    expect(hasPublishedMarkdownBlockDelimiters("host-a")).toBe(false);
+    pluginRegistry.removeHost("host-a");
+    expect(hasPublishedMarkdownBlockDelimiters("host-a")).toBe(true);
+    expect(getMarkdownBlockDelimiters("host-a")).toEqual([]);
+  });
+
+  it("keeps an empty host published after teardown", () => {
+    pluginRegistry.installCatalog("host-a", []);
+    expect(hasPublishedMarkdownBlockDelimiters("host-a")).toBe(true);
+    pluginRegistry.removeHost("host-a");
+    expect(hasPublishedMarkdownBlockDelimiters("host-a")).toBe(true);
+    expect(getMarkdownBlockDelimiters("host-a")).toEqual([]);
   });
 
   it("does not publish delimiters from an extension whose parser throws", () => {

--- a/packages/app/src/plugins/registry.ts
+++ b/packages/app/src/plugins/registry.ts
@@ -3,8 +3,10 @@ import { QueryClient } from "@tanstack/react-query";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { assertPluginCompatibility } from "@getpaseo/protocol/plugin-requirements";
 import { resolveAppVersion } from "@/utils/app-version";
+import { setMarkdownBlockDelimiters } from "@/utils/split-markdown-blocks";
 import { createPluginClientRuntime } from "./client-runtime";
 import { runPluginClientBundle, type PluginClientRuntime } from "./evaluate";
+import { collectMarkdownBlockDelimiters } from "./markdown-extensions";
 import type { InstalledPlugin } from "./types";
 
 type CatalogPlugin = Awaited<ReturnType<DaemonClient["getPluginCatalog"]>>[number];
@@ -95,6 +97,7 @@ export class PluginRegistry {
           themes: [],
           timelineTransformers: [],
           timelineRenderers: [],
+          markdownExtensions: [],
         };
         runtime = this.dependencies.createRuntime(installation, options.client);
         const evaluated = runPluginClientBundle(entry.id, entry.clientBundle, runtime, () =>
@@ -171,6 +174,9 @@ export class PluginRegistry {
       .sort((left, right) =>
         `${left.serverId}/${left.id}`.localeCompare(`${right.serverId}/${right.id}`),
       );
+    // The block splitter runs in the stream reducer and the height estimator, which cannot
+    // subscribe to this registry, so push the delimiters instead of having them pull.
+    setMarkdownBlockDelimiters(collectMarkdownBlockDelimiters(this.snapshot));
     for (const listener of this.listeners) listener();
   }
 }
@@ -194,6 +200,21 @@ export function useInstalledPlugin(serverId: string, pluginId: string): Installe
       (plugin) => plugin.serverId === serverId && plugin.id === pluginId,
     ) ?? null
   );
+}
+
+/** No host means no plugins, not every host's. */
+export function selectHostPlugins(
+  installed: readonly InstalledPlugin[],
+  serverId: string | undefined,
+): InstalledPlugin[] {
+  if (!serverId) return [];
+  return installed.filter((plugin) => plugin.serverId === serverId);
+}
+
+/** Plugins installed on one host. */
+export function useHostPlugins(serverId: string | undefined): InstalledPlugin[] {
+  const installed = useInstalledPlugins();
+  return useMemo(() => selectHostPlugins(installed, serverId), [installed, serverId]);
 }
 
 export function usePluginInstallations(pluginId: string): InstalledPlugin[] {

--- a/packages/app/src/plugins/registry.ts
+++ b/packages/app/src/plugins/registry.ts
@@ -2,6 +2,7 @@ import { useMemo, useSyncExternalStore } from "react";
 import { QueryClient } from "@tanstack/react-query";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { assertPluginCompatibility } from "@getpaseo/protocol/plugin-requirements";
+import MarkdownIt from "markdown-it";
 import { resolveAppVersion } from "@/utils/app-version";
 import {
   clearMarkdownBlockDelimiters,
@@ -9,7 +10,11 @@ import {
 } from "@/utils/split-markdown-blocks";
 import { createPluginClientRuntime } from "./client-runtime";
 import { runPluginClientBundle, type PluginClientRuntime } from "./evaluate";
-import { collectMarkdownBlockDelimiters } from "./markdown-extensions";
+import {
+  applyMarkdownExtensionParsers,
+  collectMarkdownBlockDelimiters,
+  collectMarkdownExtensions,
+} from "./markdown-extensions";
 import type { InstalledPlugin } from "./types";
 
 type CatalogPlugin = Awaited<ReturnType<DaemonClient["getPluginCatalog"]>>[number];
@@ -181,9 +186,16 @@ export class PluginRegistry {
     // The block splitter runs in the stream reducer and the height estimator, which cannot
     // subscribe to this registry, so push per-host delimiters instead of having them pull.
     for (const serverId of this.byHost.keys()) {
+      const extensions = collectMarkdownExtensions(selectHostPlugins(this.snapshot, serverId));
+      const { extensions: installed } = applyMarkdownExtensionParsers(
+        () => new MarkdownIt(),
+        extensions,
+      );
       setMarkdownBlockDelimiters(
         serverId,
-        collectMarkdownBlockDelimiters(selectHostPlugins(this.snapshot, serverId)),
+        collectMarkdownBlockDelimiters(
+          installed.map((extension) => ({ markdownExtensions: [extension] })),
+        ),
       );
     }
     for (const listener of this.listeners) listener();

--- a/packages/app/src/plugins/registry.ts
+++ b/packages/app/src/plugins/registry.ts
@@ -4,10 +4,7 @@ import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { assertPluginCompatibility } from "@getpaseo/protocol/plugin-requirements";
 import MarkdownIt from "markdown-it";
 import { resolveAppVersion } from "@/utils/app-version";
-import {
-  clearMarkdownBlockDelimiters,
-  setMarkdownBlockDelimiters,
-} from "@/utils/split-markdown-blocks";
+import { setMarkdownBlockDelimiters } from "@/utils/split-markdown-blocks";
 import { createPluginClientRuntime } from "./client-runtime";
 import { runPluginClientBundle, type PluginClientRuntime } from "./evaluate";
 import {
@@ -153,14 +150,23 @@ export class PluginRegistry {
 
   removeHost(serverId: string): void {
     const installed = this.byHost.get(serverId);
-    if (!installed) return;
-    for (const plugin of installed) this.dispose(plugin);
-    for (const key of this.evaluationErrors.keys()) {
-      if (key.startsWith(`${serverId}/`)) this.evaluationErrors.delete(key);
+    if (installed) {
+      for (const plugin of installed) this.dispose(plugin);
+      for (const key of this.evaluationErrors.keys()) {
+        if (key.startsWith(`${serverId}/`)) this.evaluationErrors.delete(key);
+      }
+      this.byHost.delete(serverId);
+      this.publish();
     }
-    this.byHost.delete(serverId);
-    clearMarkdownBlockDelimiters(serverId);
-    this.publish();
+    // Unsupported, disconnected, and torn-down hosts have no catalog to wait for.
+    // Publish empty delimiters so completed-block promotion keeps running.
+    this.acknowledgeEmptyHost(serverId);
+  }
+
+  /** Pending is only while a catalog load is in flight. */
+  acknowledgeEmptyHost(serverId: string): void {
+    if (this.byHost.has(serverId)) return;
+    setMarkdownBlockDelimiters(serverId, []);
   }
 
   private dispose(plugin: InstalledPlugin): void {

--- a/packages/app/src/plugins/registry.ts
+++ b/packages/app/src/plugins/registry.ts
@@ -3,7 +3,10 @@ import { QueryClient } from "@tanstack/react-query";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { assertPluginCompatibility } from "@getpaseo/protocol/plugin-requirements";
 import { resolveAppVersion } from "@/utils/app-version";
-import { setMarkdownBlockDelimiters } from "@/utils/split-markdown-blocks";
+import {
+  clearMarkdownBlockDelimiters,
+  setMarkdownBlockDelimiters,
+} from "@/utils/split-markdown-blocks";
 import { createPluginClientRuntime } from "./client-runtime";
 import { runPluginClientBundle, type PluginClientRuntime } from "./evaluate";
 import { collectMarkdownBlockDelimiters } from "./markdown-extensions";
@@ -151,6 +154,7 @@ export class PluginRegistry {
       if (key.startsWith(`${serverId}/`)) this.evaluationErrors.delete(key);
     }
     this.byHost.delete(serverId);
+    clearMarkdownBlockDelimiters(serverId);
     this.publish();
   }
 
@@ -175,8 +179,13 @@ export class PluginRegistry {
         `${left.serverId}/${left.id}`.localeCompare(`${right.serverId}/${right.id}`),
       );
     // The block splitter runs in the stream reducer and the height estimator, which cannot
-    // subscribe to this registry, so push the delimiters instead of having them pull.
-    setMarkdownBlockDelimiters(collectMarkdownBlockDelimiters(this.snapshot));
+    // subscribe to this registry, so push per-host delimiters instead of having them pull.
+    for (const serverId of this.byHost.keys()) {
+      setMarkdownBlockDelimiters(
+        serverId,
+        collectMarkdownBlockDelimiters(selectHostPlugins(this.snapshot, serverId)),
+      );
+    }
     for (const listener of this.listeners) listener();
   }
 }

--- a/packages/app/src/plugins/sidebar-groups.test.ts
+++ b/packages/app/src/plugins/sidebar-groups.test.ts
@@ -28,6 +28,7 @@ function installed(serverId: string, contributionId = "main"): InstalledPlugin {
     themes: [],
     timelineTransformers: [],
     timelineRenderers: [],
+    markdownExtensions: [],
   };
 }
 

--- a/packages/app/src/plugins/surface-contribution.test.ts
+++ b/packages/app/src/plugins/surface-contribution.test.ts
@@ -33,6 +33,7 @@ function installation(
     themes: [],
     timelineTransformers: [],
     timelineRenderers: [],
+    markdownExtensions: [],
   };
 }
 

--- a/packages/app/src/plugins/theme.test.ts
+++ b/packages/app/src/plugins/theme.test.ts
@@ -61,6 +61,7 @@ function installed(serverId: string, themes: PluginThemeContribution[]): Install
     themes,
     timelineTransformers: [],
     timelineRenderers: [],
+    markdownExtensions: [],
   };
 }
 

--- a/packages/app/src/plugins/timeline/model.test.ts
+++ b/packages/app/src/plugins/timeline/model.test.ts
@@ -33,6 +33,7 @@ function plugin(input: {
       },
     ],
     timelineRenderers: [],
+    markdownExtensions: [],
   };
 }
 

--- a/packages/app/src/plugins/types.ts
+++ b/packages/app/src/plugins/types.ts
@@ -14,6 +14,7 @@ import type {
   PluginSettingsScreenContribution,
   PluginTimelineRendererContribution,
   PluginTimelineTransformerContribution,
+  PluginMarkdownExtension,
   PluginPanelLocation,
   PluginWorkspacePanelContribution,
 } from "@getpaseo/plugin/client";
@@ -35,6 +36,7 @@ export interface EvaluatedPlugin {
   themes: PluginThemeContribution[];
   timelineTransformers: PluginTimelineTransformerContribution[];
   timelineRenderers: PluginTimelineRendererContribution[];
+  markdownExtensions: PluginMarkdownExtension[];
 }
 
 export interface InstalledPlugin extends EvaluatedPlugin {

--- a/packages/app/src/plugins/workspace-panels/resolution.test.ts
+++ b/packages/app/src/plugins/workspace-panels/resolution.test.ts
@@ -30,6 +30,7 @@ function installed(): InstalledPlugin {
     themes: [],
     timelineTransformers: [],
     timelineRenderers: [],
+    markdownExtensions: [],
   };
 }
 

--- a/packages/app/src/subagents/provider-store.test.ts
+++ b/packages/app/src/subagents/provider-store.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "vitest";
+import { clearMarkdownBlockDelimiters } from "@/utils/split-markdown-blocks";
 import { providerSubagentKey, useProviderSubagentStore } from "./provider-store";
 
 const SERVER_ID = "server-1";
@@ -6,6 +7,7 @@ const PARENT_ID = "parent-1";
 const SUBAGENT_ID = "child-1";
 
 afterEach(() => {
+  clearMarkdownBlockDelimiters();
   useProviderSubagentStore.setState({
     descriptors: new Map(),
     timelines: new Map(),
@@ -479,5 +481,84 @@ describe("provider subagent client store", () => {
     expect(timeline?.head).toEqual([
       expect.objectContaining({ kind: "assistant_message", text: "Current tail output." }),
     ]);
+  });
+
+  test("rebuilds list status with the host so an unpublished block stays whole", () => {
+    const text = "Before\n\n$$\na\n\nb";
+    const store = useProviderSubagentStore.getState();
+    store.applyUpdate(SERVER_ID, {
+      kind: "timeline",
+      parentAgentId: PARENT_ID,
+      subagentId: SUBAGENT_ID,
+      provider: "codex",
+      epoch: "epoch-1",
+      seq: 1,
+      timestamp: "2026-07-12T10:00:01.000Z",
+      item: { type: "assistant_message", text },
+    });
+    store.replaceList(SERVER_ID, PARENT_ID, [
+      {
+        id: SUBAGENT_ID,
+        parentAgentId: PARENT_ID,
+        provider: "codex",
+        title: "Restored child",
+        description: null,
+        status: "completed",
+        createdAt: "2026-07-12T10:00:00.000Z",
+        updatedAt: "2026-07-12T10:00:02.000Z",
+        toolCallId: "call-1",
+      },
+    ]);
+
+    const timeline = useProviderSubagentStore
+      .getState()
+      .timelines.get(providerSubagentKey(SERVER_ID, PARENT_ID, SUBAGENT_ID));
+    const messages = [...(timeline?.tail ?? []), ...(timeline?.head ?? [])].filter(
+      (item) => item.kind === "assistant_message",
+    );
+    expect(messages.map((item) => item.text)).toEqual([text]);
+  });
+
+  test("rebuilds upsert status with the host so an unpublished block stays whole", () => {
+    const text = "Before\n\n$$\na\n\nb";
+    const store = useProviderSubagentStore.getState();
+    const running = {
+      id: SUBAGENT_ID,
+      parentAgentId: PARENT_ID,
+      provider: "codex" as const,
+      title: "Explore",
+      description: null,
+      status: "running" as const,
+      createdAt: "2026-07-12T10:00:00.000Z",
+      updatedAt: "2026-07-12T10:00:00.000Z",
+      toolCallId: "call-1",
+    };
+    store.applyUpdate(SERVER_ID, { kind: "upsert", subagent: running });
+    store.applyUpdate(SERVER_ID, {
+      kind: "timeline",
+      parentAgentId: PARENT_ID,
+      subagentId: SUBAGENT_ID,
+      provider: "codex",
+      epoch: "epoch-1",
+      seq: 1,
+      timestamp: "2026-07-12T10:00:01.000Z",
+      item: { type: "assistant_message", text },
+    });
+    store.applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        ...running,
+        status: "completed",
+        updatedAt: "2026-07-12T10:00:02.000Z",
+      },
+    });
+
+    const timeline = useProviderSubagentStore
+      .getState()
+      .timelines.get(providerSubagentKey(SERVER_ID, PARENT_ID, SUBAGENT_ID));
+    const messages = [...(timeline?.tail ?? []), ...(timeline?.head ?? [])].filter(
+      (item) => item.kind === "assistant_message",
+    );
+    expect(messages.map((item) => item.text)).toEqual([text]);
   });
 });

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -135,6 +135,7 @@ function buildTimelineState(
   epoch: string | null,
   descriptor?: ProviderSubagentDescriptorPayload,
   hasOlder = false,
+  serverId?: string,
 ): ProviderSubagentTimelineState {
   let timeline = { tail: [] as StreamItem[], head: [] as StreamItem[] };
   for (const [, row] of [...rows].sort(([left], [right]) => left - right)) {
@@ -142,6 +143,7 @@ function buildTimelineState(
       ...timeline,
       event: { type: "timeline", provider: row.provider, item: row.item },
       timestamp: new Date(row.timestamp),
+      serverId,
     });
   }
   const terminalEvent = descriptor ? providerSubagentTerminalEvent(descriptor) : null;
@@ -150,6 +152,7 @@ function buildTimelineState(
       ...timeline,
       event: terminalEvent,
       timestamp: new Date(descriptor.updatedAt),
+      serverId,
     });
   }
   return {
@@ -290,12 +293,13 @@ export const useProviderSubagentStore = create<ProviderSubagentState>((set) => (
       const descriptor = state.descriptors.get(key);
       const next =
         descriptor && descriptor.status !== "running"
-          ? buildTimelineState(rows, payload.epoch, descriptor, current.hasOlder)
+          ? buildTimelineState(rows, payload.epoch, descriptor, current.hasOlder, serverId)
           : applyStreamEvent({
               tail: current.tail,
               head: current.head,
               event: { type: "timeline", provider: payload.provider, item: payload.item },
               timestamp: new Date(payload.timestamp),
+              serverId,
             });
       const timelines = new Map(state.timelines);
       timelines.set(key, {
@@ -319,7 +323,10 @@ export const useProviderSubagentStore = create<ProviderSubagentState>((set) => (
       const rows = buildTimelineResponseRows(existing, payload, provider);
       const descriptor = state.descriptors.get(key);
       const timelines = new Map(state.timelines);
-      timelines.set(key, buildTimelineState(rows, payload.epoch, descriptor, payload.hasOlder));
+      timelines.set(
+        key,
+        buildTimelineState(rows, payload.epoch, descriptor, payload.hasOlder, serverId),
+      );
       return { timelines };
     });
   },

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -234,7 +234,7 @@ export const useProviderSubagentStore = create<ProviderSubagentState>((set) => (
         if (current && previous?.status !== subagent.status) {
           timelines.set(
             key,
-            buildTimelineState(current.rows, current.epoch, subagent, current.hasOlder),
+            buildTimelineState(current.rows, current.epoch, subagent, current.hasOlder, serverId),
           );
         }
       }
@@ -262,7 +262,13 @@ export const useProviderSubagentStore = create<ProviderSubagentState>((set) => (
           timelines = new Map(state.timelines);
           timelines.set(
             key,
-            buildTimelineState(current.rows, current.epoch, payload.subagent, current.hasOlder),
+            buildTimelineState(
+              current.rows,
+              current.epoch,
+              payload.subagent,
+              current.hasOlder,
+              serverId,
+            ),
           );
         }
         return { descriptors, timelines, hiddenFromTrack };

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -3639,11 +3639,11 @@ describe("processTimelineResponse", () => {
         },
       });
 
-      const messages = [...result.tail, ...result.head].filter(
-        (item): item is Extract<StreamItem, { kind: "assistant_message" }> =>
-          item.kind === "assistant_message",
-      );
-      expect(messages.map((message) => message.text)).toEqual([text]);
+      const texts: string[] = [];
+      for (const item of [...result.tail, ...result.head]) {
+        if (item.kind === "assistant_message") texts.push(item.text);
+      }
+      expect(texts).toEqual([text]);
     });
   });
 });

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { AgentStreamEventPayload } from "@getpaseo/protocol/messages";
 import type { AgentTimelineItem, ToolCallDetail } from "@getpaseo/protocol/agent-types";
 import {
@@ -7,6 +7,7 @@ import {
   type AgentToolCallItem,
   type StreamItem,
 } from "@/types/stream";
+import { clearMarkdownBlockDelimiters } from "@/utils/split-markdown-blocks";
 import {
   createAgentStreamReducerQueue,
   deriveAgentStreamTurnLiveness,
@@ -3605,6 +3606,44 @@ describe("processTimelineResponse", () => {
       epoch: "epoch-1",
       startSeq: 1,
       endSeq: 2,
+    });
+  });
+
+  describe("host-scoped markdown during catch-up", () => {
+    afterEach(() => {
+      clearMarkdownBlockDelimiters();
+    });
+
+    it("does not split an unclosed extension block when catching up with an active head", () => {
+      const text = "Before\n\n$$\na\n\nb";
+      const liveThought: StreamItem = {
+        kind: "thought",
+        id: "live-thought",
+        text: "thinking",
+        timestamp: new Date(1500),
+        status: "loading",
+      };
+
+      const result = processTimelineResponse({
+        ...baseTimelineInput,
+        serverId: "host-a",
+        currentHead: [liveThought],
+        currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 1 },
+        payload: {
+          ...baseTimelineInput.payload,
+          direction: "after",
+          startCursor: { seq: 2 },
+          endCursor: { seq: 2 },
+          window: { minSeq: 2, maxSeq: 2, nextSeq: 3 },
+          entries: [makeTimelineEntry(2, text)],
+        },
+      });
+
+      const messages = [...result.tail, ...result.head].filter(
+        (item): item is Extract<StreamItem, { kind: "assistant_message" }> =>
+          item.kind === "assistant_message",
+      );
+      expect(messages.map((message) => message.text)).toEqual([text]);
     });
   });
 });

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -158,6 +158,7 @@ export interface ProcessTimelineResponseInput {
   hasActiveInitDeferred: boolean;
   initRequestDirection: InitRequestDirection;
   sendingClientMessageIds: readonly string[];
+  serverId?: string;
 }
 
 export interface ProcessTimelineResponseOutput {
@@ -1149,12 +1150,13 @@ function applyAcceptedTimelinePage(input: {
   currentTail: StreamItem[];
   currentHead: StreamItem[];
   currentCursor: TimelineCursor | undefined;
+  serverId?: string;
 }): {
   tail: StreamItem[];
   head: StreamItem[];
   acknowledgedClientMessageIds: string[];
 } {
-  const { acceptedUnits, payload, currentTail, currentHead, currentCursor } = input;
+  const { acceptedUnits, payload, currentTail, currentHead, currentCursor, serverId } = input;
   if (acceptedUnits.length === 0) {
     return { tail: currentTail, head: currentHead, acknowledgedClientMessageIds: [] };
   }
@@ -1165,6 +1167,7 @@ function applyAcceptedTimelinePage(input: {
       currentTail,
       currentHead,
       currentEndSeq: currentCursor?.endSeq,
+      serverId,
     });
   }
   const olderTail = hydrateStreamState(
@@ -1203,8 +1206,9 @@ function applyTimelineIncrementalPath(args: {
   currentTail: StreamItem[];
   currentHead: StreamItem[];
   currentCursor: TimelineCursor | undefined;
+  serverId?: string;
 }): TimelinePathResult {
-  const { timelineUnits, payload, currentTail, currentHead, currentCursor } = args;
+  const { timelineUnits, payload, currentTail, currentHead, currentCursor, serverId } = args;
   let nextCursor: TimelineCursor | null | undefined = currentCursor;
   let cursorChanged = false;
   const sideEffects: TimelineReducerSideEffect[] = [];
@@ -1240,6 +1244,7 @@ function applyTimelineIncrementalPath(args: {
     currentTail,
     currentHead,
     currentCursor,
+    serverId,
   });
 
   if (cursor && (!currentCursor || !timelineCursorEquals(currentCursor, cursor))) {
@@ -1274,6 +1279,7 @@ export function processTimelineResponse(
     hasActiveInitDeferred,
     initRequestDirection,
     sendingClientMessageIds,
+    serverId,
   } = input;
 
   // ------------------------------------------------------------------
@@ -1406,6 +1412,7 @@ export function processTimelineResponse(
       currentTail,
       currentHead,
       currentCursor,
+      serverId,
     });
   }
 

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -954,6 +954,7 @@ function applyCanonicalForwardUnit(params: {
   head: StreamItem[];
   unit: TimelineUnit;
   epoch: string;
+  serverId?: string;
 }): { tail: StreamItem[]; head: StreamItem[]; acknowledgedClientMessageIds: string[] } {
   const { event, timestamp, seqEnd } = params.unit;
   const timelineCursor = { epoch: params.epoch, seq: seqEnd };
@@ -965,6 +966,7 @@ function applyCanonicalForwardUnit(params: {
       timestamp,
       source: "canonical",
       timelineCursor,
+      serverId: params.serverId,
     });
     return {
       tail: applied.tail,
@@ -1019,6 +1021,7 @@ function applyCanonicalForwardUnit(params: {
     timestamp,
     source: "canonical",
     timelineCursor,
+    serverId: params.serverId,
   });
   return {
     tail: applied.tail,
@@ -1033,6 +1036,7 @@ function applyAcceptedForwardTimelineUnits(params: {
   currentTail: StreamItem[];
   currentHead: StreamItem[];
   currentEndSeq: number | undefined;
+  serverId?: string;
 }): { tail: StreamItem[]; head: StreamItem[]; acknowledgedClientMessageIds: string[] } {
   const reconciled = reconcileOverlappingProjectedStreamItems({
     tail: params.currentTail,
@@ -1051,6 +1055,7 @@ function applyAcceptedForwardTimelineUnits(params: {
       head,
       unit,
       epoch: params.epoch,
+      serverId: params.serverId,
     });
     tail = applied.tail;
     head = applied.head;
@@ -1064,6 +1069,7 @@ function applyAcceptedForwardTimelineUnits(params: {
       epoch: params.epoch,
       currentTail: params.currentTail,
       currentHead: params.currentHead,
+      serverId: params.serverId,
     }),
   };
 }
@@ -1073,13 +1079,20 @@ function deriveCanonicalAcknowledgements(params: {
   epoch: string;
   currentTail: StreamItem[];
   currentHead: StreamItem[];
+  serverId?: string;
 }): string[] {
   let tail = params.currentTail;
   let head = params.currentHead;
   const acknowledged = new Set<string>();
   for (const unit of params.units) {
     if (unit.event.type !== "timeline" || unit.event.item.type !== "user_message") continue;
-    const applied = applyCanonicalForwardUnit({ tail, head, unit, epoch: params.epoch });
+    const applied = applyCanonicalForwardUnit({
+      tail,
+      head,
+      unit,
+      epoch: params.epoch,
+      serverId: params.serverId,
+    });
     tail = applied.tail;
     head = applied.head;
     for (const clientMessageId of applied.acknowledgedClientMessageIds) {
@@ -1454,6 +1467,7 @@ export interface ProcessAgentStreamEventInput {
   currentCursor: TimelineCursor | undefined;
   hasAuthoritativeBaseline?: boolean;
   timestamp: Date;
+  serverId?: string;
 }
 
 export interface ProcessAgentStreamEventOutput {
@@ -1490,6 +1504,7 @@ export interface ProcessAgentStreamEventsInput {
   currentCursor: TimelineCursor | undefined;
   hasAuthoritativeBaseline?: boolean;
   isDetached?: boolean;
+  serverId?: string;
 }
 
 export type AgentStreamReducerSnapshot = Omit<ProcessAgentStreamEventsInput, "events">;
@@ -1599,6 +1614,7 @@ export function processAgentStreamEvent(
     currentCursor,
     timestamp,
     hasAuthoritativeBaseline = true,
+    serverId,
   } = input;
 
   const sequencing = processTimelineSequencingGate({
@@ -1633,6 +1649,7 @@ export function processAgentStreamEvent(
         source: "live",
         timelineCursor,
         unmatchedUserMessageInsert: "head",
+        serverId,
       });
     } else {
       const overlay = applyStreamEvent({
@@ -1642,6 +1659,7 @@ export function processAgentStreamEvent(
         timestamp,
         source: "live",
         timelineCursor,
+        serverId,
       });
       streamResult = {
         tail: currentTail,
@@ -1658,6 +1676,7 @@ export function processAgentStreamEvent(
       timestamp,
       source: "live",
       timelineCursor,
+      serverId,
     });
   }
   const { tail, head, changedTail, changedHead } = streamResult;
@@ -1712,6 +1731,7 @@ export function processAgentStreamEvents(
       currentCursor: cursor,
       hasAuthoritativeBaseline: input.hasAuthoritativeBaseline,
       timestamp: reducerEvent.timestamp,
+      serverId: input.serverId,
     });
 
     tail = result.tail;
@@ -1923,6 +1943,7 @@ export function createSessionAgentStreamReducerQueue(
         currentCursor: timeline.status === "synced" ? (timeline.range ?? undefined) : undefined,
         hasAuthoritativeBaseline: timeline.status === "synced",
         isDetached: timeline.status === "synced" && timeline.newer === "available",
+        serverId,
       };
     },
     commit: (agentId, result, events) => {

--- a/packages/app/src/timeline/viewed-timeline-sync.ts
+++ b/packages/app/src/timeline/viewed-timeline-sync.ts
@@ -281,6 +281,7 @@ function applyAuthoritativeTimelineResponse(input: {
     hasActiveInitDeferred: Boolean(activeInitDeferred),
     initRequestDirection: activeInitDeferred?.requestDirection ?? "tail",
     sendingClientMessageIds: getSendingClientMessageIds(session?.messageSubmissions.get(agentId)),
+    serverId,
   });
 
   if (result.error) {

--- a/packages/app/src/types/stream.test.ts
+++ b/packages/app/src/types/stream.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import invariant from "tiny-invariant";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   applyStreamEvent,
@@ -20,6 +20,10 @@ import type { AgentProvider, ToolCallDetail } from "@getpaseo/protocol/agent-typ
 import type { AgentStreamEventPayload } from "@getpaseo/protocol/messages";
 import { buildToolCallDisplayModel } from "@getpaseo/protocol/tool-call-display";
 import { timelineItemIdentity } from "@getpaseo/protocol/timeline-identity";
+import {
+  clearMarkdownBlockDelimiters,
+  setMarkdownBlockDelimiters,
+} from "@/utils/split-markdown-blocks";
 
 type CanonicalToolStatus = "running" | "completed" | "failed" | "canceled";
 
@@ -2264,5 +2268,64 @@ describe("notification timeline items", () => {
       { kind: "notification", level: "error", message: "Command blocked" },
     ]);
     expect(new Set(state.map((item) => item.id)).size).toBe(state.length);
+  });
+});
+
+describe("assistant block promotion with host catalogs", () => {
+  afterEach(() => {
+    clearMarkdownBlockDelimiters();
+  });
+
+  it("does not promote an unclosed extension block before the host catalog publishes", () => {
+    const text = "Before\n\n$$\na\n\nb";
+    const before = applyStreamEvent({
+      tail: [],
+      head: [],
+      event: assistantTimeline(text, "claude", "msg-catalog"),
+      timestamp: new Date("2025-01-01T10:02:00Z"),
+      serverId: "host-a",
+    });
+    const beforeMessages = [...before.tail, ...before.head].filter(
+      (item): item is Extract<StreamItem, { kind: "assistant_message" }> =>
+        item.kind === "assistant_message",
+    );
+    expect(before.tail).toEqual([]);
+    expect(beforeMessages.map((message) => message.text)).toEqual([text]);
+
+    setMarkdownBlockDelimiters("host-a", [{ open: "$$", close: "$$" }]);
+
+    const after = applyStreamEvent({
+      tail: before.tail,
+      head: before.head,
+      event: assistantTimeline("\n", "claude", "msg-catalog"),
+      timestamp: new Date("2025-01-01T10:02:01Z"),
+      serverId: "host-a",
+    });
+    const afterMessages = [...after.tail, ...after.head].filter(
+      (item): item is Extract<StreamItem, { kind: "assistant_message" }> =>
+        item.kind === "assistant_message",
+    );
+    expect(afterMessages).toHaveLength(2);
+    expect(afterMessages[0]?.text).toBe("Before");
+    expect(afterMessages[1]?.text.startsWith("$$\na\n\nb")).toBe(true);
+  });
+
+  it("promotes ordinary paragraphs after an empty catalog has published", () => {
+    setMarkdownBlockDelimiters("host-a", []);
+    const result = applyStreamEvent({
+      tail: [],
+      head: [],
+      event: assistantTimeline("First paragraph.\n\nSecond paragraph.", "claude", "msg-empty"),
+      timestamp: new Date("2025-01-01T10:02:00Z"),
+      serverId: "host-a",
+    });
+    const messages = [...result.tail, ...result.head].filter(
+      (item): item is Extract<StreamItem, { kind: "assistant_message" }> =>
+        item.kind === "assistant_message",
+    );
+    expect(messages.map((message) => message.text)).toEqual([
+      "First paragraph.",
+      "Second paragraph.",
+    ]);
   });
 });

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -8,7 +8,10 @@ import { timelineItemIdentity } from "@getpaseo/protocol/timeline-identity";
 import type { AgentAttachment, AgentStreamEventPayload } from "@getpaseo/protocol/messages";
 import type { AttachmentMetadata } from "@/attachments/types";
 import { extractTaskEntriesFromToolCall } from "../utils/tool-call-parsers";
-import { splitMarkdownBlocks } from "@/utils/split-markdown-blocks";
+import {
+  hasPublishedMarkdownBlockDelimiters,
+  splitMarkdownBlocks,
+} from "@/utils/split-markdown-blocks";
 
 /**
  * Simple hash function for deterministic ID generation
@@ -1797,7 +1800,11 @@ function getTailAssistantToResume(params: {
   return params.tailAssistant;
 }
 
-function promoteCompletedAssistantBlocks(params: { tail: StreamItem[]; head: StreamItem[] }): {
+function promoteCompletedAssistantBlocks(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  serverId?: string;
+}): {
   tail: StreamItem[];
   head: StreamItem[];
   changedTail: boolean;
@@ -1814,7 +1821,16 @@ function promoteCompletedAssistantBlocks(params: { tail: StreamItem[]; head: Str
     };
   }
 
-  const blocks = splitMarkdownBlocks(activeItem.text);
+  if (params.serverId !== undefined && !hasPublishedMarkdownBlockDelimiters(params.serverId)) {
+    return {
+      tail: params.tail,
+      head: params.head,
+      changedTail: false,
+      changedHead: false,
+    };
+  }
+
+  const blocks = splitMarkdownBlocks(activeItem.text, { serverId: params.serverId });
   if (blocks.length < 2) {
     return {
       tail: params.tail,
@@ -2037,6 +2053,7 @@ export function applyStreamEvent(params: {
   source?: StreamUpdateSource;
   timelineCursor?: TimelinePosition;
   unmatchedUserMessageInsert?: "tail" | "head";
+  serverId?: string;
 }): ApplyStreamEventResult {
   const { tail, head, event, timestamp } = params;
   const canonicalUserResult = applyCanonicalUserMessageEvent({
@@ -2128,6 +2145,7 @@ export function applyStreamEvent(params: {
       const promoted = promoteCompletedAssistantBlocks({
         tail: nextTail,
         head: nextHead,
+        serverId: params.serverId,
       });
       nextTail = promoted.tail;
       nextHead = promoted.head;

--- a/packages/app/src/utils/__tests__/split-markdown-blocks.test.ts
+++ b/packages/app/src/utils/__tests__/split-markdown-blocks.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  clearMarkdownBlockDelimiters,
   getMarkdownBlockDelimiters,
   setMarkdownBlockDelimiters,
   splitMarkdownBlocks,
@@ -191,18 +192,38 @@ describe("splitMarkdownBlocks", () => {
 
 describe("setMarkdownBlockDelimiters", () => {
   afterEach(() => {
-    setMarkdownBlockDelimiters([]);
+    clearMarkdownBlockDelimiters();
   });
 
-  it("supplies the default delimiters for callers that pass none", () => {
-    setMarkdownBlockDelimiters(MATH_DELIMITERS);
-    expect(getMarkdownBlockDelimiters()).toEqual(MATH_DELIMITERS);
-    expect(splitMarkdownBlocks("Before\n\n$$\na\n\nb\n$$")).toEqual(["Before", "$$\na\n\nb\n$$"]);
+  it("scopes registered delimiters to the host they were published for", () => {
+    setMarkdownBlockDelimiters("host-a", MATH_DELIMITERS);
+    expect(getMarkdownBlockDelimiters("host-a")).toEqual(MATH_DELIMITERS);
+    expect(getMarkdownBlockDelimiters("host-b")).toEqual([]);
+    expect(splitMarkdownBlocks("Before\n\n$$\na\n\nb\n$$", { serverId: "host-a" })).toEqual([
+      "Before",
+      "$$\na\n\nb\n$$",
+    ]);
+    expect(splitMarkdownBlocks("Before\n\n$$\na\n\nb\n$$", { serverId: "host-b" })).toEqual([
+      "Before",
+      "$$\na",
+      "b\n$$",
+    ]);
   });
 
-  it("clears protection when set back to an empty list", () => {
-    setMarkdownBlockDelimiters(MATH_DELIMITERS);
-    setMarkdownBlockDelimiters([]);
-    expect(splitMarkdownBlocks("$$\na\n\nb\n$$")).toEqual(["$$\na", "b\n$$"]);
+  it("clears protection for a host when set back to an empty list", () => {
+    setMarkdownBlockDelimiters("host-a", MATH_DELIMITERS);
+    setMarkdownBlockDelimiters("host-a", []);
+    expect(splitMarkdownBlocks("$$\na\n\nb\n$$", { serverId: "host-a" })).toEqual([
+      "$$\na",
+      "b\n$$",
+    ]);
+  });
+
+  it("closes a ::: pair when an unescaped close appears anywhere on a line", () => {
+    expect(
+      splitMarkdownBlocks(":::\ntext ::: literal\n\nstill inside\n:::", {
+        blockDelimiters: [{ open: ":::", close: ":::" }],
+      }),
+    ).toEqual([":::\ntext ::: literal", "still inside\n:::"]);
   });
 });

--- a/packages/app/src/utils/__tests__/split-markdown-blocks.test.ts
+++ b/packages/app/src/utils/__tests__/split-markdown-blocks.test.ts
@@ -143,6 +143,22 @@ describe("splitMarkdownBlocks", () => {
     ]);
   });
 
+  it("does not let an opener inside a blockquoted fence open protection", () => {
+    expect(
+      splitMarkdownBlocks("> ```\n> :::\n> ```\n\nOne\n\nTwo", {
+        blockDelimiters: [{ open: ":::", close: ":::" }],
+      }),
+    ).toEqual(["> ```\n> :::\n> ```", "One", "Two"]);
+  });
+
+  it("does not close a fence when the marker is followed by non-space text", () => {
+    expect(splitMarkdownBlocks("```\ncode\n```still\n```\n\nAfter\n\nDone")).toEqual([
+      "```\ncode\n```still\n```",
+      "After",
+      "Done",
+    ]);
+  });
+
   it("does not protect a pair that no extension declared", () => {
     expect(splitMarkdownBlocks("Before\n\n$$\na\n\nb\n$$")).toEqual(["Before", "$$\na", "b\n$$"]);
   });

--- a/packages/app/src/utils/__tests__/split-markdown-blocks.test.ts
+++ b/packages/app/src/utils/__tests__/split-markdown-blocks.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { splitMarkdownBlocks } from "../split-markdown-blocks";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getMarkdownBlockDelimiters,
+  setMarkdownBlockDelimiters,
+  splitMarkdownBlocks,
+} from "../split-markdown-blocks";
+
+const MATH_DELIMITERS = [
+  { open: "$$", close: "$$" },
+  { open: "\\[", close: "\\]" },
+];
+const math = { blockDelimiters: MATH_DELIMITERS };
 
 describe("splitMarkdownBlocks", () => {
   it("returns a single block for a single paragraph", () => {
@@ -50,6 +60,102 @@ describe("splitMarkdownBlocks", () => {
     ]);
   });
 
+  it("keeps display math with internal blank lines in one block", () => {
+    expect(
+      splitMarkdownBlocks(
+        "Before\n\n$$\n\\begin{aligned}\na &= b\n\nc &= d\n\\end{aligned}\n$$\n\nAfter",
+        math,
+      ),
+    ).toEqual(["Before", "$$\n\\begin{aligned}\na &= b\n\nc &= d\n\\end{aligned}\n$$", "After"]);
+  });
+
+  it("keeps bracket-delimited display math with internal blank lines in one block", () => {
+    expect(splitMarkdownBlocks("Before\n\n\\[\na^2 + b^2\n\n= c^2\n\\]\n\nAfter", math)).toEqual([
+      "Before",
+      "\\[\na^2 + b^2\n\n= c^2\n\\]",
+      "After",
+    ]);
+  });
+
+  it("splits after a punctuated same-line display formula", () => {
+    expect(splitMarkdownBlocks("$$x$$.\n\ntext\n\n$$y$$", math)).toEqual([
+      "$$x$$.",
+      "text",
+      "$$y$$",
+    ]);
+  });
+
+  it("splits after a multiline display formula with trailing content", () => {
+    expect(
+      splitMarkdownBlocks("$$\nx\n$$.\n\ntext\n\n\\[\ny\n\\] and then\n\nafter", math),
+    ).toEqual(["$$\nx\n$$.", "text", "\\[\ny\n\\] and then", "after"]);
+  });
+
+  it("ignores escaped display delimiters on interior lines", () => {
+    expect(
+      splitMarkdownBlocks("Before\n\n$$\n\\$$ is literal\n\nstill math\n$$.\n\nAfter", math),
+    ).toEqual(["Before", "$$\n\\$$ is literal\n\nstill math\n$$.", "After"]);
+    expect(
+      splitMarkdownBlocks(
+        "Before\n\n\\[\n\\\\] is literal\n\nstill math\n\\] and then\n\nAfter",
+        math,
+      ),
+    ).toEqual(["Before", "\\[\n\\\\] is literal\n\nstill math\n\\] and then", "After"]);
+  });
+
+  it("keeps an unclosed streamed display expression together", () => {
+    expect(splitMarkdownBlocks("Before\n\n$$\na^2 + b^2\n\n= c^2", math)).toEqual([
+      "Before",
+      "$$\na^2 + b^2\n\n= c^2",
+    ]);
+  });
+
+  it("keeps display math nested in a list together across blank lines", () => {
+    expect(
+      splitMarkdownBlocks(
+        "Before\n\n- $$\n  \\begin{aligned}\n  a &= b\n\n  c &= d\n  \\end{aligned}\n  $$\n\nAfter",
+        math,
+      ),
+    ).toEqual([
+      "Before",
+      "- $$\n  \\begin{aligned}\n  a &= b\n\n  c &= d\n  \\end{aligned}\n  $$",
+      "After",
+    ]);
+  });
+
+  it("keeps streamed display math nested in a blockquote together", () => {
+    expect(splitMarkdownBlocks("Before\n\n> \\[\n> a^2 + b^2\n\n> = c^2", math)).toEqual([
+      "Before",
+      "> \\[\n> a^2 + b^2\n\n> = c^2",
+    ]);
+  });
+
+  // Agents show LaTeX source in fenced blocks, so an opener inside a fence must not arm
+  // protection for the rest of the message. Fence tracking is what stops that; markdown-it's
+  // own token pass already keeps the fence's interior blank lines together.
+  it("does not let an opener inside a code fence open protection", () => {
+    expect(splitMarkdownBlocks("Source:\n\n```latex\n$$\nx^2\n```\n\nOne\n\nTwo", math)).toEqual([
+      "Source:",
+      "```latex\n$$\nx^2\n```",
+      "One",
+      "Two",
+    ]);
+  });
+
+  it("does not protect a pair that no extension declared", () => {
+    expect(splitMarkdownBlocks("Before\n\n$$\na\n\nb\n$$")).toEqual(["Before", "$$\na", "b\n$$"]);
+  });
+
+  it("prefers the longest matching opener so $$ is not read as $", () => {
+    const delimiters = [
+      { open: "$", close: "$" },
+      { open: "$$", close: "$$" },
+    ];
+    expect(splitMarkdownBlocks("$$\na\n\nb\n$$", { blockDelimiters: delimiters })).toEqual([
+      "$$\na\n\nb\n$$",
+    ]);
+  });
+
   it("returns an empty array for empty input", () => {
     expect(splitMarkdownBlocks("")).toEqual([]);
   });
@@ -80,5 +186,23 @@ describe("splitMarkdownBlocks", () => {
       "First paragraph",
       "Second paragraph",
     ]);
+  });
+});
+
+describe("setMarkdownBlockDelimiters", () => {
+  afterEach(() => {
+    setMarkdownBlockDelimiters([]);
+  });
+
+  it("supplies the default delimiters for callers that pass none", () => {
+    setMarkdownBlockDelimiters(MATH_DELIMITERS);
+    expect(getMarkdownBlockDelimiters()).toEqual(MATH_DELIMITERS);
+    expect(splitMarkdownBlocks("Before\n\n$$\na\n\nb\n$$")).toEqual(["Before", "$$\na\n\nb\n$$"]);
+  });
+
+  it("clears protection when set back to an empty list", () => {
+    setMarkdownBlockDelimiters(MATH_DELIMITERS);
+    setMarkdownBlockDelimiters([]);
+    expect(splitMarkdownBlocks("$$\na\n\nb\n$$")).toEqual(["$$\na", "b\n$$"]);
   });
 });

--- a/packages/app/src/utils/assistant-message-height-estimate.test.ts
+++ b/packages/app/src/utils/assistant-message-height-estimate.test.ts
@@ -44,4 +44,22 @@ describe("assistant message height estimate", () => {
       ),
     ).toBeGreaterThan(220);
   });
+
+  it("does not reuse a measured height from another host", () => {
+    setAssistantMarkdownBlockHeight({
+      block: "$$x$$",
+      width: 804,
+      height: 100,
+      serverId: "host-a",
+    });
+    setAssistantMarkdownBlockHeight({
+      block: "$$x$$",
+      width: 804,
+      height: 40,
+      serverId: "host-b",
+    });
+
+    expect(estimateAssistantMessageHeightFromCache("$$x$$", "host-a")).toBe(124);
+    expect(estimateAssistantMessageHeightFromCache("$$x$$", "host-b")).toBe(64);
+  });
 });

--- a/packages/app/src/utils/assistant-message-height-estimate.ts
+++ b/packages/app/src/utils/assistant-message-height-estimate.ts
@@ -10,6 +10,7 @@ const ASSISTANT_MARKDOWN_BLOCK_GAP = 12;
 interface MarkdownBlockHeightInput {
   block: string;
   width: number;
+  serverId?: string;
 }
 
 const assistantMarkdownBlockHeightCache = new Map<string, number>();
@@ -50,13 +51,14 @@ function createMarkdownBlockHeightKey(input: MarkdownBlockHeightInput): string |
   if (input.block.length === 0) {
     return null;
   }
-  return `${normalizedWidth}:${hashMarkdownBlock(input.block)}`;
+  return `${input.serverId ?? ""}:${normalizedWidth}:${hashMarkdownBlock(input.block)}`;
 }
 
 export function setAssistantMarkdownBlockHeight(input: {
   block: string;
   width: number;
   height: number;
+  serverId?: string;
 }): number | null {
   if (!Number.isFinite(input.height) || input.height <= 0) {
     return null;
@@ -64,6 +66,7 @@ export function setAssistantMarkdownBlockHeight(input: {
   const key = createMarkdownBlockHeightKey({
     block: input.block,
     width: input.width,
+    serverId: input.serverId,
   });
   if (!key) {
     return null;
@@ -78,8 +81,11 @@ export function setAssistantMarkdownBlockHeight(input: {
   return height;
 }
 
-function estimateAssistantMarkdownBlockHeightFromCache(markdown: string): number | null {
-  const blocks = splitMarkdownBlocks(markdown);
+function estimateAssistantMarkdownBlockHeightFromCache(
+  markdown: string,
+  serverId?: string,
+): number | null {
+  const blocks = splitMarkdownBlocks(markdown, { serverId });
   if (blocks.length === 0) {
     return null;
   }
@@ -89,6 +95,7 @@ function estimateAssistantMarkdownBlockHeightFromCache(markdown: string): number
     const key = createMarkdownBlockHeightKey({
       block,
       width: ASSISTANT_MARKDOWN_BLOCK_ESTIMATE_WIDTH,
+      serverId,
     });
     const cachedHeight = key ? assistantMarkdownBlockHeightCache.get(key) : undefined;
     if (cachedHeight === undefined) {
@@ -104,9 +111,12 @@ function estimateAssistantMarkdownBlockHeightFromCache(markdown: string): number
   );
 }
 
-export function estimateAssistantMessageHeightFromCache(markdown: string): number | null {
+export function estimateAssistantMessageHeightFromCache(
+  markdown: string,
+  serverId?: string,
+): number | null {
   return (
-    estimateAssistantMarkdownBlockHeightFromCache(markdown) ??
+    estimateAssistantMarkdownBlockHeightFromCache(markdown, serverId) ??
     estimateAssistantImageMessageHeightFromCache(markdown)
   );
 }

--- a/packages/app/src/utils/split-markdown-blocks.ts
+++ b/packages/app/src/utils/split-markdown-blocks.ts
@@ -122,8 +122,12 @@ function getOpenedBlockDelimiter(
 }
 
 function getFenceDelimiter(line: string) {
-  const match = /^( {0,3})(`{3,}|~{3,})/.exec(line);
-  return match?.[2] ?? null;
+  const content = stripMarkdownContainerPrefix(line);
+  const match = /^( {0,3})(`{3,}|~{3,})(.*)$/.exec(content);
+  if (!match) {
+    return null;
+  }
+  return { marker: match[2], remainder: match[3] ?? "" };
 }
 
 interface ProtectedBlockState {
@@ -147,8 +151,10 @@ function updateProtectedBlockState(
   const fenceDelimiter = getFenceDelimiter(line);
   if (state.fenceCharacter) {
     if (
-      fenceDelimiter?.[0] === state.fenceCharacter &&
-      fenceDelimiter.length >= state.fenceLength
+      fenceDelimiter &&
+      fenceDelimiter.marker[0] === state.fenceCharacter &&
+      fenceDelimiter.marker.length >= state.fenceLength &&
+      /^[ \t]*$/.test(fenceDelimiter.remainder)
     ) {
       state.fenceCharacter = null;
       state.fenceLength = 0;
@@ -157,8 +163,8 @@ function updateProtectedBlockState(
   }
 
   if (fenceDelimiter) {
-    state.fenceCharacter = fenceDelimiter[0] as "`" | "~";
-    state.fenceLength = fenceDelimiter.length;
+    state.fenceCharacter = fenceDelimiter.marker[0] as "`" | "~";
+    state.fenceLength = fenceDelimiter.marker.length;
     return;
   }
 

--- a/packages/app/src/utils/split-markdown-blocks.ts
+++ b/packages/app/src/utils/split-markdown-blocks.ts
@@ -34,17 +34,40 @@ export interface MarkdownBlockDelimiter {
 
 export interface SplitMarkdownBlocksOptions {
   blockDelimiters?: readonly MarkdownBlockDelimiter[];
+  serverId?: string;
 }
 
-let registeredBlockDelimiters: readonly MarkdownBlockDelimiter[] = [];
+const registeredBlockDelimitersByHost = new Map<string, readonly MarkdownBlockDelimiter[]>();
+const publishedMarkdownBlockDelimiterHosts = new Set<string>();
 
 /** Installed plugins push their declared pairs here; the plugin registry calls this on publish. */
-export function setMarkdownBlockDelimiters(delimiters: readonly MarkdownBlockDelimiter[]): void {
-  registeredBlockDelimiters = delimiters;
+export function setMarkdownBlockDelimiters(
+  serverId: string,
+  delimiters: readonly MarkdownBlockDelimiter[],
+): void {
+  registeredBlockDelimitersByHost.set(serverId, delimiters);
+  publishedMarkdownBlockDelimiterHosts.add(serverId);
 }
 
-export function getMarkdownBlockDelimiters(): readonly MarkdownBlockDelimiter[] {
-  return registeredBlockDelimiters;
+export function getMarkdownBlockDelimiters(
+  serverId: string | undefined,
+): readonly MarkdownBlockDelimiter[] {
+  if (!serverId) return [];
+  return registeredBlockDelimitersByHost.get(serverId) ?? [];
+}
+
+export function hasPublishedMarkdownBlockDelimiters(serverId: string | undefined): boolean {
+  return serverId !== undefined && publishedMarkdownBlockDelimiterHosts.has(serverId);
+}
+
+export function clearMarkdownBlockDelimiters(serverId?: string): void {
+  if (serverId === undefined) {
+    registeredBlockDelimitersByHost.clear();
+    publishedMarkdownBlockDelimiterHosts.clear();
+    return;
+  }
+  registeredBlockDelimitersByHost.delete(serverId);
+  publishedMarkdownBlockDelimiterHosts.delete(serverId);
 }
 
 function stripMarkdownContainerPrefix(line: string): string {
@@ -153,7 +176,7 @@ export function splitMarkdownBlocks(
     return [];
   }
 
-  const delimiters = options.blockDelimiters ?? registeredBlockDelimiters;
+  const delimiters = options.blockDelimiters ?? getMarkdownBlockDelimiters(options.serverId);
   const blocks: string[] = [];
   let currentLines: string[] = [];
   const protectedBlockState: ProtectedBlockState = {

--- a/packages/app/src/utils/split-markdown-blocks.ts
+++ b/packages/app/src/utils/split-markdown-blocks.ts
@@ -2,21 +2,176 @@ import MarkdownIt from "markdown-it";
 
 const markdownBlockParser = new MarkdownIt();
 
-export function splitMarkdownBlocks(text: string): string[] {
+function isEscaped(source: string, position: number): boolean {
+  let backslashCount = 0;
+  for (let index = position - 1; index >= 0 && source[index] === "\\"; index--) {
+    backslashCount++;
+  }
+  return backslashCount % 2 === 1;
+}
+
+function findUnescapedDelimiter(source: string, delimiter: string): number {
+  let searchStart = 0;
+
+  while (searchStart < source.length) {
+    const delimiterStart = source.indexOf(delimiter, searchStart);
+    if (delimiterStart === -1) {
+      return -1;
+    }
+    if (!isEscaped(source, delimiterStart)) {
+      return delimiterStart;
+    }
+    searchStart = delimiterStart + delimiter.length;
+  }
+
+  return -1;
+}
+
+export interface MarkdownBlockDelimiter {
+  open: string;
+  close: string;
+}
+
+export interface SplitMarkdownBlocksOptions {
+  blockDelimiters?: readonly MarkdownBlockDelimiter[];
+}
+
+let registeredBlockDelimiters: readonly MarkdownBlockDelimiter[] = [];
+
+/** Installed plugins push their declared pairs here; the plugin registry calls this on publish. */
+export function setMarkdownBlockDelimiters(delimiters: readonly MarkdownBlockDelimiter[]): void {
+  registeredBlockDelimiters = delimiters;
+}
+
+export function getMarkdownBlockDelimiters(): readonly MarkdownBlockDelimiter[] {
+  return registeredBlockDelimiters;
+}
+
+function stripMarkdownContainerPrefix(line: string): string {
+  let remainder = line;
+  let foundContainer = false;
+
+  while (true) {
+    const blockquote = /^ {0,3}>[ \t]?/.exec(remainder);
+    if (blockquote) {
+      remainder = remainder.slice(blockquote[0].length);
+      foundContainer = true;
+      continue;
+    }
+
+    const listItem = /^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/.exec(remainder);
+    if (listItem) {
+      remainder = remainder.slice(listItem[0].length);
+      foundContainer = true;
+      continue;
+    }
+
+    return foundContainer ? remainder : line;
+  }
+}
+
+interface OpenedBlockDelimiter {
+  close: string;
+  closesOnOpeningLine: boolean;
+}
+
+function getOpenedBlockDelimiter(
+  line: string,
+  delimiters: readonly MarkdownBlockDelimiter[],
+): OpenedBlockDelimiter | null {
+  if (delimiters.length === 0) {
+    return null;
+  }
+  const content = stripMarkdownContainerPrefix(line).replace(/^ {0,3}/, "");
+  // Longest opener first so "$$" is never read as "$".
+  const candidates = [...delimiters].sort((left, right) => right.open.length - left.open.length);
+  for (const delimiter of candidates) {
+    if (!content.startsWith(delimiter.open)) {
+      continue;
+    }
+    const remainder = content.slice(delimiter.open.length);
+    return {
+      close: delimiter.close,
+      closesOnOpeningLine: findUnescapedDelimiter(remainder, delimiter.close) !== -1,
+    };
+  }
+  return null;
+}
+
+function getFenceDelimiter(line: string) {
+  const match = /^( {0,3})(`{3,}|~{3,})/.exec(line);
+  return match?.[2] ?? null;
+}
+
+interface ProtectedBlockState {
+  fenceCharacter: "`" | "~" | null;
+  fenceLength: number;
+  openDelimiterClose: string | null;
+}
+
+function updateProtectedBlockState(
+  line: string,
+  state: ProtectedBlockState,
+  delimiters: readonly MarkdownBlockDelimiter[],
+): void {
+  if (state.openDelimiterClose) {
+    if (findUnescapedDelimiter(line, state.openDelimiterClose) !== -1) {
+      state.openDelimiterClose = null;
+    }
+    return;
+  }
+
+  const fenceDelimiter = getFenceDelimiter(line);
+  if (state.fenceCharacter) {
+    if (
+      fenceDelimiter?.[0] === state.fenceCharacter &&
+      fenceDelimiter.length >= state.fenceLength
+    ) {
+      state.fenceCharacter = null;
+      state.fenceLength = 0;
+    }
+    return;
+  }
+
+  if (fenceDelimiter) {
+    state.fenceCharacter = fenceDelimiter[0] as "`" | "~";
+    state.fenceLength = fenceDelimiter.length;
+    return;
+  }
+
+  const opened = getOpenedBlockDelimiter(line, delimiters);
+  if (opened && !opened.closesOnOpeningLine) {
+    state.openDelimiterClose = opened.close;
+  }
+}
+
+export function splitMarkdownBlocks(
+  text: string,
+  options: SplitMarkdownBlocksOptions = {},
+): string[] {
   if (text.length === 0) {
     return [];
   }
 
+  const delimiters = options.blockDelimiters ?? registeredBlockDelimiters;
   const blocks: string[] = [];
   let currentLines: string[] = [];
+  const protectedBlockState: ProtectedBlockState = {
+    fenceCharacter: null,
+    fenceLength: 0,
+    openDelimiterClose: null,
+  };
   let sawBlockSeparator = false;
   const lines = text.split("\n");
   const structuralBlankLines = getStructuralBlankLines(text, lines);
 
   for (const [index, line] of lines.entries()) {
     const isBlankLine = line.trim().length === 0;
+    const isInsideProtectedBlock =
+      protectedBlockState.fenceCharacter !== null ||
+      protectedBlockState.openDelimiterClose !== null;
 
-    if (isBlankLine && structuralBlankLines.has(index)) {
+    if (isBlankLine && (isInsideProtectedBlock || structuralBlankLines.has(index))) {
       currentLines.push(line);
       continue;
     }
@@ -28,13 +183,14 @@ export function splitMarkdownBlocks(text: string): string[] {
       continue;
     }
 
-    if (sawBlockSeparator) {
+    if (!isInsideProtectedBlock && sawBlockSeparator) {
       blocks.push(currentLines.join("\n"));
       currentLines = [];
       sawBlockSeparator = false;
     }
 
     currentLines.push(line);
+    updateProtectedBlockState(line, protectedBlockState, delimiters);
   }
 
   if (currentLines.length > 0) {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -67,10 +67,12 @@
   "devDependencies": {
     "@getpaseo/client": "0.8.0",
     "@getpaseo/protocol": "0.8.0",
+    "@types/markdown-it": "^10.0.3",
     "@types/node": "^20.9.0",
     "@types/react": "~19.2.0",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-markdown-display": "^7.0.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.6",
     "zod": "^4.4.3"
@@ -78,12 +80,20 @@
   "peerDependencies": {
     "@getpaseo/client": "0.8.0",
     "@getpaseo/protocol": "0.8.0",
+    "@types/markdown-it": "^10.0.3",
     "react": "~19.1.0",
     "react-native": ">=0.81.5",
+    "react-native-markdown-display": "^7.0.2",
     "zod": "^4.4.3"
   },
   "peerDependenciesMeta": {
+    "@types/markdown-it": {
+      "optional": true
+    },
     "react-native": {
+      "optional": true
+    },
+    "react-native-markdown-display": {
       "optional": true
     }
   }

--- a/packages/plugin/src/client/contracts.ts
+++ b/packages/plugin/src/client/contracts.ts
@@ -3,6 +3,7 @@ import type { PaseoApi } from "@getpaseo/client";
 import type { AgentTimelineItem } from "@getpaseo/protocol/agent-types";
 import type { ZodType, input as ZodInput, output as ZodOutput } from "zod";
 import type { PluginRpcContract } from "../rpc.js";
+import type { PluginMarkdownExtension } from "./markdown-extension.js";
 import type {
   PluginButtonRegistration,
   PluginHeaderButtonContribution,
@@ -92,6 +93,7 @@ export interface PluginClientContext extends PluginCommandCapabilities {
   addTimelineRenderer<Schema extends ZodType>(
     contribution: PluginTimelineRendererContribution<Schema>,
   ): PluginCleanup;
+  addMarkdownExtension(contribution: PluginMarkdownExtension): PluginCleanup;
   openPanel(id: string, options: PluginClientOpenPanelOptions): void;
 }
 

--- a/packages/plugin/src/client/index.ts
+++ b/packages/plugin/src/client/index.ts
@@ -36,6 +36,10 @@ export type {
   PluginComposerPillContribution,
   PluginHeaderButtonContribution,
 } from "./buttons.js";
+export type {
+  PluginMarkdownBlockDelimiter,
+  PluginMarkdownExtension,
+} from "./markdown-extension.js";
 export { usePaseo } from "./paseo-context.js";
 export { useAgent, useWorkspace } from "./client-state.js";
 export { useRpc } from "./rpc-context.js";

--- a/packages/plugin/src/client/markdown-extension.ts
+++ b/packages/plugin/src/client/markdown-extension.ts
@@ -1,0 +1,22 @@
+import type MarkdownIt from "markdown-it";
+import type { RenderRules } from "react-native-markdown-display";
+
+// markdown-it and react-native-markdown-display are optional peer dependencies
+// (see packages/plugin/package.json). Keep these two types in their own module,
+// separate from contracts.ts, so a plugin that never calls addMarkdownExtension
+// does not need either package resolvable just to import PluginClientContext.
+
+export interface PluginMarkdownBlockDelimiter {
+  open: string;
+  close: string;
+}
+
+export interface PluginMarkdownExtension {
+  id: string;
+  /** Runs once per parser build with Paseo's live markdown-it instance. */
+  parser?: (markdown: MarkdownIt) => void;
+  /** Merged after Paseo's built-in assistant rules, so a plugin rule wins on collision. */
+  rules?: RenderRules;
+  /** Line-leading pairs the streaming splitter must not split inside, open or unclosed. */
+  blockDelimiters?: PluginMarkdownBlockDelimiter[];
+}

--- a/packages/plugin/src/client/react-native.ts
+++ b/packages/plugin/src/client/react-native.ts
@@ -74,3 +74,11 @@ export declare function copyText(text: string): Promise<void>;
 export declare const TextInput: ForwardRefExoticComponent<
   TextInputProps & RefAttributes<NativeTextInput>
 >;
+
+/** Renders an SVG document string. Narrower than react-native-svg's XmlProps by design. */
+export declare const SvgXml: ComponentType<{
+  xml: string | null;
+  width?: number | string;
+  height?: number | string;
+  color?: string;
+}>;

--- a/plugin-examples/markdown-extension/README.md
+++ b/plugin-examples/markdown-extension/README.md
@@ -1,0 +1,15 @@
+# Markdown extension example
+
+The smallest plugin that uses every part of `addMarkdownExtension`. Install the directory, then
+ask an agent to reply with `::badge::` or a `:::` block.
+
+- `parser` adds two markdown-it rules: an inline `::text::` and a `:::` … `:::` block.
+- `rules` render those tokens as ordinary text, so the host assistant row stays in charge of
+  copy, selection, and pacing.
+- `blockDelimiters` declares the `:::` pair, so the streaming splitter holds a `:::` block that
+  has not closed yet in one render block instead of cutting it at the first blank line.
+
+This directory ships no `package.json` and needs none: the callbacks take their `MarkdownIt` and
+node types from the SDK contextually, so nothing here imports `markdown-it` or
+`react-native-markdown-display`. Name either type explicitly and the plugin compiler requires the
+package to resolve, even for a type-only import.

--- a/plugin-examples/markdown-extension/index.client.tsx
+++ b/plugin-examples/markdown-extension/index.client.tsx
@@ -1,0 +1,59 @@
+import type { PluginClientContext } from "@getpaseo/plugin/client";
+import { Text, View } from "react-native";
+
+const INLINE_MARKER = "::";
+const BLOCK_FENCE = ":::";
+
+export default function contribute(client: PluginClientContext) {
+  return client.addMarkdownExtension({
+    id: "badge",
+    parser: (markdown) => {
+      // `::text::` becomes one leaf token whose text is never parsed again, so a backslash
+      // inside it reaches the render rule intact.
+      markdown.inline.ruler.before("escape", "badge_inline", (state, silent) => {
+        if (!state.src.startsWith(INLINE_MARKER, state.pos)) return false;
+        const contentStart = state.pos + INLINE_MARKER.length;
+        const contentEnd = state.src.indexOf(INLINE_MARKER, contentStart);
+        if (contentEnd <= contentStart) return false;
+        if (!silent) {
+          state.push("badge_inline", "span", 0).content = state.src.slice(contentStart, contentEnd);
+        }
+        state.pos = contentEnd + INLINE_MARKER.length;
+        return true;
+      });
+      // `:::` … `:::`, or everything that is left while the closing fence has not streamed in.
+      markdown.block.ruler.before("fence", "badge_block", (state, startLine, endLine, silent) => {
+        if (state.getLines(startLine, startLine + 1, 0, false).trim() !== BLOCK_FENCE) return false;
+        if (silent) return true;
+        let closeLine = startLine + 1;
+        while (
+          closeLine < endLine &&
+          state.getLines(closeLine, closeLine + 1, 0, false).trim() !== BLOCK_FENCE
+        ) {
+          closeLine++;
+        }
+        const token = state.push("badge_block", "div", 0);
+        token.block = true;
+        token.content = state.getLines(startLine + 1, closeLine, 0, false);
+        token.markup = closeLine < endLine ? BLOCK_FENCE : "";
+        state.line = Math.min(closeLine + 1, endLine);
+        token.map = [startLine, state.line];
+        return true;
+      });
+    },
+    rules: {
+      badge_inline: (node) => (
+        <Text key={node.key} accessibilityLabel={node.content}>
+          [{node.content}]
+        </Text>
+      ),
+      // `markup` is the closing fence, or "" while the block is still streaming.
+      badge_block: (node) => (
+        <View key={node.key} accessible accessibilityLabel={node.content}>
+          <Text>{node.content}</Text>
+        </View>
+      ),
+    },
+    blockDelimiters: [{ open: BLOCK_FENCE, close: BLOCK_FENCE }],
+  });
+}

--- a/plugin-examples/markdown-extension/index.client.tsx
+++ b/plugin-examples/markdown-extension/index.client.tsx
@@ -4,6 +4,25 @@ import { Text, View } from "react-native";
 const INLINE_MARKER = "::";
 const BLOCK_FENCE = ":::";
 
+function findUnescapedDelimiter(source: string, delimiter: string): number {
+  let searchStart = 0;
+  while (searchStart < source.length) {
+    const delimiterStart = source.indexOf(delimiter, searchStart);
+    if (delimiterStart === -1) {
+      return -1;
+    }
+    let backslashCount = 0;
+    for (let index = delimiterStart - 1; index >= 0 && source[index] === "\\"; index--) {
+      backslashCount++;
+    }
+    if (backslashCount % 2 === 0) {
+      return delimiterStart;
+    }
+    searchStart = delimiterStart + delimiter.length;
+  }
+  return -1;
+}
+
 export default function contribute(client: PluginClientContext) {
   return client.addMarkdownExtension({
     id: "badge",
@@ -22,13 +41,17 @@ export default function contribute(client: PluginClientContext) {
         return true;
       });
       // `:::` … `:::`, or everything that is left while the closing fence has not streamed in.
+      // Close when an unescaped `:::` appears anywhere on the line, matching the splitter.
       markdown.block.ruler.before("fence", "badge_block", (state, startLine, endLine, silent) => {
         if (state.getLines(startLine, startLine + 1, 0, false).trim() !== BLOCK_FENCE) return false;
         if (silent) return true;
         let closeLine = startLine + 1;
         while (
           closeLine < endLine &&
-          state.getLines(closeLine, closeLine + 1, 0, false).trim() !== BLOCK_FENCE
+          findUnescapedDelimiter(
+            state.getLines(closeLine, closeLine + 1, 0, false),
+            BLOCK_FENCE,
+          ) === -1
         ) {
           closeLine++;
         }
@@ -48,9 +71,9 @@ export default function contribute(client: PluginClientContext) {
         </Text>
       ),
       // `markup` is the closing fence, or "" while the block is still streaming.
-      badge_block: (node) => (
+      badge_block: (node, _children, _parent, _styles, inheritedStyles) => (
         <View key={node.key} accessible accessibilityLabel={node.content}>
-          <Text>{node.content}</Text>
+          <Text style={inheritedStyles}>{node.content}</Text>
         </View>
       ),
     },

--- a/plugin-examples/markdown-extension/paseo-plugin.json
+++ b/plugin-examples/markdown-extension/paseo-plugin.json
@@ -1,0 +1,6 @@
+{
+  "id": "markdown-extension",
+  "requirements": {
+    "paseo": ">=0.8.0"
+  }
+}

--- a/public-docs/plugins/v0.8/migration.md
+++ b/public-docs/plugins/v0.8/migration.md
@@ -83,6 +83,7 @@ Use this table as the complete registration checklist.
 | `plugin.addTheme(theme)` in the old root entry                                                | `client.addTheme(theme)` in `index.client.tsx`                                                               |
 | `plugin.addTimelineTransformer(transformer)` in the old root entry                            | `client.addTimelineTransformer(transformer)` in `index.client.tsx`                                           |
 | `plugin.addTimelineRenderer(renderer)` in the old root entry                                  | `client.addTimelineRenderer(renderer)` in `index.client.tsx`                                                 |
+| New markdown extension                                                                        | `client.addMarkdownExtension({ id })` in `index.client.tsx`                                                  |
 | `import { defineRpc, defineAttachmentSource } from "@getpaseo/plugin/server"` in shared files | `import { defineRpc, defineAttachmentSource } from "@getpaseo/plugin"`                                       |
 | `ZodOutput<typeof contract.input>` handler parameter types                                    | `RpcInput<typeof contract>` from `@getpaseo/plugin`; `RpcOutput` for return types                            |
 

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -935,6 +935,60 @@ Do not hardcode `#000`, `#fff`, or React Native's default text color. Primary co
 
 Workspace and agent panels receive the same `theme`, `layout`, and optional `navigation` fields.
 
+## Markdown extensions
+
+`addMarkdownExtension` extends how Paseo parses and renders assistant messages. The assistant
+row stays Paseo's; the extension adds token types, render rules, and block delimiters.
+
+```tsx
+import type { PluginClientContext } from "@getpaseo/plugin/client";
+import { Text } from "react-native";
+
+export default function contribute(client: PluginClientContext) {
+  return client.addMarkdownExtension({
+    id: "badge",
+    parser: (markdown) => {
+      markdown.inline.ruler.before("escape", "badge_inline", parseBadge);
+      markdown.block.ruler.before("fence", "badge_block", parseBadgeBlock);
+    },
+    rules: {
+      badge_inline: (node) => <Text key={node.key}>[{node.content}]</Text>,
+    },
+    blockDelimiters: [{ open: ":::", close: ":::" }],
+  });
+}
+```
+
+| Field             | Type                                | Required | Behavior                                                                                 |
+| ----------------- | ----------------------------------- | -------- | ---------------------------------------------------------------------------------------- |
+| `id`              | `string`                            | Yes      | Unique per plugin. A duplicate throws.                                                   |
+| `parser`          | `(markdown: MarkdownIt) => void`    | No       | Applied with `use()` each time the assistant parser is built. A throw fails that build.  |
+| `rules`           | `RenderRules`                       | No       | Merged after Paseo's rules, so an extension rule wins on collision.                      |
+| `blockDelimiters` | `{ open: string; close: string }[]` | No       | Line-leading pairs the streaming splitter keeps in one block, closed or still streaming. |
+
+`parser` receives Paseo's live `markdown-it` instance, typed by `@types/markdown-it` at the major
+Paseo runs, so an API the host does not have will not typecheck. `rules` use
+`react-native-markdown-display`'s `RenderRules`; a leaf rule receives the inherited text style as
+its fifth argument, which is how prose color reaches a rendered token.
+
+`blockDelimiters` matter during streaming. Paseo splits a message into render blocks before any
+parser runs, so a `:::` block that has not closed yet would otherwise be split at its first blank
+line. A declared pair is matched at the start of a line, after any blockquote or list prefix, and
+holds every following line until an unescaped `close` appears or the text ends.
+
+A client that predates this capability reports `client.addMarkdownExtension is not a function`;
+set `requirements.paseo` to the first release that ships it. `plugin-examples/markdown-extension`
+is a runnable plugin that uses every field above.
+
+Writing the callbacks inline, as above, types them from the contribution's own signature and needs
+no extra package. Name `MarkdownIt`, `ASTNode`, or `RenderRules` yourself and you must add
+`@types/markdown-it` and `react-native-markdown-display` to your `devDependencies`. The SDK
+declares both as optional peer dependencies, so neither installs automatically, and two failures
+follow from a missing one: the scaffold's generated `tsconfig.json` sets `skipLibCheck: true`,
+which suppresses the missing-types error and leaves both fields typed as `any` — no completion, no
+checking, no diagnostic — and the plugin compiler refuses to build a plugin whose type-only import
+does not resolve.
+
 ## Contribute a theme
 
 `addTheme` adds a light or dark theme to Settings → Appearance, listed under the built-ins by its

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -807,6 +807,18 @@ Showing another toast replaces the currently visible toast. An empty message is 
 | `size`  | `number` | No       | Icon width and height.                          |
 | `color` | `string` | No       | Icon color. Use a plugin theme token.           |
 
+### SvgXml
+
+`SvgXml` renders an SVG document string on every platform. It is the only vector-drawing primitive
+plugins get; a plugin bundle cannot import `react-native-svg` directly.
+
+| Prop     | Type               | Required | Behavior                                     |
+| -------- | ------------------ | -------- | -------------------------------------------- |
+| `xml`    | `string \| null`   | Yes      | The SVG document. `null` renders nothing.    |
+| `width`  | `number \| string` | No       | Rendered width.                              |
+| `height` | `number \| string` | No       | Rendered height.                             |
+| `color`  | `string`           | No       | Value of `currentColor` inside the document. |
+
 ## Timeline items
 
 A plugin can replace an agent timeline entry with its own data and React Native renderer. Both


### PR DESCRIPTION
### Linked issue

Related: #2562, discussion #2778

Stacked on https://github.com/getpaseo/paseo/pull/4749. Merge that first; this branch contains that commit plus the markdown-extension work. This PR does not use `SvgXml`.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Assistant messages render markdown that only Paseo can contribute to. A plugin that wants a formula, a diagram, or a badge in a message has had to patch the host. `addMarkdownExtension` keeps the host rendering the assistant row (anchors, file links, images, selection, capped rendering, paced reveal) and lets a plugin add parser rules, render rules, and streaming block delimiters.

A throwing parser loses only that extension. A throwing render rule falls back to the previous rule. Declared block delimiters keep an unclosed pair in one streaming render block, scoped to the host the message came from. Hosts with no plugin catalog still promote completed paragraphs.

### Goals

- `addMarkdownExtension({ id, parser?, rules?, blockDelimiters? })` on `PluginClientContext`
- Rules merge after built-ins, so a plugin rule wins on collision
- A throwing parser or rule loses only that extension
- `blockDelimiters` keep an unclosed pair in one streaming render block
- Extensions are scoped to the host the message came from
- `plugin-examples/markdown-extension` exercises every field

### Non-goals

- No copy-source wrapper for text-free drawings
- The example renders with `Text`, not SVG
- Does not wrap every markdown-it parse rule; isolation is `parser.use` plus render-rule fallback
- Formulas inside list items or table cells were not tested

### QA

From `packages/app`:

```
npx vitest run \
  src/plugins/evaluate.test.ts \
  src/plugins/markdown-extensions.test.ts \
  src/plugins/markdown-extension-wiring.test.tsx \
  src/plugins/markdown-extension-example.test.tsx \
  src/plugins/registry.test.ts \
  src/utils/__tests__/split-markdown-blocks.test.ts \
  src/utils/assistant-message-height-estimate.test.ts \
  --bail=1
```

102 passed.

| Platform | Tested | Notes |
| --- | --- | --- |
| Web | Yes | Unit tests above; Playwright spec is in this PR |
| iOS | No | Not verified |
| Android | No | Not verified |
| Desktop | No | Not run |

### Checklist

- [x] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (if applicable)
- [x] One focused change
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
