### PR TITLE
fix(app): reconcile withUnistyles mappings after a suspended scheme change

### DIFF
--- a/docs/unistyles.md
+++ b/docs/unistyles.md
@@ -270,6 +270,12 @@ const markdownStyles = useMemo(() => createMarkdownStyles(theme), [theme]);
 
 If a style factory is cheap, skipping `useMemo` entirely is also fine.
 
+## Suspended Renderers Miss The Scheme Change
+
+On web, an adaptive scheme switch reaches styles through two different channels. CSS-variable styles (everything from `StyleSheet.create`) repaint from the `prefers-color-scheme` media query alone — pure CSS, no JS. `withUnistyles` mappings (markdown styles, the tab scrim's SVG colors) repaint only when Unistyles' own `matchMedia` change listeners fire.
+
+A renderer suspended while the OS switches appearance can miss those change events. The page then shows light chrome with dark-theme markdown and tab scrims until a reload — the [#3581](https://github.com/getpaseo/paseo/issues/3581) failure. `AppearanceProvider` reconciles this: on `focus`/`pageshow`/`visibilitychange` it compares the live media state against the last scheme it saw and re-runs `applyAppearance`, whose `updateTheme` calls re-emit the theme so every mapping re-reads the current scheme. Do not remove that subscription, and route any similar stale-theme report through it before inventing a second mechanism.
+
 ## Static Theme Imports
 
 Do not import `theme` from `@/styles/theme` for live UI colors. That export is a dark-theme compatibility default, so using it in render code leaves icons, placeholders, or third-party props pinned to dark colors in light mode.

--- a/packages/app/e2e/browser/markdown-theme-suspended.spec.ts
+++ b/packages/app/e2e/browser/markdown-theme-suspended.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "../support/fixtures";
+import { seedWorkspace } from "../support/helpers/seed-client";
+import { buildHostWorkspaceRoute } from "@/utils/host-routes";
+import { getServerId } from "../support/helpers/server-id";
+import {
+  createAgentTabFromMenu,
+  waitForWorkspaceTabsVisible,
+} from "../support/helpers/workspace-tabs";
+import { expectComposerVisible, submitMessage } from "../support/helpers/composer";
+import { readTranscriptColors, THEME_SWITCH_COLORS } from "../support/helpers/markdown-theme";
+
+/**
+ * getpaseo/paseo#3581 regression: the OS switches appearance while the renderer never
+ * delivers the matchMedia change events (a window suspended overnight). CSS-variable
+ * styles repaint from the media query alone, but `withUnistyles` mappings — the agent
+ * transcript markdown — keep the old theme's colors until focus reconciles the theme.
+ */
+test("markdown reconciles the system theme after suspended scheme change", async ({ page }) => {
+  test.setTimeout(180_000);
+
+  // Simulate the missed events: media queries still report `matches` live, but no
+  // listener registration ever fires. This is what a suspended renderer looks like
+  // to Unistyles' web runtime.
+  await page.addInitScript(() => {
+    const original = window.matchMedia.bind(window);
+    window.matchMedia = (query: string): MediaQueryList => {
+      const mql = original(query);
+      // A plain facade so native accessors keep their receiver: `matches` reads the
+      // live media state, but listener registration records nothing.
+      return {
+        media: mql.media,
+        get matches() {
+          return mql.matches;
+        },
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => true,
+      };
+    };
+  });
+
+  await page.emulateMedia({ colorScheme: "dark" });
+
+  const workspace = await seedWorkspace({ repoPrefix: "md-theme-suspended-" });
+
+  try {
+    await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.workspaceId));
+    await waitForWorkspaceTabsVisible(page);
+    await createAgentTabFromMenu(page);
+    await expectComposerVisible(page);
+
+    const prompt = "Please review the scroll anchor behavior overnight.";
+    await submitMessage(page, prompt);
+    const userMessage = page.getByTestId("user-message").filter({ hasText: prompt });
+    await expect(userMessage).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
+    await expect(page.getByText("Cycle 1", { exact: false }).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const dark = await readTranscriptColors(page);
+    expect(dark.heading).toBe(THEME_SWITCH_COLORS.dark.heading);
+    expect(dark.sidebar).toBe(THEME_SWITCH_COLORS.dark.sidebar);
+
+    // The OS switches to light overnight; the page never learns through events.
+    await page.emulateMedia({ colorScheme: "light" });
+    await page.waitForTimeout(1_000);
+
+    const stale = await readTranscriptColors(page);
+    expect(stale.sidebar).toBe(THEME_SWITCH_COLORS.light.sidebar); // CSS variables repainted.
+    expect(stale.heading).toBe(THEME_SWITCH_COLORS.dark.heading); // withUnistyles went stale.
+
+    // The window regains focus the next morning.
+    await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+
+    await expect
+      .poll(async () => (await readTranscriptColors(page)).heading, { timeout: 10_000 })
+      .toBe(THEME_SWITCH_COLORS.light.heading);
+  } finally {
+    await workspace.cleanup();
+  }
+});

--- a/packages/app/e2e/browser/markdown-theme-suspended.spec.ts
+++ b/packages/app/e2e/browser/markdown-theme-suspended.spec.ts
@@ -1,84 +1,40 @@
 import { expect, test } from "../support/fixtures";
-import { seedWorkspace } from "../support/helpers/seed-client";
-import { buildHostWorkspaceRoute } from "@/utils/host-routes";
-import { getServerId } from "../support/helpers/server-id";
 import {
-  createAgentTabFromMenu,
-  waitForWorkspaceTabsVisible,
-} from "../support/helpers/workspace-tabs";
-import { expectComposerVisible, submitMessage } from "../support/helpers/composer";
-import { readTranscriptColors, THEME_SWITCH_COLORS } from "../support/helpers/markdown-theme";
+  openAgentTranscriptWithCycleHeading,
+  regainWindowFocus,
+  simulateSuspendedMediaChangeDelivery,
+  THEME_SWITCH_COLORS,
+  type AgentTranscriptSurface,
+} from "../support/helpers/markdown-theme";
+
+let transcript: AgentTranscriptSurface | null = null;
+
+test.afterEach(async () => {
+  await transcript?.cleanup();
+  transcript = null;
+});
 
 /**
- * getpaseo/paseo#3581 regression: the OS switches appearance while the renderer never
- * delivers the matchMedia change events (a window suspended overnight). CSS-variable
- * styles repaint from the media query alone, but `withUnistyles` mappings — the agent
- * transcript markdown — keep the old theme's colors until focus reconciles the theme.
+ * getpaseo/paseo#3581 regression: the OS switches appearance while the renderer
+ * never delivers the matchMedia change events (a window suspended overnight).
+ * CSS-variable styles repaint from the media query alone, but `withUnistyles`
+ * mappings — the agent transcript markdown — keep the old theme's colors until
+ * focus reconciles the theme.
  */
 test("markdown reconciles the system theme after suspended scheme change", async ({ page }) => {
   test.setTimeout(180_000);
 
-  // Simulate the missed events: media queries still report `matches` live, but no
-  // listener registration ever fires. This is what a suspended renderer looks like
-  // to Unistyles' web runtime.
-  await page.addInitScript(() => {
-    const original = window.matchMedia.bind(window);
-    window.matchMedia = (query: string): MediaQueryList => {
-      const mql = original(query);
-      // A plain facade so native accessors keep their receiver: `matches` reads the
-      // live media state, but listener registration records nothing.
-      return {
-        media: mql.media,
-        get matches() {
-          return mql.matches;
-        },
-        onchange: null,
-        addEventListener: () => undefined,
-        removeEventListener: () => undefined,
-        addListener: () => undefined,
-        removeListener: () => undefined,
-        dispatchEvent: () => true,
-      };
-    };
-  });
-
+  await simulateSuspendedMediaChangeDelivery(page);
   await page.emulateMedia({ colorScheme: "dark" });
+  transcript = await openAgentTranscriptWithCycleHeading(page, {
+    repoPrefix: "md-theme-suspended-",
+  });
+  await expect(transcript.heading).toHaveCSS("color", THEME_SWITCH_COLORS.dark.heading);
 
-  const workspace = await seedWorkspace({ repoPrefix: "md-theme-suspended-" });
+  await page.emulateMedia({ colorScheme: "light" });
 
-  try {
-    await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.workspaceId));
-    await waitForWorkspaceTabsVisible(page);
-    await createAgentTabFromMenu(page);
-    await expectComposerVisible(page);
-
-    const prompt = "Please review the scroll anchor behavior overnight.";
-    await submitMessage(page, prompt);
-    const userMessage = page.getByTestId("user-message").filter({ hasText: prompt });
-    await expect(userMessage).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
-    await expect(page.getByText("Cycle 1", { exact: false }).first()).toBeVisible({
-      timeout: 30_000,
-    });
-
-    const dark = await readTranscriptColors(page);
-    expect(dark.heading).toBe(THEME_SWITCH_COLORS.dark.heading);
-    expect(dark.sidebar).toBe(THEME_SWITCH_COLORS.dark.sidebar);
-
-    // The OS switches to light overnight; the page never learns through events.
-    await page.emulateMedia({ colorScheme: "light" });
-    await page.waitForTimeout(1_000);
-
-    const stale = await readTranscriptColors(page);
-    expect(stale.sidebar).toBe(THEME_SWITCH_COLORS.light.sidebar); // CSS variables repainted.
-    expect(stale.heading).toBe(THEME_SWITCH_COLORS.dark.heading); // withUnistyles went stale.
-
-    // The window regains focus the next morning.
-    await page.evaluate(() => window.dispatchEvent(new Event("focus")));
-
-    await expect
-      .poll(async () => (await readTranscriptColors(page)).heading, { timeout: 10_000 })
-      .toBe(THEME_SWITCH_COLORS.light.heading);
-  } finally {
-    await workspace.cleanup();
-  }
+  await expect(transcript.sidebarLabel).toHaveCSS("color", THEME_SWITCH_COLORS.light.sidebar);
+  await expect(transcript.heading).toHaveCSS("color", THEME_SWITCH_COLORS.dark.heading);
+  await regainWindowFocus(page);
+  await expect(transcript.heading).toHaveCSS("color", THEME_SWITCH_COLORS.light.heading);
 });

