### PR TITLE
fix(app): restore model selection in Android tablet modals

### DIFF
--- a/packages/app/src/components/adaptive-modal-sheet.tsx
+++ b/packages/app/src/components/adaptive-modal-sheet.tsx
@@ -30,7 +30,8 @@ import {
   getCompactSheetSafeAreaPadding,
 } from "@/components/adaptive-modal-sheet-layout";
 import { ScrollView } from "@/components/ui/scroll-view";
-import { isWeb } from "@/constants/platform";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { isNative, isWeb } from "@/constants/platform";
 import { useKeyboardVisibility } from "@/hooks/use-keyboard-visibility";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AdaptiveTextInput } from "@/components/adaptive-text-input";
@@ -67,10 +68,14 @@ export interface SheetHeader {
   search?: SheetHeaderSearch;
 }
 
+const ModalRoot = isNative ? GestureHandlerRootView : View;
 const SCROLL_CONTENT_GROW = { flexGrow: 1 };
 const ABSOLUTE_FILL_STYLE = { ...StyleSheet.absoluteFillObject };
 
 const styles = StyleSheet.create((theme) => ({
+  desktopModalRoot: {
+    flex: 1,
+  },
   desktopOverlay: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: "rgba(0,0,0,0.55)",
@@ -724,7 +729,7 @@ export function AdaptiveModalSheet({
       onDismiss={notifyNativeModalDismiss}
       hardwareAccelerated
     >
-      {desktopContent}
+      <ModalRoot style={styles.desktopModalRoot}>{desktopContent}</ModalRoot>
     </Modal>
   );
 }

--- a/packages/app/src/components/adaptive-modal-sheet.tsx
+++ b/packages/app/src/components/adaptive-modal-sheet.tsx
@@ -68,6 +68,7 @@ export interface SheetHeader {
   search?: SheetHeaderSearch;
 }
 
+// Android modals open a separate native window and need their own gesture root.
 const ModalRoot = isNative ? GestureHandlerRootView : View;
 const SCROLL_CONTENT_GROW = { flexGrow: 1 };
 const ABSOLUTE_FILL_STYLE = { ...StyleSheet.absoluteFillObject };

--- a/packages/app/src/components/model-browser.tsx
+++ b/packages/app/src/components/model-browser.tsx
@@ -1,13 +1,11 @@
-import { createContext, useCallback, useContext, useMemo, useReducer, useState } from "react";
+import { useCallback, useMemo, useReducer, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   FlatList,
-  Platform,
   Pressable,
   ScrollView,
   Text,
   View,
-  type AccessibilityActionEvent,
   type GestureResponderEvent,
   type PressableStateCallbackType,
   type StyleProp,
@@ -17,7 +15,6 @@ import {
   FlatList as SheetFlatList,
   ScrollView as SheetScrollView,
 } from "@/components/ui/scroll-view";
-import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import {
   AlertTriangle,
@@ -128,10 +125,6 @@ function AgentProfilesEditAction({ onPress }: { onPress: () => void }) {
     </Tooltip>
   );
 }
-
-const IndependentScrollGestureContext = createContext<ReturnType<typeof Gesture.Native> | null>(
-  null,
-);
 
 const foregroundMutedMapping = (theme: Theme) => ({
   color: theme.colors.foregroundMuted,
@@ -447,37 +440,10 @@ function ModelBrowserPressable({
   accessibilitySelected,
   testID,
 }: ModelBrowserPressableProps) {
-  const independentScrollGesture = useContext(IndependentScrollGestureContext);
-  const [pressed, setPressed] = useState(false);
-  // Android's scroll handler must keep the pointer stream until release so a
-  // fling survives leaving the short viewport. A simultaneous Tap keeps rows
-  // interactive, while maxDistance makes a real scroll fail instead of select.
-  const tapGesture = useMemo(() => {
-    const gesture = Gesture.Tap()
-      .maxDistance(8)
-      .shouldCancelWhenOutside(true)
-      .runOnJS(true)
-      .onBegin(() => setPressed(true))
-      .onEnd((_event, success) => {
-        if (success) onPress();
-      })
-      .onFinalize(() => setPressed(false));
-    if (hitSlop !== undefined) gesture.hitSlop(hitSlop);
-    if (independentScrollGesture) {
-      gesture.simultaneousWithExternalGesture(independentScrollGesture);
-    }
-    return gesture;
-  }, [hitSlop, independentScrollGesture, onPress]);
   const handlePress = useCallback(
     (event: GestureResponderEvent) => {
       event.stopPropagation();
       onPress();
-    },
-    [onPress],
-  );
-  const handleAccessibilityAction = useCallback(
-    (event: AccessibilityActionEvent) => {
-      if (event.nativeEvent.actionName === "activate") onPress();
     },
     [onPress],
   );
@@ -486,42 +452,19 @@ function ModelBrowserPressable({
     [accessibilitySelected],
   );
 
-  if (!independentScrollGesture) {
-    return (
-      <Pressable
-        onPress={handlePress}
-        hitSlop={hitSlop}
-        style={style}
-        accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel}
-        accessibilityState={accessibilityState}
-        aria-selected={accessibilitySelected}
-        testID={testID}
-      >
-        {children}
-      </Pressable>
-    );
-  }
-
-  const state = { pressed };
-  const resolvedStyle = typeof style === "function" ? style(state) : style;
-  const resolvedChildren = typeof children === "function" ? children(state) : children;
   return (
-    <GestureDetector gesture={tapGesture}>
-      <View
-        accessible
-        accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel}
-        accessibilityState={accessibilityState}
-        aria-selected={accessibilitySelected}
-        accessibilityActions={[{ name: "activate" }]}
-        onAccessibilityAction={handleAccessibilityAction}
-        style={resolvedStyle}
-        testID={testID}
-      >
-        {resolvedChildren}
-      </View>
-    </GestureDetector>
+    <Pressable
+      onPress={handlePress}
+      hitSlop={hitSlop}
+      style={style}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={accessibilityState}
+      aria-selected={accessibilitySelected}
+      testID={testID}
+    >
+      {children}
+    </Pressable>
   );
 }
 
@@ -1055,29 +998,6 @@ function GroupedProviderRows({
   );
 }
 
-function IndependentScrollBoundary({ children }: { children: React.ReactElement }) {
-  // Prevent the parent sheet from cancelling Android's native scroll when the
-  // finger crosses this viewport; receiving ACTION_UP is what preserves fling.
-  const nativeScrollGesture = useMemo(
-    () =>
-      Gesture.Native()
-        .shouldActivateOnStart(true)
-        .shouldCancelWhenOutside(false)
-        .disallowInterruption(true),
-    [],
-  );
-
-  if (Platform.OS !== "android") {
-    return children;
-  }
-
-  return (
-    <IndependentScrollGestureContext.Provider value={nativeScrollGesture}>
-      <GestureDetector gesture={nativeScrollGesture}>{children}</GestureDetector>
-    </IndependentScrollGestureContext.Provider>
-  );
-}
-
 function IndependentModelList({
   rows,
   renderItem,
@@ -1088,21 +1008,19 @@ function IndependentModelList({
   header?: React.ReactElement;
 }) {
   return (
-    <IndependentScrollBoundary>
-      <FlatList
-        data={rows}
-        renderItem={renderItem}
-        ListHeaderComponent={header}
-        keyExtractor={getModelRowKey}
-        style={styles.virtualizedModelList}
-        keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="on-drag"
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={styles.virtualizedModelListContent}
-        nestedScrollEnabled
-        testID="compact-model-list"
-      />
-    </IndependentScrollBoundary>
+    <FlatList
+      data={rows}
+      renderItem={renderItem}
+      ListHeaderComponent={header}
+      keyExtractor={getModelRowKey}
+      style={styles.virtualizedModelList}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+      showsVerticalScrollIndicator={false}
+      contentContainerStyle={styles.virtualizedModelListContent}
+      nestedScrollEnabled
+      testID="compact-model-list"
+    />
   );
 }
 
@@ -1112,22 +1030,20 @@ function getModelRowKey(row: ProviderSelectionModelRow): string {
 
 function IndependentProviderList({ children }: { children: React.ReactNode }) {
   return (
-    <IndependentScrollBoundary>
-      <ScrollView
-        style={styles.virtualizedModelList}
-        contentContainerStyle={[
-          styles.virtualizedModelListContent,
-          styles.virtualizedProviderListContent,
-        ]}
-        keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="on-drag"
-        showsVerticalScrollIndicator={false}
-        nestedScrollEnabled
-        testID="compact-provider-list"
-      >
-        {children}
-      </ScrollView>
-    </IndependentScrollBoundary>
+    <ScrollView
+      style={styles.virtualizedModelList}
+      contentContainerStyle={[
+        styles.virtualizedModelListContent,
+        styles.virtualizedProviderListContent,
+      ]}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+      showsVerticalScrollIndicator={false}
+      nestedScrollEnabled
+      testID="compact-provider-list"
+    >
+      {children}
+    </ScrollView>
   );
 }
 

--- a/packages/app/src/components/model-browser.tsx
+++ b/packages/app/src/components/model-browser.tsx
@@ -1,11 +1,13 @@
-import { useCallback, useMemo, useReducer, useState } from "react";
+import { createContext, useCallback, useContext, useMemo, useReducer, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   FlatList,
+  Platform,
   Pressable,
   ScrollView,
   Text,
   View,
+  type AccessibilityActionEvent,
   type GestureResponderEvent,
   type PressableStateCallbackType,
   type StyleProp,
@@ -15,6 +17,7 @@ import {
   FlatList as SheetFlatList,
   ScrollView as SheetScrollView,
 } from "@/components/ui/scroll-view";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import {
   AlertTriangle,
@@ -125,6 +128,10 @@ function AgentProfilesEditAction({ onPress }: { onPress: () => void }) {
     </Tooltip>
   );
 }
+
+const IndependentScrollGestureContext = createContext<ReturnType<typeof Gesture.Native> | null>(
+  null,
+);
 
 const foregroundMutedMapping = (theme: Theme) => ({
   color: theme.colors.foregroundMuted,
@@ -440,10 +447,37 @@ function ModelBrowserPressable({
   accessibilitySelected,
   testID,
 }: ModelBrowserPressableProps) {
+  const independentScrollGesture = useContext(IndependentScrollGestureContext);
+  const [pressed, setPressed] = useState(false);
+  // Android's scroll handler must keep the pointer stream until release so a
+  // fling survives leaving the short viewport. A simultaneous Tap keeps rows
+  // interactive, while maxDistance makes a real scroll fail instead of select.
+  const tapGesture = useMemo(() => {
+    const gesture = Gesture.Tap()
+      .maxDistance(8)
+      .shouldCancelWhenOutside(true)
+      .runOnJS(true)
+      .onBegin(() => setPressed(true))
+      .onEnd((_event, success) => {
+        if (success) onPress();
+      })
+      .onFinalize(() => setPressed(false));
+    if (hitSlop !== undefined) gesture.hitSlop(hitSlop);
+    if (independentScrollGesture) {
+      gesture.simultaneousWithExternalGesture(independentScrollGesture);
+    }
+    return gesture;
+  }, [hitSlop, independentScrollGesture, onPress]);
   const handlePress = useCallback(
     (event: GestureResponderEvent) => {
       event.stopPropagation();
       onPress();
+    },
+    [onPress],
+  );
+  const handleAccessibilityAction = useCallback(
+    (event: AccessibilityActionEvent) => {
+      if (event.nativeEvent.actionName === "activate") onPress();
     },
     [onPress],
   );
@@ -452,19 +486,42 @@ function ModelBrowserPressable({
     [accessibilitySelected],
   );
 
+  if (!independentScrollGesture) {
+    return (
+      <Pressable
+        onPress={handlePress}
+        hitSlop={hitSlop}
+        style={style}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityState={accessibilityState}
+        aria-selected={accessibilitySelected}
+        testID={testID}
+      >
+        {children}
+      </Pressable>
+    );
+  }
+
+  const state = { pressed };
+  const resolvedStyle = typeof style === "function" ? style(state) : style;
+  const resolvedChildren = typeof children === "function" ? children(state) : children;
   return (
-    <Pressable
-      onPress={handlePress}
-      hitSlop={hitSlop}
-      style={style}
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      accessibilityState={accessibilityState}
-      aria-selected={accessibilitySelected}
-      testID={testID}
-    >
-      {children}
-    </Pressable>
+    <GestureDetector gesture={tapGesture}>
+      <View
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityState={accessibilityState}
+        aria-selected={accessibilitySelected}
+        accessibilityActions={[{ name: "activate" }]}
+        onAccessibilityAction={handleAccessibilityAction}
+        style={resolvedStyle}
+        testID={testID}
+      >
+        {resolvedChildren}
+      </View>
+    </GestureDetector>
   );
 }
 
@@ -998,6 +1055,29 @@ function GroupedProviderRows({
   );
 }
 
+function IndependentScrollBoundary({ children }: { children: React.ReactElement }) {
+  // Prevent the parent sheet from cancelling Android's native scroll when the
+  // finger crosses this viewport; receiving ACTION_UP is what preserves fling.
+  const nativeScrollGesture = useMemo(
+    () =>
+      Gesture.Native()
+        .shouldActivateOnStart(true)
+        .shouldCancelWhenOutside(false)
+        .disallowInterruption(true),
+    [],
+  );
+
+  if (Platform.OS !== "android") {
+    return children;
+  }
+
+  return (
+    <IndependentScrollGestureContext.Provider value={nativeScrollGesture}>
+      <GestureDetector gesture={nativeScrollGesture}>{children}</GestureDetector>
+    </IndependentScrollGestureContext.Provider>
+  );
+}
+
 function IndependentModelList({
   rows,
   renderItem,
@@ -1008,19 +1088,21 @@ function IndependentModelList({
   header?: React.ReactElement;
 }) {
   return (
-    <FlatList
-      data={rows}
-      renderItem={renderItem}
-      ListHeaderComponent={header}
-      keyExtractor={getModelRowKey}
-      style={styles.virtualizedModelList}
-      keyboardShouldPersistTaps="handled"
-      keyboardDismissMode="on-drag"
-      showsVerticalScrollIndicator={false}
-      contentContainerStyle={styles.virtualizedModelListContent}
-      nestedScrollEnabled
-      testID="compact-model-list"
-    />
+    <IndependentScrollBoundary>
+      <FlatList
+        data={rows}
+        renderItem={renderItem}
+        ListHeaderComponent={header}
+        keyExtractor={getModelRowKey}
+        style={styles.virtualizedModelList}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.virtualizedModelListContent}
+        nestedScrollEnabled
+        testID="compact-model-list"
+      />
+    </IndependentScrollBoundary>
   );
 }
 
@@ -1030,20 +1112,22 @@ function getModelRowKey(row: ProviderSelectionModelRow): string {
 
 function IndependentProviderList({ children }: { children: React.ReactNode }) {
   return (
-    <ScrollView
-      style={styles.virtualizedModelList}
-      contentContainerStyle={[
-        styles.virtualizedModelListContent,
-        styles.virtualizedProviderListContent,
-      ]}
-      keyboardShouldPersistTaps="handled"
-      keyboardDismissMode="on-drag"
-      showsVerticalScrollIndicator={false}
-      nestedScrollEnabled
-      testID="compact-provider-list"
-    >
-      {children}
-    </ScrollView>
+    <IndependentScrollBoundary>
+      <ScrollView
+        style={styles.virtualizedModelList}
+        contentContainerStyle={[
+          styles.virtualizedModelListContent,
+          styles.virtualizedProviderListContent,
+        ]}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        showsVerticalScrollIndicator={false}
+        nestedScrollEnabled
+        testID="compact-provider-list"
+      >
+        {children}
+      </ScrollView>
+    </IndependentScrollBoundary>
   );
 }
 

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -50,7 +50,8 @@ import {
   shouldShowCustomComboboxOption,
 } from "./combobox-options";
 import type { ComboboxOptionModel } from "./combobox-options";
-import { isWeb } from "@/constants/platform";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { isNative, isWeb } from "@/constants/platform";
 import {
   IsolatedBottomSheetModal,
   useIsolatedBottomSheetVisibility,
@@ -74,6 +75,7 @@ import { buildDesktopFrameStyle } from "./combobox-frame-style";
 export { buildDesktopFrameStyle } from "./combobox-frame-style";
 
 const IS_WEB = isWeb;
+const ModalRoot = isNative ? GestureHandlerRootView : View;
 
 export type ComboboxOption = ComboboxOptionModel;
 export type ComboboxDesktopPlacement = "top-start" | "bottom-start";
@@ -1266,7 +1268,7 @@ function DesktopComboboxBody(props: DesktopBodyProps): ReactElement {
       visible={props.isOpen}
       onRequestClose={props.handleClose}
     >
-      {overlay}
+      <ModalRoot style={styles.desktopModalRoot}>{overlay}</ModalRoot>
     </Modal>
   );
 }
@@ -1764,6 +1766,9 @@ const styles = StyleSheet.create((theme) => ({
     paddingTop: theme.spacing[1],
   },
   desktopOverlay: {
+    flex: 1,
+  },
+  desktopModalRoot: {
     flex: 1,
   },
   desktopOverlayWeb: {

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -75,6 +75,7 @@ import { buildDesktopFrameStyle } from "./combobox-frame-style";
 export { buildDesktopFrameStyle } from "./combobox-frame-style";
 
 const IS_WEB = isWeb;
+// Android modals open a separate native window and need their own gesture root.
 const ModalRoot = isNative ? GestureHandlerRootView : View;
 
 export type ComboboxOption = ComboboxOptionModel;


### PR DESCRIPTION
Fixes #4377.

On Android tablets, the model picker opened but tapping provider/model rows did nothing. Both the desktop Combobox and AdaptiveModalSheet render their contents in a React Native Modal, which creates a separate Android window. ModelBrowser uses Gesture Handler tap/native gestures there, but that window had no GestureHandlerRootView to dispatch their touches.

Wrap each native modal's content in a full-height GestureHandlerRootView. Keep the existing model list gestures so scrolling/flinging out of the short viewport and tap-versus-scroll handling are preserved.

Tablet QA also found the persistent left sidebar footer visible but untappable on Android: Add Project, Host, Import Session, Help and Support, and Settings did not respond. The sidebar uses a native scroll/draggable workspace list above that footer, and the wide tablet sidebar path was only honoring the top safe-area inset. Bound the sidebar as an explicit column, keep the scroll list inside its flex slot with `minHeight: 0`, give the footer native stacking priority, and apply the bottom safe-area inset to the wide/tablet sidebar so Android system navigation/taskbar space cannot sit over the footer controls.

Validation:
- `npm run format:check:files -- packages/app/src/components/left-sidebar.tsx packages/app/src/components/sidebar-workspace-list.tsx`: passed.
- `npm run lint -- --quiet src/components/left-sidebar.tsx src/components/sidebar-workspace-list.tsx` from `packages/app`: passed, zero lint warnings/errors.
- `npm run typecheck --workspace @getpaseo/app`: passed.
- Earlier modal gesture-root validation passed: targeted lint/formatting, all-workspace typecheck, targeted model/combobox/adaptive-modal Vitest suite, `git diff --check origin/main...HEAD`, and clean `git merge-tree --write-tree origin/main HEAD`.

Native QA remains outstanding in this coding environment: no Android SDK, emulator or attached device is available locally. Standalone Android tablet APKs are being built from the fork so this can be verified on a Samsung Galaxy Tab S10 Lite before marking ready. Verify populated provider/model selection in both new-agent and existing-agent tablet flows, scrolling/flinging without accidental selection, dismissal/reopening, compact phone scrolling, and the left sidebar footer buttons listed above.

Gesture Handler documents the Android Modal root requirement at https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/ .
