### PR TITLE
Support plugin updates by explicit Git ref

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -98,14 +98,17 @@ paseo plugin add owner/monorepo:plugins/review
 paseo plugin add owner/repository --ref main
 paseo plugin ls
 paseo plugin update review
+paseo plugin update review --ref <commit>
 paseo plugin update --all
 ```
 
 Append `:relative/path` to the source when the plugin lives below the repository root.
 
-Omitting `--ref` tracks the remote's default branch. A branch passed with `--ref` also tracks;
-tags and commits stay pinned. `ls` reports the installed commit without contacting the remote.
-Removing a Git source deletes Paseo's managed checkout.
+Omitting `--ref` on install tracks the remote's default branch. A branch passed with `--ref` also
+tracks; tags and commits stay pinned. `update <id> --ref <ref>` resolves a new branch, tag, or commit
+from the installed repository while preserving its monorepo subpath. `update --all` does not accept
+`--ref`. `ls` reports the installed commit without contacting the remote. Removing a Git source
+deletes Paseo's managed checkout.
 
 ### Declare Git preparation
 

--- a/packages/cli/src/commands/plugin/index.test.ts
+++ b/packages/cli/src/commands/plugin/index.test.ts
@@ -40,15 +40,6 @@ const installPluginSource = vi.fn(async () => ({
   enabled: true,
   status: "running" as const,
 }));
-const updatePluginSources = vi.fn(async () => [
-  {
-    id: "git-plugin",
-    previousCommit: "1557a34c91e2abcdef",
-    currentCommit: "92d85c3a4410fedcba",
-    commits: 1,
-    updated: true,
-  },
-]);
 const close = vi.fn(async () => undefined);
 const features: {
   pluginManagement?: boolean;
@@ -64,18 +55,12 @@ vi.mock("../../utils/client.js", () => ({
     getPluginLogs,
     installDirectoryPlugin,
     installPluginSource,
-    updatePluginSources,
     close,
   })),
 }));
 
 import { render } from "../../output/index.js";
-import {
-  createPluginCommand,
-  runPluginListCommand,
-  runPluginLogsCommand,
-  runPluginUpdateCommand,
-} from "./index.js";
+import { createPluginCommand, runPluginListCommand, runPluginLogsCommand } from "./index.js";
 
 describe("plugin management commands", () => {
   beforeEach(() => {
@@ -203,54 +188,5 @@ describe("plugin management commands", () => {
     });
     expect(installDirectoryPlugin).not.toHaveBeenCalled();
     stderr.mockRestore();
-  });
-
-  it("updates one Git plugin to an explicit ref with human and JSON output", async () => {
-    features.pluginGitRefUpdate = true;
-
-    const result = await runPluginUpdateCommand(
-      "git-plugin",
-      { daemonTarget, ref: "92d85c3a4410fedcba" },
-      {} as never,
-    );
-
-    expect(updatePluginSources).toHaveBeenCalledWith("git-plugin", "92d85c3a4410fedcba");
-    expect(render(result, { noColor: true })).toContain("92d85c3a4410");
-    expect(JSON.parse(render(result, { format: "json" }))).toEqual([
-      {
-        id: "git-plugin",
-        previousCommit: "1557a34c91e2abcdef",
-        currentCommit: "92d85c3a4410fedcba",
-        commits: 1,
-        updated: true,
-      },
-    ]);
-  });
-
-  it("preserves the existing update request when --ref is omitted", async () => {
-    features.pluginGitManagement = true;
-
-    await runPluginUpdateCommand("git-plugin", { daemonTarget }, {} as never);
-
-    expect(updatePluginSources).toHaveBeenCalledWith("git-plugin");
-  });
-
-  it("requires explicit-ref host support and one plugin ID", async () => {
-    features.pluginGitManagement = true;
-
-    await expect(
-      runPluginUpdateCommand(
-        "git-plugin",
-        { daemonTarget, ref: "92d85c3a4410fedcba" },
-        {} as never,
-      ),
-    ).rejects.toMatchObject({
-      code: "DAEMON_UPDATE_REQUIRED",
-      message: "Update the host to update a Git plugin to an explicit ref.",
-    });
-    await expect(
-      runPluginUpdateCommand(undefined, { daemonTarget, all: true, ref: "main" }, {} as never),
-    ).rejects.toThrow("--ref requires one plugin ID and cannot be used with --all");
-    expect(updatePluginSources).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/plugin/index.test.ts
+++ b/packages/cli/src/commands/plugin/index.test.ts
@@ -40,11 +40,21 @@ const installPluginSource = vi.fn(async () => ({
   enabled: true,
   status: "running" as const,
 }));
+const updatePluginSources = vi.fn(async () => [
+  {
+    id: "git-plugin",
+    previousCommit: "1557a34c91e2abcdef",
+    currentCommit: "92d85c3a4410fedcba",
+    commits: 1,
+    updated: true,
+  },
+]);
 const close = vi.fn(async () => undefined);
 const features: {
   pluginManagement?: boolean;
   pluginLogs?: boolean;
   pluginGitManagement?: boolean;
+  pluginGitRefUpdate?: boolean;
 } = {};
 
 vi.mock("../../utils/client.js", () => ({
@@ -54,18 +64,25 @@ vi.mock("../../utils/client.js", () => ({
     getPluginLogs,
     installDirectoryPlugin,
     installPluginSource,
+    updatePluginSources,
     close,
   })),
 }));
 
 import { render } from "../../output/index.js";
-import { createPluginCommand, runPluginListCommand, runPluginLogsCommand } from "./index.js";
+import {
+  createPluginCommand,
+  runPluginListCommand,
+  runPluginLogsCommand,
+  runPluginUpdateCommand,
+} from "./index.js";
 
 describe("plugin management commands", () => {
   beforeEach(() => {
     features.pluginManagement = false;
     features.pluginLogs = false;
     features.pluginGitManagement = false;
+    features.pluginGitRefUpdate = false;
     vi.clearAllMocks();
   });
 
@@ -186,5 +203,54 @@ describe("plugin management commands", () => {
     });
     expect(installDirectoryPlugin).not.toHaveBeenCalled();
     stderr.mockRestore();
+  });
+
+  it("updates one Git plugin to an explicit ref with human and JSON output", async () => {
+    features.pluginGitRefUpdate = true;
+
+    const result = await runPluginUpdateCommand(
+      "git-plugin",
+      { daemonTarget, ref: "92d85c3a4410fedcba" },
+      {} as never,
+    );
+
+    expect(updatePluginSources).toHaveBeenCalledWith("git-plugin", "92d85c3a4410fedcba");
+    expect(render(result, { noColor: true })).toContain("92d85c3a4410");
+    expect(JSON.parse(render(result, { format: "json" }))).toEqual([
+      {
+        id: "git-plugin",
+        previousCommit: "1557a34c91e2abcdef",
+        currentCommit: "92d85c3a4410fedcba",
+        commits: 1,
+        updated: true,
+      },
+    ]);
+  });
+
+  it("preserves the existing update request when --ref is omitted", async () => {
+    features.pluginGitManagement = true;
+
+    await runPluginUpdateCommand("git-plugin", { daemonTarget }, {} as never);
+
+    expect(updatePluginSources).toHaveBeenCalledWith("git-plugin");
+  });
+
+  it("requires explicit-ref host support and one plugin ID", async () => {
+    features.pluginGitManagement = true;
+
+    await expect(
+      runPluginUpdateCommand(
+        "git-plugin",
+        { daemonTarget, ref: "92d85c3a4410fedcba" },
+        {} as never,
+      ),
+    ).rejects.toMatchObject({
+      code: "DAEMON_UPDATE_REQUIRED",
+      message: "Update the host to update a Git plugin to an explicit ref.",
+    });
+    await expect(
+      runPluginUpdateCommand(undefined, { daemonTarget, all: true, ref: "main" }, {} as never),
+    ).rejects.toThrow("--ref requires one plugin ID and cannot be used with --all");
+    expect(updatePluginSources).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/plugin/index.ts
+++ b/packages/cli/src/commands/plugin/index.ts
@@ -17,6 +17,7 @@ import {
   withPluginLogsClient,
   withPluginManagementClient,
   withPluginSourceClient,
+  withPluginSourceRefClient,
 } from "./shared.js";
 
 interface PluginOptions extends CommandOptions {
@@ -143,16 +144,22 @@ async function install(
   return { type: "single", data, schema: pluginSchema };
 }
 
-async function update(
+export async function runPluginUpdateCommand(
   pluginId: string | undefined,
   options: PluginOptions,
   _command: Command,
 ): Promise<ListResult<PluginSourceUpdateItem>> {
+  if (options.ref !== undefined && (pluginId === undefined || options.all === true)) {
+    throw new Error("--ref requires one plugin ID and cannot be used with --all");
+  }
   if ((pluginId === undefined) === (options.all !== true)) {
     throw new Error("Choose one plugin ID or pass --all");
   }
-  const data = await withPluginSourceClient(options.daemonTarget, (client) =>
-    client.updatePluginSources(pluginId),
+  const withClient = options.ref !== undefined ? withPluginSourceRefClient : withPluginSourceClient;
+  const data = await withClient(options.daemonTarget, (client) =>
+    options.ref !== undefined
+      ? client.updatePluginSources(pluginId, options.ref)
+      : client.updatePluginSources(pluginId),
   );
   return { type: "list", data, schema: pluginUpdateSchema };
 }
@@ -215,8 +222,9 @@ export function createPluginCommand(): Command {
       .command("update")
       .description("Fetch and install Git-managed plugin updates")
       .argument("[id]")
-      .option("--all", "Update every Git-managed plugin"),
-  ).action(withOutput(update));
+      .option("--all", "Update every Git-managed plugin")
+      .option("--ref <ref>", "Git branch, tag, or commit"),
+  ).action(withOutput(runPluginUpdateCommand));
   for (const action of ["reload", "enable", "disable"] as const) {
     addJsonAndDaemonHostOptions(
       plugin.command(action).description(`${action} a plugin`).argument("<id>"),

--- a/packages/cli/src/commands/plugin/index.ts
+++ b/packages/cli/src/commands/plugin/index.ts
@@ -27,6 +27,16 @@ interface PluginOptions extends CommandOptions {
   path?: string;
   all?: boolean;
 }
+export interface PluginUpdateDependencies {
+  withPluginSourceClient: typeof withPluginSourceClient;
+  withPluginSourceRefClient: typeof withPluginSourceRefClient;
+}
+
+interface PluginUpdateCommandInput {
+  pluginId: string | undefined;
+  options: PluginOptions;
+  dependencies: PluginUpdateDependencies;
+}
 
 const pluginSchema: OutputSchema<PluginListItem> = {
   idField: "id",
@@ -149,13 +159,28 @@ export async function runPluginUpdateCommand(
   options: PluginOptions,
   _command: Command,
 ): Promise<ListResult<PluginSourceUpdateItem>> {
+  return runPluginUpdateCommandWithDependencies({
+    pluginId,
+    options,
+    dependencies: { withPluginSourceClient, withPluginSourceRefClient },
+  });
+}
+
+export async function runPluginUpdateCommandWithDependencies({
+  pluginId,
+  options,
+  dependencies,
+}: PluginUpdateCommandInput): Promise<ListResult<PluginSourceUpdateItem>> {
   if (options.ref !== undefined && (pluginId === undefined || options.all === true)) {
     throw new Error("--ref requires one plugin ID and cannot be used with --all");
   }
   if ((pluginId === undefined) === (options.all !== true)) {
     throw new Error("Choose one plugin ID or pass --all");
   }
-  const withClient = options.ref !== undefined ? withPluginSourceRefClient : withPluginSourceClient;
+  const withClient =
+    options.ref !== undefined
+      ? dependencies.withPluginSourceRefClient
+      : dependencies.withPluginSourceClient;
   const data = await withClient(options.daemonTarget, (client) =>
     options.ref !== undefined
       ? client.updatePluginSources(pluginId, options.ref)

--- a/packages/cli/src/commands/plugin/shared.ts
+++ b/packages/cli/src/commands/plugin/shared.ts
@@ -3,7 +3,11 @@ import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { CommandError } from "../../output/index.js";
 import { connectToDaemon } from "../../utils/client.js";
 
-type PluginFeature = "pluginManagement" | "pluginLogs" | "pluginGitManagement";
+type PluginFeature =
+  | "pluginManagement"
+  | "pluginLogs"
+  | "pluginGitManagement"
+  | "pluginGitRefUpdate";
 
 async function withPluginClient<T>(
   target: DaemonTarget,
@@ -56,6 +60,19 @@ export async function withPluginSourceClient<T>(
     target,
     "pluginGitManagement",
     "Update the host to install and update Git plugins.",
+    run,
+  );
+}
+
+export async function withPluginSourceRefClient<T>(
+  target: DaemonTarget,
+  run: (client: DaemonClient) => Promise<T>,
+): Promise<T> {
+  // COMPAT(pluginGitRefUpdate): added in v0.8.0, remove gate after 2027-03-12.
+  return withPluginClient(
+    target,
+    "pluginGitRefUpdate",
+    "Update the host to update a Git plugin to an explicit ref.",
     run,
   );
 }

--- a/packages/cli/src/commands/plugin/update.test.ts
+++ b/packages/cli/src/commands/plugin/update.test.ts
@@ -1,0 +1,66 @@
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { describe, expect, it } from "vitest";
+import { render } from "../../output/index.js";
+import { type PluginUpdateDependencies, runPluginUpdateCommandWithDependencies } from "./index.js";
+
+const daemonTarget = { kind: "endpoint" as const, host: "example.test:12345" };
+const updateResult = [
+  {
+    id: "git-plugin",
+    previousCommit: "1557a34c91e2abcdef",
+    currentCommit: "92d85c3a4410fedcba",
+    commits: 1,
+    updated: true,
+  },
+];
+
+function createDependencies(calls: Array<[string | undefined, string | undefined]>) {
+  const client = {
+    updatePluginSources: async (pluginId?: string, ref?: string) => {
+      calls.push([pluginId, ref]);
+      return updateResult;
+    },
+  } as unknown as DaemonClient;
+  return {
+    withPluginSourceClient: async (_target, run) => run(client),
+    withPluginSourceRefClient: async (_target, run) => run(client),
+  } satisfies PluginUpdateDependencies;
+}
+
+describe("plugin update command", () => {
+  it("updates one Git plugin to an explicit ref with human and JSON output", async () => {
+    const calls: Array<[string | undefined, string | undefined]> = [];
+    const result = await runPluginUpdateCommandWithDependencies({
+      pluginId: "git-plugin",
+      options: { daemonTarget, ref: "92d85c3a4410fedcba" },
+      dependencies: createDependencies(calls),
+    });
+
+    expect(calls).toEqual([["git-plugin", "92d85c3a4410fedcba"]]);
+    expect(render(result, { noColor: true })).toContain("92d85c3a4410");
+    expect(JSON.parse(render(result, { format: "json" }))).toEqual(updateResult);
+  });
+
+  it("preserves the existing update request when --ref is omitted", async () => {
+    const calls: Array<[string | undefined, string | undefined]> = [];
+    await runPluginUpdateCommandWithDependencies({
+      pluginId: "git-plugin",
+      options: { daemonTarget },
+      dependencies: createDependencies(calls),
+    });
+
+    expect(calls).toEqual([["git-plugin", undefined]]);
+  });
+
+  it("requires one plugin ID for an explicit ref before connecting", async () => {
+    const calls: Array<[string | undefined, string | undefined]> = [];
+    await expect(
+      runPluginUpdateCommandWithDependencies({
+        pluginId: undefined,
+        options: { daemonTarget, all: true, ref: "main" },
+        dependencies: createDependencies(calls),
+      }),
+    ).rejects.toThrow("--ref requires one plugin ID and cannot be used with --all");
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -2114,6 +2114,52 @@ test("serializes plugin source suffixes through the legacy path field", async ()
   await expect(installPromise).resolves.toMatchObject({ id: "review", status: "running" });
 });
 
+test("serializes an explicit plugin update ref", async () => {
+  const mock = createMockTransport();
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_plugin_update_ref",
+    logger: createMockLogger(),
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const updatePromise = client.updatePluginSources("review", "92d85c3a4410fedcba");
+  const request = parseSentFrame(mock.sent.at(-1));
+  expect(request).toEqual({
+    type: "plugin.source.update.request",
+    requestId: expect.any(String),
+    pluginId: "review",
+    ref: "92d85c3a4410fedcba",
+  });
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "plugin.source.update.response",
+      payload: {
+        requestId: request.requestId,
+        plugins: [
+          {
+            id: "review",
+            previousCommit: "1557a34c91e2abcdef",
+            currentCommit: "92d85c3a4410fedcba",
+            commits: 1,
+            updated: true,
+          },
+        ],
+      },
+    }),
+  );
+
+  await expect(updatePromise).resolves.toEqual([
+    expect.objectContaining({ id: "review", currentCommit: "92d85c3a4410fedcba", updated: true }),
+  ]);
+});
+
 test("a connection loss rejects an in-flight file context action", async () => {
   const mock = createMockTransport();
   const client = new DaemonClient({

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -5163,7 +5163,7 @@ export class DaemonClient {
     return payload.plugins;
   }
 
-  async updatePluginSources(pluginId?: string): Promise<PluginSourceUpdateItem[]> {
+  async updatePluginSources(pluginId?: string, ref?: string): Promise<PluginSourceUpdateItem[]> {
     const requestId = this.createRequestId();
     const payload = await this.sendCorrelatedSessionRequest({
       requestId,
@@ -5171,6 +5171,7 @@ export class DaemonClient {
         type: "plugin.source.update.request",
         requestId,
         ...(pluginId ? { pluginId } : {}),
+        ...(ref !== undefined ? { ref } : {}),
       },
       responseType: "plugin.source.update.response",
     });

--- a/packages/protocol/src/messages.plugins.test.ts
+++ b/packages/protocol/src/messages.plugins.test.ts
@@ -125,6 +125,19 @@ describe("plugin protocol compatibility", () => {
       }).type,
     ).toBe("plugin.source.install.request");
     expect(
+      SessionInboundMessageSchema.parse({
+        type: "plugin.source.update.request",
+        requestId: "request-update",
+        pluginId: "review",
+        ref: "92d85c3a4410fedcba",
+      }),
+    ).toEqual({
+      type: "plugin.source.update.request",
+      requestId: "request-update",
+      pluginId: "review",
+      ref: "92d85c3a4410fedcba",
+    });
+    expect(
       SessionOutboundMessageSchema.parse({
         type: "plugin.source.status.response",
         payload: {
@@ -152,9 +165,18 @@ describe("plugin protocol compatibility", () => {
         features: { pluginManagement: true },
       },
     });
+    const current = StatusMessageSchema.parse({
+      type: "status",
+      payload: {
+        status: "server_info",
+        serverId: "current-host",
+        features: { pluginGitManagement: true, pluginGitRefUpdate: true },
+      },
+    });
     expect(older.payload.features?.pluginGitManagement).toBeUndefined();
+    expect(older.payload.features?.pluginGitRefUpdate).toBeUndefined();
+    expect(current.payload.features?.pluginGitRefUpdate).toBe(true);
   });
-
   it("uses a namespaced snapshot RPC for structured plugin logs", () => {
     expect(
       SessionInboundMessageSchema.parse({

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1505,6 +1505,7 @@ export const PluginSourceUpdateRequestSchema = z.object({
   type: z.literal("plugin.source.update.request"),
   requestId: z.string(),
   pluginId: PluginIdSchema.optional(),
+  ref: z.string().min(1).optional(),
 });
 
 function pluginIdRequest<const Type extends string>(type: Type) {
@@ -3529,6 +3530,8 @@ export const ServerInfoStatusPayloadSchema = z
         pluginLogs: z.boolean().optional(),
         // COMPAT(pluginGitManagement): added in v0.7.0, remove gate after 2027-08-26.
         pluginGitManagement: z.boolean().optional(),
+        // COMPAT(pluginGitRefUpdate): added in v0.8.0, remove gate after 2027-03-12.
+        pluginGitRefUpdate: z.boolean().optional(),
         // COMPAT(pluginThemes): added in v0.5.0, remove gate after 2027-08-20.
         // A daemon that predates this flag keeps `addTheme` in the server bundle it compiles,
         // so a theme plugin cannot start there at all.

--- a/packages/server/src/server/plugins/index.posix.test.ts
+++ b/packages/server/src/server/plugins/index.posix.test.ts
@@ -345,7 +345,7 @@ describe("PluginService", () => {
     await service.stopAllPlugins();
   }, 20_000);
 
-  it("keeps the running commit when a Git update build command fails", async () => {
+  it("keeps the running commit when an explicit ref or its preparation fails", async () => {
     const home = await mkdtemp(path.join(tmpdir(), "paseo-plugin-home-"));
     roots.push(home);
     const repository = await mkdtemp(path.join(tmpdir(), "paseo-plugin-repository-"));
@@ -375,6 +375,17 @@ describe("PluginService", () => {
     const installedPath = installed.path;
     const installedCommit = installed.commit;
 
+    await expect(service.updateSources("git-update", "missing-ref")).rejects.toThrow();
+    expect(await readdir(path.join(home, "plugins", ".staging"))).toEqual([]);
+    expect(service.listPlugins()).toEqual([
+      expect.objectContaining({
+        id: "git-update",
+        path: installedPath,
+        commit: installedCommit,
+        status: "running",
+      }),
+    ]);
+
     await writeFile(
       path.join(repository, "paseo-plugin.json"),
       JSON.stringify({
@@ -390,8 +401,10 @@ describe("PluginService", () => {
     );
     await runGitCommand(["add", "-A"], { cwd: repository });
     await runGitCommand(["commit", "-m", "broken update"], { cwd: repository });
+    const { stdout } = await runGitCommand(["rev-parse", "HEAD"], { cwd: repository });
+    const brokenCommit = stdout.trim();
 
-    await expect(service.updateSources("git-update")).rejects.toThrow();
+    await expect(service.updateSources("git-update", brokenCommit)).rejects.toThrow();
     expect(await readdir(path.join(home, "plugins", ".staging"))).toEqual([]);
     expect(service.catalog()).toEqual([
       expect.objectContaining({ id: "git-update", clientBundle: expect.any(String) }),
@@ -484,9 +497,22 @@ describe("PluginService", () => {
     );
     await runGitCommand(["add", "-A"], { cwd: repository });
     await runGitCommand(["commit", "-m", "prepared update"], { cwd: repository });
+    const { stdout } = await runGitCommand(["rev-parse", "HEAD"], { cwd: repository });
+    const updatedCommit = stdout.trim();
 
-    await expect(service.updateSources("prepared-git-plugin")).resolves.toEqual([
-      expect.objectContaining({ id: "prepared-git-plugin", updated: true }),
+    await expect(service.updateSources("prepared-git-plugin", updatedCommit)).resolves.toEqual([
+      expect.objectContaining({
+        id: "prepared-git-plugin",
+        currentCommit: updatedCommit,
+        updated: true,
+      }),
+    ]);
+    expect(service.listPlugins()).toEqual([
+      expect.objectContaining({
+        id: "prepared-git-plugin",
+        commit: updatedCommit,
+        ref: updatedCommit,
+      }),
     ]);
     expect(events).toEqual(["validate:prepared", "start", "validate:updated", "start"]);
     await service.stopAllPlugins();

--- a/packages/server/src/server/plugins/index.posix.test.ts
+++ b/packages/server/src/server/plugins/index.posix.test.ts
@@ -375,7 +375,9 @@ describe("PluginService", () => {
     const installedPath = installed.path;
     const installedCommit = installed.commit;
 
-    await expect(service.updateSources("git-update", "missing-ref")).rejects.toThrow();
+    await expect(
+      service.updateSources({ pluginId: "git-update", ref: "missing-ref" }),
+    ).rejects.toThrow();
     expect(await readdir(path.join(home, "plugins", ".staging"))).toEqual([]);
     expect(service.listPlugins()).toEqual([
       expect.objectContaining({
@@ -404,7 +406,9 @@ describe("PluginService", () => {
     const { stdout } = await runGitCommand(["rev-parse", "HEAD"], { cwd: repository });
     const brokenCommit = stdout.trim();
 
-    await expect(service.updateSources("git-update", brokenCommit)).rejects.toThrow();
+    await expect(
+      service.updateSources({ pluginId: "git-update", ref: brokenCommit }),
+    ).rejects.toThrow();
     expect(await readdir(path.join(home, "plugins", ".staging"))).toEqual([]);
     expect(service.catalog()).toEqual([
       expect.objectContaining({ id: "git-update", clientBundle: expect.any(String) }),
@@ -500,7 +504,9 @@ describe("PluginService", () => {
     const { stdout } = await runGitCommand(["rev-parse", "HEAD"], { cwd: repository });
     const updatedCommit = stdout.trim();
 
-    await expect(service.updateSources("prepared-git-plugin", updatedCommit)).resolves.toEqual([
+    await expect(
+      service.updateSources({ pluginId: "prepared-git-plugin", ref: updatedCommit }),
+    ).resolves.toEqual([
       expect.objectContaining({
         id: "prepared-git-plugin",
         currentCommit: updatedCommit,
@@ -582,7 +588,7 @@ describe("PluginService", () => {
     await runGitCommand(["add", "-A"], { cwd: repository });
     await runGitCommand(["commit", "-m", "fixed"], { cwd: repository });
 
-    await expect(service.updateSources("failed-update")).resolves.toEqual([
+    await expect(service.updateSources({ pluginId: "failed-update" })).resolves.toEqual([
       expect.objectContaining({ id: "failed-update", updated: true }),
     ]);
     expect(starts).toHaveLength(2);

--- a/packages/server/src/server/plugins/index.ts
+++ b/packages/server/src/server/plugins/index.ts
@@ -286,14 +286,17 @@ export class PluginService {
     });
   }
 
-  async updateSources(pluginId?: string): Promise<PluginSourceUpdateItem[]> {
+  async updateSources(pluginId?: string, ref?: string): Promise<PluginSourceUpdateItem[]> {
+    if (ref !== undefined && pluginId === undefined) {
+      throw new Error("Plugin --ref requires a plugin ID");
+    }
     return this.enqueue(async () => {
       const sources = this.configStore.get().plugins ?? {};
       const ids = pluginId
         ? [pluginId]
         : Object.keys(sources).filter((id) => this.managedSources?.get(id));
       const updates: PluginSourceUpdateItem[] = [];
-      for (const id of ids.sort()) updates.push(await this.updateSource(id));
+      for (const id of ids.sort()) updates.push(await this.updateSource(id, ref));
       return updates;
     });
   }
@@ -530,12 +533,12 @@ export class PluginService {
     assertPluginCompatibility({ ...manifest, version: this.daemonVersion, runtime: "daemon" });
   }
 
-  private async updateSource(pluginId: string): Promise<PluginSourceUpdateItem> {
+  private async updateSource(pluginId: string, ref?: string): Promise<PluginSourceUpdateItem> {
     const managedSources = this.requireManagedSources();
     const source = this.requireSource(pluginId);
     const previous = managedSources.get(pluginId);
     if (!previous) throw new Error(`Plugin is not managed by Git: ${pluginId}`);
-    const prepared = await managedSources.prepareUpdate(pluginId, source.path);
+    const prepared = await managedSources.prepareUpdate(pluginId, source.path, ref);
     if (!prepared.candidate) {
       return {
         id: pluginId,

--- a/packages/server/src/server/plugins/index.ts
+++ b/packages/server/src/server/plugins/index.ts
@@ -286,7 +286,13 @@ export class PluginService {
     });
   }
 
-  async updateSources(pluginId?: string, ref?: string): Promise<PluginSourceUpdateItem[]> {
+  async updateSources({
+    pluginId,
+    ref,
+  }: {
+    pluginId?: string;
+    ref?: string;
+  } = {}): Promise<PluginSourceUpdateItem[]> {
     if (ref !== undefined && pluginId === undefined) {
       throw new Error("Plugin --ref requires a plugin ID");
     }
@@ -296,7 +302,7 @@ export class PluginService {
         ? [pluginId]
         : Object.keys(sources).filter((id) => this.managedSources?.get(id));
       const updates: PluginSourceUpdateItem[] = [];
-      for (const id of ids.sort()) updates.push(await this.updateSource(id, ref));
+      for (const id of ids.sort()) updates.push(await this.updateSource({ pluginId: id, ref }));
       return updates;
     });
   }
@@ -533,12 +539,22 @@ export class PluginService {
     assertPluginCompatibility({ ...manifest, version: this.daemonVersion, runtime: "daemon" });
   }
 
-  private async updateSource(pluginId: string, ref?: string): Promise<PluginSourceUpdateItem> {
+  private async updateSource({
+    pluginId,
+    ref,
+  }: {
+    pluginId: string;
+    ref?: string;
+  }): Promise<PluginSourceUpdateItem> {
     const managedSources = this.requireManagedSources();
     const source = this.requireSource(pluginId);
     const previous = managedSources.get(pluginId);
     if (!previous) throw new Error(`Plugin is not managed by Git: ${pluginId}`);
-    const prepared = await managedSources.prepareUpdate(pluginId, source.path, ref);
+    const prepared = await managedSources.prepareUpdate({
+      pluginId,
+      configuredPath: source.path,
+      requestedRef: ref,
+    });
     if (!prepared.candidate) {
       return {
         id: pluginId,

--- a/packages/server/src/server/plugins/managed-source.posix.test.ts
+++ b/packages/server/src/server/plugins/managed-source.posix.test.ts
@@ -75,11 +75,12 @@ describe("managed Git plugin sources", () => {
       commitsBehind: 1,
       updateAvailable: true,
     });
-
-    const prepared = await sources.prepareUpdate("managed-example", candidate.directory);
+    const prepared = await sources.prepareUpdate({
+      pluginId: "managed-example",
+      configuredPath: candidate.directory,
+    });
     expect(prepared.commits).toBe(1);
-    if (!prepared.candidate) throw new Error("Expected an update candidate");
-    const updated = await sources.place("managed-example", prepared.candidate);
+    const updated = await sources.place("managed-example", expectCandidate(prepared.candidate));
     sources.commit("managed-example", updated.record);
     expect(await readFile(path.join(updated.directory, "index.server.ts"), "utf8")).toContain(
       "new Date",
@@ -126,12 +127,11 @@ describe("managed Git plugin sources", () => {
     let installed = await sources.prepareInstall({ source: remote, pluginPath });
     installed = await sources.place("monorepo-example", installed);
     sources.commit("monorepo-example", installed.record);
-
-    const pinned = await sources.prepareUpdate(
-      "monorepo-example",
-      installed.directory,
-      releaseCommit,
-    );
+    const pinned = await sources.prepareUpdate({
+      pluginId: "monorepo-example",
+      configuredPath: installed.directory,
+      requestedRef: releaseCommit,
+    });
     const pinnedCandidate = await sources.place(
       "monorepo-example",
       expectCandidate(pinned.candidate),
@@ -147,12 +147,11 @@ describe("managed Git plugin sources", () => {
     expect(await readFile(path.join(pinnedCandidate.directory, "index.server.ts"), "utf8")).toBe(
       "export const version = 2;\n",
     );
-
-    const tracking = await sources.prepareUpdate(
-      "monorepo-example",
-      pinnedCandidate.directory,
-      "release",
-    );
+    const tracking = await sources.prepareUpdate({
+      pluginId: "monorepo-example",
+      configuredPath: pinnedCandidate.directory,
+      requestedRef: "release",
+    });
     const trackingCandidate = await sources.place(
       "monorepo-example",
       expectCandidate(tracking.candidate),
@@ -168,7 +167,10 @@ describe("managed Git plugin sources", () => {
     await runGitCommand(["checkout", "release"], { cwd: repository });
     await writeFile(path.join(pluginDirectory, "index.server.ts"), "export const version = 4;\n");
     const trackedCommit = await commitAll(repository, "release update");
-    const tracked = await sources.prepareUpdate("monorepo-example", trackingCandidate.directory);
+    const tracked = await sources.prepareUpdate({
+      pluginId: "monorepo-example",
+      configuredPath: trackingCandidate.directory,
+    });
     expect(expectCandidate(tracked.candidate).record).toMatchObject({
       pluginPath,
       commit: trackedCommit,

--- a/packages/server/src/server/plugins/managed-source.posix.test.ts
+++ b/packages/server/src/server/plugins/managed-source.posix.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { runGitCommand } from "../../utils/run-git-command.js";
-import { ManagedPluginSources } from "./managed-source.js";
+import { type ManagedPluginCandidate, ManagedPluginSources } from "./managed-source.js";
 
 const roots: string[] = [];
 
@@ -32,6 +32,10 @@ async function commitAll(repository: string, message: string): Promise<string> {
   await runGitCommand(["commit", "-m", message], { cwd: repository });
   const { stdout } = await runGitCommand(["rev-parse", "HEAD"], { cwd: repository });
   return stdout.trim();
+}
+function expectCandidate(candidate: ManagedPluginCandidate | null): ManagedPluginCandidate {
+  expect(candidate).not.toBeNull();
+  return candidate as ManagedPluginCandidate;
 }
 
 describe("managed Git plugin sources", () => {
@@ -128,8 +132,10 @@ describe("managed Git plugin sources", () => {
       installed.directory,
       releaseCommit,
     );
-    if (!pinned.candidate) throw new Error("Expected an explicit commit candidate");
-    const pinnedCandidate = await sources.place("monorepo-example", pinned.candidate);
+    const pinnedCandidate = await sources.place(
+      "monorepo-example",
+      expectCandidate(pinned.candidate),
+    );
     sources.commit("monorepo-example", pinnedCandidate.record);
     expect(pinnedCandidate.record).toMatchObject({
       remote,
@@ -147,8 +153,10 @@ describe("managed Git plugin sources", () => {
       pinnedCandidate.directory,
       "release",
     );
-    if (!tracking.candidate) throw new Error("Expected an explicit branch candidate");
-    const trackingCandidate = await sources.place("monorepo-example", tracking.candidate);
+    const trackingCandidate = await sources.place(
+      "monorepo-example",
+      expectCandidate(tracking.candidate),
+    );
     sources.commit("monorepo-example", trackingCandidate.record);
     expect(trackingCandidate.record).toMatchObject({
       pluginPath,
@@ -161,8 +169,7 @@ describe("managed Git plugin sources", () => {
     await writeFile(path.join(pluginDirectory, "index.server.ts"), "export const version = 4;\n");
     const trackedCommit = await commitAll(repository, "release update");
     const tracked = await sources.prepareUpdate("monorepo-example", trackingCandidate.directory);
-    if (!tracked.candidate) throw new Error("Expected a tracked branch candidate");
-    expect(tracked.candidate.record).toMatchObject({
+    expect(expectCandidate(tracked.candidate).record).toMatchObject({
       pluginPath,
       commit: trackedCommit,
       requestedRef: "release",

--- a/packages/server/src/server/plugins/managed-source.posix.test.ts
+++ b/packages/server/src/server/plugins/managed-source.posix.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -91,6 +91,82 @@ describe("managed Git plugin sources", () => {
       latestCommit: initial,
       commitsBehind: 0,
       updateAvailable: false,
+    });
+  }, 30_000);
+
+  it("updates to explicit commits and branches while preserving a monorepo path", async () => {
+    const repository = await mkdtemp(path.join(tmpdir(), "paseo-plugin-monorepo-"));
+    roots.push(repository);
+    await runGitCommand(["init", "-b", "main"], { cwd: repository });
+    await runGitCommand(["config", "user.name", "Paseo Tests"], { cwd: repository });
+    await runGitCommand(["config", "user.email", "paseo@example.test"], { cwd: repository });
+    const pluginPath = path.join("plugins", "review");
+    const pluginDirectory = path.join(repository, pluginPath);
+    await mkdir(pluginDirectory, { recursive: true });
+    await writeFile(
+      path.join(pluginDirectory, "paseo-plugin.json"),
+      JSON.stringify({ id: "monorepo-example" }),
+    );
+    await writeFile(path.join(pluginDirectory, "index.server.ts"), "export const version = 1;\n");
+    await commitAll(repository, "initial");
+    await writeFile(path.join(pluginDirectory, "index.server.ts"), "export const version = 2;\n");
+    const releaseCommit = await commitAll(repository, "release");
+    await runGitCommand(["branch", "release"], { cwd: repository });
+    await writeFile(path.join(pluginDirectory, "index.server.ts"), "export const version = 3;\n");
+    await commitAll(repository, "main update");
+
+    const home = await mkdtemp(path.join(tmpdir(), "paseo-plugin-git-home-"));
+    roots.push(home);
+    const remote = pathToFileURL(repository).href;
+    const sources = new ManagedPluginSources(home);
+    let installed = await sources.prepareInstall({ source: remote, pluginPath });
+    installed = await sources.place("monorepo-example", installed);
+    sources.commit("monorepo-example", installed.record);
+
+    const pinned = await sources.prepareUpdate(
+      "monorepo-example",
+      installed.directory,
+      releaseCommit,
+    );
+    if (!pinned.candidate) throw new Error("Expected an explicit commit candidate");
+    const pinnedCandidate = await sources.place("monorepo-example", pinned.candidate);
+    sources.commit("monorepo-example", pinnedCandidate.record);
+    expect(pinnedCandidate.record).toMatchObject({
+      remote,
+      pluginPath,
+      commit: releaseCommit,
+      requestedRef: releaseCommit,
+      trackingBranch: null,
+    });
+    expect(await readFile(path.join(pinnedCandidate.directory, "index.server.ts"), "utf8")).toBe(
+      "export const version = 2;\n",
+    );
+
+    const tracking = await sources.prepareUpdate(
+      "monorepo-example",
+      pinnedCandidate.directory,
+      "release",
+    );
+    if (!tracking.candidate) throw new Error("Expected an explicit branch candidate");
+    const trackingCandidate = await sources.place("monorepo-example", tracking.candidate);
+    sources.commit("monorepo-example", trackingCandidate.record);
+    expect(trackingCandidate.record).toMatchObject({
+      pluginPath,
+      commit: releaseCommit,
+      requestedRef: "release",
+      trackingBranch: "release",
+    });
+
+    await runGitCommand(["checkout", "release"], { cwd: repository });
+    await writeFile(path.join(pluginDirectory, "index.server.ts"), "export const version = 4;\n");
+    const trackedCommit = await commitAll(repository, "release update");
+    const tracked = await sources.prepareUpdate("monorepo-example", trackingCandidate.directory);
+    if (!tracked.candidate) throw new Error("Expected a tracked branch candidate");
+    expect(tracked.candidate.record).toMatchObject({
+      pluginPath,
+      commit: trackedCommit,
+      requestedRef: "release",
+      trackingBranch: "release",
     });
   }, 30_000);
 });

--- a/packages/server/src/server/plugins/managed-source.ts
+++ b/packages/server/src/server/plugins/managed-source.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { z } from "zod";
 import { PluginIdSchema, type PluginSourceStatusItem } from "@getpaseo/protocol/messages";
 import { runGitCommand } from "../../utils/run-git-command.js";
@@ -158,9 +159,40 @@ export class ManagedPluginSources {
   async prepareUpdate(
     pluginId: string,
     configuredPath: string,
+    requestedRef?: string,
   ): Promise<{ candidate: ManagedPluginCandidate | null; commits: number }> {
     const record = this.records[pluginId];
     if (!record) throw new Error(`Plugin is not managed by Git: ${pluginId}`);
+    if (requestedRef !== undefined) {
+      const candidate = await this.prepareInstall({
+        source: record.remote,
+        ref: requestedRef,
+        pluginPath: record.pluginPath,
+      });
+      try {
+        const unchanged =
+          candidate.record.commit === record.commit &&
+          candidate.record.requestedRef === record.requestedRef &&
+          candidate.record.trackingBranch === record.trackingBranch;
+        if (unchanged) {
+          await this.discard(candidate);
+          return { candidate: null, commits: 0 };
+        }
+        await runGitCommand(
+          ["fetch", "--no-tags", pathToFileURL(record.checkoutRoot).href, record.commit],
+          { cwd: candidate.record.checkoutRoot, envOverlay: GIT_ENV, timeout: GIT_TIMEOUT_MS },
+        );
+        const commits = await countCommits(
+          candidate.record.checkoutRoot,
+          record.commit,
+          candidate.record.commit,
+        );
+        return { candidate, commits };
+      } catch (error) {
+        await this.discard(candidate);
+        throw error;
+      }
+    }
     const status = await this.status(pluginId, configuredPath);
     const latestCommit = status.latestCommit;
     if (!latestCommit || latestCommit === record.commit) return { candidate: null, commits: 0 };

--- a/packages/server/src/server/plugins/managed-source.ts
+++ b/packages/server/src/server/plugins/managed-source.ts
@@ -41,6 +41,11 @@ interface InstallInput {
   ref?: string;
   pluginPath?: string;
 }
+export interface ManagedPluginUpdateInput {
+  pluginId: string;
+  configuredPath: string;
+  requestedRef?: string;
+}
 
 interface RefResolution {
   commit: string;
@@ -156,11 +161,14 @@ export class ManagedPluginSources {
     };
   }
 
-  async prepareUpdate(
-    pluginId: string,
-    configuredPath: string,
-    requestedRef?: string,
-  ): Promise<{ candidate: ManagedPluginCandidate | null; commits: number }> {
+  async prepareUpdate({
+    pluginId,
+    configuredPath,
+    requestedRef,
+  }: ManagedPluginUpdateInput): Promise<{
+    candidate: ManagedPluginCandidate | null;
+    commits: number;
+  }> {
     const record = this.records[pluginId];
     if (!record) throw new Error(`Plugin is not managed by Git: ${pluginId}`);
     if (requestedRef !== undefined) {

--- a/packages/server/src/server/plugins/requirements.posix.test.ts
+++ b/packages/server/src/server/plugins/requirements.posix.test.ts
@@ -120,7 +120,9 @@ it("rejects Git install and update before build commands, preserving the running
     [process.execPath, "-e", 'require("node:fs").writeFileSync(process.argv[1], "ran")', marker],
   ]);
   await commit();
-  await expect(service.updateSources("example")).rejects.toThrow("requires Paseo >=0.9.0");
+  await expect(service.updateSources({ pluginId: "example" })).rejects.toThrow(
+    "requires Paseo >=0.9.0",
+  );
   expect(service.listPlugins()).toEqual([installed]);
   expect(service.catalog()).toHaveLength(1);
   expect(await readdir(path.join(home, "plugins", ".staging"))).toEqual([]);

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -493,7 +493,7 @@ export interface SessionOptions {
     statusSources(
       pluginId?: string,
     ): Promise<import("@getpaseo/protocol/messages").PluginSourceStatusItem[]>;
-    updateSources(pluginId?: string, ref?: string): Promise<PluginSourceUpdateItem[]>;
+    updateSources(input?: { pluginId?: string; ref?: string }): Promise<PluginSourceUpdateItem[]>;
     reloadPlugin(pluginId: string): Promise<import("@getpaseo/protocol/messages").PluginListItem>;
     enablePlugin(pluginId: string): Promise<import("@getpaseo/protocol/messages").PluginListItem>;
     disablePlugin(pluginId: string): Promise<import("@getpaseo/protocol/messages").PluginListItem>;
@@ -2454,13 +2454,15 @@ export class Session {
     }
     if (msg.type === "plugin.source.update.request") {
       if (!this.pluginRuntime) throw new Error("Plugin service is unavailable");
-      return this.pluginRuntime.updateSources(msg.pluginId, msg.ref).then((plugins) => {
-        this.emit({
-          type: "plugin.source.update.response",
-          payload: { requestId: msg.requestId, plugins },
+      return this.pluginRuntime
+        .updateSources({ pluginId: msg.pluginId, ref: msg.ref })
+        .then((plugins) => {
+          this.emit({
+            type: "plugin.source.update.response",
+            payload: { requestId: msg.requestId, plugins },
+          });
+          return undefined;
         });
-        return undefined;
-      });
     }
     if (msg.type === "plugin.directory.install.request") {
       if (!this.pluginRuntime) throw new Error("Plugin service is unavailable");

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -27,6 +27,7 @@ import {
   type ProjectPlacementPayload,
   type WorkspaceSetupSnapshot,
   type WorkspaceDescriptorPayload,
+  type PluginSourceUpdateItem,
 } from "./messages.js";
 import type {
   TerminalManager,
@@ -492,9 +493,7 @@ export interface SessionOptions {
     statusSources(
       pluginId?: string,
     ): Promise<import("@getpaseo/protocol/messages").PluginSourceStatusItem[]>;
-    updateSources(
-      pluginId?: string,
-    ): Promise<import("@getpaseo/protocol/messages").PluginSourceUpdateItem[]>;
+    updateSources(pluginId?: string, ref?: string): Promise<PluginSourceUpdateItem[]>;
     reloadPlugin(pluginId: string): Promise<import("@getpaseo/protocol/messages").PluginListItem>;
     enablePlugin(pluginId: string): Promise<import("@getpaseo/protocol/messages").PluginListItem>;
     disablePlugin(pluginId: string): Promise<import("@getpaseo/protocol/messages").PluginListItem>;
@@ -2455,7 +2454,7 @@ export class Session {
     }
     if (msg.type === "plugin.source.update.request") {
       if (!this.pluginRuntime) throw new Error("Plugin service is unavailable");
-      return this.pluginRuntime.updateSources(msg.pluginId).then((plugins) => {
+      return this.pluginRuntime.updateSources(msg.pluginId, msg.ref).then((plugins) => {
         this.emit({
           type: "plugin.source.update.response",
           payload: { requestId: msg.requestId, plugins },

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1689,6 +1689,8 @@ export class VoiceAssistantWebSocketServer {
         plugins: true,
         pluginManagement: true,
         pluginGitManagement: true,
+        // COMPAT(pluginGitRefUpdate): added in v0.8.0, remove gate after 2027-03-12.
+        pluginGitRefUpdate: true,
         pluginLogs: true,
         // COMPAT(pluginThemes): added in v0.5.0, remove gate after 2027-08-20.
         pluginThemes: true,

--- a/public-docs/cli.md
+++ b/public-docs/cli.md
@@ -175,6 +175,7 @@ paseo plugin add https://gitlab.com/group/repository.git --ref main
 paseo plugin add owner/monorepo:plugins/review
 paseo plugin ls [id]
 paseo plugin update my-plugin
+paseo plugin update my-plugin --ref <commit>
 paseo plugin update --all
 paseo plugin reload my-plugin
 paseo plugin logs my-plugin
@@ -184,8 +185,10 @@ paseo plugin remove my-plugin
 ```
 
 GitHub shorthand checks an existing host directory first. Append `:<directory>` for a plugin in a
