### PR TITLE
fix(acp): forward context window usage

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2800,6 +2800,75 @@ describe("ACPAgentSession", () => {
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
   });
 
+  test("emits usage_updated for usage_update notifications and keeps context window usage on turn completion", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let resolvePrompt!: (value: PromptResponse) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    const { turnId } = await session.startTurn("hello");
+
+    // ACP usage_update: size is the total context window, used the tokens in context.
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "usage_update",
+        size: 200_000,
+        used: 175,
+      },
+    });
+
+    expect(events.filter((event) => event.type === "usage_updated")).toEqual([
+      {
+        type: "usage_updated",
+        provider: "claude-acp",
+        usage: { contextWindowMaxTokens: 200_000, contextWindowUsedTokens: 175 },
+        turnId,
+      },
+    ]);
+
+    // Updates for another session must not leak into this one.
+    await session.sessionUpdate({
+      sessionId: "other-session",
+      update: {
+        sessionUpdate: "usage_update",
+        size: 8_000,
+        used: 1,
+      },
+    });
+    expect(events.filter((event) => event.type === "usage_updated")).toHaveLength(1);
+
+    resolvePrompt({
+      stopReason: "end_turn",
+      usage: { inputTokens: 11, outputTokens: 7, totalTokens: 18 },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events.find((event) => event.type === "turn_completed")).toMatchObject({
+      type: "turn_completed",
+      turnId,
+      usage: {
+        inputTokens: 11,
+        outputTokens: 7,
+        contextWindowMaxTokens: 200_000,
+        contextWindowUsedTokens: 175,
+      },
+    });
+  });
+
   test("startTurn emits the submitted user message even when ACP does not echo it", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1682,6 +1682,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
+  private contextWindowUsage:
+    | Pick<AgentUsage, "contextWindowMaxTokens" | "contextWindowUsedTokens">
+    | undefined;
   private activeForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
   private closed = false;
@@ -2908,8 +2911,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.handleSessionInfoUpdate(update);
         return pendingUserEvents;
       case "usage_update":
-        this.handleUsageUpdate(update);
-        return pendingUserEvents;
+        return [...pendingUserEvents, ...this.handleUsageUpdate(update)];
       case "available_commands_update":
         this.cachedCommands = update.availableCommands.map((command) => ({
           name: command.name,
@@ -3069,8 +3071,34 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
-  private handleUsageUpdate(update: UsageUpdate): void {
-    void update;
+  private handleUsageUpdate(update: UsageUpdate): AgentStreamEvent[] {
+    const contextWindowMaxTokens =
+      Number.isFinite(update.size) && update.size > 0 ? update.size : undefined;
+    const contextWindowUsedTokens =
+      Number.isFinite(update.used) && update.used >= 0 ? update.used : undefined;
+    if (contextWindowMaxTokens === undefined && contextWindowUsedTokens === undefined) {
+      return [];
+    }
+    this.contextWindowUsage = {
+      ...this.contextWindowUsage,
+      ...(contextWindowMaxTokens !== undefined ? { contextWindowMaxTokens } : {}),
+      ...(contextWindowUsedTokens !== undefined ? { contextWindowUsedTokens } : {}),
+    };
+    return [
+      {
+        type: "usage_updated",
+        provider: this.provider,
+        usage: { ...this.currentTurnUsage, ...this.contextWindowUsage },
+        ...(this.activeForegroundTurnId ? { turnId: this.activeForegroundTurnId } : {}),
+      },
+    ];
+  }
+
+  private usageWithContextWindow(): AgentUsage | undefined {
+    if (!this.contextWindowUsage) {
+      return this.currentTurnUsage;
+    }
+    return { ...this.currentTurnUsage, ...this.contextWindowUsage };
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
@@ -3094,7 +3122,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.finishTurn({
           type: "turn_completed",
           provider: this.provider,
-          usage: this.currentTurnUsage,
+          usage: this.usageWithContextWindow(),
           turnId,
         });
         break;


### PR DESCRIPTION
## Summary
- forward ACP `usage_update.size` and `.used` as context-window telemetry
- emit a session-bound `usage_updated` event immediately
- preserve context-window usage when the turn completes

## Root cause
`ACPAgentSession.handleUsageUpdate` received Hermes context telemetry and discarded it. The downstream `lastUsage` projection already supported these fields.

## Testing
- regression was red with zero `usage_updated` events
- `npx vitest run src/server/agent/providers/acp-agent.test.ts --bail=1` — 103 passed
- `npm run typecheck`
- targeted `npm run lint` — 0 warnings/errors
- formatting check passed