--- a/packages/app/e2e/browser/markdown-theme-switch.spec.ts
+++ b/packages/app/e2e/browser/markdown-theme-switch.spec.ts
@@ -1,13 +1,16 @@
 import { expect, test } from "../support/fixtures";
-import { seedWorkspace } from "../support/helpers/seed-client";
-import { buildHostWorkspaceRoute } from "@/utils/host-routes";
-import { getServerId } from "../support/helpers/server-id";
 import {
-  createAgentTabFromMenu,
-  waitForWorkspaceTabsVisible,
-} from "../support/helpers/workspace-tabs";
-import { expectComposerVisible, submitMessage } from "../support/helpers/composer";
-import { readTranscriptColors, THEME_SWITCH_COLORS } from "../support/helpers/markdown-theme";
+  openAgentTranscriptWithCycleHeading,
+  THEME_SWITCH_COLORS,
+  type AgentTranscriptSurface,
+} from "../support/helpers/markdown-theme";
+
+let transcript: AgentTranscriptSurface | null = null;
+
+test.afterEach(async () => {
+  await transcript?.cleanup();
+  transcript = null;
+});
 
 /**
  * getpaseo/paseo#3581 baseline: with System appearance, a live OS scheme switch
@@ -18,33 +21,13 @@ test("markdown repaints after a live system theme switch", async ({ page }) => {
   test.setTimeout(180_000);
 
   await page.emulateMedia({ colorScheme: "dark" });
+  transcript = await openAgentTranscriptWithCycleHeading(page, {
+    repoPrefix: "md-theme-switch-",
+  });
+  await expect(transcript.heading).toHaveCSS("color", THEME_SWITCH_COLORS.dark.heading);
 
-  const workspace = await seedWorkspace({ repoPrefix: "md-theme-switch-" });
+  await page.emulateMedia({ colorScheme: "light" });
 
-  try {
-    await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.workspaceId));
-    await waitForWorkspaceTabsVisible(page);
-    await createAgentTabFromMenu(page);
-    await expectComposerVisible(page);
-
-    const prompt = "Please review the scroll anchor behavior.";
-    await submitMessage(page, prompt);
-    const userMessage = page.getByTestId("user-message").filter({ hasText: prompt });
-    await expect(userMessage).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
-    await expect(page.getByText("Cycle 1", { exact: false }).first()).toBeVisible({
-      timeout: 30_000,
-    });
-
-    const dark = await readTranscriptColors(page);
-    expect(dark.heading).toBe(THEME_SWITCH_COLORS.dark.heading);
-    expect(dark.sidebar).toBe(THEME_SWITCH_COLORS.dark.sidebar);
-
-    await page.emulateMedia({ colorScheme: "light" });
-    await expect
-      .poll(async () => (await readTranscriptColors(page)).heading, { timeout: 10_000 })
-      .toBe(THEME_SWITCH_COLORS.light.heading);
-    expect((await readTranscriptColors(page)).sidebar).toBe(THEME_SWITCH_COLORS.light.sidebar);
-  } finally {
-    await workspace.cleanup();
-  }
+  await expect(transcript.heading).toHaveCSS("color", THEME_SWITCH_COLORS.light.heading);
+  await expect(transcript.sidebarLabel).toHaveCSS("color", THEME_SWITCH_COLORS.light.sidebar);
 });

--- a/packages/app/e2e/browser/markdown-theme-switch.spec.ts
+++ b/packages/app/e2e/browser/markdown-theme-switch.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "../support/fixtures";
+import { seedWorkspace } from "../support/helpers/seed-client";
+import { buildHostWorkspaceRoute } from "@/utils/host-routes";
+import { getServerId } from "../support/helpers/server-id";
+import {
+  createAgentTabFromMenu,
+  waitForWorkspaceTabsVisible,
+} from "../support/helpers/workspace-tabs";
+import { expectComposerVisible, submitMessage } from "../support/helpers/composer";
+import { readTranscriptColors, THEME_SWITCH_COLORS } from "../support/helpers/markdown-theme";
+
+/**
+ * getpaseo/paseo#3581 baseline: with System appearance, a live OS scheme switch
+ * while the page is open must repaint the agent transcript markdown, not just
+ * the CSS-variable chrome around it.
+ */
+test("markdown repaints after a live system theme switch", async ({ page }) => {
+  test.setTimeout(180_000);
+
+  await page.emulateMedia({ colorScheme: "dark" });
+
+  const workspace = await seedWorkspace({ repoPrefix: "md-theme-switch-" });
+
+  try {
+    await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.workspaceId));
+    await waitForWorkspaceTabsVisible(page);
+    await createAgentTabFromMenu(page);
+    await expectComposerVisible(page);
+
+    const prompt = "Please review the scroll anchor behavior.";
+    await submitMessage(page, prompt);
+    const userMessage = page.getByTestId("user-message").filter({ hasText: prompt });
+    await expect(userMessage).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
+    await expect(page.getByText("Cycle 1", { exact: false }).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const dark = await readTranscriptColors(page);
+    expect(dark.heading).toBe(THEME_SWITCH_COLORS.dark.heading);
+    expect(dark.sidebar).toBe(THEME_SWITCH_COLORS.dark.sidebar);
+
+    await page.emulateMedia({ colorScheme: "light" });
+    await expect
+      .poll(async () => (await readTranscriptColors(page)).heading, { timeout: 10_000 })
+      .toBe(THEME_SWITCH_COLORS.light.heading);
+    expect((await readTranscriptColors(page)).sidebar).toBe(THEME_SWITCH_COLORS.light.sidebar);
+  } finally {
+    await workspace.cleanup();
+  }
+});