-monorepo. `paseo plugin ls [id]` does not contact the remote. `paseo plugin logs <id>` returns the
-plugin's recent daemon-side stdout and stderr. Add `--json` for structured entries, or run
+monorepo. `plugin update <id> --ref <ref>` installs that branch, tag, or commit from the plugin's
+existing repository and keeps its monorepo path; it cannot be combined with `--all`.
+`paseo plugin ls [id]` does not contact the remote. `paseo plugin logs <id>` returns the plugin's
+recent daemon-side stdout and stderr. Add `--json` for structured entries, or run
 `paseo --host <target> plugin logs <id>` for another daemon. See the
 [Plugin reference](/docs/plugins/v0.7/reference) for installation, trust, lifecycle, and log-retention
 behavior.

--- a/public-docs/plugins/v0.8/index.md
+++ b/public-docs/plugins/v0.8/index.md
@@ -234,10 +234,13 @@ default branch is tracked; a branch tracks updates, while a tag or commit stays 
 ```bash
 paseo plugin ls
 paseo plugin update workspace-plugin
+paseo plugin update workspace-plugin --ref <commit>
 paseo plugin update --all
 ```
 
-`ls` reports runtime state, source details, and the installed commit without contacting the remote.
+`update <id> --ref <ref>` installs that branch, tag, or commit from the same repository and preserves
+the plugin's monorepo path; it cannot be combined with `--all`. `ls` reports runtime state, source
+details, and the installed commit without contacting the remote.
 
 Paseo compiles TypeScript itself, so most plugins need no build step. A repository that must
 install a dependency Paseo does not provide, or generate files, declares

