### PR TITLE
fix(command-center): skip duplicate contribution IDs instead of throwing fatal error

### DIFF
--- a/packages/app/src/command-center/registry.ts
+++ b/packages/app/src/command-center/registry.ts
@@ -54,7 +54,8 @@ export function createCommandCenterRegistry(): CommandCenterRegistry {
       for (const contribution of registration.contributions) {
         const id = contributionId(registration.owner.sourceId, contribution.id);
         if (ids.has(id)) {
-          throw new Error(`Duplicate Command Center contribution id: ${id}`);
+          console.warn(`[CommandCenter] Skipping duplicate contribution id: ${id}`);
+          continue;
         }
         ids.add(id);
         contributions.push({ ...contribution, id });
@@ -84,7 +85,7 @@ export function createCommandCenterRegistry(): CommandCenterRegistry {
       const ids = new Set<string>();
       for (const contribution of registration.contributions) {
         const id = contributionId(registration.owner.sourceId, contribution.id);
-        if (ids.has(id)) throw new Error(`Duplicate Command Center contribution id: ${id}`);
+        if (ids.has(id)) { console.warn(`[CommandCenter] Skipping duplicate contribution id: ${id}`); continue; }
         ids.add(id);
       }
       registrations.set(registration.owner.sourceId, registration);


### PR DESCRIPTION
## Problem

The Command Center registry throws a fatal \Error\ when duplicate contribution IDs are detected. React's \RootErrorBoundary\ catches this and renders a **full-screen overlay** that blocks the entire UI on both desktop and mobile.

This is a UI-breaking bug:
- The overlay cannot be dismissed
- It persists across app restarts until the duplicate registration is resolved
- Affects both Paseo Desktop (Electron) and Paseo Mobile (iOS/Android)

## Root Cause

In \packages/app/src/command-center/registry.ts\, the \publish()\ and \eplace()\ functions throw a fatal error when they detect duplicate composite keys (\\:\\). This happens when a plugin or component registers the same action ID twice under the same \sourceId\ (e.g., component remount with React Strict Mode, or a plugin bug).

## Fix

Change \	hrow new Error(...)\ to \console.warn(...)\ + \continue\ in both locations:

1. **\publish()\** — iterates all registrations, checks composite keys
2. **\eplace()\** — validates a new registration batch

Duplicates are logged to the console but skipped, so the first registration wins. The overlay no longer appears.

## Testing

- Desktop: overlay no longer appears when duplicate contribution IDs are registered
- Mobile: same fix applies (shared codebase in \packages/app/\)
- Console: duplicate warnings are logged for debugging

## Related

- Closes #1201 (duplicate Command Center overlay)