--- a/packages/app/e2e/support/helpers/markdown-theme.ts
+++ b/packages/app/e2e/support/helpers/markdown-theme.ts
@@ -1,0 +1,42 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Expected transcript/sidebar colors per system scheme, used by the theme-switch
+ * e2e specs (getpaseo/paseo#3581). Hardcoded rgb is the established convention in
+ * this suite (see appearance-theme-picker.spec.ts).
+ */
+export const THEME_SWITCH_COLORS = {
+  dark: {
+    /** Markdown heading color: dark theme foreground #fafafa. */
+    heading: "rgb(250, 250, 250)",
+    /** "New workspace" label color: dark theme foregroundMuted. */
+    sidebar: "rgb(161, 165, 164)",
+  },
+  light: {
+    /** Markdown heading color: light theme foreground #1a1a1e. */
+    heading: "rgb(26, 26, 30)",
+    /** "New workspace" label color: light theme foregroundMuted #71717a. */
+    sidebar: "rgb(113, 113, 122)",
+  },
+} as const;
+
+export interface TranscriptColors {
+  heading: string | null;
+  sidebar: string | null;
+}
+
+/** Computed colors of one transcript markdown heading and one chrome label. */
+export function readTranscriptColors(page: Page): Promise<TranscriptColors> {
+  return page.evaluate(() => {
+    const findByText = (predicate: (text: string) => boolean) =>
+      [...document.querySelectorAll("div,span,p")].find(
+        (el) => el.childElementCount === 0 && predicate(el.textContent?.trim() ?? ""),
+      );
+    const headingEl = findByText((text) => text.startsWith("Cycle 1"));
+    const sidebarEl = findByText((text) => text === "New workspace");
+    return {
+      heading: headingEl ? getComputedStyle(headingEl).color : null,
+      sidebar: sidebarEl ? getComputedStyle(sidebarEl).color : null,
+    };
+  });
+}

--- a/packages/app/e2e/support/helpers/markdown-theme.ts
+++ b/packages/app/e2e/support/helpers/markdown-theme.ts
@@ -1,4 +1,10 @@
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { seedWorkspace } from "./seed-client";
+import { getServerId } from "./server-id";
+import { buildHostWorkspaceRoute } from "../../../src/utils/host-routes";
+import { createAgentTabFromMenu, waitForWorkspaceTabsVisible } from "./workspace-tabs";
+import { expectComposerVisible, submitMessage } from "./composer";
 
 /**
  * Expected transcript/sidebar colors per system scheme, used by the theme-switch
@@ -20,23 +26,81 @@ export const THEME_SWITCH_COLORS = {
   },
 } as const;
 
-export interface TranscriptColors {
-  heading: string | null;
-  sidebar: string | null;
+const CYCLE_HEADING_TEXT = "Cycle 1";
+const SIDEBAR_LABEL_TEXT = "New workspace";
+const DEFAULT_PROMPT = "Please review the scroll anchor behavior.";
+
+export interface AgentTranscriptSurface {
+  /** The transcript's first markdown heading ("Cycle 1"). */
+  heading: Locator;
+  /** A CSS-variable styled chrome label, as the repainting control surface. */
+  sidebarLabel: Locator;
+  cleanup(): Promise<void>;
 }
 