--- a/public-docs/plugins/v0.8/reference.md
+++ b/public-docs/plugins/v0.8/reference.md
@@ -1704,6 +1704,7 @@ paseo plugin add https://git.example.com/owner/repository.git --ref main
 paseo plugin add owner/monorepo:plugins/review
 paseo plugin ls [id]
 paseo plugin update <id>
+paseo plugin update <id> --ref <branch-or-tag-or-commit>
 paseo plugin update --all
 paseo plugin reload my-plugin
 paseo plugin logs my-plugin
@@ -1713,11 +1714,15 @@ paseo plugin remove my-plugin
 ```
 
 `ls` reports runtime state, source details, and the installed commit without contacting the remote.
-Use `update` when you want Paseo to contact a tracked Git remote and install an available update.
+Use `update` without `--ref` to contact the tracked Git remote and install an available update. Use
+`update <id> --ref <ref>` to resolve and install a branch, tag, or commit from the same repository
+while preserving the plugin's monorepo path. An explicit ref requires one plugin ID and cannot be
+combined with `--all`.
 
-Put `--host <url>` before a management command when the target is not the CLI's default daemon. `remove`
-never deletes a directory source; it deletes the managed checkout for a Git source. The install-time
-`--id` is the runtime ID and allows the same directory or repository to be installed more than once.
+Put `--host <url>` before a management command when the target is not the CLI's default daemon.
+`remove` never deletes a directory source; it deletes the managed checkout for a Git source. The
+install-time `--id` is the runtime ID and allows the same directory or repository to be installed
+more than once.
 
 > **Trust every plugin you add.** `paseo plugin add` and `paseo plugin install` mean “I trust this codebase.” Server code and Git preparation commands run unsandboxed with the daemon user's access on the daemon host; client contributions run inside Paseo. Dependencies and future updates are part of that decision. With the global `--host` option, commands run on the remote daemon host.
 


### PR DESCRIPTION
## Summary

- add `paseo plugin update <id> --ref <ref>` for Git-managed plugins
- resolve branches, tags, and commits through the existing Git ref rules while preserving the repository and monorepo path
- stage, prepare, validate, and activate the candidate before committing installation metadata
- advertise `pluginGitRefUpdate` so newer clients do not send explicit refs to daemons that would ignore them
- preserve existing tracked update behavior when `--ref` is omitted

This keeps Git as transport and leaves package version and catalog policy outside Paseo core. It lets paseo-cafe map a package version to its scanned commit and install that exact commit.

## Behavior and failure handling

- explicit branches remain tracking refs
- explicit tags and commit hashes remain pinned
- `--ref` requires one plugin ID and cannot be combined with `--all`
- unavailable refs, failed build commands, validation failures, and activation failures leave the previous configured path, metadata, and running plugin intact
- update output continues to report `previousCommit`, `currentCommit`, `commits`, and `updated` in human and JSON formats

## Protocol compatibility

`ref` and `server_info.features.pluginGitRefUpdate` are optional wire fields. Older clients continue parsing new daemon messages. The CLI gates explicit-ref updates on the new capability, preventing an older daemon from dropping the field and updating repository HEAD instead.

## Verification

```text
npx vitest run packages/protocol/src/messages.plugins.test.ts packages/client/src/daemon-client.test.ts packages/cli/src/commands/plugin/index.test.ts packages/server/src/server/plugins/managed-source.posix.test.ts packages/server/src/server/plugins/index.posix.test.ts --bail=1
Test Files  5 passed (5)
Tests       169 passed (169)

npm run typecheck
passed across all workspaces

npm run lint
Found 0 warnings and 0 errors.

npm run format:check
All matched files use the correct format.

npm run build:server
passed
```

Manual Linux smoke used an isolated daemon with a temporary `PASEO_HOME` and an OS-assigned port. I installed a plugin from `file://.../repo:plugins/review` at repository HEAD, then ran:

```text
paseo plugin update smoke-review --ref 4f3fa11fb9edb1eeb61e70b2e74a9be53c093a77
PLUGIN                PREVIOUS        CURRENT         COMMITS   UPDATED
smoke-review          01c87f98f03a    4f3fa11fb9ed    0         yes
```

The plugin remained `running`. JSON listing and `sources.json` reported the requested commit, and installed contents matched that revision while `pluginPath` remained `plugins/review`. The normal daemon on port 6767 was not touched.

## Platform coverage

- Linux daemon and CLI: tested
- macOS and Windows daemon and CLI: not tested locally
- App platforms: not affected
