### PR TITLE
Apply project environment variables to agents and terminals

### DIFF
--- a/packages/app/e2e/browser/projects-settings.spec.ts
+++ b/packages/app/e2e/browser/projects-settings.spec.ts
@@ -238,6 +238,35 @@ test.describe("Projects settings", () => {
     await expectNoUncommittedSetupWarning(page);
   });
 
+  test("user validates and saves project environment variables", async ({
+    page,
+    editableProject,
+  }, testInfo) => {
+    await openProjects(page);
+    await openProjectSettings(page, editableProject.name);
+    const input = page.getByRole("textbox", { name: "Project environment variables" });
+    await input.fill("MISSING_EQUALS");
+    await input.blur();
+    await expect(page.getByTestId("env-error")).toContainText("Line 1 must use KEY=value");
+    await expectSaveButtonDisabled(page);
+
+    await input.fill("PASEO_TEST_PROJECT=from-settings\nEMPTY=\nURL=https://example.com?a=b");
+    await input.blur();
+    await clickSaveProjectSettings(page);
+    await expect
+      .poll(async () => JSON.parse(await readProjectConfigFile(editableProject)).worktree.env)
+      .toEqual({ PASEO_TEST_PROJECT: "from-settings", EMPTY: "", URL: "https://example.com?a=b" });
+    await returnToProjectsList(page);
+    await openProjectSettings(page, editableProject.name);
+    await expect(input).toHaveValue(
+      "PASEO_TEST_PROJECT=from-settings\nEMPTY=\nURL=https://example.com?a=b",
+    );
+    await testInfo.attach("Project environment settings", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+  });
+
   test("project navigation stays inside the selected host", async ({ page, editableProject }) => {
     await openProjects(page);
     await openProjectSettings(page, editableProject.name);

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -2620,6 +2620,18 @@ export const ar: TranslationResources = {
         teardown: "هدم",
         teardownAccessibility: "أوامر هدم شجرة العمل",
       },
+      env: {
+        updateHost: "حدّث المضيف لاستخدام متغيرات بيئة المشروع.",
+        title: "Env",
+        info: "متغيرات البيئة للوكلاء وخطافات دورة الحياة والمحطات الطرفية والبرامج النصية الجديدة في هذا المشروع",
+        accessibility: "متغيرات بيئة المشروع",
+        placeholder: "API_URL=https://example.com\nDEBUG=1",
+        errors: {
+          missing_equals: "يجب أن يستخدم السطر {{line}} التنسيق KEY=value",
+          invalid_key: "يحتوي السطر {{line}} على اسم متغير غير صالح",
+          duplicate_key: "يكرر السطر {{line}} اسم متغير",
+        },
+      },
       scripts: {
         title: "البرامج النصية",
         info: "خدمات طويلة الأمد وأوامر لمرة واحدة يمكنك إطلاقها من أي وكيل في هذا المشروع",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -2746,6 +2746,18 @@ export const en = {
         teardown: "Teardown",
         teardownAccessibility: "Worktree teardown commands",
       },
+      env: {
+        updateHost: "Update the host to use project environment variables.",
+        title: "Env",
+        info: "Environment variables added to new agents, lifecycle hooks, terminals, and scripts in this project",
+        accessibility: "Project environment variables",
+        placeholder: "API_URL=https://example.com\nDEBUG=1",
+        errors: {
+          missing_equals: "Line {{line}} must use KEY=value",
+          invalid_key: "Line {{line}} has an invalid variable name",
+          duplicate_key: "Line {{line}} repeats a variable name",
+        },
+      },
       scripts: {
         title: "Scripts",
         info: "Long-running services and one-off commands you can launch from any agent in this project",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -2679,6 +2679,18 @@ export const es: TranslationResources = {
         teardown: "Demoler",
         teardownAccessibility: "Comandos de desmontaje del árbol de trabajo",
       },
+      env: {
+        updateHost: "Actualiza el host para usar variables de entorno del proyecto.",
+        title: "Env",
+        info: "Variables de entorno para agentes, hooks, terminales y scripts nuevos de este proyecto",
+        accessibility: "Variables de entorno del proyecto",
+        placeholder: "API_URL=https://example.com\nDEBUG=1",
+        errors: {
+          missing_equals: "La línea {{line}} debe usar KEY=value",
+          invalid_key: "La línea {{line}} tiene un nombre de variable no válido",
+          duplicate_key: "La línea {{line}} repite un nombre de variable",
+        },
+      },
       scripts: {
         title: "Scripts",
         info: "Servicios de larga duración y comandos únicos que puede iniciar desde cualquier agente en este proyecto",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -2686,6 +2686,18 @@ export const fr: TranslationResources = {
         teardown: "Démolir",
         teardownAccessibility: "Commandes de démontage de Worktree",
       },
+      env: {
+        updateHost: "Mettez à jour l’hôte pour utiliser les variables d’environnement du projet.",
+        title: "Env",
+        info: "Variables d'environnement pour les nouveaux agents, hooks, terminaux et scripts de ce projet",
+        accessibility: "Variables d'environnement du projet",
+        placeholder: "API_URL=https://example.com\nDEBUG=1",
+        errors: {
+          missing_equals: "La ligne {{line}} doit utiliser KEY=value",
+          invalid_key: "La ligne {{line}} contient un nom de variable invalide",
+          duplicate_key: "La ligne {{line}} répète un nom de variable",
+        },
+      },
       scripts: {
         title: "Scripts",
         info: "Services de longue durée et commandes ponctuelles que vous pouvez lancer à partir de n'importe quel agent de ce projet",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -2647,6 +2647,18 @@ export const ja: TranslationResources = {
         teardown: "削除時",
         teardownAccessibility: "ワークツリー削除時のコマンド",
       },
+      env: {
+        updateHost: "プロジェクトの環境変数を使用するにはホストを更新してください。",
+        title: "Env",
+        info: "このプロジェクトの新しいエージェント、ライフサイクルフック、ターミナル、スクリプトに追加する環境変数",
+        accessibility: "プロジェクトの環境変数",
+        placeholder: "API_URL=https://example.com\nDEBUG=1",
+        errors: {
+          missing_equals: "{{line}} 行目は KEY=value 形式で入力してください",
+          invalid_key: "{{line}} 行目の変数名が無効です",
+          duplicate_key: "{{line}} 行目で変数名が重複しています",
+        },
+      },
       scripts: {
         title: "スクリプト",
         info: "このプロジェクトのどのエージェントからでも起動できる、長時間実行サービスと単発コマンド",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -2634,6 +2634,18 @@ export const ko: TranslationResources = {
         teardown: "정리",
         teardownAccessibility: "워크트리 정리 명령",
       },
+      env: {
+        updateHost: "프로젝트 환경 변수를 사용하려면 호스트를 업데이트하세요.",
+        title: "Env",
+        info: "이 프로젝트의 새 에이전트, 수명 주기 훅, 터미널 및 스크립트에 추가할 환경 변수",
+        accessibility: "프로젝트 환경 변수",
+        placeholder: "API_URL=https://example.com\nDEBUG=1",
+        errors: {
+          missing_equals: "{{line}}행은 KEY=value 형식이어야 합니다",
+          invalid_key: "{{line}}행의 변수 이름이 올바르지 않습니다",
+          duplicate_key: "{{line}}행에 중복된 변수 이름이 있습니다",
+        },
+      },
       scripts: {
         title: "스크립트",
         info: "이 프로젝트의 모든 에이전트에서 실행할 수 있는 장기 실행 서비스 및 일회성 명령",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -2662,6 +2662,18 @@ export const ptBR: TranslationResources = {
         teardown: "Desmontagem",
         teardownAccessibility: "Comandos de desmontagem do worktree",
       },
+      env: {
+        updateHost: "Atualize o host para usar variáveis de ambiente do projeto.",
+        title: "Env",
+        info: "Variáveis de ambiente para novos agentes, hooks, terminais e scripts deste projeto",
+        accessibility: "Variáveis de ambiente do projeto",
+        placeholder: "API_URL=https://example.com\nDEBUG=1",
+        errors: {
+          missing_equals: "A linha {{line}} deve usar KEY=value",
+          invalid_key: "A linha {{line}} tem um nome de variável inválido",
+          duplicate_key: "A linha {{line}} repete um nome de variável",
+        },
+      },
       scripts: {
         title: "Scripts",
         info: "Serviços contínuos e comandos avulsos que você pode iniciar de qualquer agente neste projeto",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -2670,6 +2670,18 @@ export const ru: TranslationResources = {
         teardown: "Удаление",
         teardownAccessibility: "Команды удаления worktree",
       },
+      env: {
+        updateHost: "Обновите хост, чтобы использовать переменные окружения проекта.",
+        title: "Env",
+        info: "Переменные окружения для новых агентов, lifecycle-команд, терминалов и скриптов этого проекта",
+        accessibility: "Переменные окружения проекта",
+        placeholder: "API_URL=https://example.com\nDEBUG=1",
+        errors: {
+          missing_equals: "В строке {{line}} ожидается формат KEY=value",
+          invalid_key: "В строке {{line}} указано некорректное имя переменной",
+          duplicate_key: "В строке {{line}} повторяется имя переменной",
+        },
+      },
       scripts: {
         title: "Скрипты",
         info: "Долго работающие сервисы и одноразовые команды, которые можно запускать из любого агента этого проекта.",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -2588,6 +2588,18 @@ export const zhCN: TranslationResources = {
         teardown: "Teardown",
         teardownAccessibility: "Worktree teardown 命令",
       },
+      env: {
+        updateHost: "请更新主机以使用项目环境变量。",
+        title: "Env",
+        info: "添加到此项目的新代理、生命周期钩子、终端和脚本中的环境变量",
+        accessibility: "项目环境变量",
+        placeholder: "API_URL=https://example.com\nDEBUG=1",
+        errors: {
+          missing_equals: "第 {{line}} 行必须使用 KEY=value 格式",
+          invalid_key: "第 {{line}} 行的变量名无效",
+          duplicate_key: "第 {{line}} 行重复了变量名",
+        },
+      },
       scripts: {
         title: "Scripts",
         info: "可从此 Project 中任意 Agent 启动的长期服务和一次性命令",

--- a/packages/app/src/screens/project-settings-screen.tsx
+++ b/packages/app/src/screens/project-settings-screen.tsx
@@ -43,6 +43,7 @@ import {
   applyDraftToConfig,
   configToDraft,
   METADATA_PROMPT_KEYS,
+  parseProjectEnv,
   type LifecycleOriginalKind,
   type MetadataPromptKey,
   type ProjectConfigDraft,
@@ -388,6 +389,7 @@ function renderContent({
   return (
     <ProjectConfigForm
       key={formKey}
+      serverId={selectedHost.serverId}
       baseConfig={loadedConfig}
       revision={loadedRevision}
       hasUncommittedWorktreeSetupChanges={hasUncommittedWorktreeSetupChanges}
@@ -469,6 +471,7 @@ function errorToDetail(error: unknown): string | null {
 }
 
 interface ProjectConfigFormProps {
+  serverId: string;
   baseConfig: PaseoConfigRaw;
   revision: PaseoConfigRevision | null;
   hasUncommittedWorktreeSetupChanges: boolean;
@@ -479,6 +482,7 @@ interface ProjectConfigFormProps {
 }
 
 function ProjectConfigForm({
+  serverId,
   baseConfig,
   revision,
   hasUncommittedWorktreeSetupChanges,
@@ -488,6 +492,8 @@ function ProjectConfigForm({
   onReload,
 }: ProjectConfigFormProps) {
   const { t } = useTranslation();
+  // COMPAT(projectEnvironment): added in v0.8.0, remove gate after 2027-03-12.
+  const supportsProjectEnvironment = useHostFeature(serverId, "projectEnvironment");
   const queryClient = useQueryClient();
   const toast = useToast();
 
@@ -550,6 +556,10 @@ function ProjectConfigForm({
   );
   const handleTeardownChange = useCallback(
     (text: string) => updateDraft((d) => ({ ...d, teardownText: text })),
+    [updateDraft],
+  );
+  const handleEnvChange = useCallback(
+    (text: string) => updateDraft((d) => ({ ...d, envText: text })),
     [updateDraft],
   );
 
@@ -644,6 +654,13 @@ function ProjectConfigForm({
     () => draft.scripts.some((script) => validateScript(script, t).hasErrors),
     [draft.scripts, t],
   );
+  const envValidation = useMemo(() => parseProjectEnv(draft.envText), [draft.envText]);
+  const envError = useMemo(() => {
+    if (envValidation.ok) return null;
+    return t(`settings.project.env.errors.${envValidation.reason}`, {
+      line: envValidation.line,
+    });
+  }, [envValidation, t]);
 
   const scriptsTrailing = useMemo(
     () => (
@@ -686,7 +703,7 @@ function ProjectConfigForm({
 
   const isStale = writeError?.code === "stale_project_config";
   const isWriteFailed = writeError?.code === "write_failed";
-  const saveDisabled = saveMutation.isPending || isStale || hasInvalidScripts;
+  const saveDisabled = saveMutation.isPending || isStale || hasInvalidScripts || !envValidation.ok;
 
   return (
     <View>
@@ -730,6 +747,31 @@ function ProjectConfigForm({
             placeholder="docker compose down"
           />
         </SettingsSection>
+      </SettingsGroup>
+
+      <SettingsGroup
+        title={t("settings.project.env.title")}
+        info={t("settings.project.env.info")}
+        testID="env-group"
+      >
+        {supportsProjectEnvironment ? (
+          <>
+            <SettingsTextAreaCard
+              testID="env-input"
+              accessibilityLabel={t("settings.project.env.accessibility")}
+              value={draft.envText}
+              onChangeText={handleEnvChange}
+              placeholder={t("settings.project.env.placeholder")}
+            />
+            {envError ? (
+              <Text testID="env-error" style={styles.envError}>
+                {envError}
+              </Text>
+            ) : null}
+          </>
+        ) : (
+          <Text style={settingsStyles.rowHint}>{t("settings.project.env.updateHost")}</Text>
+        )}
       </SettingsGroup>
 
       <SettingsGroup
@@ -1241,6 +1283,12 @@ const styles = StyleSheet.create((theme) => ({
   fieldError: {
     color: theme.colors.palette.red[300],
     fontSize: theme.fontSize.sm,
+  },
+  envError: {
+    color: theme.colors.palette.red[300],
+    fontSize: theme.fontSize.sm,
+    marginTop: theme.spacing[2],
+    marginLeft: theme.spacing[1],
   },
   serviceToggleRow: {
     flexDirection: "row",

--- a/packages/app/src/utils/project-config-form.test.ts
+++ b/packages/app/src/utils/project-config-form.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { PaseoConfigRawSchema } from "@getpaseo/protocol/paseo-config-schema";
 import type { PaseoConfigRaw } from "@getpaseo/protocol/messages";
-import { applyDraftToConfig, configToDraft, type ProjectConfigDraft } from "./project-config-form";
+import {
+  applyDraftToConfig,
+  configToDraft,
+  formatProjectEnv,
+  parseProjectEnv,
+  type ProjectConfigDraft,
+} from "./project-config-form";
 
 function emptyDraft(): ProjectConfigDraft {
   return {
@@ -9,6 +15,7 @@ function emptyDraft(): ProjectConfigDraft {
     setupOriginalKind: "missing",
     teardownText: "",
     teardownOriginalKind: "missing",
+    envText: "",
     scripts: [],
     metadataPrompts: {
       branchName: "",
@@ -63,6 +70,51 @@ describe("configToDraft", () => {
     expect(buildRow.portText).toBe("");
     expect(buildRow.id).not.toBe(devRow.id);
   });
+
+  it("renders environment variables as key=value lines", () => {
+    const draft = configToDraft({
+      worktree: { env: { API_URL: "https://example.com?a=b", EMPTY: "" } },
+    });
+    expect(draft.envText).toBe("API_URL=https://example.com?a=b\nEMPTY=");
+  });
+});
+
+describe("project env text", () => {
+  it("accepts Windows line endings and keys that match object properties", () => {
+    expect(parseProjectEnv("__proto__=literal\r\nconstructor=value\r\n")).toEqual({
+      ok: true,
+      env: { ["__proto__"]: "literal", constructor: "value" },
+    });
+  });
+
+  it("parses values at the first equals sign and ignores blank lines", () => {
+    expect(parseProjectEnv("API_URL=https://example.com?a=b\n\nEMPTY=\n")).toEqual({
+      ok: true,
+      env: { API_URL: "https://example.com?a=b", EMPTY: "" },
+    });
+  });
+
+  it("rejects malformed, invalid, and duplicate keys with their line number", () => {
+    expect(parseProjectEnv("GOOD=1\nMISSING")).toEqual({
+      ok: false,
+      line: 2,
+      reason: "missing_equals",
+    });
+    expect(parseProjectEnv("BAD KEY=1")).toEqual({
+      ok: false,
+      line: 1,
+      reason: "invalid_key",
+    });
+    expect(parseProjectEnv("DUP=1\nDUP=2")).toEqual({
+      ok: false,
+      line: 2,
+      reason: "duplicate_key",
+    });
+  });
+
+  it("formats environment variables without changing values", () => {
+    expect(formatProjectEnv({ TOKEN: "abc=def", EMPTY: "" })).toBe("TOKEN=abc=def\nEMPTY=");
+  });
 });
 
 describe("applyDraftToConfig", () => {
@@ -106,6 +158,28 @@ describe("applyDraftToConfig", () => {
     draft.setupText = "";
     const next = applyDraftToConfig({ draft, base });
     expect(next.worktree?.setup).toBeUndefined();
+  });
+
+  it("writes and removes project environment variables", () => {
+    const base: PaseoConfigRaw = { worktree: { env: { OLD: "value" } } };
+    const draft = configToDraft(base);
+    draft.envText = "API_URL=https://example.com\nEMPTY=";
+    expect(applyDraftToConfig({ draft, base }).worktree?.env).toEqual({
+      API_URL: "https://example.com",
+      EMPTY: "",
+    });
+
+    draft.envText = "";
+    expect(applyDraftToConfig({ draft, base }).worktree?.env).toBeUndefined();
+  });
+
+  it("refuses to apply malformed project environment text", () => {
+    const base: PaseoConfigRaw = {};
+    const draft = configToDraft(base);
+    draft.envText = "MISSING_EQUALS";
+    expect(() => applyDraftToConfig({ draft, base })).toThrow(
+      "Invalid project environment on line 1",
+    );
   });
 
   it("preserves unknown top-level, worktree, and script entry fields on round-trip", () => {

--- a/packages/app/src/utils/project-config-form.ts
+++ b/packages/app/src/utils/project-config-form.ts
@@ -25,6 +25,7 @@ export interface ProjectConfigDraft {
   setupOriginalKind: LifecycleOriginalKind;
   teardownText: string;
   teardownOriginalKind: LifecycleOriginalKind;
+  envText: string;
   scripts: ProjectScriptDraft[];
   metadataPrompts: Record<MetadataPromptKey, string>;
   metadataGenerationBase: PaseoMetadataGeneration | undefined;
@@ -33,6 +34,38 @@ export interface ProjectConfigDraft {
 interface LifecycleProjection {
   text: string;
   kind: LifecycleOriginalKind;
+}
+
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export type ProjectEnvParseResult =
+  | { ok: true; env: Record<string, string> }
+  | { ok: false; line: number; reason: "missing_equals" | "invalid_key" | "duplicate_key" };
+
+export function formatProjectEnv(env: Record<string, string> | null | undefined): string {
+  return Object.entries(env ?? {})
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+}
+
+export function parseProjectEnv(text: string): ProjectEnvParseResult {
+  const env = new Map<string, string>();
+  for (const [index, rawLine] of text.split(/\r?\n/).entries()) {
+    if (rawLine.trim().length === 0) continue;
+    const separatorIndex = rawLine.indexOf("=");
+    if (separatorIndex < 0) {
+      return { ok: false, line: index + 1, reason: "missing_equals" };
+    }
+    const key = rawLine.slice(0, separatorIndex);
+    if (!ENV_KEY_PATTERN.test(key)) {
+      return { ok: false, line: index + 1, reason: "invalid_key" };
+    }
+    if (env.has(key)) {
+      return { ok: false, line: index + 1, reason: "duplicate_key" };
+    }
+    env.set(key, rawLine.slice(separatorIndex + 1));
+  }
+  return { ok: true, env: Object.fromEntries(env) };
 }
 
 function projectLifecycle(value: unknown): LifecycleProjection {
@@ -140,6 +173,7 @@ export function configToDraft(config: PaseoConfigRaw | null | undefined): Projec
     setupOriginalKind: setup.kind,
     teardownText: teardown.text,
     teardownOriginalKind: teardown.kind,
+    envText: formatProjectEnv(worktree.env),
     scripts,
     metadataPrompts,
     metadataGenerationBase: metadataGeneration,
@@ -170,6 +204,15 @@ export function applyDraftToConfig(input: ApplyDraftInput): PaseoConfigRaw {
     delete nextWorktree.teardown;
   } else {
     nextWorktree.teardown = nextTeardown;
+  }
+  const parsedEnv = parseProjectEnv(input.draft.envText);
+  if (!parsedEnv.ok) {
+    throw new Error(`Invalid project environment on line ${parsedEnv.line}`);
+  }
+  if (Object.keys(parsedEnv.env).length === 0) {
+    delete nextWorktree.env;
+  } else {
+    nextWorktree.env = parsedEnv.env;
   }
 
   const nextScripts: Record<string, PaseoScriptEntryRaw> = {};

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3482,6 +3482,8 @@ export const ServerInfoStatusPayloadSchema = z
         agentRequestReceipts: z.boolean().optional(),
         // COMPAT(hubAgentRpc): added in v0.8.0; remove gate after 2027-03-05.
         hubAgentRpc: z.boolean().optional(),
+        // COMPAT(projectEnvironment): added in v0.8.0, remove gate after 2027-03-12.
+        projectEnvironment: z.boolean().optional(),
         providersSnapshot: z.boolean().optional(),
         // COMPAT(providersSnapshotCwd): added in v0.3.2, remove gate after 2027-02-10.
         providersSnapshotCwd: z.boolean().optional(),

--- a/packages/protocol/src/paseo-config-schema.test.ts
+++ b/packages/protocol/src/paseo-config-schema.test.ts
@@ -49,6 +49,32 @@ describe("paseo config schema", () => {
     });
   });
 
+  it("parses project environment variables", () => {
+    expect(
+      PaseoConfigSchema.parse({
+        worktree: {
+          env: { API_URL: "https://example.com", DEBUG: "1", EMPTY: "" },
+        },
+      }),
+    ).toEqual({
+      worktree: {
+        setup: [],
+        teardown: [],
+        env: { API_URL: "https://example.com", DEBUG: "1", EMPTY: "" },
+      },
+    });
+  });
+
+  it("rejects non-string project environment variable values", () => {
+    expect(() => PaseoConfigRawSchema.parse({ worktree: { env: { DEBUG: true } } })).toThrow();
+  });
+
+  it("rejects invalid project environment variable names", () => {
+    expect(() =>
+      PaseoConfigRawSchema.parse({ worktree: { env: { "BAD KEY": "value" } } }),
+    ).toThrow();
+  });
+
   it("rejects invalid service port ranges", () => {
     expect(() =>
       PaseoConfigRawSchema.parse({ worktree: { servicePorts: { range: "4000-3000" } } }),

--- a/packages/protocol/src/paseo-config-schema.ts
+++ b/packages/protocol/src/paseo-config-schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 const TCP_PORT_RANGE_PATTERN = /^(\d{1,5})-(\d{1,5})$/;
+const ENV_VAR_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export const PaseoServicePortAllocationSchema = z
   .object({
@@ -47,6 +48,7 @@ export const PaseoWorktreeConfigRawSchema = z
   .object({
     setup: PaseoLifecycleCommandRawSchema.optional(),
     teardown: PaseoLifecycleCommandRawSchema.optional(),
+    env: z.record(z.string().regex(ENV_VAR_NAME_PATTERN), z.string()).optional(),
     terminals: z.unknown().optional(),
     servicePorts: PaseoServicePortAllocationSchema.optional(),
   })

--- a/packages/server/src/server/agent/create-agent/create-env.test.ts
+++ b/packages/server/src/server/agent/create-agent/create-env.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveCreateAgentEnv } from "./create.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("resolveCreateAgentEnv", () => {
+  it("adds project env and lets request-specific values override it", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "paseo-create-agent-env-"));
+    temporaryDirectories.push(cwd);
+    writeFileSync(
+      join(cwd, "paseo.json"),
+      JSON.stringify({ worktree: { env: { API_URL: "project", PROJECT_ONLY: "1" } } }),
+    );
+
+    expect(resolveCreateAgentEnv(cwd, { API_URL: "request", REQUEST_ONLY: "1" })).toEqual({
+      API_URL: "request",
+      PROJECT_ONLY: "1",
+      REQUEST_ONLY: "1",
+    });
+  });
+
+  it("leaves agent env undefined when neither source defines variables", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "paseo-create-agent-env-empty-"));
+    temporaryDirectories.push(cwd);
+
+    expect(resolveCreateAgentEnv(cwd, undefined)).toBeUndefined();
+  });
+});

--- a/packages/server/src/server/agent/create-agent/create.test.ts
+++ b/packages/server/src/server/agent/create-agent/create.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test, vi } from "vitest";
@@ -225,6 +225,52 @@ test("mcp create accepts provider-only internal input and leaves model undefined
       workspaceId: "ws-create-test",
     }),
   );
+});
+
+test("session create passes project env and request overrides to the provider", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "create-agent-project-env-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const clients = createTestAgentClients();
+  const createSession = vi.spyOn(clients.codex, "createSession");
+  const agentManager = new AgentManager({ clients, registry: storage, logger });
+  try {
+    writeFileSync(
+      join(workdir, "paseo.json"),
+      JSON.stringify({
+        worktree: { env: { PASEO_TEST_PROJECT: "project", PASEO_TEST_OVERRIDE: "project" } },
+      }),
+    );
+    await createAgentCommand(
+      {
+        agentManager,
+        agentStorage: storage,
+        logger,
+        providerSnapshotManager: createProviderSnapshotManagerStub().manager,
+      },
+      {
+        kind: "session",
+        config: { provider: "codex", cwd: workdir },
+        workspaceId: "ws-source",
+        labels: {},
+        provisionalTitle: null,
+        env: { PASEO_TEST_OVERRIDE: "request" },
+        firstAgentContext: { attachments: [] },
+        buildSessionConfig: async (config) => ({ sessionConfig: config }),
+      },
+    );
+    expect(createSession).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          PASEO_TEST_PROJECT: "project",
+          PASEO_TEST_OVERRIDE: "request",
+        }),
+      }),
+      undefined,
+    );
+  } finally {
+    await removeRealAgentManagerWorkdir({ agentManager, storage, workdir });
+  }
 });
 
 test("session create stamps the requested workspaceId when no worktree setup runs", async () => {

--- a/packages/server/src/server/agent/create-agent/create.ts
+++ b/packages/server/src/server/agent/create-agent/create.ts
@@ -26,6 +26,7 @@ import {
   emitLiveTimelineItemIfAgentKnown,
 } from "../timeline-append.js";
 import { resolveCreateAgentIntent } from "./intent.js";
+import { getWorktreeProjectEnv } from "../../../utils/paseo-config-file.js";
 
 export interface CreateAgentSessionWorktreeResult {
   sessionConfig: AgentSessionConfig;
@@ -171,6 +172,17 @@ interface ResolvedCreateAgent {
   createdWorktree?: CreatePaseoWorktreeWorkflowResult;
 }
 
+export function resolveCreateAgentEnv(
+  cwd: string,
+  requestEnv: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  const workspaceEnv = getWorktreeProjectEnv(cwd);
+  if (Object.keys(workspaceEnv).length === 0 && !requestEnv) {
+    return undefined;
+  }
+  return { ...workspaceEnv, ...requestEnv };
+}
+
 export async function createAgentCommand(
   dependencies: CreateAgentCommandDependencies,
   input: CreateAgentCommandInput,
@@ -276,13 +288,14 @@ async function resolveSessionCreateAgent(
         }
       : undefined;
   const workspaceId = setupContinuation ? createdWorkspaceId : input.workspaceId;
+  const agentEnv = resolveCreateAgentEnv(sessionConfig.cwd, input.env);
 
   return {
     config: sessionConfig,
     createOptions: {
       labels: input.labels,
       initialPrompt: trimmedPrompt,
-      env: input.env,
+      env: agentEnv,
       initialTitle: input.provisionalTitle,
       // A legacy git/worktreeName worktree creates a fresh workspace, so the
       // agent belongs to that workspace, not the source one. createdWorkspaceId
@@ -344,6 +357,7 @@ async function resolveMcpCreateAgent(
   });
 
   const trimmedPrompt = input.initialPrompt?.trim() ?? "";
+  const agentEnv = resolveCreateAgentEnv(intent.cwd, input.env);
   return {
     config: buildMcpSessionConfig({
       input,
@@ -358,7 +372,7 @@ async function resolveMcpCreateAgent(
       ...(Object.keys(intent.labels).length > 0 ? { labels: intent.labels } : {}),
       workspaceId: intent.workspaceId,
       owner: input.owner,
-      env: input.env,
+      env: agentEnv,
     },
     prompt: trimmedPrompt ? trimmedPrompt : undefined,
     setupContinuation,

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1644,6 +1644,7 @@ export class VoiceAssistantWebSocketServer {
       desktopManaged: this.daemonRuntimeConfig?.desktopManaged === true,
       ...(this.serverCapabilities ? { capabilities: this.serverCapabilities } : {}),
       features: {
+        projectEnvironment: true,
         ownedSubscriptions: true,
         agentRequestReceipts: true,
         hubAgentRpc: true,

--- a/packages/server/src/terminal/terminal-manager.test.ts
+++ b/packages/server/src/terminal/terminal-manager.test.ts
@@ -2,7 +2,15 @@ import { it, expect, afterEach } from "vitest";
 import { isPlatform } from "../test-utils/platform.js";
 import { createTerminalManager, type TerminalManager } from "./terminal-manager.js";
 import type { TerminalWorkspaceContributionChangedEvent } from "./terminal-manager.js";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -179,6 +187,45 @@ it("does not reject Windows absolute paths as relative", async () => {
     await manager.createTerminal({ cwd, workspaceId: "ws-test" });
   } catch (error) {
     expect((error as Error).message).not.toBe("cwd must be absolute path");
+  }
+});
+
+it("reads project env for each new terminal without an agent and honors explicit overrides", async () => {
+  manager = createTerminalManager();
+  const cwd = mkdtempSync(join(tmpdir(), "terminal-project-env-"));
+  temporaryDirs.push(cwd);
+  const configPath = join(cwd, "paseo.json");
+  manager.registerCwdEnv({ cwd, env: { PASEO_WORKTREE_PORT: "45678" } });
+
+  for (const [index, env] of [
+    { PASEO_TEST_PROJECT: "first", PASEO_TEST_REMOVED: "present", PASEO_TEST_OVERRIDE: "project" },
+    { PASEO_TEST_PROJECT: "updated" },
+    {},
+  ].entries()) {
+    writeFileSync(configPath, JSON.stringify({ worktree: { env } }));
+    const markerPath = join(cwd, `env-${index}.json`);
+    await manager.createTerminal({
+      workspaceId: "ws-test",
+      cwd,
+      command: process.execPath,
+      args: [
+        "-e",
+        `require('fs').writeFileSync(${JSON.stringify(markerPath)}, JSON.stringify({
+        project: process.env.PASEO_TEST_PROJECT,
+        removed: process.env.PASEO_TEST_REMOVED,
+        override: process.env.PASEO_TEST_OVERRIDE,
+        port: process.env.PASEO_WORKTREE_PORT,
+      }))`,
+      ],
+      env: { PASEO_TEST_OVERRIDE: "explicit" },
+    });
+    await waitForCondition(() => existsSync(markerPath), 10000);
+    expect(JSON.parse(readFileSync(markerPath, "utf8"))).toEqual({
+      project: env.PASEO_TEST_PROJECT,
+      removed: env.PASEO_TEST_REMOVED,
+      override: "explicit",
+      port: "45678",
+    });
   }
 });
 

--- a/packages/server/src/terminal/terminal-manager.ts
+++ b/packages/server/src/terminal/terminal-manager.ts
@@ -1,3 +1,4 @@
+import { getWorktreeProjectEnv } from "../utils/paseo-config-file.js";
 import {
   createTerminal,
   type TerminalActivityTransition,
@@ -327,8 +328,8 @@ export function createTerminalManager(
       const terminals = terminalsByCwd.get(options.cwd) ?? [];
       const defaultName = `Terminal ${terminals.length + 1}`;
       const inheritedEnv = resolveDefaultEnvForCwd(options.cwd);
-      const mergedEnv =
-        inheritedEnv || options.env ? { ...inheritedEnv, ...options.env } : undefined;
+      const projectEnv = getWorktreeProjectEnv(options.cwd);
+      const mergedEnv = { ...projectEnv, ...inheritedEnv, ...options.env };
       const terminalId = options.id ?? randomUUID();
       const activityToken = options.activityToken ?? createActivityToken();
       const terminalActivityUrl =

--- a/packages/server/src/terminal/worker-terminal-manager.test.ts
+++ b/packages/server/src/terminal/worker-terminal-manager.test.ts
@@ -415,12 +415,18 @@ it("does not surface fire-and-forget send timeouts as unhandled rejections", asy
   expect(unhandledRejections).toEqual([]);
 });
 
-it("keeps registered cwd env inheritance behind the worker manager interface", async () => {
+it("combines fresh project env with registered runtime env through the worker", async () => {
   manager = createWorkerTerminalManager();
   const cwd = mkdtempSync(join(tmpdir(), "worker-terminal-manager-env-"));
   temporaryDirs.push(cwd);
   const markerPath = join(cwd, "env.txt");
 
+  writeFileSync(
+    join(cwd, "paseo.json"),
+    JSON.stringify({
+      worktree: { env: { PASEO_PROJECT_TERMINAL_TEST: "project-env" } },
+    }),
+  );
   manager.registerCwdEnv({
     cwd,
     env: { PASEO_WORKER_TERMINAL_TEST: "worker-env" },
@@ -432,7 +438,7 @@ it("keeps registered cwd env inheritance behind the worker manager interface", a
       ...nodeTerminalCommand(`
       require("node:fs").writeFileSync(
         ${JSON.stringify(markerPath)},
-        process.env.PASEO_WORKER_TERMINAL_TEST ?? "",
+        [process.env.PASEO_WORKER_TERMINAL_TEST, process.env.PASEO_PROJECT_TERMINAL_TEST].join(":"),
       );
       setInterval(() => {}, 1000);
     `),
@@ -441,7 +447,7 @@ it("keeps registered cwd env inheritance behind the worker manager interface", a
 
   await waitForCondition(() => existsSync(markerPath), 10000);
 
-  expect(readFileSync(markerPath, "utf8")).toBe("worker-env");
+  expect(readFileSync(markerPath, "utf8")).toBe("worker-env:project-env");
 });
 
 it("injects parent-minted terminal activity env through the worker", async () => {

--- a/packages/server/src/utils/paseo-config-file.ts
+++ b/packages/server/src/utils/paseo-config-file.ts
@@ -54,6 +54,13 @@ export function readPaseoConfigJson(repoRoot: string): unknown {
   return JSON.parse(readFileSync(configPath, "utf8"));
 }
 
+export function getWorktreeProjectEnv(cwd: string): Record<string, string> {
+  const json = readPaseoConfigJson(cwd);
+  if (json === null) return {};
+  const config = PaseoConfigRawSchema.parse(json);
+  return { ...config.worktree?.env };
+}
+
 export function readPaseoConfigForEdit(repoRoot: string): ReadPaseoConfigForEditResult {
   try {
     const json = readPaseoConfigJson(repoRoot);

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -973,6 +973,34 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(progressEvents.some((event) => event.type === "command_completed")).toBe(true);
     });
 
+    it("adds configured project env to setup commands without caching it in runtime env", async () => {
+      const paseoConfig = {
+        worktree: {
+          env: {
+            PROJECT_FLAG: "configured",
+            PASEO_BRANCH_NAME: "cannot-override-runtime",
+          },
+          setup: ['echo "$PROJECT_FLAG" > project-env.log'],
+        },
+      };
+      writeFileSync(join(repoDir, "paseo.json"), JSON.stringify(paseoConfig));
+
+      const runtimeEnv = await resolveWorktreeRuntimeEnv({
+        worktreePath: repoDir,
+        branchName: "main",
+      });
+      expect(runtimeEnv.PROJECT_FLAG).toBeUndefined();
+      expect(runtimeEnv.PASEO_BRANCH_NAME).toBe("main");
+
+      await runWorktreeSetupCommands({
+        worktreePath: repoDir,
+        branchName: "main",
+        cleanupOnFailure: false,
+        runtimeEnv,
+      });
+      expect(readFileSync(join(repoDir, "project-env.log"), "utf8").trim()).toBe("configured");
+    });
+
     it("reuses persisted worktree runtime port across resolutions", async () => {
       const result = await createLegacyWorktreeForTest({
         branchName: "main",
@@ -1427,12 +1455,14 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
     it("runs teardown commands from paseo.json before deleting a worktree", async () => {
       const paseoConfig = {
         worktree: {
+          env: { PROJECT_TEARDOWN_FLAG: "configured" },
           teardown: [
             'echo "source=$PASEO_SOURCE_CHECKOUT_PATH" > "$PASEO_SOURCE_CHECKOUT_PATH/teardown.log"',
             'echo "root_alias=$PASEO_ROOT_PATH" >> "$PASEO_SOURCE_CHECKOUT_PATH/teardown.log"',
             'echo "worktree=$PASEO_WORKTREE_PATH" >> "$PASEO_SOURCE_CHECKOUT_PATH/teardown.log"',
             'echo "branch=$PASEO_BRANCH_NAME" >> "$PASEO_SOURCE_CHECKOUT_PATH/teardown.log"',
             'echo "port=$PASEO_WORKTREE_PORT" >> "$PASEO_SOURCE_CHECKOUT_PATH/teardown.log"',
+            'echo "project_env=$PROJECT_TEARDOWN_FLAG" >> "$PASEO_SOURCE_CHECKOUT_PATH/teardown.log"',
           ],
         },
       };
@@ -1463,6 +1493,7 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(teardownLog).toContain(`worktree=${created.worktreePath}`);
       expect(teardownLog).toContain("branch=teardown-branch");
       expect(teardownLog).toContain(`port=${runtimeEnv.PASEO_WORKTREE_PORT}`);
+      expect(teardownLog).toContain("project_env=configured");
     });
 
     it("runs string teardown scripts from paseo.json as a single shell command", async () => {

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -17,7 +17,11 @@ import {
   buildStringCommandShellInvocation,
   createStringCommandShellEnv,
 } from "./string-command-shell.js";
-import { readPaseoConfigJson, resolvePaseoConfigPath } from "./paseo-config-file.js";
+import {
+  getWorktreeProjectEnv,
+  readPaseoConfigJson,
+  resolvePaseoConfigPath,
+} from "./paseo-config-file.js";
 export {
   PaseoConfigRawSchema,
   PaseoLifecycleCommandRawSchema,
@@ -654,7 +658,12 @@ export async function runWorktreeSetupCommands(options: {
       branchName: options.branchName,
       ...(options.repoRootPath ? { repoRootPath: options.repoRootPath } : {}),
     }));
-  const setupEnv = createStringCommandShellEnv(createExternalProcessEnv(process.env, runtimeEnv));
+  const setupEnv = createStringCommandShellEnv(
+    createExternalProcessEnv(process.env, {
+      ...getWorktreeProjectEnv(options.worktreePath),
+      ...runtimeEnv,
+    }),
+  );
 
   const results: WorktreeSetupCommandResult[] = [];
   for (const [index, cmd] of setupCommands.entries()) {
@@ -769,6 +778,7 @@ export async function runWorktreeTeardownCommands(options: {
 
   const teardownEnv: NodeJS.ProcessEnv = createStringCommandShellEnv(
     createExternalProcessEnv(process.env, {
+      ...getWorktreeProjectEnv(teardownCwd),
       // Source checkout path is the original git repo root (shared across worktrees), not the
       // worktree itself. This allows lifecycle scripts to copy or clean resources using paths
       // from the source checkout.

--- a/public-docs/worktrees.md
+++ b/public-docs/worktrees.md
@@ -86,7 +86,8 @@ Drop a `paseo.json` in your repo root. Paseo reads it from the committed version
 {
   "worktree": {
     "setup": "npm ci",
-    "teardown": "rm -rf .cache"
+    "teardown": "rm -rf .cache",
+    "env": { "API_URL": "https://api.example.com", "DEBUG": "1" }
   },
   "scripts": {
     "test": { "command": "npm test" },
@@ -237,6 +238,19 @@ Open terminals automatically when a worktree is created. Useful for tailing logs
 ```
 
 ## Environment variables
+
+Add project variables under `worktree.env`, or edit the **Env** section in project settings. Values are strings. Paseo adds them to new agents, setup and teardown hooks, workspace terminals, scripts, and services. Variables passed directly when an agent or terminal is created take precedence over project values. Paseo runtime variables, such as service ports, also take precedence. Each new process reads the configuration from its working directory; existing agents and terminals keep their environment.
+
+```json
+{
+  "worktree": {
+    "env": {
+      "API_URL": "https://api.example.com",
+      "DEBUG": "1"
+    }
+  }
+}
+```
 
 Setup, teardown, scripts, and services all see:
 


### PR DESCRIPTION
### Linked issue

No linked issue. This comes from using project environment settings in a downstream fork.

### Type of change

- [x] New feature
- [x] Enhancement

### Reasoning

Let users configure environment variables once in project settings and use them in agents, terminals, lifecycle hooks, and workspace scripts. For example, setting `API_URL` under `worktree.env` in `paseo.json` makes it available to a newly opened terminal, even when no agent has been started first.

The downstream implementation registered project variables in memory when creating an agent. This implementation reads the file on each terminal creation, so changed or removed variables take effect for subsequent terminals. Project values are kept out of the runtime environment cache.

### Goals

- Add the Env editor, validation, and optional `worktree.env` configuration.
- Apply project variables to new agents, terminals, setup/teardown hooks, scripts, and services. Explicit launch values and Paseo runtime variables take precedence.
- Gate the editor on the optional `server_info.features.projectEnvironment` flag. Older daemons show an update message; existing RPCs remain unchanged. Older clients accept the additive feature field, and older daemons accept the existing project config schema with its passthrough fields.

### Non-goals

- Updating the environment of processes that are already running.
- Adding a separate secrets store or searching parent directories for configuration. Configuration is read from the process working directory.

### QA

Tested on Linux with real terminal processes and Chromium:

- Reproduced the missing project variables with a new terminal regression test before the fix. It passed after the fix, including changes/removals between launches, explicit overrides, and registered runtime variables.
- Verified project variables through the separate terminal worker and through agent creation to a deterministic provider adapter.
- Verified real setup and teardown commands receive project variables.
- Seven targeted Vitest files: 167 passed, 1 skipped (platform-specific). Files cover the config schema, form parsing/round trips, agent env resolution and creation, both terminal managers, and worktree lifecycle commands. No full test suite was run.
- Chromium: entered an invalid ENV line and observed the validation error and disabled Save; saved valid values including an empty value and a URL containing `=`; verified the JSON on disk and values after reopening settings. The Playwright test attaches a screenshot.
- `npm run build:server`, `npm run typecheck`, `npm run lint`, and `npm run format` passed.

Browser command (the unset prevents the test daemon from inheriting the local daemon password):

```sh
cd packages/app
env -u PASEO_PASSWORD npx playwright test e2e/browser/projects-settings.spec.ts -g 'user validates and saves project environment variables' --project=browser
```

Not exercised: native iOS/Android, Electron, Windows/macOS daemons, or live agent providers. Kept as a draft for contributor review and remaining platform QA.

### Checklist

- [x] Plugin changes follow the SDK import boundaries (not applicable)
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
