### PR TITLE
fix(acp): carry the server's stderr into a failed turn's diagnostic

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.stderr-diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.stderr-diagnostic.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, test } from "vitest";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import type { AgentStreamEvent } from "../agent-sdk-types.js";
+import { ACPAgentSession } from "./acp-agent.js";
+
+/**
+ * A turn the ACP server rejects has to reach `daemon.log` with something that
+ * explains it. The server's own stderr is the only such thing for a
+ * closed-source wrapper, so it travels in the failed turn's diagnostic (#4757).
+ *
+ * Driven through a spawned agent rather than the session's internals: the wiring
+ * under test is `child.stderr` reaching the diagnostic, which a direct call
+ * would skip.
+ */
+const FAKE_AGENT = `
+const readline = require("node:readline");
+const rl = readline.createInterface({ input: process.stdin });
+
+function reply(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");
+}
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    reply(message.id, { protocolVersion: message.params?.protocolVersion ?? 1, agentCapabilities: {} });
+    return;
+  }
+  if (message.method === "session/new") {
+    reply(message.id, { sessionId: "session-1" });
+    return;
+  }
+  if (message.method === "session/prompt") {
+    process.stderr.write("could not find doneCh for checkpoint\\n");
+    setTimeout(() => {
+      process.stdout.write(
+        JSON.stringify({ jsonrpc: "2.0", id: message.id, error: { code: -32000, message: "Agent execution error" } }) + "\\n",
+      );
+    }, 10);
+    return;
+  }
+  if (message.id !== undefined) reply(message.id, {});
+});
+`;
+
+async function withFakeAgent(
+  run: (scriptPath: string, cwd: string) => Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), "paseo-acp-stderr-"));
+  try {
+    const scriptPath = path.join(dir, "fake-acp-agent.cjs");
+    await writeFile(scriptPath, FAKE_AGENT, "utf8");
+    await run(scriptPath, dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** The first `turn_failed` the session emits. */
+function nextTurnFailure(
+  session: ACPAgentSession,
+): Promise<Extract<AgentStreamEvent, { type: "turn_failed" }>> {
+  return new Promise((resolve) => {
+    session.subscribe((event) => {
+      if (event.type === "turn_failed") resolve(event);
+    });
+  });
+}
+
+function createSession(scriptPath: string, cwd: string): ACPAgentSession {
+  return new ACPAgentSession(
+    { provider: "claude-acp", cwd },
+    {
+      provider: "claude-acp",
+      logger: createTestLogger(),
+      defaultCommand: [process.execPath, scriptPath],
+      defaultModes: [],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: false,
+        supportsMcpServers: false,
+        supportsReasoningStream: false,
+        supportsToolInvocations: true,
+      },
+    },
+  );
+}
+
+describe("ACP turn failure diagnostics", () => {
+  test("a rejected turn carries what the server wrote on stderr", async () => {
+    await withFakeAgent(async (scriptPath, cwd) => {
+      const session = createSession(scriptPath, cwd);
+      await session.initializeNewSession();
+      const failed = nextTurnFailure(session);
+
+      try {
+        await session.startTurn("hello");
+        expect((await failed).diagnostic).toContain("could not find doneCh for checkpoint");
+      } finally {
+        await session.close();
+      }
+    });
+  }, 20_000);
+});

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -95,9 +95,6 @@ interface ACPSessionInternals {
   configOptions: SessionConfigOption[];
   translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
   acpMcpServers(): unknown[];
-  appendStderrTail(chunk: string): void;
-  collectDiagnostic(message: string): string | undefined;
-  stderrTail: string;
 }
 
 interface ACPModelSelectionInternals {
@@ -3155,53 +3152,6 @@ describe("ACPAgentSession", () => {
       error: "prompt failed",
     });
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
-  });
-
-  test("a rejected turn carries the ACP server's own stderr into the diagnostic", async () => {
-    // A turn can fail while the server keeps running, and then the daemon log has
-    // only what the diagnostic carries — for a closed-source ACP server that is
-    // the single inspection point (#4757).
-    const session = createSession();
-    const events: AgentStreamEvent[] = [];
-    let rejectPrompt!: (error: Error) => void;
-    const prompt = vi.fn(
-      () =>
-        new Promise((_, reject) => {
-          rejectPrompt = reject;
-        }),
-    );
-
-    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
-    asInternals<ACPSessionInternals>(session).connection = { prompt };
-    asInternals<ACPSessionInternals>(session).appendStderrTail(
-      "could not find doneCh for checkpoint\n",
-    );
-
-    session.subscribe((event) => {
-      events.push(event);
-    });
-
-    const { turnId } = await session.startTurn("hello");
-    rejectPrompt(new Error("prompt failed"));
-    await Promise.resolve();
-    await Promise.resolve();
-
-    const failure = events.find((event) => event.type === "turn_failed");
-    expect(failure).toMatchObject({ type: "turn_failed", turnId, error: "prompt failed" });
-    expect((failure as { diagnostic?: string }).diagnostic).toContain(
-      "could not find doneCh for checkpoint",
-    );
-  });
-
-  test("keeps only the tail of a chatty ACP server's stderr", async () => {
-    const session = createSession();
-    const internals = asInternals<ACPSessionInternals>(session);
-    internals.appendStderrTail("x".repeat(20_000));
-    internals.appendStderrTail("the last thing it said");
-
-    const diagnostic = internals.collectDiagnostic("boom") as string;
-    expect(diagnostic).toContain("the last thing it said");
-    expect(internals.stderrTail.length).toBeLessThanOrEqual(8192);
   });
 
   test("flushes an image-only provider echo before a rejected turn finishes", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -95,6 +95,9 @@ interface ACPSessionInternals {
   configOptions: SessionConfigOption[];
   translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
   acpMcpServers(): unknown[];
+  appendStderrTail(chunk: string): void;
+  collectDiagnostic(message: string): string | undefined;
+  stderrTail: string;
 }
 
 interface ACPModelSelectionInternals {
@@ -3152,6 +3155,53 @@ describe("ACPAgentSession", () => {
       error: "prompt failed",
     });
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+  });
+
+  test("a rejected turn carries the ACP server's own stderr into the diagnostic", async () => {
+    // A turn can fail while the server keeps running, and then the daemon log has
+    // only what the diagnostic carries — for a closed-source ACP server that is
+    // the single inspection point (#4757).
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let rejectPrompt!: (error: Error) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise((_, reject) => {
+          rejectPrompt = reject;
+        }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+    asInternals<ACPSessionInternals>(session).appendStderrTail(
+      "could not find doneCh for checkpoint\n",
+    );
+
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    const { turnId } = await session.startTurn("hello");
+    rejectPrompt(new Error("prompt failed"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const failure = events.find((event) => event.type === "turn_failed");
+    expect(failure).toMatchObject({ type: "turn_failed", turnId, error: "prompt failed" });
+    expect((failure as { diagnostic?: string }).diagnostic).toContain(
+      "could not find doneCh for checkpoint",
+    );
+  });
+
+  test("keeps only the tail of a chatty ACP server's stderr", async () => {
+    const session = createSession();
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.appendStderrTail("x".repeat(20_000));
+    internals.appendStderrTail("the last thing it said");
+
+    const diagnostic = internals.collectDiagnostic("boom") as string;
+    expect(diagnostic).toContain("the last thing it said");
+    expect(internals.stderrTail.length).toBeLessThanOrEqual(8192);
   });
 
   test("flushes an image-only provider echo before a rejected turn finishes", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1669,7 +1669,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private readonly config: AgentSessionConfig;
   private child: ChildProcessWithoutNullStreams | null = null;
-  /** Tail of the ACP server's stderr, for the diagnostic of a failure it reports. */
+  /** Tail of what the ACP server wrote on stderr during the current turn. */
   private stderrTail = "";
   private connection: ClientSideConnection | null = null;
   private agentCapabilities: ACPAgentCapabilities | null = null;
@@ -1854,6 +1854,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
 
     this.deliverTranslatedEvents(this.flushPendingUserMessage());
+    // A diagnostic should carry what the server wrote about THIS turn. Keeping the
+    // session's whole stderr would attach initialization output, or an earlier
+    // turn's, to a failure it has nothing to do with.
+    this.stderrTail = "";
     const turnId = randomUUID();
     const messageId = options?.clientMessageId ?? randomUUID();
     this.activeForegroundTurnId = turnId;
@@ -2727,9 +2731,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     });
     assertChildWithPipes(child);
 
-    const stderrChunks: string[] = [];
     child.stderr.on("data", (chunk: Buffer | string) => {
-      stderrChunks.push(chunk.toString());
       this.appendStderrTail(chunk.toString());
     });
     child.once("exit", (code, signal) => {
@@ -2742,7 +2744,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
           type: "turn_failed",
           provider: this.provider,
           error: `ACP agent exited unexpectedly (${code ?? "null"}${signal ? `, ${signal}` : ""})`,
-          diagnostic: stderrChunks.join("").trim() || undefined,
+          diagnostic: this.stderrTail.trim() || undefined,
           turnId: this.activeForegroundTurnId,
         });
       }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -276,6 +276,12 @@ export function buildACPClientCapabilities(
 // sign-in URL in the browser) when probing an ACP agent for models/modes.
 // NO_BROWSER is honored by Gemini CLI; other ACP agents ignore it.
 const PROBE_ENV: Record<string, string> = { NO_BROWSER: "true" };
+// Matches the codex app-server and jsonl-rpc transports: keep the tail of what the
+// child wrote, not everything it ever wrote.
+const ACP_STDERR_BUFFER_LIMIT = 8192;
+// What of that tail travels in a failure diagnostic, alongside the other rows.
+const ACP_STDERR_DIAGNOSTIC_CAP = 2000;
+
 const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
 const ACP_PROBE_CLOSE_TIMEOUT_MS = 2_000;
 const ACP_IMPORT_HISTORY_LOAD_TIMEOUT_MS = 30_000;
@@ -1663,6 +1669,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private readonly config: AgentSessionConfig;
   private child: ChildProcessWithoutNullStreams | null = null;
+  /** Tail of the ACP server's stderr, for the diagnostic of a failure it reports. */
+  private stderrTail = "";
   private connection: ClientSideConnection | null = null;
   private agentCapabilities: ACPAgentCapabilities | null = null;
   private sessionId: string | null = null;
@@ -2722,6 +2730,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const stderrChunks: string[] = [];
     child.stderr.on("data", (chunk: Buffer | string) => {
       stderrChunks.push(chunk.toString());
+      this.appendStderrTail(chunk.toString());
     });
     child.once("exit", (code, signal) => {
       if (this.closed) {
@@ -3202,6 +3211,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
+  private appendStderrTail(chunk: string): void {
+    this.stderrTail = (this.stderrTail + chunk).slice(-ACP_STDERR_BUFFER_LIMIT);
+  }
+
   private collectDiagnostic(message: string): string | undefined {
     const parts: string[] = [message];
     if (this.child?.exitCode != null) {
@@ -3209,6 +3222,20 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
     if (this.child?.signalCode) {
       parts.push(`signal=${this.child.signalCode}`);
+    }
+    // What the server wrote about itself. A turn that fails while the process
+    // keeps running left daemon.log with nothing else to go on, and for a
+    // closed-source ACP server that log is the only inspection point (#4757).
+    // The END of the stream is the part that explains the failure, so the cut
+    // is taken from the front rather than through truncateForDiagnostic, which
+    // keeps the head.
+    const stderr = this.stderrTail.trim();
+    if (stderr) {
+      const tail =
+        stderr.length > ACP_STDERR_DIAGNOSTIC_CAP
+          ? `…(truncated)${stderr.slice(-ACP_STDERR_DIAGNOSTIC_CAP)}`
+          : stderr;
+      parts.push(`stderr=${tail}`);
     }
     return parts.length > 0 ? parts.join(" | ") : undefined;
   }


### PR DESCRIPTION
Closes #4757.

## What I found

The turn-failure path itself does log. `AgentManager.onStreamTurnFailed` writes `handleStreamEvent: turn_failed` at `warn` with `error`, `code` and `diagnostic` before it appends the timeline message, so a `turn_failed` does reach `daemon.log`.

What it cannot log is what the ACP server said about itself. For an ACP turn the diagnostic comes from `ACPAgentSession.collectDiagnostic`, which adds only the message, `exitCode` and `signal`. The server's stderr is captured in a local of the spawn call and read by one consumer, the `exit` handler, which uses it for the `ACP agent exited unexpectedly` diagnostic. A server that rejects a turn and keeps running therefore contributes nothing: the user sees the backend's own error text in the timeline and the log has the message with nothing that explains it. For a closed-source ACP server that log is the only inspection point, which is the general case the issue asks about.

While there: both ACP stderr buffers were unbounded, unlike the two sibling transports that keep a tail (`codex/app-server-transport.ts` and `jsonl-rpc-process.ts`, both `STDERR_BUFFER_LIMIT = 8192`). A chatty server grew that array for the life of the session.

## Change

- the session keeps `stderrTail`, the last 8192 characters of the ACP child's stderr, appended on every chunk
- `collectDiagnostic` appends `stderr=…` when there is any, so it travels with `turn_failed.diagnostic` into the existing `warn` line and into the timeline diagnostic
- the diagnostic keeps the END of the stderr, cut at 2000 characters, because the last thing the server said is what explains the failure; `truncateForDiagnostic` keeps the head, which is the wrong end here

No new log statement and no new level: this fills the field that the existing line already prints.

I could not reproduce your `could not find doneCh for checkpoint` specifically, and the issue says it is not deterministic, so I cannot claim this is the exact line that would have carried it. What I can say is that if the Antigravity server wrote anything about that failure to stderr, it now travels with the failure into `daemon.log`. If it turns out that text arrived as ordinary assistant content rather than a rejected prompt, that is a second path and worth its own issue; happy to look if you can share a timeline entry from `paseo logs` with the surrounding events.

## Tests

`acp-agent.test.ts`

- a rejected turn carries the server's stderr into the diagnostic, using your own error string
- a chatty server keeps only the tail, and the diagnostic shows the end of it

Both fail if the stderr row is dropped.

```
npx vitest run src/server/agent/providers/acp-agent.test.ts      104 passed
npx vitest run src/server/agent/providers/                       same failures as main
oxlint / oxfmt                                                   clean
```

The provider suite has pre-existing failures on `main`; the one difference on this branch was `claude/agent.nested-subagent-ownership.real.e2e.test.ts`, which passes twice in isolation, so it is the real e2e being timing sensitive under the full run rather than anything here.