-/** Computed colors of one transcript markdown heading and one chrome label. */
-export function readTranscriptColors(page: Page): Promise<TranscriptColors> {
-  return page.evaluate(() => {
-    const findByText = (predicate: (text: string) => boolean) =>
-      [...document.querySelectorAll("div,span,p")].find(
-        (el) => el.childElementCount === 0 && predicate(el.textContent?.trim() ?? ""),
-      );
-    const headingEl = findByText((text) => text.startsWith("Cycle 1"));
-    const sidebarEl = findByText((text) => text === "New workspace");
-    return {
-      heading: headingEl ? getComputedStyle(headingEl).color : null,
-      sidebar: sidebarEl ? getComputedStyle(sidebarEl).color : null,
+/**
+ * Seeds a workspace, opens a new agent tab, submits one turn, and waits for the
+ * mock agent's "Cycle 1" markdown heading to render. The returned locators are
+ * the surfaces the theme-switch specs assert computed colors on.
+ */
+export async function openAgentTranscriptWithCycleHeading(
+  page: Page,
+  input: { repoPrefix: string; prompt?: string },
+): Promise<AgentTranscriptSurface> {
+  const workspace = await seedWorkspace({ repoPrefix: input.repoPrefix });
+  const prompt = input.prompt ?? DEFAULT_PROMPT;
+  await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.workspaceId));
+  await waitForWorkspaceTabsVisible(page);
+  await createAgentTabFromMenu(page);
+  await expectComposerVisible(page);
+  await submitMessage(page, prompt);
+  const userMessage = page.getByTestId("user-message").filter({ hasText: prompt });
+  await expect(userMessage).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
+  const heading = page.getByText(CYCLE_HEADING_TEXT, { exact: true }).first();
+  await expect(heading).toBeVisible({ timeout: 30_000 });
+  return {
+    heading,
+    sidebarLabel: page.getByText(SIDEBAR_LABEL_TEXT, { exact: true }).first(),
+    cleanup: () => workspace.cleanup(),
+  };
+}
+
+/**
+ * Simulates a renderer suspended across an OS appearance switch: media queries
+ * keep reporting live `matches` state (so CSS repaints), but no `change` event is
+ * ever delivered to registered listeners — which is exactly the state a window
+ * wakes up in when the OS switched themes while it could not run tasks. Scoped to
+ * the `prefers-color-scheme` queries; all other media queries pass through.
+ */
+export function simulateSuspendedMediaChangeDelivery(page: Page): Promise<void> {
+  return page.addInitScript(() => {
+    const original = window.matchMedia.bind(window);
+    window.matchMedia = (query: string): MediaQueryList => {
+      const mql = original(query);
+      if (!query.includes("prefers-color-scheme")) {
+        return mql;
+      }
+      // A plain facade so native accessors keep their receiver: `matches` reads the
+      // live media state, but listener registration records nothing.
+      return {
+        media: mql.media,
+        get matches() {
+          return mql.matches;
+        },
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => true,
+      };
     };
+  });
+}
+
+/** The window regains focus, as it does when the user returns the next morning. */
+export function regainWindowFocus(page: Page): Promise<void> {
+  return page.evaluate(() => {
+    window.dispatchEvent(new Event("focus"));
   });
 }

--- a/packages/app/e2e/support/helpers/markdown-theme.ts
+++ b/packages/app/e2e/support/helpers/markdown-theme.ts
@@ -49,17 +49,22 @@ export async function openAgentTranscriptWithCycleHeading(
 ): Promise<AgentTranscriptSurface> {
   const workspace = await seedWorkspace({ repoPrefix: input.repoPrefix });
   const prompt = input.prompt ?? DEFAULT_PROMPT;
-  await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.workspaceId));
-  await waitForWorkspaceTabsVisible(page);
-  await createAgentTabFromMenu(page);
-  await expectComposerVisible(page);
-  await submitMessage(page, prompt);
-  const userMessage = page.getByTestId("user-message").filter({ hasText: prompt });
-  await expect(userMessage).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
-  const heading = page.getByText(CYCLE_HEADING_TEXT, { exact: true }).first();
-  await expect(heading).toBeVisible({ timeout: 30_000 });
+  try {
+    await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.workspaceId));
+    await waitForWorkspaceTabsVisible(page);
+    await createAgentTabFromMenu(page);
+    await expectComposerVisible(page);
+    await submitMessage(page, prompt);
+    const userMessage = page.getByTestId("user-message").filter({ hasText: prompt });
+    await expect(userMessage).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
+    const heading = page.getByText(CYCLE_HEADING_TEXT, { exact: true }).first();
+    await expect(heading).toBeVisible({ timeout: 30_000 });
+  } catch (error) {
+    await workspace.cleanup();
+    throw error;
+  }
   return {
-    heading,
+    heading: page.getByText(CYCLE_HEADING_TEXT, { exact: true }).first(),
     sidebarLabel: page.getByText(SIDEBAR_LABEL_TEXT, { exact: true }).first(),
     cleanup: () => workspace.cleanup(),
   };

--- a/packages/app/src/appearance/provider.tsx
+++ b/packages/app/src/appearance/provider.tsx
@@ -7,7 +7,8 @@ import {
   type PluginThemeOption,
 } from "@/plugins/themes";
 import { PLUGIN_THEME_NAMES, PLUGIN_THEME_PREFERENCE, THEME_TO_UNISTYLES } from "@/styles/theme";
-import { applyAppearance } from "./apply";
+import { isWeb } from "@/constants/platform";
+import { applyAppearance, type AppearanceInput } from "./apply";
 
 interface ContributedThemes {
   options: PluginThemeOption[];
@@ -50,28 +51,62 @@ export function AppearanceProvider({ children }: { children: ReactNode }) {
     return options.find((option) => option.id === settings.pluginThemeId) ?? null;
   }, [options, settings.pluginThemeId, settings.theme]);
 
-  useEffect(() => {
-    if (isLoading) return;
-    applyTheme({ preference: settings.theme, contributedTheme: selected });
-    applyAppearance({
+  const appearanceInput = useMemo<AppearanceInput>(
+    () => ({
       uiFontFamily: settings.uiFontFamily,
       monoFontFamily: settings.monoFontFamily,
       uiBaseFontSize: settings.uiBaseFontSize,
       contentFontSize: settings.contentFontSize,
       codeFontSize: settings.codeFontSize,
       syntaxTheme: settings.syntaxTheme,
-    });
-  }, [
-    isLoading,
-    selected,
-    settings.theme,
-    settings.uiFontFamily,
-    settings.monoFontFamily,
-    settings.uiBaseFontSize,
-    settings.contentFontSize,
-    settings.codeFontSize,
-    settings.syntaxTheme,
-  ]);
+    }),
+    [
+      settings.codeFontSize,
+      settings.contentFontSize,
+      settings.monoFontFamily,
+      settings.syntaxTheme,
+      settings.uiBaseFontSize,
+      settings.uiFontFamily,
+    ],
+  );
+
+  useEffect(() => {
+    if (isLoading) return;
+    applyTheme({ preference: settings.theme, contributedTheme: selected });
+    applyAppearance(appearanceInput);
+  }, [appearanceInput, isLoading, selected, settings.theme]);
+
+  // CSS-variable styles repaint from the `prefers-color-scheme` media query alone, but
+  // `withUnistyles` mappings (markdown styles, tab scrim colors) only re-read the theme when
+  // Unistyles' own matchMedia listeners deliver a change event. A renderer suspended while the
+  // OS switches appearance can miss that event: the surrounding chrome turns light while
+  // transcript markdown keeps the dark theme's colors until a reload. On regained focus,
+  // pageshow, or visibility, re-commit the appearance when the live scheme no longer matches
+  // the last one we saw — `applyAppearance` re-emits the theme, so every mapping re-reads the
+  // current scheme without waiting for the missed event.
+  useEffect(() => {
+    if (!isWeb || isLoading) return;
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    let lastSeenDark = media.matches;
+    const trackScheme = (event: MediaQueryListEvent) => {
+      lastSeenDark = event.matches;
+    };
+    const reconcileSuspendedSchemeChange = () => {
+      if (document.hidden || media.matches === lastSeenDark) return;
+      lastSeenDark = media.matches;
+      applyAppearance(appearanceInput);
+    };
+    media.addEventListener("change", trackScheme);
+    window.addEventListener("focus", reconcileSuspendedSchemeChange);
+    window.addEventListener("pageshow", reconcileSuspendedSchemeChange);
+    document.addEventListener("visibilitychange", reconcileSuspendedSchemeChange);
+    return () => {
+      media.removeEventListener("change", trackScheme);
+      window.removeEventListener("focus", reconcileSuspendedSchemeChange);
+      window.removeEventListener("pageshow", reconcileSuspendedSchemeChange);
+      document.removeEventListener("visibilitychange", reconcileSuspendedSchemeChange);
+    };
+  }, [appearanceInput, isLoading]);
 
   const select = useCallback(
     (option: PluginThemeOption) => {


### PR DESCRIPTION
### Linked issue

Closes #3581

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

On web there are two repaint channels for a system theme switch. `StyleSheet.create` styles compile to CSS classes over `var(--…)` theme variables, and those variables are emitted under `@media (prefers-color-scheme: …)`, so they flip via pure CSS. `withUnistyles` mappings — the transcript markdown (`markdownStyleMapping` in `packages/app/src/components/markdown/renderer.tsx`) and the tab hover scrim (`trailing-action-scrim.tsx`) — resolve raw color values in JS and only repaint when Unistyles' own `matchMedia` change listeners fire.

A renderer suspended while the OS switches appearance can miss those change events (verified on macOS 26 with the desktop app asleep overnight: Cmd+R repairs). The page then shows light chrome with dark-theme markdown and tab scrims until a reload — exactly the #3581 report.

### Goals

- Repaint `withUnistyles` consumers after a scheme change that happened while the renderer could not deliver media change events, without a reload.
- Keep the healthy path (events delivered) free of extra work.
- Keep the fix app-side: no library patch, no second theming mechanism.
- Document the two-channel behavior in `docs/unistyles.md`.

Implementation: `AppearanceProvider` tracks the last-seen `prefers-color-scheme: dark` state. On `focus`, `pageshow`, or `visibilitychange` with the document visible, it compares the live media state against that snapshot and, when they differ, re-runs `applyAppearance()` — its `UnistylesRuntime.updateTheme` calls re-emit `Theme`, so every `withUnistyles` mapping re-reads the current scheme (the runtime resolves the active theme name from the live media state at that moment). Under pinned/plugin themes the re-apply is an idempotent no-op.

### Non-goals

- No change to native (iOS/Android) theming — appearance events are delivered reliably there.
- No change to `react-native-unistyles` or its patch; the missed-event window is inherent to a suspended renderer.
- No migration of the markdown renderer or tab scrim away from `withUnistyles` — the reconciliation covers the whole class of JS-resolved theme values.

### QA

Reproduced the failure class end to end against this checkout (mock provider, real Metro web app):

1. New regression spec `markdown-theme-suspended.spec.ts` simulates a suspended renderer by installing a `matchMedia` facade whose listener registration is a no-op (`matches` stays live), flips dark→light, and asserts the split symptom: CSS-variable chrome ("New workspace" label) repaints to `rgb(113, 113, 122)` while the markdown heading stays at the stale dark `rgb(250, 250, 250)`. Dispatching `focus` then repaints the heading to `rgb(26, 26, 30)`. Verified red against `main` (heading stays stale after focus) and green with this change.
2. New baseline spec `markdown-theme-switch.spec.ts` asserts a live (events delivered) dark→light switch repaints markdown and chrome on current `main` — documents that the basic path was already healthy and stays that way.
3. `npx playwright test --project=browser e2e/browser/markdown-theme-switch.spec.ts e2e/browser/markdown-theme-suspended.spec.ts` → 2 passed.
4. Live flips while the page is foregrounded, backgrounded, and CDP-frozen all deliver events on current Chromium and repaint correctly (checked manually during investigation).

### Checklist

- [ ] Plugin changes follow the [SDK import boundaries](../docs/plugins.md#sdk-import-boundaries) (if applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense